### PR TITLE
docs: improve getting started pages and clean up CLI guide

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -31,6 +31,8 @@ Before you install Coral, make sure you have:
 
   <Tab title="Build from source">
     ```shellscript
+    git clone https://github.com/withcoral/coral.git
+    cd coral
     cargo build -p coral-cli --release
     ./target/release/coral --help
     ```

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -9,7 +9,7 @@ This tutorial gets you to a working Coral query flow with a bundled source. It a
 
 Before you start:
 
-- install Coral and verify `coral --help` works
+- [install Coral](/getting-started/installation) and verify `coral --help` works
 - have credentials ready for at least one bundled source such as GitHub
 - expect `coral source add <NAME>` to prompt interactively for required inputs
 

--- a/docs/guides/advanced-cli-queries.mdx
+++ b/docs/guides/advanced-cli-queries.mdx
@@ -39,7 +39,3 @@ coral sql "
   LIMIT 10
 "
 ```
-
-## Local runtime model
-
-The default CLI bootstraps an internal local gRPC server through `coral-client`, connects to it, and keeps it alive for the lifetime of the client handle. You do not need to start a separate long-running daemon before running normal `coral sql` commands.


### PR DESCRIPTION
## Intent

The build-from-source instructions assumed the user already had the repo cloned, and the quickstart prerequisites didn't link back to the installation page. The "Local runtime model" section in the advanced CLI guide duplicated content already covered in the Runtime and MCP concepts page.

## What it enables

New users following the docs end-to-end now get a complete build-from-source flow (clone, cd, build) and can navigate between related pages more easily.

## Changes

- Add `git clone` and `cd coral` before `cargo build` in the build-from-source tab on the installation page
- Hyperlink "install Coral" in the quickstart prerequisites to the installation page
- Remove the duplicated "Local runtime model" section from the advanced CLI queries guide