### PR TITLE
refactor(docs): Polish landing page

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -3,7 +3,9 @@ title: "Quickstart"
 description: "Install Coral, add a bundled source, inspect available tables, and run your first query."
 ---
 
-This tutorial gets you to a working Coral query flow with a bundled source. It assumes you already installed Coral and have `coral` on your `PATH`.
+<Note>
+  This tutorial gets you to a working Coral query flow with a bundled source. It assumes you already installed Coral and have `coral` on your `PATH`.
+</Note>
 
 Prefer the guided path? Run:
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -5,9 +5,12 @@ description: "Connect your AI coding tools to Coral using the Model Context Prot
 
 Coral exposes its local runtime over MCP stdio, giving coding agents access to SQL queries and schema discovery across all your installed sources.
 
+<Note>
 Before setting up a client, make sure you have [installed Coral](/getting-started/installation) and configured at least one source with `coral onboard` or the lower-level `coral source add`.
 
 If you also want reusable workflow guidance for CLI-based agent interactions, see [Agent usage](/guides/agent-usage).
+
+</Note>
 
 ## What MCP clients get
 
@@ -44,6 +47,7 @@ Coral uses stdio transport. Clients that accept a command can point directly at 
     ```
 
     If `coral` is not on Cursor's `PATH`, use the full path from `which coral`.
+
   </Tab>
 
   <Tab title="VS Code / Copilot">
@@ -60,6 +64,7 @@ Coral uses stdio transport. Clients that accept a command can point directly at 
       }
     }
     ```
+
   </Tab>
 
   <Tab title="Claude Desktop">
@@ -77,6 +82,7 @@ Coral uses stdio transport. Clients that accept a command can point directly at 
     ```
 
     Use the full path to `coral`. On macOS, open this file from Claude Desktop → Settings → Developer → Edit Config.
+
   </Tab>
 
   <Tab title="Windsurf">
@@ -92,13 +98,12 @@ Coral uses stdio transport. Clients that accept a command can point directly at 
       }
     }
     ```
+
   </Tab>
 
-  <Tab title="Codex">
-    ```shellscript
-    codex mcp add coral -- coral mcp-stdio
-    ```
-  </Tab>
+<Tab title="Codex">
+  ```shellscript codex mcp add coral -- coral mcp-stdio ```
+</Tab>
 
   <Tab title="Amp">
     **VS Code extension** — add to `settings.json`:
@@ -117,6 +122,7 @@ Coral uses stdio transport. Clients that accept a command can point directly at 
     ```shellscript
     amp mcp add coral -- coral mcp-stdio
     ```
+
   </Tab>
 
   <Tab title="Other clients">
@@ -128,6 +134,7 @@ Coral uses stdio transport. Clients that accept a command can point directly at 
     ```
 
     Consult your client's documentation for the exact config format.
+
   </Tab>
 </Tabs>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Coral documentation"
-description: "One local-first SQL interface over APIs, files, and other live sources — with bundled sources to start and a spec format to connect anything."
+title: "Introduction to Coral"
+description: "Coral is a local-first SQL interface for APIs, files, and other live sources."
 ---
 
-Coral gives agents and developers one local-first SQL interface over APIs, files, and other live sources. It ships with bundled sources for systems like GitHub, Slack, Stripe, and Sentry — and a source spec format that lets you connect any API or dataset yourself.
+Coral gives agents and developers one local-first SQL interface over APIs, files, and other live sources. It ships with bundled sources for systems like GitHub, Slack, Stripe, and Sentry, and a source spec format that lets you connect any API or dataset yourself.
 
 Install sources into a local workspace, inspect schemas through system catalog tables, run SQL from the CLI or through MCP, and write custom source specs when you need something that isn't bundled yet.
 
@@ -11,21 +11,36 @@ Install sources into a local workspace, inspect schemas through system catalog t
 
 <Steps titleSize="h3">
   <Step title="Install Coral">
-    Get the CLI on your machine.
+    Install the Coral CLI to get started.
 
-    [Installation guide](/getting-started/installation)
+    ```shellscript
+    brew install withcoral/tap/coral
+    ```
+
+    [See all installation options](/getting-started/installation)
+
   </Step>
 
-  <Step title="Run the quickstart">
-    Prefer the guided path with `coral onboard`, or follow the manual quickstart flow.
+  <Step title="Add your sources">
+   Connect GitHub, Slack, Datadog, and other [bundled sources](/reference/bundled-sources) to your workspace. For example:
 
-    [Quickstart](/getting-started/quickstart)
+    ```shellscript
+    coral source add github
+    ```
+
+    [Go to the quickstart](/getting-started/quickstart)
+
   </Step>
 
-  <Step title="Connect your own system">
-    Write a source spec for any API or local dataset and query it the same way.
+  <Step title="Start querying">
+    Write SQL directly or let your AI agent query on your behalf.
 
-    [Write a custom source](/guides/write-a-custom-source)
+    ```shellscript
+    coral sql "SELECT name, stargazers_count FROM github.repos WHERE owner = 'withcoral' ORDER BY stargazers_count DESC"
+    ```
+
+    [Or use Coral over MCP](/guides/use-coral-over-mcp)
+
   </Step>
 </Steps>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,9 +3,9 @@ title: "Introduction to Coral"
 description: "Coral is a local-first SQL interface for APIs, files, and other live sources."
 ---
 
-Coral gives agents and developers one local-first SQL interface over APIs, files, and other live sources. It ships with bundled sources for systems like GitHub, Slack, Stripe, and Sentry, and a source spec format that lets you connect any API or dataset yourself.
+Coral gives agents and developers one local-first SQL interface over APIs, files, and other live sources. It ships with [bundled sources](/reference/bundled-sources) for systems like GitHub, Slack, Stripe, and Sentry, and a [source spec](/reference/source-spec-reference) format that lets you connect any API or dataset yourself.
 
-Install sources into a local workspace, inspect schemas through system catalog tables, run SQL from the CLI or through MCP, and write custom source specs when you need something that isn't bundled yet.
+Install sources into a local [workspace](/concepts/sources-and-workspaces#workspace), inspect schemas through [system catalog](/concepts/system-catalog) tables, run SQL from the [CLI](/reference/cli-reference) or through [MCP](/guides/use-coral-over-mcp), and [write custom source specs](/guides/write-a-custom-source) when you need something that isn't bundled yet.
 
 ## Get started
 


### PR DESCRIPTION
## Summary
- Rework intro page steps with inline CLI examples (brew install, source add, SQL query)
- Rename landing page to "Introduction to Coral"
- Remove quickstart button from top navbar
- Wrap prerequisite text in `<Note>` callouts on quickstart and MCP guide pages

## Test plan

<img width="654" height="821" alt="image" src="https://github.com/user-attachments/assets/5a08711d-64ca-41b1-848b-9de934c4b1e1" />
