### PR TITLE
chore(ci): normalize pinned workflow action versions

### DIFF
--- a/.github/workflows/build-timings.yml
+++ b/.github/workflows/build-timings.yml
@@ -3,7 +3,7 @@ name: Build Timings
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: "0 6 * * *"
 
 permissions:
   actions: write
@@ -48,7 +48,7 @@ jobs:
           fi
 
       - name: Upload timings HTML report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: cargo-timings-${{ github.sha }}
@@ -56,7 +56,7 @@ jobs:
           retention-days: 30
 
       - name: Upload build output
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: build-output-${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         env:
           NEEDS_PREPARE_OUTPUTS_ARTIFACT_PREFIX: ${{ needs.prepare.outputs.artifact_prefix }}
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ needs.prepare.outputs.artifact_prefix }}-${{ matrix.target }}
           path: ${{ needs.prepare.outputs.artifact_prefix }}-${{ matrix.target }}.tar.gz
@@ -112,7 +112,7 @@ jobs:
         env:
           NEEDS_PREPARE_OUTPUTS_ARTIFACT_PREFIX: ${{ needs.prepare.outputs.artifact_prefix }}
       - name: Upload checksums
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: ${{ needs.prepare.outputs.artifact_prefix }}-checksums
           path: artifacts/checksums.sha256
@@ -132,7 +132,7 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub App token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
         id: github-app-token
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}


### PR DESCRIPTION
This PR fixes a number of [`ref-version-mismatch`](https://docs.zizmor.sh/audits/#ref-version-mismatch) violations in zizmor.

Note: to run these checks locally you need to give zizmor a github token, e.g.:

```bash
GH_TOKEN=$(gh auth token) zizmor .
```