### PR TITLE
fix(engine): enforce read-only SQL execution

### DIFF
--- a/crates/coral-app/tests/local_mode.rs
+++ b/crates/coral-app/tests/local_mode.rs
@@ -201,6 +201,59 @@ async fn local_mode_source_lifecycle_and_query_work() {
 }
 
 #[tokio::test]
+async fn query_execution_rejects_non_read_only_sql() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_yaml = fixture_manifest_yaml(temp.path());
+    let app = local_client(temp.path().join("coral-config")).await;
+    let mut source_client = app.source_client();
+    let mut query_client = app.query_client();
+
+    source_client
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml,
+            variables: Vec::new(),
+            secrets: Vec::new(),
+        }))
+        .await
+        .expect("import source");
+
+    let copy_target = temp.path().join("copied.arrow");
+    let copy_error = query_client
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: format!(
+                "COPY local_messages.messages TO '{}' STORED AS ARROW",
+                copy_target.display()
+            ),
+        }))
+        .await
+        .expect_err("COPY TO should be rejected");
+    assert_eq!(copy_error.code(), tonic::Code::InvalidArgument);
+    assert!(copy_error.message().contains("DML not supported: COPY"));
+
+    let create_error = query_client
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "CREATE TABLE copied AS SELECT * FROM local_messages.messages".to_string(),
+        }))
+        .await
+        .expect_err("CREATE TABLE should be rejected");
+    assert_eq!(create_error.code(), tonic::Code::InvalidArgument);
+    assert!(create_error.message().contains("DDL not supported"));
+
+    let set_error = query_client
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SET datafusion.execution.batch_size = 1".to_string(),
+        }))
+        .await
+        .expect_err("SET should be rejected");
+    assert_eq!(set_error.code(), tonic::Code::InvalidArgument);
+    assert!(set_error.message().contains("Statement not supported"));
+}
+
+#[tokio::test]
 async fn missing_source_manifest_file_returns_not_found() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use datafusion::common::SchemaError;
 use datafusion::error::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 
 use crate::backends::compile_query_source;
 use crate::backends::http::ProviderQueryError;
@@ -72,11 +72,22 @@ impl QueryRuntimeAdapter {
     }
 
     pub(crate) async fn execute_sql(&self, sql: &str) -> Result<QueryExecution, CoreError> {
-        let df = self.ctx.sql(sql).await.map_err(datafusion_to_core)?;
+        let df = self
+            .ctx
+            .sql_with_options(sql, read_only_sql_options())
+            .await
+            .map_err(datafusion_to_core)?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let batches = df.collect().await.map_err(datafusion_to_core)?;
         Ok(QueryExecution::new(arrow_schema, batches))
     }
+}
+
+fn read_only_sql_options() -> SQLOptions {
+    SQLOptions::new()
+        .with_allow_ddl(false)
+        .with_allow_dml(false)
+        .with_allow_statements(false)
 }
 
 fn datafusion_to_core(error: DataFusionError) -> CoreError {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -248,7 +248,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(invalid_sql.is_error, Some(true));
     assert_eq!(
         invalid_sql.structured_content.expect("structured content")["error"]["summary"],
-        "Query failed"
+        "Query request is invalid"
     );
     assert!(
         invalid_sql.content[0]


### PR DESCRIPTION
## Summary
This closes a query safety gap by enforcing the read-only contract at the engine execution seam instead of relying on callers to avoid mutating SQL.

## Why
Coral exposes SQL execution over app and MCP surfaces. DataFusion's default `sql()` path accepts DDL, DML, and session statements, which meant callers could trigger side effects like `COPY TO` writes. The fix makes the engine reject those plans before execution and adds regression coverage at the public query layer.

## Testing
- cargo test -p coral-app query_execution_rejects_non_read_only_sql -- --nocapture
- cargo test -p coral-app local_mode_source_lifecycle_and_query_work -- --nocapture
- make validate
