### PR TITLE
feat(cli): add guided onboarding flow

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,273 @@
+# Coral Setup Plan
+
+## Goal
+
+Improve Coral's setup story using the product model that already exists in this repo:
+
+1. install the CLI
+2. configure at least one source locally
+3. optionally connect an agent over MCP
+
+This plan covers:
+
+- `install.sh`
+- `coral onboard`
+- docs install and agent-usage flows
+
+## What The Repo Already Says
+
+The current repo is already internally consistent:
+
+- installation is documented in `docs/getting-started/installation.mdx`
+- first usage is documented in `docs/getting-started/quickstart.mdx`
+- agent integration is documented in `docs/guides/use-coral-over-mcp.mdx`
+- the CLI only exposes three top-level commands today: `sql`, `source`, and `mcp-stdio`
+
+The code and docs do **not** currently imply a broad environment-setup product surface. They imply a local-first CLI with source management plus an MCP export.
+
+That means the best plan is evolutionary, not expansive.
+
+## Product Direction
+
+Coral should sharpen the existing user journey instead of adding multiple new conceptual layers all at once.
+
+The recommended user journey is:
+
+1. install Coral
+2. run `coral onboard`
+3. query local data
+4. if needed, connect an agent to `coral mcp-stdio`
+
+This suggests:
+
+- `install.sh` should stay narrow
+- `coral onboard` should become the main guided source-setup flow
+- docs should emphasize the install -> onboard -> agent usage progression
+
+## Non-Goals
+
+- Do not introduce a large setup subsystem before the product actually needs one.
+- Do not mix shell configuration, source onboarding, and MCP usage into one command.
+- Do not add external-config mutation flows unless there is a specific supported integration to automate.
+- Do not replace the existing low-level `coral source ...` commands; `coral onboard` should sit above them.
+
+## Workstream 1: `install.sh`
+
+### Role
+
+`install.sh` should only solve "get the Coral binary working locally."
+
+### Responsibilities
+
+- detect platform and architecture
+- download the correct release artifact
+- verify checksums
+- place the binary in the install location
+- print verification guidance
+- print the next product step
+
+### Install channels
+
+Coral should continue to support at least two install channels:
+
+- `brew install withcoral/tap/coral`
+- `curl -fsSL https://withcoral.com/install.sh | sh`
+
+Recommended positioning:
+
+- Homebrew is the preferred managed install path
+- `install.sh` is the alternative bootstrap path
+
+This keeps package-managed lifecycle concerns with Homebrew while still supporting direct installation where Homebrew is unavailable or undesirable.
+
+### Explicitly out of scope
+
+- source onboarding
+- MCP client configuration
+- shell completion mutation
+- agent skill installation
+
+### Desired finish state
+
+The installer should end with a minimal message like:
+
+```text
+Installed Coral.
+Verify:
+  coral --help
+Next:
+  coral onboard
+Optional agent usage:
+  withcoral.com/docs/guides/agent-usage
+```
+
+### Upgrade story
+
+The install-channel behavior should be explicit in both docs and user messaging:
+
+- Homebrew upgrades via `brew upgrade withcoral/tap/coral`
+- `install.sh` upgrades by re-running the installer
+
+Coral does not need to invent an update mechanism inside onboarding to compensate for the direct-install path.
+
+Until Coral ships a dedicated self-update feature, the direct-install route should be documented as "reinstall to upgrade."
+
+### Repo-specific rationale
+
+The installation doc already frames Coral as a single local CLI in `docs/getting-started/installation.mdx`. The installer should reinforce that framing, not invent a second setup experience.
+
+## Workstream 2: `coral onboard`
+
+### Role
+
+`coral onboard` should become the missing guided layer between installation and the existing low-level source commands.
+
+### Why this is the best addition
+
+The current docs ask users to manually do:
+
+- `coral source discover`
+- `coral source add <NAME>`
+- `coral source test <NAME>`
+
+That is correct, but it is procedural rather than productized. The repo already has all the underlying primitives in `coral-cli`, `coral-client`, `coral-app`, and `coral-spec`. A guided wrapper is the cleanest improvement.
+
+### First iteration scope
+
+- add top-level `coral onboard`
+- require interactive terminal behavior
+- detect whether any sources are already installed
+- offer a simple guided flow:
+  - discover bundled sources
+  - select a bundled source to add
+  - or import a custom source manifest
+  - validate an installed source
+- end with next steps:
+  - `coral source list`
+  - `coral sql "SELECT * FROM coral.tables ..."`
+  - optional agent-usage docs
+
+### Design constraints
+
+- keep `coral-cli` as the terminal adapter
+- reuse existing app RPCs rather than inventing new onboarding-only ones unless clearly needed
+- keep source lifecycle behavior in `coral-app`
+- keep input discovery in `coral-spec`
+- make `coral onboard` a wrapper over existing primitives, not a second implementation of them
+
+## Workstream 3: Documentation
+
+### Current docs shape
+
+The current docs navigation already has the right broad sections:
+
+- install: `getting-started/installation`
+- usage: `getting-started/quickstart`
+- agent integration: `guides/use-coral-over-mcp`
+
+The better plan is to tighten those pages around `coral onboard`, not to rebuild the IA from scratch.
+
+### Install docs
+
+Keep the existing install page at:
+
+- `docs/getting-started/installation.mdx`
+
+Update it to:
+
+- verify install with `coral --help`
+- make `coral onboard` the explicit next step
+- position Homebrew as the preferred install path and `install.sh` as the manual alternative
+- document the upgrade difference between Homebrew and `install.sh`
+- move low-level local-state detail below the main path
+- link clearly to agent usage as optional follow-on setup
+
+### Agent usage docs
+
+Add or rename toward:
+
+- `docs/guides/agent-usage.mdx`
+
+Recommended approach:
+
+- keep `docs/guides/use-coral-over-mcp.mdx` as the source material
+- either rename it to `agent-usage.mdx`
+- or create `agent-usage.mdx` as the broader page and keep `use-coral-over-mcp.mdx` as an MCP-specific deep dive
+
+### Recommended content model for agent usage
+
+The agent-usage page should explain:
+
+- prerequisites:
+  - Coral installed
+  - at least one source configured
+- how agents connect:
+  - `coral mcp-stdio`
+  - client-specific MCP config examples
+  - `npx skills add ...` for agent skill distribution if Coral publishes a skills endpoint/package
+- how to verify:
+  - ask for tables
+  - run a simple SQL query
+- how to troubleshoot:
+  - `coral` not on `PATH`
+  - no sources installed
+  - source validation failures
+
+### Quickstart docs
+
+Update `docs/getting-started/quickstart.mdx` so that:
+
+- the preferred path is `coral onboard`
+- the manual `source discover` / `source add` / `source test` sequence remains documented as the transparent low-level flow
+
+### README updates
+
+Align the README with the same path:
+
+1. install
+2. `coral onboard`
+3. query
+4. optional agent integration via MCP and skills
+
+## Proposed Delivery Sequence
+
+### Phase 1: docs-first user journey cleanup
+
+- update installation doc to point to `coral onboard`
+- update quickstart framing around `coral onboard`
+- add or rename the agent-usage guide
+- update README to match
+
+### Phase 2: CLI onboarding
+
+- add `coral onboard`
+- add tests for interactive and non-interactive behavior
+
+### Phase 3: agent usage polish
+
+- add `npx skills add ...` guidance once Coral has a stable skills distribution target
+- keep agent integration primarily in docs unless a concrete automation surface is clearly warranted
+
+## Verification Plan
+
+- unit tests for onboard control-flow helpers
+- integration test for non-interactive suppression
+- docs navigation review for page naming and links
+- run `make validate`
+
+## Open Questions
+
+- Should the docs land before the command, or should `coral onboard` land first to avoid documenting a not-yet-shipped command?
+- Should `agent-usage` replace `use-coral-over-mcp`, or sit above it as the broader page?
+- What is the canonical Coral target for `npx skills add ...` and how should that artifact be versioned and distributed?
+
+## Recommendation
+
+The better repo-native plan is:
+
+1. keep `install.sh` narrow
+2. make `coral onboard` the main new product addition
+3. evolve the docs from install -> quickstart -> MCP into install -> onboard -> agent usage
+4. add `npx skills add ...` to the agent-usage story once Coral has a stable skills distribution path
+
+That plan fits the current code, current docs navigation, and current product boundaries without introducing extra surface area too early.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Coral gives agents one query interface instead:
 
 ## What Coral does today
 
+- onboard a local workspace with bundled or imported sources
 - discover bundled sources
 - add or import sources into a local workspace
 - inspect schemas and tables through SQL
@@ -46,24 +47,24 @@ brew install withcoral/tap/coral
 coral --help
 ```
 
-### 2. Discover bundled sources
+### 2. Run onboarding
+
+```bash
+coral onboard
+```
+
+`coral onboard` guides you through adding or importing a source and validating
+it before you start querying.
+
+If you prefer the low-level manual flow, you can still run:
 
 ```bash
 coral source discover
-```
-
-### 3. Add a source
-
-For example, to add GitHub:
-
-```bash
 coral source add github
+coral source test github
 ```
 
-Coral prompts interactively for any required variables or credentials to keep
-them off the command line.
-
-### 4. Inspect available tables
+### 3. Inspect available tables
 
 Use the system catalog to see what Coral can query:
 
@@ -71,7 +72,7 @@ Use the system catalog to see what Coral can query:
 coral sql "SELECT * FROM coral.tables LIMIT 20"
 ```
 
-### 5. Run a query
+### 4. Run a query
 
 For example, to inspect recent GitHub releases:
 
@@ -88,7 +89,7 @@ coral sql "
 The exact schemas and tables depend on the sources you have installed. When in
 doubt, inspect `coral.tables` first.
 
-### 6. Expose Coral over MCP
+### 5. Use Coral with an agent
 
 Coral can run as a local MCP server so agents can query your installed sources
 through the same runtime.
@@ -107,7 +108,7 @@ codex mcp add coral -- coral mcp-stdio
 
 #### OpenCode
 
-Add a new MCP app and use this command:
+Add a new MCP app configured to launch Coral with:
 
 ```bash
 coral mcp-stdio
@@ -135,6 +136,15 @@ Then add Coral to `claude_desktop_config.json`:
 Use the full path to your `coral` binary. Once configured, your agent can use
 Coral over MCP to inspect schemas, list tables, and query the sources installed
 in your local workspace.
+
+Coral also ships a reusable skill for agent workflows:
+
+```bash
+npx skills add withcoral/skills
+```
+
+For the full agent setup flow, including MCP examples and skills guidance, see
+[Agent usage](https://withcoral.com/docs/guides/agent-usage).
 
 ## Core concepts
 

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -6,25 +6,21 @@
     reason = "CLI intentionally renders user-facing output"
 )]
 
-use std::io::{IsTerminal, stdin, stdout};
+mod onboard;
+mod source_ops;
+
 use std::path::PathBuf;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use coral_api::v1::{
-    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
-    ImportSourceRequest, ListSourcesRequest, SourceInputKind, SourceInputSpec, SourceOrigin,
-    SourceSecret, SourceVariable, ValidateSourceRequest,
-};
+use coral_api::v1::ExecuteSqlRequest;
 use coral_client::{
     ClientBuilder, decode_execute_sql_response, default_workspace, format_batches_json,
     format_batches_table,
 };
-use coral_spec::{ManifestInputKind, ManifestInputSpec, collect_source_inputs_yaml};
-use dialoguer::{Input, Password};
 use tonic::Request;
 
 #[derive(Debug, Parser)]
-#[command(name = "coral", version)]
+#[command(name = "coral", version, arg_required_else_help = true)]
 /// Query and manage local data sources
 struct Cli {
     #[command(subcommand)]
@@ -37,6 +33,8 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Run the guided source onboarding flow
+    Onboard,
     /// Start the MCP server over stdio
     McpStdio,
 }
@@ -93,10 +91,6 @@ enum OutputFormat {
 }
 
 #[tokio::main]
-#[allow(
-    clippy::too_many_lines,
-    reason = "CLI dispatch is intentionally centralized for the current product surface."
-)]
 async fn main() -> Result<(), anyhow::Error> {
     let cli = Cli::parse();
     let app = ClientBuilder::new().build().await?;
@@ -116,17 +110,11 @@ async fn main() -> Result<(), anyhow::Error> {
         }
         Command::Source(args) => match args.command {
             SourceCommand::Discover => {
-                let response = app
-                    .source_client()
-                    .discover_sources(Request::new(DiscoverSourcesRequest {
-                        workspace: Some(default_workspace()),
-                    }))
-                    .await?
-                    .into_inner();
-                if response.sources.is_empty() {
+                let sources = source_ops::discover_sources(&app).await?;
+                if sources.is_empty() {
                     println!("No bundled sources available.");
                 } else {
-                    for source in response.sources {
+                    for source in sources {
                         let status = if source.installed {
                             "installed"
                         } else {
@@ -137,232 +125,61 @@ async fn main() -> Result<(), anyhow::Error> {
                 }
             }
             SourceCommand::List => {
-                let response = app
-                    .source_client()
-                    .list_sources(Request::new(ListSourcesRequest {
-                        workspace: Some(default_workspace()),
-                    }))
-                    .await?
-                    .into_inner();
-                if response.sources.is_empty() {
+                let sources = source_ops::list_sources(&app).await?;
+                if sources.is_empty() {
                     println!("No sources configured.");
                 } else {
-                    for source in response.sources {
-                        let origin = source_origin_label(source.origin);
+                    for source in sources {
+                        let origin = source_ops::source_origin_label(source.origin);
                         println!("{}\t{}\t{}", source.name, source.version, origin);
                     }
                 }
             }
             SourceCommand::Add { name } => {
-                require_interactive()?;
-                let bundled_name = source_name_arg(Some(&name))?;
-                let discover = app
-                    .source_client()
-                    .discover_sources(Request::new(DiscoverSourcesRequest {
-                        workspace: Some(default_workspace()),
-                    }))
-                    .await?
-                    .into_inner();
+                source_ops::require_interactive()?;
+                let bundled_name = source_ops::source_name_arg(Some(&name))?;
+                let discover = source_ops::discover_sources(&app).await?;
                 let available = discover
-                    .sources
                     .into_iter()
                     .find(|source| source.name == bundled_name)
                     .ok_or_else(|| anyhow::anyhow!("unknown bundled source '{bundled_name}'"))?;
                 let inputs = available
                     .inputs
                     .iter()
-                    .map(manifest_input_from_proto)
+                    .map(source_ops::manifest_input_from_proto)
                     .collect::<Result<Vec<_>, _>>()?;
-                let (variables, secrets) = prompt_for_inputs(&inputs)?;
-                let response = app
-                    .source_client()
-                    .create_bundled_source(Request::new(CreateBundledSourceRequest {
-                        workspace: Some(default_workspace()),
-                        name: available.name.clone(),
-                        variables,
-                        secrets,
-                    }))
-                    .await?
-                    .into_inner();
+                let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+                let response =
+                    source_ops::add_bundled_source(&app, &available.name, variables, secrets)
+                        .await?;
                 println!("Added source {}", response.name);
             }
             SourceCommand::Import { path } => {
-                require_interactive()?;
-                let manifest_yaml = std::fs::read_to_string(&path)?;
-                let inputs = collect_source_inputs_yaml(&manifest_yaml)?;
-                let (variables, secrets) = prompt_for_inputs(&inputs)?;
-                let response = app
-                    .source_client()
-                    .import_source(Request::new(ImportSourceRequest {
-                        workspace: Some(default_workspace()),
-                        manifest_yaml,
-                        variables,
-                        secrets,
-                    }))
-                    .await?
-                    .into_inner();
+                source_ops::require_interactive()?;
+                let (manifest_yaml, inputs) = source_ops::load_manifest_inputs(&path)?;
+                let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+                let response =
+                    source_ops::import_source(&app, manifest_yaml, variables, secrets).await?;
                 println!("Imported source {}", response.name);
             }
             SourceCommand::Test { name } => {
-                let response = app
-                    .source_client()
-                    .validate_source(Request::new(ValidateSourceRequest {
-                        workspace: Some(default_workspace()),
-                        name: source_name_arg(Some(&name))?,
-                    }))
-                    .await?
-                    .into_inner();
-                let source = response.source.expect("source");
-                println!("Source {} is queryable", source.name);
-                for table in response.tables {
-                    println!("{}.{}", table.schema_name, table.name);
-                }
+                let response = source_ops::validate_source(&app, &name).await?;
+                source_ops::print_validation_success(&response)?;
             }
             SourceCommand::Remove { name } => {
-                app.source_client()
-                    .delete_source(Request::new(DeleteSourceRequest {
-                        workspace: Some(default_workspace()),
-                        name: source_name_arg(Some(&name))?,
-                    }))
-                    .await?;
+                source_ops::delete_source(&app, &name).await?;
                 println!("Removed source {name}");
             }
         },
+        Command::Onboard => {
+            onboard::run(&app).await?;
+        }
         Command::McpStdio => {
             coral_mcp::run_stdio_with_client(app).await?;
         }
     }
 
     Ok(())
-}
-
-fn require_interactive() -> Result<(), anyhow::Error> {
-    if !stdin().is_terminal() || !stdout().is_terminal() {
-        return Err(anyhow::anyhow!("interactive source install requires a TTY"));
-    }
-    Ok(())
-}
-
-fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Error> {
-    let Some(name) = name else {
-        return Err(anyhow::anyhow!("missing source name"));
-    };
-    let name = name.trim();
-    if name.is_empty() {
-        return Err(anyhow::anyhow!("missing source name"));
-    }
-    if name.contains('/') || name.contains('\\') {
-        return Err(anyhow::anyhow!(
-            "source name must not contain '/' or '\\\\'"
-        ));
-    }
-    Ok(name.to_string())
-}
-
-fn prompt_for_inputs(
-    inputs: &[ManifestInputSpec],
-) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
-    let mut variables = Vec::new();
-    let mut secrets = Vec::new();
-
-    for input in inputs {
-        match input.kind {
-            ManifestInputKind::Variable => {
-                if let Some(variable) = prompt_variable(input)? {
-                    variables.push(variable);
-                }
-            }
-            ManifestInputKind::Secret => {
-                if let Some(secret) = prompt_secret(input)? {
-                    secrets.push(secret);
-                }
-            }
-        }
-    }
-
-    Ok((variables, secrets))
-}
-
-fn manifest_input_from_proto(input: &SourceInputSpec) -> Result<ManifestInputSpec, anyhow::Error> {
-    let kind = match SourceInputKind::try_from(input.kind) {
-        Ok(SourceInputKind::Variable) => ManifestInputKind::Variable,
-        Ok(SourceInputKind::Secret) => ManifestInputKind::Secret,
-        Ok(SourceInputKind::Unspecified) | Err(_) => {
-            return Err(anyhow::anyhow!("unknown input kind for '{}'", input.key));
-        }
-    };
-    Ok(ManifestInputSpec {
-        key: input.key.clone(),
-        kind,
-        required: input.required,
-        default_value: input.default_value.clone(),
-    })
-}
-
-fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, anyhow::Error> {
-    let prompt = if input.default_value.is_empty() {
-        input.key.clone()
-    } else {
-        format!("{} [{}]", input.key, input.default_value)
-    };
-    let value = Input::<String>::new()
-        .with_prompt(prompt)
-        .allow_empty(true)
-        .interact_text()?;
-    let Some(value) = finalize_input_value(input, value, "source variable")? else {
-        return Ok(None);
-    };
-    Ok(Some(SourceVariable {
-        key: input.key.clone(),
-        value,
-    }))
-}
-
-fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyhow::Error> {
-    let prompt = if input.default_value.is_empty() {
-        input.key.clone()
-    } else {
-        format!("{} [default hidden]", input.key)
-    };
-    let value = Password::new()
-        .with_prompt(prompt)
-        .allow_empty_password(true)
-        .interact()?;
-    let Some(value) = finalize_input_value(input, value, "source secret")? else {
-        return Ok(None);
-    };
-    Ok(Some(SourceSecret {
-        key: input.key.clone(),
-        value,
-    }))
-}
-
-fn finalize_input_value(
-    input: &ManifestInputSpec,
-    value: String,
-    kind_label: &str,
-) -> Result<Option<String>, anyhow::Error> {
-    if !value.is_empty() {
-        return Ok(Some(value));
-    }
-    if !input.default_value.is_empty() {
-        return Ok(Some(input.default_value.clone()));
-    }
-    if input.required {
-        return Err(anyhow::anyhow!(
-            "missing required {kind_label} '{}'",
-            input.key
-        ));
-    }
-    Ok(None)
-}
-
-fn source_origin_label(origin: i32) -> &'static str {
-    match SourceOrigin::try_from(origin) {
-        Ok(SourceOrigin::Bundled) => "bundled",
-        Ok(SourceOrigin::Imported) => "imported",
-        Ok(SourceOrigin::Unspecified) | Err(_) => "unknown",
-    }
 }
 
 fn print_batches(
@@ -375,39 +192,4 @@ fn print_batches(
     };
     println!("{output}");
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use coral_spec::{ManifestInputKind, ManifestInputSpec};
-
-    use super::finalize_input_value;
-
-    #[test]
-    fn empty_input_uses_default_value() {
-        let input = ManifestInputSpec {
-            key: "API_BASE".to_string(),
-            kind: ManifestInputKind::Variable,
-            required: false,
-            default_value: "https://example.com".to_string(),
-        };
-        assert_eq!(
-            finalize_input_value(&input, String::new(), "source variable")
-                .expect("default should apply"),
-            Some("https://example.com".to_string())
-        );
-    }
-
-    #[test]
-    fn empty_required_input_without_default_is_rejected() {
-        let input = ManifestInputSpec {
-            key: "API_TOKEN".to_string(),
-            kind: ManifestInputKind::Secret,
-            required: true,
-            default_value: String::new(),
-        };
-        let error = finalize_input_value(&input, String::new(), "source secret")
-            .expect_err("required empty input should fail");
-        assert!(error.to_string().contains("missing required source secret"));
-    }
 }

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -1,0 +1,371 @@
+use std::path::PathBuf;
+
+use coral_api::v1::{AvailableSource, Source};
+use coral_client::AppClient;
+use dialoguer::console::{measure_text_width, style};
+use dialoguer::{Confirm, Input, Select, theme::ColorfulTheme};
+
+use crate::source_ops;
+
+const SOURCE_DESCRIPTION_PREVIEW_LIMIT: usize = 88;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OnboardAction {
+    AddBundledSource,
+    ImportSourceManifest,
+    ValidateInstalledSource,
+    Finish,
+}
+
+pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
+    source_ops::require_interactive()?;
+    let theme = ColorfulTheme::default();
+
+    println!("{}", style("Coral onboarding").bold().cyan());
+    println!();
+    println!(
+        "{}",
+        style("Add a source to this workspace, validate it, then start querying.").dim()
+    );
+
+    loop {
+        let installed_sources = source_ops::list_sources(app).await?;
+        let bundled_sources = source_ops::discover_sources(app).await?;
+
+        print_workspace_summary(&installed_sources, &bundled_sources);
+
+        match select_onboard_action(&theme, !installed_sources.is_empty())? {
+            OnboardAction::AddBundledSource => {
+                run_add_bundled_source(app, &theme, &bundled_sources).await?;
+            }
+            OnboardAction::ImportSourceManifest => {
+                run_import_source(app, &theme).await?;
+            }
+            OnboardAction::ValidateInstalledSource => {
+                run_validate_source(app, &theme, &installed_sources).await?;
+            }
+            OnboardAction::Finish => {
+                print_next_steps(&installed_sources);
+                return Ok(());
+            }
+        }
+    }
+}
+
+fn print_workspace_summary(installed_sources: &[Source], bundled_sources: &[AvailableSource]) {
+    println!();
+    println!("{}", style("Workspace").bold());
+    for (label, value) in workspace_summary_lines(installed_sources, bundled_sources) {
+        println!("  {:<10} {}", style(label).dim(), value);
+    }
+    println!();
+}
+
+fn select_onboard_action(
+    theme: &ColorfulTheme,
+    has_installed_sources: bool,
+) -> Result<OnboardAction, anyhow::Error> {
+    let mut items = vec![
+        ("Add a bundled source", OnboardAction::AddBundledSource),
+        (
+            "Import a source manifest",
+            OnboardAction::ImportSourceManifest,
+        ),
+    ];
+    if has_installed_sources {
+        items.push(("Validate a source", OnboardAction::ValidateInstalledSource));
+    }
+    items.push(("Finish onboarding", OnboardAction::Finish));
+    let labels = items.iter().map(|(label, _)| *label).collect::<Vec<_>>();
+
+    let selection = Select::with_theme(theme)
+        .with_prompt("Choose an action")
+        .items(&labels)
+        .default(0)
+        .interact_opt()?;
+
+    Ok(selection.map_or(OnboardAction::Finish, |index| items[index].1))
+}
+
+async fn run_add_bundled_source(
+    app: &AppClient,
+    theme: &ColorfulTheme,
+    bundled_sources: &[AvailableSource],
+) -> Result<(), anyhow::Error> {
+    let addable_sources = addable_bundled_sources(bundled_sources);
+    if addable_sources.is_empty() {
+        println!("No bundled sources are available in this build.");
+        return Ok(());
+    }
+
+    let name_width = addable_sources
+        .iter()
+        .map(|source| measure_text_width(&source.name))
+        .max()
+        .unwrap_or(0);
+    let items = addable_sources
+        .iter()
+        .map(|source| format_bundled_source_item(source, name_width))
+        .collect::<Vec<_>>();
+    let selection = Select::with_theme(theme)
+        .with_prompt("Choose a bundled source")
+        .items(&items)
+        .default(0)
+        .interact_opt()?;
+    let Some(selection) = selection else {
+        return Ok(());
+    };
+    let selected = addable_sources[selection];
+
+    let inputs = selected
+        .inputs
+        .iter()
+        .map(source_ops::manifest_input_from_proto)
+        .collect::<Result<Vec<_>, _>>()?;
+    let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+    let source = source_ops::add_bundled_source(app, &selected.name, variables, secrets).await?;
+    println!("Added source {}", source.name);
+    maybe_validate_after_install(app, theme, &source.name).await
+}
+
+async fn run_import_source(app: &AppClient, theme: &ColorfulTheme) -> Result<(), anyhow::Error> {
+    let path = Input::<String>::with_theme(theme)
+        .with_prompt("Path to a source manifest YAML file")
+        .interact_text()?;
+    let path = PathBuf::from(path);
+    let (manifest_yaml, inputs) = source_ops::load_manifest_inputs(&path)?;
+    let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+    let source = source_ops::import_source(app, manifest_yaml, variables, secrets).await?;
+    println!("Imported source {}", source.name);
+    maybe_validate_after_install(app, theme, &source.name).await
+}
+
+async fn run_validate_source(
+    app: &AppClient,
+    theme: &ColorfulTheme,
+    installed_sources: &[Source],
+) -> Result<(), anyhow::Error> {
+    if installed_sources.is_empty() {
+        println!("No installed sources are available to validate.");
+        return Ok(());
+    }
+
+    let items = installed_sources
+        .iter()
+        .map(|source| {
+            format!(
+                "{} ({})",
+                source.name,
+                source_ops::source_origin_label(source.origin)
+            )
+        })
+        .collect::<Vec<_>>();
+    let selection = Select::with_theme(theme)
+        .with_prompt("Choose a source to validate")
+        .items(&items)
+        .default(0)
+        .interact_opt()?;
+    let Some(selection) = selection else {
+        return Ok(());
+    };
+    let response = source_ops::validate_source(app, &installed_sources[selection].name).await?;
+    source_ops::print_validation_success(&response)?;
+    Ok(())
+}
+
+async fn maybe_validate_after_install(
+    app: &AppClient,
+    theme: &ColorfulTheme,
+    source_name: &str,
+) -> Result<(), anyhow::Error> {
+    let should_validate = Confirm::with_theme(theme)
+        .with_prompt(format!("Validate {source_name} now?"))
+        .default(true)
+        .interact()?;
+    if should_validate {
+        let response = source_ops::validate_source(app, source_name).await?;
+        source_ops::print_validation_success(&response)?;
+    }
+    Ok(())
+}
+
+fn print_next_steps(installed_sources: &[Source]) {
+    println!();
+    println!("Next steps:");
+    if installed_sources.is_empty() {
+        println!("  coral source discover");
+        println!("  coral source list");
+    } else {
+        println!("  coral source list");
+        println!("  coral sql \"SELECT schema_name, table_name FROM coral.tables ORDER BY 1, 2\"");
+        println!("  npx skills add withcoral/skills");
+    }
+}
+
+fn addable_bundled_sources(sources: &[AvailableSource]) -> Vec<&AvailableSource> {
+    sources.iter().filter(|source| !source.installed).collect()
+}
+
+fn workspace_summary_lines(
+    installed_sources: &[Source],
+    bundled_sources: &[AvailableSource],
+) -> Vec<(&'static str, String)> {
+    let installed_value = if installed_sources.is_empty() {
+        "none".to_string()
+    } else {
+        format!(
+            "{} source{}: {}",
+            installed_sources.len(),
+            if installed_sources.len() == 1 {
+                ""
+            } else {
+                "s"
+            },
+            installed_sources
+                .iter()
+                .map(|source| source.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    let available_count = bundled_sources
+        .iter()
+        .filter(|source| !source.installed)
+        .count();
+    vec![
+        ("Installed", installed_value),
+        (
+            "Available",
+            format!(
+                "{available_count} bundled source{}",
+                if available_count == 1 { "" } else { "s" }
+            ),
+        ),
+        ("Tip", "Esc goes back".to_string()),
+    ]
+}
+
+fn format_bundled_source_item(source: &AvailableSource, name_width: usize) -> String {
+    if source.description.is_empty() {
+        source.name.clone()
+    } else {
+        let preview = truncate_description(&source.description, SOURCE_DESCRIPTION_PREVIEW_LIMIT);
+        format!("{:<name_width$}  {}", source.name, preview)
+    }
+}
+
+fn truncate_description(description: &str, max_len: usize) -> String {
+    let description = description.trim();
+    if description.chars().count() <= max_len {
+        return description.to_string();
+    }
+
+    let preview = description
+        .chars()
+        .take(max_len.saturating_sub(3))
+        .collect::<String>();
+    format!("{preview}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_api::v1::{AvailableSource, Source};
+
+    use super::{
+        addable_bundled_sources, format_bundled_source_item, truncate_description,
+        workspace_summary_lines,
+    };
+
+    #[test]
+    fn bundled_source_items_align_name_and_include_description_preview() {
+        let source = AvailableSource {
+            name: "github".to_string(),
+            description: "Query repositories and issues".to_string(),
+            version: "1.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: false,
+            origin: 1,
+        };
+        let item = format_bundled_source_item(&source, 10);
+        assert_eq!(item, "github      Query repositories and issues");
+    }
+
+    #[test]
+    fn addable_bundled_sources_omit_installed_sources() {
+        let installed = AvailableSource {
+            name: "github".to_string(),
+            description: String::new(),
+            version: "1.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: true,
+            origin: 1,
+        };
+        let available = AvailableSource {
+            name: "slack".to_string(),
+            description: String::new(),
+            version: "1.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: false,
+            origin: 1,
+        };
+
+        let sources = [installed, available];
+        let addable = addable_bundled_sources(&sources);
+        assert_eq!(addable.len(), 1);
+        assert_eq!(addable[0].name, "slack");
+    }
+
+    #[test]
+    fn workspace_summary_includes_counts_and_names() {
+        let installed_sources = vec![
+            Source {
+                workspace: None,
+                name: "github".to_string(),
+                version: "1.0.0".to_string(),
+                secrets: Vec::new(),
+                variables: Vec::new(),
+                origin: 1,
+            },
+            Source {
+                workspace: None,
+                name: "slack".to_string(),
+                version: "1.0.0".to_string(),
+                secrets: Vec::new(),
+                variables: Vec::new(),
+                origin: 1,
+            },
+        ];
+        let bundled_sources = vec![
+            AvailableSource {
+                name: "github".to_string(),
+                description: String::new(),
+                version: "1.0.0".to_string(),
+                inputs: Vec::new(),
+                installed: true,
+                origin: 1,
+            },
+            AvailableSource {
+                name: "linear".to_string(),
+                description: String::new(),
+                version: "1.0.0".to_string(),
+                inputs: Vec::new(),
+                installed: false,
+                origin: 1,
+            },
+        ];
+
+        let lines = workspace_summary_lines(&installed_sources, &bundled_sources);
+        assert_eq!(
+            lines[0],
+            ("Installed", "2 sources: github, slack".to_string())
+        );
+        assert_eq!(lines[1], ("Available", "1 bundled source".to_string()));
+        assert_eq!(lines[2], ("Tip", "Esc goes back".to_string()));
+    }
+
+    #[test]
+    fn truncate_description_adds_ascii_ellipsis_when_needed() {
+        let description = "abcdefghijklmnopqrstuvwxyz";
+        assert_eq!(truncate_description(description, 10), "abcdefg...");
+    }
+}

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -1,0 +1,286 @@
+use std::io::{IsTerminal, stdin, stdout};
+use std::path::Path;
+
+use coral_api::v1::{
+    AvailableSource, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
+    ImportSourceRequest, ListSourcesRequest, Source, SourceInputKind, SourceInputSpec,
+    SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+};
+use coral_client::{AppClient, default_workspace};
+use coral_spec::{ManifestInputKind, ManifestInputSpec, collect_source_inputs_yaml};
+use dialoguer::{Input, Password, theme::ColorfulTheme};
+use tonic::Request;
+
+pub(crate) async fn discover_sources(
+    app: &AppClient,
+) -> Result<Vec<AvailableSource>, anyhow::Error> {
+    Ok(app
+        .source_client()
+        .discover_sources(Request::new(DiscoverSourcesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await?
+        .into_inner()
+        .sources)
+}
+
+pub(crate) async fn list_sources(app: &AppClient) -> Result<Vec<Source>, anyhow::Error> {
+    Ok(app
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await?
+        .into_inner()
+        .sources)
+}
+
+pub(crate) async fn add_bundled_source(
+    app: &AppClient,
+    name: &str,
+    variables: Vec<SourceVariable>,
+    secrets: Vec<SourceSecret>,
+) -> Result<Source, anyhow::Error> {
+    Ok(app
+        .source_client()
+        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+            variables,
+            secrets,
+        }))
+        .await?
+        .into_inner())
+}
+
+pub(crate) async fn import_source(
+    app: &AppClient,
+    manifest_yaml: String,
+    variables: Vec<SourceVariable>,
+    secrets: Vec<SourceSecret>,
+) -> Result<Source, anyhow::Error> {
+    Ok(app
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml,
+            variables,
+            secrets,
+        }))
+        .await?
+        .into_inner())
+}
+
+pub(crate) async fn validate_source(
+    app: &AppClient,
+    name: &str,
+) -> Result<ValidateSourceResponse, anyhow::Error> {
+    Ok(app
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: source_name_arg(Some(name))?,
+        }))
+        .await?
+        .into_inner())
+}
+
+pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), anyhow::Error> {
+    app.source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: source_name_arg(Some(name))?,
+        }))
+        .await?;
+    Ok(())
+}
+
+pub(crate) fn require_interactive() -> Result<(), anyhow::Error> {
+    if !stdin().is_terminal() || !stdout().is_terminal() {
+        return Err(anyhow::anyhow!("interactive source install requires a TTY"));
+    }
+    Ok(())
+}
+
+pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Error> {
+    let Some(name) = name else {
+        return Err(anyhow::anyhow!("missing source name"));
+    };
+    let name = name.trim();
+    if name.is_empty() {
+        return Err(anyhow::anyhow!("missing source name"));
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err(anyhow::anyhow!(
+            "source name must not contain '/' or '\\\\'"
+        ));
+    }
+    Ok(name.to_string())
+}
+
+pub(crate) fn prompt_for_inputs(
+    inputs: &[ManifestInputSpec],
+) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
+    let mut variables = Vec::new();
+    let mut secrets = Vec::new();
+
+    for input in inputs {
+        match input.kind {
+            ManifestInputKind::Variable => {
+                if let Some(variable) = prompt_variable(input)? {
+                    variables.push(variable);
+                }
+            }
+            ManifestInputKind::Secret => {
+                if let Some(secret) = prompt_secret(input)? {
+                    secrets.push(secret);
+                }
+            }
+        }
+    }
+
+    Ok((variables, secrets))
+}
+
+pub(crate) fn manifest_input_from_proto(
+    input: &SourceInputSpec,
+) -> Result<ManifestInputSpec, anyhow::Error> {
+    let kind = match SourceInputKind::try_from(input.kind) {
+        Ok(SourceInputKind::Variable) => ManifestInputKind::Variable,
+        Ok(SourceInputKind::Secret) => ManifestInputKind::Secret,
+        Ok(SourceInputKind::Unspecified) | Err(_) => {
+            return Err(anyhow::anyhow!("unknown input kind for '{}'", input.key));
+        }
+    };
+    Ok(ManifestInputSpec {
+        key: input.key.clone(),
+        kind,
+        required: input.required,
+        default_value: input.default_value.clone(),
+    })
+}
+
+pub(crate) fn load_manifest_inputs(
+    path: &Path,
+) -> Result<(String, Vec<ManifestInputSpec>), anyhow::Error> {
+    let manifest_yaml = std::fs::read_to_string(path)?;
+    let inputs = collect_source_inputs_yaml(&manifest_yaml)?;
+    Ok((manifest_yaml, inputs))
+}
+
+pub(crate) fn source_origin_label(origin: i32) -> &'static str {
+    match SourceOrigin::try_from(origin) {
+        Ok(SourceOrigin::Bundled) => "bundled",
+        Ok(SourceOrigin::Imported) => "imported",
+        Ok(SourceOrigin::Unspecified) | Err(_) => "unknown",
+    }
+}
+
+pub(crate) fn print_validation_success(
+    response: &ValidateSourceResponse,
+) -> Result<(), anyhow::Error> {
+    let source = response
+        .source
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("validate response missing source metadata"))?;
+    println!("Source {} is queryable", source.name);
+    for table in &response.tables {
+        println!("{}.{}", table.schema_name, table.name);
+    }
+    Ok(())
+}
+
+fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, anyhow::Error> {
+    let theme = ColorfulTheme::default();
+    let prompt = if input.default_value.is_empty() {
+        input.key.clone()
+    } else {
+        format!("{} [{}]", input.key, input.default_value)
+    };
+    let value = Input::<String>::with_theme(&theme)
+        .with_prompt(prompt)
+        .allow_empty(true)
+        .interact_text()?;
+    let Some(value) = finalize_input_value(input, value, "source variable")? else {
+        return Ok(None);
+    };
+    Ok(Some(SourceVariable {
+        key: input.key.clone(),
+        value,
+    }))
+}
+
+fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyhow::Error> {
+    let theme = ColorfulTheme::default();
+    let prompt = if input.default_value.is_empty() {
+        input.key.clone()
+    } else {
+        format!("{} [default hidden]", input.key)
+    };
+    let value = Password::with_theme(&theme)
+        .with_prompt(prompt)
+        .allow_empty_password(true)
+        .interact()?;
+    let Some(value) = finalize_input_value(input, value, "source secret")? else {
+        return Ok(None);
+    };
+    Ok(Some(SourceSecret {
+        key: input.key.clone(),
+        value,
+    }))
+}
+
+pub(crate) fn finalize_input_value(
+    input: &ManifestInputSpec,
+    value: String,
+    kind_label: &str,
+) -> Result<Option<String>, anyhow::Error> {
+    if !value.is_empty() {
+        return Ok(Some(value));
+    }
+    if !input.default_value.is_empty() {
+        return Ok(Some(input.default_value.clone()));
+    }
+    if input.required {
+        return Err(anyhow::anyhow!(
+            "missing required {kind_label} '{}'",
+            input.key
+        ));
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_spec::{ManifestInputKind, ManifestInputSpec};
+
+    use super::finalize_input_value;
+
+    #[test]
+    fn empty_input_uses_default_value() {
+        let input = ManifestInputSpec {
+            key: "API_BASE".to_string(),
+            kind: ManifestInputKind::Variable,
+            required: false,
+            default_value: "https://example.com".to_string(),
+        };
+        assert_eq!(
+            finalize_input_value(&input, String::new(), "source variable")
+                .expect("default should apply"),
+            Some("https://example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_required_input_without_default_is_rejected() {
+        let input = ManifestInputSpec {
+            key: "API_TOKEN".to_string(),
+            kind: ManifestInputKind::Secret,
+            required: true,
+            default_value: String::new(),
+        };
+        let error = finalize_input_value(&input, String::new(), "source secret")
+            .expect_err("required empty input should fail");
+        assert!(error.to_string().contains("missing required source secret"));
+    }
+}

--- a/crates/coral-cli/tests/onboard.rs
+++ b/crates/coral-cli/tests/onboard.rs
@@ -1,0 +1,39 @@
+#![allow(
+    unused_crate_dependencies,
+    missing_docs,
+    reason = "Integration test crates only use a small subset of the package dependencies."
+)]
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn temp_config_dir() -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("coral-cli-test-{}-{nanos}", std::process::id()))
+}
+
+#[test]
+fn onboard_rejects_non_interactive_terminals() {
+    let config_dir = temp_config_dir();
+    let output = Command::new(env!("CARGO_BIN_EXE_coral"))
+        .arg("onboard")
+        .env("CORAL_CONFIG_DIR", &config_dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to run coral onboard");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "expected non-zero exit status");
+    assert!(
+        stderr.contains("interactive source install requires a TTY"),
+        "expected TTY error in stderr, got: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(config_dir);
+}

--- a/docs/contributors/architecture.mdx
+++ b/docs/contributors/architecture.mdx
@@ -38,7 +38,7 @@ The user-facing command-line interface.
 
 | Owns | Details |
 | --- | --- |
-| Command parsing | `coral sql`, `coral source`, `coral mcp-stdio` |
+| Command parsing | `coral sql`, `coral source`, `coral onboard`, `coral mcp-stdio` |
 | Interactive prompts | Variables and secrets during `source add` / `source import` |
 | Output formatting | Table and JSON via `coral-client` helpers |
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -54,6 +54,11 @@
         "icon": "rocket"
       },
       {
+        "label": "Agent Usage",
+        "href": "/guides/agent-usage",
+        "icon": "bot"
+      },
+      {
         "label": "Install Coral",
         "href": "/getting-started/installation",
         "icon": "download"
@@ -81,6 +86,7 @@
       {
         "group": "Guides",
         "pages": [
+          "guides/agent-usage",
           "guides/manage-sources",
           "guides/write-a-custom-source",
           "guides/advanced-cli-queries",

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Installation"
-description: "Install Coral with Homebrew, the install script, or from source."
+description: "Install Coral with Homebrew, the install script, or from source, then continue to onboarding."
 ---
 
 Coral ships as a single local CLI. Once installed, the same binary is used for source management, SQL queries, and the MCP stdio server.
@@ -37,7 +37,7 @@ Before you install Coral, make sure you have:
   </Tab>
 </Tabs>
 
-Use Homebrew for a standard install. Build from source if you are contributing to Coral or need to test the current repo state directly.
+Homebrew is the preferred managed install path. Use the install script when you want a direct bootstrap path instead. Build from source if you are contributing to Coral or need to test the current repo state directly.
 
 ## Verify the install
 
@@ -49,6 +49,16 @@ coral --help
 
 The rest of the documentation assumes `coral` is available on your `PATH`.
 
+## Next step
+
+Once Coral is installed, run:
+
+```shellscript
+coral onboard
+```
+
+This guided flow helps you add or import a source, validate it, and get ready to query real data.
+
 ## Upgrade
 
 <Tabs>
@@ -59,7 +69,7 @@ The rest of the documentation assumes `coral` is available on your `PATH`.
   </Tab>
 
   <Tab title="Install script">
-    Re-run the installer:
+    Re-run the installer to upgrade a direct install:
 
     ```shellscript
     curl -fsSL https://withcoral.com/install.sh | sh
@@ -98,6 +108,7 @@ Important files include:
 - installed source specs under `workspaces/<workspace>/sources/...`
 - source secrets stored separately within the same local trust boundary
 
-## Next step
+## Continue
 
-Continue to [Quickstart](/getting-started/quickstart) to add a source and run your first query.
+- Use [Quickstart](/getting-started/quickstart) for the manual source setup and first-query flow
+- Use [Agent usage](/guides/agent-usage) when you want Claude Code, Codex, Cursor, or another agent to call Coral

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -5,6 +5,14 @@ description: "Install Coral, add a bundled source, inspect available tables, and
 
 This tutorial gets you to a working Coral query flow with a bundled source. It assumes you already installed Coral and have `coral` on your `PATH`.
 
+Prefer the guided path? Run:
+
+```shellscript
+coral onboard
+```
+
+The rest of this page shows the equivalent manual flow so you can see each step explicitly.
+
 ## Prerequisites
 
 Before you start:
@@ -61,11 +69,11 @@ coral sql "
 "
 ```
 
-## 6. Expose Coral over MCP
+## 6. Use Coral with an agent
 
 Once you have a working local workspace, you can expose the same runtime to an MCP client (such as Claude Code, Cursor, or VS Code). 
 
-Because MCP servers are typically configured to be launched automatically by the client rather than run directly in your terminal, see [Use Coral over MCP](/guides/use-coral-over-mcp) for setup instructions.
+Because MCP servers are typically configured to be launched automatically by the client rather than run directly in your terminal, see [Agent usage](/guides/agent-usage) for the broader setup flow and [Use Coral over MCP](/guides/use-coral-over-mcp) for MCP-specific configuration examples.
 
 <Tip>
   The exact schemas and tables depend on the sources you have installed. When in

--- a/docs/guides/agent-usage.mdx
+++ b/docs/guides/agent-usage.mdx
@@ -1,0 +1,80 @@
+---
+title: "Agent usage"
+description: "Use Coral from MCP-capable coding agents and install the Coral skill with `npx skills add`."
+---
+
+Coral is built for agent workflows. Once you have Coral installed and at least one source configured locally, you can use it from coding agents in two complementary ways:
+
+- configure an MCP client to launch Coral with `coral mcp-stdio`
+- install the Coral skill with `npx skills add ...`
+
+## Prerequisites
+
+Before setting up an agent:
+
+- install Coral and verify `coral --help` works
+- configure at least one source locally with `coral onboard` or the lower-level `coral source ...` commands
+- validate source setup with `coral source test <NAME>` if something looks wrong
+
+## Option 1: Use Coral over MCP
+
+Coral ships an MCP stdio server. Configure your MCP client to launch:
+
+```shellscript
+coral mcp-stdio
+```
+
+That gives an MCP-capable client direct access to Coral's SQL and schema discovery surface. Treat this as client configuration, not a standalone interactive shell command.
+
+Use the detailed MCP guide for client-specific configuration examples:
+
+[Use Coral over MCP](/guides/use-coral-over-mcp)
+
+## Option 2: Install the Coral skill
+
+Coral also ships a reusable skill for agent workflows:
+
+```shellscript
+npx skills add withcoral/skills
+```
+
+The skill helps an agent use the Coral CLI effectively for:
+
+- first-time setup with `coral onboard`
+- source inspection with `coral source list`
+- schema discovery with `coral.tables` and `coral.columns`
+- source validation with `coral source test <NAME>`
+- SQL execution with `coral sql`
+
+Use the skill when you want the agent to follow Coral-specific CLI workflows even when it is not calling Coral directly through MCP.
+
+## Which option should you use?
+
+- Use **MCP** when you want the agent to call Coral directly as a tool and resource surface.
+- Use the **skill** when you want the agent to follow Coral-specific CLI workflows and best practices.
+- You can use both together: the skill can guide the workflow, and MCP can provide the direct runtime surface.
+
+## Verify the setup
+
+After configuring MCP or installing the skill, ask the agent to:
+
+- list the tables available in Coral
+- run a simple query against `coral.tables`
+- validate a source if there is any setup uncertainty
+
+Examples:
+
+> "List the tables available in Coral."
+
+> "Run a small Coral query against `coral.tables`."
+
+## Troubleshooting
+
+- **`coral` not found:** Make sure Coral is on your `PATH`, or use the full path from `which coral` in your MCP client config.
+- **No sources visible:** Run `coral source list`. If empty, run `coral onboard`.
+- **Source setup seems wrong:** Run `coral source test <NAME>` before changing SQL or MCP config.
+- **Agent is guessing schemas:** Start from `coral.tables` and `coral.columns` instead of assuming source-owned table names.
+
+<Tip>
+  Coral is local-first. Set up sources once in your local workspace, then reuse the same runtime from the CLI, MCP clients, and agent skills.
+</Tip>

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -5,7 +5,9 @@ description: "Connect your AI coding tools to Coral using the Model Context Prot
 
 Coral exposes its local runtime over MCP stdio, giving coding agents access to SQL queries and schema discovery across all your installed sources.
 
-Before setting up a client, make sure you have [installed Coral](/getting-started/installation) and added at least one source with `coral source add`.
+Before setting up a client, make sure you have [installed Coral](/getting-started/installation) and configured at least one source with `coral onboard` or the lower-level `coral source add`.
+
+If you also want reusable workflow guidance for CLI-based agent interactions, see [Agent usage](/guides/agent-usage).
 
 ## What MCP clients get
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -17,7 +17,7 @@ Install sources into a local workspace, inspect schemas through system catalog t
   </Step>
 
   <Step title="Run the quickstart">
-    Add a bundled source, inspect its schema, and run your first query.
+    Prefer the guided path with `coral onboard`, or follow the manual quickstart flow.
 
     [Quickstart](/getting-started/quickstart)
   </Step>
@@ -32,8 +32,8 @@ Install sources into a local workspace, inspect schemas through system catalog t
 ## Quick links
 
 <CardGroup cols={2}>
-  <Card title="Use Coral over MCP" href="/guides/use-coral-over-mcp">
-    Connect Coral to Claude Code, Cursor, VS Code, and other agents
+  <Card title="Agent usage" href="/guides/agent-usage">
+    Connect Coral to agents over MCP or install the Coral skill
   </Card>
   <Card title="Write a custom source" href="/guides/write-a-custom-source">
     Connect any API or dataset to Coral

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -65,6 +65,12 @@ Examples:
 
 Use [Quickstart](/getting-started/quickstart) for the basic flow, then use [System catalog](/concepts/system-catalog) when you need to inspect schemas, columns, descriptions, and required filters before writing larger queries.
 
+If you prefer a guided setup flow instead of running these commands manually, use:
+
+```shellscript
+coral onboard
+```
+
 ## Don't see what you need?
 
 The bundled set is growing. If your system is not listed, [write a custom source](/guides/write-a-custom-source) — source specs can connect to any HTTP API or read local files in JSONL or Parquet format.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -13,6 +13,7 @@ Top-level commands:
 
 - `sql`
 - `source`
+- `onboard`
 - `mcp-stdio`
 
 ## `coral sql`
@@ -91,6 +92,21 @@ Remove an installed source from the local workspace.
 ```shellscript
 coral source remove github
 ```
+
+## `coral onboard`
+
+Run the guided source setup flow.
+
+```shellscript
+coral onboard
+```
+
+This interactive command helps you:
+
+- add a bundled source
+- import a custom source manifest
+- validate an installed source
+- see the next recommended commands after setup
 
 ## `coral mcp-stdio`
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+
+set -eu
+
+REPO="${CORAL_REPO:-withcoral/coral}"
+INSTALL_DIR="${CORAL_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${CORAL_VERSION:-}"
+
+detect_target() {
+    os="$(uname -s)"
+    arch="$(uname -m)"
+
+    case "$os" in
+        Linux) os_part="unknown-linux-gnu" ;;
+        Darwin) os_part="apple-darwin" ;;
+        *)
+            echo "Error: unsupported OS: $os" >&2
+            exit 1
+            ;;
+    esac
+
+    case "$arch" in
+        x86_64|amd64) arch_part="x86_64" ;;
+        aarch64|arm64) arch_part="aarch64" ;;
+        *)
+            echo "Error: unsupported architecture: $arch" >&2
+            exit 1
+            ;;
+    esac
+
+    echo "${arch_part}-${os_part}"
+}
+
+fetch_latest_version() {
+    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" |
+        sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' |
+        head -n 1
+}
+
+download() {
+    url="$1"
+    output="$2"
+    curl -fsSL "$url" -o "$output"
+}
+
+main() {
+    target="$(detect_target)"
+    if [ -z "$VERSION" ]; then
+        VERSION="$(fetch_latest_version)"
+    fi
+
+    if [ -z "$VERSION" ]; then
+        echo "Error: could not determine a Coral release version." >&2
+        echo "Set CORAL_VERSION explicitly or use Homebrew instead:" >&2
+        echo "  brew install withcoral/tap/coral" >&2
+        exit 1
+    fi
+
+    archive="coral-${target}.tar.gz"
+    base_url="https://github.com/${REPO}/releases/download/${VERSION}"
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+
+    echo "Installing Coral ${VERSION} for ${target}..."
+
+    download "${base_url}/${archive}" "${tmpdir}/${archive}"
+    download "${base_url}/checksums.sha256" "${tmpdir}/checksums.sha256"
+
+    cd "$tmpdir"
+    if command -v sha256sum >/dev/null 2>&1; then
+        grep "  ${archive}$" checksums.sha256 | sha256sum -c -
+    elif command -v shasum >/dev/null 2>&1; then
+        grep "  ${archive}$" checksums.sha256 | shasum -a 256 -c -
+    else
+        echo "Error: sha256sum or shasum is required for checksum verification." >&2
+        exit 1
+    fi
+
+    tar xzf "$archive"
+    mkdir -p "$INSTALL_DIR"
+    mv coral "$INSTALL_DIR/coral"
+    chmod +x "$INSTALL_DIR/coral"
+
+    echo
+    echo "Installed Coral to ${INSTALL_DIR}/coral"
+    if ! printf '%s' ":${PATH}:" | grep -q ":${INSTALL_DIR}:"; then
+        echo
+        echo "Add ${INSTALL_DIR} to your PATH:"
+        echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    fi
+    echo
+    echo "Verify:"
+    echo "  coral --help"
+    echo "Next:"
+    echo "  coral onboard"
+    echo "Optional agent usage:"
+    echo "  withcoral.com/docs/guides/agent-usage"
+    echo
+    echo "To upgrade a direct install, re-run this script."
+}
+
+main

--- a/skills/coral/SKILL.md
+++ b/skills/coral/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: coral
+description: Use Coral's local-first SQL runtime to discover schemas, validate sources, and query installed data sources from the CLI or through MCP.
+---
+
+# Coral
+
+Use this skill when you need to work with Coral data sources, inspect schemas, or answer questions with Coral SQL.
+
+## When to use it
+
+- You need to discover what sources are installed in Coral.
+- You need to inspect available schemas or tables before writing a query.
+- You need to run `coral sql` against one or more installed sources.
+- You need to validate a source or troubleshoot source setup.
+- You need to set up Coral for first use with `coral onboard`.
+
+## Workflow
+
+1. Confirm Coral is installed:
+   - `coral --help`
+2. If no sources are installed or the user is just getting started:
+   - `coral onboard`
+3. Inspect installed sources:
+   - `coral source list`
+4. Discover available schemas and tables:
+   - `coral sql "SELECT schema_name, table_name FROM coral.tables ORDER BY 1, 2"`
+5. Validate a specific source when setup looks wrong:
+   - `coral source test <NAME>`
+6. Run the actual query:
+   - `coral sql "<SQL>"`
+
+## Source setup
+
+- Add a bundled source:
+  - `coral source add <NAME>`
+- Import a custom source manifest:
+  - `coral source import /path/to/source.yaml`
+- Validate the result:
+  - `coral source test <NAME>`
+
+Coral prompts interactively for required variables and secrets during add/import.
+
+## Agent usage
+
+If the user wants an MCP-capable client to call Coral directly, use:
+
+- `coral mcp-stdio`
+
+Then configure the client to launch that command.
+
+## Querying guidance
+
+- Start with `coral.tables` and `coral.columns` rather than guessing schema names.
+- Keep the first query small and inspectable.
+- If a query fails and setup may be the cause, validate the source before changing SQL.
+- When in doubt, prefer showing the user the exact `coral sql` command you used.


### PR DESCRIPTION
## Summary
Coral's setup story was still a sequence of low-level source commands after install. This change adds a guided onboarding path so first-time setup is easier to discover and follow, while keeping the existing source commands as the underlying primitives.

## What changed
- add `coral onboard` as an interactive source setup and validation flow
- extract reusable source operation helpers and add a non-interactive onboarding integration test
- add a narrow install script and update install, quickstart, CLI, README, and agent-usage docs to align on the new setup path
- add a Coral skill entrypoint and tighten onboarding presentation, navigation, and next-step guidance

## Validation
- `make validate`
