### PR TITLE
feat(engine): emit AIP-193 structured errors for provider failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "tonic",
+ "tonic-types",
  "tracing",
 ]
 

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -22,6 +22,7 @@ tokio-stream = { workspace = true, features = ["net"] }
 toml.workspace = true
 toml_edit.workspace = true
 tonic.workspace = true
+tonic-types.workspace = true
 tracing.workspace = true
 
 coral-api.workspace = true

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -95,22 +95,47 @@ pub(crate) fn app_status(error: AppError) -> Status {
 pub(crate) fn core_status(error: CoreError) -> Status {
     match error {
         CoreError::Structured(sqe) => {
-            let mut details: Vec<ErrorDetail> =
-                vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
-                    sqe.reason(),
-                    CORAL_ERROR_DOMAIN,
-                    sqe.metadata().clone(),
-                ))];
+            let mut metadata = sqe.metadata().clone();
+            metadata.insert("summary".to_string(), sqe.summary().to_string());
+            if !sqe.detail().is_empty() {
+                metadata.insert("detail".to_string(), sqe.detail().to_string());
+            }
+            if let Some(hint) = sqe.hint() {
+                metadata.insert("hint".to_string(), hint.to_string());
+            }
+
+            let mut details: Vec<ErrorDetail> = vec![ErrorDetail::ErrorInfo(
+                tonic_types::ErrorInfo::new(sqe.reason(), CORAL_ERROR_DOMAIN, metadata),
+            )];
             if sqe.retryable() {
                 details.push(ErrorDetail::RetryInfo(tonic_types::RetryInfo::new(None)));
             }
-            Status::with_error_details_vec(grpc_code(sqe.status()), sqe.plain_message(), details)
+
+            let plain = render_plain_message(sqe.summary(), sqe.detail(), sqe.hint());
+            Status::with_error_details_vec(
+                grpc_code(sqe.status()),
+                truncate_status_detail(plain),
+                details,
+            )
         }
         other => Status::new(
             grpc_code(other.status_code()),
             truncate_status_detail(other.to_string()),
         ),
     }
+}
+
+fn render_plain_message(summary: &str, detail: &str, hint: Option<&str>) -> String {
+    let mut message = summary.to_string();
+    if !detail.is_empty() {
+        message.push('\n');
+        message.push_str(detail);
+    }
+    if let Some(hint) = hint {
+        message.push_str("\nHint: ");
+        message.push_str(hint);
+    }
+    message
 }
 
 fn grpc_code(status: StatusCode) -> Code {

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -2,6 +2,7 @@
 
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::state::CredentialsError;
 
@@ -88,10 +89,24 @@ pub(crate) fn app_status(error: AppError) -> Status {
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn core_status(error: CoreError) -> Status {
-    Status::new(
-        grpc_code(error.status_code()),
-        truncate_status_detail(error.to_string()),
-    )
+    match error {
+        CoreError::Structured(sqe) => {
+            let mut details: Vec<ErrorDetail> =
+                vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                    sqe.reason(),
+                    "coral.withcoral.com",
+                    sqe.metadata().clone(),
+                ))];
+            if sqe.retryable() {
+                details.push(ErrorDetail::RetryInfo(tonic_types::RetryInfo::new(None)));
+            }
+            Status::with_error_details_vec(grpc_code(sqe.status()), sqe.plain_message(), details)
+        }
+        other => Status::new(
+            grpc_code(other.status_code()),
+            truncate_status_detail(other.to_string()),
+        ),
+    }
 }
 
 fn grpc_code(status: StatusCode) -> Code {

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -98,7 +98,10 @@ pub(crate) fn core_status(error: CoreError) -> Status {
             let mut metadata = sqe.metadata().clone();
             metadata.insert("summary".to_string(), sqe.summary().to_string());
             if !sqe.detail().is_empty() {
-                metadata.insert("detail".to_string(), sqe.detail().to_string());
+                metadata.insert(
+                    "detail".to_string(),
+                    truncate_status_detail(sqe.detail().to_string()),
+                );
             }
             if let Some(hint) = sqe.hint() {
                 metadata.insert("hint".to_string(), hint.to_string());

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -6,6 +6,10 @@ use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::state::CredentialsError;
 
+/// Coral error domain for `google.rpc.ErrorInfo`.
+/// Matches `coral_client::CORAL_ERROR_DOMAIN`.
+const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
+
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
@@ -94,7 +98,7 @@ pub(crate) fn core_status(error: CoreError) -> Status {
             let mut details: Vec<ErrorDetail> =
                 vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
                     sqe.reason(),
-                    "coral.withcoral.com",
+                    CORAL_ERROR_DOMAIN,
                     sqe.metadata().clone(),
                 ))];
             if sqe.retryable() {

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -94,7 +94,7 @@ pub(crate) fn app_status(error: AppError) -> Status {
 )]
 pub(crate) fn core_status(error: CoreError) -> Status {
     match error {
-        CoreError::Structured(sqe) => {
+        CoreError::QueryFailure(sqe) => {
             let mut metadata = sqe.metadata().clone();
             metadata.insert("summary".to_string(), sqe.summary().to_string());
             if !sqe.detail().is_empty() {

--- a/crates/coral-client/src/status_error.rs
+++ b/crates/coral-client/src/status_error.rs
@@ -25,19 +25,22 @@ pub enum DecodedStatusError {
 
 /// Structured Coral query error extracted from AIP-193 status details.
 ///
-/// Populated by reading `ErrorInfo` (reason, domain, metadata) and
-/// checking for `RetryInfo` presence from the server-attached details.
-/// The `message` field comes from `Status::message()`, which the server
-/// sets to the plain-text fallback rendering.
+/// First-class `summary`, `detail`, and `hint` fields are extracted from
+/// `ErrorInfo.metadata` during decoding. The remaining metadata (source,
+/// table, field, `http_status`, etc.) stays in the `metadata` map.
 pub struct CoralQueryError {
     /// Machine-readable error reason (e.g. `"MISSING_REQUIRED_FILTER"`).
     pub reason: String,
-    /// Key-value metadata from `ErrorInfo.metadata`. Contains structured
-    /// fields like `schema`, `table`, `field`, `source`, `http_status`,
-    /// `http_method`, `url`, `hint`, `detail`.
-    pub metadata: HashMap<String, String>,
+    /// One-line error summary.
+    pub summary: String,
+    /// Longer explanation (may be empty).
+    pub detail: String,
+    /// Actionable recovery guidance.
+    pub hint: Option<String>,
     /// Whether the error is transient and retrying may succeed.
     pub retryable: bool,
+    /// Additional metadata (source, table, field, `http_status`, etc.).
+    pub metadata: HashMap<String, String>,
     /// The plain-text message from `Status::message()`.
     pub message: String,
 }
@@ -76,12 +79,23 @@ pub fn decode_status_error(status: &tonic::Status) -> DecodedStatusError {
     }
 
     match error_info {
-        Some(info) => DecodedStatusError::Structured(Box::new(CoralQueryError {
-            reason: info.reason,
-            metadata: info.metadata,
-            retryable,
-            message: status.message().to_string(),
-        })),
+        Some(info) => {
+            let mut metadata = info.metadata;
+            let summary = metadata
+                .remove("summary")
+                .unwrap_or_else(|| status.message().to_string());
+            let detail = metadata.remove("detail").unwrap_or_default();
+            let hint = metadata.remove("hint");
+            DecodedStatusError::Structured(Box::new(CoralQueryError {
+                reason: info.reason,
+                summary,
+                detail,
+                hint,
+                retryable,
+                metadata,
+                message: status.message().to_string(),
+            }))
+        }
         None => DecodedStatusError::Plain(status.message().to_string()),
     }
 }
@@ -155,6 +169,10 @@ mod tests {
                 ("schema", "github"),
                 ("table", "issues"),
                 ("field", "repo"),
+                (
+                    "summary",
+                    "github.issues requires `WHERE repo = <constant>`",
+                ),
                 ("hint", "Add a constant equality filter on `repo`."),
             ],
             false,
@@ -162,14 +180,24 @@ mod tests {
         match decode_status_error(&status) {
             DecodedStatusError::Structured(err) => {
                 assert_eq!(err.reason, "MISSING_REQUIRED_FILTER");
+                assert_eq!(
+                    err.summary,
+                    "github.issues requires `WHERE repo = <constant>`"
+                );
+                assert_eq!(
+                    err.hint.as_deref(),
+                    Some("Add a constant equality filter on `repo`.")
+                );
                 assert_eq!(err.metadata.get("schema").unwrap(), "github");
                 assert_eq!(err.metadata.get("table").unwrap(), "issues");
                 assert_eq!(err.metadata.get("field").unwrap(), "repo");
                 assert!(
-                    err.metadata
-                        .get("hint")
-                        .unwrap()
-                        .contains("equality filter")
+                    !err.metadata.contains_key("summary"),
+                    "summary promoted out of metadata"
+                );
+                assert!(
+                    !err.metadata.contains_key("hint"),
+                    "hint promoted out of metadata"
                 );
                 assert!(!err.retryable);
                 assert_eq!(err.message, "test message");
@@ -195,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn metadata_carries_all_structured_fields() {
+    fn metadata_carries_provider_fields_and_promotes_presentation() {
         let status = build_coral_status(
             "PROVIDER_REQUEST_FAILED",
             vec![
@@ -204,6 +232,7 @@ mod tests {
                 ("http_status", "401"),
                 ("http_method", "GET"),
                 ("url", "https://api.github.com/repos/coral/coral/issues"),
+                ("summary", "Source authentication failed (401)"),
                 ("hint", "Re-install the source to refresh credentials."),
                 ("detail", "bad credentials"),
             ],
@@ -211,11 +240,15 @@ mod tests {
         );
         match decode_status_error(&status) {
             DecodedStatusError::Structured(err) => {
+                assert_eq!(err.summary, "Source authentication failed (401)");
+                assert_eq!(err.detail, "bad credentials");
+                assert!(err.hint.as_deref().unwrap().contains("Re-install"));
                 assert_eq!(err.metadata.get("source").unwrap(), "github");
                 assert_eq!(err.metadata.get("http_status").unwrap(), "401");
                 assert_eq!(err.metadata.get("http_method").unwrap(), "GET");
-                assert!(err.metadata.get("hint").unwrap().contains("Re-install"));
-                assert_eq!(err.metadata.get("detail").unwrap(), "bad credentials");
+                assert!(!err.metadata.contains_key("summary"));
+                assert!(!err.metadata.contains_key("detail"));
+                assert!(!err.metadata.contains_key("hint"));
             }
             DecodedStatusError::Plain(_) => panic!("expected Structured"),
         }

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -1,4 +1,8 @@
-//! Error types specific to HTTP-backed source queries.
+//! Error types and structured error mapping for HTTP-backed source queries.
+
+use std::collections::HashMap;
+
+use crate::contracts::{StatusCode, StructuredQueryError};
 
 /// Structured query-time failures for HTTP-backed tables.
 #[derive(Debug, thiserror::Error)]
@@ -30,4 +34,349 @@ pub(crate) enum ProviderQueryError {
         url: Option<String>,
         detail: String,
     },
+}
+
+// ---------------------------------------------------------------------------
+// Mapping: ProviderQueryError → StructuredQueryError
+// ---------------------------------------------------------------------------
+
+impl ProviderQueryError {
+    /// Converts this HTTP-specific error into the canonical structured error.
+    pub(crate) fn to_structured(&self) -> StructuredQueryError {
+        match self {
+            Self::MissingRequiredFilter {
+                schema,
+                table,
+                field,
+            } => {
+                let mut metadata = HashMap::new();
+                metadata.insert("schema".to_string(), schema.clone());
+                metadata.insert("table".to_string(), table.clone());
+                metadata.insert("field".to_string(), field.clone());
+                StructuredQueryError::new(
+                    "MISSING_REQUIRED_FILTER",
+                    format!("{schema}.{table} requires `WHERE {field} = <constant>`"),
+                    format!("{schema}.{table} requires a constant equality filter on {field}"),
+                    Some(format!(
+                        "Add a constant equality filter on `{field}` or inspect \
+                         `coral.columns` / `coral.tables` first."
+                    )),
+                    false,
+                    StatusCode::FailedPrecondition,
+                    metadata,
+                )
+            }
+            Self::ApiRequest {
+                source_schema,
+                table,
+                status,
+                method,
+                url,
+                detail,
+            } => http_request_to_structured(
+                source_schema,
+                table,
+                *status,
+                method.as_deref(),
+                url.as_deref(),
+                detail,
+            ),
+            Self::RateLimited {
+                source_schema,
+                table,
+                method,
+                url,
+                detail,
+            } => http_request_to_structured(
+                source_schema,
+                table,
+                Some(429),
+                method.as_deref(),
+                url.as_deref(),
+                detail,
+            ),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP status dispatch
+// ---------------------------------------------------------------------------
+
+fn http_request_to_structured(
+    source: &str,
+    table: &str,
+    http_status: Option<u16>,
+    method: Option<&str>,
+    url: Option<&str>,
+    raw_detail: &str,
+) -> StructuredQueryError {
+    let source_shell = shell_arg(source);
+    let sanitized_url = url.and_then(sanitize_request_url);
+
+    let (reason, summary, hint, status) = match http_status {
+        Some(400) => (
+            "INVALID_QUERY_SHAPE",
+            "Source rejected the request".to_string(),
+            Some(
+                "Adjust the query filters or shape to match the target table's supported inputs."
+                    .to_string(),
+            ),
+            StatusCode::InvalidArgument,
+        ),
+        Some(401) => (
+            "PROVIDER_REQUEST_FAILED",
+            "Source authentication failed".to_string(),
+            Some(format!(
+                "Credentials for this source are invalid or expired. Re-install it to refresh: \
+                 `coral source add {source_shell}` for bundled sources, or \
+                 `coral source add --file <manifest-path>` for imported sources."
+            )),
+            StatusCode::FailedPrecondition,
+        ),
+        Some(403) => (
+            "PROVIDER_REQUEST_FAILED",
+            "Source request was rejected".to_string(),
+            Some(
+                "Check the configured credentials and whether they have access to this resource."
+                    .to_string(),
+            ),
+            StatusCode::FailedPrecondition,
+        ),
+        Some(404) => (
+            "PROVIDER_REQUEST_FAILED",
+            "Source resource was not found".to_string(),
+            Some(
+                "Verify the identifier or filter values you passed; the upstream resource was not found."
+                    .to_string(),
+            ),
+            StatusCode::NotFound,
+        ),
+        Some(429) => (
+            "PROVIDER_REQUEST_FAILED",
+            "Source rate limit exceeded".to_string(),
+            Some(
+                "The upstream API is rate-limiting requests. Wait briefly and retry.".to_string(),
+            ),
+            StatusCode::Unavailable,
+        ),
+        Some(s) if (500..600).contains(&s) => (
+            "PROVIDER_REQUEST_FAILED",
+            "Source server error".to_string(),
+            Some(
+                "The upstream API returned a server error. This may be transient — retry after a brief wait."
+                    .to_string(),
+            ),
+            StatusCode::Unavailable,
+        ),
+        _ => (
+            "PROVIDER_REQUEST_FAILED",
+            "Source request failed".to_string(),
+            None,
+            StatusCode::FailedPrecondition,
+        ),
+    };
+
+    let summary = match http_status {
+        Some(s) => format!("{summary} ({s})"),
+        None => summary,
+    };
+    let detail = enrich_provider_detail(raw_detail, method, sanitized_url.as_deref());
+    let is_retryable = matches!(http_status, Some(429 | 500..=599));
+
+    let mut metadata = HashMap::new();
+    metadata.insert("source".to_string(), source.to_string());
+    metadata.insert("table".to_string(), table.to_string());
+    if let Some(s) = http_status {
+        metadata.insert("http_status".to_string(), s.to_string());
+    }
+    if let Some(m) = method {
+        metadata.insert("http_method".to_string(), m.to_string());
+    }
+    if let Some(u) = &sanitized_url {
+        metadata.insert("url".to_string(), u.clone());
+    }
+
+    StructuredQueryError::new(
+        reason,
+        summary,
+        detail,
+        hint,
+        is_retryable,
+        status,
+        metadata,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+fn shell_arg(value: &str) -> String {
+    let is_safe = !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'));
+    if is_safe {
+        value.to_string()
+    } else {
+        let escaped = value.replace('\'', "'\\''");
+        format!("'{escaped}'")
+    }
+}
+
+fn sanitize_request_url(raw: &str) -> Option<String> {
+    let without_fragment = raw.split_once('#').map_or(raw, |(before, _)| before);
+    let without_query = without_fragment
+        .split_once('?')
+        .map_or(without_fragment, |(before, _)| before);
+    let (scheme, rest) = without_query.split_once("://")?;
+    if scheme.is_empty() || rest.is_empty() {
+        return None;
+    }
+    let (authority, path) = rest.split_once('/').map_or((rest, ""), |(a, p)| (a, p));
+    let host_and_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if host_and_port.is_empty() {
+        return None;
+    }
+    if path.is_empty() {
+        Some(format!("{scheme}://{host_and_port}"))
+    } else {
+        Some(format!("{scheme}://{host_and_port}/{path}"))
+    }
+}
+
+fn enrich_provider_detail(detail: &str, method: Option<&str>, url: Option<&str>) -> String {
+    match (method, url) {
+        (Some(method), Some(url)) => format!("{detail} [{method}] {url}"),
+        (Some(method), None) => format!("{detail} [{method}]"),
+        (None, Some(url)) => format!("{detail} {url}"),
+        (None, None) => detail.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::contracts::StatusCode;
+
+    use super::ProviderQueryError;
+
+    #[test]
+    fn missing_required_filter_sets_reason_and_metadata() {
+        let error = ProviderQueryError::MissingRequiredFilter {
+            schema: "github".to_string(),
+            table: "issues".to_string(),
+            field: "repo".to_string(),
+        }
+        .to_structured();
+        assert_eq!(error.reason(), "MISSING_REQUIRED_FILTER");
+        assert_eq!(error.metadata().get("schema").unwrap(), "github");
+        assert_eq!(error.metadata().get("table").unwrap(), "issues");
+        assert_eq!(error.metadata().get("field").unwrap(), "repo");
+        assert!(error.summary().contains("repo"));
+        assert!(error.hint().is_some());
+        assert_eq!(error.status(), StatusCode::FailedPrecondition);
+    }
+
+    #[test]
+    fn http_401_includes_both_install_paths() {
+        let error = ProviderQueryError::ApiRequest {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            status: Some(401),
+            method: Some("GET".to_string()),
+            url: Some("https://api.github.com/repos/coral/coral/issues".to_string()),
+            detail: "Bad credentials".to_string(),
+        }
+        .to_structured();
+        assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.metadata().get("http_status").unwrap(), "401");
+        assert!(!error.retryable());
+        let hint = error.hint().expect("401 should have a hint");
+        assert!(hint.contains("coral source add github"));
+        assert!(hint.contains("coral source add --file"));
+    }
+
+    #[test]
+    fn http_400_maps_to_invalid_argument() {
+        let error = ProviderQueryError::ApiRequest {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            status: Some(400),
+            method: None,
+            url: None,
+            detail: "bad request".to_string(),
+        }
+        .to_structured();
+        assert_eq!(error.reason(), "INVALID_QUERY_SHAPE");
+        assert_eq!(error.status(), StatusCode::InvalidArgument);
+    }
+
+    #[test]
+    fn http_500_is_retryable() {
+        let error = ProviderQueryError::ApiRequest {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            status: Some(500),
+            method: None,
+            url: None,
+            detail: "boom".to_string(),
+        }
+        .to_structured();
+        assert!(error.retryable());
+        assert_eq!(error.status(), StatusCode::Unavailable);
+    }
+
+    #[test]
+    fn redacts_secret_query_params_from_url() {
+        let error = ProviderQueryError::ApiRequest {
+            source_schema: "datadog".to_string(),
+            table: "events".to_string(),
+            status: Some(500),
+            method: Some("GET".to_string()),
+            url: Some("https://api.datadoghq.eu/api/v1/events?api_key=SECRET".to_string()),
+            detail: "boom".to_string(),
+        }
+        .to_structured();
+        let url = error
+            .metadata()
+            .get("url")
+            .expect("url should be sanitized");
+        assert_eq!(url, "https://api.datadoghq.eu/api/v1/events");
+        assert!(!error.detail().contains("SECRET"));
+    }
+
+    #[test]
+    fn detail_preserves_method_and_sanitized_url() {
+        let error = ProviderQueryError::ApiRequest {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            status: Some(500),
+            method: Some("GET".to_string()),
+            url: Some("https://api.github.com/issues?page=3".to_string()),
+            detail: "upstream boom".to_string(),
+        }
+        .to_structured();
+        assert!(
+            error
+                .detail()
+                .contains("[GET] https://api.github.com/issues")
+        );
+        assert!(!error.detail().contains("page=3"));
+    }
+
+    #[test]
+    fn display_renders_full_message() {
+        let error = ProviderQueryError::MissingRequiredFilter {
+            schema: "github".to_string(),
+            table: "issues".to_string(),
+            field: "repo".to_string(),
+        }
+        .to_structured();
+        let text = error.to_string();
+        assert!(text.contains(error.summary()));
+        assert!(text.contains("Hint: "));
+    }
 }

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -2,7 +2,18 @@
 
 use std::collections::HashMap;
 
+use reqwest::StatusCode as HttpStatus;
+
 use crate::contracts::{StatusCode, StructuredQueryError};
+
+// Named bindings for the HTTP status codes the dispatch table matches
+// against. Declared as `const` so they can appear directly in match arm
+// patterns — the raw numeric literals read as magic; these do not.
+const BAD_REQUEST: u16 = HttpStatus::BAD_REQUEST.as_u16();
+const UNAUTHORIZED: u16 = HttpStatus::UNAUTHORIZED.as_u16();
+const FORBIDDEN: u16 = HttpStatus::FORBIDDEN.as_u16();
+const NOT_FOUND: u16 = HttpStatus::NOT_FOUND.as_u16();
+const TOO_MANY_REQUESTS: u16 = HttpStatus::TOO_MANY_REQUESTS.as_u16();
 
 /// Structured query-time failures for HTTP-backed tables.
 #[derive(Debug, thiserror::Error)]
@@ -90,7 +101,7 @@ impl ProviderQueryError {
             } => http_request_to_structured(
                 source_schema,
                 table,
-                Some(429),
+                Some(TOO_MANY_REQUESTS),
                 method.as_deref(),
                 url.as_deref(),
                 detail,
@@ -115,7 +126,7 @@ fn http_request_to_structured(
     let sanitized_url = url.and_then(sanitize_request_url);
 
     let (reason, summary, hint, status) = match http_status {
-        Some(400) => (
+        Some(BAD_REQUEST) => (
             "INVALID_QUERY_SHAPE",
             "Source rejected the request".to_string(),
             Some(
@@ -124,7 +135,7 @@ fn http_request_to_structured(
             ),
             StatusCode::InvalidArgument,
         ),
-        Some(401) => (
+        Some(UNAUTHORIZED) => (
             "PROVIDER_REQUEST_FAILED",
             "Source authentication failed".to_string(),
             Some(format!(
@@ -134,7 +145,7 @@ fn http_request_to_structured(
             )),
             StatusCode::FailedPrecondition,
         ),
-        Some(403) => (
+        Some(FORBIDDEN) => (
             "PROVIDER_REQUEST_FAILED",
             "Source request was rejected".to_string(),
             Some(
@@ -143,7 +154,7 @@ fn http_request_to_structured(
             ),
             StatusCode::FailedPrecondition,
         ),
-        Some(404) => (
+        Some(NOT_FOUND) => (
             "PROVIDER_REQUEST_FAILED",
             "Source resource was not found".to_string(),
             Some(
@@ -152,7 +163,7 @@ fn http_request_to_structured(
             ),
             StatusCode::NotFound,
         ),
-        Some(429) => (
+        Some(TOO_MANY_REQUESTS) => (
             "PROVIDER_REQUEST_FAILED",
             "Source rate limit exceeded".to_string(),
             Some(
@@ -160,7 +171,7 @@ fn http_request_to_structured(
             ),
             StatusCode::Unavailable,
         ),
-        Some(s) if (500..600).contains(&s) => (
+        Some(s) if is_server_error(s) => (
             "PROVIDER_REQUEST_FAILED",
             "Source server error".to_string(),
             Some(
@@ -182,7 +193,8 @@ fn http_request_to_structured(
         None => summary,
     };
     let detail = enrich_provider_detail(raw_detail, method, sanitized_url.as_deref());
-    let is_retryable = matches!(http_status, Some(429 | 500..=599));
+    let is_retryable =
+        matches!(http_status, Some(s) if s == TOO_MANY_REQUESTS || is_server_error(s));
 
     let mut metadata = HashMap::new();
     metadata.insert("source".to_string(), source.to_string());
@@ -206,6 +218,11 @@ fn http_request_to_structured(
         status,
         metadata,
     )
+}
+
+/// Returns `true` when the given status belongs to the 5xx server-error class.
+fn is_server_error(status: u16) -> bool {
+    HttpStatus::from_u16(status).is_ok_and(|code| code.is_server_error())
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/coral-engine/src/contracts/error.rs
+++ b/crates/coral-engine/src/contracts/error.rs
@@ -1,8 +1,8 @@
 //! Stable transport-neutral error contract for `coral-engine`.
 
-use std::collections::HashMap;
-
 use thiserror::Error;
+
+pub use super::query_error::StructuredQueryError;
 
 /// Errors surfaced by the query layer.
 #[derive(Debug, Clone, Error)]
@@ -25,109 +25,9 @@ pub enum CoreError {
     /// The service failed internally.
     #[error("internal: {0}")]
     Internal(String),
-    /// A structured query failure produced at the engine or backend layer.
-    ///
-    /// Construction is restricted to `coral-engine` via the `pub(crate)`
-    /// constructor on [`StructuredQueryError`]. The app boundary reads
-    /// the plain Rust data via getters and encodes it as AIP-193 standard
-    /// error details.
+    /// A structured query failure with first-class semantic fields.
     #[error("{_0}")]
     Structured(Box<StructuredQueryError>),
-}
-
-/// Opaque wrapper around a structured query failure.
-///
-/// Fields are private. External crates read them via getters; only
-/// `coral-engine` can construct instances (the constructor is `pub(crate)`).
-/// All fields are plain Rust data — no protobuf types — so `coral-engine`
-/// stays transport-neutral. The app boundary owns transport encoding
-/// (AIP-193 wire format) and plain-text rendering.
-#[derive(Debug, Clone)]
-pub struct StructuredQueryError {
-    reason: String,
-    summary: String,
-    detail: String,
-    hint: Option<String>,
-    retryable: bool,
-    status: StatusCode,
-    metadata: HashMap<String, String>,
-}
-
-impl StructuredQueryError {
-    pub(crate) fn new(
-        reason: &str,
-        summary: String,
-        detail: String,
-        hint: Option<String>,
-        retryable: bool,
-        status: StatusCode,
-        metadata: HashMap<String, String>,
-    ) -> Self {
-        Self {
-            reason: reason.to_string(),
-            summary,
-            detail,
-            hint,
-            retryable,
-            status,
-            metadata,
-        }
-    }
-
-    /// Machine-readable error reason (e.g. `"MISSING_REQUIRED_FILTER"`).
-    #[must_use]
-    pub fn reason(&self) -> &str {
-        &self.reason
-    }
-
-    /// One-line error summary.
-    #[must_use]
-    pub fn summary(&self) -> &str {
-        &self.summary
-    }
-
-    /// Longer explanation (may be empty).
-    #[must_use]
-    pub fn detail(&self) -> &str {
-        &self.detail
-    }
-
-    /// Actionable recovery guidance.
-    #[must_use]
-    pub fn hint(&self) -> Option<&str> {
-        self.hint.as_deref()
-    }
-
-    /// Whether the error is transient (maps to `RetryInfo` presence).
-    #[must_use]
-    pub fn retryable(&self) -> bool {
-        self.retryable
-    }
-
-    /// Transport-neutral status code.
-    #[must_use]
-    pub fn status(&self) -> StatusCode {
-        self.status
-    }
-
-    /// Additional key-value metadata (source, table, field, `http_status`, etc.).
-    #[must_use]
-    pub fn metadata(&self) -> &HashMap<String, String> {
-        &self.metadata
-    }
-}
-
-impl std::fmt::Display for StructuredQueryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.summary)?;
-        if !self.detail.is_empty() {
-            write!(f, "\n{}", self.detail)?;
-        }
-        if let Some(hint) = &self.hint {
-            write!(f, "\nHint: {hint}")?;
-        }
-        Ok(())
-    }
 }
 
 impl CoreError {

--- a/crates/coral-engine/src/contracts/error.rs
+++ b/crates/coral-engine/src/contracts/error.rs
@@ -1,5 +1,7 @@
 //! Stable transport-neutral error contract for `coral-engine`.
 
+use std::collections::HashMap;
+
 use thiserror::Error;
 
 /// Errors surfaced by the query layer.
@@ -23,6 +25,77 @@ pub enum CoreError {
     /// The service failed internally.
     #[error("internal: {0}")]
     Internal(String),
+    /// A structured query failure produced at the engine or backend layer.
+    ///
+    /// Construction is restricted to `coral-engine` via the `pub(crate)`
+    /// constructor on [`StructuredQueryError`]. The app boundary reads
+    /// the plain Rust data via getters and encodes it as AIP-193 standard
+    /// error details.
+    #[error("{}", _0.plain_message())]
+    Structured(StructuredQueryError),
+}
+
+/// Opaque wrapper around a structured query failure.
+///
+/// Fields are private. External crates read them via getters; only
+/// `coral-engine` can construct instances (the constructor is `pub(crate)`).
+/// All fields are plain Rust data — no protobuf types — so `coral-engine`
+/// stays transport-neutral.
+#[derive(Debug, Clone)]
+pub struct StructuredQueryError {
+    reason: String,
+    metadata: HashMap<String, String>,
+    retryable: bool,
+    plain_message: String,
+    status: StatusCode,
+}
+
+impl StructuredQueryError {
+    pub(crate) fn new(
+        reason: &str,
+        metadata: HashMap<String, String>,
+        retryable: bool,
+        plain_message: String,
+        status: StatusCode,
+    ) -> Self {
+        Self {
+            reason: reason.to_string(),
+            metadata,
+            retryable,
+            plain_message,
+            status,
+        }
+    }
+
+    /// Machine-readable error reason (e.g. `"MISSING_REQUIRED_FILTER"`).
+    #[must_use]
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    /// Key-value metadata for AIP-193 `ErrorInfo.metadata`.
+    #[must_use]
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.metadata
+    }
+
+    /// Whether the error is transient (maps to `RetryInfo` presence).
+    #[must_use]
+    pub fn retryable(&self) -> bool {
+        self.retryable
+    }
+
+    /// Multi-line plain-text fallback for `Status::message()`.
+    #[must_use]
+    pub fn plain_message(&self) -> &str {
+        &self.plain_message
+    }
+
+    /// Pre-computed gRPC status code.
+    #[must_use]
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
 }
 
 impl CoreError {
@@ -42,6 +115,7 @@ impl CoreError {
             Self::Unavailable(_) => StatusCode::Unavailable,
             Self::Unimplemented(_) => StatusCode::Unimplemented,
             Self::Internal(_) => StatusCode::Internal,
+            Self::Structured(sqe) => sqe.status(),
         }
     }
 }

--- a/crates/coral-engine/src/contracts/error.rs
+++ b/crates/coral-engine/src/contracts/error.rs
@@ -27,7 +27,7 @@ pub enum CoreError {
     Internal(String),
     /// A structured query failure with first-class semantic fields.
     #[error("{_0}")]
-    Structured(Box<StructuredQueryError>),
+    QueryFailure(Box<StructuredQueryError>),
 }
 
 impl CoreError {
@@ -47,7 +47,7 @@ impl CoreError {
             Self::Unavailable(_) => StatusCode::Unavailable,
             Self::Unimplemented(_) => StatusCode::Unimplemented,
             Self::Internal(_) => StatusCode::Internal,
-            Self::Structured(sqe) => sqe.status(),
+            Self::QueryFailure(sqe) => sqe.status(),
         }
     }
 }

--- a/crates/coral-engine/src/contracts/error.rs
+++ b/crates/coral-engine/src/contracts/error.rs
@@ -31,8 +31,8 @@ pub enum CoreError {
     /// constructor on [`StructuredQueryError`]. The app boundary reads
     /// the plain Rust data via getters and encodes it as AIP-193 standard
     /// error details.
-    #[error("{}", _0.plain_message())]
-    Structured(StructuredQueryError),
+    #[error("{_0}")]
+    Structured(Box<StructuredQueryError>),
 }
 
 /// Opaque wrapper around a structured query failure.
@@ -40,30 +40,37 @@ pub enum CoreError {
 /// Fields are private. External crates read them via getters; only
 /// `coral-engine` can construct instances (the constructor is `pub(crate)`).
 /// All fields are plain Rust data — no protobuf types — so `coral-engine`
-/// stays transport-neutral.
+/// stays transport-neutral. The app boundary owns transport encoding
+/// (AIP-193 wire format) and plain-text rendering.
 #[derive(Debug, Clone)]
 pub struct StructuredQueryError {
     reason: String,
-    metadata: HashMap<String, String>,
+    summary: String,
+    detail: String,
+    hint: Option<String>,
     retryable: bool,
-    plain_message: String,
     status: StatusCode,
+    metadata: HashMap<String, String>,
 }
 
 impl StructuredQueryError {
     pub(crate) fn new(
         reason: &str,
-        metadata: HashMap<String, String>,
+        summary: String,
+        detail: String,
+        hint: Option<String>,
         retryable: bool,
-        plain_message: String,
         status: StatusCode,
+        metadata: HashMap<String, String>,
     ) -> Self {
         Self {
             reason: reason.to_string(),
-            metadata,
+            summary,
+            detail,
+            hint,
             retryable,
-            plain_message,
             status,
+            metadata,
         }
     }
 
@@ -73,10 +80,22 @@ impl StructuredQueryError {
         &self.reason
     }
 
-    /// Key-value metadata for AIP-193 `ErrorInfo.metadata`.
+    /// One-line error summary.
     #[must_use]
-    pub fn metadata(&self) -> &HashMap<String, String> {
-        &self.metadata
+    pub fn summary(&self) -> &str {
+        &self.summary
+    }
+
+    /// Longer explanation (may be empty).
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+
+    /// Actionable recovery guidance.
+    #[must_use]
+    pub fn hint(&self) -> Option<&str> {
+        self.hint.as_deref()
     }
 
     /// Whether the error is transient (maps to `RetryInfo` presence).
@@ -85,16 +104,29 @@ impl StructuredQueryError {
         self.retryable
     }
 
-    /// Multi-line plain-text fallback for `Status::message()`.
-    #[must_use]
-    pub fn plain_message(&self) -> &str {
-        &self.plain_message
-    }
-
-    /// Pre-computed gRPC status code.
+    /// Transport-neutral status code.
     #[must_use]
     pub fn status(&self) -> StatusCode {
         self.status
+    }
+
+    /// Additional key-value metadata (source, table, field, `http_status`, etc.).
+    #[must_use]
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.metadata
+    }
+}
+
+impl std::fmt::Display for StructuredQueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.summary)?;
+        if !self.detail.is_empty() {
+            write!(f, "\n{}", self.detail)?;
+        }
+        if let Some(hint) = &self.hint {
+            write!(f, "\nHint: {hint}")?;
+        }
+        Ok(())
     }
 }
 

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -3,7 +3,8 @@
 mod catalog;
 mod error;
 mod query;
+pub(crate) mod query_error;
 
 pub use catalog::{ColumnInfo, TableInfo};
-pub use error::{CoreError, StatusCode};
+pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -3,7 +3,7 @@
 mod catalog;
 mod error;
 mod query;
-pub(crate) mod query_error;
+mod query_error;
 
 pub use catalog::{ColumnInfo, TableInfo};
 pub use error::{CoreError, StatusCode, StructuredQueryError};

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -1,22 +1,87 @@
 //! Structured query error type for provider failures.
 //!
-//! Internal to `coral-engine`; the app layer converts these into
-//! AIP-193 error details before they cross the gRPC boundary.
+//! `StructuredQueryError` is the canonical error shape that crosses the
+//! engine boundary. The app layer reads it via getters and encodes it
+//! as AIP-193 error details for the wire.
 
 use std::collections::HashMap;
 
 use super::error::StatusCode;
 
-/// Engine-internal structured query error.
+/// Structured query failure with first-class semantic fields.
+///
+/// External crates read fields via getters. The constructors are public
+/// so the engine runtime can build instances directly.
 #[derive(Debug, Clone)]
-pub(crate) struct QueryError {
-    pub(crate) reason: &'static str,
-    pub(crate) summary: String,
-    pub(crate) detail: String,
-    pub(crate) hint: Option<String>,
-    pub(crate) retryable: bool,
-    pub(crate) metadata: HashMap<String, String>,
-    pub(crate) status: StatusCode,
+pub struct StructuredQueryError {
+    reason: String,
+    summary: String,
+    detail: String,
+    hint: Option<String>,
+    retryable: bool,
+    status: StatusCode,
+    metadata: HashMap<String, String>,
+}
+
+impl std::fmt::Display for StructuredQueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.summary)?;
+        if !self.detail.is_empty() {
+            write!(f, "\n{}", self.detail)?;
+        }
+        if let Some(hint) = &self.hint {
+            write!(f, "\nHint: {hint}")?;
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+impl StructuredQueryError {
+    /// Machine-readable error reason (e.g. `"MISSING_REQUIRED_FILTER"`).
+    #[must_use]
+    pub fn reason(&self) -> &str {
+        &self.reason
+    }
+
+    /// One-line error summary.
+    #[must_use]
+    pub fn summary(&self) -> &str {
+        &self.summary
+    }
+
+    /// Longer explanation (may be empty).
+    #[must_use]
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+
+    /// Actionable recovery guidance.
+    #[must_use]
+    pub fn hint(&self) -> Option<&str> {
+        self.hint.as_deref()
+    }
+
+    /// Whether the error is transient (maps to `RetryInfo` presence).
+    #[must_use]
+    pub fn retryable(&self) -> bool {
+        self.retryable
+    }
+
+    /// Transport-neutral status code.
+    #[must_use]
+    pub fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    /// Additional key-value metadata (source, table, field, `http_status`, etc.).
+    #[must_use]
+    pub fn metadata(&self) -> &HashMap<String, String> {
+        &self.metadata
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -72,7 +137,7 @@ fn enrich_provider_detail(detail: &str, method: Option<&str>, url: Option<&str>)
 // Constructors
 // ---------------------------------------------------------------------------
 
-impl QueryError {
+impl StructuredQueryError {
     pub(crate) fn missing_required_filter(
         schema: impl Into<String>,
         table: impl Into<String>,
@@ -87,7 +152,7 @@ impl QueryError {
         metadata.insert("table".to_string(), table.clone());
         metadata.insert("field".to_string(), field.clone());
         Self {
-            reason: "MISSING_REQUIRED_FILTER",
+            reason: "MISSING_REQUIRED_FILTER".to_string(),
             summary: format!("{schema}.{table} requires `WHERE {field} = <constant>`"),
             detail: detail.into(),
             hint: Some(format!(
@@ -187,19 +252,15 @@ impl QueryError {
             metadata.insert("url".to_string(), u.clone());
         }
 
-        let mut error = Self {
-            reason,
+        Self {
+            reason: reason.to_string(),
             summary,
             detail,
-            hint: None,
+            hint,
             retryable: is_retryable,
             metadata,
             status,
-        };
-        if let Some(h) = hint {
-            error.hint = Some(h);
         }
-        error
     }
 }
 
@@ -209,24 +270,24 @@ mod tests {
 
     #[test]
     fn missing_required_filter_sets_reason_and_metadata() {
-        let error = QueryError::missing_required_filter(
+        let error = StructuredQueryError::missing_required_filter(
             "github",
             "issues",
             "repo",
             "missing required filter",
         );
-        assert_eq!(error.reason, "MISSING_REQUIRED_FILTER");
-        assert_eq!(error.metadata.get("schema").unwrap(), "github");
-        assert_eq!(error.metadata.get("table").unwrap(), "issues");
-        assert_eq!(error.metadata.get("field").unwrap(), "repo");
-        assert!(error.summary.contains("repo"));
-        assert!(error.hint.is_some());
-        assert_eq!(error.status, StatusCode::FailedPrecondition);
+        assert_eq!(error.reason(), "MISSING_REQUIRED_FILTER");
+        assert_eq!(error.metadata().get("schema").unwrap(), "github");
+        assert_eq!(error.metadata().get("table").unwrap(), "issues");
+        assert_eq!(error.metadata().get("field").unwrap(), "repo");
+        assert!(error.summary().contains("repo"));
+        assert!(error.hint().is_some());
+        assert_eq!(error.status(), StatusCode::FailedPrecondition);
     }
 
     #[test]
     fn http_provider_request_401_includes_both_install_paths() {
-        let error = QueryError::http_provider_request(
+        let error = StructuredQueryError::http_provider_request(
             "github",
             "issues",
             Some(401),
@@ -234,25 +295,31 @@ mod tests {
             Some("https://api.github.com/repos/coral/coral/issues".to_string()),
             "Bad credentials",
         );
-        assert_eq!(error.reason, "PROVIDER_REQUEST_FAILED");
-        assert_eq!(error.metadata.get("http_status").unwrap(), "401");
-        assert!(!error.retryable);
-        let hint = error.hint.as_ref().expect("401 should have a hint");
+        assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.metadata().get("http_status").unwrap(), "401");
+        assert!(!error.retryable());
+        let hint = error.hint().expect("401 should have a hint");
         assert!(hint.contains("coral source add github"));
         assert!(hint.contains("coral source add --file"));
     }
 
     #[test]
     fn http_provider_request_500_is_retryable() {
-        let error =
-            QueryError::http_provider_request("github", "issues", Some(500), None, None, "boom");
-        assert!(error.retryable);
-        assert_eq!(error.status, StatusCode::Unavailable);
+        let error = StructuredQueryError::http_provider_request(
+            "github",
+            "issues",
+            Some(500),
+            None,
+            None,
+            "boom",
+        );
+        assert!(error.retryable());
+        assert_eq!(error.status(), StatusCode::Unavailable);
     }
 
     #[test]
     fn http_provider_request_redacts_secret_query_params_from_url() {
-        let error = QueryError::http_provider_request(
+        let error = StructuredQueryError::http_provider_request(
             "datadog",
             "events",
             Some(500),
@@ -260,14 +327,17 @@ mod tests {
             Some("https://api.datadoghq.eu/api/v1/events?api_key=SECRET".to_string()),
             "boom",
         );
-        let url = error.metadata.get("url").expect("url should be sanitized");
+        let url = error
+            .metadata()
+            .get("url")
+            .expect("url should be sanitized");
         assert_eq!(url, "https://api.datadoghq.eu/api/v1/events");
-        assert!(!error.detail.contains("SECRET"));
+        assert!(!error.detail().contains("SECRET"));
     }
 
     #[test]
     fn http_provider_request_detail_preserves_method_and_sanitized_url() {
-        let error = QueryError::http_provider_request(
+        let error = StructuredQueryError::http_provider_request(
             "github",
             "issues",
             Some(500),
@@ -275,7 +345,25 @@ mod tests {
             Some("https://api.github.com/issues?page=3".to_string()),
             "upstream boom",
         );
-        assert!(error.detail.contains("[GET] https://api.github.com/issues"));
-        assert!(!error.detail.contains("page=3"));
+        assert!(
+            error
+                .detail()
+                .contains("[GET] https://api.github.com/issues")
+        );
+        assert!(!error.detail().contains("page=3"));
+    }
+
+    #[test]
+    fn display_renders_full_message() {
+        let error = StructuredQueryError::missing_required_filter(
+            "github",
+            "issues",
+            "repo",
+            "missing filter",
+        );
+        let text = error.to_string();
+        assert!(text.contains(&error.summary));
+        assert!(text.contains("missing filter"));
+        assert!(text.contains("Hint: "));
     }
 }

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -103,7 +103,7 @@ impl QueryError {
         clippy::needless_pass_by_value,
         reason = "method and url are conditionally moved into the metadata HashMap"
     )]
-    pub(crate) fn provider_request(
+    pub(crate) fn http_provider_request(
         source: impl Into<String>,
         table: impl Into<String>,
         http_status: Option<u16>,
@@ -239,8 +239,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_request_401_includes_both_install_paths() {
-        let error = QueryError::provider_request(
+    fn http_provider_request_401_includes_both_install_paths() {
+        let error = QueryError::http_provider_request(
             "github",
             "issues",
             Some(401),
@@ -257,15 +257,15 @@ mod tests {
     }
 
     #[test]
-    fn provider_request_500_is_retryable() {
-        let error = QueryError::provider_request("github", "issues", Some(500), None, None, "boom");
+    fn http_provider_request_500_is_retryable() {
+        let error = QueryError::http_provider_request("github", "issues", Some(500), None, None, "boom");
         assert!(error.retryable);
         assert_eq!(error.status, StatusCode::Unavailable);
     }
 
     #[test]
-    fn provider_request_redacts_secret_query_params_from_url() {
-        let error = QueryError::provider_request(
+    fn http_provider_request_redacts_secret_query_params_from_url() {
+        let error = QueryError::http_provider_request(
             "datadog",
             "events",
             Some(500),
@@ -279,8 +279,8 @@ mod tests {
     }
 
     #[test]
-    fn provider_request_detail_preserves_method_and_sanitized_url() {
-        let error = QueryError::provider_request(
+    fn http_provider_request_detail_preserves_method_and_sanitized_url() {
+        let error = QueryError::http_provider_request(
             "github",
             "issues",
             Some(500),

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -1,17 +1,10 @@
-//! Structured query error type for provider failures.
-//!
-//! `StructuredQueryError` is the canonical error shape that crosses the
-//! engine boundary. The app layer reads it via getters and encodes it
-//! as AIP-193 error details for the wire.
+//! Canonical structured query error contract.
 
 use std::collections::HashMap;
 
 use super::error::StatusCode;
 
 /// Structured query failure with first-class semantic fields.
-///
-/// External crates read fields via getters. The constructors are public
-/// so the engine runtime can build instances directly.
 #[derive(Debug, Clone)]
 pub struct StructuredQueryError {
     reason: String,
@@ -23,24 +16,28 @@ pub struct StructuredQueryError {
     metadata: HashMap<String, String>,
 }
 
-impl std::fmt::Display for StructuredQueryError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.summary)?;
-        if !self.detail.is_empty() {
-            write!(f, "\n{}", self.detail)?;
-        }
-        if let Some(hint) = &self.hint {
-            write!(f, "\nHint: {hint}")?;
-        }
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Getters
-// ---------------------------------------------------------------------------
-
 impl StructuredQueryError {
+    /// Builds a structured error from its parts.
+    pub(crate) fn new(
+        reason: impl Into<String>,
+        summary: impl Into<String>,
+        detail: impl Into<String>,
+        hint: Option<String>,
+        retryable: bool,
+        status: StatusCode,
+        metadata: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            reason: reason.into(),
+            summary: summary.into(),
+            detail: detail.into(),
+            hint,
+            retryable,
+            status,
+            metadata,
+        }
+    }
+
     /// Machine-readable error reason (e.g. `"MISSING_REQUIRED_FILTER"`).
     #[must_use]
     pub fn reason(&self) -> &str {
@@ -65,7 +62,7 @@ impl StructuredQueryError {
         self.hint.as_deref()
     }
 
-    /// Whether the error is transient (maps to `RetryInfo` presence).
+    /// Whether the error is transient.
     #[must_use]
     pub fn retryable(&self) -> bool {
         self.retryable
@@ -77,293 +74,22 @@ impl StructuredQueryError {
         self.status
     }
 
-    /// Additional key-value metadata (source, table, field, `http_status`, etc.).
+    /// Additional key-value metadata.
     #[must_use]
     pub fn metadata(&self) -> &HashMap<String, String> {
         &self.metadata
     }
 }
 
-// ---------------------------------------------------------------------------
-// String helpers
-// ---------------------------------------------------------------------------
-
-fn shell_arg(value: &str) -> String {
-    let is_safe = !value.is_empty()
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'));
-    if is_safe {
-        value.to_string()
-    } else {
-        let escaped = value.replace('\'', "'\\''");
-        format!("'{escaped}'")
-    }
-}
-
-fn sanitize_request_url(raw: &str) -> Option<String> {
-    let without_fragment = raw.split_once('#').map_or(raw, |(before, _)| before);
-    let without_query = without_fragment
-        .split_once('?')
-        .map_or(without_fragment, |(before, _)| before);
-    let (scheme, rest) = without_query.split_once("://")?;
-    if scheme.is_empty() || rest.is_empty() {
-        return None;
-    }
-    let (authority, path) = rest.split_once('/').map_or((rest, ""), |(a, p)| (a, p));
-    let host_and_port = authority
-        .rsplit_once('@')
-        .map_or(authority, |(_, host)| host);
-    if host_and_port.is_empty() {
-        return None;
-    }
-    if path.is_empty() {
-        Some(format!("{scheme}://{host_and_port}"))
-    } else {
-        Some(format!("{scheme}://{host_and_port}/{path}"))
-    }
-}
-
-fn enrich_provider_detail(detail: &str, method: Option<&str>, url: Option<&str>) -> String {
-    match (method, url) {
-        (Some(method), Some(url)) => format!("{detail} [{method}] {url}"),
-        (Some(method), None) => format!("{detail} [{method}]"),
-        (None, Some(url)) => format!("{detail} {url}"),
-        (None, None) => detail.to_string(),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Constructors
-// ---------------------------------------------------------------------------
-
-impl StructuredQueryError {
-    pub(crate) fn missing_required_filter(
-        schema: impl Into<String>,
-        table: impl Into<String>,
-        field: impl Into<String>,
-        detail: impl Into<String>,
-    ) -> Self {
-        let schema = schema.into();
-        let table = table.into();
-        let field = field.into();
-        let mut metadata = HashMap::new();
-        metadata.insert("schema".to_string(), schema.clone());
-        metadata.insert("table".to_string(), table.clone());
-        metadata.insert("field".to_string(), field.clone());
-        Self {
-            reason: "MISSING_REQUIRED_FILTER".to_string(),
-            summary: format!("{schema}.{table} requires `WHERE {field} = <constant>`"),
-            detail: detail.into(),
-            hint: Some(format!(
-                "Add a constant equality filter on `{field}` or inspect `coral.columns` / `coral.tables` first."
-            )),
-            retryable: false,
-            metadata,
-            status: StatusCode::FailedPrecondition,
+impl std::fmt::Display for StructuredQueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.summary)?;
+        if !self.detail.is_empty() {
+            write!(f, "\n{}", self.detail)?;
         }
-    }
-
-    #[allow(
-        clippy::needless_pass_by_value,
-        reason = "method and url are conditionally moved into the metadata HashMap"
-    )]
-    pub(crate) fn http_provider_request(
-        source: impl Into<String>,
-        table: impl Into<String>,
-        http_status: Option<u16>,
-        method: Option<String>,
-        url: Option<String>,
-        detail: impl Into<String>,
-    ) -> Self {
-        let source = source.into();
-        let table = table.into();
-        let raw_detail = detail.into();
-        let source_shell = shell_arg(&source);
-        let sanitized_url = url.and_then(|raw| sanitize_request_url(&raw));
-
-        let (reason, summary, hint, status) = match http_status {
-            Some(400) => (
-                "INVALID_QUERY_SHAPE",
-                "Source rejected the request".to_string(),
-                Some("Adjust the query filters or shape to match the target table's supported inputs.".to_string()),
-                StatusCode::FailedPrecondition,
-            ),
-            Some(401) => (
-                "PROVIDER_REQUEST_FAILED",
-                "Source authentication failed".to_string(),
-                Some(format!(
-                    "Credentials for this source are invalid or expired. Re-install it to refresh: \
-                     `coral source add {source_shell}` for bundled sources, or \
-                     `coral source add --file <manifest-path>` for imported sources."
-                )),
-                StatusCode::FailedPrecondition,
-            ),
-            Some(403) => (
-                "PROVIDER_REQUEST_FAILED",
-                "Source request was rejected".to_string(),
-                Some("Check the configured credentials and whether they have access to this resource.".to_string()),
-                StatusCode::FailedPrecondition,
-            ),
-            Some(404) => (
-                "PROVIDER_REQUEST_FAILED",
-                "Source resource was not found".to_string(),
-                Some("Verify the identifier or filter values you passed; the upstream resource was not found.".to_string()),
-                StatusCode::NotFound,
-            ),
-            Some(429) => (
-                "PROVIDER_REQUEST_FAILED",
-                "Source rate limit exceeded".to_string(),
-                Some("The upstream API is rate-limiting requests. Wait briefly and retry.".to_string()),
-                StatusCode::Unavailable,
-            ),
-            Some(s) if (500..600).contains(&s) => (
-                "PROVIDER_REQUEST_FAILED",
-                "Source server error".to_string(),
-                Some("The upstream API returned a server error. This may be transient — retry after a brief wait.".to_string()),
-                StatusCode::Unavailable,
-            ),
-            _ => (
-                "PROVIDER_REQUEST_FAILED",
-                "Source request failed".to_string(),
-                None,
-                StatusCode::FailedPrecondition,
-            ),
-        };
-
-        let summary = match http_status {
-            Some(s) => format!("{summary} ({s})"),
-            None => summary,
-        };
-        let detail =
-            enrich_provider_detail(&raw_detail, method.as_deref(), sanitized_url.as_deref());
-        let is_retryable = matches!(http_status, Some(429 | 500..=599));
-
-        let mut metadata = HashMap::new();
-        metadata.insert("source".to_string(), source);
-        metadata.insert("table".to_string(), table);
-        if let Some(s) = http_status {
-            metadata.insert("http_status".to_string(), s.to_string());
+        if let Some(hint) = &self.hint {
+            write!(f, "\nHint: {hint}")?;
         }
-        if let Some(m) = &method {
-            metadata.insert("http_method".to_string(), m.clone());
-        }
-        if let Some(u) = &sanitized_url {
-            metadata.insert("url".to_string(), u.clone());
-        }
-
-        Self {
-            reason: reason.to_string(),
-            summary,
-            detail,
-            hint,
-            retryable: is_retryable,
-            metadata,
-            status,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn missing_required_filter_sets_reason_and_metadata() {
-        let error = StructuredQueryError::missing_required_filter(
-            "github",
-            "issues",
-            "repo",
-            "missing required filter",
-        );
-        assert_eq!(error.reason(), "MISSING_REQUIRED_FILTER");
-        assert_eq!(error.metadata().get("schema").unwrap(), "github");
-        assert_eq!(error.metadata().get("table").unwrap(), "issues");
-        assert_eq!(error.metadata().get("field").unwrap(), "repo");
-        assert!(error.summary().contains("repo"));
-        assert!(error.hint().is_some());
-        assert_eq!(error.status(), StatusCode::FailedPrecondition);
-    }
-
-    #[test]
-    fn http_provider_request_401_includes_both_install_paths() {
-        let error = StructuredQueryError::http_provider_request(
-            "github",
-            "issues",
-            Some(401),
-            Some("GET".to_string()),
-            Some("https://api.github.com/repos/coral/coral/issues".to_string()),
-            "Bad credentials",
-        );
-        assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
-        assert_eq!(error.metadata().get("http_status").unwrap(), "401");
-        assert!(!error.retryable());
-        let hint = error.hint().expect("401 should have a hint");
-        assert!(hint.contains("coral source add github"));
-        assert!(hint.contains("coral source add --file"));
-    }
-
-    #[test]
-    fn http_provider_request_500_is_retryable() {
-        let error = StructuredQueryError::http_provider_request(
-            "github",
-            "issues",
-            Some(500),
-            None,
-            None,
-            "boom",
-        );
-        assert!(error.retryable());
-        assert_eq!(error.status(), StatusCode::Unavailable);
-    }
-
-    #[test]
-    fn http_provider_request_redacts_secret_query_params_from_url() {
-        let error = StructuredQueryError::http_provider_request(
-            "datadog",
-            "events",
-            Some(500),
-            Some("GET".to_string()),
-            Some("https://api.datadoghq.eu/api/v1/events?api_key=SECRET".to_string()),
-            "boom",
-        );
-        let url = error
-            .metadata()
-            .get("url")
-            .expect("url should be sanitized");
-        assert_eq!(url, "https://api.datadoghq.eu/api/v1/events");
-        assert!(!error.detail().contains("SECRET"));
-    }
-
-    #[test]
-    fn http_provider_request_detail_preserves_method_and_sanitized_url() {
-        let error = StructuredQueryError::http_provider_request(
-            "github",
-            "issues",
-            Some(500),
-            Some("GET".to_string()),
-            Some("https://api.github.com/issues?page=3".to_string()),
-            "upstream boom",
-        );
-        assert!(
-            error
-                .detail()
-                .contains("[GET] https://api.github.com/issues")
-        );
-        assert!(!error.detail().contains("page=3"));
-    }
-
-    #[test]
-    fn display_renders_full_message() {
-        let error = StructuredQueryError::missing_required_filter(
-            "github",
-            "issues",
-            "repo",
-            "missing filter",
-        );
-        let text = error.to_string();
-        assert!(text.contains(&error.summary));
-        assert!(text.contains("missing filter"));
-        assert!(text.contains("Hint: "));
+        Ok(())
     }
 }

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -201,20 +201,6 @@ impl QueryError {
         }
         error
     }
-
-    /// Renders a plain-text message preserving the summary, detail, and hint.
-    pub(crate) fn to_plain_message(&self) -> String {
-        let mut message = self.summary.clone();
-        if !self.detail.is_empty() {
-            message.push('\n');
-            message.push_str(&self.detail);
-        }
-        if let Some(hint) = &self.hint {
-            message.push_str("\nHint: ");
-            message.push_str(hint);
-        }
-        message
-    }
 }
 
 #[cfg(test)]
@@ -291,15 +277,5 @@ mod tests {
         );
         assert!(error.detail.contains("[GET] https://api.github.com/issues"));
         assert!(!error.detail.contains("page=3"));
-    }
-
-    #[test]
-    fn to_plain_message_includes_summary_detail_and_hint() {
-        let error =
-            QueryError::missing_required_filter("github", "issues", "repo", "missing filter");
-        let text = error.to_plain_message();
-        assert!(text.contains(&error.summary));
-        assert!(text.contains("missing filter"));
-        assert!(text.contains("Hint: "));
     }
 }

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -1,8 +1,7 @@
-//! Engine-internal structured query error with user- and agent-facing hints.
+//! Structured query error type for provider failures.
 //!
-//! This type is **not** re-exported from the `coral-engine` crate root.
-//! The app boundary converts it to AIP-193 standard error details;
-//! consumers outside the engine see only `coral-client::CoralQueryError`.
+//! Internal to `coral-engine`; the app layer converts these into
+//! AIP-193 error details before they cross the gRPC boundary.
 
 use std::collections::HashMap;
 
@@ -254,7 +253,7 @@ mod tests {
         assert!(!error.retryable);
         let hint = error.hint.as_ref().expect("401 should have a hint");
         assert!(hint.contains("coral source add github"));
-        assert!(hint.contains("coral source import"));
+        assert!(hint.contains("coral source add --file"));
     }
 
     #[test]

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -1,0 +1,305 @@
+//! Engine-internal structured query error with user- and agent-facing hints.
+//!
+//! This type is **not** re-exported from the `coral-engine` crate root.
+//! The app boundary converts it to AIP-193 standard error details;
+//! consumers outside the engine see only `coral-client::CoralQueryError`.
+
+use std::collections::HashMap;
+
+use super::error::StatusCode;
+
+/// Engine-internal structured query error.
+#[derive(Debug, Clone)]
+pub(crate) struct QueryError {
+    pub(crate) reason: &'static str,
+    pub(crate) summary: String,
+    pub(crate) detail: String,
+    pub(crate) hint: Option<String>,
+    pub(crate) retryable: bool,
+    pub(crate) metadata: HashMap<String, String>,
+    pub(crate) status: StatusCode,
+}
+
+// ---------------------------------------------------------------------------
+// String helpers
+// ---------------------------------------------------------------------------
+
+fn shell_arg(value: &str) -> String {
+    let is_safe = !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'));
+    if is_safe {
+        value.to_string()
+    } else {
+        let escaped = value.replace('\'', "'\\''");
+        format!("'{escaped}'")
+    }
+}
+
+fn sanitize_request_url(raw: &str) -> Option<String> {
+    let without_fragment = raw.split_once('#').map_or(raw, |(before, _)| before);
+    let without_query = without_fragment
+        .split_once('?')
+        .map_or(without_fragment, |(before, _)| before);
+    let (scheme, rest) = without_query.split_once("://")?;
+    if scheme.is_empty() || rest.is_empty() {
+        return None;
+    }
+    let (authority, path) = rest.split_once('/').map_or((rest, ""), |(a, p)| (a, p));
+    let host_and_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host)| host);
+    if host_and_port.is_empty() {
+        return None;
+    }
+    if path.is_empty() {
+        Some(format!("{scheme}://{host_and_port}"))
+    } else {
+        Some(format!("{scheme}://{host_and_port}/{path}"))
+    }
+}
+
+fn enrich_provider_detail(detail: &str, method: Option<&str>, url: Option<&str>) -> String {
+    match (method, url) {
+        (Some(method), Some(url)) => format!("{detail} [{method}] {url}"),
+        (Some(method), None) => format!("{detail} [{method}]"),
+        (None, Some(url)) => format!("{detail} {url}"),
+        (None, None) => detail.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Constructors
+// ---------------------------------------------------------------------------
+
+impl QueryError {
+    pub(crate) fn missing_required_filter(
+        schema: impl Into<String>,
+        table: impl Into<String>,
+        field: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        let schema = schema.into();
+        let table = table.into();
+        let field = field.into();
+        let mut metadata = HashMap::new();
+        metadata.insert("schema".to_string(), schema.clone());
+        metadata.insert("table".to_string(), table.clone());
+        metadata.insert("field".to_string(), field.clone());
+        Self {
+            reason: "MISSING_REQUIRED_FILTER",
+            summary: format!("{schema}.{table} requires `WHERE {field} = <constant>`"),
+            detail: detail.into(),
+            hint: Some(format!(
+                "Add a constant equality filter on `{field}` or inspect `coral.columns` / `coral.tables` first."
+            )),
+            retryable: false,
+            metadata,
+            status: StatusCode::FailedPrecondition,
+        }
+    }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "method and url are conditionally moved into the metadata HashMap"
+    )]
+    pub(crate) fn provider_request(
+        source: impl Into<String>,
+        table: impl Into<String>,
+        http_status: Option<u16>,
+        method: Option<String>,
+        url: Option<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        let source = source.into();
+        let table = table.into();
+        let raw_detail = detail.into();
+        let source_shell = shell_arg(&source);
+        let sanitized_url = url.and_then(|raw| sanitize_request_url(&raw));
+
+        let (reason, summary, hint, status) = match http_status {
+            Some(400) => (
+                "INVALID_QUERY_SHAPE",
+                "Source rejected the request".to_string(),
+                Some("Adjust the query filters or shape to match the target table's supported inputs.".to_string()),
+                StatusCode::FailedPrecondition,
+            ),
+            Some(401) => (
+                "PROVIDER_REQUEST_FAILED",
+                "Source authentication failed".to_string(),
+                Some(format!(
+                    "Credentials for this source are invalid or expired. Re-install it to refresh: \
+                     `coral source add {source_shell}` for bundled sources, or \
+                     `coral source import <manifest-path>` for imported sources."
+                )),
+                StatusCode::FailedPrecondition,
+            ),
+            Some(403) => (
+                "PROVIDER_REQUEST_FAILED",
+                "Source request was rejected".to_string(),
+                Some("Check the configured credentials and whether they have access to this resource.".to_string()),
+                StatusCode::FailedPrecondition,
+            ),
+            Some(404) => (
+                "PROVIDER_REQUEST_FAILED",
+                "Source resource was not found".to_string(),
+                Some("Verify the identifier or filter values you passed; the upstream resource was not found.".to_string()),
+                StatusCode::NotFound,
+            ),
+            Some(429) => (
+                "PROVIDER_REQUEST_FAILED",
+                "Source rate limit exceeded".to_string(),
+                Some("The upstream API is rate-limiting requests. Wait briefly and retry.".to_string()),
+                StatusCode::Unavailable,
+            ),
+            Some(s) if (500..600).contains(&s) => (
+                "PROVIDER_REQUEST_FAILED",
+                "Source server error".to_string(),
+                Some("The upstream API returned a server error. This may be transient — retry after a brief wait.".to_string()),
+                StatusCode::Unavailable,
+            ),
+            _ => (
+                "PROVIDER_REQUEST_FAILED",
+                "Source request failed".to_string(),
+                None,
+                StatusCode::FailedPrecondition,
+            ),
+        };
+
+        let summary = match http_status {
+            Some(s) => format!("{summary} ({s})"),
+            None => summary,
+        };
+        let detail =
+            enrich_provider_detail(&raw_detail, method.as_deref(), sanitized_url.as_deref());
+        let is_retryable = matches!(http_status, Some(429 | 500..=599));
+
+        let mut metadata = HashMap::new();
+        metadata.insert("source".to_string(), source);
+        metadata.insert("table".to_string(), table);
+        if let Some(s) = http_status {
+            metadata.insert("http_status".to_string(), s.to_string());
+        }
+        if let Some(m) = &method {
+            metadata.insert("http_method".to_string(), m.clone());
+        }
+        if let Some(u) = &sanitized_url {
+            metadata.insert("url".to_string(), u.clone());
+        }
+
+        let mut error = Self {
+            reason,
+            summary,
+            detail,
+            hint: None,
+            retryable: is_retryable,
+            metadata,
+            status,
+        };
+        if let Some(h) = hint {
+            error.hint = Some(h);
+        }
+        error
+    }
+
+    /// Renders a plain-text message preserving the summary, detail, and hint.
+    pub(crate) fn to_plain_message(&self) -> String {
+        let mut message = self.summary.clone();
+        if !self.detail.is_empty() {
+            message.push('\n');
+            message.push_str(&self.detail);
+        }
+        if let Some(hint) = &self.hint {
+            message.push_str("\nHint: ");
+            message.push_str(hint);
+        }
+        message
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_required_filter_sets_reason_and_metadata() {
+        let error = QueryError::missing_required_filter(
+            "github",
+            "issues",
+            "repo",
+            "missing required filter",
+        );
+        assert_eq!(error.reason, "MISSING_REQUIRED_FILTER");
+        assert_eq!(error.metadata.get("schema").unwrap(), "github");
+        assert_eq!(error.metadata.get("table").unwrap(), "issues");
+        assert_eq!(error.metadata.get("field").unwrap(), "repo");
+        assert!(error.summary.contains("repo"));
+        assert!(error.hint.is_some());
+        assert_eq!(error.status, StatusCode::FailedPrecondition);
+    }
+
+    #[test]
+    fn provider_request_401_includes_both_install_paths() {
+        let error = QueryError::provider_request(
+            "github",
+            "issues",
+            Some(401),
+            Some("GET".to_string()),
+            Some("https://api.github.com/repos/coral/coral/issues".to_string()),
+            "Bad credentials",
+        );
+        assert_eq!(error.reason, "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.metadata.get("http_status").unwrap(), "401");
+        assert!(!error.retryable);
+        let hint = error.hint.as_ref().expect("401 should have a hint");
+        assert!(hint.contains("coral source add github"));
+        assert!(hint.contains("coral source import"));
+    }
+
+    #[test]
+    fn provider_request_500_is_retryable() {
+        let error = QueryError::provider_request("github", "issues", Some(500), None, None, "boom");
+        assert!(error.retryable);
+        assert_eq!(error.status, StatusCode::Unavailable);
+    }
+
+    #[test]
+    fn provider_request_redacts_secret_query_params_from_url() {
+        let error = QueryError::provider_request(
+            "datadog",
+            "events",
+            Some(500),
+            Some("GET".to_string()),
+            Some("https://api.datadoghq.eu/api/v1/events?api_key=SECRET".to_string()),
+            "boom",
+        );
+        let url = error.metadata.get("url").expect("url should be sanitized");
+        assert_eq!(url, "https://api.datadoghq.eu/api/v1/events");
+        assert!(!error.detail.contains("SECRET"));
+    }
+
+    #[test]
+    fn provider_request_detail_preserves_method_and_sanitized_url() {
+        let error = QueryError::provider_request(
+            "github",
+            "issues",
+            Some(500),
+            Some("GET".to_string()),
+            Some("https://api.github.com/issues?page=3".to_string()),
+            "upstream boom",
+        );
+        assert!(error.detail.contains("[GET] https://api.github.com/issues"));
+        assert!(!error.detail.contains("page=3"));
+    }
+
+    #[test]
+    fn to_plain_message_includes_summary_detail_and_hint() {
+        let error =
+            QueryError::missing_required_filter("github", "issues", "repo", "missing filter");
+        let text = error.to_plain_message();
+        assert!(text.contains(&error.summary));
+        assert!(text.contains("missing filter"));
+        assert!(text.contains("Hint: "));
+    }
+}

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -131,7 +131,7 @@ impl QueryError {
                 Some(format!(
                     "Credentials for this source are invalid or expired. Re-install it to refresh: \
                      `coral source add {source_shell}` for bundled sources, or \
-                     `coral source import <manifest-path>` for imported sources."
+                     `coral source add --file <manifest-path>` for imported sources."
                 )),
                 StatusCode::FailedPrecondition,
             ),

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -258,7 +258,8 @@ mod tests {
 
     #[test]
     fn http_provider_request_500_is_retryable() {
-        let error = QueryError::http_provider_request("github", "issues", Some(500), None, None, "boom");
+        let error =
+            QueryError::http_provider_request("github", "issues", Some(500), None, None, "boom");
         assert!(error.retryable);
         assert_eq!(error.status, StatusCode::Unavailable);
     }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -71,7 +71,7 @@ mod runtime;
 
 pub use contracts::{
     ColumnInfo, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    StatusCode, TableInfo,
+    StatusCode, StructuredQueryError, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -117,36 +117,7 @@ fn datafusion_to_core(error: &DataFusionError) -> CoreError {
 }
 
 fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
-    match error {
-        ProviderQueryError::MissingRequiredFilter {
-            schema,
-            table,
-            field,
-        } => CoreError::FailedPrecondition(format!(
-            "{schema}.{table} requires WHERE {field} = <constant>"
-        )),
-        ProviderQueryError::ApiRequest {
-            status,
-            detail,
-            method,
-            url,
-            ..
-        } => match status {
-            Some(429 | 500..=599) => CoreError::Unavailable(format!(
-                "{}{}{}",
-                detail,
-                method
-                    .as_ref()
-                    .map(|value| format!(" [{value}]"))
-                    .unwrap_or_default(),
-                url.as_ref()
-                    .map(|value| format!(" {value}"))
-                    .unwrap_or_default()
-            )),
-            _ => CoreError::FailedPrecondition(detail.clone()),
-        },
-        ProviderQueryError::RateLimited { .. } => CoreError::Unavailable(error.to_string()),
-    }
+    CoreError::Structured(Box::new(error.to_structured()))
 }
 
 #[cfg(test)]

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -117,7 +117,7 @@ fn datafusion_to_core(error: &DataFusionError) -> CoreError {
 }
 
 fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
-    CoreError::Structured(Box::new(error.to_structured()))
+    CoreError::QueryFailure(Box::new(error.to_structured()))
 }
 
 #[cfg(test)]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -387,7 +387,7 @@ async fn api_returns_500() {
             assert!(sqe.retryable());
             assert_eq!(sqe.metadata().get("http_status").unwrap(), "500");
             assert_eq!(sqe.metadata().get("source").unwrap(), "http_500");
-            assert!(sqe.plain_message().contains("boom"));
+            assert!(sqe.detail().contains("boom"));
         }
         other => panic!("unexpected 500 error variant: {other:?}"),
     }
@@ -416,13 +416,8 @@ async fn api_returns_401() {
             assert!(!sqe.retryable());
             assert_eq!(sqe.metadata().get("http_status").unwrap(), "401");
             assert_eq!(sqe.metadata().get("source").unwrap(), "http_401");
-            assert!(
-                sqe.metadata()
-                    .get("hint")
-                    .unwrap()
-                    .contains("coral source add http_401")
-            );
-            assert!(sqe.plain_message().contains("unauthorized"));
+            assert!(sqe.hint().unwrap().contains("coral source add http_401"));
+            assert!(sqe.detail().contains("unauthorized"));
         }
         other => panic!("unexpected 401 error variant: {other:?}"),
     }
@@ -580,13 +575,8 @@ async fn missing_required_filter_surfaces_structured_error() {
             assert_eq!(sqe.metadata().get("schema").unwrap(), "http_required");
             assert_eq!(sqe.metadata().get("table").unwrap(), "users");
             assert_eq!(sqe.metadata().get("field").unwrap(), "id");
-            assert!(sqe.plain_message().contains("WHERE id"));
-            assert!(
-                sqe.metadata()
-                    .get("hint")
-                    .unwrap()
-                    .contains("coral.columns")
-            );
+            assert!(sqe.summary().contains("WHERE id"));
+            assert!(sqe.hint().unwrap().contains("coral.columns"));
         }
         other => panic!("unexpected missing-filter error variant: {other:?}"),
     }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -381,8 +381,14 @@ async fn api_returns_500() {
         .expect_err("500 should fail");
 
     assert_eq!(error.status_code(), StatusCode::Unavailable);
-    match error {
-        CoreError::Unavailable(detail) => assert!(detail.contains("boom")),
+    match &error {
+        CoreError::Structured(sqe) => {
+            assert_eq!(sqe.reason(), "PROVIDER_REQUEST_FAILED");
+            assert!(sqe.retryable());
+            assert_eq!(sqe.metadata().get("http_status").unwrap(), "500");
+            assert_eq!(sqe.metadata().get("source").unwrap(), "http_500");
+            assert!(sqe.plain_message().contains("boom"));
+        }
         other => panic!("unexpected 500 error variant: {other:?}"),
     }
 }
@@ -404,8 +410,20 @@ async fn api_returns_401() {
         .expect_err("401 should fail");
 
     assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
-    match error {
-        CoreError::FailedPrecondition(detail) => assert!(detail.contains("unauthorized")),
+    match &error {
+        CoreError::Structured(sqe) => {
+            assert_eq!(sqe.reason(), "PROVIDER_REQUEST_FAILED");
+            assert!(!sqe.retryable());
+            assert_eq!(sqe.metadata().get("http_status").unwrap(), "401");
+            assert_eq!(sqe.metadata().get("source").unwrap(), "http_401");
+            assert!(
+                sqe.metadata()
+                    .get("hint")
+                    .unwrap()
+                    .contains("coral source add http_401")
+            );
+            assert!(sqe.plain_message().contains("unauthorized"));
+        }
         other => panic!("unexpected 401 error variant: {other:?}"),
     }
 }
@@ -529,6 +547,49 @@ async fn slack_messages_have_formatted_ts_and_permalink() {
         rows[1]["permalink"],
         "https://slack.com/archives/C123456/p1609459300000200"
     );
+}
+
+#[tokio::test]
+async fn missing_required_filter_surfaces_structured_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": [] })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_required", &server.uri());
+    let table = &mut manifest["tables"][0];
+    table["filters"] = json!([{ "name": "id", "required": true }]);
+    table["request"]["query"] = json!([
+        { "name": "id", "from": "filter", "key": "id" }
+    ]);
+    let source = build_source(manifest);
+
+    let error =
+        CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM http_required.users")
+            .await
+            .expect_err("query without the required filter should fail");
+
+    assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
+    match &error {
+        CoreError::Structured(sqe) => {
+            assert_eq!(sqe.reason(), "MISSING_REQUIRED_FILTER");
+            assert!(!sqe.retryable());
+            assert_eq!(sqe.metadata().get("schema").unwrap(), "http_required");
+            assert_eq!(sqe.metadata().get("table").unwrap(), "users");
+            assert_eq!(sqe.metadata().get("field").unwrap(), "id");
+            assert!(sqe.plain_message().contains("WHERE id"));
+            assert!(
+                sqe.metadata()
+                    .get("hint")
+                    .unwrap()
+                    .contains("coral.columns")
+            );
+        }
+        other => panic!("unexpected missing-filter error variant: {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -382,7 +382,7 @@ async fn api_returns_500() {
 
     assert_eq!(error.status_code(), StatusCode::Unavailable);
     match &error {
-        CoreError::Structured(sqe) => {
+        CoreError::QueryFailure(sqe) => {
             assert_eq!(sqe.reason(), "PROVIDER_REQUEST_FAILED");
             assert!(sqe.retryable());
             assert_eq!(sqe.metadata().get("http_status").unwrap(), "500");
@@ -411,7 +411,7 @@ async fn api_returns_401() {
 
     assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
     match &error {
-        CoreError::Structured(sqe) => {
+        CoreError::QueryFailure(sqe) => {
             assert_eq!(sqe.reason(), "PROVIDER_REQUEST_FAILED");
             assert!(!sqe.retryable());
             assert_eq!(sqe.metadata().get("http_status").unwrap(), "401");
@@ -569,7 +569,7 @@ async fn missing_required_filter_surfaces_structured_error() {
 
     assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
     match &error {
-        CoreError::Structured(sqe) => {
+        CoreError::QueryFailure(sqe) => {
             assert_eq!(sqe.reason(), "MISSING_REQUIRED_FILTER");
             assert!(!sqe.retryable());
             assert_eq!(sqe.metadata().get("schema").unwrap(), "http_required");


### PR DESCRIPTION
## Summary

- Introduces `StructuredQueryError` with first-class `summary`, `detail`, `hint` fields (not metadata conventions) and a `pub(crate)` constructor so only `coral-engine` can build them
- Rewrites `provider_error_to_core` to produce structured errors for HTTP provider failures (400/401/403/404/429/5xx) with actionable hints
- `coral-app` owns wire encoding: inserts fields into `ErrorInfo.metadata`, renders plain-text fallback for `Status::message()`, applies trailer-safe truncation
- `coral-client` decodes AIP-193 details and promotes `summary`/`detail`/`hint` out of metadata into first-class `CoralQueryError` fields
- `StructuredQueryError` implements `Display` with the full multi-line message so direct `CoreError` consumers retain detail and hint

### Ownership model

| Layer | Crate | Owns |
|---|---|---|
| Error semantics | `coral-engine` | `StructuredQueryError` with typed fields, no transport awareness |
| Wire encoding | `coral-app` | AIP-193 `ErrorInfo` packing, plain-text rendering, trailer truncation |
| Wire decoding | `coral-client` | `CoralQueryError` with first-class summary/detail/hint |
| Rendering | `coral-cli`, `coral-mcp` | Consume `CoralQueryError` fields directly (PRs #100, #102) |

**Stacked on:** #84 (merged)

## Test plan

- [x] 5 engine unit tests (missing filter, 401/500 provider errors, URL sanitization)
- [x] 15 engine integration tests (HTTP 500/401, missing required filter assertions via `sqe.summary()`/`sqe.detail()`/`sqe.hint()`)
- [x] 7 client decoder tests (structured decode, promotion out of metadata, plain fallback)
- [x] clippy + fmt clean