### PR TITLE
fix(ci): persist checkout credentials for paths-filter

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Detect release script changes
         id: release-script-changes


### PR DESCRIPTION
## Summary
- The `dorny/paths-filter` action needs git credentials to fetch the previous commit when detecting changes on push events
- With `persist-credentials: false`, the fetch fails with `fatal: could not read Username for 'https://github.com'`
- Switches to `persist-credentials: true` so the token remains available

## Test plan
- [ ] Verify the validate workflow passes on this PR
- [ ] Merge and confirm the next push to `main` no longer fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)