### PR TITLE
ci: enforce conventional PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,47 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-pr-title:
+    name: Conventional PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?!?: .+$'
+
+          if [[ "$PR_TITLE" =~ $pattern ]]; then
+            exit 0
+          fi
+
+          {
+            echo "Invalid title: $PR_TITLE"
+            echo
+            echo "Expected Conventional Commits format:"
+            echo "  type(scope?): summary"
+            echo
+            echo "See:"
+            echo "  https://www.conventionalcommits.org/"
+            echo
+            echo "Allowed types:"
+            echo "  build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
+            echo
+            echo "Scope guidance for this repo:"
+            echo "  Prefer a scope that matches the primary area changed,"
+            echo "  usually the crate name minus the coral- prefix,"
+            echo "  docs, or sources/<name>."
+          } >&2
+
+          exit 1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,4 +1,4 @@
-name: PR Title
+name: Lint PR Title
 
 on:
   pull_request:
@@ -9,39 +9,29 @@ on:
       - synchronize
 
 permissions:
-  contents: read
+  pull-requests: read
 
 jobs:
-  conventional-pr-title:
-    name: Conventional PR title
+  lint:
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - name: Validate PR title
+      - id: lint_pr_title
+        name: Validate PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9][a-z0-9._/-]*\))?!?: .+$'
-
-          if [[ "$PR_TITLE" =~ $pattern ]]; then
-            exit 0
-          fi
-
-          {
-            echo "Invalid title: $PR_TITLE"
-            echo
-            echo "Expected Conventional Commits format:"
-            echo "  type(scope?): summary"
-            echo
-            echo "See:"
-            echo "  https://www.conventionalcommits.org/"
-            echo
-            echo "Allowed types:"
-            echo "  build, chore, ci, docs, feat, fix, perf, refactor, revert, style, test"
-            echo
-            echo "Scope guidance for this repo:"
-            echo "  Prefer a scope that matches the primary area changed,"
-            echo "  usually the crate name minus the coral- prefix,"
-            echo "  docs, or sources/<name>."
-          } >&2
-
-          exit 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,35 @@
   its bootstrap seam today.
 - If a caller needs explicit local server control, prefer `coral-client::local`
   over widening the default client surface.
+- When proposing or updating a PR title, use Conventional Commits:
+  `type(scope): summary`.
+- When using a scope, prefer one that matches the primary area changed,
+  usually the crate name minus the `coral-` prefix, `docs`, or
+  `sources/<name>`.
+- Keep the PR title up to date as the branch evolves. If the change shifts in
+  scope or intent, update the title to match the current final shape of the
+  branch.
+- Use `!` only for breaking changes. Local WIP commit messages can stay
+  pragmatic unless the user explicitly asks for polished commit history.
+
+## What Counts As a Breaking Change for a CLI?
+
+For a CLI, the user interface is the API.
+
+A change is breaking if it can break existing:
+
+- commands people run manually
+- scripts and CI jobs
+- documented workflows
+- integrations that parse output
+
+Treat these as stable contract surfaces:
+
+- command/subcommand names
+- flags and positional arguments
+- exit codes
+- structured output (for example JSON)
+- config file keys, format, and location
+- environment variables and precedence rules
+
+If any of those change incompatibly, it is a breaking change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,9 @@
 - Keep the PR title up to date as the branch evolves. If the change shifts in
   scope or intent, update the title to match the current final shape of the
   branch.
-- Use `!` only for breaking changes. Local WIP commit messages can stay
-  pragmatic unless the user explicitly asks for polished commit history.
+- Use `!` only for breaking changes, placing it immediately before the colon:
+  `type!: summary` or `type(scope)!: summary`. Local WIP commit messages can
+  stay pragmatic unless the user explicitly asks for polished commit history.
 
 ## What Counts As a Breaking Change for a CLI?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,52 @@ Please include:
 We may ask to narrow a PR even if the idea is good. That is usually about
 keeping Coral coherent and maintainable.
 
+### PR titles and squash commits
+
+Coral uses squash merges for changes that land on `main`. The pull request
+title should therefore be treated as the final commit title.
+
+PR titles must use the Conventional Commits format:
+
+```text
+type(scope): summary
+```
+
+Scope is optional, `!` is reserved for breaking changes, and PR titles are
+validated in CI.
+
+When you use a scope, prefer one that matches the primary area changed,
+usually the crate name minus the `coral-` prefix, `docs`, or `sources/<name>`.
+
+Examples:
+
+- `feat(cli): add source status command`
+- `fix(engine): preserve projected column aliases`
+- `docs: clarify workspace setup`
+- `refactor(spec)!: remove legacy manifest field`
+
+### What counts as a breaking change for a CLI?
+
+For a CLI, the user interface is the API.
+
+A change is breaking if it can break existing:
+
+- commands people run manually
+- scripts and CI jobs
+- documented workflows
+- integrations that parse output
+
+Treat these as stable contract surfaces:
+
+- command/subcommand names
+- flags and positional arguments
+- exit codes
+- structured output (for example JSON)
+- config file keys, format, and location
+- environment variables and precedence rules
+
+If any of those change incompatibly, it is a breaking change.
+
 ## Code of conduct
 
 This project follows the rules in [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,9 @@ PR titles must use the Conventional Commits format:
 type(scope): summary
 ```
 
-Scope is optional, `!` is reserved for breaking changes, and PR titles are
-validated in CI.
+Scope is optional. For breaking changes, place `!` immediately before the
+colon: `type!: summary` or `type(scope)!: summary`. PR titles are validated in
+CI.
 
 When you use a scope, prefer one that matches the primary area changed,
 usually the crate name minus the `coral-` prefix, `docs`, or `sources/<name>`.


### PR DESCRIPTION
This adds a GitHub Actions check that validates pull request titles against the Conventional Commits format so squash merges onto `main` can produce compliant commit titles.
It documents the policy in `CONTRIBUTING.md` and `AGENTS.md`, including guidance on keeping PR titles current and on treating incompatible CLI surface changes as breaking changes.

Validation: `make validate`.
