### PR TITLE
feat(engine): add benchmark needle retrieval tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -809,6 +809,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "bytes",
+ "chrono",
  "coral-spec",
  "datafusion",
  "futures",

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 async-trait.workspace = true
 arrow.workspace = true
 bytes.workspace = true
+chrono.workspace = true
 datafusion.workspace = true
 futures.workspace = true
 glob.workspace = true

--- a/crates/coral-engine/src/needles/loader.rs
+++ b/crates/coral-engine/src/needles/loader.rs
@@ -3,9 +3,9 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use super::error::NeedleError;
+use super::{NeedleSpec, error::NeedleError};
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Deserialize)]
 #[serde(deny_unknown_fields)]
 struct NeedleEntry {
     schema: String,
@@ -24,6 +24,12 @@ pub(crate) struct TableKey {
 #[derive(Debug, Default)]
 pub(crate) struct NeedleGroups {
     inner: HashMap<TableKey, Vec<serde_json::Value>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct LoadedNeedles {
+    pub(crate) groups: NeedleGroups,
+    pub(crate) specs: Vec<NeedleSpec>,
 }
 
 impl NeedleGroups {
@@ -48,25 +54,14 @@ impl NeedleGroups {
         self.inner.remove(&key)
     }
 
-    pub(crate) fn table_names_for_schema(&self, schema: &str) -> Vec<String> {
-        let mut tables = self
-            .inner
-            .keys()
-            .filter(|key| key.schema == schema)
-            .map(|key| key.table.clone())
-            .collect::<Vec<_>>();
-        tables.sort();
-        tables
-    }
-
-    pub(crate) fn ensure_all_consumed(self) -> Result<(), NeedleError> {
+    pub(crate) fn ensure_all_consumed(&self) -> Result<(), NeedleError> {
         if self.inner.is_empty() {
             return Ok(());
         }
 
         let mut tables = self
             .inner
-            .into_keys()
+            .keys()
             .map(|key| format!("{}.{}", key.schema, key.table))
             .collect::<Vec<_>>();
         tables.sort();
@@ -87,13 +82,19 @@ impl NeedleGroups {
 /// # Errors
 ///
 /// Returns [`NeedleError`] if the file cannot be read or parsed.
-pub(crate) fn load_needle_groups(path: &Path) -> Result<NeedleGroups, NeedleError> {
+pub(crate) fn load_needles(path: &Path) -> Result<LoadedNeedles, NeedleError> {
     let contents = std::fs::read_to_string(path).map_err(|e| NeedleError::io(path, e))?;
     let entries: Vec<NeedleEntry> =
         serde_yaml::from_str(&contents).map_err(|e| NeedleError::Yaml(e.to_string()))?;
 
     let mut inner: HashMap<TableKey, Vec<serde_json::Value>> = HashMap::new();
+    let mut specs = Vec::with_capacity(entries.len());
     for entry in entries {
+        specs.push(NeedleSpec {
+            schema: entry.schema.clone(),
+            table: entry.table.clone(),
+            column_values: entry.data.clone(),
+        });
         inner
             .entry(TableKey {
                 schema: entry.schema,
@@ -103,7 +104,10 @@ pub(crate) fn load_needle_groups(path: &Path) -> Result<NeedleGroups, NeedleErro
             .push(serde_json::Value::Object(entry.data));
     }
 
-    Ok(NeedleGroups { inner })
+    Ok(LoadedNeedles {
+        groups: NeedleGroups { inner },
+        specs,
+    })
 }
 
 #[cfg(test)]
@@ -115,7 +119,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("needles.yaml");
         std::fs::write(&path, "[]").unwrap();
-        let groups = load_needle_groups(&path).unwrap();
+        let groups = load_needles(&path).unwrap().groups;
         assert!(groups.is_empty());
     }
 
@@ -144,7 +148,7 @@ mod tests {
         )
         .unwrap();
 
-        let groups = load_needle_groups(&path).unwrap();
+        let groups = load_needles(&path).unwrap().groups;
         assert!(!groups.is_empty());
         assert_eq!(groups.get("github", "issues").unwrap().len(), 2);
         assert_eq!(groups.get("slack", "messages").unwrap().len(), 1);
@@ -156,7 +160,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let path = dir.path().join("needles.yaml");
         std::fs::write(&path, "not: valid: yaml: [").unwrap();
-        let result = load_needle_groups(&path);
+        let result = load_needles(&path);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(err.contains("YAML"), "error should mention YAML: {err}");
@@ -175,7 +179,7 @@ mod tests {
 "#,
         )
         .unwrap();
-        let result = load_needle_groups(&path);
+        let result = load_needles(&path);
         assert!(result.is_err());
     }
 
@@ -192,7 +196,7 @@ mod tests {
 "#,
         )
         .unwrap();
-        let result = load_needle_groups(&path);
+        let result = load_needles(&path);
         assert!(result.is_err());
     }
 
@@ -210,13 +214,13 @@ mod tests {
 "#,
         )
         .unwrap();
-        let result = load_needle_groups(&path);
+        let result = load_needles(&path);
         assert!(result.is_err(), "typo'd field should be rejected");
     }
 
     #[test]
     fn missing_file_returns_io_error() {
-        let result = load_needle_groups(Path::new("/nonexistent/needles.yaml"));
+        let result = load_needles(Path::new("/nonexistent/needles.yaml"));
         assert!(result.is_err());
     }
 
@@ -235,7 +239,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut groups = load_needle_groups(&path).unwrap();
+        let mut groups = load_needles(&path).unwrap().groups;
         assert_eq!(groups.take("github", "issues").unwrap().len(), 1);
         assert!(groups.get("github", "issues").is_none());
     }
@@ -255,7 +259,7 @@ mod tests {
         )
         .unwrap();
 
-        let groups = load_needle_groups(&path).unwrap();
+        let groups = load_needles(&path).unwrap().groups;
         let error = groups.ensure_all_consumed().unwrap_err();
         assert!(error.to_string().contains("github.issues"));
     }
@@ -283,11 +287,21 @@ mod tests {
         )
         .unwrap();
 
-        let groups = load_needle_groups(&path).unwrap();
+        let groups = load_needles(&path).unwrap().groups;
+        let mut github_tables = groups
+            .inner
+            .keys()
+            .filter(|key| key.schema == "github")
+            .map(|key| key.table.clone())
+            .collect::<Vec<_>>();
+        github_tables.sort();
         assert_eq!(
-            groups.table_names_for_schema("github"),
+            github_tables,
             vec!["issues".to_string(), "pull_requests".to_string()]
         );
-        assert!(groups.table_names_for_schema("linear").is_empty());
+        assert!(
+            groups.inner.keys().all(|key| key.schema != "linear"),
+            "unexpected linear entries"
+        );
     }
 }

--- a/crates/coral-engine/src/needles/mod.rs
+++ b/crates/coral-engine/src/needles/mod.rs
@@ -7,6 +7,7 @@
 //! [`provider::NeedleTableProvider`].
 
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use datafusion::datasource::TableProvider;
@@ -17,22 +18,41 @@ use crate::backends::BackendRegistration;
 pub(crate) mod error;
 pub(crate) mod loader;
 pub(crate) mod provider;
+pub(crate) mod tracker;
 
 use error::NeedleError;
-use loader::NeedleGroups;
+use loader::{LoadedNeedles, NeedleGroups};
 use provider::{NeedleTableProvider, build_needle_batches};
+pub(crate) use tracker::NeedleTracker;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct NeedleSpec {
+    pub(crate) schema: String,
+    pub(crate) table: String,
+    pub(crate) column_values: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Default)]
 pub(crate) struct NeedleState {
     groups: NeedleGroups,
+    tracker_specs: Vec<NeedleSpec>,
+    log_path: Option<PathBuf>,
 }
 
 impl NeedleState {
     pub(crate) fn from_path(path: Option<&Path>) -> Result<Self> {
-        let groups = match path {
-            Some(path) => loader::load_needle_groups(path).map_err(DataFusionError::from)?,
-            None => NeedleGroups::default(),
-        };
-        Ok(Self { groups })
+        match path {
+            Some(path) => {
+                let LoadedNeedles { groups, specs } =
+                    loader::load_needles(path).map_err(DataFusionError::from)?;
+                Ok(Self {
+                    groups,
+                    tracker_specs: specs,
+                    log_path: Some(log_path_for_needles(path)),
+                })
+            }
+            None => Ok(Self::default()),
+        }
     }
 
     pub(crate) fn decorate(
@@ -49,7 +69,7 @@ impl NeedleState {
         schema_name: &str,
         detail: &impl std::fmt::Display,
     ) -> Option<DataFusionError> {
-        let tables = self.groups.table_names_for_schema(schema_name);
+        let tables = tracked_table_names(&self.tracker_specs, schema_name);
         if tables.is_empty() {
             return None;
         }
@@ -64,8 +84,16 @@ impl NeedleState {
         )
     }
 
-    pub(crate) fn finish(self) -> Result<()> {
+    pub(crate) fn finish(&self) -> Result<()> {
         self.groups.ensure_all_consumed().map_err(Into::into)
+    }
+
+    pub(crate) fn into_tracker(self) -> Option<NeedleTracker> {
+        let log_path = self.log_path?;
+        if self.tracker_specs.is_empty() {
+            return None;
+        }
+        Some(NeedleTracker::new(log_path, self.tracker_specs))
     }
 
     fn wrap_tables(
@@ -93,4 +121,21 @@ impl NeedleState {
 
         Ok(tables)
     }
+}
+
+fn tracked_table_names(specs: &[NeedleSpec], schema_name: &str) -> Vec<String> {
+    let mut tables = specs
+        .iter()
+        .filter(|spec| spec.schema == schema_name)
+        .map(|spec| spec.table.clone())
+        .collect::<Vec<_>>();
+    tables.sort();
+    tables.dedup();
+    tables
+}
+
+fn log_path_for_needles(path: &Path) -> PathBuf {
+    let mut log_path = path.as_os_str().to_os_string();
+    log_path.push(".log");
+    PathBuf::from(log_path)
 }

--- a/crates/coral-engine/src/needles/tracker.rs
+++ b/crates/coral-engine/src/needles/tracker.rs
@@ -1,0 +1,273 @@
+//! Tracks whether planted needle rows appear in query results.
+
+use std::io::Cursor;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::SecondsFormat;
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
+use datafusion::arrow::json::ReaderBuilder;
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::ScalarValue;
+
+use super::{NeedleSpec, error::NeedleError};
+
+const MIN_MATCHING_COLUMNS: usize = 2;
+
+pub(crate) struct NeedleTracker {
+    log_path: PathBuf,
+    specs: Vec<NeedleSpec>,
+}
+
+#[derive(Debug)]
+struct MatchCheck {
+    column_index: usize,
+    expected_value: ScalarValue,
+}
+
+#[derive(serde::Serialize)]
+struct NeedleLogEntry<'a> {
+    ts: String,
+    schema: &'a str,
+    table: &'a str,
+    needle: &'a serde_json::Map<String, serde_json::Value>,
+    sql: &'a str,
+}
+
+impl NeedleTracker {
+    pub(crate) fn new(log_path: PathBuf, specs: Vec<NeedleSpec>) -> Self {
+        Self { log_path, specs }
+    }
+
+    pub(crate) fn check_and_log(
+        &self,
+        sql: &str,
+        batches: &[RecordBatch],
+    ) -> Result<(), NeedleError> {
+        let matching_specs = self
+            .specs
+            .iter()
+            .filter(|spec| result_contains_needle(batches, &spec.column_values))
+            .collect::<Vec<_>>();
+        if matching_specs.is_empty() {
+            return Ok(());
+        }
+
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.log_path)
+            .map_err(|e| NeedleError::io(&self.log_path, e))?;
+        let ts = chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+
+        for spec in matching_specs {
+            let line = NeedleLogEntry {
+                ts: ts.clone(),
+                schema: &spec.schema,
+                table: &spec.table,
+                needle: &spec.column_values,
+                sql,
+            };
+            let mut encoded = serde_json::to_vec(&line)
+                .map_err(|e| NeedleError::JsonConversion(e.to_string()))?;
+            encoded.push(b'\n');
+            file.write_all(&encoded)
+                .map_err(|e| NeedleError::io(&self.log_path, e))?;
+        }
+
+        Ok(())
+    }
+}
+
+fn result_contains_needle(
+    batches: &[RecordBatch],
+    column_values: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    batches
+        .iter()
+        .any(|batch| batch_contains_needle(batch, column_values))
+}
+
+fn batch_contains_needle(
+    batch: &RecordBatch,
+    column_values: &serde_json::Map<String, serde_json::Value>,
+) -> bool {
+    let checks = build_match_checks(batch, column_values);
+    if checks.len() < MIN_MATCHING_COLUMNS {
+        return false;
+    }
+
+    (0..batch.num_rows()).any(|row| row_matches_needle(batch, row, &checks))
+}
+
+fn build_match_checks(
+    batch: &RecordBatch,
+    column_values: &serde_json::Map<String, serde_json::Value>,
+) -> Vec<MatchCheck> {
+    let schema = batch.schema();
+
+    column_values
+        .iter()
+        .filter_map(|(column_name, json_value)| {
+            let column_index = schema.index_of(column_name).ok()?;
+            let data_type = schema.field(column_index).data_type();
+            let expected_value = json_to_scalar(json_value, data_type)?;
+
+            Some(MatchCheck {
+                column_index,
+                expected_value,
+            })
+        })
+        .collect()
+}
+
+fn row_matches_needle(batch: &RecordBatch, row: usize, checks: &[MatchCheck]) -> bool {
+    checks.iter().all(|check| {
+        ScalarValue::try_from_array(batch.column(check.column_index), row)
+            .ok()
+            .as_ref()
+            == Some(&check.expected_value)
+    })
+}
+
+fn json_to_scalar(value: &serde_json::Value, data_type: &DataType) -> Option<ScalarValue> {
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "value",
+        data_type.clone(),
+        true,
+    )]));
+    let mut line = serde_json::to_vec(&serde_json::json!({ "value": value })).ok()?;
+    line.push(b'\n');
+
+    let mut reader = ReaderBuilder::new(schema).build(Cursor::new(line)).ok()?;
+    let batch = reader.next()?.ok()?;
+    ScalarValue::try_from_array(batch.column(0), 0).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Int32Array, StringArray};
+    use datafusion::arrow::datatypes::{Field, Schema};
+    use serde_json::json;
+
+    use super::*;
+
+    fn query_results(ids: &[&str], values: &[i32]) -> Vec<RecordBatch> {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, true),
+            Field::new("value", DataType::Int32, true),
+        ]));
+        vec![
+            RecordBatch::try_new(
+                schema,
+                vec![
+                    Arc::new(StringArray::from(ids.to_vec())),
+                    Arc::new(Int32Array::from(values.to_vec())),
+                ],
+            )
+            .expect("query results batch should build"),
+        ]
+    }
+
+    #[test]
+    fn json_to_scalar_supports_uint64() {
+        let scalar = json_to_scalar(&json!(42), &DataType::UInt64);
+        assert_eq!(scalar, Some(ScalarValue::UInt64(Some(42))));
+    }
+
+    #[test]
+    fn json_to_scalar_supports_timestamps() {
+        let scalar = json_to_scalar(
+            &json!("2024-01-02T03:04:05Z"),
+            &DataType::Timestamp(
+                datafusion::arrow::datatypes::TimeUnit::Microsecond,
+                Some("UTC".into()),
+            ),
+        );
+        assert_eq!(
+            scalar,
+            Some(ScalarValue::TimestampMicrosecond(
+                Some(1_704_164_645_000_000),
+                Some("UTC".into()),
+            ))
+        );
+    }
+
+    #[test]
+    fn batch_contains_needle_matches_and_rejects_non_matching_rows() {
+        let batches = query_results(&["needle-1", "other"], &[42, 1]);
+        let needle = json!({"id": "needle-1", "value": 42});
+        let miss = json!({"id": "needle-1", "value": 999});
+
+        assert!(batch_contains_needle(
+            &batches[0],
+            needle.as_object().expect("object")
+        ));
+        assert!(!batch_contains_needle(
+            &batches[0],
+            miss.as_object().expect("object")
+        ));
+    }
+
+    #[test]
+    fn single_column_overlap_is_ignored() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Utf8, true)]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(vec!["needle-1"]))])
+                .expect("single-column batch should build");
+        let needle = json!({"id": "needle-1", "value": 42});
+
+        assert!(!batch_contains_needle(
+            &batch,
+            needle.as_object().expect("needle should be object")
+        ));
+    }
+
+    #[test]
+    fn check_and_log_writes_ndjson_for_matches() {
+        let dir = tempfile::TempDir::new().expect("tempdir should be created");
+        let log_path = dir.path().join("needles.yaml.log");
+        let tracker = NeedleTracker::new(
+            log_path.clone(),
+            vec![
+                NeedleSpec {
+                    schema: "test".to_string(),
+                    table: "items".to_string(),
+                    column_values: json!({"id": "needle-1", "value": 42})
+                        .as_object()
+                        .expect("object")
+                        .clone(),
+                },
+                NeedleSpec {
+                    schema: "test".to_string(),
+                    table: "items".to_string(),
+                    column_values: json!({"id": "needle-2", "value": 99})
+                        .as_object()
+                        .expect("object")
+                        .clone(),
+                },
+            ],
+        );
+
+        tracker
+            .check_and_log(
+                "SELECT id, value FROM test.items",
+                &query_results(&["needle-1"], &[42]),
+            )
+            .expect("matching tracker write should succeed");
+
+        let log = std::fs::read_to_string(&log_path).expect("log should be readable");
+        let lines = log.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 1);
+
+        let entry: serde_json::Value =
+            serde_json::from_str(lines[0]).expect("log entry should parse as JSON");
+        assert_eq!(entry["schema"], "test");
+        assert_eq!(entry["table"], "items");
+        assert_eq!(entry["needle"]["id"], "needle-1");
+        assert_eq!(entry["sql"], "SELECT id, value FROM test.items");
+    }
+}

--- a/crates/coral-engine/src/needles/tracker.rs
+++ b/crates/coral-engine/src/needles/tracker.rs
@@ -13,6 +13,7 @@ use datafusion::common::ScalarValue;
 
 use super::{NeedleSpec, error::NeedleError};
 
+/// A single overlapping column is too collision-prone to count as retrieval.
 const MIN_MATCHING_COLUMNS: usize = 2;
 
 pub(crate) struct NeedleTracker {
@@ -93,7 +94,9 @@ fn batch_contains_needle(
     batch: &RecordBatch,
     column_values: &serde_json::Map<String, serde_json::Value>,
 ) -> bool {
-    let checks = build_match_checks(batch, column_values);
+    let Some(checks) = build_match_checks(batch, column_values) else {
+        return false;
+    };
     if checks.len() < MIN_MATCHING_COLUMNS {
         return false;
     }
@@ -104,22 +107,24 @@ fn batch_contains_needle(
 fn build_match_checks(
     batch: &RecordBatch,
     column_values: &serde_json::Map<String, serde_json::Value>,
-) -> Vec<MatchCheck> {
+) -> Option<Vec<MatchCheck>> {
     let schema = batch.schema();
+    let mut checks = Vec::new();
 
-    column_values
-        .iter()
-        .filter_map(|(column_name, json_value)| {
-            let column_index = schema.index_of(column_name).ok()?;
-            let data_type = schema.field(column_index).data_type();
-            let expected_value = json_to_scalar(json_value, data_type)?;
+    for (column_name, json_value) in column_values {
+        let Ok(column_index) = schema.index_of(column_name) else {
+            continue;
+        };
+        let data_type = schema.field(column_index).data_type();
+        let expected_value = json_to_scalar(json_value, data_type)?;
 
-            Some(MatchCheck {
-                column_index,
-                expected_value,
-            })
-        })
-        .collect()
+        checks.push(MatchCheck {
+            column_index,
+            expected_value,
+        });
+    }
+
+    Some(checks)
 }
 
 fn row_matches_needle(batch: &RecordBatch, row: usize, checks: &[MatchCheck]) -> bool {
@@ -131,6 +136,8 @@ fn row_matches_needle(batch: &RecordBatch, row: usize, checks: &[MatchCheck]) ->
     })
 }
 
+/// Converts one JSON value into the batch column's scalar type by round-tripping
+/// through Arrow's NDJSON reader instead of hand-implementing JSON -> `ScalarValue`.
 fn json_to_scalar(value: &serde_json::Value, data_type: &DataType) -> Option<ScalarValue> {
     let schema = Arc::new(Schema::new(vec![Field::new(
         "value",
@@ -222,6 +229,17 @@ mod tests {
 
         assert!(!batch_contains_needle(
             &batch,
+            needle.as_object().expect("needle should be object")
+        ));
+    }
+
+    #[test]
+    fn conversion_failure_prevents_match() {
+        let batches = query_results(&["needle-1"], &[42]);
+        let needle = json!({"id": "needle-1", "value": "not-an-int"});
+
+        assert!(!batch_contains_needle(
+            &batches[0],
             needle.as_object().expect("needle should be object")
         ));
     }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -10,6 +10,7 @@ use datafusion::prelude::{SessionConfig, SessionContext};
 use crate::backends::compile_query_source;
 use crate::backends::http::ProviderQueryError;
 use crate::needles::error::NeedleError;
+use crate::needles::{NeedleState, NeedleTracker};
 use crate::runtime::catalog;
 use crate::runtime::registry::{SourceRegistrationFailure, register_sources};
 use crate::{CoreError, QueryExecution, QueryRuntimeProvider, QuerySource, TableInfo};
@@ -17,6 +18,7 @@ use crate::{CoreError, QueryExecution, QueryRuntimeProvider, QuerySource, TableI
 pub(crate) struct QueryRuntimeAdapter {
     ctx: Arc<SessionContext>,
     tables: Vec<TableInfo>,
+    needle_tracker: Option<NeedleTracker>,
 }
 
 pub(crate) async fn build_runtime(
@@ -36,6 +38,8 @@ pub(crate) async fn build_runtime(
     ));
 
     let runtime_context = runtime.runtime_context();
+    let mut needles = NeedleState::from_path(runtime_context.needles_file.as_deref())
+        .map_err(datafusion_to_core)?;
     let mut compiled_sources = Vec::new();
     let mut failures = Vec::new();
     for source in sources {
@@ -47,15 +51,12 @@ pub(crate) async fn build_runtime(
             }),
         }
     }
-    let registration = register_sources(
-        &ctx,
-        compiled_sources,
-        runtime_context.needles_file.as_deref(),
-    )
-    .await
-    .map_err(datafusion_to_core)?;
+    let registration = register_sources(&ctx, compiled_sources, &mut needles)
+        .await
+        .map_err(datafusion_to_core)?;
     catalog::register(&ctx, &registration.active_sources).map_err(datafusion_to_core)?;
     let tables = catalog::collect_tables(&registration.active_sources);
+    let needle_tracker = needles.into_tracker();
     for failure in &failures {
         tracing::warn!(
             source = %failure.schema_name,
@@ -64,7 +65,11 @@ pub(crate) async fn build_runtime(
         );
     }
 
-    Ok(QueryRuntimeAdapter { ctx, tables })
+    Ok(QueryRuntimeAdapter {
+        ctx,
+        tables,
+        needle_tracker,
+    })
 }
 
 impl QueryRuntimeAdapter {
@@ -80,6 +85,11 @@ impl QueryRuntimeAdapter {
         let df = self.ctx.sql(sql).await.map_err(datafusion_to_core)?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let batches = df.collect().await.map_err(datafusion_to_core)?;
+        if let Some(tracker) = &self.needle_tracker {
+            tracker
+                .check_and_log(sql, &batches)
+                .map_err(|error| needle_error_to_core(&error))?;
+        }
         Ok(QueryExecution::new(arrow_schema, batches))
     }
 }
@@ -150,5 +160,117 @@ fn needle_error_to_core(error: &NeedleError) -> CoreError {
         | NeedleError::JsonConversion(_)
         | NeedleError::Arrow(_)
         | NeedleError::UnusedEntries { .. } => CoreError::InvalidInput(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    use super::build_runtime;
+    use crate::{CoreError, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};
+    use coral_spec::{ValidatedSourceManifest, parse_source_manifest_value};
+
+    struct TestRuntimeProvider {
+        ctx: QueryRuntimeContext,
+    }
+
+    impl QueryRuntimeProvider for TestRuntimeProvider {
+        fn resolve_source_secrets(
+            &self,
+            _source: &QuerySource,
+            _secret_names: &BTreeSet<String>,
+        ) -> Result<BTreeMap<String, String>, CoreError> {
+            Ok(BTreeMap::new())
+        }
+
+        fn runtime_context(&self) -> QueryRuntimeContext {
+            self.ctx.clone()
+        }
+    }
+
+    fn jsonl_manifest(location: &str) -> ValidatedSourceManifest {
+        parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "test_jsonl",
+            "version": "0.1.0",
+            "backend": "jsonl",
+            "tables": [{
+                "name": "events",
+                "description": "test events",
+                "source": {
+                    "location": location,
+                    "glob": "**/*.jsonl",
+                    "partitions": [],
+                },
+                "columns": [
+                    {"name": "id", "type": "Utf8", "nullable": false},
+                    {"name": "text", "type": "Utf8"},
+                    {"name": "score", "type": "Int64", "nullable": false},
+                ],
+            }]
+        }))
+        .expect("jsonl manifest should parse")
+    }
+
+    #[tokio::test]
+    async fn execute_sql_logs_matching_needles_to_ndjson() {
+        let fixture_dir = tempdir().expect("tempdir should be created");
+        std::fs::write(
+            fixture_dir.path().join("events.jsonl"),
+            r#"{"id":"live-1","text":"baseline row","score":10}
+{"id":"live-2","text":"high priority live row","score":75}
+"#,
+        )
+        .expect("write jsonl fixture");
+
+        let needles_path = fixture_dir.path().join("needles.yaml");
+        std::fs::write(
+            &needles_path,
+            r#"
+- schema: test_jsonl
+  table: events
+  data:
+    id: "needle-1"
+    text: "matching needle row"
+    score: 99
+"#,
+        )
+        .expect("write needles fixture");
+
+        let source = QuerySource::new(
+            "default",
+            jsonl_manifest(&format!("file://{}/", fixture_dir.path().display())),
+            BTreeMap::new(),
+        );
+        let runtime = TestRuntimeProvider {
+            ctx: QueryRuntimeContext::default().with_needles_file(Some(needles_path.clone())),
+        };
+
+        let adapter = build_runtime(&[source], &runtime)
+            .await
+            .expect("runtime should build");
+        adapter
+            .execute_sql("SELECT id, text FROM test_jsonl.events WHERE score > 50 ORDER BY id")
+            .await
+            .expect("query should succeed");
+
+        let log = std::fs::read_to_string(format!("{}.log", needles_path.display()))
+            .expect("log should be readable");
+        let lines = log.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 1);
+
+        let entry: serde_json::Value =
+            serde_json::from_str(lines[0]).expect("log entry should parse");
+        assert_eq!(entry["schema"], "test_jsonl");
+        assert_eq!(entry["table"], "events");
+        assert_eq!(entry["needle"]["id"], "needle-1");
+        assert_eq!(
+            entry["sql"],
+            "SELECT id, text FROM test_jsonl.events WHERE score > 50 ORDER BY id"
+        );
     }
 }

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -1,6 +1,5 @@
 //! Registers compiled backend sources into a shared `DataFusion` session.
 
-use std::path::Path;
 use std::sync::Arc;
 
 use datafusion::error::{DataFusionError, Result};
@@ -46,13 +45,11 @@ fn check_reserved_schema(schema: &str) -> Result<()> {
 pub(crate) async fn register_sources(
     ctx: &SessionContext,
     sources: Vec<Box<dyn CompiledBackendSource>>,
-    needles_file: Option<&Path>,
+    needles: &mut NeedleState,
 ) -> Result<SourceRegistrationResult> {
     let catalog = ctx
         .catalog("datafusion")
         .ok_or_else(|| DataFusionError::Plan("catalog 'datafusion' not found".to_string()))?;
-
-    let mut needles = NeedleState::from_path(needles_file)?;
 
     let mut result = SourceRegistrationResult::default();
     let mut seen_schemas = std::collections::HashSet::new();
@@ -110,7 +107,8 @@ pub(crate) fn register_sources_blocking(
     ctx: &SessionContext,
     sources: Vec<Box<dyn CompiledBackendSource>>,
 ) -> Result<SourceRegistrationResult> {
-    futures::executor::block_on(register_sources(ctx, sources, None))
+    let mut needles = NeedleState::default();
+    futures::executor::block_on(register_sources(ctx, sources, &mut needles))
 }
 
 async fn register_source(
@@ -142,6 +140,7 @@ mod tests {
     use super::{check_reserved_schema, register_sources};
     use crate::QueryRuntimeContext;
     use crate::backends::{CompiledBackendSource, compile_source_manifest};
+    use crate::needles::NeedleState;
     use coral_spec::{ValidatedSourceManifest, parse_source_manifest_value};
 
     fn compile_sources(
@@ -262,7 +261,9 @@ mod tests {
         let location = format!("file://{}/", fixture_dir.path().display());
         let manifest = jsonl_manifest(&location);
 
-        register_sources(&ctx, compile_sources(vec![manifest]), Some(&needles_path))
+        let mut needles =
+            NeedleState::from_path(Some(&needles_path)).expect("needles file should load");
+        register_sources(&ctx, compile_sources(vec![manifest]), &mut needles)
             .await
             .expect("jsonl source with needles should register");
 
@@ -283,9 +284,7 @@ mod tests {
         let needles_path = fixture_dir.path().join("needles.yaml");
         fs::write(&needles_path, "not: valid: yaml: [").expect("write malformed needles fixture");
 
-        let ctx = SessionContext::new();
-        let error = register_sources(&ctx, Vec::new(), Some(&needles_path))
-            .await
+        let error = NeedleState::from_path(Some(&needles_path))
             .expect_err("invalid needles yaml should fail runtime build");
         assert!(
             error.to_string().contains("failed to parse needles YAML"),
@@ -321,7 +320,9 @@ mod tests {
         let location = format!("file://{}/", fixture_dir.path().display());
         let manifest = jsonl_manifest(&location);
 
-        let error = register_sources(&ctx, compile_sources(vec![manifest]), Some(&needles_path))
+        let mut needles =
+            NeedleState::from_path(Some(&needles_path)).expect("needles file should load");
+        let error = register_sources(&ctx, compile_sources(vec![manifest]), &mut needles)
             .await
             .expect_err("invalid needle row should fail runtime build");
         assert!(
@@ -361,7 +362,9 @@ mod tests {
         let location = format!("file://{}/", fixture_dir.path().display());
         let manifest = jsonl_manifest(&location);
 
-        let error = register_sources(&ctx, compile_sources(vec![manifest]), Some(&needles_path))
+        let mut needles =
+            NeedleState::from_path(Some(&needles_path)).expect("needles file should load");
+        let error = register_sources(&ctx, compile_sources(vec![manifest]), &mut needles)
             .await
             .expect_err("unused needle entries should fail runtime build");
         assert!(
@@ -391,7 +394,9 @@ mod tests {
         let ctx = SessionContext::new();
         let manifest = jsonl_manifest("file:///path/that/does/not/exist/");
 
-        let error = register_sources(&ctx, compile_sources(vec![manifest]), Some(&needles_path))
+        let mut needles =
+            NeedleState::from_path(Some(&needles_path)).expect("needles file should load");
+        let error = register_sources(&ctx, compile_sources(vec![manifest]), &mut needles)
             .await
             .expect_err("source failure for targeted needles should be fatal");
         assert!(


### PR DESCRIPTION
## Summary

- Adds needle retrieval tracking: after query execution, scans result batches for planted needles and logs matches to an append-only NDJSON file
- Refactors needle registration orchestration so needle-related errors are fatal (not silently swallowed)
- Moves registry tests into a sibling module and inlines test helpers
- Tightens tracker matching heuristic (`MIN_MATCHING_COLUMNS = 2`) to prevent single-column false positives

## Detail

When `CORAL_NEEDLES_FILE` is set, the engine now:
1. Plants synthetic needle rows into table query results (from PR #29)
2. **[New]** After each query, scans result batches for rows matching planted needles
3. Logs matches to a `.log` NDJSON sibling file with timestamp, schema, table, needle data, and the SQL that found it

The tracker uses `json_to_scalar` for type-aware comparison (NDJSON round-trip through Arrow's JSON reader) and requires at least 2 matching columns to count a hit. Tracking is completely inert when `CORAL_NEEDLES_FILE` is unset.

## Test plan

- [ ] Set `CORAL_NEEDLES_FILE` to a needle YAML, run `coral sql`, query a table with a planted needle, verify `.log` NDJSON file is written with correct match entry
- [ ] Query a table without needles, verify no log entry is written
- [ ] Unset `CORAL_NEEDLES_FILE`, verify tracking is completely inert