### PR TITLE
feat(onboarding): add manifest-driven input hints for source setup

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -67,6 +67,8 @@ message SourceInputSpec {
   bool required = 3;
   // Optional manifest-declared default value.
   string default_value = 4;
+  // Optional human-readable help describing how to obtain this value.
+  string help = 5;
 }
 
 // One bundled or imported source available for installation.

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 
 use coral_api::v1::{AvailableSource, SourceInputKind, SourceInputSpec, SourceOrigin, Workspace};
 use coral_spec::{
-    ManifestInputKind, ManifestInputSpec, collect_source_inputs_value, parse_source_manifest_value,
+    InputSpec, InputKind, collect_source_inputs_value, parse_source_manifest_value,
 };
 use serde_yaml::Value;
 
@@ -60,31 +60,33 @@ pub(crate) fn describe_manifest(
     let manifest = parse_source_manifest_value(serde_json::to_value(&root)?)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
     let description = manifest_description(&root);
+    let inputs = collect_source_inputs_value(&root)
+        .map(|inputs| inputs.into_iter().map(proto_input_spec).collect())
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
     Ok(AvailableSource {
         name: manifest.schema_name().to_string(),
         description,
         version: manifest.source_version().to_string(),
-        inputs: collect_source_inputs_value(&root)
-            .map(|inputs| inputs.into_iter().map(proto_input_spec).collect())
-            .map_err(|error| AppError::InvalidInput(error.to_string()))?,
+        inputs,
         installed,
         origin: origin as i32,
     })
 }
 
-fn proto_input_spec(input: ManifestInputSpec) -> SourceInputSpec {
+fn proto_input_spec(input: InputSpec) -> SourceInputSpec {
     SourceInputSpec {
         key: input.key,
         kind: proto_input_kind(input.kind) as i32,
         required: input.required,
         default_value: input.default_value,
+        help: input.help.unwrap_or_default(),
     }
 }
 
-fn proto_input_kind(kind: ManifestInputKind) -> SourceInputKind {
+fn proto_input_kind(kind: InputKind) -> SourceInputKind {
     match kind {
-        ManifestInputKind::Variable => SourceInputKind::Variable,
-        ManifestInputKind::Secret => SourceInputKind::Secret,
+        InputKind::Variable => SourceInputKind::Variable,
+        InputKind::Secret => SourceInputKind::Secret,
     }
 }
 
@@ -206,5 +208,44 @@ tables:
         )
         .expect_err("legacy schema field should fail");
         assert!(error.to_string().contains("unknown field `schema`"));
+    }
+
+    #[test]
+    fn describe_manifest_attaches_onboarding_help_to_inputs() {
+        let source = describe_manifest(
+            r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: "{{variable.API_BASE|https://example.com}}"
+auth:
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{secret.API_TOKEN}}
+onboarding:
+  input_help:
+    API_TOKEN: "Create a token at https://example.com/settings/tokens"
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    response: {}
+    columns:
+      - name: id
+        type: Utf8
+"#,
+            coral_api::v1::SourceOrigin::Imported,
+            false,
+        )
+        .expect("describe manifest");
+        assert_eq!(source.inputs[0].help, "");
+        assert_eq!(
+            source.inputs[1].help,
+            "Create a token at https://example.com/settings/tokens"
+        );
     }
 }

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -3,10 +3,7 @@
 use std::collections::BTreeSet;
 
 use coral_api::v1::{AvailableSource, SourceInputKind, SourceInputSpec, SourceOrigin, Workspace};
-use coral_spec::{
-    InputSpec, InputKind, collect_source_inputs_value, parse_source_manifest_value,
-};
-use serde_yaml::Value;
+use coral_spec::{InputSpec, InputKind, collect_inputs, parse_source_manifest_yaml};
 
 use crate::bootstrap::AppError;
 
@@ -56,13 +53,14 @@ pub(crate) fn describe_manifest(
     origin: SourceOrigin,
     installed: bool,
 ) -> Result<AvailableSource, AppError> {
-    let root: Value = serde_yaml::from_str(manifest_yaml)?;
-    let manifest = parse_source_manifest_value(serde_json::to_value(&root)?)
+    let manifest = parse_source_manifest_yaml(manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-    let description = manifest_description(&root);
-    let inputs = collect_source_inputs_value(&root)
-        .map(|inputs| inputs.into_iter().map(proto_input_spec).collect())
-        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    let description = manifest_description_yaml(manifest_yaml);
+    let inputs: Vec<SourceInputSpec> = collect_inputs(&manifest)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?
+        .into_iter()
+        .map(proto_input_spec)
+        .collect();
     Ok(AvailableSource {
         name: manifest.schema_name().to_string(),
         description,
@@ -90,9 +88,13 @@ fn proto_input_kind(kind: InputKind) -> SourceInputKind {
     }
 }
 
-fn manifest_description(root: &Value) -> String {
+fn manifest_description_yaml(manifest_yaml: &str) -> String {
+    let root: serde_yaml::Value = match serde_yaml::from_str(manifest_yaml) {
+        Ok(v) => v,
+        Err(_) => return String::new(),
+    };
     root.get("description")
-        .and_then(Value::as_str)
+        .and_then(serde_yaml::Value::as_str)
         .unwrap_or_default()
         .to_string()
 }

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 
 use coral_api::v1::{AvailableSource, SourceInputKind, SourceInputSpec, SourceOrigin, Workspace};
-use coral_spec::{InputSpec, InputKind, collect_inputs, parse_source_manifest_yaml};
+use coral_spec::{InputKind, InputSpec, collect_inputs, parse_source_manifest_yaml};
 
 use crate::bootstrap::AppError;
 
@@ -55,7 +55,6 @@ pub(crate) fn describe_manifest(
 ) -> Result<AvailableSource, AppError> {
     let manifest = parse_source_manifest_yaml(manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
-    let description = manifest_description_yaml(manifest_yaml);
     let inputs: Vec<SourceInputSpec> = collect_inputs(&manifest)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?
         .into_iter()
@@ -63,7 +62,7 @@ pub(crate) fn describe_manifest(
         .collect();
     Ok(AvailableSource {
         name: manifest.schema_name().to_string(),
-        description,
+        description: manifest.source_description().to_string(),
         version: manifest.source_version().to_string(),
         inputs,
         installed,
@@ -86,17 +85,6 @@ fn proto_input_kind(kind: InputKind) -> SourceInputKind {
         InputKind::Variable => SourceInputKind::Variable,
         InputKind::Secret => SourceInputKind::Secret,
     }
-}
-
-fn manifest_description_yaml(manifest_yaml: &str) -> String {
-    let root: serde_yaml::Value = match serde_yaml::from_str(manifest_yaml) {
-        Ok(v) => v,
-        Err(_) => return String::new(),
-    };
-    root.get("description")
-        .and_then(serde_yaml::Value::as_str)
-        .unwrap_or_default()
-        .to_string()
 }
 
 #[cfg(test)]

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -147,7 +147,7 @@ async fn main() -> Result<(), anyhow::Error> {
                 let inputs = available
                     .inputs
                     .iter()
-                    .map(source_ops::manifest_input_from_proto)
+                    .map(source_ops::input_from_proto)
                     .collect::<Result<Vec<_>, _>>()?;
                 let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
                 let response =
@@ -182,7 +182,6 @@ async fn main() -> Result<(), anyhow::Error> {
 
     Ok(())
 }
-
 fn print_batches(
     batches: &[arrow::record_batch::RecordBatch],
     format: OutputFormat,

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -147,7 +147,7 @@ async fn run_installed_source_menu(
             let inputs = source
                 .inputs
                 .iter()
-                .map(source_ops::manifest_input_from_proto)
+                .map(source_ops::input_from_proto)
                 .collect::<Result<Vec<_>, _>>()?;
             let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
             let result =
@@ -168,7 +168,7 @@ async fn run_add_bundled_source(
     let inputs = source
         .inputs
         .iter()
-        .map(source_ops::manifest_input_from_proto)
+        .map(source_ops::input_from_proto)
         .collect::<Result<Vec<_>, _>>()?;
     let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
     let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -7,7 +7,8 @@ use coral_api::v1::{
     SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
 };
 use coral_client::{AppClient, default_workspace};
-use coral_spec::{InputKind, InputSpec, collect_source_inputs_yaml};
+use coral_spec::{InputKind, InputSpec, collect_inputs, parse_source_manifest_yaml};
+use dialoguer::console::Style;
 use dialoguer::{Input, Password, theme::ColorfulTheme};
 use tonic::Request;
 
@@ -119,7 +120,7 @@ pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Erro
 }
 
 pub(crate) fn prompt_for_inputs(
-    inputs: &[ManifestInputSpec],
+    inputs: &[InputSpec],
 ) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
     let mut variables = Vec::new();
     let mut secrets = Vec::new();
@@ -144,7 +145,7 @@ pub(crate) fn prompt_for_inputs(
 
 pub(crate) fn input_from_proto(
     input: &SourceInputSpec,
-) -> Result<ManifestInputSpec, anyhow::Error> {
+) -> Result<InputSpec, anyhow::Error> {
     let kind = match SourceInputKind::try_from(input.kind) {
         Ok(SourceInputKind::Variable) => InputKind::Variable,
         Ok(SourceInputKind::Secret) => InputKind::Secret,
@@ -167,9 +168,10 @@ pub(crate) fn input_from_proto(
 
 pub(crate) fn load_manifest_inputs(
     path: &Path,
-) -> Result<(String, Vec<ManifestInputSpec>), anyhow::Error> {
+) -> Result<(String, Vec<InputSpec>), anyhow::Error> {
     let manifest_yaml = std::fs::read_to_string(path)?;
-    let inputs = collect_source_inputs_yaml(&manifest_yaml)?;
+    let manifest = parse_source_manifest_yaml(&manifest_yaml)?;
+    let inputs = collect_inputs(&manifest)?;
     Ok((manifest_yaml, inputs))
 }
 
@@ -195,7 +197,11 @@ pub(crate) fn print_validation_success(
     Ok(())
 }
 
-fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, anyhow::Error> {
+fn prompt_variable(input: &InputSpec) -> Result<Option<SourceVariable>, anyhow::Error> {
+    if let Some(help) = &input.help {
+        let dim = Style::new().dim();
+        eprintln!("{}", dim.apply_to(help));
+    }
     let theme = ColorfulTheme::default();
     let prompt = if input.default_value.is_empty() {
         input.key.clone()
@@ -215,7 +221,11 @@ fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, 
     }))
 }
 
-fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyhow::Error> {
+fn prompt_secret(input: &InputSpec) -> Result<Option<SourceSecret>, anyhow::Error> {
+    if let Some(help) = &input.help {
+        let dim = Style::new().dim();
+        eprintln!("{}", dim.apply_to(help));
+    }
     let theme = ColorfulTheme::default();
     let prompt = if input.default_value.is_empty() {
         input.key.clone()
@@ -236,7 +246,7 @@ fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyh
 }
 
 pub(crate) fn finalize_input_value(
-    input: &ManifestInputSpec,
+    input: &InputSpec,
     value: String,
     kind_label: &str,
 ) -> Result<Option<String>, anyhow::Error> {
@@ -257,17 +267,18 @@ pub(crate) fn finalize_input_value(
 
 #[cfg(test)]
 mod tests {
-    use coral_spec::{InputKind, ManifestInputSpec};
+    use coral_spec::{InputKind, InputSpec};
 
     use super::finalize_input_value;
 
     #[test]
     fn empty_input_uses_default_value() {
-        let input = ManifestInputSpec {
+        let input = InputSpec {
             key: "API_BASE".to_string(),
             kind: InputKind::Variable,
             required: false,
             default_value: "https://example.com".to_string(),
+            help: None,
         };
         assert_eq!(
             finalize_input_value(&input, String::new(), "source variable")
@@ -278,11 +289,12 @@ mod tests {
 
     #[test]
     fn empty_required_input_without_default_is_rejected() {
-        let input = ManifestInputSpec {
+        let input = InputSpec {
             key: "API_TOKEN".to_string(),
             kind: InputKind::Secret,
             required: true,
             default_value: String::new(),
+            help: None,
         };
         let error = finalize_input_value(&input, String::new(), "source secret")
             .expect_err("required empty input should fail");

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -143,9 +143,7 @@ pub(crate) fn prompt_for_inputs(
     Ok((variables, secrets))
 }
 
-pub(crate) fn input_from_proto(
-    input: &SourceInputSpec,
-) -> Result<InputSpec, anyhow::Error> {
+pub(crate) fn input_from_proto(input: &SourceInputSpec) -> Result<InputSpec, anyhow::Error> {
     let kind = match SourceInputKind::try_from(input.kind) {
         Ok(SourceInputKind::Variable) => InputKind::Variable,
         Ok(SourceInputKind::Secret) => InputKind::Secret,
@@ -166,9 +164,7 @@ pub(crate) fn input_from_proto(
     })
 }
 
-pub(crate) fn load_manifest_inputs(
-    path: &Path,
-) -> Result<(String, Vec<InputSpec>), anyhow::Error> {
+pub(crate) fn load_manifest_inputs(path: &Path) -> Result<(String, Vec<InputSpec>), anyhow::Error> {
     let manifest_yaml = std::fs::read_to_string(path)?;
     let manifest = parse_source_manifest_yaml(&manifest_yaml)?;
     let inputs = collect_inputs(&manifest)?;

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -7,7 +7,7 @@ use coral_api::v1::{
     SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
 };
 use coral_client::{AppClient, default_workspace};
-use coral_spec::{ManifestInputKind, ManifestInputSpec, collect_source_inputs_yaml};
+use coral_spec::{InputKind, InputSpec, collect_source_inputs_yaml};
 use dialoguer::{Input, Password, theme::ColorfulTheme};
 use tonic::Request;
 
@@ -126,12 +126,12 @@ pub(crate) fn prompt_for_inputs(
 
     for input in inputs {
         match input.kind {
-            ManifestInputKind::Variable => {
+            InputKind::Variable => {
                 if let Some(variable) = prompt_variable(input)? {
                     variables.push(variable);
                 }
             }
-            ManifestInputKind::Secret => {
+            InputKind::Secret => {
                 if let Some(secret) = prompt_secret(input)? {
                     secrets.push(secret);
                 }
@@ -142,21 +142,26 @@ pub(crate) fn prompt_for_inputs(
     Ok((variables, secrets))
 }
 
-pub(crate) fn manifest_input_from_proto(
+pub(crate) fn input_from_proto(
     input: &SourceInputSpec,
 ) -> Result<ManifestInputSpec, anyhow::Error> {
     let kind = match SourceInputKind::try_from(input.kind) {
-        Ok(SourceInputKind::Variable) => ManifestInputKind::Variable,
-        Ok(SourceInputKind::Secret) => ManifestInputKind::Secret,
+        Ok(SourceInputKind::Variable) => InputKind::Variable,
+        Ok(SourceInputKind::Secret) => InputKind::Secret,
         Ok(SourceInputKind::Unspecified) | Err(_) => {
             return Err(anyhow::anyhow!("unknown input kind for '{}'", input.key));
         }
     };
-    Ok(ManifestInputSpec {
+    Ok(InputSpec {
         key: input.key.clone(),
         kind,
         required: input.required,
         default_value: input.default_value.clone(),
+        help: if input.help.is_empty() {
+            None
+        } else {
+            Some(input.help.clone())
+        },
     })
 }
 
@@ -252,7 +257,7 @@ pub(crate) fn finalize_input_value(
 
 #[cfg(test)]
 mod tests {
-    use coral_spec::{ManifestInputKind, ManifestInputSpec};
+    use coral_spec::{InputKind, ManifestInputSpec};
 
     use super::finalize_input_value;
 
@@ -260,7 +265,7 @@ mod tests {
     fn empty_input_uses_default_value() {
         let input = ManifestInputSpec {
             key: "API_BASE".to_string(),
-            kind: ManifestInputKind::Variable,
+            kind: InputKind::Variable,
             required: false,
             default_value: "https://example.com".to_string(),
         };
@@ -275,7 +280,7 @@ mod tests {
     fn empty_required_input_without_default_is_rejected() {
         let input = ManifestInputSpec {
             key: "API_TOKEN".to_string(),
-            kind: ManifestInputKind::Secret,
+            kind: InputKind::Secret,
             required: true,
             default_value: String::new(),
         };

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 use std::collections::HashSet;
 use url::Url;
 
-use crate::common::{build_source_manifest_common, parse_manifest_data_type};
+use crate::common::{Onboarding, build_source_manifest_common, parse_manifest_data_type};
 use crate::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ParsedTemplate, Result, SourceBackend,
     SourceManifestCommon, TableCommon, validate_columns, validate_filters_and_column_exprs,
@@ -45,6 +45,7 @@ struct RawFileSourceManifest {
     description: Option<String>,
     backend: SourceBackend,
     tables: Vec<RawFileTableSpec>,
+    onboarding: Option<Onboarding>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -280,8 +281,9 @@ impl ParquetSourceManifest {
             description: _description,
             backend: _backend,
             tables,
+            onboarding,
         } = raw;
-        let common = build_source_manifest_common(dsl_version, name, version);
+        let common = build_source_manifest_common(dsl_version, name, version, onboarding);
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_parquet(&common.name))
@@ -310,8 +312,9 @@ impl JsonlSourceManifest {
             description: _description,
             backend: _backend,
             tables,
+            onboarding,
         } = raw;
-        let common = build_source_manifest_common(dsl_version, name, version);
+        let common = build_source_manifest_common(dsl_version, name, version, onboarding);
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_jsonl(&common.name))

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -278,12 +278,18 @@ impl ParquetSourceManifest {
             dsl_version,
             name,
             version,
-            description: _description,
+            description,
             backend: _backend,
             tables,
             onboarding,
         } = raw;
-        let common = build_source_manifest_common(dsl_version, name, version, onboarding);
+        let common = build_source_manifest_common(
+            dsl_version,
+            name,
+            version,
+            description.unwrap_or_default(),
+            onboarding,
+        );
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_parquet(&common.name))
@@ -309,12 +315,18 @@ impl JsonlSourceManifest {
             dsl_version,
             name,
             version,
-            description: _description,
+            description,
             backend: _backend,
             tables,
             onboarding,
         } = raw;
-        let common = build_source_manifest_common(dsl_version, name, version, onboarding);
+        let common = build_source_manifest_common(
+            dsl_version,
+            name,
+            version,
+            description.unwrap_or_default(),
+            onboarding,
+        );
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_jsonl(&common.name))

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeSet, HashSet};
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::common::build_source_manifest_common;
+use crate::common::{Onboarding, build_source_manifest_common};
 use crate::{
     AuthSpec, ColumnSpec, FilterSpec, ManifestError, PaginationSpec, ParsedTemplate,
     RequestRouteSpec, RequestSpec, ResponseSpec, Result, SourceBackend, SourceManifestCommon,
@@ -46,6 +46,7 @@ struct RawHttpSourceManifest {
     #[serde(default)]
     auth: AuthSpec,
     tables: Vec<RawHttpTableSpec>,
+    onboarding: Option<Onboarding>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -196,8 +197,9 @@ impl HttpSourceManifest {
             base_url,
             auth,
             tables,
+            onboarding,
         } = raw;
-        let common = build_source_manifest_common(dsl_version, name, version);
+        let common = build_source_manifest_common(dsl_version, name, version, onboarding);
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -192,14 +192,20 @@ impl HttpSourceManifest {
             dsl_version,
             name,
             version,
-            description: _description,
+            description,
             backend: _backend,
             base_url,
             auth,
             tables,
             onboarding,
         } = raw;
-        let common = build_source_manifest_common(dsl_version, name, version, onboarding);
+        let common = build_source_manifest_common(
+            dsl_version,
+            name,
+            version,
+            description.unwrap_or_default(),
+            onboarding,
+        );
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -9,10 +9,43 @@
 //! source identity, filters, request templating, response extraction, typed
 //! columns, and pagination.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{ManifestError, ParsedTemplate, Result};
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct Onboarding {
+    instructions: Option<String>,
+    #[serde(default)]
+    input_help: Option<BTreeMap<String, String>>,
+}
+
+impl Onboarding {
+    pub fn instructions(&self) -> Option<&str> {
+        self.instructions.as_deref()
+    }
+
+    pub fn help_for_input(&self, key: &str) -> Option<&str> {
+        self.input_help.as_ref()?.get(key).map(String::as_str)
+    }
+}
+
+pub fn collect_source_onboarding_value(root: &serde_yaml::Value) -> Result<Option<Onboarding>> {
+    let Some(onboarding) = root.get("onboarding") else {
+        return Ok(None);
+    };
+    let onboarding = serde_json::to_value(onboarding).map_err(ManifestError::deserialize)?;
+    let onboarding = serde_json::from_value(onboarding).map_err(ManifestError::deserialize)?;
+    Ok(Some(onboarding))
+}
+
+pub fn collect_source_onboarding_yaml(raw: &str) -> Result<Option<Onboarding>> {
+    let root: serde_yaml::Value = serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
+    collect_source_onboarding_value(&root)
+}
 
 /// Common top-level source metadata shared by every backend source spec.
 #[derive(Debug, Clone)]
@@ -20,6 +53,7 @@ pub struct SourceManifestCommon {
     pub dsl_version: u32,
     pub name: String,
     pub version: String,
+    pub onboarding: Option<Onboarding>,
 }
 
 /// Supported source-spec backends.
@@ -46,11 +80,13 @@ pub(crate) fn build_source_manifest_common(
     dsl_version: u32,
     name: String,
     version: String,
+    onboarding: Option<Onboarding>,
 ) -> SourceManifestCommon {
     SourceManifestCommon {
         dsl_version,
         name,
         version,
+        onboarding,
     }
 }
 
@@ -617,6 +653,52 @@ mod tests {
     use super::*;
     use crate::backends::http::test_http_table_spec;
     use std::collections::HashSet;
+
+    #[test]
+    fn extracts_onboarding_help() {
+        let manifest = r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+onboarding:
+  instructions: Setup docs
+  input_help:
+    API_TOKEN: "Create a token at https://example.com/settings/tokens"
+tables: []
+"#;
+
+        let onboarding = collect_source_onboarding_yaml(manifest)
+            .expect("onboarding")
+            .expect("onboarding should exist");
+        assert_eq!(onboarding.instructions(), Some("Setup docs"));
+        assert_eq!(
+            onboarding.help_for_input("API_TOKEN"),
+            Some("Create a token at https://example.com/settings/tokens")
+        );
+        assert_eq!(onboarding.help_for_input("API_BASE"), None);
+    }
+
+    #[test]
+    fn rejects_onboarding_input_without_help() {
+        let root: serde_yaml::Value = serde_yaml::from_str(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+onboarding:
+  input_help:
+    API_TOKEN: {}
+tables: []
+",
+        )
+        .expect("yaml");
+
+        let error =
+            collect_source_onboarding_value(&root).expect_err("non-string input help should fail");
+        assert!(error.to_string().contains("invalid type"));
+    }
 
     #[test]
     fn resolve_request_returns_default_when_no_routes() {

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -655,52 +655,6 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn extracts_onboarding_help() {
-        let manifest = r#"
-name: demo
-version: 1.0.0
-dsl_version: 3
-backend: http
-onboarding:
-  instructions: Setup docs
-  input_help:
-    API_TOKEN: "Create a token at https://example.com/settings/tokens"
-tables: []
-"#;
-
-        let onboarding = collect_source_onboarding_yaml(manifest)
-            .expect("onboarding")
-            .expect("onboarding should exist");
-        assert_eq!(onboarding.instructions(), Some("Setup docs"));
-        assert_eq!(
-            onboarding.help_for_input("API_TOKEN"),
-            Some("Create a token at https://example.com/settings/tokens")
-        );
-        assert_eq!(onboarding.help_for_input("API_BASE"), None);
-    }
-
-    #[test]
-    fn rejects_onboarding_input_without_help() {
-        let root: serde_yaml::Value = serde_yaml::from_str(
-            r"
-name: demo
-version: 1.0.0
-dsl_version: 3
-backend: http
-onboarding:
-  input_help:
-    API_TOKEN: {}
-tables: []
-",
-        )
-        .expect("yaml");
-
-        let error =
-            collect_source_onboarding_value(&root).expect_err("non-string input help should fail");
-        assert!(error.to_string().contains("invalid type"));
-    }
-
-    #[test]
     fn resolve_request_returns_default_when_no_routes() {
         let table = test_http_table_spec(
             "items",

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -53,6 +53,7 @@ pub struct SourceManifestCommon {
     pub dsl_version: u32,
     pub name: String,
     pub version: String,
+    pub description: String,
     pub onboarding: Option<Onboarding>,
 }
 
@@ -80,12 +81,14 @@ pub(crate) fn build_source_manifest_common(
     dsl_version: u32,
     name: String,
     version: String,
+    description: String,
     onboarding: Option<Onboarding>,
 ) -> SourceManifestCommon {
     SourceManifestCommon {
         dsl_version,
         name,
         version,
+        description,
         onboarding,
     }
 }

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -79,6 +79,9 @@ pub fn collect_source_inputs_yaml(raw: &str) -> Result<Vec<InputSpec>> {
     collect_source_inputs_value(&root)
 }
 
+/// Keys containing metadata that should not be walked for input discovery.
+const METADATA_KEYS: &[&str] = &["onboarding"];
+
 fn collect_from_value(
     value: &Value,
     ordered: &mut Vec<InputSpec>,
@@ -87,8 +90,13 @@ fn collect_from_value(
     match value {
         Value::Mapping(map) => {
             collect_from_mapping(map, ordered, seen)?;
-            for nested in map.values() {
-                collect_from_value(nested, ordered, seen)?;
+            for (key, nested) in map {
+                let skip = key
+                    .as_str()
+                    .is_some_and(|k| METADATA_KEYS.contains(&k));
+                if !skip {
+                    collect_from_value(nested, ordered, seen)?;
+                }
             }
         }
         Value::Sequence(items) => {
@@ -286,6 +294,35 @@ tables: []
         assert_eq!(
             inputs[1].help.as_deref(),
             Some("Create a token at https://example.com/settings/tokens")
+        );
+    }
+
+    #[test]
+    fn onboarding_template_syntax_does_not_register_phantom_inputs() {
+        let manifest = r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: "{{variable.API_BASE|https://example.com}}"
+onboarding:
+  input_help:
+    API_BASE: "Use {{secret.PHANTOM}} to authenticate"
+auth:
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{secret.API_TOKEN}}
+tables: []
+"#;
+
+        let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
+        assert_eq!(inputs.len(), 2);
+        assert_eq!(inputs[0].key, "API_BASE");
+        assert_eq!(inputs[1].key, "API_TOKEN");
+        assert!(
+            !inputs.iter().any(|i| i.key == "PHANTOM"),
+            "onboarding metadata should not register inputs"
         );
     }
 

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -294,12 +294,13 @@ tables:
 
     #[test]
     fn collects_input_help_from_onboarding() {
-        let inputs = collect_source_inputs_yaml(
+        let manifest = parse_source_manifest_yaml(
             r#"
 name: demo
 version: 1.0.0
 dsl_version: 3
 backend: http
+base_url: "https://example.com"
 onboarding:
   input_help:
     API_TOKEN: "Create a token at https://example.com/settings/tokens"
@@ -308,10 +309,20 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{secret.API_TOKEN}}
-tables: []
+tables:
+  - name: items
+    description: Demo items
+    request:
+      method: GET
+      path: /items
+    columns:
+      - name: id
+        type: Utf8
 "#,
         )
-        .expect("inputs");
+        .expect("parse");
+
+        let inputs = collect_inputs(&manifest).expect("collect");
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].kind, InputKind::Secret);
         assert_eq!(

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -1,35 +1,25 @@
-//! Extracts interactive source inputs from source-spec documents.
+//! Extracts interactive source inputs from validated source-spec models.
 //!
-//! These helpers walk the source-spec DSL and collect install-time inputs in
-//! declaration order. They stay close to the authored file format so callers
-//! can use them before any app- or transport-level mapping.
+//! Walks the parsed, typed source-spec model and collects install-time inputs
+//! in declaration order. Input help is sourced from the parsed `Onboarding`
+//! metadata — no raw YAML re-scraping.
 
 use std::collections::BTreeMap;
 
-use serde_yaml::{Mapping, Value};
-
-use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
+use crate::{
+    HeaderSpec, ManifestError, ParsedTemplate, RequestRouteSpec, RequestSpec, Result,
+    TemplateNamespace, ValidatedSourceManifest, ValueSourceSpec,
+};
 
 /// The kind of interactive input required by one validated source spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum InputKind {
+pub enum InputKind {
+    /// A non-secret input persisted in source variables.
     Variable,
+    /// A secret input persisted separately from source variables.
     Secret,
 }
-
-impl InputKind {
-    fn as_manifest_kind(self) -> InputKind {
-        match self {
-            Self::Variable => InputKind::Variable,
-            Self::Secret => InputKind::Secret,
-        }
-    }
-}
-
 /// One install-time input extracted from a validated source spec.
-///
-/// The app and CLI can map this into prompts, persisted variables, or secret
-/// collection flows without depending on protobuf-specific types.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InputSpec {
     /// The source-spec-declared input key.
@@ -44,221 +34,148 @@ pub struct InputSpec {
     pub help: Option<String>,
 }
 
-#[derive(Debug, Clone)]
-struct InputState {
-    kind: InputKind,
-    default_value: Option<String>,
-}
-
-/// Collect interactive source inputs from structured source-spec data.
+/// Collect interactive source inputs from a validated source manifest.
 ///
 /// # Errors
 ///
-/// Returns a [`ManifestError`] when the source spec contains unsupported legacy
-/// source-input forms or malformed template tokens.
-pub fn collect_source_inputs_value(root: &Value) -> Result<Vec<InputSpec>> {
-    let input_help = collect_input_help(root)?;
-    let mut ordered = Vec::new();
-    let mut seen = BTreeMap::<String, InputState>::new();
-    collect_from_value(root, &mut ordered, &mut seen)?;
-    for input in &mut ordered {
-        input.help = input_help.get(&input.key).cloned();
+/// Returns a [`ManifestError`] if the same input key is declared with
+/// inconsistent kind or default value.
+pub fn collect_inputs(manifest: &ValidatedSourceManifest) -> Result<Vec<InputSpec>> {
+    InputCollector::new().collect(manifest)
+}
+
+struct InputCollector {
+    ordered: Vec<InputSpec>,
+    seen: BTreeMap<String, (InputKind, Option<String>)>,
+}
+
+impl InputCollector {
+    fn new() -> Self {
+        Self {
+            ordered: Vec::new(),
+            seen: BTreeMap::new(),
+        }
     }
-    Ok(ordered)
-}
 
-/// Collect interactive source inputs from raw source-spec YAML.
-///
-/// # Errors
-///
-/// Returns a [`ManifestError`] when the YAML cannot be parsed or when the
-/// source spec contains unsupported legacy source-input forms or malformed
-/// template tokens.
-pub fn collect_source_inputs_yaml(raw: &str) -> Result<Vec<InputSpec>> {
-    let root: Value = serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
-    collect_source_inputs_value(&root)
-}
+    fn collect(mut self, manifest: &ValidatedSourceManifest) -> Result<Vec<InputSpec>> {
+        if let Some(http) = manifest.as_http() {
+            self.visit_template(&http.base_url)?;
 
-/// Keys containing metadata that should not be walked for input discovery.
-const METADATA_KEYS: &[&str] = &["onboarding"];
+            for header in &http.auth.headers {
+                self.visit_value_source(&header.value)?;
+            }
 
-fn collect_from_value(
-    value: &Value,
-    ordered: &mut Vec<InputSpec>,
-    seen: &mut BTreeMap<String, InputState>,
-) -> Result<()> {
-    match value {
-        Value::Mapping(map) => {
-            collect_from_mapping(map, ordered, seen)?;
-            for (key, nested) in map {
-                let skip = key
-                    .as_str()
-                    .is_some_and(|k| METADATA_KEYS.contains(&k));
-                if !skip {
-                    collect_from_value(nested, ordered, seen)?;
+            for table in &http.tables {
+                self.visit_request(&table.request)?;
+                for route in &table.requests {
+                    self.visit_route(route)?;
                 }
             }
         }
-        Value::Sequence(items) => {
-            for item in items {
-                collect_from_value(item, ordered, seen)?;
+
+        if let Some(onboarding) = manifest.common().onboarding.as_ref() {
+            for input in &mut self.ordered {
+                input.help = onboarding.help_for_input(&input.key).map(str::to_string);
             }
         }
-        Value::String(raw) => collect_from_template(raw, ordered, seen)?,
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::Tagged(_) => {}
+
+        Ok(self.ordered)
     }
-    Ok(())
-}
 
-fn collect_input_help(root: &Value) -> Result<BTreeMap<String, String>> {
-    let Some(root) = root.as_mapping() else {
-        return Ok(BTreeMap::new());
-    };
-    let Some(onboarding) = root
-        .get(Value::String("onboarding".to_string()))
-        .and_then(Value::as_mapping)
-    else {
-        return Ok(BTreeMap::new());
-    };
-    let Some(input_help) = onboarding
-        .get(Value::String("input_help".to_string()))
-        .and_then(Value::as_mapping)
-    else {
-        return Ok(BTreeMap::new());
-    };
-
-    let mut help = BTreeMap::new();
-    for (key, value) in input_help {
-        let key = key.as_str().ok_or_else(|| {
-            ManifestError::validation("onboarding.input_help key must be a string")
-        })?;
-        let value = value.as_str().ok_or_else(|| {
-            ManifestError::validation(format!(
-                "onboarding.input_help.{key} value must be a string"
-            ))
-        })?;
-        help.insert(key.to_string(), value.to_string());
-    }
-    Ok(help)
-}
-
-fn collect_from_mapping(
-    map: &Mapping,
-    ordered: &mut Vec<InputSpec>,
-    seen: &mut BTreeMap<String, InputState>,
-) -> Result<()> {
-    let Some(from) = map
-        .get(Value::String("from".to_string()))
-        .and_then(Value::as_str)
-    else {
-        return Ok(());
-    };
-
-    let kind = match from {
-        "secret" => Some(InputKind::Secret),
-        "variable" => Some(InputKind::Variable),
-        "env" | "env_any" | "secret_any" | "variable_any" => {
-            return Err(ManifestError::validation(format!(
-                "unsupported manifest input source '{from}'"
-            )));
-        }
-        _ => None,
-    };
-    let Some(kind) = kind else {
-        return Ok(());
-    };
-
-    let key = map
-        .get(Value::String("key".to_string()))
-        .and_then(Value::as_str)
-        .ok_or_else(|| {
-            ManifestError::validation(format!("manifest '{from}' input is missing key"))
-        })?;
-    let default_value = map
-        .get(Value::String("default".to_string()))
-        .and_then(Value::as_str)
-        .map(ToString::to_string);
-    register_input(key, kind, default_value, ordered, seen)
-}
-
-fn collect_from_template(
-    template: &str,
-    ordered: &mut Vec<InputSpec>,
-    seen: &mut BTreeMap<String, InputState>,
-) -> Result<()> {
-    let template = ParsedTemplate::parse(template)?;
-    for token in template.tokens() {
-        match token.namespace() {
-            TemplateNamespace::Secret => {
-                register_input(
-                    token.key(),
-                    InputKind::Secret,
-                    token.default_value().map(ToString::to_string),
-                    ordered,
-                    seen,
-                )?;
-            }
-            TemplateNamespace::Variable => {
-                register_input(
-                    token.key(),
-                    InputKind::Variable,
-                    token.default_value().map(ToString::to_string),
-                    ordered,
-                    seen,
-                )?;
-            }
-            TemplateNamespace::Env => {
+    fn register(&mut self, key: &str, kind: InputKind, default_value: Option<String>) -> Result<()> {
+        if let Some(existing) = self.seen.get(key) {
+            if existing.0 != kind || existing.1 != default_value {
                 return Err(ManifestError::validation(format!(
-                    "unsupported template namespace '{}'",
-                    token.raw_key()
+                    "manifest input '{key}' is declared inconsistently"
                 )));
             }
-            TemplateNamespace::Filter | TemplateNamespace::State | TemplateNamespace::Other(_) => {}
+            return Ok(());
         }
-    }
-    Ok(())
-}
 
-fn register_input(
-    key: &str,
-    kind: InputKind,
-    default_value: Option<String>,
-    ordered: &mut Vec<InputSpec>,
-    seen: &mut BTreeMap<String, InputState>,
-) -> Result<()> {
-    if let Some(existing) = seen.get(key) {
-        if existing.kind != kind || existing.default_value != default_value {
-            return Err(ManifestError::validation(format!(
-                "manifest input '{key}' is declared inconsistently"
-            )));
-        }
-        return Ok(());
-    }
-
-    ordered.push(InputSpec {
-        key: key.to_string(),
-        kind: kind.as_manifest_kind(),
-        required: default_value.is_none(),
-        default_value: default_value.clone().unwrap_or_default(),
-        help: None,
-    });
-    seen.insert(
-        key.to_string(),
-        InputState {
+        self.ordered.push(InputSpec {
+            key: key.to_string(),
             kind,
-            default_value,
-        },
-    );
-    Ok(())
+            required: default_value.is_none(),
+            default_value: default_value.clone().unwrap_or_default(),
+            help: None,
+        });
+        self.seen.insert(key.to_string(), (kind, default_value));
+        Ok(())
+    }
+
+    fn visit_template(&mut self, template: &ParsedTemplate) -> Result<()> {
+        for token in template.tokens() {
+            match token.namespace() {
+                TemplateNamespace::Secret => {
+                    self.register(
+                        token.key(),
+                        InputKind::Secret,
+                        token.default_value().map(str::to_string),
+                    )?;
+                }
+                TemplateNamespace::Variable => {
+                    self.register(
+                        token.key(),
+                        InputKind::Variable,
+                        token.default_value().map(str::to_string),
+                    )?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    fn visit_value_source(&mut self, source: &ValueSourceSpec) -> Result<()> {
+        match source {
+            ValueSourceSpec::Secret { key, default } => {
+                self.register(key, InputKind::Secret, default.clone())?;
+            }
+            ValueSourceSpec::Variable { key, default } => {
+                self.register(key, InputKind::Variable, default.clone())?;
+            }
+            ValueSourceSpec::Template { template } => {
+                self.visit_template(template)?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn visit_headers(&mut self, headers: &[HeaderSpec]) -> Result<()> {
+        for header in headers {
+            self.visit_value_source(&header.value)?;
+        }
+        Ok(())
+    }
+
+    fn visit_request(&mut self, request: &RequestSpec) -> Result<()> {
+        self.visit_template(&request.path)?;
+        for param in &request.query {
+            self.visit_value_source(&param.value)?;
+        }
+        for field in &request.body {
+            self.visit_value_source(&field.value)?;
+        }
+        self.visit_headers(&request.headers)?;
+        Ok(())
+    }
+
+    fn visit_route(&mut self, route: &RequestRouteSpec) -> Result<()> {
+        self.visit_request(&route.request)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{InputKind, collect_source_inputs_yaml};
+    use crate::parse_source_manifest_yaml;
+
+    use super::{InputKind, collect_inputs};
 
     #[test]
     fn extracts_variables_and_secrets_in_manifest_order() {
-        let manifest = r#"
+        let manifest = parse_source_manifest_yaml(
+            r#"
 name: demo
 version: 1.0.0
 dsl_version: 3
@@ -273,10 +190,20 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{secret.API_TOKEN}}
-tables: []
-"#;
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+"#,
+        )
+        .expect("parse");
 
-        let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
+        let inputs = collect_inputs(&manifest).expect("collect");
         assert_eq!(inputs.len(), 2);
 
         assert_eq!(inputs[0].key, "API_BASE");
@@ -298,8 +225,9 @@ tables: []
     }
 
     #[test]
-    fn onboarding_template_syntax_does_not_register_phantom_inputs() {
-        let manifest = r#"
+    fn onboarding_metadata_does_not_register_phantom_inputs() {
+        let manifest = parse_source_manifest_yaml(
+            r#"
 name: demo
 version: 1.0.0
 dsl_version: 3
@@ -313,10 +241,20 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{secret.API_TOKEN}}
-tables: []
-"#;
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    columns:
+      - name: id
+        type: Utf8
+"#,
+        )
+        .expect("parse");
 
-        let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
+        let inputs = collect_inputs(&manifest).expect("collect");
         assert_eq!(inputs.len(), 2);
         assert_eq!(inputs[0].key, "API_BASE");
         assert_eq!(inputs[1].key, "API_TOKEN");
@@ -327,17 +265,26 @@ tables: []
     }
 
     #[test]
-    fn rejects_legacy_env_inputs() {
-        let manifest = r#"
+    fn file_backend_returns_empty_inputs() {
+        let manifest = parse_source_manifest_yaml(
+            r#"
 name: demo
 version: 1.0.0
 dsl_version: 3
-backend: http
-base_url: "{{env.API_BASE}}"
-tables: []
-"#;
-        let error = collect_source_inputs_yaml(manifest).expect_err("legacy env unsupported");
-        assert!(error.to_string().contains("unsupported"));
+backend: parquet
+tables:
+  - name: data
+    description: Some data
+    source:
+      location: file:///tmp/demo/
+      glob: "**/*.parquet"
+    columns: []
+"#,
+        )
+        .expect("parse");
+
+        let inputs = collect_inputs(&manifest).expect("collect");
+        assert!(inputs.is_empty());
     }
 
     #[test]
@@ -367,3 +314,4 @@ tables: []
             Some("Create a token at https://example.com/settings/tokens")
         );
     }
+}

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -82,7 +82,12 @@ impl InputCollector {
         Ok(self.ordered)
     }
 
-    fn register(&mut self, key: &str, kind: InputKind, default_value: Option<String>) -> Result<()> {
+    fn register(
+        &mut self,
+        key: &str,
+        kind: InputKind,
+        default_value: Option<String>,
+    ) -> Result<()> {
         if let Some(existing) = self.seen.get(key) {
             if existing.0 != kind || existing.1 != default_value {
                 return Err(ManifestError::validation(format!(

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -12,7 +12,7 @@ use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
 /// The kind of interactive input required by one validated source spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ManifestInputKind {
+pub enum InputKind {
     /// A non-secret input persisted in source variables.
     Variable,
     /// A secret input persisted separately from source variables.
@@ -26,28 +26,30 @@ enum InputKind {
 }
 
 impl InputKind {
-    fn as_manifest_kind(self) -> ManifestInputKind {
+    fn as_manifest_kind(self) -> InputKind {
         match self {
-            Self::Variable => ManifestInputKind::Variable,
-            Self::Secret => ManifestInputKind::Secret,
+            Self::Variable => InputKind::Variable,
+            Self::Secret => InputKind::Secret,
         }
     }
 }
 
-/// One interactive input extracted from a validated source spec.
+/// One install-time input extracted from a validated source spec.
 ///
 /// The app and CLI can map this into prompts, persisted variables, or secret
 /// collection flows without depending on protobuf-specific types.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ManifestInputSpec {
+pub struct InputSpec {
     /// The source-spec-declared input key.
     pub key: String,
     /// Whether this input is a variable or a secret.
-    pub kind: ManifestInputKind,
+    pub kind: InputKind,
     /// Whether the user must provide an explicit value.
     pub required: bool,
     /// The source-spec-declared default value, if any.
     pub default_value: String,
+    /// Optional human-readable help describing how to acquire this value.
+    pub help: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -62,10 +64,14 @@ struct InputState {
 ///
 /// Returns a [`ManifestError`] when the source spec contains unsupported legacy
 /// source-input forms or malformed template tokens.
-pub fn collect_source_inputs_value(root: &Value) -> Result<Vec<ManifestInputSpec>> {
+pub fn collect_source_inputs_value(root: &Value) -> Result<Vec<InputSpec>> {
+    let input_help = collect_input_help(root)?;
     let mut ordered = Vec::new();
     let mut seen = BTreeMap::<String, InputState>::new();
     collect_from_value(root, &mut ordered, &mut seen)?;
+    for input in &mut ordered {
+        input.help = input_help.get(&input.key).cloned();
+    }
     Ok(ordered)
 }
 
@@ -76,14 +82,14 @@ pub fn collect_source_inputs_value(root: &Value) -> Result<Vec<ManifestInputSpec
 /// Returns a [`ManifestError`] when the YAML cannot be parsed or when the
 /// source spec contains unsupported legacy source-input forms or malformed
 /// template tokens.
-pub fn collect_source_inputs_yaml(raw: &str) -> Result<Vec<ManifestInputSpec>> {
+pub fn collect_source_inputs_yaml(raw: &str) -> Result<Vec<InputSpec>> {
     let root: Value = serde_yaml::from_str(raw).map_err(ManifestError::parse_yaml)?;
     collect_source_inputs_value(&root)
 }
 
 fn collect_from_value(
     value: &Value,
-    ordered: &mut Vec<ManifestInputSpec>,
+    ordered: &mut Vec<InputSpec>,
     seen: &mut BTreeMap<String, InputState>,
 ) -> Result<()> {
     match value {
@@ -104,9 +110,39 @@ fn collect_from_value(
     Ok(())
 }
 
+fn collect_input_help(root: &Value) -> Result<BTreeMap<String, String>> {
+    let Some(root) = root.as_mapping() else {
+        return Ok(BTreeMap::new());
+    };
+    let Some(onboarding) = root
+        .get(Value::String("onboarding".to_string()))
+        .and_then(Value::as_mapping)
+    else {
+        return Ok(BTreeMap::new());
+    };
+    let Some(input_help) = onboarding
+        .get(Value::String("input_help".to_string()))
+        .and_then(Value::as_mapping)
+    else {
+        return Ok(BTreeMap::new());
+    };
+
+    let mut help = BTreeMap::new();
+    for (key, value) in input_help {
+        let key = key.as_str().ok_or_else(|| {
+            ManifestError::validation("onboarding.input_help key must be a string")
+        })?;
+        let value = value.as_str().ok_or_else(|| {
+            ManifestError::validation(format!("onboarding.input_help.{key} value must be a string"))
+        })?;
+        help.insert(key.to_string(), value.to_string());
+    }
+    Ok(help)
+}
+
 fn collect_from_mapping(
     map: &Mapping,
-    ordered: &mut Vec<ManifestInputSpec>,
+    ordered: &mut Vec<InputSpec>,
     seen: &mut BTreeMap<String, InputState>,
 ) -> Result<()> {
     let Some(from) = map
@@ -145,7 +181,7 @@ fn collect_from_mapping(
 
 fn collect_from_template(
     template: &str,
-    ordered: &mut Vec<ManifestInputSpec>,
+    ordered: &mut Vec<InputSpec>,
     seen: &mut BTreeMap<String, InputState>,
 ) -> Result<()> {
     let template = ParsedTemplate::parse(template)?;
@@ -185,7 +221,7 @@ fn register_input(
     key: &str,
     kind: InputKind,
     default_value: Option<String>,
-    ordered: &mut Vec<ManifestInputSpec>,
+    ordered: &mut Vec<InputSpec>,
     seen: &mut BTreeMap<String, InputState>,
 ) -> Result<()> {
     if let Some(existing) = seen.get(key) {
@@ -197,11 +233,12 @@ fn register_input(
         return Ok(());
     }
 
-    ordered.push(ManifestInputSpec {
+    ordered.push(InputSpec {
         key: key.to_string(),
         kind: kind.as_manifest_kind(),
         required: default_value.is_none(),
         default_value: default_value.clone().unwrap_or_default(),
+        help: None,
     });
     seen.insert(
         key.to_string(),
@@ -215,7 +252,7 @@ fn register_input(
 
 #[cfg(test)]
 mod tests {
-    use super::{ManifestInputKind, collect_source_inputs_yaml};
+    use super::{InputKind, collect_source_inputs_yaml};
 
     #[test]
     fn extracts_variables_and_secrets_in_manifest_order() {
@@ -236,12 +273,57 @@ tables: []
         let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
         assert_eq!(inputs.len(), 2);
         assert_eq!(inputs[0].key, "API_BASE");
-        assert_eq!(inputs[0].kind, ManifestInputKind::Variable);
+        assert_eq!(inputs[0].kind, InputKind::Variable);
         assert!(!inputs[0].required);
         assert_eq!(inputs[0].default_value, "https://example.com");
         assert_eq!(inputs[1].key, "API_TOKEN");
-        assert_eq!(inputs[1].kind, ManifestInputKind::Secret);
+        assert_eq!(inputs[1].kind, InputKind::Secret);
         assert!(inputs[1].required);
+    }
+
+    #[test]
+    fn ignores_onboarding_templates_during_input_discovery() {
+        let manifest = r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: "https://example.com"
+auth:
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{secret.API_TOKEN}}
+onboarding:
+  instructions: "Use {{env.SHOULD_NOT_BE_DISCOVERED}} only in docs"
+  input_help:
+    API_TOKEN: "Run {{env.SHOULD_NOT_BE_VALIDATED}} or create a token manually"
+tables: []
+"#;
+
+        let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].key, "API_TOKEN");
+    }
+
+    #[test]
+    fn inputs_without_onboarding_are_collected() {
+        let manifest = r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+auth:
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{secret.API_TOKEN}}
+tables: []
+";
+
+        let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].key, "API_TOKEN");
     }
 
     #[test]
@@ -256,5 +338,33 @@ tables: []
 "#;
         let error = collect_source_inputs_yaml(manifest).expect_err("legacy env unsupported");
         assert!(error.to_string().contains("unsupported"));
+    }
+
+    #[test]
+    fn collects_input_help_from_onboarding() {
+        let inputs = collect_source_inputs_yaml(
+            r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+onboarding:
+  input_help:
+    API_TOKEN: "Create a token at https://example.com/settings/tokens"
+auth:
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{secret.API_TOKEN}}
+tables: []
+"#,
+        )
+        .expect("inputs");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].kind, InputKind::Secret);
+        assert_eq!(
+            inputs[0].help.as_deref(),
+            Some("Create a token at https://example.com/settings/tokens")
+        );
     }
 }

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -12,14 +12,6 @@ use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
 /// The kind of interactive input required by one validated source spec.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InputKind {
-    /// A non-secret input persisted in source variables.
-    Variable,
-    /// A secret input persisted separately from source variables.
-    Secret,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InputKind {
     Variable,
     Secret,
@@ -133,7 +125,9 @@ fn collect_input_help(root: &Value) -> Result<BTreeMap<String, String>> {
             ManifestError::validation("onboarding.input_help key must be a string")
         })?;
         let value = value.as_str().ok_or_else(|| {
-            ManifestError::validation(format!("onboarding.input_help.{key} value must be a string"))
+            ManifestError::validation(format!(
+                "onboarding.input_help.{key} value must be a string"
+            ))
         })?;
         help.insert(key.to_string(), value.to_string());
     }
@@ -262,6 +256,10 @@ version: 1.0.0
 dsl_version: 3
 backend: http
 base_url: "{{variable.API_BASE|https://example.com}}"
+onboarding:
+  input_help:
+    API_TOKEN: "Create a token at https://example.com/settings/tokens"
+    API_BASE: "Your API base URL for self-hosted instances"
 auth:
   headers:
     - name: Authorization
@@ -272,58 +270,23 @@ tables: []
 
         let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
         assert_eq!(inputs.len(), 2);
+
         assert_eq!(inputs[0].key, "API_BASE");
         assert_eq!(inputs[0].kind, InputKind::Variable);
         assert!(!inputs[0].required);
         assert_eq!(inputs[0].default_value, "https://example.com");
+        assert_eq!(
+            inputs[0].help.as_deref(),
+            Some("Your API base URL for self-hosted instances")
+        );
+
         assert_eq!(inputs[1].key, "API_TOKEN");
         assert_eq!(inputs[1].kind, InputKind::Secret);
         assert!(inputs[1].required);
-    }
-
-    #[test]
-    fn ignores_onboarding_templates_during_input_discovery() {
-        let manifest = r#"
-name: demo
-version: 1.0.0
-dsl_version: 3
-backend: http
-base_url: "https://example.com"
-auth:
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{secret.API_TOKEN}}
-onboarding:
-  instructions: "Use {{env.SHOULD_NOT_BE_DISCOVERED}} only in docs"
-  input_help:
-    API_TOKEN: "Run {{env.SHOULD_NOT_BE_VALIDATED}} or create a token manually"
-tables: []
-"#;
-
-        let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
-        assert_eq!(inputs.len(), 1);
-        assert_eq!(inputs[0].key, "API_TOKEN");
-    }
-
-    #[test]
-    fn inputs_without_onboarding_are_collected() {
-        let manifest = r"
-name: demo
-version: 1.0.0
-dsl_version: 3
-backend: http
-auth:
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{secret.API_TOKEN}}
-tables: []
-";
-
-        let inputs = collect_source_inputs_yaml(manifest).expect("inputs");
-        assert_eq!(inputs.len(), 1);
-        assert_eq!(inputs[0].key, "API_TOKEN");
+        assert_eq!(
+            inputs[1].help.as_deref(),
+            Some("Create a token at https://example.com/settings/tokens")
+        );
     }
 
     #[test]
@@ -367,4 +330,3 @@ tables: []
             Some("Create a token at https://example.com/settings/tokens")
         );
     }
-}

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -81,13 +81,14 @@ mod validate;
 
 pub use common::{
     AuthSpec, BodyFieldSpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, HeaderSpec, HttpMethod,
-    ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,
+    ManifestDataType, Onboarding, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,
     RequestRouteSpec, RequestSpec, ResponseSpec, RowStrategy, SourceBackend, SourceManifestCommon,
     TableCommon, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
 };
+pub use common::{collect_source_onboarding_value, collect_source_onboarding_yaml};
 pub use error::{ManifestError, Result};
 pub use inputs::{
-    ManifestInputKind, ManifestInputSpec, collect_source_inputs_value, collect_source_inputs_yaml,
+    InputSpec, InputKind, collect_source_inputs_value, collect_source_inputs_yaml,
 };
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -24,8 +24,7 @@
 //!   data
 //! - [`ValidatedSourceManifest`] provides a backend-agnostic validated
 //!   source-spec view with typed accessors for backend-specific models
-//! - [`collect_source_inputs_yaml`] and [`collect_source_inputs_value`] extract
-//!   variables and secrets that must be collected at install time
+//! - [`collect_inputs`] extracts variables and secrets from a validated manifest
 //!
 //! # Crate Relationships
 //!
@@ -87,9 +86,7 @@ pub use common::{
 };
 pub use common::{collect_source_onboarding_value, collect_source_onboarding_yaml};
 pub use error::{ManifestError, Result};
-pub use inputs::{
-    InputSpec, InputKind, collect_source_inputs_value, collect_source_inputs_yaml,
-};
+pub use inputs::{InputSpec, InputKind, collect_inputs};
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
 };

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -86,7 +86,7 @@ pub use common::{
 };
 pub use common::{collect_source_onboarding_value, collect_source_onboarding_yaml};
 pub use error::{ManifestError, Result};
-pub use inputs::{InputSpec, InputKind, collect_inputs};
+pub use inputs::{InputKind, InputSpec, collect_inputs};
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
 };

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -73,6 +73,16 @@ impl ValidatedSourceManifest {
         }
     }
 
+    #[must_use]
+    /// Returns the source-spec description, if declared.
+    pub fn source_description(&self) -> &str {
+        match &self.inner {
+            ValidatedManifestKind::Http(manifest) => &manifest.common.description,
+            ValidatedManifestKind::Parquet(manifest) => &manifest.common.description,
+            ValidatedManifestKind::Jsonl(manifest) => &manifest.common.description,
+        }
+    }
+
     /// Returns the set of source secrets required to compile or authenticate
     /// the source spec.
     ///

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -45,6 +45,15 @@ impl ValidatedSourceManifest {
     }
 
     #[must_use]
+    pub(crate) fn common(&self) -> &crate::SourceManifestCommon {
+        match &self.inner {
+            ValidatedManifestKind::Http(manifest) => &manifest.common,
+            ValidatedManifestKind::Parquet(manifest) => &manifest.common,
+            ValidatedManifestKind::Jsonl(manifest) => &manifest.common,
+        }
+    }
+
+    #[must_use]
     /// Returns the source-spec `name`, which is also the stable SQL schema name.
     pub fn schema_name(&self) -> &str {
         match &self.inner {

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -21,11 +21,18 @@
     "onboarding": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["instructions"],
       "properties": {
         "instructions": {
           "type": "string",
           "description": "Freeform instructions for an AI agent to discover shared workspace context for this provider"
+        },
+        "input_help": {
+          "type": "object",
+          "description": "Per-input help describing how to acquire each variable or secret",
+          "additionalProperties": {
+            "type": "string",
+            "description": "Human-readable help shown during source setup explaining how to obtain this value"
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Add `onboarding.input_help` to the manifest schema so source authors can provide human-readable hints that are displayed during interactive `source add` and `source import` prompts.

## Testing Strategy

Tested manually 
`make validate`