### PR TITLE
feat(cli): auto-generate CLI reference docs from clap metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4933,6 +4933,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "coral-cli",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
+gen-cli-docs:
+	cargo run -p xtask
+
 validate:
 	cargo fmt --all -- --check
 	cargo check --workspace --all-targets --all-features --locked
 	cargo clippy --workspace --all-targets --all-features -- -D warnings
 	cargo test --workspace --all-targets --all-features --locked
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+	cargo run -p xtask -- --check
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -1,0 +1,125 @@
+//! Clap CLI definitions for the `coral` binary.
+//!
+//! These types are public so that tooling (such as the `xtask` doc generator)
+//! can introspect the full command tree via [`clap::CommandFactory`].
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "lib target only re-exports clap types; other deps are consumed by the bin target"
+)]
+
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+/// Query and manage local data sources
+#[derive(Debug, Parser)]
+#[command(name = "coral", version)]
+pub struct Cli {
+    /// Subcommand to run
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Top-level CLI commands
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Execute a SQL query
+    #[command(after_long_help = "\
+Examples:
+  coral sql \"SELECT * FROM coral.tables LIMIT 10\"
+  coral sql --format json \"SELECT * FROM coral.tables LIMIT 10\"
+  coral sql --format table \"SELECT * FROM slack.messages LIMIT 10\"")]
+    Sql(SqlArgs),
+
+    /// Manage bundled and imported sources in the local workspace
+    Source(SourceArgs),
+
+    /// Expose the local Coral runtime as an MCP stdio server
+    #[command(after_long_help = "\
+This command is intended to be launched by an MCP-capable client rather \
+than used directly in an interactive shell.
+
+The current MCP surface is intentionally small:
+
+- tools: `sql`, `list_tables`
+- resources: `coral://guide`, `coral://tables`")]
+    McpStdio,
+}
+
+/// Arguments for the `sql` command
+#[derive(Debug, Args)]
+pub struct SqlArgs {
+    /// Output format for query results
+    #[arg(long, value_enum, default_value = "table")]
+    pub format: OutputFormat,
+
+    /// SQL query to execute
+    pub sql: String,
+}
+
+/// Arguments for the `source` command
+#[derive(Debug, Args)]
+pub struct SourceArgs {
+    /// Source management subcommand
+    #[command(subcommand)]
+    pub command: SourceCommand,
+}
+
+/// Source management subcommands
+#[derive(Debug, Subcommand)]
+pub enum SourceCommand {
+    /// List bundled sources available in your build
+    Discover,
+
+    /// List sources currently installed in the workspace
+    List,
+
+    /// Install a bundled source by name
+    #[command(after_long_help = "\
+Coral prompts for required variables or secrets interactively.
+
+Examples:
+  coral source add github")]
+    Add {
+        /// Name of the bundled source to install
+        name: String,
+    },
+
+    /// Import a custom source from a manifest file
+    #[command(after_long_help = "\
+Examples:
+  coral source import ./local-messages.yaml")]
+    Import {
+        /// Path to the source manifest file
+        path: PathBuf,
+    },
+
+    /// Validate that an installed source can initialize and expose tables
+    #[command(after_long_help = "\
+Examples:
+  coral source test github
+  coral source test local_messages")]
+    Test {
+        /// Name of the source to test
+        name: String,
+    },
+
+    /// Remove an installed source from the local workspace
+    #[command(after_long_help = "\
+Examples:
+  coral source remove github")]
+    Remove {
+        /// Name of the source to remove
+        name: String,
+    },
+}
+
+/// Output format for query results
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum OutputFormat {
+    /// ASCII table
+    Table,
+    /// JSON
+    Json,
+}

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -7,9 +7,9 @@
 )]
 
 use std::io::{IsTerminal, stdin, stdout};
-use std::path::PathBuf;
 
-use clap::{Args, Parser, Subcommand, ValueEnum};
+use clap::Parser;
+use coral_cli::{Cli, Command, OutputFormat, SourceCommand};
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     ImportSourceRequest, ListSourcesRequest, SourceInputKind, SourceInputSpec, SourceOrigin,
@@ -23,74 +23,6 @@ use coral_spec::{ManifestInputKind, ManifestInputSpec, collect_source_inputs_yam
 use dialoguer::{Input, Password};
 use tonic::Request;
 
-#[derive(Debug, Parser)]
-#[command(name = "coral", version)]
-/// Query and manage local data sources
-struct Cli {
-    #[command(subcommand)]
-    command: Command,
-}
-
-#[derive(Debug, Subcommand)]
-enum Command {
-    /// Execute a SQL query
-    Sql(SqlArgs),
-    /// Manage data sources
-    Source(SourceArgs),
-    /// Start the MCP server over stdio
-    McpStdio,
-}
-
-#[derive(Debug, Args)]
-/// Execute a SQL query
-struct SqlArgs {
-    /// Output format for query results
-    #[arg(long, value_enum, default_value = "table")]
-    format: OutputFormat,
-    /// SQL query to execute
-    sql: String,
-}
-
-#[derive(Debug, Args)]
-/// Manage data sources
-struct SourceArgs {
-    #[command(subcommand)]
-    command: SourceCommand,
-}
-
-#[derive(Debug, Subcommand)]
-enum SourceCommand {
-    /// Discover available sources
-    Discover,
-    /// List configured sources
-    List,
-    /// Add a new source
-    Add {
-        /// Name for the new source
-        name: String,
-    },
-    /// Import a source from a manifest file
-    Import {
-        /// Path to the source manifest file
-        path: PathBuf,
-    },
-    /// Test connectivity for a source
-    Test {
-        /// Name of the source to test
-        name: String,
-    },
-    /// Remove a source
-    Remove {
-        /// Name of the source to remove
-        name: String,
-    },
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum OutputFormat {
-    Table,
-    Json,
-}
 
 #[tokio::main]
 #[allow(

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+clap = { workspace = true }
+coral-cli = { workspace = true }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -78,22 +78,16 @@ fn generate_cli_reference(root: &clap::Command) -> String {
     // Intro
     writeln!(
         out,
-        "Coral is currently a CLI-first product. The main command surface is:"
+        "This reference is generated from the current clap command tree."
     )
     .unwrap();
     writeln!(out).unwrap();
-    writeln!(out, "```shellscript").unwrap();
-    writeln!(out, "{} <COMMAND>", root.get_name()).unwrap();
+    writeln!(out, "```text").unwrap();
+    writeln!(out, "{}", render_help(root, None)).unwrap();
     writeln!(out, "```").unwrap();
-    writeln!(out).unwrap();
-    writeln!(out, "Top-level commands:").unwrap();
     writeln!(out).unwrap();
 
     let subs: Vec<_> = visible_subcommands(root).collect();
-    for sub in &subs {
-        writeln!(out, "- `{}`", sub.get_name()).unwrap();
-    }
-
     for sub in &subs {
         render_command(&mut out, &[root.get_name()], sub, 2);
     }
@@ -104,107 +98,16 @@ fn generate_cli_reference(root: &clap::Command) -> String {
 fn render_command(out: &mut String, parents: &[&str], cmd: &clap::Command, depth: usize) {
     let cmd_path = format!("{} {}", parents.join(" "), cmd.get_name());
 
-    // Build heading: include positional args in display name
-    let mut display = cmd_path.clone();
-    for arg in cmd.get_arguments() {
-        if arg.is_positional() {
-            write!(display, " <{}>", arg.get_id().as_str().to_uppercase()).unwrap();
-        }
-    }
-
     let hashes = "#".repeat(depth);
 
-    // Heading
     writeln!(out).unwrap();
-    writeln!(out, "{hashes} `{display}`").unwrap();
+    writeln!(out, "{hashes} `{cmd_path}`").unwrap();
     writeln!(out).unwrap();
+    writeln!(out, "```text").unwrap();
+    writeln!(out, "{}", render_help(cmd, Some(&cmd_path))).unwrap();
+    writeln!(out, "```").unwrap();
 
-    // Description
-    if let Some(about) = cmd.get_about() {
-        writeln!(out, "{}", as_sentence(&about.to_string())).unwrap();
-    }
-
-    // Usage block — only for leaf commands (no visible subcommands)
     let children: Vec<_> = visible_subcommands(cmd).collect();
-    if children.is_empty() {
-        writeln!(out).unwrap();
-        let usage = build_usage(&cmd_path, cmd);
-        writeln!(out, "```shellscript").unwrap();
-        writeln!(out, "{usage}").unwrap();
-        writeln!(out, "```").unwrap();
-    }
-
-    // Options table
-    let options: Vec<_> = cmd
-        .get_arguments()
-        .filter(|a| !a.is_positional() && !is_builtin_arg(a))
-        .collect();
-    if !options.is_empty() {
-        writeln!(out).unwrap();
-        let sub_hashes = "#".repeat(depth + 1);
-        writeln!(out, "{sub_hashes} Options").unwrap();
-        writeln!(out).unwrap();
-        writeln!(out, "| Option | Type | Default | Description |").unwrap();
-        writeln!(out, "| --- | --- | --- | --- |").unwrap();
-        for opt in &options {
-            let name = opt
-                .get_long()
-                .map(|l| format!("`--{l}`"))
-                .or_else(|| opt.get_short().map(|s| format!("`-{s}`")))
-                .unwrap_or_else(|| format!("`{}`", opt.get_id()));
-
-            let vals = possible_values(opt);
-            let type_str = if vals.is_empty() {
-                "`string`".to_string()
-            } else {
-                vals.iter()
-                    .map(|v| format!("`{v}`"))
-                    .collect::<Vec<_>>()
-                    .join(" \\| ")
-            };
-
-            let default = {
-                let defs = opt.get_default_values();
-                if defs.is_empty() {
-                    "\u{2014}".to_string()
-                } else {
-                    format!("`{}`", defs[0].to_str().unwrap_or(""))
-                }
-            };
-
-            let desc = opt
-                .get_help()
-                .map(std::string::ToString::to_string)
-                .unwrap_or_default();
-
-            writeln!(out, "| {name} | {type_str} | {default} | {desc} |").unwrap();
-        }
-    }
-
-    // After-long-help (prose notes + examples)
-    if let Some(after) = cmd.get_after_long_help() {
-        let text = after.to_string();
-        let (prose, examples) = parse_after_help(&text);
-
-        if !prose.is_empty() {
-            writeln!(out).unwrap();
-            writeln!(out, "{prose}").unwrap();
-        }
-
-        if !examples.is_empty() {
-            writeln!(out).unwrap();
-            let sub_hashes = "#".repeat(depth + 1);
-            writeln!(out, "{sub_hashes} Examples").unwrap();
-            writeln!(out).unwrap();
-            writeln!(out, "```shellscript").unwrap();
-            for ex in &examples {
-                writeln!(out, "{ex}").unwrap();
-            }
-            writeln!(out, "```").unwrap();
-        }
-    }
-
-    // Recurse into subcommands
     let mut parents = parents.to_vec();
     parents.push(cmd.get_name());
     for sub in &children {
@@ -212,85 +115,15 @@ fn render_command(out: &mut String, parents: &[&str], cmd: &clap::Command, depth
     }
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn build_usage(cmd_path: &str, cmd: &clap::Command) -> String {
-    let mut parts = vec![cmd_path.to_string()];
-
-    for arg in cmd.get_arguments() {
-        if arg.is_positional() || is_builtin_arg(arg) {
-            continue;
-        }
-        let flag = arg.get_long().map_or_else(
-            || format!("-{}", arg.get_short().unwrap()),
-            |l| format!("--{l}"),
-        );
-        let vals = possible_values(arg);
-        let value_hint = if vals.is_empty() {
-            format!("<{}>", arg.get_id().as_str().to_uppercase())
-        } else {
-            vals.join("|")
-        };
-        parts.push(format!("[{flag} {value_hint}]"));
+fn render_help(cmd: &clap::Command, cmd_path: Option<&str>) -> String {
+    let mut render = cmd.clone().term_width(100);
+    if let Some(cmd_path) = cmd_path {
+        render = render.bin_name(cmd_path).display_name(cmd_path);
     }
-
-    for arg in cmd.get_arguments() {
-        if !arg.is_positional() {
-            continue;
-        }
-        let name = arg.get_id().as_str().to_uppercase();
-        if arg.is_required_set() {
-            parts.push(format!("<{name}>"));
-        } else {
-            parts.push(format!("[{name}]"));
-        }
-    }
-
-    parts.join(" ")
-}
-
-fn parse_after_help(text: &str) -> (String, Vec<String>) {
-    let marker = "Examples:\n";
-    if let Some(idx) = text.find(marker) {
-        let prose = text[..idx].trim_end().to_string();
-        let examples = text[idx + marker.len()..]
-            .lines()
-            .map(|l| l.trim().to_string())
-            .filter(|l| !l.is_empty())
-            .collect();
-        (prose, examples)
-    } else {
-        (text.to_string(), vec![])
-    }
-}
-
-fn as_sentence(text: &str) -> String {
-    let text = text.trim();
-    if text.ends_with('.') || text.ends_with('!') || text.ends_with('?') {
-        text.to_string()
-    } else {
-        format!("{text}.")
-    }
-}
-
-fn is_builtin_arg(arg: &clap::Arg) -> bool {
-    matches!(arg.get_id().as_str(), "help" | "version")
+    render.render_long_help().to_string().trim_end().to_string()
 }
 
 fn visible_subcommands(cmd: &clap::Command) -> impl Iterator<Item = &clap::Command> {
     cmd.get_subcommands()
         .filter(|s| !s.is_hide_set() && s.get_name() != "help")
-}
-
-fn possible_values(arg: &clap::Arg) -> Vec<String> {
-    arg.get_value_parser()
-        .possible_values()
-        .map(|iter| {
-            iter.filter(|v| !v.is_hide_set())
-                .map(|v| v.get_name().to_string())
-                .collect()
-        })
-        .unwrap_or_default()
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,0 +1,296 @@
+//! CLI reference documentation generator.
+//!
+//! Generates `docs/reference/cli-reference.mdx` from the `clap` command tree
+//! defined in [`coral_cli::Cli`].
+//!
+//! Run without arguments to regenerate the file:
+//! ```sh
+//! cargo run -p xtask
+//! ```
+//!
+//! Run with `--check` in CI to verify the file is up to date:
+//! ```sh
+//! cargo run -p xtask -- --check
+//! ```
+
+#![allow(
+    clippy::print_stdout,
+    clippy::print_stderr,
+    reason = "xtask intentionally prints status to the terminal"
+)]
+
+use std::fmt::Write;
+use std::path::Path;
+use std::{fs, process};
+
+use clap::CommandFactory;
+use coral_cli::Cli;
+
+fn main() {
+    let check = std::env::args().any(|a| a == "--check");
+
+    let cmd = Cli::command();
+    let expected = generate_cli_reference(&cmd);
+
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("cannot resolve workspace root");
+    let path = workspace.join("docs/reference/cli-reference.mdx");
+
+    if check {
+        let actual = fs::read_to_string(&path).unwrap_or_default();
+        if actual != expected {
+            eprintln!(
+                "error: {} is out of date. Run `cargo run -p xtask` to regenerate.",
+                path.display()
+            );
+            process::exit(1);
+        }
+        println!("cli-reference.mdx is up to date.");
+    } else {
+        fs::write(&path, &expected).unwrap_or_else(|e| {
+            eprintln!("error: failed to write {}: {e}", path.display());
+            process::exit(1);
+        });
+        println!("Wrote {}", path.display());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MDX generation
+// ---------------------------------------------------------------------------
+
+fn generate_cli_reference(root: &clap::Command) -> String {
+    let mut out = String::new();
+
+    // Frontmatter
+    writeln!(out, "---").unwrap();
+    writeln!(out, "title: \"CLI reference\"").unwrap();
+    writeln!(
+        out,
+        "description: \"Reference for the current Coral CLI commands and options.\""
+    )
+    .unwrap();
+    writeln!(out, "---").unwrap();
+    writeln!(out).unwrap();
+
+    // Intro
+    writeln!(
+        out,
+        "Coral is currently a CLI-first product. The main command surface is:"
+    )
+    .unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "```shellscript").unwrap();
+    writeln!(out, "{} <COMMAND>", root.get_name()).unwrap();
+    writeln!(out, "```").unwrap();
+    writeln!(out).unwrap();
+    writeln!(out, "Top-level commands:").unwrap();
+    writeln!(out).unwrap();
+
+    let subs: Vec<_> = visible_subcommands(root).collect();
+    for sub in &subs {
+        writeln!(out, "- `{}`", sub.get_name()).unwrap();
+    }
+
+    for sub in &subs {
+        render_command(&mut out, &[root.get_name()], sub, 2);
+    }
+
+    out
+}
+
+fn render_command(out: &mut String, parents: &[&str], cmd: &clap::Command, depth: usize) {
+    let cmd_path = format!("{} {}", parents.join(" "), cmd.get_name());
+
+    // Build heading: include positional args in display name
+    let mut display = cmd_path.clone();
+    for arg in cmd.get_arguments() {
+        if arg.is_positional() {
+            write!(display, " <{}>", arg.get_id().as_str().to_uppercase()).unwrap();
+        }
+    }
+
+    let hashes = "#".repeat(depth);
+
+    // Heading
+    writeln!(out).unwrap();
+    writeln!(out, "{hashes} `{display}`").unwrap();
+    writeln!(out).unwrap();
+
+    // Description
+    if let Some(about) = cmd.get_about() {
+        writeln!(out, "{}", as_sentence(&about.to_string())).unwrap();
+    }
+
+    // Usage block — only for leaf commands (no visible subcommands)
+    let children: Vec<_> = visible_subcommands(cmd).collect();
+    if children.is_empty() {
+        writeln!(out).unwrap();
+        let usage = build_usage(&cmd_path, cmd);
+        writeln!(out, "```shellscript").unwrap();
+        writeln!(out, "{usage}").unwrap();
+        writeln!(out, "```").unwrap();
+    }
+
+    // Options table
+    let options: Vec<_> = cmd
+        .get_arguments()
+        .filter(|a| !a.is_positional() && !is_builtin_arg(a))
+        .collect();
+    if !options.is_empty() {
+        writeln!(out).unwrap();
+        let sub_hashes = "#".repeat(depth + 1);
+        writeln!(out, "{sub_hashes} Options").unwrap();
+        writeln!(out).unwrap();
+        writeln!(out, "| Option | Type | Default | Description |").unwrap();
+        writeln!(out, "| --- | --- | --- | --- |").unwrap();
+        for opt in &options {
+            let name = opt
+                .get_long()
+                .map(|l| format!("`--{l}`"))
+                .or_else(|| opt.get_short().map(|s| format!("`-{s}`")))
+                .unwrap_or_else(|| format!("`{}`", opt.get_id()));
+
+            let vals = possible_values(opt);
+            let type_str = if vals.is_empty() {
+                "`string`".to_string()
+            } else {
+                vals.iter()
+                    .map(|v| format!("`{v}`"))
+                    .collect::<Vec<_>>()
+                    .join(" \\| ")
+            };
+
+            let default = {
+                let defs = opt.get_default_values();
+                if defs.is_empty() {
+                    "\u{2014}".to_string()
+                } else {
+                    format!("`{}`", defs[0].to_str().unwrap_or(""))
+                }
+            };
+
+            let desc = opt
+                .get_help()
+                .map(std::string::ToString::to_string)
+                .unwrap_or_default();
+
+            writeln!(out, "| {name} | {type_str} | {default} | {desc} |").unwrap();
+        }
+    }
+
+    // After-long-help (prose notes + examples)
+    if let Some(after) = cmd.get_after_long_help() {
+        let text = after.to_string();
+        let (prose, examples) = parse_after_help(&text);
+
+        if !prose.is_empty() {
+            writeln!(out).unwrap();
+            writeln!(out, "{prose}").unwrap();
+        }
+
+        if !examples.is_empty() {
+            writeln!(out).unwrap();
+            let sub_hashes = "#".repeat(depth + 1);
+            writeln!(out, "{sub_hashes} Examples").unwrap();
+            writeln!(out).unwrap();
+            writeln!(out, "```shellscript").unwrap();
+            for ex in &examples {
+                writeln!(out, "{ex}").unwrap();
+            }
+            writeln!(out, "```").unwrap();
+        }
+    }
+
+    // Recurse into subcommands
+    let mut parents = parents.to_vec();
+    parents.push(cmd.get_name());
+    for sub in &children {
+        render_command(out, &parents, sub, depth + 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_usage(cmd_path: &str, cmd: &clap::Command) -> String {
+    let mut parts = vec![cmd_path.to_string()];
+
+    for arg in cmd.get_arguments() {
+        if arg.is_positional() || is_builtin_arg(arg) {
+            continue;
+        }
+        let flag = arg.get_long().map_or_else(
+            || format!("-{}", arg.get_short().unwrap()),
+            |l| format!("--{l}"),
+        );
+        let vals = possible_values(arg);
+        let value_hint = if vals.is_empty() {
+            format!("<{}>", arg.get_id().as_str().to_uppercase())
+        } else {
+            vals.join("|")
+        };
+        parts.push(format!("[{flag} {value_hint}]"));
+    }
+
+    for arg in cmd.get_arguments() {
+        if !arg.is_positional() {
+            continue;
+        }
+        let name = arg.get_id().as_str().to_uppercase();
+        if arg.is_required_set() {
+            parts.push(format!("<{name}>"));
+        } else {
+            parts.push(format!("[{name}]"));
+        }
+    }
+
+    parts.join(" ")
+}
+
+fn parse_after_help(text: &str) -> (String, Vec<String>) {
+    let marker = "Examples:\n";
+    if let Some(idx) = text.find(marker) {
+        let prose = text[..idx].trim_end().to_string();
+        let examples = text[idx + marker.len()..]
+            .lines()
+            .map(|l| l.trim().to_string())
+            .filter(|l| !l.is_empty())
+            .collect();
+        (prose, examples)
+    } else {
+        (text.to_string(), vec![])
+    }
+}
+
+fn as_sentence(text: &str) -> String {
+    let text = text.trim();
+    if text.ends_with('.') || text.ends_with('!') || text.ends_with('?') {
+        text.to_string()
+    } else {
+        format!("{text}.")
+    }
+}
+
+fn is_builtin_arg(arg: &clap::Arg) -> bool {
+    matches!(arg.get_id().as_str(), "help" | "version")
+}
+
+fn visible_subcommands(cmd: &clap::Command) -> impl Iterator<Item = &clap::Command> {
+    cmd.get_subcommands()
+        .filter(|s| !s.is_hide_set() && s.get_name() != "help")
+}
+
+fn possible_values(arg: &clap::Arg) -> Vec<String> {
+    arg.get_value_parser()
+        .possible_values()
+        .map(|iter| {
+            iter.filter(|v| !v.is_hide_set())
+                .map(|v| v.get_name().to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -15,19 +15,19 @@ Top-level commands:
 - `source`
 - `mcp-stdio`
 
-## `coral sql`
+## `coral sql <SQL>`
 
-Run one SQL query and exit.
+Execute a SQL query.
 
 ```shellscript
-coral sql [--format table|json] "<SQL>"
+coral sql [--format table|json] <SQL>
 ```
 
 ### Options
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `--format` | `table` \| `json` | `table` | Output format |
+| `--format` | `table` \| `json` | `table` | Output format for query results |
 
 ### Examples
 
@@ -62,14 +62,26 @@ coral source list
 Install a bundled source by name.
 
 ```shellscript
-coral source add github
+coral source add <NAME>
 ```
 
 Coral prompts for required variables or secrets interactively.
 
+#### Examples
+
+```shellscript
+coral source add github
+```
+
 ### `coral source import <PATH>`
 
-Import a custom source spec from a YAML file.
+Import a custom source from a manifest file.
+
+```shellscript
+coral source import <PATH>
+```
+
+#### Examples
 
 ```shellscript
 coral source import ./local-messages.yaml
@@ -80,6 +92,12 @@ coral source import ./local-messages.yaml
 Validate that an installed source can initialize and expose tables.
 
 ```shellscript
+coral source test <NAME>
+```
+
+#### Examples
+
+```shellscript
 coral source test github
 coral source test local_messages
 ```
@@ -87,6 +105,12 @@ coral source test local_messages
 ### `coral source remove <NAME>`
 
 Remove an installed source from the local workspace.
+
+```shellscript
+coral source remove <NAME>
+```
+
+#### Examples
 
 ```shellscript
 coral source remove github

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -3,127 +3,193 @@ title: "CLI reference"
 description: "Reference for the current Coral CLI commands and options."
 ---
 
-Coral is currently a CLI-first product. The main command surface is:
+This reference is generated from the current clap command tree.
 
-```shellscript
-coral <COMMAND>
+```text
+Query and manage local data sources
+
+Usage: coral <COMMAND>
+
+Commands:
+  sql        Execute a SQL query
+  source     Manage bundled and imported sources in the local workspace
+  onboard    Run the guided source setup flow
+  mcp-stdio  Expose the local Coral runtime as an MCP stdio server
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help
+
+  -V, --version
+          Print version
 ```
 
-Top-level commands:
 
-- `sql`
-- `source`
-- `onboard`
-- `mcp-stdio`
+## `coral sql`
 
-## `coral sql <SQL>`
+```text
+Execute a SQL query
 
-Execute a SQL query.
+Usage: coral sql [OPTIONS] <SQL>
 
-```shellscript
-coral sql [--format table|json] <SQL>
-```
+Arguments:
+  <SQL>
+          SQL query to execute
 
-### Options
+Options:
+      --format <FORMAT>
+          Output format for query results
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `--format` | `table` \| `json` | `table` | Output format for query results |
+          Possible values:
+          - table: ASCII table
+          - json:  JSON
+          
+          [default: table]
 
-### Examples
+  -h, --help
+          Print help (see a summary with '-h')
 
-```shellscript
-coral sql "SELECT * FROM coral.tables LIMIT 10"
-coral sql --format json "SELECT * FROM coral.tables LIMIT 10"
-coral sql --format table "SELECT * FROM slack.messages LIMIT 10"
+Examples:
+  coral sql "SELECT * FROM coral.tables LIMIT 10"
+  coral sql --format json "SELECT * FROM coral.tables LIMIT 10"
+  coral sql --format table "SELECT * FROM slack.messages LIMIT 10"
 ```
 
 ## `coral source`
 
-Manage bundled and imported sources in the local workspace.
+```text
+Manage bundled and imported sources in the local workspace
+
+Usage: coral source <COMMAND>
+
+Commands:
+  discover  List bundled sources available in your build
+  list      List sources currently installed in the workspace
+  add       Install a bundled source by name
+  import    Import a custom source from a manifest file
+  test      Validate that an installed source can initialize and expose tables
+  remove    Remove an installed source from the local workspace
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help
+```
 
 ### `coral source discover`
 
-List bundled sources available in your build.
+```text
+List bundled sources available in your build
 
-```shellscript
-coral source discover
+Usage: coral source discover
+
+Options:
+  -h, --help
+          Print help
 ```
 
 ### `coral source list`
 
-List sources currently installed in the workspace.
+```text
+List sources currently installed in the workspace
 
-```shellscript
-coral source list
+Usage: coral source list
+
+Options:
+  -h, --help
+          Print help
 ```
 
-### `coral source add <NAME>`
+### `coral source add`
 
-Install a bundled source by name.
+```text
+Install a bundled source by name
 
-```shellscript
-coral source add <NAME>
-```
+Usage: coral source add <NAME>
+
+Arguments:
+  <NAME>
+          Name of the bundled source to install
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
 
 Coral prompts for required variables or secrets interactively.
 
-#### Examples
-
-```shellscript
-coral source add github
+Examples:
+  coral source add github
 ```
 
-### `coral source import <PATH>`
+### `coral source import`
 
-Import a custom source from a manifest file.
+```text
+Import a custom source from a manifest file
 
-```shellscript
-coral source import <PATH>
+Usage: coral source import <PATH>
+
+Arguments:
+  <PATH>
+          Path to the source manifest file
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+  coral source import ./local-messages.yaml
 ```
 
-#### Examples
+### `coral source test`
 
-```shellscript
-coral source import ./local-messages.yaml
+```text
+Validate that an installed source can initialize and expose tables
+
+Usage: coral source test <NAME>
+
+Arguments:
+  <NAME>
+          Name of the source to test
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+
+Examples:
+  coral source test github
+  coral source test local_messages
 ```
 
-### `coral source test <NAME>`
+### `coral source remove`
 
-Validate that an installed source can initialize and expose tables.
+```text
+Remove an installed source from the local workspace
 
-```shellscript
-coral source test <NAME>
-```
+Usage: coral source remove <NAME>
 
-#### Examples
+Arguments:
+  <NAME>
+          Name of the source to remove
 
-```shellscript
-coral source test github
-coral source test local_messages
-```
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
 
-### `coral source remove <NAME>`
-
-Remove an installed source from the local workspace.
-
-```shellscript
-coral source remove <NAME>
-```
-
-#### Examples
-
-```shellscript
-coral source remove github
+Examples:
+  coral source remove github
 ```
 
 ## `coral onboard`
 
-Run the guided source setup flow.
+```text
+Run the guided source setup flow
 
-```shellscript
-coral onboard
-```
+Usage: coral onboard
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
 
 This interactive command helps you:
 
@@ -131,14 +197,18 @@ This interactive command helps you:
 - import a custom source manifest
 - validate an installed source
 - see the next recommended commands after setup
+```
 
 ## `coral mcp-stdio`
 
-Expose the local Coral runtime as an MCP stdio server.
+```text
+Expose the local Coral runtime as an MCP stdio server
 
-```shellscript
-coral mcp-stdio
-```
+Usage: coral mcp-stdio
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
 
 This command is intended to be launched by an MCP-capable client rather than used directly in an interactive shell.
 
@@ -146,3 +216,4 @@ The current MCP surface is intentionally small:
 
 - tools: `sql`, `list_tables`
 - resources: `coral://guide`, `coral://tables`
+```


### PR DESCRIPTION
## Intent

The CLI reference (`docs/reference/cli-reference.mdx`) was manually maintained and could drift from the actual clap definitions. This PR makes the docs fully generated from clap metadata so they stay in sync automatically.

## What it enables

- Adding or modifying CLI commands/arguments automatically updates the docs — no manual MDX editing required.
- `make validate` catches drift via `cargo run -p xtask -- --check`.
- `make gen-cli-docs` regenerates the file in one step.

## Usage examples

Regenerate the CLI reference after changing command definitions:
```sh
make gen-cli-docs
# or: cargo run -p xtask
```

Check that the docs are up to date (runs automatically in `make validate`):
```sh
cargo run -p xtask -- --check
```

All command descriptions, argument help text, examples, and notes are defined via clap attributes (`about`, `after_long_help`) in `crates/coral-cli/src/lib.rs`. The xtask walks the command tree and emits the MDX file.