### PR TITLE
docs: sync bundled source install behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,12 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 Important files include:
 
 - `config.toml` for installed-source metadata and non-secret variables
-- installed source specs under `workspaces/<workspace>/sources/...`
+- imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
+
+Bundled source specs are not copied into the config directory. Coral resolves
+them from the current binary when you validate or query a bundled source, so
+upgrades pick up newer bundled manifests without re-adding the source.
 
 ## Current focus
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -87,4 +87,6 @@ Important files include:
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 
-Bundled source specs are not copied into the config directory. Coral resolves them from the current binary when you validate or query a bundled source, so upgrades pick up newer bundled manifests without re-adding the source.
+<Note>
+  [Bundled source](/reference/bundled-sources) specs are not copied into the config directory. Coral resolves them from the current binary when you validate or query a bundled source, so upgrades pick up newer bundled manifests without re-adding the source.
+</Note>

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -84,5 +84,7 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 Important files include:
 
 - `config.toml` for installed-source metadata and non-secret variables
-- installed source specs under `workspaces/<workspace>/sources/...`
+- imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
+
+Bundled source specs are not copied into the config directory. Coral resolves them from the current binary when you validate or query a bundled source, so upgrades pick up newer bundled manifests without re-adding the source.

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -36,6 +36,10 @@ Supported sources fall into two categories.
 - **HTTP API** — Coral translates SQL queries into paginated HTTP requests against a provider's REST API.
 - **File-backed** — Coral reads local Parquet or JSONL files directly.
 
+## Upgrade behavior
+
+When you install a bundled source, Coral stores its source identity plus your configured variables and secrets in local state. The bundled manifest itself is resolved from the current Coral binary when you validate or query the source. That means upgrading Coral can pick up bundled-source fixes or new required inputs without requiring you to remove and re-add the source.
+
 ## Don't see what you need?
 
 The bundled set is growing. If your data source is not listed, [write a custom source](/guides/write-a-custom-source), or reach out to us via [Discord](https://discord.gg/h9aun8KpFF) or [GitHub](https://github.com/withcoral/coral/issues).

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -36,10 +36,9 @@ Supported sources fall into two categories.
 - **HTTP API** — Coral translates SQL queries into paginated HTTP requests against a provider's REST API.
 - **File-backed** — Coral reads local Parquet or JSONL files directly.
 
-## Upgrade behavior
+## Upgrading bundled sources
 
-When you install a bundled source, Coral stores its source identity plus your configured variables and secrets in local state. The bundled manifest itself is resolved from the current Coral binary when you validate or query the source. That means upgrading Coral can pick up bundled-source fixes or new required inputs without requiring you to remove and re-add the source.
-
+To update bundled sources, upgrade the Coral binary. Coral resolves each bundled manifest from the current binary at validate or query time, so spec fixes and newly required inputs are picked up automatically, you don't need to remove and re-add the source. Your configured variables and secrets stay in local state across upgrades.
 ## Don't see what you need?
 
 The bundled set is growing. If your data source is not listed, [write a custom source](/guides/write-a-custom-source), or reach out to us via [Discord](https://discord.gg/h9aun8KpFF) or [GitHub](https://github.com/withcoral/coral/issues).

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -23,7 +23,7 @@ Manage configured sources, either the bundled ones, or your custom source specs.
 
 ### `coral source discover`
 
-List the bundled sources available in your current Coral build.
+List the [bundled sources](/reference/bundled-sources) available in your current Coral build.
 
 ```shellscript
 coral source discover

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -23,11 +23,13 @@ Manage configured sources, either the bundled ones, or your custom source specs.
 
 ### `coral source discover`
 
-List all configured sources.
+List the bundled sources available in your current Coral build.
 
 ```shellscript
 coral source discover
 ```
+
+The output includes each source name, the bundled version currently shipped in the binary, and whether it is already `installed` or still `available`.
 
 ### `coral source list`
 


### PR DESCRIPTION
## Summary
- document that only imported sources persist `manifest.yaml` in local state
- explain that bundled sources resolve manifests from the current binary, so upgrades pick up bundled-spec fixes and new required inputs without reinstalling
- correct `coral source discover` docs so they describe the bundled source catalog instead of configured sources

## Validation
- `git diff --check origin/main...HEAD`

## Context
These docs changes keep the installation and reference pages aligned with the current bundled-source loading behavior shipped in the app.
