### PR TITLE
docs: update `github.repos` example on landing page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -34,7 +34,7 @@ Coral gives agents and developers one local-first SQL interface over APIs, files
     Write SQL directly or let your AI agent query on your behalf.
 
     ```shellscript
-    coral sql "SELECT name, stargazers_count FROM github.repos WHERE owner = 'withcoral' ORDER BY stargazers_count DESC"
+    coral sql "SELECT name, stargazers_count FROM github.org_repos WHERE org = 'withcoral' ORDER BY stargazers_count DESC"
     ```
 
     [Or use Coral over MCP](/guides/use-coral-over-mcp)


### PR DESCRIPTION
## Summary

All SQL snippets we show on the docs should run successfully. This one was using the old `github` source tables, updating it.

## Test plan

```
 Bash(coral sql "SELECT name, stargazers_count FROM github.org_repos WHERE org = 'withcoral' ORDER BY stargazers_count DESC")
  ⎿  +------------------+------------------+
     | name             | stargazers_count |
     +------------------+------------------+
     | coral            | 17               |
    [...]
```