### PR TITLE
ci(release): trigger homebrew tap bump

### DIFF
--- a/.github/scripts/prepare_release.py
+++ b/.github/scripts/prepare_release.py
@@ -188,6 +188,7 @@ def prepare_outputs() -> dict[str, str]:
 
     return {
         "should_release": "true",
+        "version": current_version,
         "build_ref": resolved_sha,
         "tag_name": tag_name,
         "release_name": tag_name,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,8 @@ jobs:
             artifacts/${{ needs.prepare.outputs.artifact_prefix }}-*.tar.gz
             artifacts/checksums.sha256
 
+      # Dispatch the tap workflow after publishing the release:
+      # https://octokit.github.io/rest.js/v22/#repos-create-dispatch-event
       - name: Trigger Homebrew tap bump
         uses: actions/github-script@v8
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_release: ${{ steps.meta.outputs.should_release }}
+      version: ${{ steps.meta.outputs.version }}
       build_ref: ${{ steps.meta.outputs.build_ref }}
       tag_name: ${{ steps.meta.outputs.tag_name }}
       release_name: ${{ steps.meta.outputs.release_name }}
@@ -155,6 +156,9 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          repositories: |
+            coral
+            homebrew-tap
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -170,3 +174,17 @@ jobs:
           files: |
             artifacts/${{ needs.prepare.outputs.artifact_prefix }}-*.tar.gz
             artifacts/checksums.sha256
+
+      - name: Trigger Homebrew tap bump
+        uses: actions/github-script@v8
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        with:
+          github-token: ${{ steps.github-app-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: "withcoral",
+              repo: "homebrew-tap",
+              event_type: "coral-release",
+              client_payload: { version: process.env.RELEASE_VERSION },
+            });


### PR DESCRIPTION
This updates the release workflow to dispatch `coral-release` to `withcoral/homebrew-tap` after publishing a GitHub release so the Homebrew cask can be bumped automatically.
The prepare step now exposes the raw workspace version as a workflow output, which lets the dispatch payload use the existing semver string directly instead of reconstructing it from the `v`-prefixed tag.
The release job also scopes the GitHub App token to `homebrew-tap` so the dispatch call can access the target repository.
Validation: `make validate`.
