### PR TITLE
docs: update session ID field name in custom source guide

### DIFF
--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -26,8 +26,8 @@ The fastest way to see a custom source working is with a local file.
 ```shellscript
 mkdir -p demo-data
 cat > demo-data/messages.jsonl <<'EOF'
-{"type":"user","sessionId":"s1","text":"hello"}
-{"type":"assistant","sessionId":"s1","text":"world"}
+{"type":"user","session_id":"s1","text":"hello"}
+{"type":"assistant","session_id":"s1","text":"world"}
 EOF
 ```
 
@@ -49,7 +49,7 @@ tables:
     columns:
       - name: type
         type: Utf8
-      - name: sessionId
+      - name: session_id
         type: Utf8
       - name: text
         type: Utf8
@@ -68,9 +68,9 @@ coral source test local_messages
 
 ```shellscript
 coral sql "
-  SELECT type, sessionId, text
+  SELECT type, session_id, text
   FROM local_messages.messages
-  ORDER BY sessionId, type
+  ORDER BY session_id, type
 "
 ```
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -62,7 +62,7 @@ tables:
     columns:
       - name: type
         type: Utf8
-      - name: sessionId
+      - name: session_id
         type: Utf8
       - name: text
         type: Utf8


### PR DESCRIPTION
## Summary
This update renames `sessionId` to `session_id` in the custom source guide.

## Changes
- Updated `sessionId` to `session_id` in example JSONL data.
- Modified the data connector configuration to use `session_id`.
- Adjusted SQL queries in the guide to reflect the `session_id` column name.

<!-- mintlify-editor-comments:start -->
Mintlify
---
0 threads from 0 users in Mintlify

- No unresolved comments
<!-- mintlify-editor-comments:end -->

<!-- mintlify-comment-->

<a href="https://dashboard.mintlify.com/phoebe-a505b5b8/withcoral/editor/simonwhitaker%2Flocal-messages-fix?source=pr_comment" target="_blank" rel="noopener noreferrer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg"><img src="https://d3gk2c5xim1je2.cloudfront.net/assets/open-mintlify-editor-light.svg" alt="Open in Mintlify Editor"></picture></a>

<!-- /mintlify-comment -->