### PR TITLE
docs: require docs updates for CLI and MCP changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@
   its bootstrap seam today.
 - If a caller needs explicit local server control, prefer `coral-client::local`
   over widening the default client surface.
+- Changes to CLI or MCP surfaces must include corresponding documentation
+  updates under `docs/` in the same change.
 - When proposing or updating a PR title, use Conventional Commits:
   `type(scope): summary`.
 - When using a scope, prefer one that matches the primary area changed,

--- a/crates/coral-cli/AGENTS.md
+++ b/crates/coral-cli/AGENTS.md
@@ -24,5 +24,7 @@
   handling here.
 - Keep install/import user-friendly, but move reusable behavior inward instead
   of duplicating app or MCP logic.
+- Treat CLI commands, flags, output, and workflows as documented surfaces; when
+  they change, update the relevant docs under `docs/` in the same change.
 - Prefer improving prompts and terminal presentation here rather than pushing
   user-facing formatting concerns into `coral-app` or `coral-engine`.

--- a/crates/coral-mcp/AGENTS.md
+++ b/crates/coral-mcp/AGENTS.md
@@ -28,3 +28,6 @@
 - Decode query payloads through `coral-client`; do not fork Arrow IPC handling
   here.
 - Shape MCP surfaces for agent ergonomics, not raw proto parity.
+- Treat MCP tools, resources, prompts, and other user-facing protocol surfaces
+  as documented surfaces; when they change, update the relevant docs under
+  `docs/` in the same change.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -17,6 +17,9 @@
 - Search for existing information before adding new content. Avoid duplication unless it is done for a strategic reason
 - Check existing patterns for consistency
 - Start by making the smallest reasonable changes
+- Keep `docs/` aligned with CLI and MCP user-facing surfaces; if commands,
+  flags, output contracts, tools, resources, prompts, or workflows change
+  elsewhere in the repo, update the relevant docs in the same change
 
 ## Frontmatter requirements for pages
 - title: Clear, descriptive page title


### PR DESCRIPTION
## Why
CLI and MCP behavior is a user-facing contract, so instruction drift between code changes and `docs/` creates avoidable confusion. This change makes the documentation requirement explicit anywhere those surfaces are governed.

## What changed
- add a repo-wide rule that CLI and MCP surface changes must include matching `docs/` updates
- add crate-scoped guidance in `coral-cli` and `coral-mcp` for the specific documented surfaces each adapter owns
- add the same expectation to `docs/AGENTS.md` so the docs area reinforces the rule from its side

## Validation
- run `make validate`
