### PR TITLE
chore(docs): add docs code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@ AGENTS.md @jsummerfield
 Cargo.toml @jsummerfield
 README.md @jsummerfield
 
+/docs/ @simonwhitaker @AlbertQM
 /crates/coral-api/ @jsummerfield
 /crates/coral-app/ @jsummerfield
 /crates/coral-cli/ @jsummerfield


### PR DESCRIPTION
## Summary
This change assigns explicit owners for `/docs/` so documentation updates automatically request review from the people responsible for the docs experience.

## Validation
- `make validate`
