### PR TITLE
fix(engine): default coral.columns to schema order

### DIFF
--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -166,10 +166,10 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
         .collect::<Vec<_>>();
 
     rows.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name, &left.column_name).cmp(&(
+        (&left.schema_name, &left.table_name, left.ordinal_position).cmp(&(
             &right.schema_name,
             &right.table_name,
-            &right.column_name,
+            right.ordinal_position,
         ))
     });
 

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -128,6 +128,31 @@ async fn coral_columns_returns_metadata() {
 }
 
 #[tokio::test]
+async fn coral_columns_default_row_order_matches_ordinal_position() {
+    let (_temp, sources) = build_catalog_sources();
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT column_name, ordinal_position \
+             FROM coral.columns WHERE schema_name = 'alpha' AND table_name = 'users'",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({"column_name": "id", "ordinal_position": 0}),
+            json!({"column_name": "team_id", "ordinal_position": 1}),
+            json!({"column_name": "name", "ordinal_position": 2}),
+        ]
+    );
+}
+
+#[tokio::test]
 async fn list_tables_matches_catalog() {
     let (_temp, sources) = build_catalog_sources();
 


### PR DESCRIPTION
## Summary
- change `coral.columns` materialization to sort by `schema_name`, `table_name`, and `ordinal_position`
- add a regression test that verifies the default row order without an explicit `ORDER BY`

## Why
The metadata table exposed `ordinal_position` as the schema-definition order, but its default emitted rows were sorted alphabetically by `column_name`. This keeps the default output aligned with the schema order the metadata is already advertising, while still allowing callers to request a different sort explicitly.

## Validation
- `cargo test -p coral-engine coral_columns_default_row_order_matches_ordinal_position`
- `make rust-checks`
