### PR TITLE
fix: reject '.' and '..' in workspace and source name validation

### DIFF
--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -91,7 +91,7 @@ impl SourceManager {
             .require_app(request.workspace.as_ref())?;
         let bundled_name = self
             .workspace_manager
-            .validate_name("source name", &request.name)?;
+            .validate_path_name("source name", &request.name)?;
         let bundled = load_bundled_source(&bundled_name)?;
         let available = self.describe_bundled_source(&workspace, &bundled.manifest_yaml)?;
         let bindings = validate_bindings(
@@ -193,7 +193,7 @@ impl SourceManager {
     ) -> Result<ManagedSource, AppError> {
         let source_name = self
             .workspace_manager
-            .validate_name("source name", &request.available.name)?;
+            .validate_path_name("source name", &request.available.name)?;
         let previous = self.load_existing_state(workspace, &source_name)?;
         let manifest_path = self.layout.manifest_file(workspace, &source_name);
         if let Some(parent) = manifest_path.parent() {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -73,7 +73,7 @@ impl SourceServiceApi for SourceService {
         let workspace = self.workspaces.require(request.workspace.as_ref())?;
         let source_name = self
             .workspaces
-            .status_validate_name("source name", &request.name)?;
+            .status_validate_path_name("source name", &request.name)?;
         let source = self
             .sources
             .get_source(&workspace, &source_name)
@@ -110,7 +110,7 @@ impl SourceServiceApi for SourceService {
         let workspace = self.workspaces.require(request.workspace.as_ref())?;
         let source_name = self
             .workspaces
-            .status_validate_name("source name", &request.name)?;
+            .status_validate_path_name("source name", &request.name)?;
         let _stored = self
             .sources
             .delete_source(&workspace, &source_name)
@@ -126,7 +126,7 @@ impl SourceServiceApi for SourceService {
         let workspace = self.workspaces.require(request.workspace.as_ref())?;
         let source_name = self
             .workspaces
-            .status_validate_name("source name", &request.name)?;
+            .status_validate_path_name("source name", &request.name)?;
         let result = self
             .queries
             .validate_source(&workspace, &source_name)

--- a/crates/coral-app/src/workspaces/manager.rs
+++ b/crates/coral-app/src/workspaces/manager.rs
@@ -41,7 +41,7 @@ impl WorkspaceManager {
 
     pub(crate) fn normalize(&self, workspace: &Workspace) -> Result<Workspace, AppError> {
         Ok(Workspace {
-            name: self.validate_name("workspace name", &workspace.name)?,
+            name: self.validate_path_name("workspace name", &workspace.name)?,
         })
     }
 
@@ -63,8 +63,22 @@ impl WorkspaceManager {
         Ok(trimmed.to_string())
     }
 
-    pub(crate) fn status_validate_name(&self, label: &str, value: &str) -> Result<String, Status> {
-        self.validate_name(label, value)
+    pub(crate) fn validate_path_name(&self, label: &str, value: &str) -> Result<String, AppError> {
+        let trimmed = self.validate_name(label, value)?;
+        if trimmed == "." || trimmed == ".." {
+            return Err(AppError::InvalidInput(format!(
+                "{label} must not be '.' or '..'"
+            )));
+        }
+        Ok(trimmed)
+    }
+
+    pub(crate) fn status_validate_path_name(
+        &self,
+        label: &str,
+        value: &str,
+    ) -> Result<String, Status> {
+        self.validate_path_name(label, value)
             .map_err(app_error_to_status)
     }
 }
@@ -103,10 +117,43 @@ mod tests {
         assert!(error.to_string().contains("'/' or '\\\\'"));
 
         let error = manager
-            .validate_name("source name", "bad/source")
+            .validate_path_name("source name", "bad/source")
             .expect_err("name should fail");
         assert!(error.to_string().contains("'/' or '\\\\'"));
 
         assert_eq!(workspace.name, DEFAULT_WORKSPACE_ID);
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        let manager = WorkspaceManager::new();
+
+        let error = manager
+            .validate_path_name("workspace name", "..")
+            .expect_err("'..' should be rejected");
+        assert!(error.to_string().contains("'.' or '..'"));
+
+        let error = manager
+            .validate_path_name("source name", ".")
+            .expect_err("'.' should be rejected");
+        assert!(error.to_string().contains("'.' or '..'"));
+
+        // Padded with whitespace should also be rejected after trimming
+        let error = manager
+            .validate_path_name("source name", " .. ")
+            .expect_err("' .. ' should be rejected");
+        assert!(error.to_string().contains("'.' or '..'"));
+    }
+
+    #[test]
+    fn allows_dot_only_logical_binding_keys() {
+        let manager = WorkspaceManager::new();
+
+        assert_eq!(
+            manager
+                .validate_name("source variable key", "..")
+                .expect("logical binding key named '..' should remain valid"),
+            ".."
+        );
     }
 }


### PR DESCRIPTION
## Summary
- `validate_name()` rejected `/` and `\` but allowed `.` and `..` as workspace/source names
- Since names are joined into filesystem paths via `PathBuf::join()`, this allowed escaping the intended directory (e.g. a source named `..` resolves to the workspace root)
- Added validation to reject `.` and `..` after trimming, with corresponding tests

## Test plan
- [x] New `rejects_path_traversal` test covers `..`, `.`, and whitespace-padded ` .. `
- [x] Existing `rejects_forward_and_backward_slashes` test still passes