### PR TITLE
feat(app): version bundled manifest cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ rusqlite = { version = "0.37", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+sha2 = "0.10"
 sqlparser = "0.59.0"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -13,6 +13,15 @@ enum SourceOrigin {
   SOURCE_ORIGIN_IMPORTED = 2;
 }
 
+// Whether a bundled source is following Coral's bundled manifest cache or a
+// workspace-local override.
+enum BundledManifestState {
+  BUNDLED_MANIFEST_STATE_UNSPECIFIED = 0;
+  BUNDLED_MANIFEST_STATE_NOT_APPLICABLE = 1;
+  BUNDLED_MANIFEST_STATE_FOLLOWING_CURRENT = 2;
+  BUNDLED_MANIFEST_STATE_LOCAL_OVERRIDE = 3;
+}
+
 // One configured non-secret source variable.
 message SourceVariable {
   // Logical variable key expected by the source manifest.
@@ -48,6 +57,9 @@ message Source {
   repeated SourceVariable variables = 5;
   // Where this installed source came from.
   SourceOrigin origin = 6;
+  // Whether a bundled source is following Coral's bundled manifest cache or a
+  // local override.
+  BundledManifestState bundled_manifest_state = 7;
 }
 
 // Input kinds that Coral prompts for while installing or importing a source.

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -16,6 +16,7 @@ fs2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -16,6 +16,7 @@ use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
+use crate::sources::bundled_store::BundledStore;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
@@ -84,6 +85,13 @@ impl ServerBuilder {
         layout.ensure()?;
         let config_store = ConfigStore::new(layout.clone());
         let secret_store = SecretStore::new(layout.clone());
+        let bundled_store = BundledStore::new(layout.clone());
+        if let Err(error) = bundled_store.startup_maintenance(&config_store) {
+            tracing::warn!(
+                detail = %error,
+                "best-effort bundled manifest startup maintenance did not complete cleanly"
+            );
+        }
         let source_manager =
             SourceManager::new(config_store.clone(), secret_store.clone(), layout.clone());
         let query_manager = QueryManager::new(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use coral_api::v1::Workspace;
+use coral_api::v1::{BundledManifestState, Source, Workspace};
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
     TableInfo,
@@ -10,6 +10,7 @@ use coral_engine::{
 use coral_spec::parse_source_manifest_yaml;
 
 use crate::bootstrap::AppError;
+use crate::sources::bundled_store::BundledStore;
 use crate::sources::model::ManagedSource;
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
 
@@ -20,7 +21,7 @@ pub(crate) enum QueryManagerError {
 }
 
 pub(crate) struct ValidatedSource {
-    pub(crate) source: ManagedSource,
+    pub(crate) source: Source,
     pub(crate) tables: Vec<TableInfo>,
 }
 
@@ -29,7 +30,7 @@ pub(crate) struct QueryManager {
     config_store: ConfigStore,
     secret_store: SecretStore,
     runtime_context: QueryRuntimeContext,
-    layout: AppStateLayout,
+    bundled_store: BundledStore,
 }
 
 impl QueryManager {
@@ -43,7 +44,7 @@ impl QueryManager {
             config_store,
             secret_store,
             runtime_context,
-            layout,
+            bundled_store: BundledStore::new(layout),
         }
     }
 
@@ -83,7 +84,7 @@ impl QueryManager {
             .config_store
             .get_source(workspace, source_name)
             .map_err(QueryManagerError::App)?;
-        let query_source = self
+        let (query_source, resource) = self
             .load_query_source(&source)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_provider();
@@ -91,14 +92,17 @@ impl QueryManager {
             .await
             .map_err(QueryManagerError::Core)?;
 
-        Ok(ValidatedSource { source, tables })
+        Ok(ValidatedSource {
+            source: resource,
+            tables,
+        })
     }
 
     fn load_query_sources(&self, workspace: &Workspace) -> Result<Vec<QuerySource>, AppError> {
         let mut query_sources = Vec::new();
         for source in self.config_store.list_workspace_sources(workspace)? {
             match self.load_query_source(&source) {
-                Ok(query_source) => query_sources.push(query_source),
+                Ok((query_source, _)) => query_sources.push(query_source),
                 Err(error) => {
                     tracing::warn!(
                         source = %source.name,
@@ -111,9 +115,9 @@ impl QueryManager {
         Ok(query_sources)
     }
 
-    fn load_query_source(&self, source: &ManagedSource) -> Result<QuerySource, AppError> {
-        let manifest_path = self.layout.manifest_file(&source.workspace, &source.name);
-        let manifest_yaml = std::fs::read_to_string(&manifest_path)?;
+    fn load_query_source(&self, source: &ManagedSource) -> Result<(QuerySource, Source), AppError> {
+        let resolved = self.bundled_store.resolve_manifest(source)?;
+        let manifest_yaml = std::fs::read_to_string(&resolved.manifest_path)?;
         let source_spec = parse_source_manifest_yaml(&manifest_yaml)
             .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         if source_spec.schema_name() != source.name {
@@ -123,7 +127,7 @@ impl QueryManager {
                 source_spec.schema_name()
             )));
         }
-        if source_spec.source_version() != source.version {
+        if !source.origin.is_bundled() && source_spec.source_version() != source.version {
             return Err(AppError::FailedPrecondition(format!(
                 "installed source '{}' version '{}' does not match manifest version '{}'",
                 source.name,
@@ -144,10 +148,15 @@ impl QueryManager {
             };
             resolved_secrets.insert(secret_name, value);
         }
-        Ok(QuerySource::new(
-            source_spec,
-            source.variables.clone(),
-            resolved_secrets,
+        let version = source_spec.source_version().to_string();
+        let bundled_manifest_state = if source.origin.is_bundled() {
+            resolved.bundled_manifest_state
+        } else {
+            BundledManifestState::NotApplicable
+        };
+        Ok((
+            QuerySource::new(source_spec, source.variables.clone(), resolved_secrets),
+            source.to_source_resource_with(version, bundled_manifest_state),
         ))
     }
 

--- a/crates/coral-app/src/sources/bundled_store.rs
+++ b/crates/coral-app/src/sources/bundled_store.rs
@@ -1,0 +1,546 @@
+//! App-owned storage and resolution for bundled source manifests.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+
+use coral_api::v1::BundledManifestState;
+use coral_spec::parse_source_manifest_yaml;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::bootstrap::AppError;
+use crate::sources::catalog::{
+    BundledSourceManifest, bundled_source_manifests, find_bundled_source,
+};
+use crate::sources::model::ManagedSource;
+use crate::state::{AppStateLayout, ConfigStore, INSTALLED_MANIFEST_FILE_NAME};
+use crate::storage::fs::{self, FileLock};
+
+#[derive(Debug, Clone)]
+pub(crate) struct BundledStore {
+    layout: AppStateLayout,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedManifest {
+    pub(crate) manifest_path: PathBuf,
+    pub(crate) version: String,
+    pub(crate) bundled_manifest_state: BundledManifestState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BundledManifestTracking {
+    bundle_id: String,
+}
+
+impl BundledStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    pub(crate) fn bundle_id_for(source_name: &str, manifest_yaml: &str) -> String {
+        bundle_id_for(source_name, manifest_yaml)
+    }
+
+    pub(crate) fn ensure_current_bundle_available(
+        &self,
+        bundled: &BundledSourceManifest,
+    ) -> Result<String, AppError> {
+        let bundle_id = Self::bundle_id_for(&bundled.name, &bundled.manifest_yaml);
+        self.materialize_bundle(&bundled.name, &bundle_id, &bundled.manifest_yaml)
+            .map_err(|error| {
+                AppError::FailedPrecondition(format!(
+                    "failed to materialize bundled manifest cache for '{}': {error}. rerun the command or reinstall Coral if the problem persists",
+                    bundled.name
+                ))
+            })?;
+        Ok(bundle_id)
+    }
+
+    pub(crate) fn startup_maintenance(&self, config_store: &ConfigStore) -> Result<(), AppError> {
+        let mut first_error = None;
+
+        if let Err(error) = self.materialize_current_bundle_cache() {
+            first_error = Some(error);
+        }
+        record_first_error(
+            &mut first_error,
+            self.migrate_legacy_bundled_sources(config_store).err(),
+        );
+        record_first_error(
+            &mut first_error,
+            self.sync_bundled_source_versions(config_store).err(),
+        );
+
+        if let Some(error) = first_error {
+            Err(error)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn write_tracking_file(
+        &self,
+        workspace: &coral_api::v1::Workspace,
+        source_name: &str,
+        bundle_id: &str,
+    ) -> Result<(), AppError> {
+        let path = self
+            .layout
+            .bundled_manifest_tracking_file(workspace, source_name);
+        if let Some(parent) = path.parent() {
+            fs::ensure_dir(parent)?;
+        }
+        let raw = toml::to_string(&BundledManifestTracking {
+            bundle_id: bundle_id.to_string(),
+        })?;
+        fs::write_atomic(&path, raw.as_bytes())?;
+        Ok(())
+    }
+
+    pub(crate) fn read_tracking_file(
+        &self,
+        workspace: &coral_api::v1::Workspace,
+        source_name: &str,
+    ) -> Result<Option<String>, AppError> {
+        let path = self
+            .layout
+            .bundled_manifest_tracking_file(workspace, source_name);
+        match std::fs::read_to_string(path) {
+            Ok(raw) => Ok(Some(
+                toml::from_str::<BundledManifestTracking>(&raw)?.bundle_id,
+            )),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(crate) fn resolve_manifest(
+        &self,
+        source: &ManagedSource,
+    ) -> Result<ResolvedManifest, AppError> {
+        if !source.origin.is_bundled() {
+            return Ok(ResolvedManifest {
+                manifest_path: self.layout.manifest_file(&source.workspace, &source.name),
+                version: source.version.clone(),
+                bundled_manifest_state: BundledManifestState::NotApplicable,
+            });
+        }
+
+        let workspace_manifest = self.layout.manifest_file(&source.workspace, &source.name);
+        if workspace_manifest.exists() {
+            let manifest_yaml = std::fs::read_to_string(&workspace_manifest)?;
+            return Ok(ResolvedManifest {
+                manifest_path: workspace_manifest,
+                version: manifest_version(&manifest_yaml)?,
+                bundled_manifest_state: BundledManifestState::LocalOverride,
+            });
+        }
+
+        let recorded_bundle_id = self
+            .read_tracking_file(&source.workspace, &source.name)?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "bundled source '{}' is missing bundled-manifest.toml. rerun `coral source add {}` to relink it",
+                    source.name, source.name
+                ))
+            })?;
+        let current_bundle_manifest = find_bundled_source(&source.name).map(|bundled| {
+            (
+                Self::bundle_id_for(&bundled.name, &bundled.manifest_yaml),
+                bundled.manifest_yaml,
+            )
+        });
+
+        if let Some((bundle_id, manifest_yaml)) = current_bundle_manifest {
+            let current_path = self
+                .layout
+                .bundled_source_manifest_file(&source.name, &bundle_id);
+            if current_path.exists() {
+                return Ok(ResolvedManifest {
+                    manifest_path: current_path,
+                    version: manifest_version(&manifest_yaml)?,
+                    bundled_manifest_state: BundledManifestState::FollowingCurrent,
+                });
+            }
+        }
+
+        let recorded_path = self
+            .layout
+            .bundled_source_manifest_file(&source.name, &recorded_bundle_id);
+        if recorded_path.exists() {
+            let manifest_yaml = std::fs::read_to_string(&recorded_path)?;
+            return Ok(ResolvedManifest {
+                manifest_path: recorded_path,
+                version: manifest_version(&manifest_yaml)?,
+                bundled_manifest_state: BundledManifestState::Unspecified,
+            });
+        }
+
+        Err(AppError::FailedPrecondition(format!(
+            "bundled source '{}' has no usable bundled manifest cache. rerun `coral source add {}` to restore it",
+            source.name, source.name
+        )))
+    }
+
+    fn materialize_current_bundle_cache(&self) -> Result<(), AppError> {
+        let mut first_error = None;
+
+        for bundled in bundled_source_manifests() {
+            let bundle_id = Self::bundle_id_for(&bundled.name, &bundled.manifest_yaml);
+            if let Err(error) =
+                self.materialize_bundle(&bundled.name, &bundle_id, &bundled.manifest_yaml)
+            {
+                tracing::warn!(
+                    source = %bundled.name,
+                    detail = %error,
+                    "failed to materialize bundled manifest cache"
+                );
+                if first_error.is_none() {
+                    first_error = Some(AppError::Io(error));
+                }
+            }
+        }
+
+        if let Some(error) = first_error {
+            Err(error)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn migrate_legacy_bundled_sources(&self, config_store: &ConfigStore) -> Result<(), AppError> {
+        let mut first_error = None;
+
+        for source in config_store
+            .list_all_sources()?
+            .into_iter()
+            .filter(|source| source.origin.is_bundled())
+        {
+            match self.read_tracking_file(&source.workspace, &source.name) {
+                Ok(Some(_)) => continue,
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        source = %source.name,
+                        detail = %error,
+                        "failed to inspect bundled tracking file during migration"
+                    );
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                    continue;
+                }
+            }
+
+            let Some(bundled) = find_bundled_source(&source.name) else {
+                let error = AppError::FailedPrecondition(format!(
+                    "bundled source '{}' is no longer compiled into this Coral build",
+                    source.name
+                ));
+                tracing::warn!(source = %source.name, detail = %error, "failed to migrate bundled source");
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+                continue;
+            };
+
+            let bundle_id = match self.ensure_current_bundle_available(&bundled) {
+                Ok(bundle_id) => bundle_id,
+                Err(error) => {
+                    tracing::warn!(
+                        source = %source.name,
+                        detail = %error,
+                        "failed to ensure bundled cache during migration"
+                    );
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                    continue;
+                }
+            };
+
+            if let Err(error) =
+                self.write_tracking_file(&source.workspace, &source.name, &bundle_id)
+            {
+                tracing::warn!(
+                    source = %source.name,
+                    detail = %error,
+                    "failed to write bundled tracking file during migration"
+                );
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+                continue;
+            }
+
+            let manifest_path = self.layout.manifest_file(&source.workspace, &source.name);
+            if manifest_path.exists()
+                && let Err(error) = std::fs::remove_file(&manifest_path)
+            {
+                tracing::warn!(
+                    source = %source.name,
+                    detail = %error,
+                    "failed to remove legacy bundled workspace manifest during migration"
+                );
+                if first_error.is_none() {
+                    first_error = Some(error.into());
+                }
+            }
+        }
+
+        if let Some(error) = first_error {
+            Err(error)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn sync_bundled_source_versions(&self, config_store: &ConfigStore) -> Result<(), AppError> {
+        let mut first_error = None;
+
+        for mut source in config_store
+            .list_all_sources()?
+            .into_iter()
+            .filter(|source| source.origin.is_bundled())
+        {
+            let resolved = match self.resolve_manifest(&source) {
+                Ok(resolved) => resolved,
+                Err(error) => {
+                    tracing::warn!(
+                        source = %source.name,
+                        detail = %error,
+                        "failed to resolve bundled manifest while syncing versions"
+                    );
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                    continue;
+                }
+            };
+
+            if source.version == resolved.version {
+                continue;
+            }
+
+            source.version = resolved.version;
+            if let Err(error) = config_store.upsert_source(source) {
+                tracing::warn!(
+                    detail = %error,
+                    "failed to update bundled source version in config"
+                );
+                if first_error.is_none() {
+                    first_error = Some(error);
+                }
+            }
+        }
+
+        if let Some(error) = first_error {
+            Err(error)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn materialize_bundle(
+        &self,
+        source_name: &str,
+        bundle_id: &str,
+        manifest_yaml: &str,
+    ) -> Result<(), std::io::Error> {
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let source_root = self.layout.bundled_source_root(source_name);
+        fs::ensure_dir(&source_root)?;
+        let bundle_dir = self
+            .layout
+            .bundled_source_bundle_dir(source_name, bundle_id);
+        if bundle_dir.exists() {
+            return Ok(());
+        }
+
+        let temp_dir = source_root.join(format!(".tmp-{bundle_id}-{}", std::process::id()));
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir)?;
+        }
+        fs::ensure_dir(&temp_dir)?;
+        fs::write_atomic(
+            &temp_dir.join(INSTALLED_MANIFEST_FILE_NAME),
+            manifest_yaml.as_bytes(),
+        )?;
+        match std::fs::rename(&temp_dir, &bundle_dir) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                let _ = std::fs::remove_dir_all(&temp_dir);
+                Ok(())
+            }
+            Err(error) => {
+                let _ = std::fs::remove_dir_all(&temp_dir);
+                Err(error)
+            }
+        }
+    }
+}
+
+fn manifest_version(manifest_yaml: &str) -> Result<String, AppError> {
+    Ok(parse_source_manifest_yaml(manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?
+        .source_version()
+        .to_string())
+}
+
+fn bundle_id_for(source_name: &str, manifest_yaml: &str) -> String {
+    let mut parts = BTreeMap::new();
+    parts.insert("manifest_yaml", manifest_yaml);
+    parts.insert("name", source_name);
+
+    let mut hasher = Sha256::new();
+    for (key, value) in parts {
+        hasher.update(key.as_bytes());
+        hasher.update([0]);
+        hasher.update(value.as_bytes());
+        hasher.update([0]);
+    }
+    let digest = hasher.finalize();
+    let mut value = String::with_capacity(12);
+    for byte in &digest[..6] {
+        let _ = write!(&mut value, "{byte:02x}");
+    }
+    value
+}
+
+fn record_first_error(slot: &mut Option<AppError>, error: Option<AppError>) {
+    if slot.is_none() {
+        *slot = error;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write as _;
+
+    use coral_api::v1::{BundledManifestState, Workspace};
+    use tempfile::TempDir;
+
+    use super::{BundledStore, bundle_id_for};
+    use crate::sources::catalog::load_bundled_source;
+    use crate::sources::model::{ManagedSource, ManagedSourceOrigin};
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceManager;
+
+    fn default_workspace() -> Workspace {
+        WorkspaceManager::new().default_workspace()
+    }
+
+    fn manifest_with_version(manifest_yaml: &str, version: &str) -> String {
+        let mut rewritten = String::new();
+        let mut replaced = false;
+
+        for line in manifest_yaml.lines() {
+            if !replaced && line.starts_with("version: ") {
+                let _ = writeln!(&mut rewritten, "version: {version}");
+                replaced = true;
+            } else {
+                rewritten.push_str(line);
+                rewritten.push('\n');
+            }
+        }
+
+        assert!(replaced, "manifest fixture must contain a version line");
+        rewritten
+    }
+
+    #[test]
+    fn bundle_ids_are_content_addressed() {
+        let first = bundle_id_for("demo", "name: demo\nversion: 1.0.0\n");
+        let second = bundle_id_for("demo", "name: demo\nversion: 1.0.0\n");
+        let changed = bundle_id_for("demo", "name: demo\nversion: 1.1.0\n");
+
+        assert_eq!(first.len(), 12);
+        assert_eq!(first, second);
+        assert_ne!(first, changed);
+    }
+
+    #[test]
+    fn tracking_file_round_trips() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure");
+        let store = BundledStore::new(layout);
+
+        store
+            .write_tracking_file(&default_workspace(), "github", "bundle-123")
+            .expect("write tracking");
+
+        assert_eq!(
+            store
+                .read_tracking_file(&default_workspace(), "github")
+                .expect("read tracking"),
+            Some("bundle-123".to_string())
+        );
+    }
+
+    #[test]
+    fn ensure_current_bundle_available_materializes_expected_path() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure");
+        let store = BundledStore::new(layout.clone());
+        let bundled = load_bundled_source("github").expect("bundled source");
+
+        let bundle_id = store
+            .ensure_current_bundle_available(&bundled)
+            .expect("materialize bundle");
+
+        assert!(
+            layout
+                .bundled_source_manifest_file("github", &bundle_id)
+                .exists()
+        );
+    }
+
+    #[test]
+    fn falling_back_to_recorded_bundle_reports_unspecified_state() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure");
+        let store = BundledStore::new(layout.clone());
+        let bundled = load_bundled_source("github").expect("bundled source");
+        let stale_manifest = manifest_with_version(&bundled.manifest_yaml, "0.0.1");
+        let stale_bundle_id = bundle_id_for("github", &stale_manifest);
+
+        std::fs::create_dir_all(layout.source_dir(&default_workspace(), "github"))
+            .expect("create source dir");
+        store
+            .write_tracking_file(&default_workspace(), "github", &stale_bundle_id)
+            .expect("write tracking");
+        std::fs::create_dir_all(layout.bundled_source_bundle_dir("github", &stale_bundle_id))
+            .expect("create stale bundle dir");
+        std::fs::write(
+            layout.bundled_source_manifest_file("github", &stale_bundle_id),
+            stale_manifest,
+        )
+        .expect("write stale manifest");
+
+        let resolved = store
+            .resolve_manifest(&ManagedSource {
+                workspace: default_workspace(),
+                name: "github".to_string(),
+                version: "ignored".to_string(),
+                variables: std::collections::BTreeMap::default(),
+                secrets: Vec::new(),
+                origin: ManagedSourceOrigin::Bundled,
+            })
+            .expect("resolve recorded fallback");
+
+        assert_eq!(resolved.version, "0.0.1");
+        assert_eq!(
+            resolved.bundled_manifest_state,
+            BundledManifestState::Unspecified
+        );
+    }
+}

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -14,7 +14,18 @@ include!(concat!(env!("OUT_DIR"), "/bundled_sources.rs"));
 
 #[derive(Debug, Clone)]
 pub(crate) struct BundledSourceManifest {
+    pub(crate) name: String,
     pub(crate) manifest_yaml: String,
+}
+
+pub(crate) fn bundled_source_manifests() -> Vec<BundledSourceManifest> {
+    BUNDLED_SOURCES
+        .iter()
+        .map(|(name, manifest_yaml)| BundledSourceManifest {
+            name: (*name).to_string(),
+            manifest_yaml: (*manifest_yaml).to_string(),
+        })
+        .collect()
 }
 
 pub(crate) fn list_bundled_sources(
@@ -38,15 +49,16 @@ pub(crate) fn list_bundled_sources(
 }
 
 pub(crate) fn load_bundled_source(name: &str) -> Result<BundledSourceManifest, AppError> {
-    let Some((_, manifest_yaml)) = BUNDLED_SOURCES
+    find_bundled_source(name)
+        .ok_or_else(|| AppError::InvalidInput(format!("unknown bundled source '{name}'")))
+}
+
+pub(crate) fn find_bundled_source(name: &str) -> Option<BundledSourceManifest> {
+    let (_, manifest_yaml) = BUNDLED_SOURCES
         .iter()
-        .find(|(candidate, _)| *candidate == name)
-    else {
-        return Err(AppError::InvalidInput(format!(
-            "unknown bundled source '{name}'"
-        )));
-    };
-    Ok(BundledSourceManifest {
+        .find(|(candidate, _)| *candidate == name)?;
+    Some(BundledSourceManifest {
+        name: name.to_string(),
         manifest_yaml: (*manifest_yaml).to_string(),
     })
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -1,14 +1,16 @@
 //! Owns the source lifecycle workflow for the local app.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::io::ErrorKind;
 use std::path::PathBuf;
 
 use coral_api::v1::{
-    AvailableSource, CreateBundledSourceRequest, ImportSourceRequest, SourceInputKind,
-    SourceSecret, SourceVariable, Workspace,
+    AvailableSource, BundledManifestState, CreateBundledSourceRequest, ImportSourceRequest, Source,
+    SourceInputKind, SourceSecret, SourceVariable, Workspace,
 };
 
 use crate::bootstrap::AppError;
+use crate::sources::bundled_store::BundledStore;
 use crate::sources::catalog::{describe_manifest, list_bundled_sources, load_bundled_source};
 use crate::sources::model::{ManagedSource, ManagedSourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
@@ -20,6 +22,7 @@ pub(crate) struct SourceManager {
     config_store: ConfigStore,
     secret_store: SecretStore,
     layout: AppStateLayout,
+    bundled_store: BundledStore,
     workspace_manager: WorkspaceManager,
 }
 
@@ -28,16 +31,22 @@ struct ValidatedBindings {
     secrets: BTreeMap<String, String>,
 }
 
+enum ManifestPersistence<'a> {
+    WorkspaceManifest(&'a str),
+    BundledTracking { bundle_id: String },
+}
+
 struct PersistSourceRequest<'a> {
     available: &'a AvailableSource,
-    manifest_yaml: &'a str,
     bindings: ValidatedBindings,
     origin: ManagedSourceOrigin,
+    manifest_persistence: ManifestPersistence<'a>,
 }
 
 struct ExistingSourceState {
     source: ManagedSource,
-    manifest_yaml: String,
+    manifest_yaml: Option<String>,
+    bundled_manifest_tracking: Option<String>,
     secrets: BTreeMap<String, String>,
 }
 
@@ -50,6 +59,7 @@ impl SourceManager {
         Self {
             config_store,
             secret_store,
+            bundled_store: BundledStore::new(layout.clone()),
             layout,
             workspace_manager: WorkspaceManager::new(),
         }
@@ -62,12 +72,31 @@ impl SourceManager {
         self.config_store.list_workspace_sources(workspace)
     }
 
+    pub(crate) fn list_workspace_source_resources(
+        &self,
+        workspace: &Workspace,
+    ) -> Result<Vec<Source>, AppError> {
+        self.list_workspace_sources(workspace)?
+            .into_iter()
+            .map(|source| self.to_source_resource(&source))
+            .collect()
+    }
+
     pub(crate) fn get_source(
         &self,
         workspace: &Workspace,
         source_name: &str,
     ) -> Result<ManagedSource, AppError> {
         self.config_store.get_source(workspace, source_name)
+    }
+
+    pub(crate) fn get_source_resource(
+        &self,
+        workspace: &Workspace,
+        source_name: &str,
+    ) -> Result<Source, AppError> {
+        let source = self.get_source(workspace, source_name)?;
+        self.to_source_resource(&source)
     }
 
     pub(crate) fn discover_sources(
@@ -100,13 +129,16 @@ impl SourceManager {
             &request.variables,
             &request.secrets,
         )?;
+        let bundle_id = self
+            .bundled_store
+            .ensure_current_bundle_available(&bundled)?;
         self.persist_source(
             &workspace,
             PersistSourceRequest {
                 available: &available,
-                manifest_yaml: &bundled.manifest_yaml,
                 bindings,
                 origin: ManagedSourceOrigin::Bundled,
+                manifest_persistence: ManifestPersistence::BundledTracking { bundle_id },
             },
         )
     }
@@ -134,9 +166,11 @@ impl SourceManager {
             &workspace,
             PersistSourceRequest {
                 available: &available,
-                manifest_yaml: &request.manifest_yaml,
                 bindings,
                 origin: ManagedSourceOrigin::Imported,
+                manifest_persistence: ManifestPersistence::WorkspaceManifest(
+                    &request.manifest_yaml,
+                ),
             },
         )
     }
@@ -148,15 +182,14 @@ impl SourceManager {
     ) -> Result<ManagedSource, AppError> {
         let stored = self.config_store.get_source(workspace, source_name)?;
         let source_dir = self.layout.source_dir(&stored.workspace, &stored.name);
-        let previous = ExistingSourceState {
-            source: stored.clone(),
-            manifest_yaml: std::fs::read_to_string(
-                self.layout.manifest_file(&stored.workspace, &stored.name),
-            )?,
-            secrets: self
-                .secret_store
-                .read_source_secrets_for(&stored.workspace, &stored.name)?,
-        };
+        let previous = self
+            .load_existing_state(&stored.workspace, &stored.name)?
+            .ok_or_else(|| {
+                AppError::FailedPrecondition(format!(
+                    "source '{}' exists in config without on-disk state",
+                    stored.name
+                ))
+            })?;
         if source_dir.exists()
             && let Err(error) = std::fs::remove_dir_all(&source_dir)
         {
@@ -195,11 +228,18 @@ impl SourceManager {
             .workspace_manager
             .validate_path_name("source name", &request.available.name)?;
         let previous = self.load_existing_state(workspace, &source_name)?;
-        let manifest_path = self.layout.manifest_file(workspace, &source_name);
-        if let Some(parent) = manifest_path.parent() {
-            fs::ensure_dir(parent)?;
+        let source_dir = self.layout.source_dir(workspace, &source_name);
+        if let Err(error) = fs::ensure_dir(&source_dir) {
+            self.restore_existing_state(workspace, &source_name, previous);
+            return Err(error.into());
         }
-        fs::write_atomic(&manifest_path, request.manifest_yaml.as_bytes())?;
+
+        if let Err(error) =
+            self.persist_manifest_artifacts(workspace, &source_name, &request.manifest_persistence)
+        {
+            self.restore_existing_state(workspace, &source_name, previous);
+            return Err(error);
+        }
 
         let persisted_secrets = match self.secret_store.replace_source_secrets_for(
             workspace,
@@ -228,6 +268,43 @@ impl SourceManager {
         Ok(stored)
     }
 
+    fn persist_manifest_artifacts(
+        &self,
+        workspace: &Workspace,
+        source_name: &str,
+        persistence: &ManifestPersistence<'_>,
+    ) -> Result<(), AppError> {
+        let manifest_path = self.layout.manifest_file(workspace, source_name);
+        let tracking_path = self
+            .layout
+            .bundled_manifest_tracking_file(workspace, source_name);
+
+        match persistence {
+            ManifestPersistence::WorkspaceManifest(manifest_yaml) => {
+                fs::write_atomic(&manifest_path, manifest_yaml.as_bytes())?;
+                remove_file_if_exists(&tracking_path)?;
+            }
+            ManifestPersistence::BundledTracking { bundle_id } => {
+                self.bundled_store
+                    .write_tracking_file(workspace, source_name, bundle_id)?;
+                remove_file_if_exists(&manifest_path)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn to_source_resource(&self, source: &ManagedSource) -> Result<Source, AppError> {
+        if source.origin.is_bundled() {
+            let resolved = self.bundled_store.resolve_manifest(source)?;
+            Ok(source.to_source_resource_with(resolved.version, resolved.bundled_manifest_state))
+        } else {
+            Ok(source.to_source_resource_with(
+                source.version.clone(),
+                BundledManifestState::NotApplicable,
+            ))
+        }
+    }
+
     fn source_exists(&self, workspace: &Workspace, source_name: &str) -> Result<bool, AppError> {
         match self.config_store.get_source(workspace, source_name) {
             Ok(_) => Ok(true),
@@ -246,14 +323,18 @@ impl SourceManager {
             Err(AppError::SourceNotFound(_)) => return Ok(None),
             Err(error) => return Err(error),
         };
-        let manifest_yaml =
-            std::fs::read_to_string(self.layout.manifest_file(workspace, source_name))?;
+        let manifest_yaml = read_optional_file(self.layout.manifest_file(workspace, source_name))?;
+        let bundled_manifest_tracking = read_optional_file(
+            self.layout
+                .bundled_manifest_tracking_file(workspace, source_name),
+        )?;
         let secrets = self
             .secret_store
             .read_source_secrets_for(workspace, source_name)?;
         Ok(Some(ExistingSourceState {
             source,
             manifest_yaml,
+            bundled_manifest_tracking,
             secrets,
         }))
     }
@@ -265,11 +346,19 @@ impl SourceManager {
         previous: Option<ExistingSourceState>,
     ) {
         if let Some(previous) = previous {
-            let manifest_path = self.layout.manifest_file(workspace, source_name);
-            if let Some(parent) = manifest_path.parent() {
-                let _ = fs::ensure_dir(parent);
-            }
-            let _ = fs::write_atomic(&manifest_path, previous.manifest_yaml.as_bytes());
+            let source_dir = self.layout.source_dir(workspace, source_name);
+            let _ = fs::ensure_dir(&source_dir);
+
+            restore_optional_file(
+                &self.layout.manifest_file(workspace, source_name),
+                previous.manifest_yaml.as_deref(),
+            );
+            restore_optional_file(
+                &self
+                    .layout
+                    .bundled_manifest_tracking_file(workspace, source_name),
+                previous.bundled_manifest_tracking.as_deref(),
+            );
             let _ = self.secret_store.replace_source_secrets_for(
                 workspace,
                 source_name,
@@ -282,6 +371,36 @@ impl SourceManager {
                 let _ = std::fs::remove_dir_all(&source_dir);
             }
         }
+    }
+}
+
+fn read_optional_file(path: PathBuf) -> Result<Option<String>, AppError> {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => Ok(Some(raw)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn restore_optional_file(path: &std::path::Path, contents: Option<&str>) {
+    match contents {
+        Some(contents) => {
+            if let Some(parent) = path.parent() {
+                let _ = fs::ensure_dir(parent);
+            }
+            let _ = fs::write_atomic(path, contents.as_bytes());
+        }
+        None => {
+            let _ = remove_file_if_exists(path);
+        }
+    }
+}
+
+fn remove_file_if_exists(path: &std::path::Path) -> Result<(), AppError> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
     }
 }
 

--- a/crates/coral-app/src/sources/mod.rs
+++ b/crates/coral-app/src/sources/mod.rs
@@ -1,5 +1,6 @@
 //! Source lifecycle workflow, catalog inspection, and transport adapters.
 
+pub(crate) mod bundled_store;
 pub(crate) mod catalog;
 pub(crate) mod manager;
 pub(crate) mod model;

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -5,7 +5,9 @@
 
 use std::collections::BTreeMap;
 
-use coral_api::v1::{Source, SourceOrigin, SourceSecret, SourceVariable, Workspace};
+use coral_api::v1::{
+    BundledManifestState, Source, SourceOrigin, SourceSecret, SourceVariable, Workspace,
+};
 use serde::{Deserialize, Serialize};
 
 /// App-owned persisted representation of one managed source.
@@ -43,12 +45,16 @@ impl ManagedSource {
     }
 
     #[must_use]
-    /// Returns the installed source resource exposed by the management plane.
-    pub(crate) fn to_source_resource(&self) -> Source {
+    /// Returns the installed source resource with runtime-resolved manifest metadata.
+    pub(crate) fn to_source_resource_with(
+        &self,
+        version: impl Into<String>,
+        bundled_manifest_state: BundledManifestState,
+    ) -> Source {
         Source {
             workspace: Some(self.workspace.clone()),
             name: self.name.clone(),
-            version: self.version.clone(),
+            version: version.into(),
             secrets: self
                 .secrets()
                 .into_iter()
@@ -66,11 +72,16 @@ impl ManagedSource {
                 })
                 .collect(),
             origin: self.origin.to_proto() as i32,
+            bundled_manifest_state: bundled_manifest_state as i32,
         }
     }
 }
 
 impl ManagedSourceOrigin {
+    pub(crate) fn is_bundled(self) -> bool {
+        matches!(self, Self::Bundled)
+    }
+
     pub(crate) fn to_proto(self) -> SourceOrigin {
         match self {
             Self::Bundled => SourceOrigin::Bundled,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -55,13 +55,10 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<ListSourcesResponse>, Status> {
         let request = request.into_inner();
         let workspace = self.workspaces.require(request.workspace.as_ref())?;
-        let sources: Vec<_> = self
+        let sources = self
             .sources
-            .list_workspace_sources(&workspace)
-            .map_err(app_status)?
-            .into_iter()
-            .map(|source| source.to_source_resource())
-            .collect();
+            .list_workspace_source_resources(&workspace)
+            .map_err(app_status)?;
         Ok(Response::new(ListSourcesResponse { sources }))
     }
 
@@ -76,9 +73,9 @@ impl SourceServiceApi for SourceService {
             .status_validate_path_name("source name", &request.name)?;
         let source = self
             .sources
-            .get_source(&workspace, &source_name)
+            .get_source_resource(&workspace, &source_name)
             .map_err(app_status)?;
-        Ok(Response::new(source.to_source_resource()))
+        Ok(Response::new(source))
     }
 
     async fn create_bundled_source(
@@ -90,7 +87,11 @@ impl SourceServiceApi for SourceService {
             .sources
             .create_bundled_source(&request)
             .map_err(app_status)?;
-        Ok(Response::new(stored.to_source_resource()))
+        let resource = self
+            .sources
+            .get_source_resource(&stored.workspace, &stored.name)
+            .map_err(app_status)?;
+        Ok(Response::new(resource))
     }
 
     async fn import_source(
@@ -99,7 +100,11 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Source>, Status> {
         let request = request.into_inner();
         let stored = self.sources.import_source(&request).map_err(app_status)?;
-        Ok(Response::new(stored.to_source_resource()))
+        let resource = self
+            .sources
+            .get_source_resource(&stored.workspace, &stored.name)
+            .map_err(app_status)?;
+        Ok(Response::new(resource))
     }
 
     async fn delete_source(
@@ -138,7 +143,7 @@ impl SourceServiceApi for SourceService {
             .map(|table| table_to_proto(&workspace, table))
             .collect::<Vec<_>>();
         Ok(Response::new(ValidateSourceResponse {
-            source: Some(result.source.to_source_resource()),
+            source: Some(result.source),
             tables,
         }))
     }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -105,6 +105,11 @@ impl ConfigStore {
         })
     }
 
+    pub(crate) fn list_all_sources(&self) -> Result<Vec<ManagedSource>, AppError> {
+        let _lock = self.lock_shared()?;
+        self.load_unlocked().map(|config| config.sources)
+    }
+
     pub(crate) fn get_source(
         &self,
         workspace: &Workspace,

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -9,6 +9,7 @@ use crate::bootstrap::AppError;
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
+pub(crate) const BUNDLED_MANIFEST_TRACKING_FILE_NAME: &str = "bundled-manifest.toml";
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppStateLayout {
@@ -52,6 +53,27 @@ impl AppStateLayout {
         self.config_dir.join("workspaces")
     }
 
+    pub(crate) fn bundled_sources_root(&self) -> PathBuf {
+        self.config_dir.join("bundled-sources")
+    }
+
+    pub(crate) fn bundled_source_root(&self, source_name: &str) -> PathBuf {
+        self.bundled_sources_root().join(source_name)
+    }
+
+    pub(crate) fn bundled_source_bundle_dir(&self, source_name: &str, bundle_id: &str) -> PathBuf {
+        self.bundled_source_root(source_name).join(bundle_id)
+    }
+
+    pub(crate) fn bundled_source_manifest_file(
+        &self,
+        source_name: &str,
+        bundle_id: &str,
+    ) -> PathBuf {
+        self.bundled_source_bundle_dir(source_name, bundle_id)
+            .join(INSTALLED_MANIFEST_FILE_NAME)
+    }
+
     pub(crate) fn workspace_dir(&self, workspace: &coral_api::v1::Workspace) -> PathBuf {
         self.workspaces_root().join(&workspace.name)
     }
@@ -85,6 +107,15 @@ impl AppStateLayout {
         self.source_dir(workspace, source_name)
             .join(INSTALLED_SECRETS_FILE_NAME)
     }
+
+    pub(crate) fn bundled_manifest_tracking_file(
+        &self,
+        workspace: &coral_api::v1::Workspace,
+        source_name: &str,
+    ) -> PathBuf {
+        self.source_dir(workspace, source_name)
+            .join(BUNDLED_MANIFEST_TRACKING_FILE_NAME)
+    }
 }
 
 #[cfg(test)]
@@ -111,8 +142,20 @@ mod tests {
             )
         );
         assert_eq!(
+            layout.bundled_source_manifest_file("github", "bundle-123"),
+            std::path::Path::new(
+                "/tmp/coral-config/bundled-sources/github/bundle-123/manifest.yaml"
+            )
+        );
+        assert_eq!(
             layout.secret_file(&workspace, "github"),
             std::path::Path::new("/tmp/coral-config/workspaces/default/sources/github/secrets.env")
+        );
+        assert_eq!(
+            layout.bundled_manifest_tracking_file(&workspace, "github"),
+            std::path::Path::new(
+                "/tmp/coral-config/workspaces/default/sources/github/bundled-manifest.toml"
+            )
         );
     }
 }

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -5,5 +5,5 @@ mod layout;
 mod secrets;
 
 pub(crate) use config::ConfigStore;
-pub(crate) use layout::AppStateLayout;
+pub(crate) use layout::{AppStateLayout, INSTALLED_MANIFEST_FILE_NAME};
 pub(crate) use secrets::{CredentialsError, SecretStore};

--- a/crates/coral-app/tests/local_mode.rs
+++ b/crates/coral-app/tests/local_mode.rs
@@ -5,13 +5,14 @@
     reason = "Integration tests inherit the library crate's dependency set and intentionally exercise only a subset of it."
 )]
 
+use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::{
-    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
-    ImportSourceRequest, ListSourcesRequest, ListTablesRequest, SourceSecret, SourceVariable,
-    ValidateSourceRequest, Workspace,
+    BundledManifestState, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
+    ExecuteSqlRequest, ImportSourceRequest, ListSourcesRequest, ListTablesRequest, SourceSecret,
+    SourceVariable, ValidateSourceRequest, Workspace,
 };
 use coral_client::{
     AppClient, batches_to_json_rows, decode_execute_sql_response, default_workspace,
@@ -78,6 +79,35 @@ tables:
         type: Utf8
 "#
     .to_string()
+}
+
+fn bundled_manifest_yaml(source_name: &str) -> String {
+    let crate_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fs::read_to_string(
+        crate_root
+            .join("../../sources")
+            .join(source_name)
+            .join("manifest.yaml"),
+    )
+    .expect("read bundled manifest fixture")
+}
+
+fn manifest_with_version(manifest_yaml: &str, version: &str) -> String {
+    let mut rewritten = String::new();
+    let mut replaced = false;
+
+    for line in manifest_yaml.lines() {
+        if !replaced && line.starts_with("version: ") {
+            let _ = writeln!(&mut rewritten, "version: {version}");
+            replaced = true;
+        } else {
+            rewritten.push_str(line);
+            rewritten.push('\n');
+        }
+    }
+
+    assert!(replaced, "manifest fixture must contain a version line");
+    rewritten
 }
 
 async fn local_client(config_dir: impl Into<PathBuf>) -> AppClient {
@@ -345,9 +375,152 @@ async fn config_persists_across_rebuilds_without_local_trace_state() {
 #[tokio::test]
 async fn bundled_github_source_initializes_tables_with_template_secret_binding() {
     let temp = TempDir::new().expect("temp dir");
-    let app = local_client(temp.path().join("coral-config")).await;
+    let config_dir = temp.path().join("coral-config");
+    let app = local_client(&config_dir).await;
     let mut source_client = app.source_client();
     let mut query_client = app.query_client();
+
+    let added = source_client
+        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "github".to_string(),
+            variables: vec![SourceVariable {
+                key: "GITHUB_API_BASE".to_string(),
+                value: "https://api.github.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "GITHUB_TOKEN".to_string(),
+                value: "fake-token".to_string(),
+            }],
+        }))
+        .await
+        .expect("create bundled github source")
+        .into_inner();
+
+    assert_eq!(added.name, "github");
+    assert_eq!(
+        BundledManifestState::try_from(added.bundled_manifest_state),
+        Ok(BundledManifestState::FollowingCurrent)
+    );
+
+    let source_dir = config_dir
+        .join("workspaces")
+        .join("default")
+        .join("sources")
+        .join("github");
+    assert!(
+        !source_dir.join("manifest.yaml").exists(),
+        "bundled installs should not keep a workspace manifest by default"
+    );
+    let tracking_raw =
+        fs::read_to_string(source_dir.join("bundled-manifest.toml")).expect("read tracking file");
+    let bundle_id = tracking_raw
+        .lines()
+        .find_map(|line| {
+            line.strip_prefix("bundle_id = ")
+                .map(|value| value.trim_matches('"').to_string())
+        })
+        .expect("bundle_id in tracking file");
+    assert!(
+        config_dir
+            .join("bundled-sources")
+            .join("github")
+            .join(&bundle_id)
+            .join("manifest.yaml")
+            .exists(),
+        "bundled cache should contain the tracked manifest"
+    );
+
+    let tables = query_client
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list tables")
+        .into_inner()
+        .tables;
+    assert!(
+        tables.iter().any(|table| table.schema_name == "github"),
+        "github tables should register once the template secret dependency is provided"
+    );
+
+    let listed = source_client
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list sources")
+        .into_inner();
+    assert_eq!(listed.sources.len(), 1);
+    assert_eq!(
+        BundledManifestState::try_from(listed.sources[0].bundled_manifest_state),
+        Ok(BundledManifestState::FollowingCurrent)
+    );
+}
+
+#[tokio::test]
+async fn startup_migrates_legacy_bundled_installs_to_tracking_mode() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let source_dir = config_dir
+        .join("workspaces")
+        .join("default")
+        .join("sources")
+        .join("github");
+    fs::create_dir_all(&source_dir).expect("create legacy bundled dir");
+    fs::write(
+        source_dir.join("manifest.yaml"),
+        bundled_manifest_yaml("github"),
+    )
+    .expect("write legacy manifest");
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"
+version = 1
+
+[workspaces.default.sources.github]
+version = "0.0.0"
+origin = "bundled"
+"#,
+    )
+    .expect("write legacy config");
+
+    let app = local_client(&config_dir).await;
+    let mut source_client = app.source_client();
+
+    assert!(
+        !source_dir.join("manifest.yaml").exists(),
+        "startup migration should remove legacy workspace manifests"
+    );
+    assert!(
+        source_dir.join("bundled-manifest.toml").exists(),
+        "startup migration should create bundled tracking metadata"
+    );
+
+    let listed = source_client
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list sources after migration")
+        .into_inner();
+    assert_eq!(listed.sources.len(), 1);
+    assert_eq!(
+        BundledManifestState::try_from(listed.sources[0].bundled_manifest_state),
+        Ok(BundledManifestState::FollowingCurrent)
+    );
+    assert_ne!(
+        listed.sources[0].version, "0.0.0",
+        "startup sync should refresh the bundled version from the resolved manifest"
+    );
+}
+
+#[tokio::test]
+async fn bundled_local_override_is_reported_and_source_add_resets_it() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let app = local_client(&config_dir).await;
+    let mut source_client = app.source_client();
 
     source_client
         .create_bundled_source(Request::new(CreateBundledSourceRequest {
@@ -365,17 +538,128 @@ async fn bundled_github_source_initializes_tables_with_template_secret_binding()
         .await
         .expect("create bundled github source");
 
-    let tables = query_client
-        .list_tables(Request::new(ListTablesRequest {
+    let override_manifest = manifest_with_version(&bundled_manifest_yaml("github"), "9.9.9");
+    let source_dir = config_dir
+        .join("workspaces")
+        .join("default")
+        .join("sources")
+        .join("github");
+    fs::write(source_dir.join("manifest.yaml"), override_manifest).expect("write local override");
+
+    let override_list = source_client
+        .list_sources(Request::new(ListSourcesRequest {
             workspace: Some(default_workspace()),
         }))
         .await
-        .expect("list tables")
-        .into_inner()
-        .tables;
+        .expect("list overridden source")
+        .into_inner();
+    assert_eq!(override_list.sources.len(), 1);
+    assert_eq!(override_list.sources[0].version, "9.9.9");
+    assert_eq!(
+        BundledManifestState::try_from(override_list.sources[0].bundled_manifest_state),
+        Ok(BundledManifestState::LocalOverride)
+    );
+
+    let tested = source_client
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "github".to_string(),
+        }))
+        .await
+        .expect("validate overridden source")
+        .into_inner();
+    assert_eq!(
+        BundledManifestState::try_from(
+            tested
+                .source
+                .expect("validated source metadata")
+                .bundled_manifest_state
+        ),
+        Ok(BundledManifestState::LocalOverride)
+    );
+
+    source_client
+        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "github".to_string(),
+            variables: vec![SourceVariable {
+                key: "GITHUB_API_BASE".to_string(),
+                value: "https://api.github.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "GITHUB_TOKEN".to_string(),
+                value: "fake-token".to_string(),
+            }],
+        }))
+        .await
+        .expect("re-add bundled source to reset override");
+
     assert!(
-        tables.iter().any(|table| table.schema_name == "github"),
-        "github tables should register once the template secret dependency is provided"
+        !source_dir.join("manifest.yaml").exists(),
+        "re-adding a bundled source should remove the local override"
+    );
+    let relisted = source_client
+        .list_sources(Request::new(ListSourcesRequest {
+            workspace: Some(default_workspace()),
+        }))
+        .await
+        .expect("list relinked source")
+        .into_inner();
+    assert_eq!(
+        BundledManifestState::try_from(relisted.sources[0].bundled_manifest_state),
+        Ok(BundledManifestState::FollowingCurrent)
+    );
+}
+
+#[tokio::test]
+async fn deleting_bundled_source_keeps_shared_cache() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let app = local_client(&config_dir).await;
+    let mut source_client = app.source_client();
+
+    source_client
+        .create_bundled_source(Request::new(CreateBundledSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "github".to_string(),
+            variables: vec![SourceVariable {
+                key: "GITHUB_API_BASE".to_string(),
+                value: "https://api.github.com".to_string(),
+            }],
+            secrets: vec![SourceSecret {
+                key: "GITHUB_TOKEN".to_string(),
+                value: "fake-token".to_string(),
+            }],
+        }))
+        .await
+        .expect("create bundled github source");
+
+    let bundle_root = config_dir.join("bundled-sources").join("github");
+    assert!(
+        bundle_root.exists(),
+        "bundle cache should exist before delete"
+    );
+
+    source_client
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "github".to_string(),
+        }))
+        .await
+        .expect("delete bundled source");
+
+    assert!(
+        bundle_root.exists(),
+        "deleting a bundled source should leave shared cache entries intact"
+    );
+    assert!(
+        !config_dir
+            .join("workspaces")
+            .join("default")
+            .join("sources")
+            .join("github")
+            .exists(),
+        "workspace-specific source artifacts should be removed"
     );
 }
 

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
 use coral_api::v1::ExecuteSqlRequest;
 use coral_client::{
-    ClientBuilder, decode_execute_sql_response, default_workspace, format_batches_json,
+    AppClient, ClientBuilder, decode_execute_sql_response, default_workspace, format_batches_json,
     format_batches_table,
 };
 use tonic::Request;
@@ -105,92 +105,105 @@ async fn main() -> Result<(), anyhow::Error> {
     let app = ClientBuilder::new().build().await?;
 
     match cli.command {
-        Command::Sql(args) => {
-            let response = app
-                .query_client()
-                .execute_sql(Request::new(ExecuteSqlRequest {
-                    workspace: Some(default_workspace()),
-                    sql: args.sql,
-                }))
-                .await?
-                .into_inner();
-            let result = decode_execute_sql_response(&response)?;
-            print_batches(result.batches(), args.format)?;
-        }
-        Command::Source(args) => match args.command {
-            SourceCommand::Discover => {
-                let sources = source_ops::discover_sources(&app).await?;
-                if sources.is_empty() {
-                    println!("No bundled sources available.");
-                } else {
-                    for source in sources {
-                        let status = if source.installed {
-                            "installed"
-                        } else {
-                            "available"
-                        };
-                        println!("{}\t{}\t{}", source.name, source.version, status);
-                    }
-                }
-            }
-            SourceCommand::List => {
-                let sources = source_ops::list_sources(&app).await?;
-                if sources.is_empty() {
-                    println!("No sources configured.");
-                } else {
-                    for source in sources {
-                        let origin = source_ops::source_origin_label(source.origin);
-                        println!("{}\t{}\t{}", source.name, source.version, origin);
-                    }
-                }
-            }
-            SourceCommand::Add(SourceAddArgs { name, file }) => {
-                source_ops::require_interactive()?;
-                let response = match (name, file) {
-                    (Some(name), None) => {
-                        let bundled_name = source_ops::source_name_arg(Some(&name))?;
-                        let discover = source_ops::discover_sources(&app).await?;
-                        let available = discover
-                            .into_iter()
-                            .find(|source| source.name == bundled_name)
-                            .ok_or_else(|| {
-                                anyhow::anyhow!("unknown bundled source '{bundled_name}'")
-                            })?;
-                        let inputs = available
-                            .inputs
-                            .iter()
-                            .map(source_ops::manifest_input_from_proto)
-                            .collect::<Result<Vec<_>, _>>()?;
-                        let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
-                        source_ops::add_bundled_source(&app, &available.name, variables, secrets)
-                            .await?
-                    }
-                    (None, Some(file)) => {
-                        let (manifest_yaml, inputs) = source_ops::load_manifest_inputs(&file)?;
-                        let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
-                        source_ops::import_source(&app, manifest_yaml, variables, secrets).await?
-                    }
-                    _ => unreachable!("clap enforces exactly one of name or file"),
-                };
-                println!("Added source {}", response.name);
-            }
-            SourceCommand::Test { name } => {
-                let response = source_ops::validate_source(&app, &name).await?;
-                source_ops::print_validation_success(&response)?;
-            }
-            SourceCommand::Remove { name } => {
-                source_ops::delete_source(&app, &name).await?;
-                println!("Removed source {name}");
-            }
-        },
-        Command::Onboard => {
-            onboard::run(&app).await?;
-        }
+        Command::Sql(args) => run_sql(&app, args).await?,
+        Command::Source(args) => run_source_command(&app, args.command).await?,
+        Command::Onboard => onboard::run(&app).await?,
         Command::McpStdio => {
             coral_mcp::run_stdio_with_client(app).await?;
         }
     }
 
+    Ok(())
+}
+
+async fn run_sql(app: &AppClient, args: SqlArgs) -> Result<(), anyhow::Error> {
+    let response = app
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: args.sql,
+        }))
+        .await?
+        .into_inner();
+    let result = decode_execute_sql_response(&response)?;
+    print_batches(result.batches(), args.format)
+}
+
+async fn run_source_command(app: &AppClient, command: SourceCommand) -> Result<(), anyhow::Error> {
+    match command {
+        SourceCommand::Discover => {
+            let sources = source_ops::discover_sources(app).await?;
+            if sources.is_empty() {
+                println!("No bundled sources available.");
+            } else {
+                for source in sources {
+                    let status = if source.installed {
+                        "installed"
+                    } else {
+                        "available"
+                    };
+                    println!("{}\t{}\t{}", source.name, source.version, status);
+                }
+            }
+        }
+        SourceCommand::List => {
+            let sources = source_ops::list_sources(app).await?;
+            if sources.is_empty() {
+                println!("No sources configured.");
+            } else {
+                for source in sources {
+                    let origin = source_ops::source_origin_label(source.origin);
+                    match source_ops::bundled_manifest_state_label(source.bundled_manifest_state) {
+                        Some(state) => {
+                            println!("{}\t{}\t{}\t{}", source.name, source.version, origin, state);
+                        }
+                        None => {
+                            println!("{}\t{}\t{}", source.name, source.version, origin);
+                        }
+                    }
+                }
+            }
+        }
+        SourceCommand::Add(args) => run_source_add(app, args).await?,
+        SourceCommand::Test { name } => {
+            let response = source_ops::validate_source(app, &name).await?;
+            source_ops::print_validation_success(&response)?;
+        }
+        SourceCommand::Remove { name } => {
+            source_ops::delete_source(app, &name).await?;
+            println!("Removed source {name}");
+        }
+    }
+
+    Ok(())
+}
+
+async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyhow::Error> {
+    source_ops::require_interactive()?;
+    let response = match (args.name, args.file) {
+        (Some(name), None) => {
+            let bundled_name = source_ops::source_name_arg(Some(&name))?;
+            let discover = source_ops::discover_sources(app).await?;
+            let available = discover
+                .into_iter()
+                .find(|source| source.name == bundled_name)
+                .ok_or_else(|| anyhow::anyhow!("unknown bundled source '{bundled_name}'"))?;
+            let inputs = available
+                .inputs
+                .iter()
+                .map(source_ops::manifest_input_from_proto)
+                .collect::<Result<Vec<_>, _>>()?;
+            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
+        }
+        (None, Some(file)) => {
+            let (manifest_yaml, inputs) = source_ops::load_manifest_inputs(&file)?;
+            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            source_ops::import_source(app, manifest_yaml, variables, secrets).await?
+        }
+        _ => unreachable!("clap enforces exactly one of name or file"),
+    };
+    println!("Added source {}", response.name);
     Ok(())
 }
 

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -2,9 +2,10 @@ use std::io::{IsTerminal, stdin, stdout};
 use std::path::Path;
 
 use coral_api::v1::{
-    AvailableSource, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
-    ImportSourceRequest, ListSourcesRequest, Source, SourceInputKind, SourceInputSpec,
-    SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+    AvailableSource, BundledManifestState, CreateBundledSourceRequest, DeleteSourceRequest,
+    DiscoverSourcesRequest, ImportSourceRequest, ListSourcesRequest, Source, SourceInputKind,
+    SourceInputSpec, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
+    ValidateSourceResponse,
 };
 use coral_client::{AppClient, default_workspace};
 use coral_spec::{ManifestInputKind, ManifestInputSpec, collect_source_inputs_yaml};
@@ -176,6 +177,16 @@ pub(crate) fn source_origin_label(origin: i32) -> &'static str {
     }
 }
 
+pub(crate) fn bundled_manifest_state_label(state: i32) -> Option<&'static str> {
+    match BundledManifestState::try_from(state) {
+        Ok(BundledManifestState::FollowingCurrent) => Some("following-current"),
+        Ok(BundledManifestState::LocalOverride) => Some("local-override"),
+        Ok(BundledManifestState::NotApplicable | BundledManifestState::Unspecified) | Err(_) => {
+            None
+        }
+    }
+}
+
 pub(crate) fn print_validation_success(
     response: &ValidateSourceResponse,
 ) -> Result<(), anyhow::Error> {
@@ -184,6 +195,9 @@ pub(crate) fn print_validation_success(
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("validate response missing source metadata"))?;
     println!("Source {} is queryable", source.name);
+    if let Some(state) = bundled_manifest_state_label(source.bundled_manifest_state) {
+        println!("Manifest state: {state}");
+    }
     for table in &response.tables {
         println!("{}.{}", table.schema_name, table.name);
     }
@@ -252,9 +266,10 @@ pub(crate) fn finalize_input_value(
 
 #[cfg(test)]
 mod tests {
+    use coral_api::v1::BundledManifestState;
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
-    use super::finalize_input_value;
+    use super::{bundled_manifest_state_label, finalize_input_value};
 
     #[test]
     fn empty_input_uses_default_value() {
@@ -282,5 +297,21 @@ mod tests {
         let error = finalize_input_value(&input, String::new(), "source secret")
             .expect_err("required empty input should fail");
         assert!(error.to_string().contains("missing required source secret"));
+    }
+
+    #[test]
+    fn bundled_manifest_states_render_expected_labels() {
+        assert_eq!(
+            bundled_manifest_state_label(BundledManifestState::FollowingCurrent as i32),
+            Some("following-current")
+        );
+        assert_eq!(
+            bundled_manifest_state_label(BundledManifestState::LocalOverride as i32),
+            Some("local-override")
+        );
+        assert_eq!(
+            bundled_manifest_state_label(BundledManifestState::NotApplicable as i32),
+            None
+        );
     }
 }

--- a/crates/coral-mcp/src/surface.rs
+++ b/crates/coral-mcp/src/surface.rs
@@ -328,7 +328,7 @@ fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
 
 #[cfg(test)]
 mod tests {
-    use coral_api::v1::{Source, Table, Workspace};
+    use coral_api::v1::{BundledManifestState, Source, Table, Workspace};
 
     use super::{ToolError, guide_resource_content, tool_error_result};
 
@@ -342,6 +342,7 @@ mod tests {
             secrets: Vec::new(),
             variables: Vec::new(),
             origin: 0,
+            bundled_manifest_state: BundledManifestState::NotApplicable as i32,
         }
     }
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -84,5 +84,12 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 Important files include:
 
 - `config.toml` for installed-source metadata and non-secret variables
+- bundled manifest cache entries under `bundled-sources/<source>/<bundle_id>/manifest.yaml`
 - installed source specs under `workspaces/<workspace>/sources/...`
 - source secrets stored separately within the same local trust boundary
+
+Bundled sources follow the Coral-owned cache across upgrades. If you create or
+edit `workspaces/<workspace>/sources/<source>/manifest.yaml` for a bundled
+source, Coral treats that file as a local override. Running
+`coral source add <source>` removes the override and restores the bundled
+version.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -37,6 +37,9 @@ List sources currently installed.
 coral source list
 ```
 
+Output includes the source origin, and for bundled sources whether they are
+`following-current` or using a `local-override`.
+
 ### `coral source add <NAME>`
 
 Add a bundled source or update its credentials.
@@ -46,6 +49,10 @@ coral source add github
 ```
 
 Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
+
+For bundled sources, running `coral source add <NAME>` also resets any local
+workspace manifest override and relinks the source to Coral's current bundled
+manifest cache.
 
 ### `coral source add --file <PATH>`
 
@@ -63,6 +70,9 @@ Validate that an installed source can initialize and expose tables.
 coral source test github
 coral source test local_messages
 ```
+
+Bundled sources also print their manifest state as `following-current` or
+`local-override`.
 
 ### `coral source remove <NAME>`
 


### PR DESCRIPTION
## Summary

This PR replaces the current bundled-source install model, which copies a
bundled manifest into each workspace, with a versioned Coral-owned bundled
manifest cache plus explicit per-source tracking metadata.

Bundled sources now resolve from `bundled-sources/<source>/<bundle_id>/`,
installed bundled sources track the bundle they were linked to via
`bundled-manifest.toml`, and a workspace-local `manifest.yaml` becomes an
explicit override instead of an implicit copy of bundled state. This lets Coral
move bundled installs forward when the compiled-in manifest changes while still
preserving a clear local override path.

## Why this change

The previous model made bundled installs look like imported installs on disk.
That caused two problems:

1. Bundled installs did not have a stable Coral-owned link back to the compiled
   manifest that created them.
2. Upgrading Coral could not reliably update existing bundled sources to the
   new bundled manifest without treating workspace state ambiguously.

This PR gives bundled sources an explicit ownership model:

- Coral owns the shared bundled manifest cache in the config directory.
- Each bundled install records which bundle it is linked to.
- A workspace `manifest.yaml` for a bundled source is treated as a deliberate
  local override.

## What changed

### Bundled manifest storage and startup maintenance

- Added a new internal bundled-manifest store in
  `crates/coral-app/src/sources/bundled_store.rs`.
- Added config layout support for:
  - `bundled-sources/<source>/<bundle_id>/manifest.yaml`
  - `workspaces/<workspace>/sources/<source>/bundled-manifest.toml`
- Introduced content-addressed `bundle_id` generation using a SHA-256-derived
  hash of the bundled source name plus raw manifest YAML.
- On startup, Coral now best-effort:
  - materializes the current bundled cache for all compiled bundled sources
  - migrates legacy bundled installs to sidecar tracking mode
  - syncs stored bundled source versions in `config.toml` to the currently
    resolved manifest version
- Startup still logs warnings and continues if this maintenance fails.

### Source install and resolution behavior

- `create_bundled_source` now requires a usable bundled cache entry, writes
  `bundled-manifest.toml`, and removes any workspace `manifest.yaml`.
- Imported sources keep the existing workspace-manifest behavior.
- If an imported source replaces a bundled source with the same name, the old
  bundled tracking file is removed.
- Bundled source resolution now works as:
  1. use workspace `manifest.yaml` if present (`local_override`)
  2. otherwise use the current compiled bundle cache if available
  3. otherwise fall back to the recorded cached bundle
- Delete/rollback logic restores both workspace `manifest.yaml` and
  `bundled-manifest.toml` when persistence fails.

### Query/API/CLI surface

- Added `BundledManifestState` to the protobuf API and exposed it on `Source`.
- `ListSources`, `GetSource`, and `ValidateSource` now return:
  - the effective resolved manifest version
  - the bundled manifest state for bundled installs
- Query-time loading now resolves bundled manifests through the bundled cache
  and relaxes strict version matching for bundled sources, since the effective
  version now comes from the resolved manifest.
- `coral source list` now shows bundled manifest state as
  `following-current` or `local-override`.
- `coral source test <NAME>` now prints the manifest state for bundled sources.
- `coral source add <NAME>` now acts as the reset/relink path for bundled
  sources by removing any local override and relinking to the current bundled
  manifest cache.

### Docs and supporting updates

- Updated CLI reference docs for the new bundled-manifest state output and
  reset behavior.
- Updated installation docs to describe the bundled cache layout and override
  semantics.
- Updated MCP test fixtures and supporting code for the expanded `Source`
  protobuf.
- Added `sha2` as a dependency for bundle hashing.

## Tests and verification

Added and updated test coverage for:

- bundled cache materialization
- tracking file read/write
- legacy bundled-install migration
- bundled source resolution from cache
- local override detection and reset via `source add`
- stale recorded-cache fallback state reporting
- shared bundled-cache retention on source delete
- CLI state-label rendering

Validation run:

- `make rust-checks`
