### PR TITLE
feat(cli): add help text to all commands and arguments

### DIFF
--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -25,6 +25,7 @@ use tonic::Request;
 
 #[derive(Debug, Parser)]
 #[command(name = "coral", version)]
+/// Query and manage local data sources
 struct Cli {
     #[command(subcommand)]
     command: Command,
@@ -32,19 +33,26 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Command {
+    /// Execute a SQL query
     Sql(SqlArgs),
+    /// Manage data sources
     Source(SourceArgs),
+    /// Start the MCP server over stdio
     McpStdio,
 }
 
 #[derive(Debug, Args)]
+/// Execute a SQL query
 struct SqlArgs {
+    /// Output format for query results
     #[arg(long, value_enum, default_value = "table")]
     format: OutputFormat,
+    /// SQL query to execute
     sql: String,
 }
 
 #[derive(Debug, Args)]
+/// Manage data sources
 struct SourceArgs {
     #[command(subcommand)]
     command: SourceCommand,
@@ -52,12 +60,30 @@ struct SourceArgs {
 
 #[derive(Debug, Subcommand)]
 enum SourceCommand {
+    /// Discover available sources
     Discover,
+    /// List configured sources
     List,
-    Add { name: String },
-    Import { path: PathBuf },
-    Test { name: String },
-    Remove { name: String },
+    /// Add a new source
+    Add {
+        /// Name for the new source
+        name: String,
+    },
+    /// Import a source from a manifest file
+    Import {
+        /// Path to the source manifest file
+        path: PathBuf,
+    },
+    /// Test connectivity for a source
+    Test {
+        /// Name of the source to test
+        name: String,
+    },
+    /// Remove a source
+    Remove {
+        /// Name of the source to remove
+        name: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]


### PR DESCRIPTION
## Summary
- Adds doc-comment-based help text to all CLI commands (`sql`, `source`, `mcp-stdio`) and `source` subcommands (`discover`, `list`, `add`, `import`, `test`, `remove`)
- Adds help text to all command arguments (`--format`, `sql`, `name`, `path`)
- Uses idiomatic clap doc comments instead of explicit `about` attributes

## Examples

`coral --help`
```
Query and manage local data sources

Usage: coral <COMMAND>

Commands:
  sql        Execute a SQL query
  source     Manage data sources
  mcp-stdio  Start the MCP server over stdio
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

`coral sql --help`
```
Execute a SQL query

Usage: coral sql [OPTIONS] <SQL>

Arguments:
  <SQL>  SQL query to execute

Options:
      --format <FORMAT>  Output format for query results [default: table] [possible values: table, json]
  -h, --help             Print help
```

`coral source --help`
```
Manage data sources

Usage: coral source <COMMAND>

Commands:
  discover  Discover available sources
  list      List configured sources
  add       Add a new source
  import    Import a source from a manifest file
  test      Test connectivity for a source
  remove    Remove a source
  help      Print this message or the help of the given subcommand(s)

Options:
  -h, --help  Print help
```