### PR TITLE
refactor(query): materialize source secrets before engine runtime

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,6 +1,6 @@
 //! Query-time loading, validation, and execution over installed sources.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use coral_api::v1::Workspace;
 use coral_engine::{
@@ -131,17 +131,28 @@ impl QueryManager {
                 source_spec.source_version()
             )));
         }
+        let stored_secrets = self
+            .secret_store
+            .read_source_secrets_for(&source.workspace, &source.name)?;
+        let mut resolved_secrets = BTreeMap::new();
+        for secret_name in source_spec.required_secret_names() {
+            let Some(value) = stored_secrets.get(&secret_name).cloned() else {
+                return Err(AppError::FailedPrecondition(format!(
+                    "source '{}' is missing secret '{}'",
+                    source.name, secret_name
+                )));
+            };
+            resolved_secrets.insert(secret_name, value);
+        }
         Ok(QuerySource::new(
-            source.workspace.name.clone(),
             source_spec,
             source.variables.clone(),
+            resolved_secrets,
         ))
     }
 
     fn runtime_provider(&self) -> RuntimeProvider {
         RuntimeProvider {
-            config_store: self.config_store.clone(),
-            secret_store: self.secret_store.clone(),
             runtime_context: self.runtime_context.clone(),
         }
     }
@@ -149,69 +160,11 @@ impl QueryManager {
 
 #[derive(Clone)]
 struct RuntimeProvider {
-    config_store: ConfigStore,
-    secret_store: SecretStore,
     runtime_context: QueryRuntimeContext,
 }
 
 impl QueryRuntimeProvider for RuntimeProvider {
-    fn resolve_source_secrets(
-        &self,
-        query_source: &QuerySource,
-        secret_names: &BTreeSet<String>,
-    ) -> Result<BTreeMap<String, String>, CoreError> {
-        let source = self
-            .config_store
-            .get_source(
-                &Workspace {
-                    name: query_source.workspace_name().to_string(),
-                },
-                query_source.source_name(),
-            )
-            .map_err(app_error_to_core)?;
-        let values = self
-            .secret_store
-            .read_source_secrets_for(&source.workspace, &source.name)
-            .map_err(app_error_to_core)?;
-        let mut entries = BTreeMap::new();
-        for key in secret_names {
-            let Some(value) = values.get(key).cloned() else {
-                return Err(CoreError::FailedPrecondition(format!(
-                    "source '{}' is missing secret '{}'",
-                    query_source.source_name(),
-                    key
-                )));
-            };
-            entries.insert(key.clone(), value);
-        }
-        Ok(entries)
-    }
-
     fn runtime_context(&self) -> QueryRuntimeContext {
         self.runtime_context.clone()
-    }
-}
-
-fn app_error_to_core(error: AppError) -> CoreError {
-    match error {
-        AppError::SourceNotFound(source_name) => {
-            CoreError::NotFound(format!("source '{source_name}'"))
-        }
-        AppError::InvalidInput(detail) => CoreError::InvalidInput(detail),
-        AppError::FailedPrecondition(detail) => CoreError::FailedPrecondition(detail),
-        AppError::Io(inner) => CoreError::internal(inner.to_string()),
-        AppError::Yaml(inner) => CoreError::internal(inner.to_string()),
-        AppError::TomlDecode(inner) => CoreError::internal(inner.to_string()),
-        AppError::TomlEncode(inner) => CoreError::internal(inner.to_string()),
-        AppError::Json(inner) => CoreError::internal(inner.to_string()),
-        AppError::Transport(inner) => CoreError::internal(inner.to_string()),
-        AppError::TaskJoin(inner) => CoreError::internal(inner.to_string()),
-        AppError::Credentials(crate::state::CredentialsError::Parse(detail)) => {
-            CoreError::FailedPrecondition(detail)
-        }
-        AppError::Credentials(inner) => CoreError::internal(inner.to_string()),
-        AppError::MissingConfigDir => {
-            CoreError::FailedPrecondition("failed to determine Coral config directory".into())
-        }
     }
 }

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -1,6 +1,6 @@
 //! Backend-specific source implementations and compilation into runtime sources.
 
-use crate::{CoreError, QueryRuntimeProvider, QuerySource};
+use crate::{CoreError, QuerySource};
 use coral_spec::ValidatedSourceManifest;
 
 pub(crate) mod common;
@@ -18,16 +18,13 @@ pub(crate) mod shared;
 
 pub(crate) fn compile_query_source(
     source: &QuerySource,
-    runtime: &dyn QueryRuntimeProvider,
     runtime_context: &crate::QueryRuntimeContext,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
-    let source_secrets =
-        runtime.resolve_source_secrets(source, &source.source_spec().required_secret_names())?;
     compile_validated_manifest(
         source.source_spec(),
         &BackendCompileRequest {
             runtime_context,
-            source_secrets,
+            source_secrets: source.secrets().clone(),
             source_variables: source.variables().clone(),
         },
     )

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -1,6 +1,6 @@
 //! Typed query inputs and results.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -8,16 +8,14 @@ use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 use coral_spec::ValidatedSourceManifest;
 
-use crate::CoreError;
-
 use super::ColumnInfo;
 
 /// One managed source selected into the current query runtime.
 #[derive(Debug, Clone)]
 pub struct QuerySource {
-    workspace_name: String,
     source_spec: ValidatedSourceManifest,
     variables: BTreeMap<String, String>,
+    secrets: BTreeMap<String, String>,
 }
 
 impl QuerySource {
@@ -25,21 +23,15 @@ impl QuerySource {
     /// Builds one app-to-query source selection from installed metadata and a
     /// validated declarative source spec.
     pub fn new(
-        workspace_name: impl Into<String>,
         source_spec: ValidatedSourceManifest,
         variables: BTreeMap<String, String>,
+        secrets: BTreeMap<String, String>,
     ) -> Self {
         Self {
-            workspace_name: workspace_name.into(),
             source_spec,
             variables,
+            secrets,
         }
-    }
-
-    #[must_use]
-    /// Returns the owning workspace name.
-    pub fn workspace_name(&self) -> &str {
-        &self.workspace_name
     }
 
     #[must_use]
@@ -65,6 +57,12 @@ impl QuerySource {
     pub fn variables(&self) -> &BTreeMap<String, String> {
         &self.variables
     }
+
+    #[must_use]
+    /// Returns resolved source secrets required by the manifest.
+    pub fn secrets(&self) -> &BTreeMap<String, String> {
+        &self.secrets
+    }
 }
 
 /// App-owned non-secret runtime inputs needed while compiling sources.
@@ -76,18 +74,6 @@ pub struct QueryRuntimeContext {
 
 /// Resolves app-owned runtime inputs at query time.
 pub trait QueryRuntimeProvider: Send + Sync {
-    /// Resolves named source-owned secrets for one selected source.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CoreError`] if the source's credentials cannot be loaded from
-    /// the owning application environment.
-    fn resolve_source_secrets(
-        &self,
-        source: &QuerySource,
-        secret_names: &BTreeSet<String>,
-    ) -> Result<BTreeMap<String, String>, CoreError>;
-
     /// Returns non-secret runtime inputs owned by the application layer.
     fn runtime_context(&self) -> QueryRuntimeContext;
 }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -23,24 +23,16 @@
 //! # Example
 //!
 //! ```no_run
-//! use std::collections::{BTreeMap, BTreeSet};
+//! use std::collections::BTreeMap;
 //!
 //! use coral_engine::{CoralQuery, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};
 //! use coral_spec::parse_source_manifest_yaml;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!
-//! struct EmptyCredentials;
+//! struct EmptyRuntime;
 //!
-//! impl QueryRuntimeProvider for EmptyCredentials {
-//!     fn resolve_source_secrets(
-//!         &self,
-//!         _source: &QuerySource,
-//!         _secret_names: &BTreeSet<String>,
-//!     ) -> Result<BTreeMap<String, String>, coral_engine::CoreError> {
-//!         Ok(BTreeMap::new())
-//!     }
-//!
+//! impl QueryRuntimeProvider for EmptyRuntime {
 //!     fn runtime_context(&self) -> QueryRuntimeContext {
 //!         QueryRuntimeContext::default()
 //!     }
@@ -50,11 +42,11 @@
 //! #     "name: demo\nversion: 0.1.0\ndsl_version: 3\nbackend: jsonl\ntables: []",
 //! # )?;
 //! # let sources = vec![QuerySource::new(
-//! #     "default",
 //! #     source_spec,
 //! #     BTreeMap::new(),
+//! #     BTreeMap::new(),
 //! # )];
-//! # let provider = EmptyCredentials;
+//! # let provider = EmptyRuntime;
 //! # async fn demo(
 //! #     sources: &[QuerySource],
 //! #     provider: &dyn QueryRuntimeProvider,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -38,7 +38,7 @@ pub(crate) async fn build_runtime(
     let mut compiled_sources = Vec::new();
     let mut failures = Vec::new();
     for source in sources {
-        match compile_query_source(source, runtime, &runtime_context) {
+        match compile_query_source(source, &runtime_context) {
             Ok(compiled) => compiled_sources.push(compiled),
             Err(error) => failures.push(SourceRegistrationFailure {
                 schema_name: source.source_name().to_string(),


### PR DESCRIPTION
## Summary
- materialize required source secrets in `coral-app` when building `QuerySource`
- remove workspace-based secret lookup from the app-to-engine seam
- narrow `QueryRuntimeProvider` so the engine only receives runtime context plus fully materialized source inputs

## Verification
- `cargo test -p coral-engine`
- `cargo test -p coral-app`
- `make validate`
