### PR TITLE
chore: upgrade to actions/github-script@v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
     steps:
       - name: Compose release notes
         id: compose
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           TAG_NAME: ${{ needs.prepare.outputs.tag_name }}
           BUILD_REF: ${{ needs.prepare.outputs.build_ref }}


### PR DESCRIPTION
v7 uses node.js 20, which is [now deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).