### PR TITLE
fix(ci): remove Rust cache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,6 @@ jobs:
         run: rustup show
       - name: Ensure target is installed
         run: rustup target add ${{ matrix.target }}
-      - name: Cache Rust artifacts
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-        with:
-          shared-key: coral-${{ runner.os }}-${{ matrix.target }}
       - name: Install cross
         if: matrix.cross
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
         run: rustup show
       - name: Ensure target is installed
         run: rustup target add ${{ matrix.target }}
+      # No Rust cache here — release builds must compile from a clean state
+      # to guard against cache poisoning attacks.
       - name: Install cross
         if: matrix.cross
         run: |


### PR DESCRIPTION
Removes the `Swatinem/rust-cache` step from the release build job to guard against potential cache poisoning attacks. Release builds will now always compile from a clean state.