### PR TITLE
docs(reference): add pagerduty to bundled sources

### DIFF
--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -22,6 +22,7 @@ If the source you need is not available, you can extend Coral by [writing a cust
 | `launchdarkly` | `http`    | Projects, flags, environments, segments, and audit surfaces      |
 | `linear`       | `http`    | Teams, issues, projects, cycles, and initiatives                 |
 | `otel`         | `parquet` | OpenTelemetry logs and metrics exported as Parquet               |
+| `pagerduty`    | `http`    | Incidents, on-call schedules, services, users, and escalation data |
 | `sentry`       | `http`    | Projects, releases, deployments, and error monitoring data       |
 | `slack`        | `http`    | Channels, messages, and workspace users                          |
 | `statusgator`  | `http`    | Status boards, incidents, and uptime history                     |


### PR DESCRIPTION
## Why
The PagerDuty connector now ships as a bundled source, and `coral source discover` already exposes it in the CLI. The reference docs should list the same bundled sources so users can find PagerDuty from the canonical catalog page instead of only from the source folder.

## What changed
- add `pagerduty` to the bundled sources reference table
- describe it in the same style as the other shipped HTTP connectors

## Verification
- `cargo run -q -p coral-cli -- source discover`
