### PR TITLE
feat(sources/linear): add attachments table

### DIFF
--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -1,5 +1,5 @@
 name: linear
-version: 2.0.0
+version: 2.1.0
 dsl_version: 3
 backend: http
 description: Manage issues, projects, cycles, and initiatives across teams
@@ -1263,3 +1263,157 @@ tables:
     filters:
       - name: team_id
         required: true
+  - name: attachments
+    description: Attachments (including pull requests) linked to Linear issues
+    request:
+      method: POST
+      path: /graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query Attachments($first: Int!, $after: String) {
+              attachments(first: $first, after: $after) {
+                nodes {
+                  id
+                  title
+                  subtitle
+                  url
+                  sourceType
+                  createdAt
+                  updatedAt
+                  issue {
+                    id
+                    identifier
+                  }
+                  creator {
+                    id
+                    name
+                  }
+                }
+                pageInfo {
+                  endCursor
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - data
+        - attachments
+        - nodes
+    pagination:
+      mode: cursor_body
+      cursor_body_path:
+        - variables
+        - after
+      response_cursor_path:
+        - data
+        - attachments
+        - pageInfo
+        - endCursor
+      page_size:
+        default: 100
+        max: 250
+        body_path:
+          - variables
+          - first
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Attachment ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Attachment title
+        expr:
+          kind: path
+          path:
+            - title
+      - name: subtitle
+        type: Utf8
+        nullable: true
+        description: Attachment subtitle
+        expr:
+          kind: path
+          path:
+            - subtitle
+      - name: url
+        type: Utf8
+        nullable: false
+        description: Attachment URL (for example a pull request URL)
+        expr:
+          kind: path
+          path:
+            - url
+      - name: source_type
+        type: Utf8
+        nullable: true
+        description: Source type (for example github or gitlab)
+        expr:
+          kind: path
+          path:
+            - sourceType
+      - name: issue_id
+        type: Utf8
+        nullable: true
+        description: Linked issue ID
+        expr:
+          kind: path
+          path:
+            - issue
+            - id
+      - name: issue_identifier
+        type: Utf8
+        nullable: true
+        description: Linked issue identifier (for example ENG-123)
+        expr:
+          kind: path
+          path:
+            - issue
+            - identifier
+      - name: creator_id
+        type: Utf8
+        nullable: true
+        description: Creator user ID
+        expr:
+          kind: path
+          path:
+            - creator
+            - id
+      - name: creator_name
+        type: Utf8
+        nullable: true
+        description: Creator name
+        expr:
+          kind: path
+          path:
+            - creator
+            - name
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Updated timestamp
+        expr:
+          kind: path
+          path:
+            - updatedAt


### PR DESCRIPTION
## Summary

- Adds a new `linear.attachments` table that queries Linear's GraphQL `attachments` API, exposing PRs, branches, and other linked resources directly from the Linear schema.
- Includes columns for `url`, `source_type`, `issue_identifier`, and creator metadata, enabling queries like "which of my Linear issues have associated PRs?" without GitHub-side workarounds.
- Bumps the Linear source manifest version from 2.0.0 to 2.1.0.


## Test plan

```
coral sql "SELECT
  i.identifier,
  a.url AS pr_url
FROM linear.issues i
LEFT JOIN linear.attachments a
  ON i.id = a.issue_id
AND a.url LIKE 'https://github.com/%'
WHERE i.assignee_id = '$MY_LINEAR_USER_ID'
  AND i.completed_at IS NULL
  AND i.state_name NOT IN ('Canceled', 'Duplicate', 'Done')
ORDER BY i.priority ASC, i.identifier"
+------------+--------------------------------------------+
| identifier | pr_url                                     |
+------------+--------------------------------------------+
| DATA-113   |                                            |
| DATA-141   |                                            |
| DATA-142   |                                            |
| DATA-197   |                                            |
| DATA-253   |                                            |
| DATA-291   |                                            |
| DATA-293   |                                            |
| DATA-357   | https://github.com/withcoral/coral/pull/55 |
| DATA-85    |                                            |
+------------+--------------------------------------------+
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)