### PR TITLE
feat: add OpenObserve source and filter_int support

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -674,6 +674,19 @@ fn resolve_value_source(
             .get(key)
             .map(|v| Value::String(v.clone()))
             .or_else(|| default.clone())),
+        ValueSourceSpec::FilterInt { key, default } => {
+            let value = if let Some(filter) = filters.get(key) {
+                let parsed = filter.parse::<i64>().map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "filter '{key}' value '{filter}' is not a valid i64: {error}"
+                    ))
+                })?;
+                Some(json!(parsed))
+            } else {
+                default.map(|value| json!(value))
+            };
+            Ok(value)
+        }
         ValueSourceSpec::Secret { key, default } => Ok(source_secrets
             .get(key)
             .cloned()
@@ -1078,6 +1091,11 @@ mod tests {
                 "key": key,
                 "default": default,
             }),
+            ValueSourceSpec::FilterInt { key, default } => json!({
+                "from": "filter_int",
+                "key": key,
+                "default": default,
+            }),
             ValueSourceSpec::Variable { key, default } => json!({
                 "from": "variable",
                 "key": key,
@@ -1192,6 +1210,48 @@ mod tests {
         .expect("secret lookup should succeed");
 
         assert_eq!(value, Some(json!("alpha-secret")));
+    }
+
+    #[test]
+    fn resolve_value_source_parses_filter_ints_as_numbers() {
+        let filters = HashMap::from([("start_time".to_string(), "1700000000000000".to_string())]);
+
+        let value = resolve_value_source(
+            &ValueSourceSpec::FilterInt {
+                key: "start_time".to_string(),
+                default: None,
+            },
+            &filters,
+            &HashMap::new(),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect("integer filter should resolve");
+
+        assert_eq!(value, Some(json!(1_700_000_000_000_000_i64)));
+    }
+
+    #[test]
+    fn resolve_value_source_rejects_invalid_filter_ints() {
+        let filters = HashMap::from([("start_time".to_string(), "not-a-number".to_string())]);
+
+        let error = resolve_value_source(
+            &ValueSourceSpec::FilterInt {
+                key: "start_time".to_string(),
+                default: None,
+            },
+            &filters,
+            &HashMap::new(),
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect_err("invalid integer filter should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("filter 'start_time' value 'not-a-number' is not a valid i64")
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -273,6 +273,7 @@ fn collect_value_source_secret_names(
         }
         ValueSourceSpec::Literal { .. }
         | ValueSourceSpec::Filter { .. }
+        | ValueSourceSpec::FilterInt { .. }
         | ValueSourceSpec::Variable { .. }
         | ValueSourceSpec::State { .. }
         | ValueSourceSpec::NowEpochMinusSeconds { .. } => {}

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -192,6 +192,11 @@ pub enum ValueSourceSpec {
         #[serde(default)]
         default: Option<Value>,
     },
+    FilterInt {
+        key: String,
+        #[serde(default)]
+        default: Option<i64>,
+    },
     Secret {
         key: String,
         #[serde(default)]

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -236,6 +236,14 @@
         },
         {
           "properties": {
+            "from": { "const": "filter_int" },
+            "key": { "type": "string", "minLength": 1 },
+            "default": { "type": "integer" }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
             "from": { "const": "secret" },
             "key": { "type": "string", "minLength": 1 },
             "default": { "type": "string" }

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -233,7 +233,7 @@ fn validate_value_source(
     context: &str,
 ) -> Result<()> {
     match source {
-        ValueSourceSpec::Filter { key, .. } => {
+        ValueSourceSpec::Filter { key, .. } | ValueSourceSpec::FilterInt { key, .. } => {
             if !known_filters.contains(key) {
                 return Err(ManifestError::validation(format!(
                     "{context} references unknown filter '{key}'"

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -109,6 +109,21 @@ In this minimal example:
 - with the default response rules, Coral treats the selected response value directly as rows unless you configure a different `row_strategy`
 - `{{secret.API_TOKEN}}` is replaced with the secret value you provided when adding the source to Coral
 
+### HTTP value sources
+
+Request query params, body fields, and headers support these `from` values:
+
+| `from` value | Description |
+| ------------ | ----------- |
+| `literal` | Use the manifest-authored JSON value directly |
+| `template` | Render a string template with `variable`, `secret`, `filter`, or `state` tokens |
+| `filter` | Read a SQL filter as a string |
+| `filter_int` | Read a SQL filter and serialize it as a JSON integer |
+| `variable` | Read a non-secret source variable |
+| `secret` | Read a source secret |
+| `state` | Read pagination/runtime state |
+| `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |
+
 ### HTTP response fields
 
 The `response` object controls how Coral extracts rows from an HTTP response body.

--- a/sources/openobserve/README.md
+++ b/sources/openobserve/README.md
@@ -1,0 +1,62 @@
+# OpenObserve
+
+This source connects Coral to an OpenObserve instance over HTTP.
+
+## Auth
+
+Set `OPENOBSERVE_BASIC_AUTH` to the base64-encoded `user:password` value that should be sent in the `Authorization: Basic ...` header.
+
+Example:
+
+```text
+echo -n 'user@example.com:password' | base64
+```
+
+## Inputs
+
+- `OPENOBSERVE_URL`: Base URL for the OpenObserve instance, for example `http://localhost:5080`
+- `OPENOBSERVE_ORG`: OpenObserve organization name. Defaults to `default`
+- `OPENOBSERVE_BASIC_AUTH`: Base64-encoded `user:password` for HTTP Basic auth
+
+## Example Queries
+
+List streams:
+
+```sql
+SELECT name, stream_type, doc_num
+FROM openobserve.streams
+ORDER BY doc_num DESC
+```
+
+Search logs:
+
+```sql
+SELECT _timestamp, body, severity, service_name
+FROM openobserve.logs
+WHERE stream = 'default'
+  AND start_time = 1700000000000000
+  AND end_time = 1700003600000000
+LIMIT 10
+```
+
+Search metrics:
+
+```sql
+SELECT _timestamp, metric_name, value, service_name
+FROM openobserve.metrics
+WHERE stream = 'my_metric_stream'
+  AND start_time = 1700000000000000
+  AND end_time = 1700003600000000
+LIMIT 10
+```
+
+Search traces:
+
+```sql
+SELECT _timestamp, trace_id, span_id, operation_name, duration
+FROM openobserve.traces
+WHERE stream = 'default'
+  AND start_time = 1700000000000000
+  AND end_time = 1700003600000000
+LIMIT 10
+```

--- a/sources/openobserve/manifest.yaml
+++ b/sources/openobserve/manifest.yaml
@@ -133,13 +133,13 @@ tables:
         expr: { kind: 'null' }
         virtual: true
       - name: start_time
-        type: Utf8
+        type: Int64
         nullable: true
         description: "Start time in microseconds (virtual filter, required)"
         expr: { kind: 'null' }
         virtual: true
       - name: end_time
-        type: Utf8
+        type: Int64
         nullable: true
         description: "End time in microseconds (virtual filter, required)"
         expr: { kind: 'null' }
@@ -224,13 +224,13 @@ tables:
         expr: { kind: 'null' }
         virtual: true
       - name: start_time
-        type: Utf8
+        type: Int64
         nullable: true
         description: "Start time in microseconds (virtual filter, required)"
         expr: { kind: 'null' }
         virtual: true
       - name: end_time
-        type: Utf8
+        type: Int64
         nullable: true
         description: "End time in microseconds (virtual filter, required)"
         expr: { kind: 'null' }
@@ -324,13 +324,13 @@ tables:
         expr: { kind: 'null' }
         virtual: true
       - name: start_time
-        type: Utf8
+        type: Int64
         nullable: true
         description: "Start time in microseconds (virtual filter, required)"
         expr: { kind: 'null' }
         virtual: true
       - name: end_time
-        type: Utf8
+        type: Int64
         nullable: true
         description: "End time in microseconds (virtual filter, required)"
         expr: { kind: 'null' }

--- a/sources/openobserve/manifest.yaml
+++ b/sources/openobserve/manifest.yaml
@@ -1,0 +1,344 @@
+dsl_version: 3
+name: openobserve
+version: 0.1.0
+backend: http
+description: Query logs, metrics, and traces stored in OpenObserve
+base_url: "{{variable.OPENOBSERVE_URL}}"
+auth:
+  required_secrets:
+    - OPENOBSERVE_BASIC_AUTH
+  headers:
+    - name: Authorization
+      from: template
+      template: "Basic {{secret.OPENOBSERVE_BASIC_AUTH}}"
+
+tables:
+  - name: streams
+    description: List available OpenObserve streams.
+    guide: >
+      No required filters. Optionally filter by stream_type (logs, metrics, traces).
+    request:
+      method: GET
+      path: "/api/{{variable.OPENOBSERVE_ORG|default}}/streams"
+      query:
+        - name: type
+          from: filter
+          key: stream_type
+          default: "logs"
+        - name: fetchSchema
+          from: literal
+          value: "false"
+    response:
+      rows_path: [list]
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Stream name
+        expr: { kind: path, path: [name] }
+      - name: stream_type
+        type: Utf8
+        nullable: true
+        description: "Stream type (logs, metrics, traces). Also a virtual filter."
+        expr: { kind: path, path: [stream_type] }
+      - name: storage_type
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [storage_type] }
+      - name: doc_num
+        type: Int64
+        nullable: true
+        description: Number of documents
+        expr: { kind: path, path: [stats, doc_num] }
+      - name: storage_size
+        type: Float64
+        nullable: true
+        description: Storage size in bytes
+        expr: { kind: path, path: [stats, storage_size] }
+      - name: compressed_size
+        type: Float64
+        nullable: true
+        description: Compressed size in bytes
+        expr: { kind: path, path: [stats, compressed_size] }
+    filters:
+      - name: stream_type
+
+  - name: logs
+    description: Search OpenObserve log streams via SQL.
+    guide: >
+      Requires stream, start_time, and end_time filters.
+      start_time and end_time are Unix timestamps in microseconds.
+      Returns up to 10000 rows per query.
+      For OTLP-exported logs, the message content is in the 'body' column.
+    request:
+      method: POST
+      path: "/api/{{variable.OPENOBSERVE_ORG|default}}/_search"
+      body:
+        - path: [query, sql]
+          from: template
+          template: "SELECT * FROM \"{{filter.stream}}\""
+        - path: [query, start_time]
+          from: filter_int
+          key: start_time
+        - path: [query, end_time]
+          from: filter_int
+          key: end_time
+        - path: [query, from]
+          from: literal
+          value: 0
+        - path: [query, size]
+          from: literal
+          value: 10000
+    response:
+      rows_path: [hits]
+    pagination:
+      mode: none
+    columns:
+      - name: _timestamp
+        type: Int64
+        nullable: false
+        description: "Event timestamp in microseconds"
+        expr: { kind: path, path: [_timestamp] }
+      - name: body
+        type: Utf8
+        nullable: true
+        description: "Log message body (OTLP log content)"
+        expr: { kind: path, path: [body] }
+      - name: severity
+        type: Utf8
+        nullable: true
+        description: "Log severity level"
+        expr: { kind: path, path: [severity] }
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: "Service that emitted the log"
+        expr: { kind: path, path: [service_name] }
+      - name: event_name
+        type: Utf8
+        nullable: true
+        description: "Event name"
+        expr: { kind: path, path: [event_name] }
+      - name: session_id
+        type: Utf8
+        nullable: true
+        description: "Session identifier"
+        expr: { kind: path, path: [session_id] }
+      - name: stream
+        type: Utf8
+        nullable: true
+        description: "OpenObserve stream name (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+      - name: start_time
+        type: Utf8
+        nullable: true
+        description: "Start time in microseconds (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+      - name: end_time
+        type: Utf8
+        nullable: true
+        description: "End time in microseconds (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+    filters:
+      - name: stream
+        required: true
+      - name: start_time
+        required: true
+      - name: end_time
+        required: true
+
+  - name: metrics
+    description: Search OpenObserve metric streams via SQL.
+    guide: >
+      Requires stream, start_time, and end_time filters.
+      start_time and end_time are Unix timestamps in microseconds.
+      The stream name is the metric name (e.g. 'coral_http_count').
+      Returns up to 10000 rows per query.
+    request:
+      method: POST
+      path: "/api/{{variable.OPENOBSERVE_ORG|default}}/_search"
+      query:
+        - name: type
+          from: literal
+          value: "metrics"
+      body:
+        - path: [query, sql]
+          from: template
+          template: "SELECT * FROM \"{{filter.stream}}\""
+        - path: [query, start_time]
+          from: filter_int
+          key: start_time
+        - path: [query, end_time]
+          from: filter_int
+          key: end_time
+        - path: [query, from]
+          from: literal
+          value: 0
+        - path: [query, size]
+          from: literal
+          value: 10000
+    response:
+      rows_path: [hits]
+    pagination:
+      mode: none
+    columns:
+      - name: _timestamp
+        type: Int64
+        nullable: false
+        description: "Event timestamp in microseconds"
+        expr: { kind: path, path: [_timestamp] }
+      - name: metric_name
+        type: Utf8
+        nullable: true
+        description: "Metric name"
+        expr: { kind: path, path: [__name__] }
+      - name: value
+        type: Float64
+        nullable: true
+        description: "Metric value"
+        expr: { kind: path, path: [value] }
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: "Service that emitted the metric"
+        expr: { kind: path, path: [service_name] }
+      - name: model
+        type: Utf8
+        nullable: true
+        description: "Model name (for AI-related metrics)"
+        expr: { kind: path, path: [model] }
+      - name: session_id
+        type: Utf8
+        nullable: true
+        description: "Session identifier"
+        expr: { kind: path, path: [session_id] }
+      - name: stream
+        type: Utf8
+        nullable: true
+        description: "OpenObserve metric stream name (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+      - name: start_time
+        type: Utf8
+        nullable: true
+        description: "Start time in microseconds (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+      - name: end_time
+        type: Utf8
+        nullable: true
+        description: "End time in microseconds (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+    filters:
+      - name: stream
+        required: true
+      - name: start_time
+        required: true
+      - name: end_time
+        required: true
+
+  - name: traces
+    description: Search OpenObserve trace/span streams via SQL.
+    guide: >
+      Requires stream, start_time, and end_time filters.
+      start_time and end_time are Unix timestamps in microseconds.
+      Returns up to 10000 rows per query.
+    request:
+      method: POST
+      path: "/api/{{variable.OPENOBSERVE_ORG|default}}/_search"
+      query:
+        - name: type
+          from: literal
+          value: "traces"
+      body:
+        - path: [query, sql]
+          from: template
+          template: "SELECT * FROM \"{{filter.stream}}\""
+        - path: [query, start_time]
+          from: filter_int
+          key: start_time
+        - path: [query, end_time]
+          from: filter_int
+          key: end_time
+        - path: [query, from]
+          from: literal
+          value: 0
+        - path: [query, size]
+          from: literal
+          value: 10000
+    response:
+      rows_path: [hits]
+    pagination:
+      mode: none
+    columns:
+      - name: _timestamp
+        type: Int64
+        nullable: false
+        description: "Event timestamp in microseconds"
+        expr: { kind: path, path: [_timestamp] }
+      - name: trace_id
+        type: Utf8
+        nullable: false
+        description: "Trace identifier grouping related spans"
+        expr: { kind: path, path: [trace_id] }
+      - name: span_id
+        type: Utf8
+        nullable: false
+        description: "Unique span identifier"
+        expr: { kind: path, path: [span_id] }
+      - name: operation_name
+        type: Utf8
+        nullable: true
+        description: "Span operation name"
+        expr: { kind: path, path: [operation_name] }
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: "Service that emitted the span"
+        expr: { kind: path, path: [service_name] }
+      - name: duration
+        type: Int64
+        nullable: true
+        description: "Span duration in microseconds"
+        expr: { kind: path, path: [duration] }
+      - name: span_kind
+        type: Utf8
+        nullable: true
+        description: "Span kind (1=Internal, 2=Server, 3=Client, 4=Producer, 5=Consumer)"
+        expr: { kind: path, path: [span_kind] }
+      - name: span_status
+        type: Utf8
+        nullable: true
+        description: "Span status (OK, ERROR, UNSET)"
+        expr: { kind: path, path: [span_status] }
+      - name: stream
+        type: Utf8
+        nullable: true
+        description: "OpenObserve trace stream name (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+      - name: start_time
+        type: Utf8
+        nullable: true
+        description: "Start time in microseconds (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+      - name: end_time
+        type: Utf8
+        nullable: true
+        description: "End time in microseconds (virtual filter, required)"
+        expr: { kind: 'null' }
+        virtual: true
+    filters:
+      - name: stream
+        required: true
+      - name: start_time
+        required: true
+      - name: end_time
+        required: true


### PR DESCRIPTION
- Adds a new `openobserve` bundled source with four tables: `streams`, `logs`, `metrics`, `traces`
- Adds a `filter_int` value source type to the spec and engine so that SQL filter values are serialized as JSON integers rather than strings — required by the OpenObserve `_search` API
- Documents `filter_int` and all other HTTP value source types in the source spec reference

## Why `filter_int`

The OpenObserve `_search` endpoint requires `start_time` and `end_time` in the JSON request body to be integers (Unix microseconds). The existing `from: filter` variant passes values as JSON strings, which the API silently rejects or misinterprets. `filter_int` parses the SQL filter value as `i64` before serializing it, ensuring the correct wire type.

## Changes

### `coral-spec`
- `common.rs` — added `FilterInt { key, default: Option<i64> }` variant to `ValueSourceSpec`
- `validate.rs` — extended filter reference validation to cover `FilterInt`
- `backends/http.rs` — excluded `FilterInt` from secret-name collection (same as `Filter`)
- `schema/source_manifest.schema.json` — added `filter_int` JSON Schema definition

### `coral-engine`
- `backends/http/client.rs` — implemented `FilterInt` resolution: parses filter string to `i64`, emits a JSON number; added two unit tests (valid parse, invalid parse)

### `sources/openobserve/`
- `manifest.yaml` — full connector for OpenObserve HTTP API (ported from ADP `connector.yaml`):
  - `streams` — `GET /api/{org}/streams`, lists available streams by type
  - `logs` — `POST /api/{org}/_search`, SQL search over log streams
  - `metrics` — `POST /api/{org}/_search?type=metrics`, SQL search over metric streams
  - `traces` — `POST /api/{org}/_search?type=traces`, SQL search over trace streams
- `README.md` — setup instructions and example queries

### `docs/reference/source-spec-reference.mdx`
- Added HTTP value sources table documenting all `from` values including `filter_int`

## Inputs

| Name | Kind | Required | Default | Description |
|---|---|---|---|---|
| `OPENOBSERVE_URL` | variable | yes | — | Base URL (e.g. `http://host:5080`) |
| `OPENOBSERVE_ORG` | variable | no | `default` | Organization name |
| `OPENOBSERVE_BASIC_AUTH` | secret | yes | — | Base64-encoded `user:password` |

## Testing

Validated against a live OpenObserve instance (Lima VM, `host.lima.internal:5080`). All four tables returned real data:

| Query | Result |
|---|---|
| `SELECT * FROM openobserve.streams` | `default / logs / 94589 docs` |
| `SELECT * FROM openobserve.logs WHERE stream = 'default' AND ...` | 10 rows from `claude-code` service |
| `SELECT * FROM openobserve.metrics WHERE stream = 'claude_code_session_count' AND ...` | `value = 1.0` |
| `SELECT * FROM openobserve.traces WHERE stream = 'default' AND ...` | 10 spans with trace/span IDs |
