### PR TITLE
fix(ci): pass --repo to gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
           gh release create "$TAG_NAME" \
             artifacts/${ARTIFACT_PREFIX}-*.tar.gz \
             artifacts/checksums.sha256 \
+            --repo "$GITHUB_REPOSITORY" \
             --target "$BUILD_REF" \
             --title "$RELEASE_NAME" \
             --generate-notes


### PR DESCRIPTION
## Summary
- The `publish-version` job in the release workflow has no `actions/checkout` step, so `gh release create` fails with `fatal: not a git repository` when trying to infer the repo from the local git config.
- Fixes this by passing `--repo "$GITHUB_REPOSITORY"` explicitly so `gh` doesn't need a local checkout.

## Test plan
- [ ] Re-run the release workflow and verify the `Create GitHub release` step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)