### PR TITLE
fix(app): stop local gRPC PROTOCOL_ERROR on wide-manifest queries

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -39,3 +39,20 @@
 pub mod v1 {
     tonic::include_proto!("coral.v1");
 }
+
+/// Maximum gRPC message size for the local `QueryService` transport, in
+/// bytes.
+///
+/// `ExecuteSql` is a unary RPC that returns the full Arrow IPC result in
+/// one message. Tonic's default of 4 MB is easily exceeded by wide
+/// manifests like `github.search_issues`
+pub const QUERY_SERVICE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+
+/// HTTP/2 `SETTINGS_MAX_HEADER_LIST_SIZE` for the local Coral transport,
+/// in bytes.
+///
+/// The hyper/h2 default (~16 KiB) is too small for some error trailers on
+/// wide manifests even after we truncate `Status` details, and also caps
+/// HPACK-encoded request headers on the way in. 128 KiB gives plenty of
+/// headroom in both directions.
+pub const HTTP2_MAX_HEADER_LIST_SIZE: u32 = 128 * 1024;

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -40,13 +40,13 @@ pub mod v1 {
     tonic::include_proto!("coral.v1");
 }
 
-/// Maximum gRPC message size for the local `QueryService` transport, in
-/// bytes.
+/// Maximum gRPC message size for `QueryService` *responses*, in bytes.
 ///
 /// `ExecuteSql` is a unary RPC that returns the full Arrow IPC result in
 /// one message. Tonic's default of 4 MB is easily exceeded by wide
-/// manifests like `github.search_issues`
-pub const QUERY_SERVICE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
+/// manifests like `github.search_issues`. Only the response direction
+/// needs the bump — requests are small SQL strings.
+pub const QUERY_RESPONSE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 
 /// HTTP/2 `SETTINGS_MAX_HEADER_LIST_SIZE` for the local Coral transport,
 /// in bytes.

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -46,12 +46,41 @@ pub enum AppError {
     MissingConfigDir,
 }
 
+/// Upper bound on the byte length of a `tonic::Status` message (detail).
+///
+/// gRPC `Status` details travel in HTTP/2 trailers; peers bound the total
+/// trailer set via `MAX_HEADER_LIST_SIZE` (default ~16 KiB on hyper/h2).
+/// Oversized details cause the server to emit invalid trailers and the
+/// client's h2 stack reports `PROTOCOL_ERROR` instead of surfacing the
+/// status. 4 KiB leaves ample room for other trailer entries
+/// (`grpc-status`, `grpc-status-details-bin`, `content-type`, …).
+pub(crate) const MAX_STATUS_DETAIL_BYTES: usize = 4 * 1024;
+
+/// Generic safety-net truncation for `tonic::Status` details.
+///
+/// Intentionally format-agnostic: no string heuristics on `DataFusion`
+/// error shapes, no "did you mean?" hints (those live in the structured
+/// error-conversion path where we have typed `Column` data — see
+/// `coral_engine::runtime::query`). This function's only job is to keep
+/// whatever string it's given under the trailer budget.
+fn truncate_status_detail(detail: String) -> String {
+    const MARKER: &str = "… (truncated)";
+    if detail.len() <= MAX_STATUS_DETAIL_BYTES {
+        return detail;
+    }
+    let mut cut = MAX_STATUS_DETAIL_BYTES.saturating_sub(MARKER.len());
+    while cut > 0 && !detail.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}{MARKER}", &detail[..cut])
+}
+
 #[allow(
     clippy::needless_pass_by_value,
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn app_status(error: AppError) -> Status {
-    Status::new(app_code(&error), error.to_string())
+    Status::new(app_code(&error), truncate_status_detail(error.to_string()))
 }
 
 #[allow(
@@ -59,7 +88,10 @@ pub(crate) fn app_status(error: AppError) -> Status {
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn core_status(error: CoreError) -> Status {
-    Status::new(grpc_code(error.status_code()), error.to_string())
+    Status::new(
+        grpc_code(error.status_code()),
+        truncate_status_detail(error.to_string()),
+    )
 }
 
 fn grpc_code(status: StatusCode) -> Code {
@@ -89,5 +121,36 @@ fn app_code(error: &AppError) -> Code {
         | AppError::Transport(_)
         | AppError::TaskJoin(_)
         | AppError::Credentials(_) => Code::Internal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_status_detail_leaves_short_detail_unchanged() {
+        let detail = "short message".to_string();
+        assert_eq!(truncate_status_detail(detail.clone()), detail);
+    }
+
+    #[test]
+    fn truncate_status_detail_caps_long_ascii_and_marks_it() {
+        let detail = "x".repeat(20 * 1024);
+        let out = truncate_status_detail(detail);
+        assert!(out.len() <= MAX_STATUS_DETAIL_BYTES);
+        assert!(out.ends_with("… (truncated)"), "missing marker: {out:?}");
+    }
+
+    #[test]
+    fn truncate_status_detail_preserves_utf8_boundaries() {
+        // Fill with a 4-byte codepoint so the raw-byte cut point is
+        // guaranteed to land mid-codepoint and must be walked backwards.
+        let detail = "𝕏".repeat(2 * 1024); // 4 bytes per char → 8 KiB total
+        let out = truncate_status_detail(detail);
+        assert!(out.len() <= MAX_STATUS_DETAIL_BYTES);
+        // Result must still be valid UTF-8 (guaranteed by String type) and
+        // end with the truncation marker.
+        assert!(out.ends_with("… (truncated)"));
     }
 }

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -5,6 +5,8 @@ mod env;
 mod error;
 mod server;
 
+#[cfg(test)]
+pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
 pub(crate) use error::{app_status, core_status};
 
 pub use error::AppError;

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
-use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_SERVICE_MAX_MESSAGE_SIZE};
+use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -180,8 +180,7 @@ async fn start_server(
             .add_service(SourceServiceServer::new(source_service))
             .add_service(
                 QueryServiceServer::new(query_service)
-                    .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
-                    .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE),
+                    .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
             )
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                 let _ = shutdown_rx.await;
@@ -201,7 +200,7 @@ mod tests {
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::{ExecuteSqlRequest, ImportSourceRequest, Workspace};
-    use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_SERVICE_MAX_MESSAGE_SIZE};
+    use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
     use tempfile::TempDir;
     use tonic::Request;
@@ -257,8 +256,7 @@ mod tests {
             .expect("connect");
         let mut source_client = SourceServiceClient::new(channel.clone());
         let mut query_client = QueryServiceClient::new(channel)
-            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
-            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
 
         source_client
             .import_source(Request::new(ImportSourceRequest {
@@ -332,8 +330,7 @@ tables:
             .await
             .expect("connect");
         let mut query_client = QueryServiceClient::new(channel)
-            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
-            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
 
         // No underscore separator — DataFusion's SQL parser is conservative
         // about numeric literal formats.
@@ -421,8 +418,7 @@ tables:
             .expect("connect");
         let mut source_client = SourceServiceClient::new(channel.clone());
         let mut query_client = QueryServiceClient::new(channel)
-            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
-            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
 
         source_client
             .import_source(Request::new(ImportSourceRequest {

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
+use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_SERVICE_MAX_MESSAGE_SIZE};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -175,8 +176,13 @@ async fn start_server(
 
     let task = tokio::spawn(async move {
         Server::builder()
+            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
             .add_service(SourceServiceServer::new(source_service))
-            .add_service(QueryServiceServer::new(query_service))
+            .add_service(
+                QueryServiceServer::new(query_service)
+                    .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
+                    .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE),
+            )
             .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                 let _ = shutdown_rx.await;
             })
@@ -195,6 +201,7 @@ mod tests {
     use coral_api::v1::query_service_client::QueryServiceClient;
     use coral_api::v1::source_service_client::SourceServiceClient;
     use coral_api::v1::{ExecuteSqlRequest, ImportSourceRequest, Workspace};
+    use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_SERVICE_MAX_MESSAGE_SIZE};
     use coral_engine::QueryRuntimeContext;
     use tempfile::TempDir;
     use tonic::Request;
@@ -244,11 +251,14 @@ mod tests {
             .expect("start server");
         let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
             .expect("endpoint")
+            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
             .connect()
             .await
             .expect("connect");
         let mut source_client = SourceServiceClient::new(channel.clone());
-        let mut query_client = QueryServiceClient::new(channel);
+        let mut query_client = QueryServiceClient::new(channel)
+            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
 
         source_client
             .import_source(Request::new(ImportSourceRequest {
@@ -290,5 +300,163 @@ tables:
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0]["text"], "hello");
         assert_eq!(rows[1]["text"], "world");
+    }
+
+    /// an `ExecuteSql` response larger than
+    /// the previous tonic 4 MB default must round-trip cleanly. Before the
+    /// fix, this query failed with `h2 protocol error … PROTOCOL_ERROR`.
+    #[tokio::test]
+    async fn execute_sql_response_above_default_4mb_limit_round_trips() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        let source_manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            SecretStore::new(layout.clone()),
+            layout.clone(),
+        );
+        let query_manager = QueryManager::new(
+            ConfigStore::new(layout.clone()),
+            SecretStore::new(layout.clone()),
+            QueryRuntimeContext { home_dir: None },
+            layout,
+        );
+        let running = start_server(source_manager, query_manager)
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
+            .expect("endpoint")
+            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
+            .connect()
+            .await
+            .expect("connect");
+        let mut query_client = QueryServiceClient::new(channel)
+            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
+
+        // No underscore separator — DataFusion's SQL parser is conservative
+        // about numeric literal formats.
+        let sql = "SELECT repeat('x', 5000000) AS pad";
+        let response = query_client
+            .execute_sql(Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: sql.to_string(),
+            }))
+            .await
+            .expect("execute_sql >4MB response")
+            .into_inner();
+
+        // Prove the payload actually crossed the old 4 MB ceiling — without
+        // this check the test could silently start passing for the wrong
+        // reason if `repeat` ever returned a smaller value.
+        assert!(
+            response.arrow_ipc_stream.len() > 4 * 1024 * 1024,
+            "regression payload was {} bytes; expected >4MB",
+            response.arrow_ipc_stream.len()
+        );
+
+        let result = coral_client::decode_execute_sql_response(&response).expect("decode");
+        assert_eq!(result.row_count(), 1);
+    }
+
+    /// an invalid column against a wide manifest must surface as a clean `tonic::Status`,
+    /// not a transport-level `h2 protocol error`. Pre-fix, `DataFusion`'s
+    /// "Valid fields are …" error enumerating ~600 field names
+    /// overflowed HTTP/2 trailers; the CLI saw `PROTOCOL_ERROR` instead
+    /// of the intended status.
+    ///
+    /// Also verifies the behavior change: wrapped `SchemaError` now maps
+    /// to `Code::InvalidArgument` (via `find_root()`), not `Code::Internal`.
+    #[tokio::test]
+    async fn invalid_column_on_wide_manifest_returns_clean_status() {
+        use std::fmt::Write as _;
+
+        use crate::bootstrap::MAX_STATUS_DETAIL_BYTES;
+
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        let data_dir = temp.path().join("wide-data");
+        std::fs::create_dir_all(&data_dir).expect("create data dir");
+        // No rows needed — the test cares only about schema width.
+        let location = format!("file://{}/", data_dir.display());
+
+        let mut manifest = String::new();
+        manifest.push_str("name: wide_demo\n");
+        manifest.push_str("version: 0.1.0\n");
+        manifest.push_str("dsl_version: 3\n");
+        manifest.push_str("backend: jsonl\n");
+        manifest.push_str("tables:\n");
+        manifest.push_str("  - name: wide\n");
+        manifest.push_str("    description: Wide fixture\n");
+        manifest.push_str("    source:\n");
+        writeln!(manifest, "      location: {location}").expect("write to String");
+        manifest.push_str("      glob: \"**/*.jsonl\"\n");
+        manifest.push_str("    columns:\n");
+        for i in 0..600 {
+            writeln!(manifest, "      - name: col_{i:04}\n        type: Utf8")
+                .expect("write to String");
+        }
+
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+        let source_manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            SecretStore::new(layout.clone()),
+            layout.clone(),
+        );
+        let query_manager = QueryManager::new(
+            ConfigStore::new(layout.clone()),
+            SecretStore::new(layout.clone()),
+            QueryRuntimeContext { home_dir: None },
+            layout,
+        );
+        let running = start_server(source_manager, query_manager)
+            .await
+            .expect("start server");
+        let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
+            .expect("endpoint")
+            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
+            .connect()
+            .await
+            .expect("connect");
+        let mut source_client = SourceServiceClient::new(channel.clone());
+        let mut query_client = QueryServiceClient::new(channel)
+            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
+
+        source_client
+            .import_source(Request::new(ImportSourceRequest {
+                workspace: Some(default_workspace()),
+                manifest_yaml: manifest,
+                variables: Vec::new(),
+                secrets: Vec::new(),
+            }))
+            .await
+            .expect("import wide source");
+
+        let status = query_client
+            .execute_sql(Request::new(ExecuteSqlRequest {
+                workspace: Some(default_workspace()),
+                sql: "SELECT bogus_column FROM wide_demo.wide LIMIT 0".to_string(),
+            }))
+            .await
+            .expect_err("expected gRPC Status, not a transport-level PROTOCOL_ERROR");
+
+        assert_eq!(
+            status.code(),
+            tonic::Code::InvalidArgument,
+            "wrapped schema error should map to InvalidArgument via find_root(); message = {:?}",
+            status.message()
+        );
+        assert!(
+            status.message().len() <= MAX_STATUS_DETAIL_BYTES,
+            "status message was {} bytes; truncator should have clipped it to <= {MAX_STATUS_DETAIL_BYTES}",
+            status.message().len(),
+        );
+        assert!(
+            status.message().contains("No field named"),
+            "missing expected schema-error head in: {:?}",
+            status.message()
+        );
     }
 }

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -81,5 +81,5 @@ async fn broken_source_does_not_block_healthy_sources() {
         }))
         .await
         .expect_err("broken source query should fail");
-    assert_eq!(broken.code(), tonic::Code::InvalidArgument);
+    assert_eq!(broken.code(), tonic::Code::NotFound);
 }

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -81,5 +81,5 @@ async fn broken_source_does_not_block_healthy_sources() {
         }))
         .await
         .expect_err("broken source query should fail");
-    assert_eq!(broken.code(), tonic::Code::Internal);
+    assert_eq!(broken.code(), tonic::Code::InvalidArgument);
 }

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -81,5 +81,5 @@ async fn broken_source_does_not_block_healthy_sources() {
         }))
         .await
         .expect_err("broken source query should fail");
-    assert_eq!(broken.code(), tonic::Code::NotFound);
+    assert_eq!(broken.code(), tonic::Code::InvalidArgument);
 }

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -3,7 +3,7 @@
 use coral_api::v1::Workspace;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
-use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_SERVICE_MAX_MESSAGE_SIZE};
+use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
 use tonic::transport::{Channel, Endpoint};
 
 use crate::error::ClientError;
@@ -82,14 +82,8 @@ impl AppClient {
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
         let channel = endpoint.connect().await?;
         let source_client = SourceServiceClient::new(channel.clone());
-        // Bump the per-call message size limits above tonic's 4 MB default
-        // to fit large `ExecuteSql` responses produced by wide manifests
-        // such as `github.search_issues`. Both directions
-        // are set symmetrically — only decode is strictly required for
-        // the failing direction, but symmetry is clearer operationally.
         let query_client = QueryServiceClient::new(channel)
-            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
-            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
         Ok((source_client, query_client))
     }
 

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -3,6 +3,7 @@
 use coral_api::v1::Workspace;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
+use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_SERVICE_MAX_MESSAGE_SIZE};
 use tonic::transport::{Channel, Endpoint};
 
 use crate::error::ClientError;
@@ -77,12 +78,19 @@ impl AppClient {
     async fn connect_clients(
         endpoint_uri: &str,
     ) -> Result<(SourceClient, QueryClient), ClientError> {
-        let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?;
+        let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
+            .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
         let channel = endpoint.connect().await?;
-        Ok((
-            SourceServiceClient::new(channel.clone()),
-            QueryServiceClient::new(channel),
-        ))
+        let source_client = SourceServiceClient::new(channel.clone());
+        // Bump the per-call message size limits above tonic's 4 MB default
+        // to fit large `ExecuteSql` responses produced by wide manifests
+        // such as `github.search_issues`. Both directions
+        // are set symmetrically — only decode is strictly required for
+        // the failing direction, but symmetry is clearer operationally.
+        let query_client = QueryServiceClient::new(channel)
+            .max_decoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE)
+            .max_encoding_message_size(QUERY_SERVICE_MAX_MESSAGE_SIZE);
+        Ok((source_client, query_client))
     }
 
     pub(crate) async fn from_running_server(

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use datafusion::common::{Column, SchemaError};
 use datafusion::error::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
@@ -104,13 +103,9 @@ fn datafusion_to_core(error: &DataFusionError) -> CoreError {
             CoreError::NotFound(detail.clone())
         }
         DataFusionError::Plan(detail) => CoreError::InvalidInput(detail.clone()),
-        DataFusionError::SchemaError(schema_error, _) => match schema_error.as_ref() {
-            SchemaError::FieldNotFound {
-                field,
-                valid_fields,
-            } => CoreError::InvalidInput(format_field_not_found(field, valid_fields)),
-            other => CoreError::InvalidInput(other.to_string()),
-        },
+        DataFusionError::SchemaError(schema_error, _) => {
+            CoreError::InvalidInput(schema_error.to_string())
+        }
         DataFusionError::NotImplemented(detail) => CoreError::Unimplemented(detail.clone()),
         DataFusionError::External(inner) => {
             if let Some(provider_error) = inner.downcast_ref::<ProviderQueryError>() {
@@ -122,39 +117,6 @@ fn datafusion_to_core(error: &DataFusionError) -> CoreError {
         DataFusionError::ResourcesExhausted(detail) => CoreError::Unavailable(detail.clone()),
         other => CoreError::internal(other.to_string()),
     }
-}
-
-/// Format a `SchemaError::FieldNotFound` into a concise, hint-bearing
-/// `Status` detail. The full `valid_fields` list is deliberately *not*
-/// embedded in the message — on wide manifests (e.g. `github.search_issues`
-/// with ~561 columns) that list can exceed the HTTP/2 trailer size limit
-/// and trigger a `PROTOCOL_ERROR` before the CLI ever sees the status.
-/// Callers who want the full set of valid columns can query
-/// `coral.columns`.
-fn format_field_not_found(field: &Column, valid_fields: &[Column]) -> String {
-    let missing = field.name();
-    // Match a `__`-flattened counterpart by normalizing away underscores
-    // on both sides and requiring the candidate to actually contain `__`
-    // (i.e. be a flattened nested path). Catches the common `user_login`
-    // → `user__login` typo regardless of which underscore the user
-    // wrote as single vs. double.
-    let missing_squashed = missing.replace('_', "");
-    let nested_hint = valid_fields
-        .iter()
-        .find(|c| c.name().contains("__") && c.name().replace('_', "") == missing_squashed)
-        .map(|c| {
-            format!(
-                ". Did you mean `{}`? Nested JSON paths are flattened with `__`",
-                c.name(),
-            )
-        })
-        .unwrap_or_default();
-    format!(
-        "No field named `{}` ({} valid fields; query `coral.columns` for the list{})",
-        field.quoted_flat_name(),
-        valid_fields.len(),
-        nested_hint,
-    )
 }
 
 fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
@@ -193,36 +155,16 @@ fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
 mod tests {
     use super::*;
 
-    fn col(name: &str) -> Column {
-        Column::new_unqualified(name)
-    }
-
-    #[test]
-    fn format_field_not_found_emits_nested_hint_when_typo_matches_flattened_column() {
-        let msg = format_field_not_found(
-            &col("user_login"),
-            &[col("title"), col("user__login"), col("state")],
-        );
-        assert!(msg.contains("`user__login`"), "missing hint target: {msg}");
-        assert!(
-            msg.contains("Nested JSON paths are flattened with `__`"),
-            "missing hint explanation: {msg}"
-        );
-        assert!(msg.contains("3 valid fields"));
-    }
-
-    #[test]
-    fn format_field_not_found_omits_hint_when_no_flattened_match_exists() {
-        let msg = format_field_not_found(&col("bogus"), &[col("title"), col("state")]);
-        assert!(!msg.contains("Did you mean"), "unexpected hint: {msg}");
-        assert!(msg.contains("2 valid fields"));
-    }
-
     #[test]
     fn datafusion_to_core_unwraps_context_wrapped_schema_error_to_invalid_input() {
+        use datafusion::common::{Column, SchemaError};
+
         let schema_err = Box::new(SchemaError::FieldNotFound {
-            field: Box::new(col("user_login")),
-            valid_fields: vec![col("user__login"), col("title")],
+            field: Box::new(Column::new_unqualified("user_login")),
+            valid_fields: vec![
+                Column::new_unqualified("user__login"),
+                Column::new_unqualified("title"),
+            ],
         });
         let inner = DataFusionError::SchemaError(schema_err, Box::new(None));
         let wrapped = DataFusionError::Context("wrapping context".to_string(), Box::new(inner));
@@ -231,10 +173,7 @@ mod tests {
 
         match core {
             CoreError::InvalidInput(msg) => {
-                assert!(
-                    msg.contains("`user__login`"),
-                    "expected nested-field hint in: {msg}"
-                );
+                assert!(msg.contains("user_login"), "expected field name in: {msg}");
             }
             other => panic!("expected CoreError::InvalidInput, got {other:?}"),
         }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -100,6 +100,9 @@ fn datafusion_to_core(error: &DataFusionError) -> CoreError {
     // from the match arms below.
     match error.find_root() {
         DataFusionError::SQL(detail, _) => CoreError::InvalidInput(detail.to_string()),
+        DataFusionError::Plan(detail) if detail.contains("not found") => {
+            CoreError::NotFound(detail.clone())
+        }
         DataFusionError::Plan(detail) => CoreError::InvalidInput(detail.clone()),
         DataFusionError::SchemaError(schema_error, _) => match schema_error.as_ref() {
             SchemaError::FieldNotFound {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use datafusion::common::SchemaError;
+use datafusion::common::{Column, SchemaError};
 use datafusion::error::DataFusionError;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
@@ -27,7 +27,7 @@ pub(crate) async fn build_runtime(
         RuntimeEnvBuilder::new()
             .with_object_list_cache_limit(0)
             .build()
-            .map_err(datafusion_to_core)?,
+            .map_err(|err| datafusion_to_core(&err))?,
     );
     let ctx = Arc::new(SessionContext::new_with_config_rt(
         session_config,
@@ -48,8 +48,9 @@ pub(crate) async fn build_runtime(
     }
     let registration = register_sources(&ctx, compiled_sources)
         .await
-        .map_err(datafusion_to_core)?;
-    catalog::register(&ctx, &registration.active_sources).map_err(datafusion_to_core)?;
+        .map_err(|err| datafusion_to_core(&err))?;
+    catalog::register(&ctx, &registration.active_sources)
+        .map_err(|err| datafusion_to_core(&err))?;
     let tables = catalog::collect_tables(&registration.active_sources);
     for failure in &failures {
         tracing::warn!(
@@ -76,9 +77,9 @@ impl QueryRuntimeAdapter {
             .ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
-            .map_err(datafusion_to_core)?;
+            .map_err(|err| datafusion_to_core(&err))?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
-        let batches = df.collect().await.map_err(datafusion_to_core)?;
+        let batches = df.collect().await.map_err(|err| datafusion_to_core(&err))?;
         Ok(QueryExecution::new(arrow_schema, batches))
     }
 }
@@ -90,25 +91,67 @@ fn read_only_sql_options() -> SQLOptions {
         .with_allow_statements(false)
 }
 
-fn datafusion_to_core(error: DataFusionError) -> CoreError {
-    match error {
+fn datafusion_to_core(error: &DataFusionError) -> CoreError {
+    // Unwrap Context/Shared/Diagnostic wrappers so wrapped schema errors
+    // get classified by their root variant instead of all landing in the
+    // `Internal` bucket. Without `find_root()`, `SELECT bogus FROM wide`
+    // surfaces as `CoreError::Internal` because DataFusion wraps the
+    // SchemaError in `Context`/`Execution`, hiding the structured variant
+    // from the match arms below.
+    match error.find_root() {
         DataFusionError::SQL(detail, _) => CoreError::InvalidInput(detail.to_string()),
-        DataFusionError::Plan(detail) => CoreError::InvalidInput(detail),
+        DataFusionError::Plan(detail) => CoreError::InvalidInput(detail.clone()),
         DataFusionError::SchemaError(schema_error, _) => match schema_error.as_ref() {
-            SchemaError::FieldNotFound { field, .. } => CoreError::NotFound(field.to_string()),
-            _ => CoreError::InvalidInput(schema_error.to_string()),
+            SchemaError::FieldNotFound {
+                field,
+                valid_fields,
+            } => CoreError::InvalidInput(format_field_not_found(field, valid_fields)),
+            other => CoreError::InvalidInput(other.to_string()),
         },
-        DataFusionError::NotImplemented(detail) => CoreError::Unimplemented(detail),
+        DataFusionError::NotImplemented(detail) => CoreError::Unimplemented(detail.clone()),
         DataFusionError::External(inner) => {
             if let Some(provider_error) = inner.downcast_ref::<ProviderQueryError>() {
                 return provider_error_to_core(provider_error);
             }
             CoreError::internal(inner.to_string())
         }
-        DataFusionError::ObjectStore(error) => CoreError::Unavailable(error.to_string()),
-        DataFusionError::ResourcesExhausted(detail) => CoreError::Unavailable(detail),
+        DataFusionError::ObjectStore(err) => CoreError::Unavailable(err.to_string()),
+        DataFusionError::ResourcesExhausted(detail) => CoreError::Unavailable(detail.clone()),
         other => CoreError::internal(other.to_string()),
     }
+}
+
+/// Format a `SchemaError::FieldNotFound` into a concise, hint-bearing
+/// `Status` detail. The full `valid_fields` list is deliberately *not*
+/// embedded in the message — on wide manifests (e.g. `github.search_issues`
+/// with ~561 columns) that list can exceed the HTTP/2 trailer size limit
+/// and trigger a `PROTOCOL_ERROR` before the CLI ever sees the status.
+/// Callers who want the full set of valid columns can query
+/// `coral.columns`.
+fn format_field_not_found(field: &Column, valid_fields: &[Column]) -> String {
+    let missing = field.name();
+    // Match a `__`-flattened counterpart by normalizing away underscores
+    // on both sides and requiring the candidate to actually contain `__`
+    // (i.e. be a flattened nested path). Catches the common `user_login`
+    // → `user__login` typo regardless of which underscore the user
+    // wrote as single vs. double.
+    let missing_squashed = missing.replace('_', "");
+    let nested_hint = valid_fields
+        .iter()
+        .find(|c| c.name().contains("__") && c.name().replace('_', "") == missing_squashed)
+        .map(|c| {
+            format!(
+                ". Did you mean `{}`? Nested JSON paths are flattened with `__`",
+                c.name(),
+            )
+        })
+        .unwrap_or_default();
+    format!(
+        "No field named `{}` ({} valid fields; query `coral.columns` for the list{})",
+        field.quoted_flat_name(),
+        valid_fields.len(),
+        nested_hint,
+    )
 }
 
 fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
@@ -140,5 +183,57 @@ fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
             )),
             _ => CoreError::FailedPrecondition(detail.clone()),
         },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn col(name: &str) -> Column {
+        Column::new_unqualified(name)
+    }
+
+    #[test]
+    fn format_field_not_found_emits_nested_hint_when_typo_matches_flattened_column() {
+        let msg = format_field_not_found(
+            &col("user_login"),
+            &[col("title"), col("user__login"), col("state")],
+        );
+        assert!(msg.contains("`user__login`"), "missing hint target: {msg}");
+        assert!(
+            msg.contains("Nested JSON paths are flattened with `__`"),
+            "missing hint explanation: {msg}"
+        );
+        assert!(msg.contains("3 valid fields"));
+    }
+
+    #[test]
+    fn format_field_not_found_omits_hint_when_no_flattened_match_exists() {
+        let msg = format_field_not_found(&col("bogus"), &[col("title"), col("state")]);
+        assert!(!msg.contains("Did you mean"), "unexpected hint: {msg}");
+        assert!(msg.contains("2 valid fields"));
+    }
+
+    #[test]
+    fn datafusion_to_core_unwraps_context_wrapped_schema_error_to_invalid_input() {
+        let schema_err = Box::new(SchemaError::FieldNotFound {
+            field: Box::new(col("user_login")),
+            valid_fields: vec![col("user__login"), col("title")],
+        });
+        let inner = DataFusionError::SchemaError(schema_err, Box::new(None));
+        let wrapped = DataFusionError::Context("wrapping context".to_string(), Box::new(inner));
+
+        let core = datafusion_to_core(&wrapped);
+
+        match core {
+            CoreError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("`user__login`"),
+                    "expected nested-field hint in: {msg}"
+                );
+            }
+            other => panic!("expected CoreError::InvalidInput, got {other:?}"),
+        }
     }
 }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -99,9 +99,6 @@ fn datafusion_to_core(error: &DataFusionError) -> CoreError {
     // from the match arms below.
     match error.find_root() {
         DataFusionError::SQL(detail, _) => CoreError::InvalidInput(detail.to_string()),
-        DataFusionError::Plan(detail) if detail.contains("not found") => {
-            CoreError::NotFound(detail.clone())
-        }
         DataFusionError::Plan(detail) => CoreError::InvalidInput(detail.clone()),
         DataFusionError::SchemaError(schema_error, _) => {
             CoreError::InvalidInput(schema_error.to_string())

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -3,7 +3,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_internal, build_source, dir_url, execution_to_rows, write_jsonl_file,
+    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, write_jsonl_file,
 };
 
 fn users_manifest(dir: &std::path::Path) -> Value {
@@ -206,10 +206,7 @@ async fn query_nonexistent_schema_returns_error() {
         .await
         .expect_err("missing schema should fail");
 
-    assert_internal(
-        error,
-        "Error during planning: table 'datafusion.missing.users' not found",
-    );
+    assert_invalid_input(error, "table 'datafusion.missing.users' not found");
 }
 
 fn table_summary(table: &TableInfo) -> (String, String, String) {

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -3,7 +3,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_not_found, build_source, dir_url, execution_to_rows, write_jsonl_file,
+    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, write_jsonl_file,
 };
 
 fn users_manifest(dir: &std::path::Path) -> Value {
@@ -206,7 +206,7 @@ async fn query_nonexistent_schema_returns_error() {
         .await
         .expect_err("missing schema should fail");
 
-    assert_not_found(error, "table 'datafusion.missing.users' not found");
+    assert_invalid_input(error, "table 'datafusion.missing.users' not found");
 }
 
 fn table_summary(table: &TableInfo) -> (String, String, String) {

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -3,7 +3,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, write_jsonl_file,
+    TestRuntime, assert_not_found, build_source, dir_url, execution_to_rows, write_jsonl_file,
 };
 
 fn users_manifest(dir: &std::path::Path) -> Value {
@@ -206,7 +206,7 @@ async fn query_nonexistent_schema_returns_error() {
         .await
         .expect_err("missing schema should fail");
 
-    assert_invalid_input(error, "table 'datafusion.missing.users' not found");
+    assert_not_found(error, "table 'datafusion.missing.users' not found");
 }
 
 fn table_summary(table: &TableInfo) -> (String, String, String) {

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -58,14 +58,6 @@ pub(crate) fn assert_row_count(execution: &QueryExecution, expected: usize) {
     assert_eq!(execution_to_rows(execution).len(), expected);
 }
 
-pub(crate) fn assert_internal(error: CoreError, expected_detail: &str) {
-    assert_eq!(error.status_code(), StatusCode::Internal);
-    match error {
-        CoreError::Internal(detail) => assert_eq!(detail, expected_detail),
-        other => panic!("expected CoreError::Internal, got {other:?}"),
-    }
-}
-
 pub(crate) fn assert_invalid_input(error: CoreError, expected_detail: &str) {
     assert_eq!(error.status_code(), StatusCode::InvalidArgument);
     match error {

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -58,14 +58,6 @@ pub(crate) fn assert_row_count(execution: &QueryExecution, expected: usize) {
     assert_eq!(execution_to_rows(execution).len(), expected);
 }
 
-pub(crate) fn assert_not_found(error: CoreError, expected_detail: &str) {
-    assert_eq!(error.status_code(), StatusCode::NotFound);
-    match error {
-        CoreError::NotFound(detail) => assert_eq!(detail, expected_detail),
-        other => panic!("expected CoreError::NotFound, got {other:?}"),
-    }
-}
-
 pub(crate) fn assert_invalid_input(error: CoreError, expected_detail: &str) {
     assert_eq!(error.status_code(), StatusCode::InvalidArgument);
     match error {

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -58,6 +58,14 @@ pub(crate) fn assert_row_count(execution: &QueryExecution, expected: usize) {
     assert_eq!(execution_to_rows(execution).len(), expected);
 }
 
+pub(crate) fn assert_not_found(error: CoreError, expected_detail: &str) {
+    assert_eq!(error.status_code(), StatusCode::NotFound);
+    match error {
+        CoreError::NotFound(detail) => assert_eq!(detail, expected_detail),
+        other => panic!("expected CoreError::NotFound, got {other:?}"),
+    }
+}
+
 pub(crate) fn assert_invalid_input(error: CoreError, expected_detail: &str) {
     assert_eq!(error.status_code(), StatusCode::InvalidArgument);
     match error {

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_internal, assert_row_count, build_source, dir_url, execution_to_rows,
+    TestRuntime, assert_invalid_input, assert_row_count, build_source, dir_url, execution_to_rows,
     users_rows, write_jsonl_file,
 };
 
@@ -169,8 +169,5 @@ async fn missing_file_returns_error() {
             .await
             .expect_err("missing jsonl source should fail");
 
-    assert_internal(
-        error,
-        "Error during planning: table 'datafusion.jsonl_missing.users' not found",
-    );
+    assert_invalid_input(error, "table 'datafusion.jsonl_missing.users' not found");
 }

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, assert_row_count, build_source, dir_url, execution_to_rows,
+    TestRuntime, assert_not_found, assert_row_count, build_source, dir_url, execution_to_rows,
     users_rows, write_jsonl_file,
 };
 
@@ -169,5 +169,5 @@ async fn missing_file_returns_error() {
             .await
             .expect_err("missing jsonl source should fail");
 
-    assert_invalid_input(error, "table 'datafusion.jsonl_missing.users' not found");
+    assert_not_found(error, "table 'datafusion.jsonl_missing.users' not found");
 }

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_not_found, assert_row_count, build_source, dir_url, execution_to_rows,
+    TestRuntime, assert_invalid_input, assert_row_count, build_source, dir_url, execution_to_rows,
     users_rows, write_jsonl_file,
 };
 
@@ -169,5 +169,5 @@ async fn missing_file_returns_error() {
             .await
             .expect_err("missing jsonl source should fail");
 
-    assert_not_found(error, "table 'datafusion.jsonl_missing.users' not found");
+    assert_invalid_input(error, "table 'datafusion.jsonl_missing.users' not found");
 }

--- a/crates/coral-engine/tests/engine/parquet_tests.rs
+++ b/crates/coral-engine/tests/engine/parquet_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_internal, build_source, dir_url, execution_to_rows, users_batch,
+    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, users_batch,
     write_parquet_file,
 };
 
@@ -156,8 +156,5 @@ async fn missing_file_returns_error() {
     .await
     .expect_err("missing parquet source should fail");
 
-    assert_internal(
-        error,
-        "Error during planning: table 'datafusion.parquet_missing.users' not found",
-    );
+    assert_invalid_input(error, "table 'datafusion.parquet_missing.users' not found");
 }

--- a/crates/coral-engine/tests/engine/parquet_tests.rs
+++ b/crates/coral-engine/tests/engine/parquet_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_not_found, build_source, dir_url, execution_to_rows, users_batch,
+    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, users_batch,
     write_parquet_file,
 };
 
@@ -156,5 +156,5 @@ async fn missing_file_returns_error() {
     .await
     .expect_err("missing parquet source should fail");
 
-    assert_not_found(error, "table 'datafusion.parquet_missing.users' not found");
+    assert_invalid_input(error, "table 'datafusion.parquet_missing.users' not found");
 }

--- a/crates/coral-engine/tests/engine/parquet_tests.rs
+++ b/crates/coral-engine/tests/engine/parquet_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, users_batch,
+    TestRuntime, assert_not_found, build_source, dir_url, execution_to_rows, users_batch,
     write_parquet_file,
 };
 
@@ -156,5 +156,5 @@ async fn missing_file_returns_error() {
     .await
     .expect_err("missing parquet source should fail");
 
-    assert_invalid_input(error, "table 'datafusion.parquet_missing.users' not found");
+    assert_not_found(error, "table 'datafusion.parquet_missing.users' not found");
 }


### PR DESCRIPTION
## Summary

`coral sql` against wide manifests like `github.search_issues` surfaced as `h2 protocol error … PROTOCOL_ERROR` instead of a normal gRPC status. Two independent tonic 0.14 defaults on our in-process CLI ↔ server channel were too tight:

- **Response body:** `ExecuteSql` is unary and ships the full Arrow IPC stream in one message. Raised `QueryService` response message size limit to 64 MB (tonic default: 4 MB). Only the response direction is bumped — requests are small SQL strings.
- **Error trailers:** DataFusion's `"No field named X. Valid fields are …"` message enumerating ~391 field names overflowed HTTP/2 trailers (default `MAX_HEADER_LIST_SIZE` ~16 KiB), so the server emitted invalid trailers and the client's h2 stack reported `PROTOCOL_ERROR` before surfacing the intended status.

### Fixes

**Transport layer** (`coral-app`, `coral-client`, `coral-api`):

1. `QUERY_RESPONSE_MAX_MESSAGE_SIZE` (64 MB) — server encode only, client decode only.
2. `HTTP2_MAX_HEADER_LIST_SIZE` (128 KiB) — on server, production client, and test endpoints.
3. 4 KiB UTF-8-safe `truncate_status_detail` chokepoint in `app_status` and `core_status`.

**Semantic error mapping** (`coral-engine`):

4. `datafusion_to_core` now calls `DataFusionError::find_root()` to unwrap `Context`/`Shared` wrappers, so schema errors map to the correct `CoreError` variant instead of falling through to `Internal`.
5. `SchemaError` uses DataFusion's own `Display` — no custom formatting in the engine. The `truncate_status_detail` chokepoint in the app layer handles oversized messages. Presentation hints (discovery guidance, UX explanations) belong in the app/CLI/MCP layer, not the engine.

## Behavior changes

- Missing-column errors: `Code::Internal` → `Code::InvalidArgument` (via `find_root()` exposing the real `SchemaError`).
- Missing-table/schema errors: `Code::Internal` → `Code::InvalidArgument` (`Plan` errors now map to `InvalidInput`). The `NotFound` distinction for missing resources needs more thought and is deferred to a follow-up.
- Error detail strings from `Plan` errors no longer carry the `"Error during planning: "` prefix (matched on the variant directly).

## Before / after

| Query | Before | After |
|---|---|---|
| `SELECT bogus_column FROM github.search_issues LIMIT 0` | `h2 PROTOCOL_ERROR` | `InvalidArgument: No field named "bogus_column". Valid fields are …(truncated)` |
| `SELECT user_login FROM github.search_issues LIMIT 1` | `h2 PROTOCOL_ERROR` | Same clean error (hint can be added in app/MCP layer later) |
| `SELECT … user__login FROM github.search_issues WHERE q = 'NoSuchBucket' …` | `h2 PROTOCOL_ERROR` | Rows |
| `SELECT * FROM missing.table` | `Code::Internal` | `Code::InvalidArgument` |

## Known follow-up (not in this PR)

- Streaming `ExecuteSql` RPC to remove the 64 MB body ceiling entirely.
- App/MCP-layer "Did you mean?" hints and `coral.columns` discovery guidance for `InvalidArgument` schema errors.

## Test plan

- [x] Regression test: >4 MB `ExecuteSqlResponse` round-trips (asserts payload `> 4 * 1024 * 1024`).
- [x] Regression test: 600-column synthetic manifest + invalid column returns `Code::InvalidArgument` with `message.len() <= 4 KiB`, no PROTOCOL_ERROR.
- [x] Unit tests for `truncate_status_detail` (short passthrough, long ASCII + marker, UTF-8 boundary safety).
- [x] Unit test proving `find_root()` unwraps `Context`-wrapped `SchemaError` to `CoreError::InvalidInput`.
- [x] `cargo test --workspace` and `make rust-checks` green.