### PR TITLE
feat(sources/linear): expose project_id on issues and team_issues

### DIFF
--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -1,5 +1,5 @@
 name: linear
-version: 2.1.0
+version: 2.2.0
 dsl_version: 3
 backend: http
 description: Manage issues, projects, cycles, and initiatives across teams
@@ -835,6 +835,9 @@ tables:
                     name
                     email
                   }
+                  project {
+                    id
+                  }
                 }
                 pageInfo {
                   endCursor
@@ -995,6 +998,15 @@ tables:
           kind: path
           path:
             - updatedAt
+      - name: project_id
+        type: Utf8
+        nullable: true
+        description: Project ID
+        expr:
+          kind: path
+          path:
+            - project
+            - id
       - name: completed_at
         type: Utf8
         nullable: true
@@ -1137,6 +1149,9 @@ tables:
                       name
                       email
                     }
+                    project {
+                      id
+                    }
                   }
                   pageInfo {
                     endCursor
@@ -1252,6 +1267,15 @@ tables:
           kind: path
           path:
             - createdAt
+      - name: project_id
+        type: Utf8
+        nullable: true
+        description: Project ID
+        expr:
+          kind: path
+          path:
+            - project
+            - id
       - name: updated_at
         type: Utf8
         nullable: true


### PR DESCRIPTION
## Summary

Adds `project_id` column to the `issues` and `team_issues` tables in the Linear source. This enables Coral to join issues with projects, so queries like "show issues for project X" can correctly filter by project.

Closes DATA-354

## Changes

- Added `project { id }` to the GraphQL queries for both tables
- Added `project_id` column definitions (Utf8, nullable)
- Bumped manifest version from 2.1.0 to 2.2.0

## Test

```
$ coral sql "select i.identifier, i.state_name from linear.issues i
  left join linear.projects p
  on i.project_id = p.id
  where p.name ilike '%bug bash%'
  and i.assignee_name = 'Simon Whitaker'"
+------------+------------+
| identifier | state_name |
+------------+------------+
| DATA-363   | Backlog    |
| DATA-357   | Done       |
| DATA-354   | Backlog    |
+------------+------------+
```