### PR TITLE
docs(readme): point agent section to MCP guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,58 +92,10 @@ doubt, inspect `coral.tables` first.
 ### 5. Use Coral with an agent
 
 Coral can run as a local MCP server so agents can query your installed sources
-through the same runtime.
-
-#### Claude Code
-
-```bash
-claude mcp add coral -- coral mcp-stdio
-```
-
-#### Codex
-
-```bash
-codex mcp add coral -- coral mcp-stdio
-```
-
-#### OpenCode
-
-Add a new MCP app configured to launch Coral with:
-
-```bash
-coral mcp-stdio
-```
-
-#### Claude Desktop
-
-Open:
-
-`Settings -> Developer -> Edit Config`
-
-Then add Coral to `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "coral": {
-      "command": "coral",
-      "args": ["mcp-stdio"]
-    }
-  }
-}
-```
-
-Once configured, your agent can use Coral over MCP to inspect schemas,
-list tables, and query the sources installed in your local workspace.
-
-Coral also ships a reusable skill for agent workflows:
-
-```bash
-npx skills add withcoral/skills
-```
-
-For the full agent setup flow, including MCP examples and skills guidance, see
-[Agent usage](https://withcoral.com/docs/guides/agent-usage).
+through the same runtime. Once connected, your agent can inspect schemas, list
+tables, and run SQL against the sources installed in your local workspace. For
+setup and client-specific MCP examples, see [Use Coral over
+MCP](https://withcoral.com/docs/guides/use-coral-over-mcp).
 
 ## Core concepts
 


### PR DESCRIPTION
## Summary
This keeps the README's agent section lightweight and points readers to the maintained MCP setup guide instead of repeating client-specific setup steps in multiple places.

## Changes
- replace the outdated inline MCP setup walkthrough in the README with a short inline link to the canonical guide
- remove duplicated client-specific examples and the stale agent-usage reference

## Verification
- reviewed the README diff
- ran `git diff --check -- README.md`
