### PR TITLE
refactor(spec): centralize template DSL parsing in coral-spec

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -12,8 +12,8 @@ use crate::backends::http::ProviderQueryError;
 use crate::backends::shared::json_path::get_path_value;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::{
-    HeaderSpec, HttpMethod, PageSizeSpec, RowStrategy, ValidatedPagination,
-    ValidatedPaginationMode, ValueSourceSpec,
+    HeaderSpec, HttpMethod, PageSizeSpec, ParsedTemplate, RowStrategy, TemplateNamespace,
+    TemplatePart, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
 };
 
 const DEFAULT_RETRY_WAIT_SECS: u64 = 5;
@@ -26,7 +26,7 @@ const MAX_RATE_LIMIT_WAIT_SECS: u64 = 300;
 pub(crate) struct HttpSourceClient {
     http: reqwest::Client,
     source_schema: String,
-    base_url_template: String,
+    base_url: ParsedTemplate,
     auth_headers: Vec<HeaderSpec>,
     source_secrets: Arc<BTreeMap<String, String>>,
     source_variables: Arc<BTreeMap<String, String>>,
@@ -36,7 +36,7 @@ impl std::fmt::Debug for HttpSourceClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HttpSourceClient")
             .field("source_schema", &self.source_schema)
-            .field("base_url_template", &self.base_url_template)
+            .field("base_url", &self.base_url)
             .field("auth_headers", &self.auth_headers)
             .finish_non_exhaustive()
     }
@@ -80,7 +80,6 @@ impl HttpSourceClient {
         source_secrets: BTreeMap<String, String>,
         source_variables: BTreeMap<String, String>,
     ) -> Result<Self> {
-        let source_schema = manifest.common.name.as_str();
         let auth = &manifest.auth;
 
         for key in &auth.required_secrets {
@@ -94,7 +93,6 @@ impl HttpSourceClient {
 
         for header in &auth.headers {
             let resolved = resolve_value_source(
-                source_schema,
                 &header.value,
                 &HashMap::new(),
                 &HashMap::new(),
@@ -112,7 +110,7 @@ impl HttpSourceClient {
         Ok(Self {
             http: reqwest::Client::new(),
             source_schema: manifest.common.name.clone(),
-            base_url_template: manifest.base_url.clone(),
+            base_url: manifest.base_url.clone(),
             auth_headers: manifest.auth.headers.clone(),
             source_secrets: Arc::new(source_secrets),
             source_variables: Arc::new(source_variables),
@@ -170,8 +168,7 @@ impl HttpSourceClient {
             }
 
             let base_url = render_template(
-                &self.source_schema,
-                &self.base_url_template,
+                &self.base_url,
                 filters,
                 &pagination_state_values(&state),
                 self.source_secrets.as_ref(),
@@ -191,7 +188,6 @@ impl HttpSourceClient {
                 next
             } else {
                 let rendered_path = render_template(
-                    &self.source_schema,
                     &active_request.path,
                     filters,
                     &pagination_state_values(&state),
@@ -205,7 +201,6 @@ impl HttpSourceClient {
                 (Vec::new(), None)
             } else {
                 let mut query_pairs = build_query_pairs(
-                    &self.source_schema,
                     active_request,
                     filters,
                     &state,
@@ -221,7 +216,6 @@ impl HttpSourceClient {
                 )?;
 
                 let mut body = build_request_body(
-                    &self.source_schema,
                     active_request,
                     filters,
                     &state,
@@ -371,7 +365,6 @@ async fn execute_request(
 
         for header in auth_headers {
             let value = resolve_value_source(
-                source_schema,
                 &header.value,
                 filters,
                 state,
@@ -389,7 +382,6 @@ async fn execute_request(
 
         for header in table_headers {
             if let Some(value) = resolve_value_source(
-                source_schema,
                 &header.value,
                 filters,
                 state,
@@ -514,7 +506,6 @@ fn build_http_request(
 }
 
 fn build_query_pairs(
-    source_schema: &str,
     request: &coral_spec::RequestSpec,
     filters: &HashMap<String, String>,
     state: &PageState,
@@ -526,7 +517,6 @@ fn build_query_pairs(
 
     for param in &request.query {
         let value = resolve_value_source(
-            source_schema,
             &param.value,
             filters,
             &state_values,
@@ -584,7 +574,6 @@ fn apply_pagination_query_pairs(
 }
 
 fn build_request_body(
-    source_schema: &str,
     request: &coral_spec::RequestSpec,
     filters: &HashMap<String, String>,
     state: &PageState,
@@ -600,7 +589,6 @@ fn build_request_body(
 
     for field in &request.body {
         if let Some(value) = resolve_value_source(
-            source_schema,
             &field.value,
             filters,
             &state_values,
@@ -665,7 +653,6 @@ fn resolve_page_size(spec: Option<&PageSizeSpec>, sql_limit: Option<usize>) -> O
 }
 
 fn resolve_value_source(
-    source_schema: &str,
     value: &ValueSourceSpec,
     filters: &HashMap<String, String>,
     state: &HashMap<String, String>,
@@ -674,14 +661,8 @@ fn resolve_value_source(
 ) -> Result<Option<Value>> {
     match value {
         ValueSourceSpec::Template { template } => {
-            let rendered = render_template(
-                source_schema,
-                template,
-                filters,
-                state,
-                source_secrets,
-                source_variables,
-            )?;
+            let rendered =
+                render_template(template, filters, state, source_secrets, source_variables)?;
             Ok(Some(Value::String(rendered)))
         }
         ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
@@ -726,86 +707,79 @@ fn pagination_state_values(state: &PageState) -> HashMap<String, String> {
 }
 
 fn render_template(
-    source_schema: &str,
-    template: &str,
+    template: &ParsedTemplate,
     filters: &HashMap<String, String>,
     state: &HashMap<String, String>,
     source_secrets: &BTreeMap<String, String>,
     source_variables: &BTreeMap<String, String>,
 ) -> Result<String> {
-    let mut out = String::with_capacity(template.len());
-    let mut rest = template;
-
-    while let Some(start) = rest.find("{{") {
-        out.push_str(&rest[..start]);
-        let token_start = start + 2;
-        let Some(end_rel) = rest[token_start..].find("}}") else {
-            return Err(DataFusionError::Execution(format!(
-                "unclosed template token in '{template}'"
-            )));
-        };
-        let end = token_start + end_rel;
-        let token = rest[token_start..end].trim();
-        out.push_str(&resolve_template_token(
-            source_schema,
-            token,
-            filters,
-            state,
-            source_secrets,
-            source_variables,
-        )?);
-        rest = &rest[end + 2..];
+    let mut out = String::with_capacity(template.raw().len());
+    for part in template.parts() {
+        match part {
+            TemplatePart::Literal(part) => out.push_str(part),
+            TemplatePart::Token(token) => out.push_str(&resolve_template_token(
+                token,
+                filters,
+                state,
+                source_secrets,
+                source_variables,
+            )?),
+        }
     }
-
-    out.push_str(rest);
     Ok(out)
 }
 
 fn resolve_template_token(
-    _source_schema: &str,
-    token: &str,
+    token: &coral_spec::TemplateToken,
     filters: &HashMap<String, String>,
     state: &HashMap<String, String>,
     source_secrets: &BTreeMap<String, String>,
     source_variables: &BTreeMap<String, String>,
 ) -> Result<String> {
-    let (raw_key, default) = match token.split_once('|') {
-        Some((key, default)) => (key.trim(), Some(default.to_string())),
-        None => (token, None),
-    };
+    let default = token.default_value().map(ToString::to_string);
 
-    if let Some(key) = raw_key.strip_prefix("secret.") {
-        return source_secrets.get(key).cloned().or(default).ok_or_else(|| {
-            DataFusionError::Execution(format!("missing source secret '{key}' for template token"))
+    if token.namespace() == &TemplateNamespace::Secret {
+        return source_secrets
+            .get(token.key())
+            .cloned()
+            .or(default)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "missing source secret '{}' for template token",
+                    token.key()
+                ))
+            });
+    }
+
+    if token.namespace() == &TemplateNamespace::Filter {
+        return filters
+            .get(token.key())
+            .cloned()
+            .or(default)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!("missing filter '{}'", token.key()))
+            });
+    }
+
+    if token.namespace() == &TemplateNamespace::Variable {
+        return source_variables
+            .get(token.key())
+            .cloned()
+            .or(default)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!("missing source variable '{}'", token.key()))
+            });
+    }
+
+    if token.namespace() == &TemplateNamespace::State {
+        return state.get(token.key()).cloned().or(default).ok_or_else(|| {
+            DataFusionError::Execution(format!("missing state value '{}'", token.key()))
         });
     }
 
-    if let Some(key) = raw_key.strip_prefix("filter.") {
-        return filters
-            .get(key)
-            .cloned()
-            .or(default)
-            .ok_or_else(|| DataFusionError::Execution(format!("missing filter '{key}'")));
-    }
-
-    if let Some(key) = raw_key.strip_prefix("variable.") {
-        return source_variables
-            .get(key)
-            .cloned()
-            .or(default)
-            .ok_or_else(|| DataFusionError::Execution(format!("missing source variable '{key}'")));
-    }
-
-    if let Some(key) = raw_key.strip_prefix("state.") {
-        return state
-            .get(key)
-            .cloned()
-            .or(default)
-            .ok_or_else(|| DataFusionError::Execution(format!("missing state value '{key}'")));
-    }
-
     Err(DataFusionError::Execution(format!(
-        "unsupported template token '{token}'"
+        "unsupported template token '{}'",
+        token.raw()
     )))
 }
 
@@ -1038,8 +1012,8 @@ mod tests {
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
     use coral_spec::{
-        HttpMethod, PaginationSpec, RequestSpec, RowStrategy, ValidatedPaginationMode,
-        ValueSourceSpec, parse_source_manifest_value,
+        HttpMethod, PaginationSpec, ParsedTemplate, RequestSpec, RowStrategy,
+        ValidatedPaginationMode, ValueSourceSpec, parse_source_manifest_value,
     };
 
     fn parse_http_manifest(value: serde_json::Value) -> HttpSourceManifest {
@@ -1202,7 +1176,6 @@ mod tests {
         let source_secrets = BTreeMap::from([("API_KEY".to_string(), "alpha-secret".to_string())]);
 
         let value = resolve_value_source(
-            "alpha",
             &ValueSourceSpec::Secret {
                 key: "API_KEY".to_string(),
                 default: None,
@@ -1256,7 +1229,7 @@ mod tests {
             &json!([]),
             &RequestSpec {
                 method: HttpMethod::GET,
-                path: "/items".to_string(),
+                path: ParsedTemplate::parse("/items").expect("template"),
                 query: vec![],
                 body: vec![],
                 headers: vec![],
@@ -1306,7 +1279,7 @@ mod tests {
             &json!([]),
             &RequestSpec {
                 method: HttpMethod::GET,
-                path: "/items".to_string(),
+                path: ParsedTemplate::parse("/items").expect("template"),
                 query: vec![],
                 body: vec![],
                 headers: vec![],

--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -275,9 +275,14 @@ mod tests {
     }
 
     fn request_json(request: &RequestSpec) -> Value {
+        let path = if request.path.is_empty() {
+            "/items"
+        } else {
+            request.path.raw()
+        };
         json!({
             "method": format!("{:?}", request.method),
-            "path": if request.path.is_empty() { "/items" } else { &request.path },
+            "path": path,
             "query": [],
             "body": [],
             "headers": [],

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 use crate::common::{build_source_manifest_common, parse_manifest_data_type};
 use crate::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, Result, SourceBackend,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ParsedTemplate, Result, SourceBackend,
     SourceManifestCommon, TableCommon, validate_columns, validate_filters_and_column_exprs,
     validate_manifest_top_level,
 };
@@ -270,6 +270,7 @@ impl RawFileTableSpec {
 
 impl ParquetSourceManifest {
     pub(crate) fn parse_manifest_value(value: Value) -> Result<Self> {
+        let empty_base_url = ParsedTemplate::default();
         let raw: RawFileSourceManifest =
             serde_json::from_value(value).map_err(ManifestError::deserialize)?;
         let RawFileSourceManifest {
@@ -290,7 +291,7 @@ impl ParquetSourceManifest {
             &common.name,
             &common.name,
             SourceBackend::Parquet,
-            "",
+            &empty_base_url,
             tables.len(),
         )?;
         Ok(Self { common, tables })
@@ -299,6 +300,7 @@ impl ParquetSourceManifest {
 
 impl JsonlSourceManifest {
     pub(crate) fn parse_manifest_value(value: Value) -> Result<Self> {
+        let empty_base_url = ParsedTemplate::default();
         let raw: RawFileSourceManifest =
             serde_json::from_value(value).map_err(ManifestError::deserialize)?;
         let RawFileSourceManifest {
@@ -319,7 +321,7 @@ impl JsonlSourceManifest {
             &common.name,
             &common.name,
             SourceBackend::Jsonl,
-            "",
+            &empty_base_url,
             tables.len(),
         )?;
         Ok(Self { common, tables })

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -17,16 +17,17 @@ use serde_json::Value;
 
 use crate::common::build_source_manifest_common;
 use crate::{
-    AuthSpec, ColumnSpec, FilterSpec, ManifestError, PaginationSpec, RequestRouteSpec, RequestSpec,
-    ResponseSpec, Result, SourceBackend, SourceManifestCommon, TableCommon, ValueSourceSpec,
-    validate_http_table, validate_manifest_top_level,
+    AuthSpec, ColumnSpec, FilterSpec, ManifestError, PaginationSpec, ParsedTemplate,
+    RequestRouteSpec, RequestSpec, ResponseSpec, Result, SourceBackend, SourceManifestCommon,
+    TableCommon, TemplateNamespace, ValueSourceSpec, validate_http_table,
+    validate_manifest_top_level,
 };
 
 /// Validated top-level manifest for an HTTP-backed source.
 #[derive(Debug, Clone)]
 pub struct HttpSourceManifest {
     pub common: SourceManifestCommon,
-    pub base_url: String,
+    pub base_url: ParsedTemplate,
     pub auth: AuthSpec,
     pub tables: Vec<HttpTableSpec>,
 }
@@ -41,7 +42,7 @@ struct RawHttpSourceManifest {
     description: Option<String>,
     backend: SourceBackend,
     #[serde(default)]
-    base_url: String,
+    base_url: ParsedTemplate,
     #[serde(default)]
     auth: AuthSpec,
     tables: Vec<RawHttpTableSpec>,
@@ -278,24 +279,10 @@ fn collect_value_source_secret_names(
     }
 }
 
-fn collect_template_secret_names(template: &str, secret_names: &mut BTreeSet<String>) {
-    let mut rest = template;
-    while let Some(start) = rest.find("{{") {
-        let token_start = start + 2;
-        let Some(end_rel) = rest[token_start..].find("}}") else {
-            break;
-        };
-        let end = token_start + end_rel;
-        let token = rest[token_start..end].trim();
-        let (raw_key, default) = match token.split_once('|') {
-            Some((key, default)) => (key.trim(), Some(default)),
-            None => (token, None),
-        };
-        if let Some(key) = raw_key.strip_prefix("secret.")
-            && default.is_none()
-        {
-            secret_names.insert(key.to_string());
+fn collect_template_secret_names(template: &ParsedTemplate, secret_names: &mut BTreeSet<String>) {
+    for token in template.tokens() {
+        if token.namespace() == &TemplateNamespace::Secret && token.default_value().is_none() {
+            secret_names.insert(token.key().to_string());
         }
-        rest = &rest[end + 2..];
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -12,7 +12,7 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{ManifestError, Result};
+use crate::{ManifestError, ParsedTemplate, Result};
 
 /// Common top-level source metadata shared by every backend source spec.
 #[derive(Debug, Clone)]
@@ -131,7 +131,7 @@ pub struct RequestSpec {
     #[serde(default)]
     pub method: HttpMethod,
     #[serde(default)]
-    pub path: String,
+    pub path: ParsedTemplate,
     #[serde(default)]
     pub query: Vec<QueryParamSpec>,
     #[serde(default)]
@@ -182,7 +182,7 @@ pub struct BodyFieldSpec {
 #[serde(tag = "from", rename_all = "snake_case")]
 pub enum ValueSourceSpec {
     Template {
-        template: String,
+        template: ParsedTemplate,
     },
     Literal {
         value: Value,
@@ -626,7 +626,7 @@ mod tests {
             vec![],
             RequestSpec {
                 method: HttpMethod::GET,
-                path: "/items".into(),
+                path: ParsedTemplate::parse("/items").expect("template"),
                 query: vec![],
                 body: vec![],
                 headers: vec![],
@@ -648,7 +648,7 @@ mod tests {
             }],
             RequestSpec {
                 method: HttpMethod::GET,
-                path: "/items".into(),
+                path: ParsedTemplate::parse("/items").expect("template"),
                 query: vec![],
                 body: vec![],
                 headers: vec![],
@@ -658,7 +658,7 @@ mod tests {
             when_filters: vec!["id".into()],
             request: RequestSpec {
                 method: HttpMethod::GET,
-                path: "/items/{{filter.id}}".into(),
+                path: ParsedTemplate::parse("/items/{{filter.id}}").expect("template"),
                 query: vec![],
                 body: vec![],
                 headers: vec![],
@@ -689,7 +689,7 @@ mod tests {
             ],
             RequestSpec {
                 method: HttpMethod::GET,
-                path: "/items".into(),
+                path: ParsedTemplate::parse("/items").expect("template"),
                 query: vec![],
                 body: vec![],
                 headers: vec![],
@@ -700,7 +700,7 @@ mod tests {
                 when_filters: vec!["id".into()],
                 request: RequestSpec {
                     method: HttpMethod::GET,
-                    path: "/items/by-id/{{filter.id}}".into(),
+                    path: ParsedTemplate::parse("/items/by-id/{{filter.id}}").expect("template"),
                     query: vec![],
                     body: vec![],
                     headers: vec![],
@@ -710,7 +710,8 @@ mod tests {
                 when_filters: vec!["id".into(), "org".into()],
                 request: RequestSpec {
                     method: HttpMethod::GET,
-                    path: "/orgs/{{filter.org}}/items/{{filter.id}}".into(),
+                    path: ParsedTemplate::parse("/orgs/{{filter.org}}/items/{{filter.id}}")
+                        .expect("template"),
                     query: vec![],
                     body: vec![],
                     headers: vec![],

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 
 use serde_yaml::{Mapping, Value};
 
-use crate::{ManifestError, Result};
+use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
 /// The kind of interactive input required by one validated source spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -148,30 +148,35 @@ fn collect_from_template(
     ordered: &mut Vec<ManifestInputSpec>,
     seen: &mut BTreeMap<String, InputState>,
 ) -> Result<()> {
-    let mut rest = template;
-    while let Some(start) = rest.find("{{") {
-        let token_start = start + 2;
-        let Some(end_rel) = rest[token_start..].find("}}") else {
-            return Err(ManifestError::validation(format!(
-                "unclosed template token in '{template}'"
-            )));
-        };
-        let end = token_start + end_rel;
-        let token = rest[token_start..end].trim();
-        let (raw_key, default_value) = match token.split_once('|') {
-            Some((key, default)) => (key.trim(), Some(default.to_string())),
-            None => (token, None),
-        };
-        if let Some(key) = raw_key.strip_prefix("secret.") {
-            register_input(key, InputKind::Secret, default_value, ordered, seen)?;
-        } else if let Some(key) = raw_key.strip_prefix("variable.") {
-            register_input(key, InputKind::Variable, default_value, ordered, seen)?;
-        } else if raw_key.starts_with("env.") {
-            return Err(ManifestError::validation(format!(
-                "unsupported template namespace '{raw_key}'"
-            )));
+    let template = ParsedTemplate::parse(template)?;
+    for token in template.tokens() {
+        match token.namespace() {
+            TemplateNamespace::Secret => {
+                register_input(
+                    token.key(),
+                    InputKind::Secret,
+                    token.default_value().map(ToString::to_string),
+                    ordered,
+                    seen,
+                )?;
+            }
+            TemplateNamespace::Variable => {
+                register_input(
+                    token.key(),
+                    InputKind::Variable,
+                    token.default_value().map(ToString::to_string),
+                    ordered,
+                    seen,
+                )?;
+            }
+            TemplateNamespace::Env => {
+                return Err(ManifestError::validation(format!(
+                    "unsupported template namespace '{}'",
+                    token.raw_key()
+                )));
+            }
+            TemplateNamespace::Filter | TemplateNamespace::State | TemplateNamespace::Other(_) => {}
         }
-        rest = &rest[end + 2..];
     }
     Ok(())
 }

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -76,6 +76,7 @@ mod inputs;
 #[cfg(test)]
 mod loader;
 mod parser;
+mod template;
 mod validate;
 
 pub use common::{
@@ -91,6 +92,7 @@ pub use inputs::{
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
 };
+pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{
     validate_columns, validate_filters_and_column_exprs, validate_http_table,
     validate_manifest_top_level,

--- a/crates/coral-spec/src/template.rs
+++ b/crates/coral-spec/src/template.rs
@@ -1,0 +1,249 @@
+//! Shared template parsing for source-spec string interpolation.
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use crate::{ManifestError, Result};
+
+/// One parsed template string from the source-spec DSL.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ParsedTemplate {
+    raw: String,
+    parts: Vec<TemplatePart>,
+}
+
+impl ParsedTemplate {
+    /// Parse one authored template string into literal and token parts.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ManifestError`] when the template contains an unclosed token.
+    pub fn parse(raw: impl Into<String>) -> Result<Self> {
+        let raw = raw.into();
+        let mut parts = Vec::new();
+        let mut rest = raw.as_str();
+
+        while let Some(start) = rest.find("{{") {
+            if start > 0 {
+                parts.push(TemplatePart::Literal(rest[..start].to_string()));
+            }
+
+            let token_start = start + 2;
+            let Some(end_rel) = rest[token_start..].find("}}") else {
+                return Err(ManifestError::validation(format!(
+                    "unclosed template token in '{raw}'"
+                )));
+            };
+            let end = token_start + end_rel;
+            let token = rest[token_start..end].trim();
+            let (raw_key, default_value) = match token.split_once('|') {
+                Some((key, default)) => (key.trim(), Some(default.to_string())),
+                None => (token, None),
+            };
+            let (namespace, key) = match raw_key.split_once('.') {
+                Some((namespace, key)) => (TemplateNamespace::parse(namespace), key.to_string()),
+                None => (TemplateNamespace::Other(raw_key.to_string()), String::new()),
+            };
+            parts.push(TemplatePart::Token(TemplateToken {
+                raw: token.to_string(),
+                raw_key: raw_key.to_string(),
+                namespace,
+                key,
+                default_value,
+            }));
+            rest = &rest[end + 2..];
+        }
+
+        if !rest.is_empty() {
+            parts.push(TemplatePart::Literal(rest.to_string()));
+        }
+
+        Ok(Self { raw, parts })
+    }
+
+    #[must_use]
+    /// Returns the original authored template string.
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    #[must_use]
+    /// Returns whether the authored template string is empty.
+    pub fn is_empty(&self) -> bool {
+        self.raw.is_empty()
+    }
+
+    #[must_use]
+    /// Returns the parsed literal and token parts in source order.
+    pub fn parts(&self) -> &[TemplatePart] {
+        &self.parts
+    }
+
+    /// Iterates over parsed template tokens in source order.
+    pub fn tokens(&self) -> impl Iterator<Item = &TemplateToken> {
+        self.parts.iter().filter_map(|part| match part {
+            TemplatePart::Literal(_) => None,
+            TemplatePart::Token(token) => Some(token),
+        })
+    }
+}
+
+impl Serialize for ParsedTemplate {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.raw)
+    }
+}
+
+impl<'de> Deserialize<'de> for ParsedTemplate {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(raw).map_err(serde::de::Error::custom)
+    }
+}
+
+impl PartialEq<&str> for ParsedTemplate {
+    fn eq(&self, other: &&str) -> bool {
+        self.raw == *other
+    }
+}
+
+/// One part of a parsed template string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplatePart {
+    /// A literal string segment copied directly into rendered output.
+    Literal(String),
+    /// One parsed interpolation token.
+    Token(TemplateToken),
+}
+
+/// One parsed `{{namespace.key|default}}` token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateToken {
+    raw: String,
+    raw_key: String,
+    namespace: TemplateNamespace,
+    key: String,
+    default_value: Option<String>,
+}
+
+impl TemplateToken {
+    #[must_use]
+    /// Returns the raw token body inside `{{...}}`, after trimming whitespace.
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    #[must_use]
+    /// Returns the raw namespace-plus-key portion before any default value.
+    pub fn raw_key(&self) -> &str {
+        &self.raw_key
+    }
+
+    #[must_use]
+    /// Returns the parsed namespace for this token.
+    pub fn namespace(&self) -> &TemplateNamespace {
+        &self.namespace
+    }
+
+    #[must_use]
+    /// Returns the token key after the namespace separator.
+    pub fn key(&self) -> &str {
+        &self.key
+    }
+
+    #[must_use]
+    /// Returns the authored default value, if any.
+    pub fn default_value(&self) -> Option<&str> {
+        self.default_value.as_deref()
+    }
+}
+
+/// The namespace component of one template token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplateNamespace {
+    /// A source secret token.
+    Secret,
+    /// A source variable token.
+    Variable,
+    /// A SQL filter token.
+    Filter,
+    /// A runtime pagination or request state token.
+    State,
+    /// A legacy environment token.
+    Env,
+    /// Any other namespace, preserved for higher-level validation.
+    Other(String),
+}
+
+impl TemplateNamespace {
+    fn parse(raw: &str) -> Self {
+        match raw {
+            "secret" => Self::Secret,
+            "variable" => Self::Variable,
+            "filter" => Self::Filter,
+            "state" => Self::State,
+            "env" => Self::Env,
+            other => Self::Other(other.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ParsedTemplate, TemplateNamespace, TemplatePart};
+
+    #[test]
+    fn parses_literals_and_tokens_in_order() {
+        let template =
+            ParsedTemplate::parse("Bearer {{secret.API_TOKEN}} for {{filter.org|openai}}")
+                .expect("template");
+
+        assert_eq!(
+            template.raw(),
+            "Bearer {{secret.API_TOKEN}} for {{filter.org|openai}}"
+        );
+        assert_eq!(template.parts().len(), 4);
+        assert!(matches!(
+            &template.parts()[0],
+            TemplatePart::Literal(part) if part == "Bearer "
+        ));
+        assert!(matches!(
+            &template.parts()[1],
+            TemplatePart::Token(token)
+                if token.namespace() == &TemplateNamespace::Secret && token.key() == "API_TOKEN"
+        ));
+        assert!(matches!(
+            &template.parts()[2],
+            TemplatePart::Literal(part) if part == " for "
+        ));
+        assert!(matches!(
+            &template.parts()[3],
+            TemplatePart::Token(token)
+                if token.namespace() == &TemplateNamespace::Filter
+                    && token.key() == "org"
+                    && token.default_value() == Some("openai")
+        ));
+    }
+
+    #[test]
+    fn parses_unknown_token_namespaces_without_rejecting() {
+        let template = ParsedTemplate::parse("{{custom.value}}").expect("template");
+        let token = template.tokens().next().expect("token");
+        assert_eq!(
+            token.namespace(),
+            &TemplateNamespace::Other("custom".to_string())
+        );
+        assert_eq!(token.key(), "value");
+    }
+
+    #[test]
+    fn rejects_unclosed_tokens() {
+        let error = ParsedTemplate::parse("{{secret.API_TOKEN").expect_err("unclosed token");
+        assert!(error.to_string().contains("unclosed template token"));
+    }
+}

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -6,14 +6,14 @@ use crate::common::{
     ColumnSpec, ExprSpec, FilterSpec, PaginationSpec, RequestRouteSpec, RequestSpec, SourceBackend,
     ValueSourceSpec, parse_manifest_data_type,
 };
-use crate::{ManifestError, Result};
+use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
 pub(crate) fn validate_manifest_top_level(
     dsl_version: u32,
     name: &str,
     schema: &str,
     backend: SourceBackend,
-    base_url: &str,
+    base_url: &ParsedTemplate,
     table_count: usize,
 ) -> Result<()> {
     if dsl_version != 3 {
@@ -30,7 +30,7 @@ pub(crate) fn validate_manifest_top_level(
 
     match backend {
         SourceBackend::Http => {
-            if base_url.trim().is_empty() {
+            if base_url.raw().trim().is_empty() {
                 return Err(ManifestError::validation(format!(
                     "source '{name}' must define a non-empty base_url"
                 )));
@@ -39,7 +39,7 @@ pub(crate) fn validate_manifest_top_level(
             validate_template(base_url, &HashSet::new(), &format!("source '{schema}'"))?;
         }
         SourceBackend::Parquet | SourceBackend::Jsonl => {
-            if !base_url.trim().is_empty() {
+            if !base_url.raw().trim().is_empty() {
                 return Err(ManifestError::validation(format!(
                     "source '{name}' uses a file backend and must not define base_url"
                 )));
@@ -59,7 +59,7 @@ pub(crate) fn validate_http_table(
     requests: &[RequestRouteSpec],
     pagination: &PaginationSpec,
 ) -> Result<()> {
-    if request.path.trim().is_empty() {
+    if request.path.raw().trim().is_empty() {
         return Err(ManifestError::validation(format!(
             "{schema}.{table_name} has an empty request.path"
         )));
@@ -277,38 +277,30 @@ fn validate_expr(expr: &ExprSpec, known_filters: &HashSet<String>, context: &str
     Ok(())
 }
 
-fn validate_template(template: &str, known_filters: &HashSet<String>, context: &str) -> Result<()> {
-    let mut rest = template;
-
-    while let Some(start) = rest.find("{{") {
-        let token_start = start + 2;
-        let Some(end_rel) = rest[token_start..].find("}}") else {
-            return Err(ManifestError::validation(format!(
-                "{context} has an unclosed template token in '{template}'"
-            )));
-        };
-        let end = token_start + end_rel;
-        let token = rest[token_start..end].trim();
-        let raw_key = token.split_once('|').map_or(token, |(key, _)| key.trim());
-
-        if let Some(key) = raw_key.strip_prefix("filter.") {
-            if !known_filters.contains(key) {
+fn validate_template(
+    template: &ParsedTemplate,
+    known_filters: &HashSet<String>,
+    context: &str,
+) -> Result<()> {
+    for token in template.tokens() {
+        match token.namespace() {
+            TemplateNamespace::Filter => {
+                if !known_filters.contains(token.key()) {
+                    return Err(ManifestError::validation(format!(
+                        "{context} references unknown filter '{}' in template '{}'",
+                        token.key(),
+                        template.raw()
+                    )));
+                }
+            }
+            TemplateNamespace::Secret | TemplateNamespace::Variable | TemplateNamespace::State => {}
+            TemplateNamespace::Env | TemplateNamespace::Other(_) => {
                 return Err(ManifestError::validation(format!(
-                    "{context} references unknown filter '{key}' in template '{template}'"
+                    "{context} uses unsupported template token '{}'",
+                    token.raw()
                 )));
             }
-        } else if raw_key.starts_with("secret.")
-            || raw_key.starts_with("variable.")
-            || raw_key.starts_with("state.")
-        {
-            // Supported template namespaces.
-        } else {
-            return Err(ManifestError::validation(format!(
-                "{context} uses unsupported template token '{token}'"
-            )));
         }
-
-        rest = &rest[end + 2..];
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- centralize template DSL parsing in `coral-spec` with a shared parsed token model
- thread parsed templates through validated HTTP manifest types for `base_url`, request `path`, and template value sources
- update the HTTP engine to render parsed template parts instead of rescanning raw strings

## Verification
- `cargo test -p coral-spec --quiet`
- `cargo test -p coral-engine http --quiet`
- `make validate`
