### PR TITLE
fix(engine): correct stale X-RateLimit-Reset epoch handling

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1593,13 +1593,12 @@ mod tests {
         let now = UNIX_EPOCH + Duration::from_secs(1_700_000_100);
 
         // Reset happened 1 second ago (epoch 1_700_000_099)
-        headers.insert(
-            "X-RateLimit-Reset",
-            HeaderValue::from_static("1700000099"),
-        );
+        headers.insert("X-RateLimit-Reset", HeaderValue::from_static("1700000099"));
 
         let wait = rate_limit_wait_secs(&headers, now);
-        assert_eq!(wait, 0, "past epoch means reset already happened; wait should be 0");
+        assert_eq!(
+            wait, 0,
+            "past epoch means reset already happened; wait should be 0"
+        );
     }
-
 }

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -521,13 +521,9 @@ fn parse_retry_after(headers: &HeaderMap, now: SystemTime) -> Option<u64> {
 
 fn parse_rate_limit_reset(headers: &HeaderMap, now: SystemTime) -> Option<u64> {
     let value = headers.get("X-RateLimit-Reset")?.to_str().ok()?.trim();
-    let parsed = value.parse::<u64>().ok()?;
+    let reset_epoch = value.parse::<u64>().ok()?;
     let now_epoch = now.duration_since(UNIX_EPOCH).ok()?.as_secs();
-    Some(if parsed > now_epoch {
-        parsed.saturating_sub(now_epoch)
-    } else {
-        parsed
-    })
+    Some(reset_epoch.saturating_sub(now_epoch))
 }
 
 fn http_method_label(method: HttpMethod) -> &'static str {
@@ -1064,7 +1060,7 @@ fn extract_next_link_url(
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
-    use std::time::Duration;
+    use std::time::{Duration, UNIX_EPOCH};
 
     use reqwest::header::{HeaderMap, HeaderValue};
     use serde_json::json;
@@ -1074,7 +1070,7 @@ mod tests {
     use super::{
         HttpSourceClient, PageState, RequestSpec as HttpRequestSpec, apply_pagination_query_pairs,
         execute_request, extract_next_link_url, extract_rows, join_url, normalize_base_url,
-        page_is_exhausted, resolve_value_source,
+        page_is_exhausted, rate_limit_wait_secs, resolve_value_source,
     };
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
@@ -1588,4 +1584,22 @@ mod tests {
         assert!(error.to_string().contains("timed out"));
         task.abort();
     }
+
+    #[test]
+    fn stale_rate_limit_reset_epoch_should_not_wait() {
+        // When X-RateLimit-Reset is an epoch timestamp that already passed,
+        // the rate-limit window has reset — we should retry immediately.
+        let mut headers = HeaderMap::new();
+        let now = UNIX_EPOCH + Duration::from_secs(1_700_000_100);
+
+        // Reset happened 1 second ago (epoch 1_700_000_099)
+        headers.insert(
+            "X-RateLimit-Reset",
+            HeaderValue::from_static("1700000099"),
+        );
+
+        let wait = rate_limit_wait_secs(&headers, now);
+        assert_eq!(wait, 0, "past epoch means reset already happened; wait should be 0");
+    }
+
 }


### PR DESCRIPTION
## Summary
Fix `parse_rate_limit_reset` so that a past `X-RateLimit-Reset` epoch
timestamp results in an immediate retry instead of a 300-second stall.

## Why
`X-RateLimit-Reset` is a Unix epoch timestamp indicating when the
rate-limit window resets. When this timestamp is in the past (common
under network latency or clock skew), the old code returned the raw
epoch value as seconds-to-wait — e.g. 1.7 billion — which got capped
at the 300s maximum. Queries that should retry instantly would hang
for up to 5 minutes per attempt (25 minutes worst-case across 5
retries).

## What changed
- Replace the future/past branching in `parse_rate_limit_reset` with
  a single `saturating_sub`: future epochs compute the delta, past
  epochs saturate to 0.
- Add a regression test that asserts a past epoch produces a 0-second
  wait.