### PR TITLE
feat(sources): adds source validate command. uses manifest schema file

### DIFF
--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -205,6 +205,9 @@ tables:
             false,
         )
         .expect_err("legacy schema field should fail");
-        assert!(error.to_string().contains("unknown field `schema`"));
+        assert_eq!(
+            error.to_string(),
+            "invalid input: manifest failed schema validation: Additional properties are not allowed ('schema' was unexpected)"
+        );
     }
 }

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -83,6 +83,11 @@ enum SourceCommand {
         /// Name of the source to remove
         name: String,
     },
+    /// Validate a source manifest file
+    Validate {
+        /// Path to the source manifest file
+        path: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -170,6 +175,9 @@ async fn main() -> Result<(), anyhow::Error> {
             SourceCommand::Remove { name } => {
                 source_ops::delete_source(&app, &name).await?;
                 println!("Removed source {name}");
+            }
+            SourceCommand::Validate { path } => {
+                source_ops::validate_manifest(&path)?;
             }
         },
         Command::Onboard => {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -7,7 +7,9 @@ use coral_api::v1::{
     SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
 };
 use coral_client::{AppClient, default_workspace};
-use coral_spec::{ManifestInputKind, ManifestInputSpec, collect_source_inputs_yaml};
+use coral_spec::{
+    ManifestInputKind, ManifestInputSpec, collect_source_inputs_yaml, parse_source_manifest_yaml,
+};
 use dialoguer::{Input, Password, theme::ColorfulTheme};
 use tonic::Request;
 
@@ -158,6 +160,17 @@ pub(crate) fn manifest_input_from_proto(
         required: input.required,
         default_value: input.default_value.clone(),
     })
+}
+
+pub(crate) fn validate_manifest(path: &Path) -> Result<(), anyhow::Error> {
+    let raw = std::fs::read_to_string(path)?;
+    let manifest = parse_source_manifest_yaml(&raw)?;
+    println!(
+        "Manifest OK: source '{}' (version {})",
+        manifest.schema_name(),
+        manifest.source_version()
+    );
+    Ok(())
 }
 
 pub(crate) fn load_manifest_inputs(

--- a/crates/coral-spec/Cargo.toml
+++ b/crates/coral-spec/Cargo.toml
@@ -16,6 +16,8 @@ serde_yaml.workspace = true
 thiserror.workspace = true
 url.workspace = true
 
+[dependencies.jsonschema]
+workspace = true
+
 [dev-dependencies]
-jsonschema.workspace = true
 tracing.workspace = true

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -287,12 +287,10 @@ impl ParquetSourceManifest {
             .map(|table| table.into_validated_parquet(&common.name))
             .collect::<Result<Vec<_>>>()?;
         validate_manifest_top_level(
-            common.dsl_version,
             &common.name,
             &common.name,
             SourceBackend::Parquet,
             &empty_base_url,
-            tables.len(),
         )?;
         Ok(Self { common, tables })
     }
@@ -317,12 +315,10 @@ impl JsonlSourceManifest {
             .map(|table| table.into_validated_jsonl(&common.name))
             .collect::<Result<Vec<_>>>()?;
         validate_manifest_top_level(
-            common.dsl_version,
             &common.name,
             &common.name,
             SourceBackend::Jsonl,
             &empty_base_url,
-            tables.len(),
         )?;
         Ok(Self { common, tables })
     }

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -203,12 +203,10 @@ impl HttpSourceManifest {
             .map(|table| table.into_validated(&common.name))
             .collect::<Result<Vec<_>>>()?;
         validate_manifest_top_level(
-            common.dsl_version,
             &common.name,
             &common.name,
             SourceBackend::Http,
             &base_url,
-            tables.len(),
         )?;
         Ok(Self {
             common,

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -202,12 +202,7 @@ impl HttpSourceManifest {
             .into_iter()
             .map(|table| table.into_validated(&common.name))
             .collect::<Result<Vec<_>>>()?;
-        validate_manifest_top_level(
-            &common.name,
-            &common.name,
-            SourceBackend::Http,
-            &base_url,
-        )?;
+        validate_manifest_top_level(&common.name, &common.name, SourceBackend::Http, &base_url)?;
         Ok(Self {
             common,
             base_url,

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -409,7 +409,6 @@ impl PaginationSpec {
             return Ok(None);
         };
 
-        // page_size.default >= 1 and page_size.max >= 1 are enforced by the JSON Schema.
         if page_size.query_param.is_none() && page_size.body_path.is_empty() {
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} pagination.page_size must define query_param or body_path"

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -377,11 +377,6 @@ impl PaginationSpec {
                         "{schema}.{table} pagination.mode=page requires page_param"
                     )));
                 }
-                if self.page_step <= 0 {
-                    return Err(ManifestError::validation(format!(
-                        "{schema}.{table} pagination.page_step must be > 0"
-                    )));
-                }
                 Ok(ValidatedPaginationMode::Page)
             }
             PaginationMode::Offset => {
@@ -391,12 +386,7 @@ impl PaginationSpec {
                     ))
                 })?;
                 let step = match self.offset_step {
-                    Some(offset_step) if offset_step > 0 => OffsetStep::Explicit(offset_step),
-                    Some(_) => {
-                        return Err(ManifestError::validation(format!(
-                            "{schema}.{table} pagination.offset_step must be > 0"
-                        )));
-                    }
+                    Some(offset_step) => OffsetStep::Explicit(offset_step),
                     None if has_page_size => OffsetStep::PageSize,
                     None => {
                         return Err(ManifestError::validation(format!(
@@ -419,16 +409,7 @@ impl PaginationSpec {
             return Ok(None);
         };
 
-        if page_size.default == 0 {
-            return Err(ManifestError::validation(format!(
-                "{schema}.{table} pagination.page_size.default must be > 0"
-            )));
-        }
-        if page_size.max == 0 {
-            return Err(ManifestError::validation(format!(
-                "{schema}.{table} pagination.page_size.max must be > 0"
-            )));
-        }
+        // page_size.default >= 1 and page_size.max >= 1 are enforced by the JSON Schema.
         if page_size.query_param.is_none() && page_size.body_path.is_empty() {
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} pagination.page_size must define query_param or body_path"

--- a/crates/coral-spec/src/loader.rs
+++ b/crates/coral-spec/src/loader.rs
@@ -5,20 +5,14 @@ use std::path::Path;
 
 #[cfg(test)]
 use std::path::PathBuf;
-use std::sync::OnceLock;
 
-use jsonschema::JSONSchema;
-use serde_json::Value as JsonValue;
-
-use crate::{ManifestError, Result, ValidatedSourceManifest, parse_source_manifest_value};
+use crate::{ManifestError, Result, ValidatedSourceManifest, parse_source_manifest_yaml};
 
 /// Base name for source manifest files (without extension).
 const SOURCE_MANIFEST_NAME: &str = "source";
 
 /// Accepted `YAML` extensions in preferred order.
 const YAML_EXTENSIONS: &[&str] = &["yml", "yaml"];
-
-static SOURCE_SCHEMA: OnceLock<JSONSchema> = OnceLock::new();
 
 /// Load and validate source manifests from a sources directory.
 ///
@@ -89,42 +83,7 @@ fn load_manifest_path(path: &Path) -> Result<ValidatedSourceManifest> {
     let raw = fs::read_to_string(path).map_err(|e| {
         ManifestError::validation(format!("failed to read {}: {e}", path.display()))
     })?;
-
-    let manifest_value: serde_yaml::Value =
-        serde_yaml::from_str(&raw).map_err(ManifestError::parse_yaml)?;
-    let manifest_json: JsonValue = serde_json::to_value(manifest_value)
-        .map_err(|e| ManifestError::validation(format!("failed to encode manifest value: {e}")))?;
-
-    validate_manifest_schema(path, &manifest_json)?;
-
-    let manifest = parse_source_manifest_value(manifest_json)?;
-
-    Ok(manifest)
-}
-
-fn validate_manifest_schema(path: &Path, manifest_json: &JsonValue) -> Result<()> {
-    let validator = source_schema_validator();
-    if let Err(errors) = validator.validate(manifest_json) {
-        let problems = errors
-            .take(8)
-            .map(|e| e.to_string())
-            .collect::<Vec<_>>()
-            .join("; ");
-        return Err(ManifestError::validation(format!(
-            "{} failed schema validation: {problems}",
-            path.display()
-        )));
-    }
-    Ok(())
-}
-
-fn source_schema_validator() -> &'static JSONSchema {
-    SOURCE_SCHEMA.get_or_init(|| {
-        let schema_json: JsonValue =
-            serde_json::from_str(include_str!("schema/source_manifest.schema.json"))
-                .expect("embedded source schema must be valid JSON");
-        JSONSchema::compile(&schema_json).expect("embedded source schema must compile")
-    })
+    parse_source_manifest_yaml(&raw)
 }
 
 #[cfg(test)]

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -5,12 +5,16 @@
 //! through narrow accessors such as [`ValidatedSourceManifest::as_http`].
 
 use std::collections::BTreeSet;
+use std::sync::OnceLock;
 
+use jsonschema::JSONSchema;
 use serde_json::Value;
 
 use crate::backends::file::{JsonlSourceManifest, ParquetSourceManifest};
 use crate::backends::http::HttpSourceManifest;
 use crate::{ManifestError, Result, SourceBackend};
+
+static SOURCE_SCHEMA: OnceLock<JSONSchema> = OnceLock::new();
 
 /// Validated top-level source spec for one registered source.
 ///
@@ -118,11 +122,15 @@ pub fn parse_source_manifest_yaml(raw: &str) -> Result<ValidatedSourceManifest> 
 
 /// Parse and validate a source spec from structured source-spec data.
 ///
+/// Runs JSON Schema validation first to catch structural problems, then
+/// deserializes and applies semantic validation rules.
+///
 /// # Errors
 ///
-/// Returns a [`ManifestError`] if the source spec violates any validation
-/// rules.
+/// Returns a [`ManifestError`] if the source spec fails schema validation
+/// or violates any semantic validation rules.
 pub fn parse_source_manifest_value(value: Value) -> Result<ValidatedSourceManifest> {
+    validate_manifest_schema(&value)?;
     let backend_kind = parse_source_backend(&value)?;
     match backend_kind {
         SourceBackend::Http => Ok(ValidatedSourceManifest {
@@ -146,4 +154,28 @@ fn parse_source_backend(value: &Value) -> Result<SourceBackend> {
     let backend: SourceBackend =
         serde_json::from_value(backend).map_err(ManifestError::deserialize)?;
     Ok(backend)
+}
+
+fn validate_manifest_schema(value: &Value) -> Result<()> {
+    let validator = source_schema_validator();
+    if let Err(errors) = validator.validate(value) {
+        let problems = errors
+            .take(8)
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(ManifestError::validation(format!(
+            "manifest failed schema validation: {problems}"
+        )));
+    }
+    Ok(())
+}
+
+fn source_schema_validator() -> &'static JSONSchema {
+    SOURCE_SCHEMA.get_or_init(|| {
+        let schema_json: Value =
+            serde_json::from_str(include_str!("schema/source_manifest.schema.json"))
+                .expect("embedded source schema must be valid JSON");
+        JSONSchema::compile(&schema_json).expect("embedded source schema must compile")
+    })
 }

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -122,7 +122,7 @@
     "request": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["method", "path"],
+      "required": ["path"],
       "properties": {
         "method": { "type": "string", "enum": ["GET", "POST"] },
         "path": { "type": "string", "minLength": 1 },

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -45,7 +45,6 @@ pub(crate) fn validate_http_table(
     requests: &[RequestRouteSpec],
     pagination: &PaginationSpec,
 ) -> Result<()> {
-    // Empty request.path is rejected by the JSON Schema (minLength: 1).
     validate_columns(columns, schema, table_name)?;
     let known_filters = validate_filters_and_column_exprs(filters, columns, schema, table_name)?;
 
@@ -121,7 +120,6 @@ pub(crate) fn validate_filters_and_column_exprs(
 ) -> Result<HashSet<String>> {
     let mut known_filters = HashSet::new();
     for filter in filters {
-        // Empty filter names are rejected by the JSON Schema (minLength: 1).
         if !known_filters.insert(filter.name.clone()) {
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} has duplicate filter '{}'",

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -9,25 +9,11 @@ use crate::common::{
 use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
 pub(crate) fn validate_manifest_top_level(
-    dsl_version: u32,
     name: &str,
     schema: &str,
     backend: SourceBackend,
     base_url: &ParsedTemplate,
-    table_count: usize,
 ) -> Result<()> {
-    if dsl_version != 3 {
-        return Err(ManifestError::validation(format!(
-            "source '{name}' uses unsupported dsl_version={dsl_version} (expected 3)"
-        )));
-    }
-
-    if table_count == 0 {
-        return Err(ManifestError::validation(format!(
-            "source '{name}' has no tables"
-        )));
-    }
-
     match backend {
         SourceBackend::Http => {
             if base_url.raw().trim().is_empty() {
@@ -59,12 +45,7 @@ pub(crate) fn validate_http_table(
     requests: &[RequestRouteSpec],
     pagination: &PaginationSpec,
 ) -> Result<()> {
-    if request.path.raw().trim().is_empty() {
-        return Err(ManifestError::validation(format!(
-            "{schema}.{table_name} has an empty request.path"
-        )));
-    }
-
+    // Empty request.path is rejected by the JSON Schema (minLength: 1).
     validate_columns(columns, schema, table_name)?;
     let known_filters = validate_filters_and_column_exprs(filters, columns, schema, table_name)?;
 
@@ -140,11 +121,7 @@ pub(crate) fn validate_filters_and_column_exprs(
 ) -> Result<HashSet<String>> {
     let mut known_filters = HashSet::new();
     for filter in filters {
-        if filter.name.trim().is_empty() {
-            return Err(ManifestError::validation(format!(
-                "{schema}.{table} has a filter with an empty name"
-            )));
-        }
+        // Empty filter names are rejected by the JSON Schema (minLength: 1).
         if !known_filters.insert(filter.name.clone()) {
             return Err(ManifestError::validation(format!(
                 "{schema}.{table} has duplicate filter '{}'",


### PR DESCRIPTION
  ## Summary
  - All callers get structural checks before semantic validation
  - Remove duplicate Rust validation checks 
  - Add `coral source validate <path>` CLI command
 
  ## Test plan
  Modified accordingly existing tests
`make validate`