### PR TITLE
refactor(cli): redesign onboard landing page with branding and interactive source list

### DIFF
--- a/crates/coral-cli/src/branding.rs
+++ b/crates/coral-cli/src/branding.rs
@@ -1,0 +1,59 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "CLI branding intentionally writes directly to stdout"
+)]
+
+use dialoguer::console::style;
+
+const CORAL_LOGO_ASCII: [&str; 17] = [
+    "              ###",
+    "         ##   ###",
+    "        .##   .##",
+    "         ##   ##   ###",
+    "   .      ######   ##",
+    "   ### ##  .#.##  ##   ##",
+    "   ##. ###  ##    ##  ###",
+    "   ##  .##  ##  ########.",
+    "    #####   #######.",
+    "###    #    # .##  .",
+    "######.###  ####   ##  ###",
+    "  ########  ##    ##  ###",
+    "        ###. #  ########",
+    "          ##  #######",
+    "          ######",
+    "           .##",
+    "            ##",
+];
+
+const CORAL_WORDMARK_ASCII: [&str; 6] = [
+    " ██████╗ ██████╗ ██████╗  █████╗ ██╗",
+    "██╔════╝██╔═══██╗██╔══██╗██╔══██╗██║",
+    "██║     ██║   ██║██████╔╝███████║██║",
+    "██║     ██║   ██║██╔══██╗██╔══██║██║",
+    "╚██████╗╚██████╔╝██║  ██║██║  ██║███████╗",
+    " ╚═════╝ ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝",
+];
+
+pub(crate) fn print_welcome_header() {
+    let wordmark_offset = 5;
+    let logo_width = CORAL_LOGO_ASCII.iter().map(|s| s.len()).max().unwrap_or(0);
+
+    for (row, logo_line) in CORAL_LOGO_ASCII.iter().enumerate() {
+        let padded_logo = format!("{logo_line:<logo_width$}");
+        if row >= wordmark_offset && row < wordmark_offset + CORAL_WORDMARK_ASCII.len() {
+            let mark_idx = row - wordmark_offset;
+            println!(
+                "{}  {}",
+                style(&padded_logo).color256(209),
+                style(CORAL_WORDMARK_ASCII[mark_idx]).bold(),
+            );
+        } else {
+            println!("{}", style(&padded_logo).color256(209));
+        }
+    }
+
+    println!();
+    println!("Coral gives you one SQL interface to query APIs, files, and live data sources.");
+    println!("The more sources you connect, the more powerful it gets.");
+    println!("Data never leaves your environment.");
+}

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -6,6 +6,7 @@
     reason = "CLI intentionally renders user-facing output"
 )]
 
+mod branding;
 mod onboard;
 mod source_ops;
 
@@ -33,7 +34,7 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
-    /// Run the guided source onboarding flow
+    /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
     McpStdio,

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -73,7 +73,7 @@ fn select_top_level(
     let first_uninstalled = bundled_sources
         .iter()
         .position(|s| !s.installed)
-        .unwrap_or(0);
+        .unwrap_or(bundled_sources.len());
 
     let selection = Select::with_theme(theme)
         .with_prompt("Choose a source")

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -9,42 +9,49 @@ use crate::source_ops;
 
 const SOURCE_DESCRIPTION_PREVIEW_LIMIT: usize = 88;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum OnboardAction {
-    AddBundledSource,
-    ImportSourceManifest,
-    ValidateInstalledSource,
+enum TopLevelChoice {
+    BundledSource(usize),
+    ImportManifest,
     Finish,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InstalledSourceAction {
+    Validate,
+    Reconfigure,
+    Back,
 }
 
 pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
     source_ops::require_interactive()?;
     let theme = ColorfulTheme::default();
 
-    println!("{}", style("Coral onboarding").bold().cyan());
-    println!();
-    println!(
-        "{}",
-        style("Add a source to this workspace, validate it, then start querying.").dim()
-    );
+    crate::branding::print_welcome_header();
 
     loop {
         let installed_sources = source_ops::list_sources(app).await?;
         let bundled_sources = source_ops::discover_sources(app).await?;
 
-        print_workspace_summary(&installed_sources, &bundled_sources);
+        println!();
+        println!(
+            "{}",
+            style("To start, we recommend connecting as many sources as possible:").bold()
+        );
+        println!();
 
-        match select_onboard_action(&theme, !installed_sources.is_empty())? {
-            OnboardAction::AddBundledSource => {
-                run_add_bundled_source(app, &theme, &bundled_sources).await?;
+        match select_top_level(&theme, &bundled_sources)? {
+            TopLevelChoice::BundledSource(idx) => {
+                let source = &bundled_sources[idx];
+                if source.installed {
+                    run_installed_source_menu(app, &theme, source).await?;
+                } else {
+                    run_add_bundled_source(app, &theme, source).await?;
+                }
             }
-            OnboardAction::ImportSourceManifest => {
+            TopLevelChoice::ImportManifest => {
                 run_import_source(app, &theme).await?;
             }
-            OnboardAction::ValidateInstalledSource => {
-                run_validate_source(app, &theme, &installed_sources).await?;
-            }
-            OnboardAction::Finish => {
+            TopLevelChoice::Finish => {
                 print_next_steps(&installed_sources);
                 return Ok(());
             }
@@ -52,80 +59,110 @@ pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
     }
 }
 
-fn print_workspace_summary(installed_sources: &[Source], bundled_sources: &[AvailableSource]) {
-    println!();
-    println!("{}", style("Workspace").bold());
-    for (label, value) in workspace_summary_lines(installed_sources, bundled_sources) {
-        println!("  {:<10} {}", style(label).dim(), value);
-    }
-    println!();
-}
-
-fn select_onboard_action(
+fn select_top_level(
     theme: &ColorfulTheme,
-    has_installed_sources: bool,
-) -> Result<OnboardAction, anyhow::Error> {
-    let mut items = vec![
-        ("Add a bundled source", OnboardAction::AddBundledSource),
-        (
-            "Import a source manifest",
-            OnboardAction::ImportSourceManifest,
-        ),
-    ];
-    if has_installed_sources {
-        items.push(("Validate a source", OnboardAction::ValidateInstalledSource));
-    }
-    items.push(("Finish onboarding", OnboardAction::Finish));
-    let labels = items.iter().map(|(label, _)| *label).collect::<Vec<_>>();
+    bundled_sources: &[AvailableSource],
+) -> Result<TopLevelChoice, anyhow::Error> {
+    let name_width = bundled_sources
+        .iter()
+        .map(|s| measure_text_width(&s.name))
+        .max()
+        .unwrap_or(0);
+
+    let mut labels: Vec<String> = bundled_sources
+        .iter()
+        .map(|source| format_source_list_item(source, name_width))
+        .collect();
+
+    labels.push("  Import a source manifest".to_string());
+    labels.push("Finish onboarding".to_string());
+
+    let first_uninstalled = bundled_sources
+        .iter()
+        .position(|s| !s.installed)
+        .unwrap_or(0);
 
     let selection = Select::with_theme(theme)
-        .with_prompt("Choose an action")
+        .with_prompt("Choose a source")
         .items(&labels)
+        .default(first_uninstalled)
+        .interact_opt()?;
+
+    match selection {
+        Some(idx) if idx < bundled_sources.len() => Ok(TopLevelChoice::BundledSource(idx)),
+        Some(idx) if idx == bundled_sources.len() => Ok(TopLevelChoice::ImportManifest),
+        _ => Ok(TopLevelChoice::Finish),
+    }
+}
+
+fn format_source_list_item(source: &AvailableSource, name_width: usize) -> String {
+    let check = if source.installed { "✓ " } else { "  " };
+    let preview = if source.description.is_empty() {
+        String::new()
+    } else {
+        format!(
+            "  {}",
+            truncate_description(&source.description, SOURCE_DESCRIPTION_PREVIEW_LIMIT)
+        )
+    };
+    format!("{check}{:<name_width$}{preview}", source.name)
+}
+
+async fn run_installed_source_menu(
+    app: &AppClient,
+    theme: &ColorfulTheme,
+    source: &AvailableSource,
+) -> Result<(), anyhow::Error> {
+    let items = ["Validate", "Reconfigure", "Back"];
+    let actions = [
+        InstalledSourceAction::Validate,
+        InstalledSourceAction::Reconfigure,
+        InstalledSourceAction::Back,
+    ];
+
+    let selection = Select::with_theme(theme)
+        .with_prompt(format!("{} is already installed", source.name))
+        .items(items)
         .default(0)
         .interact_opt()?;
 
-    Ok(selection.map_or(OnboardAction::Finish, |index| items[index].1))
+    match selection.map(|i| actions[i]) {
+        Some(InstalledSourceAction::Validate) => {
+            let response = source_ops::validate_source(app, &source.name).await?;
+            source_ops::print_validation_success(&response)?;
+        }
+        Some(InstalledSourceAction::Reconfigure) => {
+            let inputs = source
+                .inputs
+                .iter()
+                .map(source_ops::manifest_input_from_proto)
+                .collect::<Result<Vec<_>, _>>()?;
+            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            let result =
+                source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
+            println!("Reconfigured source {}", result.name);
+            maybe_validate_after_install(app, theme, &result.name).await?;
+        }
+        Some(InstalledSourceAction::Back) | None => {}
+    }
+
+    Ok(())
 }
 
 async fn run_add_bundled_source(
     app: &AppClient,
     theme: &ColorfulTheme,
-    bundled_sources: &[AvailableSource],
+    source: &AvailableSource,
 ) -> Result<(), anyhow::Error> {
-    let addable_sources = addable_bundled_sources(bundled_sources);
-    if addable_sources.is_empty() {
-        println!("No bundled sources are available in this build.");
-        return Ok(());
-    }
-
-    let name_width = addable_sources
-        .iter()
-        .map(|source| measure_text_width(&source.name))
-        .max()
-        .unwrap_or(0);
-    let items = addable_sources
-        .iter()
-        .map(|source| format_bundled_source_item(source, name_width))
-        .collect::<Vec<_>>();
-    let selection = Select::with_theme(theme)
-        .with_prompt("Choose a bundled source")
-        .items(&items)
-        .default(0)
-        .interact_opt()?;
-    let Some(selection) = selection else {
-        return Ok(());
-    };
-    let selected = addable_sources[selection];
-
-    let inputs = selected
+    let inputs = source
         .inputs
         .iter()
         .map(source_ops::manifest_input_from_proto)
         .collect::<Result<Vec<_>, _>>()?;
     let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
-    let source = source_ops::add_bundled_source(app, &selected.name, variables, secrets).await?;
-    println!("Added source {}", source.name);
-    maybe_validate_after_install(app, theme, &source.name).await
+    let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
+    println!("Added source {}", result.name);
+    maybe_validate_after_install(app, theme, &result.name).await
 }
 
 async fn run_import_source(app: &AppClient, theme: &ColorfulTheme) -> Result<(), anyhow::Error> {
@@ -138,39 +175,6 @@ async fn run_import_source(app: &AppClient, theme: &ColorfulTheme) -> Result<(),
     let source = source_ops::import_source(app, manifest_yaml, variables, secrets).await?;
     println!("Imported source {}", source.name);
     maybe_validate_after_install(app, theme, &source.name).await
-}
-
-async fn run_validate_source(
-    app: &AppClient,
-    theme: &ColorfulTheme,
-    installed_sources: &[Source],
-) -> Result<(), anyhow::Error> {
-    if installed_sources.is_empty() {
-        println!("No installed sources are available to validate.");
-        return Ok(());
-    }
-
-    let items = installed_sources
-        .iter()
-        .map(|source| {
-            format!(
-                "{} ({})",
-                source.name,
-                source_ops::source_origin_label(source.origin)
-            )
-        })
-        .collect::<Vec<_>>();
-    let selection = Select::with_theme(theme)
-        .with_prompt("Choose a source to validate")
-        .items(&items)
-        .default(0)
-        .interact_opt()?;
-    let Some(selection) = selection else {
-        return Ok(());
-    };
-    let response = source_ops::validate_source(app, &installed_sources[selection].name).await?;
-    source_ops::print_validation_success(&response)?;
-    Ok(())
 }
 
 async fn maybe_validate_after_install(
@@ -202,58 +206,6 @@ fn print_next_steps(installed_sources: &[Source]) {
     }
 }
 
-fn addable_bundled_sources(sources: &[AvailableSource]) -> Vec<&AvailableSource> {
-    sources.iter().filter(|source| !source.installed).collect()
-}
-
-fn workspace_summary_lines(
-    installed_sources: &[Source],
-    bundled_sources: &[AvailableSource],
-) -> Vec<(&'static str, String)> {
-    let installed_value = if installed_sources.is_empty() {
-        "none".to_string()
-    } else {
-        format!(
-            "{} source{}: {}",
-            installed_sources.len(),
-            if installed_sources.len() == 1 {
-                ""
-            } else {
-                "s"
-            },
-            installed_sources
-                .iter()
-                .map(|source| source.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
-    };
-    let available_count = bundled_sources
-        .iter()
-        .filter(|source| !source.installed)
-        .count();
-    vec![
-        ("Installed", installed_value),
-        (
-            "Available",
-            format!(
-                "{available_count} bundled source{}",
-                if available_count == 1 { "" } else { "s" }
-            ),
-        ),
-        ("Tip", "Esc goes back".to_string()),
-    ]
-}
-
-fn format_bundled_source_item(source: &AvailableSource, name_width: usize) -> String {
-    if source.description.is_empty() {
-        source.name.clone()
-    } else {
-        let preview = truncate_description(&source.description, SOURCE_DESCRIPTION_PREVIEW_LIMIT);
-        format!("{:<name_width$}  {}", source.name, preview)
-    }
-}
-
 fn truncate_description(description: &str, max_len: usize) -> String {
     let description = description.trim();
     if description.chars().count() <= max_len {
@@ -269,98 +221,66 @@ fn truncate_description(description: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use coral_api::v1::{AvailableSource, Source};
+    use coral_api::v1::AvailableSource;
 
-    use super::{
-        addable_bundled_sources, format_bundled_source_item, truncate_description,
-        workspace_summary_lines,
-    };
+    use super::{format_source_list_item, truncate_description};
 
     #[test]
-    fn bundled_source_items_align_name_and_include_description_preview() {
+    fn source_list_item_shows_checkmark_for_installed() {
         let source = AvailableSource {
             name: "github".to_string(),
             description: "Query repositories and issues".to_string(),
             version: "1.0.0".to_string(),
             inputs: Vec::new(),
-            installed: false,
-            origin: 1,
-        };
-        let item = format_bundled_source_item(&source, 10);
-        assert_eq!(item, "github      Query repositories and issues");
-    }
-
-    #[test]
-    fn addable_bundled_sources_omit_installed_sources() {
-        let installed = AvailableSource {
-            name: "github".to_string(),
-            description: String::new(),
-            version: "1.0.0".to_string(),
-            inputs: Vec::new(),
             installed: true,
             origin: 1,
         };
-        let available = AvailableSource {
+        let item = format_source_list_item(&source, 10);
+        assert!(item.starts_with("✓ "));
+        assert!(item.contains("github"));
+        assert!(item.contains("Query repositories and issues"));
+    }
+
+    #[test]
+    fn source_list_item_shows_space_for_uninstalled() {
+        let source = AvailableSource {
             name: "slack".to_string(),
-            description: String::new(),
+            description: "Send and receive messages".to_string(),
             version: "1.0.0".to_string(),
             inputs: Vec::new(),
             installed: false,
             origin: 1,
         };
-
-        let sources = [installed, available];
-        let addable = addable_bundled_sources(&sources);
-        assert_eq!(addable.len(), 1);
-        assert_eq!(addable[0].name, "slack");
+        let item = format_source_list_item(&source, 10);
+        assert!(item.starts_with("  "));
+        assert!(item.contains("slack"));
     }
 
     #[test]
-    fn workspace_summary_includes_counts_and_names() {
-        let installed_sources = vec![
-            Source {
-                workspace: None,
-                name: "github".to_string(),
-                version: "1.0.0".to_string(),
-                secrets: Vec::new(),
-                variables: Vec::new(),
-                origin: 1,
-            },
-            Source {
-                workspace: None,
-                name: "slack".to_string(),
-                version: "1.0.0".to_string(),
-                secrets: Vec::new(),
-                variables: Vec::new(),
-                origin: 1,
-            },
-        ];
-        let bundled_sources = vec![
-            AvailableSource {
-                name: "github".to_string(),
-                description: String::new(),
-                version: "1.0.0".to_string(),
-                inputs: Vec::new(),
-                installed: true,
-                origin: 1,
-            },
-            AvailableSource {
-                name: "linear".to_string(),
-                description: String::new(),
-                version: "1.0.0".to_string(),
-                inputs: Vec::new(),
-                installed: false,
-                origin: 1,
-            },
-        ];
-
-        let lines = workspace_summary_lines(&installed_sources, &bundled_sources);
-        assert_eq!(
-            lines[0],
-            ("Installed", "2 sources: github, slack".to_string())
-        );
-        assert_eq!(lines[1], ("Available", "1 bundled source".to_string()));
-        assert_eq!(lines[2], ("Tip", "Esc goes back".to_string()));
+    fn source_list_item_aligns_names() {
+        let short = AvailableSource {
+            name: "gh".to_string(),
+            description: "GitHub".to_string(),
+            version: "1.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: false,
+            origin: 1,
+        };
+        let long = AvailableSource {
+            name: "statusgator".to_string(),
+            description: "Status pages".to_string(),
+            version: "1.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: false,
+            origin: 1,
+        };
+        let width = 11; // len of "statusgator"
+        let short_item = format_source_list_item(&short, width);
+        let long_item = format_source_list_item(&long, width);
+        // Description columns should start at the same position
+        let short_desc_pos = short_item.find("GitHub").unwrap();
+        let long_desc_pos = long_item.find("Status pages").unwrap();
+        assert_eq!(short_desc_pos, long_desc_pos);
     }
 
     #[test]

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -1,9 +1,7 @@
-use std::path::PathBuf;
-
 use coral_api::v1::{AvailableSource, Source};
 use coral_client::AppClient;
 use dialoguer::console::{measure_text_width, style};
-use dialoguer::{Confirm, Input, Select, theme::ColorfulTheme};
+use dialoguer::{Confirm, Select, theme::ColorfulTheme};
 
 use crate::source_ops;
 
@@ -11,7 +9,6 @@ const SOURCE_DESCRIPTION_PREVIEW_LIMIT: usize = 88;
 
 enum TopLevelChoice {
     BundledSource(usize),
-    ImportManifest,
     Finish,
 }
 
@@ -48,9 +45,6 @@ pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
                     run_add_bundled_source(app, &theme, source).await?;
                 }
             }
-            TopLevelChoice::ImportManifest => {
-                run_import_source(app, &theme).await?;
-            }
             TopLevelChoice::Finish => {
                 print_next_steps(&installed_sources);
                 return Ok(());
@@ -74,7 +68,6 @@ fn select_top_level(
         .map(|source| format_source_list_item(source, name_width))
         .collect();
 
-    labels.push("  Import a source manifest".to_string());
     labels.push("Finish onboarding".to_string());
 
     let first_uninstalled = bundled_sources
@@ -90,7 +83,7 @@ fn select_top_level(
 
     match selection {
         Some(idx) if idx < bundled_sources.len() => Ok(TopLevelChoice::BundledSource(idx)),
-        Some(idx) if idx == bundled_sources.len() => Ok(TopLevelChoice::ImportManifest),
+        Some(idx) if idx == bundled_sources.len() => Ok(TopLevelChoice::Finish),
         _ => Ok(TopLevelChoice::Finish),
     }
 }
@@ -163,18 +156,6 @@ async fn run_add_bundled_source(
     let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
     println!("Added source {}", result.name);
     maybe_validate_after_install(app, theme, &result.name).await
-}
-
-async fn run_import_source(app: &AppClient, theme: &ColorfulTheme) -> Result<(), anyhow::Error> {
-    let path = Input::<String>::with_theme(theme)
-        .with_prompt("Path to a source manifest YAML file")
-        .interact_text()?;
-    let path = PathBuf::from(path);
-    let (manifest_yaml, inputs) = source_ops::load_manifest_inputs(&path)?;
-    let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
-    let source = source_ops::import_source(app, manifest_yaml, variables, secrets).await?;
-    println!("Imported source {}", source.name);
-    maybe_validate_after_install(app, theme, &source.name).await
 }
 
 async fn maybe_validate_after_install(


### PR DESCRIPTION
## Summary

The goal of `onboard` is to go from "I just installed `coral`" to "this is cool" in an interactive way, with the least amount of friction possible.
We're not going to teach everything here; my goal is to make the 0-to-hero path as short and sweet as possible.

This PR changes what you see when you run `onboard`.
This should make it both easy and clear that you should add some sources if you want `coral` to be useful.

This is not the end game, I plan on improve "next steps" too: they are currently briefly shown after you exit `onboard`; instead, I think we can make it a subsequent step of the interactive wizard.

## Test plan

Manually tested the various paths. Here's one:

<img width="817" height="571" alt="image" src="https://github.com/user-attachments/assets/06c48565-065c-465c-b4ba-dc8843973345" />
<img width="726" height="101" alt="image" src="https://github.com/user-attachments/assets/4648b1ad-663b-4000-a383-22327ec28928" />
<img width="336" height="68" alt="image" src="https://github.com/user-attachments/assets/4222e192-bdc2-438d-9b0c-5171cc3bbef8" />
