### PR TITLE
feat(app): add OpenTelemetry tracing and metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,6 +1056,7 @@ dependencies = [
  "coral-api",
  "coral-app",
  "opentelemetry",
+ "opentelemetry_sdk",
  "serde_json",
  "thiserror",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,10 @@ dependencies = [
  "coral-spec",
  "directories",
  "fs2",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
@@ -1002,6 +1006,8 @@ dependencies = [
  "tonic",
  "tonic-types",
  "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1049,10 +1055,14 @@ dependencies = [
  "arrow",
  "coral-api",
  "coral-app",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "serde_json",
  "thiserror",
  "tonic",
  "tonic-types",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -3027,6 +3037,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3100,6 +3119,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3262,6 +3290,92 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.4",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "option-ext"
@@ -3962,6 +4076,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4332,6 +4447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,6 +4683,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -4917,6 +5050,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5019,6 +5198,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1056,7 +1056,6 @@ dependencies = [
  "coral-api",
  "coral-app",
  "opentelemetry",
- "opentelemetry_sdk",
  "serde_json",
  "thiserror",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,10 @@ glob = "0.3"
 httpdate = "1.0.3"
 jsonschema = { version = "0.18", default-features = false }
 object_store = { version = "0.13.2", features = ["aws"] }
+opentelemetry = "0.31.0"
+opentelemetry-appender-tracing = "0.31.0"
+opentelemetry-otlp = "0.31.0"
+opentelemetry_sdk = "0.31.0"
 parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
 reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls-native-roots", "system-proxy"] }
@@ -62,6 +66,8 @@ tonic-prost = "0.14.2"
 tonic-types = "0.14.2"
 tower = "0.5"
 tracing = "0.1.44"
+tracing-opentelemetry = "0.32.1"
+tracing-subscriber = { version = "0.3.22", features = ["env-filter"] }
 tempfile = "3"
 url = "2"
 urlencoding = "2"

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -13,6 +13,10 @@ workspace = true
 arrow.workspace = true
 directories.workspace = true
 fs2.workspace = true
+opentelemetry.workspace = true
+opentelemetry-appender-tracing.workspace = true
+opentelemetry-otlp.workspace = true
+opentelemetry_sdk.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
@@ -24,14 +28,17 @@ toml_edit.workspace = true
 tonic.workspace = true
 tonic-types.workspace = true
 tracing.workspace = true
+tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true
 
 coral-api.workspace = true
 coral-auth-aws = { path = "../auth/aws" }
-coral-spec.workspace = true
 coral-engine.workspace = true
+coral-spec.workspace = true
 
 [dev-dependencies]
 coral-client.workspace = true
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio.workspace = true

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -22,6 +22,7 @@ use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
+use crate::telemetry::TelemetryConfig;
 
 /// Server-side bootstrap configuration for the Coral server.
 #[derive(Clone)]
@@ -119,6 +120,8 @@ impl ServerBuilder {
                 .or_else(|| env.coral_config_dir_override()),
         )?;
         layout.ensure()?;
+        let telemetry_config = TelemetryConfig::load(&layout)?;
+        crate::telemetry::init_tracing(&telemetry_config);
         let config_store = ConfigStore::new(layout.clone());
         let secret_store = SecretStore::new(layout.clone());
         let source_manager =
@@ -179,6 +182,9 @@ impl RunningServer {
         if let Some(task) = task {
             task.await??;
         }
+        tokio::task::spawn_blocking(crate::telemetry::shutdown_tracing)
+            .await
+            .ok();
         Ok(())
     }
 }
@@ -229,6 +235,7 @@ async fn start_server(
 
 #[cfg(test)]
 mod tests {
+    use std::net::{Ipv4Addr, TcpListener};
     use std::sync::Arc;
 
     use coral_api::v1::query_service_client::QueryServiceClient;
@@ -259,8 +266,16 @@ mod tests {
             .add_engine_extensions_provider(Arc::new(NoopEngineExtensionsProvider));
     }
 
+    fn loopback_sockets_available() -> bool {
+        TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).is_ok()
+    }
+
     #[tokio::test]
     async fn file_tilde_sources_resolve_from_app_owned_runtime_context() {
+        if !loopback_sockets_available() {
+            return;
+        }
+
         let temp = TempDir::new().expect("temp dir");
         let fake_home = temp.path().join("fake-home");
         let config_dir = temp.path().join("coral-config");

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -121,7 +121,7 @@ impl ServerBuilder {
         )?;
         layout.ensure()?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
-        crate::telemetry::init_tracing(&telemetry_config);
+        crate::telemetry::init_tracing(&telemetry_config)?;
         let config_store = ConfigStore::new(layout.clone());
         let secret_store = SecretStore::new(layout.clone());
         let source_manager =

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -29,6 +29,7 @@ use crate::telemetry::TelemetryConfig;
 pub(crate) struct ServerConfig {
     config_dir: Option<PathBuf>,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    enable_stderr_logs: bool,
 }
 
 impl Default for ServerConfig {
@@ -44,6 +45,7 @@ impl ServerConfig {
         Self {
             config_dir: None,
             engine_extensions_providers: Vec::new(),
+            enable_stderr_logs: false,
         }
     }
 
@@ -61,6 +63,12 @@ impl ServerConfig {
     ) -> Self {
         self.engine_extensions_providers
             .push(engine_extensions_provider);
+        self
+    }
+
+    #[must_use]
+    pub(crate) fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
+        self.enable_stderr_logs = enable_stderr_logs;
         self
     }
 }
@@ -102,6 +110,17 @@ impl ServerBuilder {
         self
     }
 
+    #[must_use]
+    /// Enables or disables local stderr log rendering for this server.
+    ///
+    /// `MCP` stdio adapters can enable this for diagnostics while keeping
+    /// stdout reserved for protocol messages. Other command surfaces should
+    /// leave it disabled and rely on OTEL export for logs.
+    pub fn with_stderr_logs(mut self, enable_stderr_logs: bool) -> Self {
+        self.config = self.config.with_stderr_logs(enable_stderr_logs);
+        self
+    }
+
     /// Starts the Coral gRPC server on loopback TCP.
     ///
     /// Coral keeps a real local gRPC boundary here so the public client talks
@@ -121,7 +140,7 @@ impl ServerBuilder {
         )?;
         layout.ensure()?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
-        crate::telemetry::init_tracing(&telemetry_config)?;
+        crate::telemetry::init_tracing(&telemetry_config, self.config.enable_stderr_logs)?;
         let config_store = ConfigStore::new(layout.clone());
         let secret_store = SecretStore::new(layout.clone());
         let source_manager =

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -201,9 +201,6 @@ impl RunningServer {
         if let Some(task) = task {
             task.await??;
         }
-        tokio::task::spawn_blocking(crate::telemetry::shutdown_tracing)
-            .await
-            .ok();
         Ok(())
     }
 }

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -37,6 +37,7 @@ mod query;
 mod sources;
 mod state;
 mod storage;
+pub mod telemetry;
 mod transport;
 mod workspaces;
 
@@ -45,4 +46,5 @@ pub use coral_engine::{EngineExtensions, QuerySource};
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
+pub use telemetry::{seed_root_span, shutdown_tracing};
 pub use workspaces::DEFAULT_WORKSPACE_ID;

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -46,5 +46,5 @@ pub use coral_engine::{EngineExtensions, QuerySource};
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
-pub use telemetry::{seed_root_span, shutdown_tracing};
+pub use telemetry::{RunContext, run_with_context, shutdown_tracing};
 pub use workspaces::DEFAULT_WORKSPACE_ID;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -91,9 +91,10 @@ impl QueryManager {
         let metrics = crate::telemetry::metrics::metrics();
         let status = crate::telemetry::metrics::status_attr(result.is_ok());
         metrics.count.add(1, std::slice::from_ref(&status));
-        metrics
-            .duration
-            .record(started_at.elapsed().as_secs_f64(), std::slice::from_ref(&status));
+        metrics.duration.record(
+            started_at.elapsed().as_secs_f64(),
+            std::slice::from_ref(&status),
+        );
 
         if let Ok(execution) = &result {
             let row_count = u64::try_from(execution.row_count()).unwrap_or(u64::MAX);

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -90,10 +90,10 @@ impl QueryManager {
 
         let metrics = crate::telemetry::metrics::metrics();
         let status = crate::telemetry::metrics::status_attr(result.is_ok());
-        metrics.count.add(1, &[status.clone()]);
+        metrics.count.add(1, std::slice::from_ref(&status));
         metrics
             .duration
-            .record(started_at.elapsed().as_secs_f64(), &[status]);
+            .record(started_at.elapsed().as_secs_f64(), std::slice::from_ref(&status));
 
         if let Ok(execution) = &result {
             let row_count = u64::try_from(execution.row_count()).unwrap_or(u64::MAX);

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -92,7 +92,7 @@ impl QueryManager {
         metrics.count.add(1, &[]);
         metrics
             .duration
-            .record(started_at.elapsed().as_secs_f64() * 1000.0, &[]);
+            .record(started_at.elapsed().as_secs_f64(), &[]);
 
         if let Ok(execution) = &result {
             let row_count = u64::try_from(execution.row_count()).unwrap_or(u64::MAX);

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -89,10 +89,11 @@ impl QueryManager {
         .await;
 
         let metrics = crate::telemetry::metrics::metrics();
-        metrics.count.add(1, &[]);
+        let status = crate::telemetry::metrics::status_attr(result.is_ok());
+        metrics.count.add(1, &[status.clone()]);
         metrics
             .duration
-            .record(started_at.elapsed().as_secs_f64(), &[]);
+            .record(started_at.elapsed().as_secs_f64(), &[status]);
 
         if let Ok(execution) = &result {
             let row_count = u64::try_from(execution.row_count()).unwrap_or(u64::MAX);
@@ -101,7 +102,6 @@ impl QueryManager {
             metrics.rows.record(row_count, &[]);
         } else {
             query_span.record("status", "error");
-            metrics.errors.add(1, &[]);
         }
 
         result

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -2,12 +2,14 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     SourceValidationReport, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_source_manifest_yaml};
+use tracing::Instrument as _;
 
 use crate::bootstrap::AppError;
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
@@ -72,13 +74,37 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         sql: &str,
     ) -> Result<QueryExecution, QueryManagerError> {
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_config(&sources);
-        CoralQuery::execute_sql(&sources, runtime, sql)
-            .await
-            .map_err(QueryManagerError::Core)
+        let started_at = Instant::now();
+        let query_span = create_query_span(sql);
+        let result = async {
+            let sources = self
+                .load_query_sources(workspace_name)
+                .map_err(QueryManagerError::App)?;
+            let runtime = self.runtime_config(&sources);
+            CoralQuery::execute_sql(&sources, runtime, sql)
+                .await
+                .map_err(QueryManagerError::Core)
+        }
+        .instrument(query_span.clone())
+        .await;
+
+        let metrics = crate::telemetry::metrics::metrics();
+        metrics.count.add(1, &[]);
+        metrics
+            .duration
+            .record(started_at.elapsed().as_secs_f64() * 1000.0, &[]);
+
+        if let Ok(execution) = &result {
+            let row_count = u64::try_from(execution.row_count()).unwrap_or(u64::MAX);
+            query_span.record("row_count", row_count);
+            query_span.record("status", "ok");
+            metrics.rows.record(row_count, &[]);
+        } else {
+            query_span.record("status", "error");
+            metrics.errors.add(1, &[]);
+        }
+
+        result
     }
 
     pub(crate) async fn validate_source(
@@ -174,6 +200,16 @@ impl QueryManager {
             engine_extensions_for_providers(&self.engine_extensions_providers, selected_sources),
         )
     }
+}
+
+fn create_query_span(sql: &str) -> tracing::Span {
+    tracing::info_span!(
+        "coral.query",
+        otel.name = "coral.query",
+        sql = %sql,
+        row_count = tracing::field::Empty,
+        status = tracing::field::Empty,
+    )
 }
 
 fn validate_required_variables(

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -5,15 +5,12 @@ use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
 use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, ListTablesRequest, ListTablesResponse};
-use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
-use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tonic::{Request, Response, Status};
 use tracing::Instrument as _;
-use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::core_status;
 use crate::query::manager::QueryManager;
-use crate::transport::{query_status, table_to_proto, workspace_name_from_proto};
+use crate::transport::{grpc_span, query_status, table_to_proto, workspace_name_from_proto};
 
 #[derive(Clone)]
 pub(crate) struct QueryService {
@@ -28,58 +25,36 @@ impl QueryService {
     }
 }
 
-struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
-
-impl Extractor for MetadataExtractor<'_> {
-    fn get(&self, key: &str) -> Option<&str> {
-        self.0.get(key).and_then(|v| v.to_str().ok())
-    }
-
-    fn keys(&self) -> Vec<&str> {
-        use tonic::metadata::KeyRef;
-        self.0
-            .keys()
-            .filter_map(|k| match k {
-                KeyRef::Ascii(key) => Some(key.as_str()),
-                KeyRef::Binary(_) => None,
-            })
-            .collect()
-    }
-}
-
-fn extract_trace_context(metadata: &tonic::metadata::MetadataMap) -> opentelemetry::Context {
-    TraceContextPropagator::new().extract(&MetadataExtractor(metadata))
-}
-
 #[tonic::async_trait]
 impl QueryServiceApi for QueryService {
     async fn list_tables(
         &self,
         request: Request<ListTablesRequest>,
     ) -> Result<Response<ListTablesResponse>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let tables = self
-            .queries
-            .list_tables(&workspace_name)
-            .await
-            .map_err(query_status)?
-            .into_iter()
-            .map(|table| table_to_proto(&workspace_name, table))
-            .collect();
-        Ok(Response::new(ListTablesResponse { tables }))
+        let span = grpc_span(request.metadata(), "list_tables");
+        let queries = self.queries.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let tables = queries
+                .list_tables(&workspace_name)
+                .await
+                .map_err(query_status)?
+                .into_iter()
+                .map(|table| table_to_proto(&workspace_name, table))
+                .collect();
+            Ok(Response::new(ListTablesResponse { tables }))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn execute_sql(
         &self,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
-        let parent_cx = extract_trace_context(request.metadata());
-        let span = tracing::info_span!("grpc.execute_sql");
-        let _ = span.set_parent(parent_cx);
-
+        let span = grpc_span(request.metadata(), "execute_sql");
         let queries = self.queries.clone();
-
         async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -5,7 +5,11 @@ use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
 use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, ListTablesRequest, ListTablesResponse};
+use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tonic::{Request, Response, Status};
+use tracing::Instrument as _;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::core_status;
 use crate::query::manager::QueryManager;
@@ -22,6 +26,29 @@ impl QueryService {
             queries: query_manager,
         }
     }
+}
+
+struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
+
+impl Extractor for MetadataExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        use tonic::metadata::KeyRef;
+        self.0
+            .keys()
+            .filter_map(|k| match k {
+                KeyRef::Ascii(key) => Some(key.as_str()),
+                KeyRef::Binary(_) => None,
+            })
+            .collect()
+    }
+}
+
+fn extract_trace_context(metadata: &tonic::metadata::MetadataMap) -> opentelemetry::Context {
+    TraceContextPropagator::new().extract(&MetadataExtractor(metadata))
 }
 
 #[tonic::async_trait]
@@ -47,23 +74,32 @@ impl QueryServiceApi for QueryService {
         &self,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let execution = self
-            .queries
-            .execute_sql(&workspace_name, &request.sql)
-            .await
-            .map_err(query_status)?;
-        let response = ExecuteSqlResponse {
-            arrow_ipc_stream: encode_arrow_ipc_stream(
-                execution.arrow_schema(),
-                execution.batches(),
-            )
-            .map_err(coral_engine::CoreError::from)
-            .map_err(core_status)?,
-            row_count: i64::try_from(execution.row_count()).unwrap_or(i64::MAX),
-        };
-        Ok(Response::new(response))
+        let parent_cx = extract_trace_context(request.metadata());
+        let span = tracing::info_span!("grpc.execute_sql");
+        let _ = span.set_parent(parent_cx);
+
+        let queries = self.queries.clone();
+
+        async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let execution = queries
+                .execute_sql(&workspace_name, &inner.sql)
+                .await
+                .map_err(query_status)?;
+            let response = ExecuteSqlResponse {
+                arrow_ipc_stream: encode_arrow_ipc_stream(
+                    execution.arrow_schema(),
+                    execution.batches(),
+                )
+                .map_err(coral_engine::CoreError::from)
+                .map_err(core_status)?,
+                row_count: i64::try_from(execution.row_count()).unwrap_or(i64::MAX),
+            };
+            Ok(Response::new(response))
+        }
+        .instrument(span)
+        .await
     }
 }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -10,6 +10,7 @@ use coral_api::v1::{
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use tonic::{Request, Response, Status};
+use tracing::Instrument as _;
 
 use crate::bootstrap::app_status;
 use crate::query::manager::QueryManager;
@@ -17,7 +18,8 @@ use crate::sources::SourceName;
 use crate::sources::manager::SourceManager;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
-    query_status, validate_source_response_to_proto, workspace_name_from_proto, workspace_to_proto,
+    grpc_span, query_status, validate_source_response_to_proto, workspace_name_from_proto,
+    workspace_to_proto,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -42,131 +44,171 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<DiscoverSourcesRequest>,
     ) -> Result<Response<DiscoverSourcesResponse>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let sources = self
-            .sources
-            .discover_sources(&workspace_name)
-            .map_err(app_status)?
-            .into_iter()
-            .map(candidate_source_to_proto)
-            .collect();
-        Ok(Response::new(DiscoverSourcesResponse { sources }))
+        let span = grpc_span(request.metadata(), "discover_sources");
+        let sources = self.sources.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let sources = sources
+                .discover_sources(&workspace_name)
+                .map_err(app_status)?
+                .into_iter()
+                .map(candidate_source_to_proto)
+                .collect();
+            Ok(Response::new(DiscoverSourcesResponse { sources }))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn list_sources(
         &self,
         request: Request<ListSourcesRequest>,
     ) -> Result<Response<ListSourcesResponse>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let sources: Vec<_> = self
-            .sources
-            .list_workspace_sources(&workspace_name)
-            .map_err(app_status)?
-            .into_iter()
-            .map(|source| installed_source_to_proto(&workspace_name, source))
-            .collect();
-        Ok(Response::new(ListSourcesResponse { sources }))
+        let span = grpc_span(request.metadata(), "list_sources");
+        let sources = self.sources.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let sources: Vec<_> = sources
+                .list_workspace_sources(&workspace_name)
+                .map_err(app_status)?
+                .into_iter()
+                .map(|source| installed_source_to_proto(&workspace_name, source))
+                .collect();
+            Ok(Response::new(ListSourcesResponse { sources }))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn get_source(
         &self,
         request: Request<GetSourceRequest>,
     ) -> Result<Response<Source>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-        let source = self
-            .sources
-            .get_source(&workspace_name, &source_name)
-            .map_err(app_status)?;
-        Ok(Response::new(installed_source_to_proto(
-            &workspace_name,
-            source,
-        )))
+        let span = grpc_span(request.metadata(), "get_source");
+        let sources = self.sources.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let source = sources
+                .get_source(&workspace_name, &source_name)
+                .map_err(app_status)?;
+            Ok(Response::new(installed_source_to_proto(
+                &workspace_name,
+                source,
+            )))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn get_source_info(
         &self,
         request: Request<GetSourceInfoRequest>,
     ) -> Result<Response<SourceInfo>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-        let source = self
-            .sources
-            .get_source_info(&workspace_name, &source_name)
-            .map_err(app_status)?;
-        Ok(Response::new(candidate_source_to_proto(source)))
+        let span = grpc_span(request.metadata(), "get_source_info");
+        let sources = self.sources.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let source = sources
+                .get_source_info(&workspace_name, &source_name)
+                .map_err(app_status)?;
+            Ok(Response::new(candidate_source_to_proto(source)))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn create_bundled_source(
         &self,
         request: Request<CreateBundledSourceRequest>,
     ) -> Result<Response<Source>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
-        let installed = self
-            .sources
-            .create_bundled_source(&workspace_name, &bundled_name, &request)
-            .map_err(app_status)?;
-        Ok(Response::new(installed_source_to_proto(
-            &workspace_name,
-            installed,
-        )))
+        let span = grpc_span(request.metadata(), "create_bundled_source");
+        let sources = self.sources.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let installed = sources
+                .create_bundled_source(&workspace_name, &bundled_name, &request)
+                .map_err(app_status)?;
+            Ok(Response::new(installed_source_to_proto(
+                &workspace_name,
+                installed,
+            )))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn import_source(
         &self,
         request: Request<ImportSourceRequest>,
     ) -> Result<Response<Source>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let installed = self
-            .sources
-            .import_source(&workspace_name, &request)
-            .map_err(app_status)?;
-        Ok(Response::new(installed_source_to_proto(
-            &workspace_name,
-            installed,
-        )))
+        let span = grpc_span(request.metadata(), "import_source");
+        let sources = self.sources.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let installed = sources
+                .import_source(&workspace_name, &request)
+                .map_err(app_status)?;
+            Ok(Response::new(installed_source_to_proto(
+                &workspace_name,
+                installed,
+            )))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn delete_source(
         &self,
         request: Request<DeleteSourceRequest>,
     ) -> Result<Response<()>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-        let _installed = self
-            .sources
-            .delete_source(&workspace_name, &source_name)
-            .map_err(app_status)?;
-        Ok(Response::new(()))
+        let span = grpc_span(request.metadata(), "delete_source");
+        let sources = self.sources.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            sources
+                .delete_source(&workspace_name, &source_name)
+                .map_err(app_status)?;
+            Ok(Response::new(()))
+        }
+        .instrument(span)
+        .await
     }
 
     async fn validate_source(
         &self,
         request: Request<ValidateSourceRequest>,
     ) -> Result<Response<ValidateSourceResponse>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let source_name = SourceName::parse(&request.name).map_err(app_status)?;
-        let result = self
-            .queries
-            .validate_source(&workspace_name, &source_name)
-            .await
-            .map_err(query_status)?;
-        let crate::query::manager::ValidatedSource { source, report } = result;
-        let source = installed_source_to_proto(&workspace_name, source);
-        Ok(Response::new(validate_source_response_to_proto(
-            source,
-            &workspace_name,
-            report,
-        )))
+        let span = grpc_span(request.metadata(), "validate_source");
+        let queries = self.queries.clone();
+        async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let result = queries
+                .validate_source(&workspace_name, &source_name)
+                .await
+                .map_err(query_status)?;
+            let crate::query::manager::ValidatedSource { source, report } = result;
+            let source = installed_source_to_proto(&workspace_name, source);
+            Ok(Response::new(validate_source_response_to_proto(
+                source,
+                &workspace_name,
+                report,
+            )))
+        }
+        .instrument(span)
+        .await
     }
 }
 

--- a/crates/coral-app/src/telemetry/config.rs
+++ b/crates/coral-app/src/telemetry/config.rs
@@ -1,0 +1,110 @@
+//! Telemetry configuration loading from app state.
+
+use serde::Deserialize;
+
+use crate::bootstrap::AppError;
+use crate::state::AppStateLayout;
+
+pub(super) const DEFAULT_TRACE_FILTER: &str = "coral_app=trace,coral_engine=trace";
+const DEFAULT_SERVICE_NAME: &str = "coral";
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct TelemetryConfigFile {
+    #[serde(default)]
+    telemetry: TelemetryConfig,
+}
+
+/// Telemetry settings loaded from `config.toml`.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+#[allow(
+    clippy::struct_field_names,
+    reason = "field names mirror the TOML config keys for direct serde deserialization"
+)]
+pub struct TelemetryConfig {
+    pub(crate) otel_endpoint: Option<String>,
+    pub(crate) otel_headers: Option<String>,
+    pub(crate) otel_log_filter: Option<String>,
+    pub(crate) otel_trace_filter: String,
+    pub(crate) otel_service_name: String,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            otel_endpoint: None,
+            otel_headers: None,
+            otel_log_filter: None,
+            otel_trace_filter: DEFAULT_TRACE_FILTER.to_string(),
+            otel_service_name: DEFAULT_SERVICE_NAME.to_string(),
+        }
+    }
+}
+
+impl TelemetryConfig {
+    /// Load the `[telemetry]` section from `config.toml`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, AppError> {
+        let config = if layout.config_file().exists() {
+            let raw = std::fs::read_to_string(layout.config_file())?;
+            toml::from_str::<TelemetryConfigFile>(&raw)?.telemetry
+        } else {
+            Self::default()
+        };
+
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::TelemetryConfig;
+    use crate::state::AppStateLayout;
+
+    #[test]
+    fn defaults_when_config_file_is_missing() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+
+        let config = TelemetryConfig::load(&layout).expect("default telemetry config");
+
+        assert_eq!(config, TelemetryConfig::default());
+    }
+
+    #[test]
+    fn loads_telemetry_section_from_config_file() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("ensure config dir");
+        std::fs::write(
+            layout.config_file(),
+            r#"
+version = 1
+
+[telemetry]
+otel_endpoint = "http://localhost:4318"
+otel_headers = "from=config"
+otel_log_filter = "info"
+otel_trace_filter = "coral_app=debug"
+otel_service_name = "from-config"
+"#,
+        )
+        .expect("write config");
+
+        let config = TelemetryConfig::load(&layout).expect("telemetry config");
+
+        assert_eq!(
+            config.otel_endpoint.as_deref(),
+            Some("http://localhost:4318")
+        );
+        assert_eq!(config.otel_headers.as_deref(), Some("from=config"));
+        assert_eq!(config.otel_log_filter.as_deref(), Some("info"));
+        assert_eq!(config.otel_trace_filter, "coral_app=debug");
+        assert_eq!(config.otel_service_name, "from-config");
+    }
+}

--- a/crates/coral-app/src/telemetry/config.rs
+++ b/crates/coral-app/src/telemetry/config.rs
@@ -6,6 +6,7 @@ use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
 
 pub(super) const DEFAULT_TRACE_FILTER: &str = "coral_app=trace,coral_engine=trace";
+pub(super) const DEFAULT_LOG_FILTER: &str = "coral_app=info,coral_engine=info";
 const DEFAULT_SERVICE_NAME: &str = "coral";
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/crates/coral-app/src/telemetry/config.rs
+++ b/crates/coral-app/src/telemetry/config.rs
@@ -12,38 +12,34 @@ const DEFAULT_SERVICE_NAME: &str = "coral";
 #[derive(Debug, Clone, Default, Deserialize)]
 struct TelemetryConfigFile {
     #[serde(default)]
-    telemetry: TelemetryConfig,
+    otel: TelemetryConfig,
 }
 
 /// Telemetry settings loaded from `config.toml`.
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(default)]
-#[allow(
-    clippy::struct_field_names,
-    reason = "field names mirror the TOML config keys for direct serde deserialization"
-)]
 pub struct TelemetryConfig {
-    pub(crate) otel_endpoint: Option<String>,
-    pub(crate) otel_headers: Option<String>,
-    pub(crate) otel_log_filter: Option<String>,
-    pub(crate) otel_trace_filter: String,
-    pub(crate) otel_service_name: String,
+    pub(crate) endpoint: Option<String>,
+    pub(crate) headers: Option<String>,
+    pub(crate) log_filter: Option<String>,
+    pub(crate) trace_filter: String,
+    pub(crate) service_name: String,
 }
 
 impl Default for TelemetryConfig {
     fn default() -> Self {
         Self {
-            otel_endpoint: None,
-            otel_headers: None,
-            otel_log_filter: None,
-            otel_trace_filter: DEFAULT_TRACE_FILTER.to_string(),
-            otel_service_name: DEFAULT_SERVICE_NAME.to_string(),
+            endpoint: None,
+            headers: None,
+            log_filter: None,
+            trace_filter: DEFAULT_TRACE_FILTER.to_string(),
+            service_name: DEFAULT_SERVICE_NAME.to_string(),
         }
     }
 }
 
 impl TelemetryConfig {
-    /// Load the `[telemetry]` section from `config.toml`.
+    /// Load the `[otel]` section from `config.toml`.
     ///
     /// # Errors
     ///
@@ -51,7 +47,7 @@ impl TelemetryConfig {
     pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, AppError> {
         let config = if layout.config_file().exists() {
             let raw = std::fs::read_to_string(layout.config_file())?;
-            toml::from_str::<TelemetryConfigFile>(&raw)?.telemetry
+            toml::from_str::<TelemetryConfigFile>(&raw)?.otel
         } else {
             Self::default()
         };
@@ -78,7 +74,7 @@ mod tests {
     }
 
     #[test]
-    fn loads_telemetry_section_from_config_file() {
+    fn loads_otel_section_from_config_file() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
         layout.ensure().expect("ensure config dir");
@@ -87,25 +83,22 @@ mod tests {
             r#"
 version = 1
 
-[telemetry]
-otel_endpoint = "http://localhost:4318"
-otel_headers = "from=config"
-otel_log_filter = "info"
-otel_trace_filter = "coral_app=debug"
-otel_service_name = "from-config"
+[otel]
+endpoint = "http://localhost:4318"
+headers = "from=config"
+log_filter = "info"
+trace_filter = "coral_app=debug"
+service_name = "from-config"
 "#,
         )
         .expect("write config");
 
         let config = TelemetryConfig::load(&layout).expect("telemetry config");
 
-        assert_eq!(
-            config.otel_endpoint.as_deref(),
-            Some("http://localhost:4318")
-        );
-        assert_eq!(config.otel_headers.as_deref(), Some("from=config"));
-        assert_eq!(config.otel_log_filter.as_deref(), Some("info"));
-        assert_eq!(config.otel_trace_filter, "coral_app=debug");
-        assert_eq!(config.otel_service_name, "from-config");
+        assert_eq!(config.endpoint.as_deref(), Some("http://localhost:4318"));
+        assert_eq!(config.headers.as_deref(), Some("from=config"));
+        assert_eq!(config.log_filter.as_deref(), Some("info"));
+        assert_eq!(config.trace_filter, "coral_app=debug");
+        assert_eq!(config.service_name, "from-config");
     }
 }

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -1,0 +1,204 @@
+//! Shared query metric instruments.
+
+use std::sync::RwLock;
+
+use opentelemetry::metrics::{Counter, Histogram, Meter};
+
+#[derive(Clone)]
+pub(crate) struct Metrics {
+    pub(crate) count: Counter<u64>,
+    pub(crate) duration: Histogram<f64>,
+    pub(crate) errors: Counter<u64>,
+    pub(crate) rows: Histogram<u64>,
+}
+
+static METRICS: RwLock<Option<Metrics>> = RwLock::new(None);
+
+fn build_metrics(meter: &Meter) -> Metrics {
+    Metrics {
+        count: meter
+            .u64_counter("coral.query.count")
+            .with_unit("{queries}")
+            .with_description("Total queries executed")
+            .build(),
+        duration: meter
+            .f64_histogram("coral.query.duration")
+            .with_unit("ms")
+            .with_description("Query execution latency")
+            .build(),
+        errors: meter
+            .u64_counter("coral.query.errors")
+            .with_unit("{errors}")
+            .with_description("Failed queries")
+            .build(),
+        rows: meter
+            .u64_histogram("coral.query.rows")
+            .with_unit("{rows}")
+            .with_description("Rows returned per query")
+            .build(),
+    }
+}
+
+pub(crate) fn init(meter: &Meter) {
+    let mut metrics = METRICS
+        .write()
+        .expect("metrics lock poisoned during initialization");
+    *metrics = Some(build_metrics(meter));
+}
+
+pub(crate) fn init_global() {
+    let meter = opentelemetry::global::meter("coral");
+    init(&meter);
+}
+
+pub(crate) fn metrics() -> Metrics {
+    #[cfg(test)]
+    if let Some(metrics) = test_support::metrics_for_test() {
+        return metrics;
+    }
+
+    if let Some(metrics) = METRICS
+        .read()
+        .expect("metrics lock poisoned during read")
+        .clone()
+    {
+        return metrics;
+    }
+
+    let mut metrics = METRICS
+        .write()
+        .expect("metrics lock poisoned during initialization");
+    if metrics.is_none() {
+        let meter = opentelemetry::global::meter("coral");
+        *metrics = Some(build_metrics(&meter));
+    }
+
+    metrics
+        .clone()
+        .expect("metrics must be initialized before use")
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use opentelemetry::metrics::MeterProvider as _;
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    use super::METRICS;
+
+    std::thread_local! {
+        static TEST_METER_PROVIDER: std::cell::RefCell<Option<SdkMeterProvider>> =
+            const { std::cell::RefCell::new(None) };
+        static TEST_METRICS: std::cell::RefCell<Option<super::Metrics>> =
+            const { std::cell::RefCell::new(None) };
+    }
+
+    pub(crate) fn metrics_for_test() -> Option<super::Metrics> {
+        TEST_METRICS.with(|metrics| metrics.borrow().clone())
+    }
+
+    fn install_provider(provider: SdkMeterProvider) {
+        let meter = provider.meter("coral");
+        let metrics = super::build_metrics(&meter);
+        TEST_METRICS.with(|slot| {
+            *slot.borrow_mut() = Some(metrics);
+        });
+        TEST_METER_PROVIDER.with(|slot| {
+            *slot.borrow_mut() = Some(provider);
+        });
+    }
+
+    pub(crate) fn install_metrics_exporter() -> InMemoryMetricExporter {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(PeriodicReader::builder(exporter.clone()).build())
+            .build();
+        install_provider(provider);
+        exporter
+    }
+
+    pub(crate) fn flush_metrics() {
+        TEST_METER_PROVIDER.with(|slot| {
+            if let Some(provider) = slot.borrow().as_ref() {
+                provider
+                    .force_flush()
+                    .expect("test metrics flush should work");
+            }
+        });
+    }
+
+    pub(crate) fn reset_metrics() {
+        TEST_METRICS.with(|slot| {
+            *slot.borrow_mut() = None;
+        });
+        TEST_METER_PROVIDER.with(|slot| {
+            *slot.borrow_mut() = None;
+        });
+        *METRICS
+            .write()
+            .expect("metrics lock poisoned during test reset") = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+
+    use super::metrics;
+
+    fn sum_u64(metrics: &[ResourceMetrics], name: &str) -> u64 {
+        metrics
+            .iter()
+            .rev()
+            .flat_map(ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == name)
+            .and_then(|metric| match metric.data() {
+                AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
+                    .data_points()
+                    .next()
+                    .map(opentelemetry_sdk::metrics::data::SumDataPoint::value),
+                _ => None,
+            })
+            .unwrap_or(0)
+    }
+
+    fn histogram_count(metrics: &[ResourceMetrics], name: &str) -> u64 {
+        metrics
+            .iter()
+            .rev()
+            .flat_map(ResourceMetrics::scope_metrics)
+            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+            .find(|metric| metric.name() == name)
+            .and_then(|metric| match metric.data() {
+                AggregatedMetrics::F64(MetricData::Histogram(histogram)) => histogram
+                    .data_points()
+                    .next()
+                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count),
+                AggregatedMetrics::U64(MetricData::Histogram(histogram)) => histogram
+                    .data_points()
+                    .next()
+                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count),
+                _ => None,
+            })
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn query_metrics_record_counts_errors_and_rows() {
+        super::test_support::reset_metrics();
+        let exporter = super::test_support::install_metrics_exporter();
+        let metrics = metrics();
+
+        metrics.count.add(2, &[]);
+        metrics.errors.add(1, &[]);
+        metrics.duration.record(12.5, &[]);
+        metrics.rows.record(7, &[]);
+
+        super::test_support::flush_metrics();
+        let finished = exporter.get_finished_metrics().expect("finished metrics");
+        assert_eq!(sum_u64(&finished, "coral.query.count"), 2);
+        assert_eq!(sum_u64(&finished, "coral.query.errors"), 1);
+        assert_eq!(histogram_count(&finished, "coral.query.duration"), 1);
+        assert_eq!(histogram_count(&finished, "coral.query.rows"), 1);
+    }
+}

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -144,23 +144,6 @@ mod tests {
 
     use super::metrics;
 
-    fn sum_u64(metrics: &[ResourceMetrics], name: &str) -> u64 {
-        metrics
-            .iter()
-            .rev()
-            .flat_map(ResourceMetrics::scope_metrics)
-            .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
-            .find(|metric| metric.name() == name)
-            .and_then(|metric| match metric.data() {
-                AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
-                    .data_points()
-                    .next()
-                    .map(opentelemetry_sdk::metrics::data::SumDataPoint::value),
-                _ => None,
-            })
-            .unwrap_or(0)
-    }
-
     fn histogram_total_count(metrics: &[ResourceMetrics], name: &str) -> u64 {
         metrics
             .iter()
@@ -168,7 +151,7 @@ mod tests {
             .flat_map(ResourceMetrics::scope_metrics)
             .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
             .find(|metric| metric.name() == name)
-            .map(|metric| match metric.data() {
+            .map_or(0, |metric| match metric.data() {
                 AggregatedMetrics::F64(MetricData::Histogram(histogram)) => histogram
                     .data_points()
                     .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
@@ -179,7 +162,6 @@ mod tests {
                     .sum(),
                 _ => 0,
             })
-            .unwrap_or(0)
     }
 
     #[test]
@@ -190,10 +172,10 @@ mod tests {
 
         let ok = super::status_attr(true);
         let err = super::status_attr(false);
-        metrics.count.add(2, &[ok.clone()]);
-        metrics.count.add(1, &[err.clone()]);
-        metrics.duration.record(0.5, &[ok]);
-        metrics.duration.record(0.1, &[err]);
+        metrics.count.add(2, std::slice::from_ref(&ok));
+        metrics.count.add(1, std::slice::from_ref(&err));
+        metrics.duration.record(0.5, std::slice::from_ref(&ok));
+        metrics.duration.record(0.1, std::slice::from_ref(&err));
         metrics.rows.record(7, &[]);
 
         super::test_support::flush_metrics();

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -23,7 +23,7 @@ fn build_metrics(meter: &Meter) -> Metrics {
             .build(),
         duration: meter
             .f64_histogram("coral.query.duration")
-            .with_unit("ms")
+            .with_unit("s")
             .with_description("Query execution latency")
             .build(),
         errors: meter

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -2,14 +2,18 @@
 
 use std::sync::RwLock;
 
+use opentelemetry::KeyValue;
 use opentelemetry::metrics::{Counter, Histogram, Meter};
 
 #[derive(Clone)]
 pub(crate) struct Metrics {
     pub(crate) count: Counter<u64>,
     pub(crate) duration: Histogram<f64>,
-    pub(crate) errors: Counter<u64>,
     pub(crate) rows: Histogram<u64>,
+}
+
+pub(crate) fn status_attr(ok: bool) -> KeyValue {
+    KeyValue::new("status", if ok { "ok" } else { "error" })
 }
 
 static METRICS: RwLock<Option<Metrics>> = RwLock::new(None);
@@ -25,11 +29,6 @@ fn build_metrics(meter: &Meter) -> Metrics {
             .f64_histogram("coral.query.duration")
             .with_unit("s")
             .with_description("Query execution latency")
-            .build(),
-        errors: meter
-            .u64_counter("coral.query.errors")
-            .with_unit("{errors}")
-            .with_description("Failed queries")
             .build(),
         rows: meter
             .u64_histogram("coral.query.rows")
@@ -162,43 +161,44 @@ mod tests {
             .unwrap_or(0)
     }
 
-    fn histogram_count(metrics: &[ResourceMetrics], name: &str) -> u64 {
+    fn histogram_total_count(metrics: &[ResourceMetrics], name: &str) -> u64 {
         metrics
             .iter()
             .rev()
             .flat_map(ResourceMetrics::scope_metrics)
             .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
             .find(|metric| metric.name() == name)
-            .and_then(|metric| match metric.data() {
+            .map(|metric| match metric.data() {
                 AggregatedMetrics::F64(MetricData::Histogram(histogram)) => histogram
                     .data_points()
-                    .next()
-                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count),
+                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
+                    .sum(),
                 AggregatedMetrics::U64(MetricData::Histogram(histogram)) => histogram
                     .data_points()
-                    .next()
-                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count),
-                _ => None,
+                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
+                    .sum(),
+                _ => 0,
             })
             .unwrap_or(0)
     }
 
     #[test]
-    fn query_metrics_record_counts_errors_and_rows() {
+    fn query_metrics_record_counts_and_rows_with_status() {
         super::test_support::reset_metrics();
         let exporter = super::test_support::install_metrics_exporter();
         let metrics = metrics();
 
-        metrics.count.add(2, &[]);
-        metrics.errors.add(1, &[]);
-        metrics.duration.record(12.5, &[]);
+        let ok = super::status_attr(true);
+        let err = super::status_attr(false);
+        metrics.count.add(2, &[ok.clone()]);
+        metrics.count.add(1, &[err.clone()]);
+        metrics.duration.record(0.5, &[ok]);
+        metrics.duration.record(0.1, &[err]);
         metrics.rows.record(7, &[]);
 
         super::test_support::flush_metrics();
         let finished = exporter.get_finished_metrics().expect("finished metrics");
-        assert_eq!(sum_u64(&finished, "coral.query.count"), 2);
-        assert_eq!(sum_u64(&finished, "coral.query.errors"), 1);
-        assert_eq!(histogram_count(&finished, "coral.query.duration"), 1);
-        assert_eq!(histogram_count(&finished, "coral.query.rows"), 1);
+        assert_eq!(histogram_total_count(&finished, "coral.query.duration"), 2);
+        assert_eq!(histogram_total_count(&finished, "coral.query.rows"), 1);
     }
 }

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -144,24 +144,40 @@ mod tests {
 
     use super::metrics;
 
-    fn histogram_total_count(metrics: &[ResourceMetrics], name: &str) -> u64 {
+    fn find_metric<'a>(
+        metrics: &'a [ResourceMetrics],
+        name: &str,
+    ) -> Option<&'a opentelemetry_sdk::metrics::data::Metric> {
         metrics
             .iter()
             .rev()
             .flat_map(ResourceMetrics::scope_metrics)
             .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
             .find(|metric| metric.name() == name)
-            .map_or(0, |metric| match metric.data() {
-                AggregatedMetrics::F64(MetricData::Histogram(histogram)) => histogram
-                    .data_points()
-                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
-                    .sum(),
-                AggregatedMetrics::U64(MetricData::Histogram(histogram)) => histogram
-                    .data_points()
-                    .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
-                    .sum(),
-                _ => 0,
-            })
+    }
+
+    fn histogram_total_count(metrics: &[ResourceMetrics], name: &str) -> u64 {
+        find_metric(metrics, name).map_or(0, |metric| match metric.data() {
+            AggregatedMetrics::F64(MetricData::Histogram(histogram)) => histogram
+                .data_points()
+                .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
+                .sum(),
+            AggregatedMetrics::U64(MetricData::Histogram(histogram)) => histogram
+                .data_points()
+                .map(opentelemetry_sdk::metrics::data::HistogramDataPoint::count)
+                .sum(),
+            _ => 0,
+        })
+    }
+
+    fn counter_total(metrics: &[ResourceMetrics], name: &str) -> u64 {
+        find_metric(metrics, name).map_or(0, |metric| match metric.data() {
+            AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
+                .data_points()
+                .map(opentelemetry_sdk::metrics::data::SumDataPoint::value)
+                .sum(),
+            _ => 0,
+        })
     }
 
     #[test]
@@ -180,6 +196,7 @@ mod tests {
 
         super::test_support::flush_metrics();
         let finished = exporter.get_finished_metrics().expect("finished metrics");
+        assert_eq!(counter_total(&finished, "coral.query.count"), 3);
         assert_eq!(histogram_total_count(&finished, "coral.query.duration"), 2);
         assert_eq!(histogram_total_count(&finished, "coral.query.rows"), 1);
     }

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -5,7 +5,7 @@ use std::sync::{Mutex, Once};
 use std::time::Duration;
 
 use opentelemetry::metrics::MeterProvider as _;
-use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
+use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_otlp::{
     LogExporter, MetricExporter, SpanExporter, WithExportConfig, WithHttpConfig,
@@ -103,7 +103,9 @@ pub fn seed_root_span() -> tracing::span::EnteredSpan {
             }
         }
         let carrier = HashMap::from([("traceparent".to_string(), traceparent)]);
-        let parent_cx = TraceContextPropagator::new().extract(&StringMapExtractor(&carrier));
+        let parent_cx = opentelemetry::global::get_text_map_propagator(|p| {
+            p.extract(&StringMapExtractor(&carrier))
+        });
         let _ = span.set_parent(parent_cx);
     }
     span.entered()
@@ -115,6 +117,7 @@ pub fn seed_root_span() -> tracing::span::EnteredSpan {
 )]
 pub(crate) fn init_tracing(config: &TelemetryConfig) {
     INIT.call_once(|| {
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
         let endpoint = config
             .otel_endpoint
             .as_deref()

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -234,11 +234,18 @@ fn try_init_tracing(config: &TelemetryConfig, enable_stderr_logs: bool) -> Resul
             *guard = Some(provider);
         }
 
-        Registry::default()
+        if let Err(error) = Registry::default()
             .with(stderr_layer)
             .with(otel_trace_layer)
             .with(otel_log_layer)
-            .init();
+            .try_init()
+        {
+            tracing::warn!(
+                detail = %error,
+                "skipping coral-app tracing subscriber: host process has already installed one"
+            );
+            return Ok(());
+        }
         if let Some(error) = log_filter_error {
             tracing::warn!(
                 provided_filter = %config.log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),
@@ -256,7 +263,13 @@ fn try_init_tracing(config: &TelemetryConfig, enable_stderr_logs: bool) -> Resul
             );
         }
     } else {
-        Registry::default().with(stderr_layer).init();
+        if let Err(error) = Registry::default().with(stderr_layer).try_init() {
+            tracing::warn!(
+                detail = %error,
+                "skipping coral-app tracing subscriber: host process has already installed one"
+            );
+            return Ok(());
+        }
         if let Some(error) = log_filter_error {
             tracing::warn!(
                 provided_filter = %config.log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -25,8 +25,8 @@ pub mod config;
 pub mod metrics;
 
 use crate::bootstrap::AppError;
-use config::DEFAULT_TRACE_FILTER;
 pub use config::TelemetryConfig;
+use config::{DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
 
 static INIT: OnceLock<Result<(), String>> = OnceLock::new();
 static PROVIDER: Mutex<Option<SdkTracerProvider>> = Mutex::new(None);
@@ -35,8 +35,15 @@ static METER_PROVIDER: Mutex<Option<SdkMeterProvider>> = Mutex::new(None);
 
 const METRICS_INTERVAL: Duration = Duration::from_secs(5);
 
-fn build_filter(log: &str) -> EnvFilter {
-    EnvFilter::new(log)
+fn build_log_filter(filter: Option<&str>) -> (EnvFilter, Option<String>) {
+    let Some(filter) = filter else {
+        return (EnvFilter::new(DEFAULT_LOG_FILTER), None);
+    };
+
+    match EnvFilter::try_new(filter) {
+        Ok(filter) => (filter, None),
+        Err(error) => (EnvFilter::new(DEFAULT_LOG_FILTER), Some(error.to_string())),
+    }
 }
 
 fn build_trace_targets(filter: &str) -> (Targets, Option<String>) {
@@ -122,8 +129,11 @@ pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
     span
 }
 
-pub(crate) fn init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
-    INIT.get_or_init(|| try_init_tracing(config).map_err(|e| e.to_string()))
+pub(crate) fn init_tracing(
+    config: &TelemetryConfig,
+    enable_stderr_logs: bool,
+) -> Result<(), AppError> {
+    INIT.get_or_init(|| try_init_tracing(config, enable_stderr_logs).map_err(|e| e.to_string()))
         .as_ref()
         .map_err(|e| AppError::InvalidInput(e.clone()))?;
     Ok(())
@@ -133,19 +143,20 @@ pub(crate) fn init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
     clippy::too_many_lines,
     reason = "Initialization configures three OTLP pipelines in one place"
 )]
-fn try_init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
+fn try_init_tracing(config: &TelemetryConfig, enable_stderr_logs: bool) -> Result<(), AppError> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     let endpoint = config
         .otel_endpoint
         .as_deref()
         .filter(|value| !value.is_empty())
         .map(str::to_string);
-    let stderr_layer = config.otel_log_filter.as_deref().map(|log_filter| {
+    let (log_filter, log_filter_error) = build_log_filter(config.otel_log_filter.as_deref());
+    let stderr_layer = enable_stderr_logs.then(|| {
         tracing_subscriber::fmt::layer()
             .with_target(true)
             .compact()
             .with_writer(std::io::stderr)
-            .with_filter(build_filter(log_filter))
+            .with_filter(log_filter.clone())
     });
 
     if let Some(ref endpoint) = endpoint {
@@ -215,7 +226,7 @@ fn try_init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
         let otel_log_layer = LOGGER_PROVIDER.lock().ok().and_then(|guard| {
             guard.as_ref().map(|provider| {
                 opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(provider)
-                    .with_filter(trace_targets)
+                    .with_filter(log_filter)
             })
         });
 
@@ -228,6 +239,14 @@ fn try_init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
             .with(otel_trace_layer)
             .with(otel_log_layer)
             .init();
+        if let Some(error) = log_filter_error {
+            tracing::warn!(
+                provided_filter = %config.otel_log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),
+                fallback_filter = DEFAULT_LOG_FILTER,
+                detail = %error,
+                "invalid otel_log_filter; falling back to default filter"
+            );
+        }
         if let Some(error) = trace_filter_error {
             tracing::warn!(
                 provided_filter = %config.otel_trace_filter,
@@ -238,6 +257,14 @@ fn try_init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
         }
     } else {
         Registry::default().with(stderr_layer).init();
+        if let Some(error) = log_filter_error {
+            tracing::warn!(
+                provided_filter = %config.otel_log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),
+                fallback_filter = DEFAULT_LOG_FILTER,
+                detail = %error,
+                "invalid otel_log_filter; falling back to default filter"
+            );
+        }
         initialize_metrics(None);
     }
 
@@ -271,7 +298,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        DEFAULT_TRACE_FILTER, build_trace_targets, normalize_otlp_endpoint, parse_headers,
+        DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER, build_log_filter, build_trace_targets,
+        normalize_otlp_endpoint, parse_headers,
     };
 
     #[test]
@@ -310,6 +338,26 @@ mod tests {
 
         assert_eq!(format!("{targets:?}"), format!("{expected:?}"));
         assert!(error.is_some());
+        assert!(default_error.is_none());
+    }
+
+    #[test]
+    fn invalid_log_filter_falls_back_to_default() {
+        let (filter, error) = build_log_filter(Some("coral_app=["));
+        let (expected, default_error) = build_log_filter(Some(DEFAULT_LOG_FILTER));
+
+        assert_eq!(format!("{filter:?}"), format!("{expected:?}"));
+        assert!(error.is_some());
+        assert!(default_error.is_none());
+    }
+
+    #[test]
+    fn missing_log_filter_uses_default_without_error() {
+        let (filter, error) = build_log_filter(None);
+        let (expected, default_error) = build_log_filter(Some(DEFAULT_LOG_FILTER));
+
+        assert_eq!(format!("{filter:?}"), format!("{expected:?}"));
+        assert!(error.is_none());
         assert!(default_error.is_none());
     }
 }

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -1,7 +1,7 @@
 //! Tracing and OpenTelemetry initialization for the local Coral process.
 
 use std::collections::HashMap;
-use std::sync::{Mutex, Once};
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use opentelemetry::metrics::MeterProvider as _;
@@ -24,10 +24,11 @@ use tracing_subscriber::{EnvFilter, Registry};
 pub mod config;
 pub mod metrics;
 
+use crate::bootstrap::AppError;
 use config::DEFAULT_TRACE_FILTER;
 pub use config::TelemetryConfig;
 
-static INIT: Once = Once::new();
+static INIT: OnceLock<Result<(), String>> = OnceLock::new();
 static PROVIDER: Mutex<Option<SdkTracerProvider>> = Mutex::new(None);
 static LOGGER_PROVIDER: Mutex<Option<SdkLoggerProvider>> = Mutex::new(None);
 static METER_PROVIDER: Mutex<Option<SdkMeterProvider>> = Mutex::new(None);
@@ -121,120 +122,126 @@ pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
     span
 }
 
+pub(crate) fn init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
+    INIT.get_or_init(|| try_init_tracing(config).map_err(|e| e.to_string()))
+        .as_ref()
+        .map_err(|e| AppError::InvalidInput(e.clone()))?;
+    Ok(())
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "Initialization configures three OTLP pipelines in one place"
 )]
-pub(crate) fn init_tracing(config: &TelemetryConfig) {
-    INIT.call_once(|| {
-        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
-        let endpoint = config
-            .otel_endpoint
-            .as_deref()
-            .filter(|value| !value.is_empty())
-            .map(str::to_string);
-        let stderr_layer = config.otel_log_filter.as_deref().map(|log_filter| {
-            tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .compact()
-                .with_writer(std::io::stderr)
-                .with_filter(build_filter(log_filter))
+fn try_init_tracing(config: &TelemetryConfig) -> Result<(), AppError> {
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    let endpoint = config
+        .otel_endpoint
+        .as_deref()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let stderr_layer = config.otel_log_filter.as_deref().map(|log_filter| {
+        tracing_subscriber::fmt::layer()
+            .with_target(true)
+            .compact()
+            .with_writer(std::io::stderr)
+            .with_filter(build_filter(log_filter))
+    });
+
+    if let Some(ref endpoint) = endpoint {
+        let resource = opentelemetry_sdk::Resource::builder()
+            .with_attribute(opentelemetry::KeyValue::new(
+                "service.name",
+                config.otel_service_name.clone(),
+            ))
+            .build();
+
+        let headers = parse_headers(config.otel_headers.as_deref().unwrap_or_default());
+
+        let trace_exporter = SpanExporter::builder()
+            .with_http()
+            .with_endpoint(normalize_otlp_endpoint(endpoint, "traces"))
+            .with_headers(headers.clone())
+            .build()
+            .map_err(|e| AppError::InvalidInput(e.to_string()))?;
+        let builder = SdkTracerProvider::builder()
+            .with_resource(resource.clone())
+            .with_span_processor(
+                opentelemetry_sdk::trace::BatchSpanProcessor::builder(trace_exporter).build(),
+            );
+
+        let log_exporter = LogExporter::builder()
+            .with_http()
+            .with_endpoint(normalize_otlp_endpoint(endpoint, "logs"))
+            .with_headers(headers.clone())
+            .build()
+            .map_err(|e| AppError::InvalidInput(e.to_string()))?;
+        let logger_provider = SdkLoggerProvider::builder()
+            .with_resource(resource.clone())
+            .with_log_processor(
+                opentelemetry_sdk::logs::BatchLogProcessor::builder(log_exporter).build(),
+            )
+            .build();
+        if let Ok(mut guard) = LOGGER_PROVIDER.lock() {
+            *guard = Some(logger_provider);
+        }
+
+        let metric_exporter = MetricExporter::builder()
+            .with_http()
+            .with_endpoint(normalize_otlp_endpoint(endpoint, "metrics"))
+            .with_headers(headers)
+            .build()
+            .map_err(|e| AppError::InvalidInput(e.to_string()))?;
+        let meter_provider = SdkMeterProvider::builder()
+            .with_resource(resource.clone())
+            .with_reader(
+                opentelemetry_sdk::metrics::PeriodicReader::builder(metric_exporter)
+                    .with_interval(METRICS_INTERVAL)
+                    .build(),
+            )
+            .build();
+        opentelemetry::global::set_meter_provider(meter_provider.clone());
+        initialize_metrics(Some(&meter_provider));
+        if let Ok(mut guard) = METER_PROVIDER.lock() {
+            *guard = Some(meter_provider);
+        }
+
+        let provider = builder.build();
+        let tracer = provider.tracer("coral");
+        let (trace_targets, trace_filter_error) = build_trace_targets(&config.otel_trace_filter);
+        let otel_trace_layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_filter(trace_targets.clone());
+        let otel_log_layer = LOGGER_PROVIDER.lock().ok().and_then(|guard| {
+            guard.as_ref().map(|provider| {
+                opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(provider)
+                    .with_filter(trace_targets)
+            })
         });
 
-        if let Some(ref endpoint) = endpoint {
-            let resource = opentelemetry_sdk::Resource::builder()
-                .with_attribute(opentelemetry::KeyValue::new(
-                    "service.name",
-                    config.otel_service_name.clone(),
-                ))
-                .build();
-
-            let headers = parse_headers(config.otel_headers.as_deref().unwrap_or_default());
-
-            let trace_exporter = SpanExporter::builder()
-                .with_http()
-                .with_endpoint(normalize_otlp_endpoint(endpoint, "traces"))
-                .with_headers(headers.clone())
-                .build()
-                .expect("failed to build OTLP span exporter");
-            let builder = SdkTracerProvider::builder()
-                .with_resource(resource.clone())
-                .with_span_processor(
-                    opentelemetry_sdk::trace::BatchSpanProcessor::builder(trace_exporter).build(),
-                );
-
-            let log_exporter = LogExporter::builder()
-                .with_http()
-                .with_endpoint(normalize_otlp_endpoint(endpoint, "logs"))
-                .with_headers(headers.clone())
-                .build()
-                .expect("failed to build OTLP log exporter");
-            let logger_provider = SdkLoggerProvider::builder()
-                .with_resource(resource.clone())
-                .with_log_processor(
-                    opentelemetry_sdk::logs::BatchLogProcessor::builder(log_exporter).build(),
-                )
-                .build();
-            if let Ok(mut guard) = LOGGER_PROVIDER.lock() {
-                *guard = Some(logger_provider);
-            }
-
-            let metric_exporter = MetricExporter::builder()
-                .with_http()
-                .with_endpoint(normalize_otlp_endpoint(endpoint, "metrics"))
-                .with_headers(headers)
-                .build()
-                .expect("failed to build OTLP metric exporter");
-            let meter_provider = SdkMeterProvider::builder()
-                .with_resource(resource.clone())
-                .with_reader(
-                    opentelemetry_sdk::metrics::PeriodicReader::builder(metric_exporter)
-                        .with_interval(METRICS_INTERVAL)
-                        .build(),
-                )
-                .build();
-            opentelemetry::global::set_meter_provider(meter_provider.clone());
-            initialize_metrics(Some(&meter_provider));
-            if let Ok(mut guard) = METER_PROVIDER.lock() {
-                *guard = Some(meter_provider);
-            }
-
-            let provider = builder.build();
-            let tracer = provider.tracer("coral");
-            let (trace_targets, trace_filter_error) =
-                build_trace_targets(&config.otel_trace_filter);
-            let otel_trace_layer = tracing_opentelemetry::layer()
-                .with_tracer(tracer)
-                .with_filter(trace_targets.clone());
-            let otel_log_layer = LOGGER_PROVIDER.lock().ok().and_then(|guard| {
-                guard.as_ref().map(|provider| {
-                    opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(provider)
-                        .with_filter(trace_targets)
-                })
-            });
-
-            if let Ok(mut guard) = PROVIDER.lock() {
-                *guard = Some(provider);
-            }
-
-            Registry::default()
-                .with(stderr_layer)
-                .with(otel_trace_layer)
-                .with(otel_log_layer)
-                .init();
-            if let Some(error) = trace_filter_error {
-                tracing::warn!(
-                    provided_filter = %config.otel_trace_filter,
-                    fallback_filter = DEFAULT_TRACE_FILTER,
-                    detail = %error,
-                    "invalid otel_trace_filter; falling back to default filter"
-                );
-            }
-        } else {
-            Registry::default().with(stderr_layer).init();
-            initialize_metrics(None);
+        if let Ok(mut guard) = PROVIDER.lock() {
+            *guard = Some(provider);
         }
-    });
+
+        Registry::default()
+            .with(stderr_layer)
+            .with(otel_trace_layer)
+            .with(otel_log_layer)
+            .init();
+        if let Some(error) = trace_filter_error {
+            tracing::warn!(
+                provided_filter = %config.otel_trace_filter,
+                fallback_filter = DEFAULT_TRACE_FILTER,
+                detail = %error,
+                "invalid otel_trace_filter; falling back to default filter"
+            );
+        }
+    } else {
+        Registry::default().with(stderr_layer).init();
+        initialize_metrics(None);
+    }
+
+    Ok(())
 }
 
 /// Flush any pending tracing, log, and metric exports before process exit.

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -146,11 +146,11 @@ pub(crate) fn init_tracing(
 fn try_init_tracing(config: &TelemetryConfig, enable_stderr_logs: bool) -> Result<(), AppError> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
     let endpoint = config
-        .otel_endpoint
+        .endpoint
         .as_deref()
         .filter(|value| !value.is_empty())
         .map(str::to_string);
-    let (log_filter, log_filter_error) = build_log_filter(config.otel_log_filter.as_deref());
+    let (log_filter, log_filter_error) = build_log_filter(config.log_filter.as_deref());
     let stderr_layer = enable_stderr_logs.then(|| {
         tracing_subscriber::fmt::layer()
             .with_target(true)
@@ -163,11 +163,11 @@ fn try_init_tracing(config: &TelemetryConfig, enable_stderr_logs: bool) -> Resul
         let resource = opentelemetry_sdk::Resource::builder()
             .with_attribute(opentelemetry::KeyValue::new(
                 "service.name",
-                config.otel_service_name.clone(),
+                config.service_name.clone(),
             ))
             .build();
 
-        let headers = parse_headers(config.otel_headers.as_deref().unwrap_or_default());
+        let headers = parse_headers(config.headers.as_deref().unwrap_or_default());
 
         let trace_exporter = SpanExporter::builder()
             .with_http()
@@ -219,7 +219,7 @@ fn try_init_tracing(config: &TelemetryConfig, enable_stderr_logs: bool) -> Resul
 
         let provider = builder.build();
         let tracer = provider.tracer("coral");
-        let (trace_targets, trace_filter_error) = build_trace_targets(&config.otel_trace_filter);
+        let (trace_targets, trace_filter_error) = build_trace_targets(&config.trace_filter);
         let otel_trace_layer = tracing_opentelemetry::layer()
             .with_tracer(tracer)
             .with_filter(trace_targets.clone());
@@ -241,28 +241,28 @@ fn try_init_tracing(config: &TelemetryConfig, enable_stderr_logs: bool) -> Resul
             .init();
         if let Some(error) = log_filter_error {
             tracing::warn!(
-                provided_filter = %config.otel_log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),
+                provided_filter = %config.log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),
                 fallback_filter = DEFAULT_LOG_FILTER,
                 detail = %error,
-                "invalid otel_log_filter; falling back to default filter"
+                "invalid log_filter; falling back to default filter"
             );
         }
         if let Some(error) = trace_filter_error {
             tracing::warn!(
-                provided_filter = %config.otel_trace_filter,
+                provided_filter = %config.trace_filter,
                 fallback_filter = DEFAULT_TRACE_FILTER,
                 detail = %error,
-                "invalid otel_trace_filter; falling back to default filter"
+                "invalid trace_filter; falling back to default filter"
             );
         }
     } else {
         Registry::default().with(stderr_layer).init();
         if let Some(error) = log_filter_error {
             tracing::warn!(
-                provided_filter = %config.otel_log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),
+                provided_filter = %config.log_filter.as_deref().unwrap_or(DEFAULT_LOG_FILTER),
                 fallback_filter = DEFAULT_LOG_FILTER,
                 detail = %error,
-                "invalid otel_log_filter; falling back to default filter"
+                "invalid log_filter; falling back to default filter"
             );
         }
         initialize_metrics(None);

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -81,18 +81,28 @@ fn parse_headers(raw: &str) -> HashMap<String, String> {
         .collect()
 }
 
-/// Enters a root CLI span, optionally parented to the W3C `traceparent` value
-/// in the `CORAL_TRACE_PARENT` environment variable.
+/// Per-invocation context populated from the process environment by the CLI binary.
+#[derive(Debug, Default)]
+pub struct RunContext {
+    /// W3C `traceparent` for linking CLI spans to a parent distributed trace.
+    pub trace_parent: Option<String>,
+}
+
+/// Runs `fut` under a root CLI span configured from `ctx`.
+pub async fn run_with_context<F: std::future::Future>(ctx: &RunContext, fut: F) -> F::Output {
+    use tracing::Instrument as _;
+    fut.instrument(build_root_span(ctx.trace_parent.as_deref()))
+        .await
+}
+
+/// Builds a root CLI span, optionally parented to a W3C `traceparent` string.
 ///
-/// The returned [`tracing::span::EnteredSpan`] must be kept alive for the
-/// duration of the CLI invocation — dropping it exits the span.
-#[allow(
-    clippy::disallowed_methods,
-    reason = "CORAL_TRACE_PARENT is intentionally read from the environment as a per-invocation CLI seed"
-)]
-pub fn seed_root_span() -> tracing::span::EnteredSpan {
+/// Pass the value of `CORAL_TRACE_PARENT` (read by the CLI's env module) or
+/// `None` for an unparented span. Use `.instrument(span).await` to run the
+/// CLI future under this span.
+pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
     let span = tracing::info_span!("coral.cli");
-    if let Ok(traceparent) = std::env::var("CORAL_TRACE_PARENT") {
+    if let Some(tp) = traceparent {
         struct StringMapExtractor<'a>(&'a HashMap<String, String>);
         impl Extractor for StringMapExtractor<'_> {
             fn get(&self, key: &str) -> Option<&str> {
@@ -102,13 +112,13 @@ pub fn seed_root_span() -> tracing::span::EnteredSpan {
                 self.0.keys().map(String::as_str).collect()
             }
         }
-        let carrier = HashMap::from([("traceparent".to_string(), traceparent)]);
+        let carrier = HashMap::from([("traceparent".to_string(), tp.to_string())]);
         let parent_cx = opentelemetry::global::get_text_map_propagator(|p| {
             p.extract(&StringMapExtractor(&carrier))
         });
         let _ = span.set_parent(parent_cx);
     }
-    span.entered()
+    span
 }
 
 #[allow(

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -1,0 +1,295 @@
+//! Tracing and OpenTelemetry initialization for the local Coral process.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, Once};
+use std::time::Duration;
+
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_otlp::{
+    LogExporter, MetricExporter, SpanExporter, WithExportConfig, WithHttpConfig,
+};
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+use tracing_subscriber::Layer as _;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Registry};
+
+pub mod config;
+pub mod metrics;
+
+use config::DEFAULT_TRACE_FILTER;
+pub use config::TelemetryConfig;
+
+static INIT: Once = Once::new();
+static PROVIDER: Mutex<Option<SdkTracerProvider>> = Mutex::new(None);
+static LOGGER_PROVIDER: Mutex<Option<SdkLoggerProvider>> = Mutex::new(None);
+static METER_PROVIDER: Mutex<Option<SdkMeterProvider>> = Mutex::new(None);
+
+const METRICS_INTERVAL: Duration = Duration::from_secs(5);
+
+fn build_filter(log: &str) -> EnvFilter {
+    EnvFilter::new(log)
+}
+
+fn build_trace_targets(filter: &str) -> (Targets, Option<String>) {
+    match filter.parse() {
+        Ok(targets) => (targets, None),
+        Err(error) => (
+            DEFAULT_TRACE_FILTER
+                .parse()
+                .expect("default trace filter must be valid"),
+            Some(error.to_string()),
+        ),
+    }
+}
+
+fn initialize_metrics(meter_provider: Option<&SdkMeterProvider>) {
+    if let Some(provider) = meter_provider {
+        let meter = provider.meter("coral");
+        metrics::init(&meter);
+    } else {
+        metrics::init_global();
+    }
+}
+
+fn normalize_otlp_endpoint(endpoint: &str, signal: &str) -> String {
+    let base = endpoint.trim_end_matches('/');
+    let base = ["traces", "logs", "metrics"]
+        .into_iter()
+        .find_map(|existing_signal| {
+            base.strip_suffix(&format!("/v1/{existing_signal}"))
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| base.to_string());
+    format!("{base}/v1/{signal}")
+}
+
+fn parse_headers(raw: &str) -> HashMap<String, String> {
+    raw.split(',')
+        .filter_map(|pair| {
+            let pair = pair.trim();
+            let (key, value) = pair.split_once('=')?;
+            Some((key.trim().to_string(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+/// Enters a root CLI span, optionally parented to the W3C `traceparent` value
+/// in the `CORAL_TRACE_PARENT` environment variable.
+///
+/// The returned [`tracing::span::EnteredSpan`] must be kept alive for the
+/// duration of the CLI invocation — dropping it exits the span.
+#[allow(
+    clippy::disallowed_methods,
+    reason = "CORAL_TRACE_PARENT is intentionally read from the environment as a per-invocation CLI seed"
+)]
+pub fn seed_root_span() -> tracing::span::EnteredSpan {
+    let span = tracing::info_span!("coral.cli");
+    if let Ok(traceparent) = std::env::var("CORAL_TRACE_PARENT") {
+        struct StringMapExtractor<'a>(&'a HashMap<String, String>);
+        impl Extractor for StringMapExtractor<'_> {
+            fn get(&self, key: &str) -> Option<&str> {
+                self.0.get(key).map(String::as_str)
+            }
+            fn keys(&self) -> Vec<&str> {
+                self.0.keys().map(String::as_str).collect()
+            }
+        }
+        let carrier = HashMap::from([("traceparent".to_string(), traceparent)]);
+        let parent_cx = TraceContextPropagator::new().extract(&StringMapExtractor(&carrier));
+        let _ = span.set_parent(parent_cx);
+    }
+    span.entered()
+}
+
+#[allow(
+    clippy::too_many_lines,
+    reason = "Initialization configures three OTLP pipelines in one place"
+)]
+pub(crate) fn init_tracing(config: &TelemetryConfig) {
+    INIT.call_once(|| {
+        let endpoint = config
+            .otel_endpoint
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .map(str::to_string);
+        let stderr_layer = config.otel_log_filter.as_deref().map(|log_filter| {
+            tracing_subscriber::fmt::layer()
+                .with_target(true)
+                .compact()
+                .with_writer(std::io::stderr)
+                .with_filter(build_filter(log_filter))
+        });
+
+        if let Some(ref endpoint) = endpoint {
+            let resource = opentelemetry_sdk::Resource::builder()
+                .with_attribute(opentelemetry::KeyValue::new(
+                    "service.name",
+                    config.otel_service_name.clone(),
+                ))
+                .build();
+
+            let headers = parse_headers(config.otel_headers.as_deref().unwrap_or_default());
+
+            let trace_exporter = SpanExporter::builder()
+                .with_http()
+                .with_endpoint(normalize_otlp_endpoint(endpoint, "traces"))
+                .with_headers(headers.clone())
+                .build()
+                .expect("failed to build OTLP span exporter");
+            let builder = SdkTracerProvider::builder()
+                .with_resource(resource.clone())
+                .with_span_processor(
+                    opentelemetry_sdk::trace::BatchSpanProcessor::builder(trace_exporter).build(),
+                );
+
+            let log_exporter = LogExporter::builder()
+                .with_http()
+                .with_endpoint(normalize_otlp_endpoint(endpoint, "logs"))
+                .with_headers(headers.clone())
+                .build()
+                .expect("failed to build OTLP log exporter");
+            let logger_provider = SdkLoggerProvider::builder()
+                .with_resource(resource.clone())
+                .with_log_processor(
+                    opentelemetry_sdk::logs::BatchLogProcessor::builder(log_exporter).build(),
+                )
+                .build();
+            if let Ok(mut guard) = LOGGER_PROVIDER.lock() {
+                *guard = Some(logger_provider);
+            }
+
+            let metric_exporter = MetricExporter::builder()
+                .with_http()
+                .with_endpoint(normalize_otlp_endpoint(endpoint, "metrics"))
+                .with_headers(headers)
+                .build()
+                .expect("failed to build OTLP metric exporter");
+            let meter_provider = SdkMeterProvider::builder()
+                .with_resource(resource.clone())
+                .with_reader(
+                    opentelemetry_sdk::metrics::PeriodicReader::builder(metric_exporter)
+                        .with_interval(METRICS_INTERVAL)
+                        .build(),
+                )
+                .build();
+            opentelemetry::global::set_meter_provider(meter_provider.clone());
+            initialize_metrics(Some(&meter_provider));
+            if let Ok(mut guard) = METER_PROVIDER.lock() {
+                *guard = Some(meter_provider);
+            }
+
+            let provider = builder.build();
+            let tracer = provider.tracer("coral");
+            let (trace_targets, trace_filter_error) =
+                build_trace_targets(&config.otel_trace_filter);
+            let otel_trace_layer = tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(trace_targets.clone());
+            let otel_log_layer = LOGGER_PROVIDER.lock().ok().and_then(|guard| {
+                guard.as_ref().map(|provider| {
+                    opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(provider)
+                        .with_filter(trace_targets)
+                })
+            });
+
+            if let Ok(mut guard) = PROVIDER.lock() {
+                *guard = Some(provider);
+            }
+
+            Registry::default()
+                .with(stderr_layer)
+                .with(otel_trace_layer)
+                .with(otel_log_layer)
+                .init();
+            if let Some(error) = trace_filter_error {
+                tracing::warn!(
+                    provided_filter = %config.otel_trace_filter,
+                    fallback_filter = DEFAULT_TRACE_FILTER,
+                    detail = %error,
+                    "invalid otel_trace_filter; falling back to default filter"
+                );
+            }
+        } else {
+            Registry::default().with(stderr_layer).init();
+            initialize_metrics(None);
+        }
+    });
+}
+
+/// Flush any pending tracing, log, and metric exports before process exit.
+pub fn shutdown_tracing() {
+    if let Ok(mut guard) = METER_PROVIDER.lock()
+        && let Some(provider) = guard.take()
+        && let Err(error) = provider.shutdown()
+    {
+        tracing::warn!("OTEL meter provider shutdown error: {error}");
+    }
+    if let Ok(mut guard) = PROVIDER.lock()
+        && let Some(provider) = guard.take()
+        && let Err(error) = provider.shutdown()
+    {
+        tracing::warn!("OTEL trace provider shutdown error: {error}");
+    }
+    if let Ok(mut guard) = LOGGER_PROVIDER.lock()
+        && let Some(provider) = guard.take()
+        && let Err(error) = provider.shutdown()
+    {
+        tracing::warn!("OTEL logger provider shutdown error: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{
+        DEFAULT_TRACE_FILTER, build_trace_targets, normalize_otlp_endpoint, parse_headers,
+    };
+
+    #[test]
+    fn normalize_otlp_endpoint_handles_signal_paths() {
+        assert_eq!(
+            normalize_otlp_endpoint("http://localhost:4318", "traces"),
+            "http://localhost:4318/v1/traces"
+        );
+        assert_eq!(
+            normalize_otlp_endpoint("http://localhost:4318/v1/traces", "logs"),
+            "http://localhost:4318/v1/logs"
+        );
+        assert_eq!(
+            normalize_otlp_endpoint("http://localhost:4318/", "metrics"),
+            "http://localhost:4318/v1/metrics"
+        );
+    }
+
+    #[test]
+    fn parse_headers_ignores_invalid_pairs() {
+        let headers = parse_headers("x-api-key=secret, invalid, user = coral ");
+
+        assert_eq!(
+            headers,
+            HashMap::from([
+                ("x-api-key".to_string(), "secret".to_string()),
+                ("user".to_string(), "coral".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn invalid_trace_filter_falls_back_to_default() {
+        let (targets, error) = build_trace_targets("coral_app=[");
+        let (expected, default_error) = build_trace_targets(DEFAULT_TRACE_FILTER);
+
+        assert_eq!(format!("{targets:?}"), format!("{expected:?}"));
+        assert!(error.is_some());
+        assert!(default_error.is_none());
+    }
+}

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -4,8 +4,7 @@ use coral_api::v1::{
     Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table,
     ValidateSourceResponse, Workspace, query_test_result,
 };
-use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
-use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry::propagation::Extractor;
 use tonic::Status;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
@@ -36,7 +35,7 @@ impl Extractor for MetadataExtractor<'_> {
 pub(crate) fn extract_trace_context(
     metadata: &tonic::metadata::MetadataMap,
 ) -> opentelemetry::Context {
-    TraceContextPropagator::new().extract(&MetadataExtractor(metadata))
+    opentelemetry::global::get_text_map_propagator(|p| p.extract(&MetadataExtractor(metadata)))
 }
 
 /// Creates a span parented to the trace context extracted from `metadata`.

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -4,11 +4,51 @@ use coral_api::v1::{
     Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table,
     ValidateSourceResponse, Workspace, query_test_result,
 };
+use opentelemetry::propagation::{Extractor, TextMapPropagator as _};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tonic::Status;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::{AppError, app_status, core_status};
 use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
+
+struct MetadataExtractor<'a>(&'a tonic::metadata::MetadataMap);
+
+impl Extractor for MetadataExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        use tonic::metadata::KeyRef;
+        self.0
+            .keys()
+            .filter_map(|k| match k {
+                KeyRef::Ascii(key) => Some(key.as_str()),
+                KeyRef::Binary(_) => None,
+            })
+            .collect()
+    }
+}
+
+/// Extracts a W3C trace context from incoming gRPC request metadata.
+pub(crate) fn extract_trace_context(
+    metadata: &tonic::metadata::MetadataMap,
+) -> opentelemetry::Context {
+    TraceContextPropagator::new().extract(&MetadataExtractor(metadata))
+}
+
+/// Creates a span parented to the trace context extracted from `metadata`.
+pub(crate) fn grpc_span(
+    metadata: &tonic::metadata::MetadataMap,
+    name: &'static str,
+) -> tracing::Span {
+    let parent_cx = extract_trace_context(metadata);
+    let span = tracing::info_span!("grpc", grpc.method = name);
+    let _ = span.set_parent(parent_cx);
+    span
+}
 
 #[allow(
     clippy::needless_pass_by_value,

--- a/crates/coral-app/tests/grpc.rs
+++ b/crates/coral-app/tests/grpc.rs
@@ -9,5 +9,7 @@
 mod harness;
 #[path = "grpc/resilience_tests.rs"]
 mod resilience_tests;
+#[path = "grpc/server_lifecycle_tests.rs"]
+mod server_lifecycle_tests;
 #[path = "grpc/source_lifecycle_tests.rs"]
 mod source_lifecycle_tests;

--- a/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/server_lifecycle_tests.rs
@@ -1,0 +1,42 @@
+//! Pins the server lifecycle contract.
+//!
+//! `ServerBuilder::start` and `RunningServer::shutdown` describe the local
+//! gRPC server lifecycle and may be invoked repeatedly within a single
+//! process. Telemetry is process-scoped: it is initialized once via
+//! `OnceLock` and flushed by the owning binary or test harness via
+//! `coral_app::shutdown_tracing` at process exit.
+
+use coral_api::v1::ListSourcesRequest;
+use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use tempfile::TempDir;
+use tonic::Request;
+
+#[tokio::test]
+async fn server_lifecycle_can_repeat_within_process() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+
+    for _ in 0..2 {
+        let server = ServerBuilder::new()
+            .with_config_dir(&config_dir)
+            .start()
+            .await
+            .expect("start server");
+        let app = AppClient::connect(server.endpoint_uri())
+            .await
+            .expect("connect client");
+
+        let sources = app
+            .source_client()
+            .list_sources(Request::new(ListSourcesRequest {
+                workspace: Some(default_workspace()),
+            }))
+            .await
+            .expect("list sources")
+            .into_inner()
+            .sources;
+        assert!(sources.is_empty());
+
+        server.shutdown().await.expect("shutdown server");
+    }
+}

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -1050,21 +1050,22 @@ async fn config_persists_across_rebuilds_without_local_trace_state() {
 }
 
 #[tokio::test]
-async fn corrupted_config_surfaces_internal_error() {
+async fn corrupted_config_fails_at_startup() {
+    use coral_client::local::ServerBuilder;
+
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(config_dir.join("config.toml"), "[[sources]\n").expect("write invalid config");
 
-    let harness = GrpcHarness::start_with_config_dir(config_dir).await;
-    let error = harness
-        .source_client()
-        .discover_sources(Request::new(DiscoverSourcesRequest {
-            workspace: Some(default_workspace()),
-        }))
-        .await
-        .expect_err("corrupted config should surface as an error");
-    assert_eq!(error.code(), tonic::Code::Internal);
+    assert!(
+        ServerBuilder::new()
+            .with_config_dir(&config_dir)
+            .start()
+            .await
+            .is_err(),
+        "corrupted config should prevent server startup"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/coral-app/tests/telemetry_host_subscriber.rs
+++ b/crates/coral-app/tests/telemetry_host_subscriber.rs
@@ -1,0 +1,56 @@
+//! Pins the host-owned subscriber policy.
+//!
+//! `init_tracing` installs coral-app's own tracing subscriber as a side effect
+//! of `ServerBuilder::start`. When the host process has already installed a
+//! global tracing subscriber, coral-app does not overwrite it and does not
+//! fail startup — telemetry init becomes a no-op (an explanatory warning is
+//! logged through the host's subscriber) and the gRPC server bootstraps
+//! normally.
+//!
+//! This test must live in its own integration test binary: `init_tracing`
+//! caches its outcome in a process-global `OnceLock`, so co-locating this
+//! scenario with tests that perform a normal startup would let the cached
+//! success short-circuit `try_init` and hide the conflict path.
+
+#![allow(
+    unused_crate_dependencies,
+    reason = "Integration tests inherit the library crate's dependency set and intentionally exercise only a subset of it."
+)]
+
+use coral_api::v1::ListSourcesRequest;
+use coral_client::{AppClient, default_workspace, local::ServerBuilder};
+use tempfile::TempDir;
+use tonic::Request;
+use tracing_subscriber::util::SubscriberInitExt as _;
+
+#[tokio::test]
+async fn host_subscriber_does_not_block_server_startup() {
+    tracing_subscriber::registry()
+        .try_init()
+        .expect("install host subscriber once per test process");
+
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+
+    let server = ServerBuilder::new()
+        .with_config_dir(&config_dir)
+        .start()
+        .await
+        .expect("start server with host-owned subscriber");
+    let app = AppClient::connect(server.endpoint_uri())
+        .await
+        .expect("connect client");
+
+    let sources = app
+        .source_client()
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list sources")
+        .into_inner()
+        .sources;
+    assert!(sources.is_empty());
+
+    server.shutdown().await.expect("shutdown server");
+}

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -28,8 +28,8 @@ tonic.workspace = true
 coral-api.workspace = true
 coral-app.workspace = true
 coral-client.workspace = true
-coral-spec.workspace = true
 coral-mcp.workspace = true
+coral-spec.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -27,7 +27,7 @@ pub(crate) enum BootstrapError {
     Connect(#[from] ClientError),
 }
 
-pub(crate) async fn bootstrap() -> Result<Bootstrap, BootstrapError> {
+pub(crate) async fn bootstrap(enable_stderr_logs: bool) -> Result<Bootstrap, BootstrapError> {
     if let Some(endpoint) = bootstrap_endpoint() {
         return Ok(Bootstrap {
             app: AppClient::connect(&endpoint).await?,
@@ -35,7 +35,7 @@ pub(crate) async fn bootstrap() -> Result<Bootstrap, BootstrapError> {
         });
     }
 
-    let server = configure_server_builder(ServerBuilder::new())
+    let server = configure_server_builder(ServerBuilder::new(), enable_stderr_logs)
         .start()
         .await?;
     let app = AppClient::connect(server.endpoint_uri()).await?;
@@ -45,8 +45,10 @@ pub(crate) async fn bootstrap() -> Result<Bootstrap, BootstrapError> {
     })
 }
 
-fn configure_server_builder(builder: ServerBuilder) -> ServerBuilder {
-    builder.add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
+fn configure_server_builder(builder: ServerBuilder, enable_stderr_logs: bool) -> ServerBuilder {
+    builder
+        .with_stderr_logs(enable_stderr_logs)
+        .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
 }
 
 #[cfg(feature = "cli-test-server")]

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -8,7 +8,15 @@ use coral_client::{
 
 pub(crate) struct Bootstrap {
     pub(crate) app: AppClient,
-    pub(crate) _server: Option<RunningServer>,
+    server: Option<RunningServer>,
+}
+
+impl Bootstrap {
+    pub(crate) async fn shutdown(self) {
+        if let Some(server) = self.server {
+            let _ = server.shutdown().await;
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -23,7 +31,7 @@ pub(crate) async fn bootstrap() -> Result<Bootstrap, BootstrapError> {
     if let Some(endpoint) = bootstrap_endpoint() {
         return Ok(Bootstrap {
             app: AppClient::connect(&endpoint).await?,
-            _server: None,
+            server: None,
         });
     }
 
@@ -33,7 +41,7 @@ pub(crate) async fn bootstrap() -> Result<Bootstrap, BootstrapError> {
     let app = AppClient::connect(server.endpoint_uri()).await?;
     Ok(Bootstrap {
         app,
-        _server: Some(server),
+        server: Some(server),
     })
 }
 

--- a/crates/coral-cli/src/env.rs
+++ b/crates/coral-cli/src/env.rs
@@ -18,3 +18,15 @@ pub fn bootstrap_endpoint() -> Option<String> {
         .and_then(|value| value.into_string().ok())
         .filter(|value| !value.is_empty())
 }
+
+const CORAL_TRACE_PARENT_ENV: &str = "CORAL_TRACE_PARENT";
+
+/// Reads the optional W3C `traceparent` used to link CLI spans to a parent trace.
+#[allow(
+    clippy::disallowed_methods,
+    reason = "CORAL_TRACE_PARENT is a CLI-owned per-invocation distributed tracing seed."
+)]
+#[must_use]
+pub fn trace_parent() -> Option<String> {
+    std::env::var(CORAL_TRACE_PARENT_ENV).ok()
+}

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -152,6 +152,27 @@ impl CliExitError {
     }
 }
 
+/// Returns whether this CLI invocation should render telemetry logs to stderr.
+///
+/// `MCP` stdio reserves stdout for protocol messages, so stderr is the only
+/// local diagnostics stream that can be safely exposed while the server is
+/// running.
+#[must_use]
+pub fn enables_stderr_logs() -> bool {
+    command_enables_stderr_logs(std::env::args_os())
+}
+
+fn command_enables_stderr_logs<I, T>(args: I) -> bool
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    matches!(
+        Cli::try_parse_from(args).map(|cli| cli.command),
+        Ok(Command::McpStdio)
+    )
+}
+
 /// Parses CLI arguments and runs the shared Coral CLI.
 ///
 /// # Errors
@@ -365,4 +386,19 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyh
     };
     println!("Added source {}", response.name);
     source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::command_enables_stderr_logs;
+
+    #[test]
+    fn mcp_stdio_invocation_enables_stderr_logs() {
+        assert!(command_enables_stderr_logs(["coral", "mcp-stdio"]));
+    }
+
+    #[test]
+    fn non_mcp_invocation_disables_stderr_logs() {
+        assert!(!command_enables_stderr_logs(["coral", "sql", "SELECT 1"]));
+    }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -158,9 +158,8 @@ impl CliExitError {
 ///
 /// Returns an error if argument parsing, command execution, or output
 /// formatting fails.
-pub async fn run(app: AppClient) -> Result<(), anyhow::Error> {
-    let cli = Cli::parse();
-    run_parsed(app, cli).await
+pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), anyhow::Error> {
+    coral_app::run_with_context(&ctx, Box::pin(run_parsed(app, Cli::parse()))).await
 }
 
 async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -13,7 +13,9 @@ use bootstrap::bootstrap;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let bootstrap = bootstrap().await?;
-    let result = match coral_cli::run(bootstrap.app.clone()).await {
+    let result = coral_cli::run(bootstrap.app.clone()).await;
+    bootstrap.shutdown().await;
+    match result {
         Ok(()) => Ok(()),
         Err(error) => {
             if let Some(cli_error) = error.downcast_ref::<coral_cli::CliExitError>() {
@@ -22,7 +24,5 @@ async fn main() -> Result<(), anyhow::Error> {
             }
             Err(error)
         }
-    };
-    bootstrap.shutdown().await;
-    result
+    }
 }

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -12,7 +12,7 @@ use bootstrap::bootstrap;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let bootstrap = bootstrap().await?;
+    let bootstrap = bootstrap(coral_cli::enables_stderr_logs()).await?;
     let ctx = coral_app::RunContext {
         trace_parent: coral_cli::env::trace_parent(),
     };

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -18,6 +18,9 @@ async fn main() -> Result<(), anyhow::Error> {
     };
     let result = coral_cli::run(bootstrap.app.clone(), ctx).await;
     bootstrap.shutdown().await;
+    tokio::task::spawn_blocking(coral_app::shutdown_tracing)
+        .await
+        .ok();
     match result {
         Ok(()) => Ok(()),
         Err(error) => {

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -13,7 +13,10 @@ use bootstrap::bootstrap;
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let bootstrap = bootstrap().await?;
-    let result = coral_cli::run(bootstrap.app.clone()).await;
+    let ctx = coral_app::RunContext {
+        trace_parent: coral_cli::env::trace_parent(),
+    };
+    let result = coral_cli::run(bootstrap.app.clone(), ctx).await;
     bootstrap.shutdown().await;
     match result {
         Ok(()) => Ok(()),

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -12,8 +12,8 @@ use bootstrap::bootstrap;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let bootstrap::Bootstrap { app, _server } = bootstrap().await?;
-    match coral_cli::run(app).await {
+    let bootstrap = bootstrap().await?;
+    let result = match coral_cli::run(bootstrap.app.clone()).await {
         Ok(()) => Ok(()),
         Err(error) => {
             if let Some(cli_error) = error.downcast_ref::<coral_cli::CliExitError>() {
@@ -22,5 +22,7 @@ async fn main() -> Result<(), anyhow::Error> {
             }
             Err(error)
         }
-    }
+    };
+    bootstrap.shutdown().await;
+    result
 }

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -11,10 +11,14 @@ workspace = true
 
 [dependencies]
 arrow.workspace = true
+opentelemetry.workspace = true
+opentelemetry_sdk.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tonic.workspace = true
 tonic-types.workspace = true
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
 
 coral-api.workspace = true
 coral-app.workspace = true

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 arrow.workspace = true
 opentelemetry.workspace = true
+opentelemetry_sdk.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tonic.workspace = true

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 [dependencies]
 arrow.workspace = true
 opentelemetry.workspace = true
-opentelemetry_sdk.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tonic.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -46,6 +46,7 @@ impl AppClient {
     ///
     /// Returns [`ClientError`] if the gRPC clients cannot connect.
     pub async fn connect(endpoint_uri: &str) -> Result<Self, ClientError> {
+        crate::propagation::ensure_global_propagator();
         let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
         let channel = endpoint.connect().await?;

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -4,9 +4,11 @@ use coral_api::v1::Workspace;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
+use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::error::ClientError;
+use crate::propagation::TraceContextInterceptor;
 
 /// Default workspace used by local Coral clients.
 pub use coral_app::DEFAULT_WORKSPACE_ID;
@@ -20,22 +22,15 @@ pub fn default_workspace() -> Workspace {
 }
 
 /// Public source-management gRPC client.
-///
-/// This stays intentionally thin for now: `coral-client` is a local transport
-/// bootstrap, so it exposes the generated typed client directly rather than
-/// wrapping it in a higher-level SDK surface.
-pub type SourceClient = SourceServiceClient<Channel>;
+pub type SourceClient = SourceServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
 
 /// Public SQL query gRPC client.
-///
-/// This stays intentionally thin for now: `coral-client` is a local transport
-/// bootstrap, so it exposes the generated typed client directly rather than
-/// wrapping it in a higher-level SDK surface.
-pub type QueryClient = QueryServiceClient<Channel>;
+pub type QueryClient = QueryServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
 
 /// Public Coral client handle.
 ///
 /// Wraps the generated gRPC clients for a Coral endpoint.
+#[derive(Clone)]
 pub struct AppClient {
     source_client: SourceClient,
     query_client: QueryClient,
@@ -54,8 +49,9 @@ impl AppClient {
         let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
         let channel = endpoint.connect().await?;
-        let source_client = SourceServiceClient::new(channel.clone());
-        let query_client = QueryServiceClient::new(channel)
+        let source_client =
+            SourceServiceClient::with_interceptor(channel.clone(), TraceContextInterceptor);
+        let query_client = QueryServiceClient::with_interceptor(channel, TraceContextInterceptor)
             .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
         Ok(Self {
             source_client,

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -17,6 +17,7 @@
 mod client;
 mod error;
 pub mod local;
+mod propagation;
 mod status_error;
 
 use std::io::Cursor;
@@ -29,6 +30,7 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{AppClient, DEFAULT_WORKSPACE_ID, QueryClient, SourceClient, default_workspace};
+pub use coral_app::seed_root_span;
 pub use error::{ClientError, QueryResultError};
 pub use status_error::{
     CORAL_ERROR_DOMAIN, CoralQueryError, DecodedStatusError, decode_status_error,

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -30,7 +30,6 @@ use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
 pub use client::{AppClient, DEFAULT_WORKSPACE_ID, QueryClient, SourceClient, default_workspace};
-pub use coral_app::seed_root_span;
 pub use error::{ClientError, QueryResultError};
 pub use status_error::{
     CORAL_ERROR_DOMAIN, CoralQueryError, DecodedStatusError, decode_status_error,

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -1,7 +1,6 @@
 //! W3C Trace Context propagation for tonic gRPC clients.
 
-use opentelemetry::propagation::{Injector, TextMapPropagator as _};
-use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry::propagation::Injector;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 struct MetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
@@ -27,8 +26,9 @@ impl tonic::service::Interceptor for TraceContextInterceptor {
         mut request: tonic::Request<()>,
     ) -> Result<tonic::Request<()>, tonic::Status> {
         let cx = tracing::Span::current().context();
-        TraceContextPropagator::new()
-            .inject_context(&cx, &mut MetadataInjector(request.metadata_mut()));
+        opentelemetry::global::get_text_map_propagator(|p| {
+            p.inject_context(&cx, &mut MetadataInjector(request.metadata_mut()));
+        });
         Ok(request)
     }
 }

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -1,7 +1,27 @@
 //! W3C Trace Context propagation for tonic gRPC clients.
 
+use std::sync::OnceLock;
+
 use opentelemetry::propagation::Injector;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+static PROPAGATOR_INIT: OnceLock<()> = OnceLock::new();
+
+/// Installs `TraceContextPropagator` as the process-global text-map
+/// propagator the first time this is called.
+///
+/// `TraceContextInterceptor` injects via the global propagator on every
+/// outgoing request. Without this, a client-only process (talking to a
+/// remote endpoint or a separate test server, with no local
+/// `ServerBuilder::start` to install one) would fall back to the default
+/// no-op propagator and silently drop `traceparent` even when the caller
+/// has an active span.
+pub(crate) fn ensure_global_propagator() {
+    PROPAGATOR_INIT.get_or_init(|| {
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    });
+}
 
 struct MetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
 

--- a/crates/coral-client/src/propagation.rs
+++ b/crates/coral-client/src/propagation.rs
@@ -1,0 +1,34 @@
+//! W3C Trace Context propagation for tonic gRPC clients.
+
+use opentelemetry::propagation::{Injector, TextMapPropagator as _};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+struct MetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes())
+            && let Ok(val) = tonic::metadata::MetadataValue::try_from(&value)
+        {
+            self.0.insert(key, val);
+        }
+    }
+}
+
+/// tonic client interceptor that injects the current W3C `traceparent` into
+/// outgoing gRPC request metadata.
+#[derive(Clone)]
+pub struct TraceContextInterceptor;
+
+impl tonic::service::Interceptor for TraceContextInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, tonic::Status> {
+        let cx = tracing::Span::current().context();
+        TraceContextPropagator::new()
+            .inject_context(&cx, &mut MetadataInjector(request.metadata_mut()));
+        Ok(request)
+    }
+}


### PR DESCRIPTION
Adds opt-in OpenTelemetry instrumentation to Coral so that traces, metrics,
and logs can be exported to any OTLP-compatible backend (tested with
OpenObserve). Telemetry is **off by default** -- it activates only when a
`[telemetry]` section is present in `config.toml`.

## What changed

### New: `crates/coral-app/src/telemetry/`

- **`mod.rs`** -- `init_tracing()` / `shutdown_tracing()` configure a
  `tracing-subscriber` registry with up to three layers:
  - **stderr** (compact fmt) -- active only when `log_filter` is set in
    config.
  - **OTLP traces** -- batch span exporter to `{otel_endpoint}/v1/traces`.
  - **OTLP logs** -- log bridge via `opentelemetry-appender-tracing`.
  - **OTLP metrics** -- periodic reader to `{otel_endpoint}/v1/metrics`.
  - Supports `CORAL_TRACE_PARENT` env var for distributed tracing
    (`FixedTraceIdGenerator` pins all spans to the parent trace ID).
- **`config.rs`** -- `TelemetryConfig` loaded from `[telemetry]` in
  `config.toml`. No environment variable overrides -- all telemetry
  settings live in the config file.
- **`metrics.rs`** -- Four query instruments (`coral.query.count`,
  `coral.query.duration`, `coral.query.errors`, `coral.query.rows`) with
  thread-local test support for isolated metric assertions.

## Configuration

```toml
# ~/.config/coral/config.toml
[otel]
endpoint = "http://localhost:4318"          # OTLP/HTTP base URL
headers = "key1=value1, ..."         # comma-separated key=value
log_filter = "info"                              # stderr tracing (off by default)
trace_filter = "coral_app=trace,coral_engine=trace"  # OTLP span filter
service_name = "coral"                      # service.name resource attribute
```

`CORAL_TRACE_PARENT` is the only env var supported -- it propagates a W3C
traceparent for distributed tracing (e.g. when invoked by an AI agent).

## TODO (following PRs)

- Add Datafusion Tracing (requires Datafusion upgrade)
- Update README.md and CONTRIBUTING.md once we have real feedback from internal users
- Add env variables expansion
- ~~Review the -j1 flag in the makefile~~

## Validation

| # | Test | Result |
|---|------|--------|
| 1 | `cargo build -p coral-cli` compiles | PASS |
| 2 | Normal mode produces no stderr tracing | PASS |
| 3 | `log_filter` in config enables stderr tracing | PASS |
| 4 | `coral.query` trace spans arrive in OpenObserve | PASS |
| 5 | OTLP logs arrive in OpenObserve | PASS  |
| 6 | Metrics (`coral_query_count/duration/rows`) arrive | PASS |
| 7 | `CORAL_TRACE_PARENT` links spans to fixed trace ID | PASS |
| 8 | No `[telemetry]` config = no export, no stderr | PASS |
