### PR TITLE
feat(cli): auto-validate after adding a source

### DIFF
--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -183,14 +183,22 @@ async fn main() -> Result<(), anyhow::Error> {
                     _ => unreachable!("clap enforces exactly one of name or file"),
                 };
                 println!("Added source {}", response.name);
+                if let Err(err) = source_ops::validate_and_print(
+                    &app,
+                    &response.name,
+                    Some(source_ops::MAX_TABLES_PER_SCHEMA),
+                )
+                .await
+                {
+                    eprintln!("Warning: validation failed: {err}");
+                }
             }
             SourceCommand::Lint { file } => {
                 source_ops::load_validated_manifest_file(&file)?;
                 println!("Manifest is valid");
             }
             SourceCommand::Test { name } => {
-                let response = source_ops::validate_source(&app, &name).await?;
-                source_ops::print_validation_success(&response)?;
+                source_ops::validate_and_print(&app, &name, None).await?;
             }
             SourceCommand::Remove { name } => {
                 source_ops::delete_source(&app, &name).await?;

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use coral_api::v1::ExecuteSqlRequest;
 use coral_client::{
-    ClientBuilder, decode_execute_sql_response, default_workspace, format_batches_json,
+    AppClient, ClientBuilder, decode_execute_sql_response, default_workspace, format_batches_json,
     format_batches_table,
 };
 use tonic::Request;
@@ -153,52 +153,14 @@ async fn main() -> Result<(), anyhow::Error> {
                     }
                 }
             }
-            SourceCommand::Add(SourceAddArgs { name, file }) => {
-                source_ops::require_interactive()?;
-                let response = match (name, file) {
-                    (Some(name), None) => {
-                        let bundled_name = source_ops::source_name_arg(Some(&name))?;
-                        let discover = source_ops::discover_sources(&app).await?;
-                        let available = discover
-                            .into_iter()
-                            .find(|source| source.name == bundled_name)
-                            .ok_or_else(|| {
-                                anyhow::anyhow!("unknown bundled source '{bundled_name}'")
-                            })?;
-                        let inputs = available
-                            .inputs
-                            .iter()
-                            .map(source_ops::manifest_input_from_proto)
-                            .collect::<Result<Vec<_>, _>>()?;
-                        let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
-                        source_ops::add_bundled_source(&app, &available.name, variables, secrets)
-                            .await?
-                    }
-                    (None, Some(file)) => {
-                        let (manifest_yaml, _, inputs) =
-                            source_ops::load_validated_manifest_file(&file)?;
-                        let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
-                        source_ops::import_source(&app, manifest_yaml, variables, secrets).await?
-                    }
-                    _ => unreachable!("clap enforces exactly one of name or file"),
-                };
-                println!("Added source {}", response.name);
-                if let Err(err) = source_ops::validate_and_print(
-                    &app,
-                    &response.name,
-                    Some(source_ops::MAX_TABLES_PER_SCHEMA),
-                )
-                .await
-                {
-                    eprintln!("Warning: validation failed: {err}");
-                }
-            }
+            SourceCommand::Add(args) => run_source_add(&app, args).await?,
             SourceCommand::Lint { file } => {
                 source_ops::load_validated_manifest_file(&file)?;
                 println!("Manifest is valid");
             }
             SourceCommand::Test { name } => {
-                source_ops::validate_and_print(&app, &name, None).await?;
+                source_ops::validate_and_print(&app, &name, source_ops::TableDisplayLimit::All)
+                    .await?;
             }
             SourceCommand::Remove { name } => {
                 source_ops::delete_source(&app, &name).await?;
@@ -225,5 +187,41 @@ fn print_batches(
         OutputFormat::Json => format_batches_json(batches)?,
     };
     println!("{output}");
+    Ok(())
+}
+
+async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyhow::Error> {
+    source_ops::require_interactive()?;
+    let SourceAddArgs { name, file } = args;
+    let response = match (name, file) {
+        (Some(name), None) => {
+            let bundled_name = source_ops::source_name_arg(Some(&name))?;
+            let discover = source_ops::discover_sources(app).await?;
+            let available = discover
+                .into_iter()
+                .find(|source| source.name == bundled_name)
+                .ok_or_else(|| anyhow::anyhow!("unknown bundled source '{bundled_name}'"))?;
+            let inputs = available
+                .inputs
+                .iter()
+                .map(source_ops::manifest_input_from_proto)
+                .collect::<Result<Vec<_>, _>>()?;
+            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
+        }
+        (None, Some(file)) => {
+            let (manifest_yaml, _, inputs) = source_ops::load_validated_manifest_file(&file)?;
+            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            source_ops::import_source(app, manifest_yaml, variables, secrets).await?
+        }
+        _ => unreachable!("clap enforces exactly one of name or file"),
+    };
+    println!("Added source {}", response.name);
+    if let Err(err) =
+        source_ops::validate_and_print(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
+            .await
+    {
+        eprintln!("Warning: validation failed: {err}");
+    }
     Ok(())
 }

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -1,6 +1,4 @@
-use std::collections::BTreeMap;
-
-use coral_api::v1::{AvailableSource, ExecuteSqlRequest, Source, ValidateSourceResponse};
+use coral_api::v1::{AvailableSource, ExecuteSqlRequest, Source};
 use coral_client::{
     AppClient, decode_execute_sql_response, default_workspace, format_batches_table,
 };
@@ -156,7 +154,12 @@ async fn run_installed_source_menu(
 
     match selection.map(|i| actions[i]) {
         Some(InstalledSourceAction::Validate) => {
-            validate_after_install(app, &source.name).await?;
+            source_ops::validate_and_print(
+                app,
+                &source.name,
+                Some(source_ops::MAX_TABLES_PER_SCHEMA),
+            )
+            .await?;
         }
         Some(InstalledSourceAction::Reconfigure) => {
             let inputs = source
@@ -168,7 +171,12 @@ async fn run_installed_source_menu(
             let result =
                 source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
             println!("Reconfigured source {}", result.name);
-            validate_after_install(app, &result.name).await?;
+            source_ops::validate_and_print(
+                app,
+                &result.name,
+                Some(source_ops::MAX_TABLES_PER_SCHEMA),
+            )
+            .await?;
         }
         Some(InstalledSourceAction::Back) | None => {}
     }
@@ -188,73 +196,7 @@ async fn run_add_bundled_source(
     let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
     let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
     println!("Added source {}", result.name);
-    validate_after_install(app, &result.name).await
-}
-
-async fn validate_after_install(app: &AppClient, source_name: &str) -> Result<(), anyhow::Error> {
-    let response = source_ops::validate_source(app, source_name).await?;
-    print_validation_pretty(&response)
-}
-
-const MAX_TABLES_PER_SCHEMA: usize = 9;
-
-fn print_validation_pretty(response: &ValidateSourceResponse) -> Result<(), anyhow::Error> {
-    let source = response
-        .source
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("validate response missing source metadata"))?;
-
-    println!();
-    println!(
-        "  {} {}",
-        style("✓").green(),
-        style(format!("{} connected successfully", source.name)).bold()
-    );
-
-    // Group tables by schema, sorted.
-    let mut by_schema: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
-    for table in &response.tables {
-        by_schema
-            .entry(&table.schema_name)
-            .or_default()
-            .push(&table.name);
-    }
-    for tables in by_schema.values_mut() {
-        tables.sort_unstable();
-    }
-
-    for (schema, tables) in &by_schema {
-        let count = tables.len();
-        println!();
-        println!(
-            "    {}",
-            style(format!(
-                "{schema} ({count} {})",
-                if count == 1 { "table" } else { "tables" }
-            ))
-            .bold()
-        );
-
-        let show_count = tables.len().min(MAX_TABLES_PER_SCHEMA);
-        let remaining = tables.len() - show_count;
-
-        for (i, table) in tables.iter().take(show_count).enumerate() {
-            let is_last = i == show_count - 1 && remaining == 0;
-            let branch = if is_last { "└─" } else { "├─" };
-            println!("    {} {}", style(branch).dim(), table);
-        }
-
-        if remaining > 0 {
-            println!(
-                "    {} {}",
-                style("└─").dim(),
-                style(format!("... and {remaining} more")).dim()
-            );
-        }
-    }
-    println!();
-
-    Ok(())
+    source_ops::validate_and_print(app, &result.name, Some(source_ops::MAX_TABLES_PER_SCHEMA)).await
 }
 
 async fn run_next_steps(

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -157,7 +157,7 @@ async fn run_installed_source_menu(
             source_ops::validate_and_print(
                 app,
                 &source.name,
-                Some(source_ops::MAX_TABLES_PER_SCHEMA),
+                source_ops::TableDisplayLimit::DEFAULT,
             )
             .await?;
         }
@@ -174,7 +174,7 @@ async fn run_installed_source_menu(
             source_ops::validate_and_print(
                 app,
                 &result.name,
-                Some(source_ops::MAX_TABLES_PER_SCHEMA),
+                source_ops::TableDisplayLimit::DEFAULT,
             )
             .await?;
         }
@@ -196,7 +196,7 @@ async fn run_add_bundled_source(
     let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
     let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
     println!("Added source {}", result.name);
-    source_ops::validate_and_print(app, &result.name, Some(source_ops::MAX_TABLES_PER_SCHEMA)).await
+    source_ops::validate_and_print(app, &result.name, source_ops::TableDisplayLimit::DEFAULT).await
 }
 
 async fn run_next_steps(

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::{IsTerminal, stdin, stdout};
 use std::path::Path;
 
@@ -10,8 +11,11 @@ use coral_client::{AppClient, default_workspace};
 use coral_spec::{
     ManifestInputKind, ManifestInputSpec, ValidatedSourceManifest, parse_manifest_and_inputs,
 };
+use dialoguer::console::style;
 use dialoguer::{Input, Password, theme::ColorfulTheme};
 use tonic::Request;
+
+pub(crate) const MAX_TABLES_PER_SCHEMA: usize = 9;
 
 pub(crate) async fn discover_sources(
     app: &AppClient,
@@ -178,17 +182,74 @@ pub(crate) fn source_origin_label(origin: i32) -> &'static str {
     }
 }
 
-pub(crate) fn print_validation_success(
+pub(crate) async fn validate_and_print(
+    app: &AppClient,
+    source_name: &str,
+    max_tables: Option<usize>,
+) -> Result<(), anyhow::Error> {
+    let response = validate_source(app, source_name).await?;
+    print_validation_pretty(&response, max_tables)
+}
+
+pub(crate) fn print_validation_pretty(
     response: &ValidateSourceResponse,
+    max_tables: Option<usize>,
 ) -> Result<(), anyhow::Error> {
     let source = response
         .source
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("validate response missing source metadata"))?;
-    println!("Source {} is queryable", source.name);
+
+    println!();
+    println!(
+        "  {} {}",
+        style("✓").green(),
+        style(format!("{} connected successfully", source.name)).bold()
+    );
+
+    // Group tables by schema, sorted.
+    let mut by_schema: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
     for table in &response.tables {
-        println!("{}.{}", table.schema_name, table.name);
+        by_schema
+            .entry(&table.schema_name)
+            .or_default()
+            .push(&table.name);
     }
+    for tables in by_schema.values_mut() {
+        tables.sort_unstable();
+    }
+
+    for (schema, tables) in &by_schema {
+        let count = tables.len();
+        println!();
+        println!(
+            "    {}",
+            style(format!(
+                "{schema} ({count} {})",
+                if count == 1 { "table" } else { "tables" }
+            ))
+            .bold()
+        );
+
+        let show_count = max_tables.map_or(tables.len(), |max| tables.len().min(max));
+        let remaining = tables.len() - show_count;
+
+        for (i, table) in tables.iter().take(show_count).enumerate() {
+            let is_last = i == show_count - 1 && remaining == 0;
+            let branch = if is_last { "└─" } else { "├─" };
+            println!("    {} {}", style(branch).dim(), table);
+        }
+
+        if remaining > 0 {
+            println!(
+                "    {} {}",
+                style("└─").dim(),
+                style(format!("... and {remaining} more")).dim()
+            );
+        }
+    }
+    println!();
+
     Ok(())
 }
 

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -15,7 +15,21 @@ use dialoguer::console::style;
 use dialoguer::{Input, Password, theme::ColorfulTheme};
 use tonic::Request;
 
-pub(crate) const MAX_TABLES_PER_SCHEMA: usize = 9;
+const MAX_TABLES_PER_SCHEMA: usize = 9;
+
+/// How many tables to show per schema when pretty-printing validation results.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TableDisplayLimit {
+    /// Show every table the source exposes.
+    All,
+    /// Show at most this many tables per schema, with a summary for the rest.
+    Max(usize),
+}
+
+impl TableDisplayLimit {
+    /// The default truncation used after `source add` and during onboarding.
+    pub(crate) const DEFAULT: Self = Self::Max(MAX_TABLES_PER_SCHEMA);
+}
 
 pub(crate) async fn discover_sources(
     app: &AppClient,
@@ -185,15 +199,15 @@ pub(crate) fn source_origin_label(origin: i32) -> &'static str {
 pub(crate) async fn validate_and_print(
     app: &AppClient,
     source_name: &str,
-    max_tables: Option<usize>,
+    limit: TableDisplayLimit,
 ) -> Result<(), anyhow::Error> {
     let response = validate_source(app, source_name).await?;
-    print_validation_pretty(&response, max_tables)
+    print_validation_pretty(&response, limit)
 }
 
 pub(crate) fn print_validation_pretty(
     response: &ValidateSourceResponse,
-    max_tables: Option<usize>,
+    limit: TableDisplayLimit,
 ) -> Result<(), anyhow::Error> {
     let source = response
         .source
@@ -231,7 +245,10 @@ pub(crate) fn print_validation_pretty(
             .bold()
         );
 
-        let show_count = max_tables.map_or(tables.len(), |max| tables.len().min(max));
+        let show_count = match limit {
+            TableDisplayLimit::All => tables.len(),
+            TableDisplayLimit::Max(max) => tables.len().min(max),
+        };
         let remaining = tables.len() - show_count;
 
         for (i, table) in tables.iter().take(show_count).enumerate() {

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -28,10 +28,7 @@ coral source add github
 
 Coral prompts for any required variables or secrets. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
 
-<Tip>
-  Run `coral source test github` to validate the connection and see the tables
-  the source exposes.
-</Tip>
+<Tip>You can re-validate anytime with `coral source test github`.</Tip>
 
 ## 3. Query your data
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -56,6 +56,8 @@ Add a custom source spec from a YAML file.
 coral source add --file ./local-messages.yaml
 ```
 
+Like `source add`, this automatically validates and prints discovered tables after install.
+
 ### `coral source lint <FILE>`
 
 Validate a source spec YAML file without installing it. Checks YAML syntax, JSON schema conformance, and semantic rules such as duplicate columns or references to unknown filters.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -46,6 +46,7 @@ coral source add github
 ```
 
 Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
+After installation, it automatically validates the connection and prints the discovered tables.
 
 ### `coral source add --file <PATH>`
 


### PR DESCRIPTION
## Summary

- `source add`  now automatically validate the source after installation and pretty-print discovered tables (with truncation). Validation failures are surfaced as warnings — the command still exits successfully since the source is already persisted.
- `source test` now uses the same rich tree format (without truncation, showing all tables).
- Moves `print_validation_pretty` from `onboard.rs` into `source_ops.rs` so onboarding, `source add`, `source import`, and `source test` all share one code path.

## Test plan

<img width="708" height="264" alt="image" src="https://github.com/user-attachments/assets/516b92aa-ed40-40cc-b33e-f5a823004c81" />
<img width="519" height="276" alt="image" src="https://github.com/user-attachments/assets/7eb55a1b-d052-4cef-875c-6bd63afcb230" />
<img width="550" height="296" alt="image" src="https://github.com/user-attachments/assets/38ac3318-bcf6-4b9a-aa04-8b18670cce31" />
