### PR TITLE
feat(cli): run source-spec test queries during source test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ target
 # Local task files
 tasks/
 /.github/scripts/__pycache__
-.omx/

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ target
 # Local task files
 tasks/
 /.github/scripts/__pycache__
+.omx/

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -180,11 +180,11 @@ message ValidateSourceResponse {
   // Validation-query results declared by the source spec.
   repeated QueryTestResult query_tests = 3;
   // Total number of declared validation queries.
-  uint32 declared_query_count = 4;
+  uint64 declared_query_count = 4;
   // Number of validation queries that passed.
-  uint32 passed_query_count = 5;
+  uint64 passed_query_count = 5;
   // Number of validation queries that failed.
-  uint32 failed_query_count = 6;
+  uint64 failed_query_count = 6;
   // Whether every declared validation query passed.
   bool all_query_tests_passed = 7;
 }

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -159,16 +159,29 @@ message ValidateSourceRequest {
   string name = 2;
 }
 
+// Success details for one validation query.
+message QueryTestSuccess {
+  // Row count captured for the successful query.
+  uint64 row_count = 1;
+}
+
+// Failure details for one validation query.
+message QueryTestFailure {
+  // Error message captured for the failed query.
+  string error_message = 1;
+}
+
 // One validation query executed for a source.
 message QueryTestResult {
   // SQL text declared by the source spec.
   string sql = 1;
-  // Whether the query executed successfully.
-  bool passed = 2;
-  // Row count captured for the query result; zero when not reported.
-  uint64 row_count = 3;
-  // Error message captured for failed queries; empty when none.
-  string error_message = 4;
+  // Outcome of the validation query.
+  oneof outcome {
+    // Successful query execution metadata.
+    QueryTestSuccess success = 2;
+    // Failed query execution metadata.
+    QueryTestFailure failure = 3;
+  }
 }
 
 // Returns source details plus the tables exposed during validation.

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -159,12 +159,34 @@ message ValidateSourceRequest {
   string name = 2;
 }
 
+// One validation query executed for a source.
+message QueryTestResult {
+  // SQL text declared by the source spec.
+  string sql = 1;
+  // Whether the query executed successfully.
+  bool passed = 2;
+  // Optional row count captured for successful queries.
+  optional uint64 row_count = 3;
+  // Optional error message captured for failed queries.
+  optional string error_message = 4;
+}
+
 // Returns source details plus the tables exposed during validation.
 message ValidateSourceResponse {
   // The validated source resource.
   Source source = 1;
   // Tables exposed by the validated source.
   repeated Table tables = 2;
+  // Validation-query results declared by the source spec.
+  repeated QueryTestResult query_tests = 3;
+  // Total number of declared validation queries.
+  uint32 declared_query_count = 4;
+  // Number of validation queries that passed.
+  uint32 passed_query_count = 5;
+  // Number of validation queries that failed.
+  uint32 failed_query_count = 6;
+  // Whether every declared validation query passed.
+  bool all_query_tests_passed = 7;
 }
 
 // Source registration and validation APIs.

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -165,10 +165,10 @@ message QueryTestResult {
   string sql = 1;
   // Whether the query executed successfully.
   bool passed = 2;
-  // Optional row count captured for successful queries.
-  optional uint64 row_count = 3;
-  // Optional error message captured for failed queries.
-  optional string error_message = 4;
+  // Row count captured for the query result; zero when not reported.
+  uint64 row_count = 3;
+  // Error message captured for failed queries; empty when none.
+  string error_message = 4;
 }
 
 // Returns source details plus the tables exposed during validation.

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -192,14 +192,6 @@ message ValidateSourceResponse {
   repeated Table tables = 2;
   // Validation-query results declared by the source spec.
   repeated QueryTestResult query_tests = 3;
-  // Total number of declared validation queries.
-  uint64 declared_query_count = 4;
-  // Number of validation queries that passed.
-  uint64 passed_query_count = 5;
-  // Number of validation queries that failed.
-  uint64 failed_query_count = 6;
-  // Whether every declared validation query passed.
-  bool all_query_tests_passed = 7;
 }
 
 // Source registration and validation APIs.

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    TableInfo,
+    SourceValidationOutcome, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_source_manifest_yaml};
 
@@ -23,7 +23,7 @@ pub(crate) enum QueryManagerError {
 
 pub(crate) struct ValidatedSource {
     pub(crate) source: InstalledSource,
-    pub(crate) tables: Vec<TableInfo>,
+    pub(crate) outcome: SourceValidationOutcome,
 }
 
 #[derive(Clone)]
@@ -89,13 +89,17 @@ impl QueryManager {
             .load_query_source(workspace_name, &source)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_provider();
-        let tables = CoralQuery::test_source(&query_source, &runtime)
+        let outcome = CoralQuery::validate_source_with_tests(
+            &query_source,
+            &runtime,
+            query_source.source_spec().test_queries(),
+        )
             .await
             .map_err(QueryManagerError::Core)?;
         let mut source = source;
         source.version = version;
 
-        Ok(ValidatedSource { source, tables })
+        Ok(ValidatedSource { source, outcome })
     }
 
     fn load_query_sources(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -94,8 +94,8 @@ impl QueryManager {
             &runtime,
             query_source.source_spec().test_queries(),
         )
-            .await
-            .map_err(QueryManagerError::Core)?;
+        .await
+        .map_err(QueryManagerError::Core)?;
         let mut source = source;
         source.version = version;
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    SourceValidationOutcome, TableInfo,
+    SourceValidationReport, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_source_manifest_yaml};
 
@@ -23,7 +23,7 @@ pub(crate) enum QueryManagerError {
 
 pub(crate) struct ValidatedSource {
     pub(crate) source: InstalledSource,
-    pub(crate) outcome: SourceValidationOutcome,
+    pub(crate) report: SourceValidationReport,
 }
 
 #[derive(Clone)]
@@ -89,7 +89,7 @@ impl QueryManager {
             .load_query_source(workspace_name, &source)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_provider();
-        let outcome = CoralQuery::validate_source_with_tests(
+        let report = CoralQuery::validate_source(
             &query_source,
             &runtime,
             query_source.source_spec().test_queries(),
@@ -99,7 +99,7 @@ impl QueryManager {
         let mut source = source;
         source.version = version;
 
-        Ok(ValidatedSource { source, outcome })
+        Ok(ValidatedSource { source, report })
     }
 
     fn load_query_sources(

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -17,7 +17,9 @@ use crate::sources::manager::SourceManager;
 use crate::sources::model::{
     CandidateSource, CandidateSourceInput, CandidateSourceInputKind, InstalledSource, SourceOrigin,
 };
-use crate::transport::{query_status, table_to_proto, workspace_to_proto};
+use crate::transport::{
+    query_status, query_test_result_to_proto, table_to_proto, workspace_to_proto,
+};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Clone)]
@@ -181,13 +183,25 @@ impl SourceServiceApi for SourceService {
             .await
             .map_err(query_status)?;
         let tables = result
+            .outcome
             .tables
             .into_iter()
             .map(|table| table_to_proto(&workspace_name, table))
             .collect::<Vec<_>>();
+        let query_tests = result
+            .outcome
+            .query_tests
+            .into_iter()
+            .map(query_test_result_to_proto)
+            .collect();
         Ok(Response::new(ValidateSourceResponse {
             source: Some(installed_source_to_proto(&workspace_name, result.source)),
             tables,
+            query_tests,
+            declared_query_count: result.outcome.declared_query_count,
+            passed_query_count: result.outcome.passed_query_count,
+            failed_query_count: result.outcome.failed_query_count,
+            all_query_tests_passed: result.outcome.all_query_tests_passed,
         }))
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -195,7 +195,7 @@ impl SourceServiceApi for SourceService {
             .map(|table| table_to_proto(&workspace_name, table))
             .collect::<Vec<_>>();
         let query_tests = query_tests
-            .into_iter()
+            .iter()
             .map(query_test_result_to_proto)
             .collect::<Vec<_>>();
         Ok(Response::new(ValidateSourceResponse {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -182,26 +182,30 @@ impl SourceServiceApi for SourceService {
             .validate_source(&workspace_name, &source_name)
             .await
             .map_err(query_status)?;
-        let tables = result
-            .outcome
-            .tables
+        let coral_engine::SourceValidationOutcome {
+            tables,
+            query_tests,
+            declared_query_count,
+            passed_query_count,
+            failed_query_count,
+            all_query_tests_passed,
+        } = result.outcome;
+        let tables = tables
             .into_iter()
             .map(|table| table_to_proto(&workspace_name, table))
             .collect::<Vec<_>>();
-        let query_tests = result
-            .outcome
-            .query_tests
+        let query_tests = query_tests
             .into_iter()
             .map(query_test_result_to_proto)
-            .collect();
+            .collect::<Vec<_>>();
         Ok(Response::new(ValidateSourceResponse {
             source: Some(installed_source_to_proto(&workspace_name, result.source)),
             tables,
             query_tests,
-            declared_query_count: result.outcome.declared_query_count,
-            passed_query_count: result.outcome.passed_query_count,
-            failed_query_count: result.outcome.failed_query_count,
-            all_query_tests_passed: result.outcome.all_query_tests_passed,
+            declared_query_count,
+            passed_query_count,
+            failed_query_count,
+            all_query_tests_passed,
         }))
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -17,9 +17,7 @@ use crate::sources::manager::SourceManager;
 use crate::sources::model::{
     CandidateSource, CandidateSourceInput, CandidateSourceInputKind, InstalledSource, SourceOrigin,
 };
-use crate::transport::{
-    query_status, query_test_result_to_proto, table_to_proto, workspace_to_proto,
-};
+use crate::transport::{query_status, validate_source_response_to_proto, workspace_to_proto};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Clone)]
@@ -182,31 +180,13 @@ impl SourceServiceApi for SourceService {
             .validate_source(&workspace_name, &source_name)
             .await
             .map_err(query_status)?;
-        let coral_engine::SourceValidationOutcome {
-            tables,
-            query_tests,
-            declared_query_count,
-            passed_query_count,
-            failed_query_count,
-            all_query_tests_passed,
-        } = result.outcome;
-        let tables = tables
-            .into_iter()
-            .map(|table| table_to_proto(&workspace_name, table))
-            .collect::<Vec<_>>();
-        let query_tests = query_tests
-            .iter()
-            .map(query_test_result_to_proto)
-            .collect::<Vec<_>>();
-        Ok(Response::new(ValidateSourceResponse {
-            source: Some(installed_source_to_proto(&workspace_name, result.source)),
-            tables,
-            query_tests,
-            declared_query_count,
-            passed_query_count,
-            failed_query_count,
-            all_query_tests_passed,
-        }))
+        let crate::query::manager::ValidatedSource { source, report } = result;
+        let source = installed_source_to_proto(&workspace_name, source);
+        Ok(Response::new(validate_source_response_to_proto(
+            source,
+            &workspace_name,
+            report,
+        )))
     }
 }
 

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,6 +1,6 @@
 //! Shared gRPC transport helpers for app-owned services.
 
-use coral_api::v1::{Column, Table, Workspace};
+use coral_api::v1::{Column, QueryTestResult, Table, Workspace};
 use tonic::Status;
 
 use crate::bootstrap::{app_status, core_status};
@@ -46,15 +46,24 @@ pub(crate) fn table_to_proto(
     }
 }
 
+pub(crate) fn query_test_result_to_proto(result: coral_engine::QueryTestResult) -> QueryTestResult {
+    QueryTestResult {
+        sql: result.sql().to_string(),
+        passed: result.passed(),
+        row_count: result.row_count(),
+        error_message: result.error_message().map(ToString::to_string),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use tonic::Code;
 
-    use super::{query_status, table_to_proto, workspace_to_proto};
+    use super::{query_status, query_test_result_to_proto, table_to_proto, workspace_to_proto};
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
     use crate::workspaces::WorkspaceName;
-    use coral_engine::{ColumnInfo, CoreError, TableInfo};
+    use coral_engine::{ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo};
 
     #[test]
     fn query_status_maps_app_errors() {
@@ -102,5 +111,20 @@ mod tests {
         assert_eq!(proto.columns[0].data_type, "Int64");
         assert!(!proto.columns[0].nullable);
         assert_eq!(proto.required_filters, vec!["org_id"]);
+    }
+
+    #[test]
+    fn query_test_result_to_proto_preserves_result_metadata() {
+        let proto = query_test_result_to_proto(EngineQueryTestResult::new(
+            "SELECT 1",
+            false,
+            None,
+            Some("failed precondition: boom".to_string()),
+        ));
+
+        assert_eq!(proto.sql, "SELECT 1");
+        assert!(!proto.passed);
+        assert_eq!(proto.row_count, None);
+        assert_eq!(proto.error_message.as_deref(), Some("failed precondition: boom"));
     }
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,8 +1,8 @@
 //! Shared gRPC transport helpers for app-owned services.
 
 use coral_api::v1::{
-    Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Table, Workspace,
-    query_test_result,
+    Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table,
+    ValidateSourceResponse, Workspace, query_test_result,
 };
 use tonic::Status;
 
@@ -52,21 +52,36 @@ pub(crate) fn table_to_proto(
 pub(crate) fn query_test_result_to_proto(
     result: &coral_engine::QueryTestResult,
 ) -> QueryTestResult {
-    let outcome = match result.outcome() {
-        coral_engine::QueryTestOutcome::Success { row_count } => {
-            Some(query_test_result::Outcome::Success(QueryTestSuccess {
-                row_count: *row_count,
-            }))
-        }
-        coral_engine::QueryTestOutcome::Failure { error_message } => {
-            Some(query_test_result::Outcome::Failure(QueryTestFailure {
-                error_message: error_message.clone(),
-            }))
-        }
+    let outcome = match result.result() {
+        Ok(success) => Some(query_test_result::Outcome::Success(QueryTestSuccess {
+            row_count: success.row_count(),
+        })),
+        Err(failure) => Some(query_test_result::Outcome::Failure(QueryTestFailure {
+            error_message: failure.error_message().to_string(),
+        })),
     };
     QueryTestResult {
         sql: result.sql().to_string(),
         outcome,
+    }
+}
+
+pub(crate) fn validate_source_response_to_proto(
+    source: Source,
+    workspace_name: &WorkspaceName,
+    report: coral_engine::SourceValidationReport,
+) -> ValidateSourceResponse {
+    let coral_engine::SourceValidationReport {
+        tables,
+        query_tests,
+    } = report;
+    ValidateSourceResponse {
+        source: Some(source),
+        tables: tables
+            .into_iter()
+            .map(|table| table_to_proto(workspace_name, table))
+            .collect(),
+        query_tests: query_tests.iter().map(query_test_result_to_proto).collect(),
     }
 }
 

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -53,7 +53,7 @@ pub(crate) fn query_test_result_to_proto(
         sql: result.sql().to_string(),
         passed: result.passed(),
         row_count: result.row_count(),
-        error_message: result.error_message().map(ToString::to_string),
+        error_message: result.error_message().to_string(),
     }
 }
 
@@ -122,16 +122,13 @@ mod tests {
         let proto = query_test_result_to_proto(&EngineQueryTestResult::new(
             "SELECT 1",
             false,
-            None,
-            Some("failed precondition: boom".to_string()),
+            0,
+            "failed precondition: boom",
         ));
 
         assert_eq!(proto.sql, "SELECT 1");
         assert!(!proto.passed);
-        assert_eq!(proto.row_count, None);
-        assert_eq!(
-            proto.error_message.as_deref(),
-            Some("failed precondition: boom")
-        );
+        assert_eq!(proto.row_count, 0);
+        assert_eq!(proto.error_message, "failed precondition: boom");
     }
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -46,7 +46,9 @@ pub(crate) fn table_to_proto(
     }
 }
 
-pub(crate) fn query_test_result_to_proto(result: coral_engine::QueryTestResult) -> QueryTestResult {
+pub(crate) fn query_test_result_to_proto(
+    result: &coral_engine::QueryTestResult,
+) -> QueryTestResult {
     QueryTestResult {
         sql: result.sql().to_string(),
         passed: result.passed(),
@@ -115,7 +117,7 @@ mod tests {
 
     #[test]
     fn query_test_result_to_proto_preserves_result_metadata() {
-        let proto = query_test_result_to_proto(EngineQueryTestResult::new(
+        let proto = query_test_result_to_proto(&EngineQueryTestResult::new(
             "SELECT 1",
             false,
             None,

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -125,6 +125,9 @@ mod tests {
         assert_eq!(proto.sql, "SELECT 1");
         assert!(!proto.passed);
         assert_eq!(proto.row_count, None);
-        assert_eq!(proto.error_message.as_deref(), Some("failed precondition: boom"));
+        assert_eq!(
+            proto.error_message.as_deref(),
+            Some("failed precondition: boom")
+        );
     }
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -65,7 +65,9 @@ mod tests {
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
     use crate::workspaces::WorkspaceName;
-    use coral_engine::{ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo};
+    use coral_engine::{
+        ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo,
+    };
 
     #[test]
     fn query_status_maps_app_errors() {

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,6 +1,9 @@
 //! Shared gRPC transport helpers for app-owned services.
 
-use coral_api::v1::{Column, QueryTestResult, Table, Workspace};
+use coral_api::v1::{
+    Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Table, Workspace,
+    query_test_result,
+};
 use tonic::Status;
 
 use crate::bootstrap::{app_status, core_status};
@@ -49,16 +52,27 @@ pub(crate) fn table_to_proto(
 pub(crate) fn query_test_result_to_proto(
     result: &coral_engine::QueryTestResult,
 ) -> QueryTestResult {
+    let outcome = match result.outcome() {
+        coral_engine::QueryTestOutcome::Success { row_count } => {
+            Some(query_test_result::Outcome::Success(QueryTestSuccess {
+                row_count: *row_count,
+            }))
+        }
+        coral_engine::QueryTestOutcome::Failure { error_message } => {
+            Some(query_test_result::Outcome::Failure(QueryTestFailure {
+                error_message: error_message.clone(),
+            }))
+        }
+    };
     QueryTestResult {
         sql: result.sql().to_string(),
-        passed: result.passed(),
-        row_count: result.row_count(),
-        error_message: result.error_message().to_string(),
+        outcome,
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use coral_api::v1::{QueryTestFailure, query_test_result};
     use tonic::Code;
 
     use super::{query_status, query_test_result_to_proto, table_to_proto, workspace_to_proto};
@@ -119,16 +133,16 @@ mod tests {
 
     #[test]
     fn query_test_result_to_proto_preserves_result_metadata() {
-        let proto = query_test_result_to_proto(&EngineQueryTestResult::new(
+        let proto = query_test_result_to_proto(&EngineQueryTestResult::failure(
             "SELECT 1",
-            false,
-            0,
             "failed precondition: boom",
         ));
 
         assert_eq!(proto.sql, "SELECT 1");
-        assert!(!proto.passed);
-        assert_eq!(proto.row_count, 0);
-        assert_eq!(proto.error_message, "failed precondition: boom");
+        assert!(matches!(
+            proto.outcome,
+            Some(query_test_result::Outcome::Failure(QueryTestFailure { error_message }))
+                if error_message == "failed precondition: boom"
+        ));
     }
 }

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -198,7 +198,10 @@ pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
     fixture_manifest_with_test_queries_yaml(root, &[])
 }
 
-pub(crate) fn fixture_manifest_with_test_queries_yaml(root: &Path, test_queries: &[&str]) -> String {
+pub(crate) fn fixture_manifest_with_test_queries_yaml(
+    root: &Path,
+    test_queries: &[&str],
+) -> String {
     let data_dir = root.join("fixture-data");
     fs::create_dir_all(&data_dir).expect("create data dir");
     fs::write(

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -161,12 +161,17 @@ impl FailingHttpFixture {
     }
 
     pub(crate) fn manifest_yaml(&self) -> String {
+        self.manifest_yaml_with_test_queries(&[])
+    }
+
+    pub(crate) fn manifest_yaml_with_test_queries(&self, test_queries: &[&str]) -> String {
         manifest_yaml(&json!({
             "name": "unreachable_messages",
             "version": "0.1.0",
             "dsl_version": 3,
             "backend": "http",
             "base_url": self.base_url,
+            "test_queries": test_queries,
             "tables": [{
                 "name": "messages",
                 "description": "Unreachable messages",
@@ -190,6 +195,10 @@ impl Drop for FailingHttpFixture {
 }
 
 pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
+    fixture_manifest_with_test_queries_yaml(root, &[])
+}
+
+pub(crate) fn fixture_manifest_with_test_queries_yaml(root: &Path, test_queries: &[&str]) -> String {
     let data_dir = root.join("fixture-data");
     fs::create_dir_all(&data_dir).expect("create data dir");
     fs::write(
@@ -204,6 +213,7 @@ pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
         "version": "0.1.0",
         "dsl_version": 3,
         "backend": "jsonl",
+        "test_queries": test_queries,
         "tables": [{
             "name": "messages",
             "description": "Fixture messages",

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -232,13 +232,10 @@ async fn validate_source_returns_query_test_results_without_unary_error() {
     assert!(!validated.all_query_tests_passed);
     assert_eq!(validated.query_tests.len(), 2);
     assert!(validated.query_tests[0].passed);
-    assert_eq!(validated.query_tests[0].row_count, Some(1));
+    assert_eq!(validated.query_tests[0].row_count, 1);
     assert!(!validated.query_tests[1].passed);
     assert!(
-        validated.query_tests[1]
-            .error_message
-            .as_deref()
-            .is_some_and(|message| !message.is_empty()),
+        !validated.query_tests[1].error_message.is_empty(),
         "failed query should carry a non-empty error message"
     );
 }
@@ -332,10 +329,7 @@ async fn validate_source_with_unreachable_api_and_test_queries_returns_query_fai
     assert_eq!(validated.failed_query_count, 1);
     assert!(!validated.all_query_tests_passed);
     assert!(
-        validated.query_tests[0]
-            .error_message
-            .as_deref()
-            .is_some_and(|message| !message.is_empty()),
+        !validated.query_tests[0].error_message.is_empty(),
         "failed query should carry a non-empty error message"
     );
 }
@@ -355,8 +349,8 @@ async fn validate_source_with_non_read_only_test_query_returns_stable_query_erro
     assert_eq!(validated.query_tests.len(), 1);
     assert_eq!(validated.failed_query_count, 1);
     assert_eq!(
-        validated.query_tests[0].error_message.as_deref(),
-        Some("test query must be read-only SQL")
+        validated.query_tests[0].error_message,
+        "test query must be read-only SQL"
     );
 }
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -238,8 +238,8 @@ async fn validate_source_returns_query_test_results_without_unary_error() {
         validated.query_tests[1]
             .error_message
             .as_deref()
-            .expect("failed query should have an error")
-            .contains("resource not found")
+            .is_some_and(|message| !message.is_empty()),
+        "failed query should carry a non-empty error message"
     );
 }
 
@@ -319,9 +319,8 @@ async fn validate_source_with_unreachable_api_and_test_queries_returns_query_fai
     let failing_http = FailingHttpFixture::new().await;
     harness
         .import_source(
-            failing_http.manifest_yaml_with_test_queries(&[
-                "SELECT * FROM unreachable_messages.messages",
-            ]),
+            failing_http
+                .manifest_yaml_with_test_queries(&["SELECT * FROM unreachable_messages.messages"]),
             Vec::new(),
             Vec::new(),
         )
@@ -336,13 +335,8 @@ async fn validate_source_with_unreachable_api_and_test_queries_returns_query_fai
         validated.query_tests[0]
             .error_message
             .as_deref()
-            .expect("failed query should carry an error")
-            .contains("failed precondition")
-            || validated.query_tests[0]
-                .error_message
-                .as_deref()
-                .expect("failed query should carry an error")
-                .contains("unavailable")
+            .is_some_and(|message| !message.is_empty()),
+        "failed query should carry a non-empty error message"
     );
 }
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -199,10 +199,6 @@ async fn validate_source_returns_tables() {
     assert_eq!(validated.tables[0].name, "messages");
     assert!(validated.tables[0].required_filters.is_empty());
     assert!(validated.query_tests.is_empty());
-    assert_eq!(validated.declared_query_count, 0);
-    assert_eq!(validated.passed_query_count, 0);
-    assert_eq!(validated.failed_query_count, 0);
-    assert!(validated.all_query_tests_passed);
 
     let rows = harness
         .execute_sql_rows("SELECT type, text FROM local_messages.messages ORDER BY text")
@@ -227,10 +223,6 @@ async fn validate_source_returns_query_test_results_without_unary_error() {
 
     let validated = harness.validate_source("local_messages").await;
     assert_eq!(validated.tables.len(), 1);
-    assert_eq!(validated.declared_query_count, 2);
-    assert_eq!(validated.passed_query_count, 1);
-    assert_eq!(validated.failed_query_count, 1);
-    assert!(!validated.all_query_tests_passed);
     assert_eq!(validated.query_tests.len(), 2);
     assert!(matches!(
         &validated.query_tests[0].outcome,
@@ -310,7 +302,6 @@ async fn validate_source_with_unreachable_api_returns_declared_tables() {
     assert_eq!(validated.tables[0].schema_name, "unreachable_messages");
     assert_eq!(validated.tables[0].name, "messages");
     assert!(validated.query_tests.is_empty());
-    assert!(validated.all_query_tests_passed);
 }
 
 #[tokio::test]
@@ -329,8 +320,6 @@ async fn validate_source_with_unreachable_api_and_test_queries_returns_query_fai
     let validated = harness.validate_source("unreachable_messages").await;
     assert_eq!(validated.tables.len(), 1);
     assert_eq!(validated.query_tests.len(), 1);
-    assert_eq!(validated.failed_query_count, 1);
-    assert!(!validated.all_query_tests_passed);
     assert!(matches!(
         &validated.query_tests[0].outcome,
         Some(query_test_result::Outcome::Failure(QueryTestFailure { error_message }))
@@ -351,7 +340,6 @@ async fn validate_source_with_non_read_only_test_query_returns_stable_query_erro
 
     let validated = harness.validate_source("local_messages").await;
     assert_eq!(validated.query_tests.len(), 1);
-    assert_eq!(validated.failed_query_count, 1);
     assert!(matches!(
         &validated.query_tests[0].outcome,
         Some(query_test_result::Outcome::Failure(QueryTestFailure { error_message }))

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -11,8 +11,8 @@ use tonic::Request;
 
 use crate::harness::{
     FailingHttpFixture, GrpcHarness, fixture_manifest_with_inputs_yaml,
-    fixture_manifest_with_required_inputs_yaml, fixture_manifest_yaml, invalid_manifest_yaml,
-    source_dir,
+    fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
+    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
 };
 
 #[tokio::test]
@@ -197,12 +197,50 @@ async fn validate_source_returns_tables() {
     assert_eq!(validated.tables[0].schema_name, "local_messages");
     assert_eq!(validated.tables[0].name, "messages");
     assert!(validated.tables[0].required_filters.is_empty());
+    assert!(validated.query_tests.is_empty());
+    assert_eq!(validated.declared_query_count, 0);
+    assert_eq!(validated.passed_query_count, 0);
+    assert_eq!(validated.failed_query_count, 0);
+    assert!(validated.all_query_tests_passed);
 
     let rows = harness
         .execute_sql_rows("SELECT type, text FROM local_messages.messages ORDER BY text")
         .await;
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["text"], "hello");
+}
+
+#[tokio::test]
+async fn validate_source_returns_query_test_results_without_unary_error() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_with_test_queries_yaml(
+        harness.temp_path(),
+        &[
+            "SELECT COUNT(*) AS n FROM local_messages.messages",
+            "SELECT * FROM local_messages.missing",
+        ],
+    );
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    let validated = harness.validate_source("local_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.declared_query_count, 2);
+    assert_eq!(validated.passed_query_count, 1);
+    assert_eq!(validated.failed_query_count, 1);
+    assert!(!validated.all_query_tests_passed);
+    assert_eq!(validated.query_tests.len(), 2);
+    assert!(validated.query_tests[0].passed);
+    assert_eq!(validated.query_tests[0].row_count, Some(1));
+    assert!(!validated.query_tests[1].passed);
+    assert!(
+        validated.query_tests[1]
+            .error_message
+            .as_deref()
+            .expect("failed query should have an error")
+            .contains("resource not found")
+    );
 }
 
 #[tokio::test]
@@ -271,6 +309,99 @@ async fn validate_source_with_unreachable_api_returns_declared_tables() {
     assert_eq!(validated.tables.len(), 1);
     assert_eq!(validated.tables[0].schema_name, "unreachable_messages");
     assert_eq!(validated.tables[0].name, "messages");
+    assert!(validated.query_tests.is_empty());
+    assert!(validated.all_query_tests_passed);
+}
+
+#[tokio::test]
+async fn validate_source_with_unreachable_api_and_test_queries_returns_query_failures() {
+    let harness = GrpcHarness::new().await;
+    let failing_http = FailingHttpFixture::new().await;
+    harness
+        .import_source(
+            failing_http.manifest_yaml_with_test_queries(&[
+                "SELECT * FROM unreachable_messages.messages",
+            ]),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let validated = harness.validate_source("unreachable_messages").await;
+    assert_eq!(validated.tables.len(), 1);
+    assert_eq!(validated.query_tests.len(), 1);
+    assert_eq!(validated.failed_query_count, 1);
+    assert!(!validated.all_query_tests_passed);
+    assert!(
+        validated.query_tests[0]
+            .error_message
+            .as_deref()
+            .expect("failed query should carry an error")
+            .contains("failed precondition")
+            || validated.query_tests[0]
+                .error_message
+                .as_deref()
+                .expect("failed query should carry an error")
+                .contains("unavailable")
+    );
+}
+
+#[tokio::test]
+async fn validate_source_with_non_read_only_test_query_returns_stable_query_error() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_with_test_queries_yaml(
+        harness.temp_path(),
+        &["SET datafusion.execution.batch_size = 1"],
+    );
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    let validated = harness.validate_source("local_messages").await;
+    assert_eq!(validated.query_tests.len(), 1);
+    assert_eq!(validated.failed_query_count, 1);
+    assert_eq!(
+        validated.query_tests[0].error_message.as_deref(),
+        Some("test query must be read-only SQL")
+    );
+}
+
+#[tokio::test]
+async fn validate_source_skipped_registration_returns_unary_failed_precondition() {
+    let harness = GrpcHarness::new().await;
+    let missing_dir = harness.temp_path().join("missing");
+    let manifest_yaml = serde_yaml::to_string(&serde_json::json!({
+        "name": "missing_messages",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "tables": [{
+            "name": "messages",
+            "description": "Missing messages",
+            "source": {
+                "location": format!("file://{}/", missing_dir.display()),
+                "glob": "**/*.jsonl",
+            },
+            "columns": [
+                {"name": "type", "type": "Utf8"},
+            ],
+        }],
+    }))
+    .expect("serialize manifest yaml");
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    let error = harness
+        .source_client()
+        .validate_source(Request::new(ValidateSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "missing_messages".to_string(),
+        }))
+        .await
+        .expect_err("validation should fail when the source never registers");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(error.message().contains("is not a directory"));
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -2,8 +2,9 @@ use std::fs;
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
-    GetSourceRequest, ImportSourceRequest, ListTablesRequest, SourceOrigin, SourceSecret,
-    SourceVariable, ValidateSourceRequest, Workspace,
+    GetSourceRequest, ImportSourceRequest, ListTablesRequest, QueryTestFailure, QueryTestSuccess,
+    SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, Workspace,
+    query_test_result,
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
@@ -231,13 +232,15 @@ async fn validate_source_returns_query_test_results_without_unary_error() {
     assert_eq!(validated.failed_query_count, 1);
     assert!(!validated.all_query_tests_passed);
     assert_eq!(validated.query_tests.len(), 2);
-    assert!(validated.query_tests[0].passed);
-    assert_eq!(validated.query_tests[0].row_count, 1);
-    assert!(!validated.query_tests[1].passed);
-    assert!(
-        !validated.query_tests[1].error_message.is_empty(),
-        "failed query should carry a non-empty error message"
-    );
+    assert!(matches!(
+        &validated.query_tests[0].outcome,
+        Some(query_test_result::Outcome::Success(QueryTestSuccess { row_count })) if *row_count == 1
+    ));
+    assert!(matches!(
+        &validated.query_tests[1].outcome,
+        Some(query_test_result::Outcome::Failure(QueryTestFailure { error_message }))
+            if !error_message.is_empty()
+    ));
 }
 
 #[tokio::test]
@@ -328,10 +331,11 @@ async fn validate_source_with_unreachable_api_and_test_queries_returns_query_fai
     assert_eq!(validated.query_tests.len(), 1);
     assert_eq!(validated.failed_query_count, 1);
     assert!(!validated.all_query_tests_passed);
-    assert!(
-        !validated.query_tests[0].error_message.is_empty(),
-        "failed query should carry a non-empty error message"
-    );
+    assert!(matches!(
+        &validated.query_tests[0].outcome,
+        Some(query_test_result::Outcome::Failure(QueryTestFailure { error_message }))
+            if !error_message.is_empty()
+    ));
 }
 
 #[tokio::test]
@@ -348,10 +352,11 @@ async fn validate_source_with_non_read_only_test_query_returns_stable_query_erro
     let validated = harness.validate_source("local_messages").await;
     assert_eq!(validated.query_tests.len(), 1);
     assert_eq!(validated.failed_query_count, 1);
-    assert_eq!(
-        validated.query_tests[0].error_message,
-        "test query must be read-only SQL"
-    );
+    assert!(matches!(
+        &validated.query_tests[0].outcome,
+        Some(query_test_result::Outcome::Failure(QueryTestFailure { error_message }))
+            if error_message == "test query must be read-only SQL"
+    ));
 }
 
 #[tokio::test]

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -230,15 +230,7 @@ async fn run_source_add(
         _ => unreachable!("clap enforces exactly one of name or file"),
     };
     println!("Added source {}", response.name);
-    if let Err(err) = source_ops::validate_and_print(
-        app,
-        &response.name,
-        source_ops::TableDisplayLimit::DEFAULT,
-        source_ops::ValidationSeverityMode::WarnOnly,
-    )
-    .await
-    {
-        eprintln!("Warning: validation failed: {err}");
-    }
+    source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
+        .await?;
     Ok(())
 }

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -230,14 +230,13 @@ async fn run_source_add(
         _ => unreachable!("clap enforces exactly one of name or file"),
     };
     println!("Added source {}", response.name);
-    if let Err(err) =
-        source_ops::validate_and_print(
-            app,
-            &response.name,
-            source_ops::TableDisplayLimit::DEFAULT,
-            source_ops::ValidationSeverityMode::WarnOnly,
-        )
-        .await
+    if let Err(err) = source_ops::validate_and_print(
+        app,
+        &response.name,
+        source_ops::TableDisplayLimit::DEFAULT,
+        source_ops::ValidationSeverityMode::WarnOnly,
+    )
+    .await
     {
         eprintln!("Warning: validation failed: {err}");
     }

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -168,6 +168,7 @@ async fn main() -> Result<(), anyhow::Error> {
                     &bootstrap.app,
                     &name,
                     source_ops::TableDisplayLimit::All,
+                    source_ops::ValidationSeverityMode::Strict,
                 )
                 .await?;
             }
@@ -230,8 +231,13 @@ async fn run_source_add(
     };
     println!("Added source {}", response.name);
     if let Err(err) =
-        source_ops::validate_and_print(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
-            .await
+        source_ops::validate_and_print(
+            app,
+            &response.name,
+            source_ops::TableDisplayLimit::DEFAULT,
+            source_ops::ValidationSeverityMode::WarnOnly,
+        )
+        .await
     {
         eprintln!("Warning: validation failed: {err}");
     }

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -158,6 +158,7 @@ async fn run_installed_source_menu(
                 app,
                 &source.name,
                 source_ops::TableDisplayLimit::DEFAULT,
+                source_ops::ValidationSeverityMode::Strict,
             )
             .await?;
         }
@@ -175,6 +176,7 @@ async fn run_installed_source_menu(
                 app,
                 &result.name,
                 source_ops::TableDisplayLimit::DEFAULT,
+                source_ops::ValidationSeverityMode::WarnOnly,
             )
             .await?;
         }
@@ -196,7 +198,13 @@ async fn run_add_bundled_source(
     let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
     let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
     println!("Added source {}", result.name);
-    source_ops::validate_and_print(app, &result.name, source_ops::TableDisplayLimit::DEFAULT).await
+    source_ops::validate_and_print(
+        app,
+        &result.name,
+        source_ops::TableDisplayLimit::DEFAULT,
+        source_ops::ValidationSeverityMode::WarnOnly,
+    )
+    .await
 }
 
 async fn run_next_steps(

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -154,11 +154,10 @@ async fn run_installed_source_menu(
 
     match selection.map(|i| actions[i]) {
         Some(InstalledSourceAction::Validate) => {
-            source_ops::validate_and_print(
+            source_ops::validate_and_warn(
                 app,
                 &source.name,
                 source_ops::TableDisplayLimit::DEFAULT,
-                source_ops::ValidationSeverityMode::Strict,
             )
             .await?;
         }
@@ -172,11 +171,10 @@ async fn run_installed_source_menu(
             let result =
                 source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
             println!("Reconfigured source {}", result.name);
-            source_ops::validate_and_print(
+            source_ops::validate_and_warn(
                 app,
                 &result.name,
                 source_ops::TableDisplayLimit::DEFAULT,
-                source_ops::ValidationSeverityMode::WarnOnly,
             )
             .await?;
         }
@@ -198,13 +196,7 @@ async fn run_add_bundled_source(
     let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
     let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
     println!("Added source {}", result.name);
-    source_ops::validate_and_print(
-        app,
-        &result.name,
-        source_ops::TableDisplayLimit::DEFAULT,
-        source_ops::ValidationSeverityMode::WarnOnly,
-    )
-    .await
+    source_ops::validate_and_warn(app, &result.name, source_ops::TableDisplayLimit::DEFAULT).await
 }
 
 async fn run_next_steps(

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -26,6 +26,19 @@ pub(crate) enum TableDisplayLimit {
     Max(usize),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ValidationSeverityMode {
+    Strict,
+    WarnOnly,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ValidationFollowUp {
+    None,
+    Warn(String),
+    Fail(String),
+}
+
 impl TableDisplayLimit {
     /// The default truncation used after `source add` and during onboarding.
     pub(crate) const DEFAULT: Self = Self::Max(MAX_TABLES_PER_SCHEMA);
@@ -201,9 +214,18 @@ pub(crate) async fn validate_and_print(
     app: &AppClient,
     source_name: &str,
     limit: TableDisplayLimit,
+    severity_mode: ValidationSeverityMode,
 ) -> Result<(), anyhow::Error> {
     let response = validate_source(app, source_name).await?;
-    print_validation_pretty(&response, limit)
+    print_validation_pretty(&response, limit)?;
+    match validation_follow_up(&response, severity_mode) {
+        ValidationFollowUp::None => Ok(()),
+        ValidationFollowUp::Warn(message) => {
+            eprintln!("Warning: {message}");
+            Ok(())
+        }
+        ValidationFollowUp::Fail(message) => Err(anyhow::anyhow!(message)),
+    }
 }
 
 pub(crate) fn print_validation_pretty(
@@ -266,9 +288,71 @@ pub(crate) fn print_validation_pretty(
             );
         }
     }
+
+    if response.declared_query_count > 0 {
+        println!("    {}", style("Query tests").bold());
+        println!(
+            "    {}",
+            style(format!(
+                "{} declared · {} passed · {} failed",
+                response.declared_query_count,
+                response.passed_query_count,
+                response.failed_query_count
+            ))
+            .dim()
+        );
+        for test in &response.query_tests {
+            println!();
+            let status = if test.passed {
+                style("✓").green()
+            } else {
+                style("✗").red()
+            };
+            println!("    {} {}", status, style(test.sql.trim()).bold());
+            match (test.passed, test.row_count, test.error_message.as_deref()) {
+                (true, Some(row_count), _) => println!(
+                    "      {}",
+                    style(format!(
+                        "{row_count} row{}",
+                        if row_count == 1 { "" } else { "s" }
+                    ))
+                    .dim()
+                ),
+                (false, _, Some(error_message)) => {
+                    println!("      {}", style(error_message).yellow())
+                }
+                _ => {}
+            }
+        }
+    }
     println!();
 
     Ok(())
+}
+
+fn validation_follow_up(
+    response: &ValidateSourceResponse,
+    severity_mode: ValidationSeverityMode,
+) -> ValidationFollowUp {
+    if response.declared_query_count == 0 || response.all_query_tests_passed {
+        return ValidationFollowUp::None;
+    }
+
+    let failure_count = response.failed_query_count.max(1);
+    let message = format!(
+        "{} of {} validation quer{} failed",
+        failure_count,
+        response.declared_query_count.max(failure_count),
+        if response.declared_query_count == 1 {
+            "y"
+        } else {
+            "ies"
+        }
+    );
+    match severity_mode {
+        ValidationSeverityMode::Strict => ValidationFollowUp::Fail(message),
+        ValidationSeverityMode::WarnOnly => ValidationFollowUp::Warn(message),
+    }
 }
 
 fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, anyhow::Error> {
@@ -340,9 +424,12 @@ pub(crate) fn finalize_input_value(
 
 #[cfg(test)]
 mod tests {
+    use coral_api::v1::ValidateSourceResponse;
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
-    use super::finalize_input_value;
+    use super::{
+        ValidationFollowUp, ValidationSeverityMode, finalize_input_value, validation_follow_up,
+    };
 
     #[test]
     fn empty_optional_input_is_omitted_for_server_side_defaults() {
@@ -372,5 +459,59 @@ mod tests {
         let error = finalize_input_value(&input, String::new(), "source secret")
             .expect_err("required empty input should fail");
         assert!(error.to_string().contains("missing required source secret"));
+    }
+
+    #[test]
+    fn validation_follow_up_is_none_when_all_query_tests_pass() {
+        let response = ValidateSourceResponse {
+            source: None,
+            tables: Vec::new(),
+            query_tests: Vec::new(),
+            declared_query_count: 1,
+            passed_query_count: 1,
+            failed_query_count: 0,
+            all_query_tests_passed: true,
+        };
+
+        assert_eq!(
+            validation_follow_up(&response, ValidationSeverityMode::Strict),
+            ValidationFollowUp::None
+        );
+    }
+
+    #[test]
+    fn validation_follow_up_is_error_in_strict_mode() {
+        let response = ValidateSourceResponse {
+            source: None,
+            tables: Vec::new(),
+            query_tests: Vec::new(),
+            declared_query_count: 2,
+            passed_query_count: 1,
+            failed_query_count: 1,
+            all_query_tests_passed: false,
+        };
+
+        assert_eq!(
+            validation_follow_up(&response, ValidationSeverityMode::Strict),
+            ValidationFollowUp::Fail("1 of 2 validation queries failed".to_string())
+        );
+    }
+
+    #[test]
+    fn validation_follow_up_is_warning_in_warn_only_mode() {
+        let response = ValidateSourceResponse {
+            source: None,
+            tables: Vec::new(),
+            query_tests: Vec::new(),
+            declared_query_count: 1,
+            passed_query_count: 0,
+            failed_query_count: 1,
+            all_query_tests_passed: false,
+        };
+
+        assert_eq!(
+            validation_follow_up(&response, ValidationSeverityMode::WarnOnly),
+            ValidationFollowUp::Warn("1 of 1 validation query failed".to_string())
+        );
     }
 }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -309,19 +309,18 @@ pub(crate) fn print_validation_pretty(
                 style("✗").red()
             };
             println!("    {} {}", status, style(test.sql.trim()).bold());
-            match (test.passed, test.row_count, test.error_message.as_deref()) {
-                (true, Some(row_count), _) => println!(
+            if test.passed {
+                let row_count = test.row_count;
+                println!(
                     "      {}",
                     style(format!(
                         "{row_count} row{}",
                         if row_count == 1 { "" } else { "s" }
                     ))
                     .dim()
-                ),
-                (false, _, Some(error_message)) => {
-                    println!("      {}", style(error_message).yellow());
-                }
-                _ => {}
+                );
+            } else if !test.error_message.is_empty() {
+                println!("      {}", style(test.error_message.as_str()).yellow());
             }
         }
     }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -319,7 +319,7 @@ pub(crate) fn print_validation_pretty(
                     .dim()
                 ),
                 (false, _, Some(error_message)) => {
-                    println!("      {}", style(error_message).yellow())
+                    println!("      {}", style(error_message).yellow());
                 }
                 _ => {}
             }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -4,8 +4,9 @@ use std::path::Path;
 
 use coral_api::v1::{
     AvailableSource, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
-    ImportSourceRequest, ListSourcesRequest, Source, SourceInputKind, SourceInputSpec,
-    SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+    ImportSourceRequest, ListSourcesRequest, QueryTestFailure, QueryTestSuccess, Source,
+    SourceInputKind, SourceInputSpec, SourceOrigin, SourceSecret, SourceVariable,
+    ValidateSourceRequest, ValidateSourceResponse, query_test_result,
 };
 use coral_client::{AppClient, default_workspace};
 use coral_spec::{
@@ -303,24 +304,29 @@ pub(crate) fn print_validation_pretty(
         );
         for test in &response.query_tests {
             println!();
-            let status = if test.passed {
+            let status = if matches!(test.outcome, Some(query_test_result::Outcome::Success(_))) {
                 style("✓").green()
             } else {
                 style("✗").red()
             };
             println!("    {} {}", status, style(test.sql.trim()).bold());
-            if test.passed {
-                let row_count = test.row_count;
-                println!(
-                    "      {}",
-                    style(format!(
-                        "{row_count} row{}",
-                        if row_count == 1 { "" } else { "s" }
-                    ))
-                    .dim()
-                );
-            } else if !test.error_message.is_empty() {
-                println!("      {}", style(test.error_message.as_str()).yellow());
+            match &test.outcome {
+                Some(query_test_result::Outcome::Success(QueryTestSuccess { row_count })) => {
+                    println!(
+                        "      {}",
+                        style(format!(
+                            "{row_count} row{}",
+                            if *row_count == 1 { "" } else { "s" }
+                        ))
+                        .dim()
+                    );
+                }
+                Some(query_test_result::Outcome::Failure(QueryTestFailure { error_message })) => {
+                    if !error_message.is_empty() {
+                        println!("      {}", style(error_message.as_str()).yellow());
+                    }
+                }
+                None => {}
             }
         }
     }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -40,6 +40,13 @@ enum ValidationFollowUp {
     Fail(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct QueryTestCounts {
+    declared: usize,
+    passed: usize,
+    failed: usize,
+}
+
 impl TableDisplayLimit {
     /// The default truncation used after `source add` and during onboarding.
     pub(crate) const DEFAULT: Self = Self::Max(MAX_TABLES_PER_SCHEMA);
@@ -229,6 +236,19 @@ pub(crate) async fn validate_and_print(
     }
 }
 
+pub(crate) async fn validate_and_warn(
+    app: &AppClient,
+    source_name: &str,
+    limit: TableDisplayLimit,
+) -> Result<(), anyhow::Error> {
+    if let Err(err) =
+        validate_and_print(app, source_name, limit, ValidationSeverityMode::WarnOnly).await
+    {
+        eprintln!("Warning: validation failed: {err}");
+    }
+    Ok(())
+}
+
 pub(crate) fn print_validation_pretty(
     response: &ValidateSourceResponse,
     limit: TableDisplayLimit,
@@ -290,15 +310,14 @@ pub(crate) fn print_validation_pretty(
         }
     }
 
-    if response.declared_query_count > 0 {
+    let query_test_counts = query_test_counts(response);
+    if query_test_counts.declared > 0 {
         println!("    {}", style("Query tests").bold());
         println!(
             "    {}",
             style(format!(
                 "{} declared · {} passed · {} failed",
-                response.declared_query_count,
-                response.passed_query_count,
-                response.failed_query_count
+                query_test_counts.declared, query_test_counts.passed, query_test_counts.failed
             ))
             .dim()
         );
@@ -339,16 +358,17 @@ fn validation_follow_up(
     response: &ValidateSourceResponse,
     severity_mode: ValidationSeverityMode,
 ) -> ValidationFollowUp {
-    if response.declared_query_count == 0 || response.all_query_tests_passed {
+    let query_test_counts = query_test_counts(response);
+    if query_test_counts.declared == 0 || query_test_counts.failed == 0 {
         return ValidationFollowUp::None;
     }
 
-    let failure_count = response.failed_query_count.max(1);
+    let failure_count = query_test_counts.failed.max(1);
     let message = format!(
         "{} of {} validation quer{} failed",
         failure_count,
-        response.declared_query_count.max(failure_count),
-        if response.declared_query_count == 1 {
+        query_test_counts.declared.max(failure_count),
+        if query_test_counts.declared == 1 {
             "y"
         } else {
             "ies"
@@ -357,6 +377,20 @@ fn validation_follow_up(
     match severity_mode {
         ValidationSeverityMode::Strict => ValidationFollowUp::Fail(message),
         ValidationSeverityMode::WarnOnly => ValidationFollowUp::Warn(message),
+    }
+}
+
+fn query_test_counts(response: &ValidateSourceResponse) -> QueryTestCounts {
+    let declared = response.query_tests.len();
+    let passed = response
+        .query_tests
+        .iter()
+        .filter(|test| matches!(test.outcome, Some(query_test_result::Outcome::Success(_))))
+        .count();
+    QueryTestCounts {
+        declared,
+        passed,
+        failed: declared.saturating_sub(passed),
     }
 }
 
@@ -471,11 +505,12 @@ mod tests {
         let response = ValidateSourceResponse {
             source: None,
             tables: Vec::new(),
-            query_tests: Vec::new(),
-            declared_query_count: 1,
-            passed_query_count: 1,
-            failed_query_count: 0,
-            all_query_tests_passed: true,
+            query_tests: vec![coral_api::v1::QueryTestResult {
+                sql: "SELECT 1".to_string(),
+                outcome: Some(coral_api::v1::query_test_result::Outcome::Success(
+                    coral_api::v1::QueryTestSuccess { row_count: 1 },
+                )),
+            }],
         };
 
         assert_eq!(
@@ -489,11 +524,22 @@ mod tests {
         let response = ValidateSourceResponse {
             source: None,
             tables: Vec::new(),
-            query_tests: Vec::new(),
-            declared_query_count: 2,
-            passed_query_count: 1,
-            failed_query_count: 1,
-            all_query_tests_passed: false,
+            query_tests: vec![
+                coral_api::v1::QueryTestResult {
+                    sql: "SELECT 1".to_string(),
+                    outcome: Some(coral_api::v1::query_test_result::Outcome::Success(
+                        coral_api::v1::QueryTestSuccess { row_count: 1 },
+                    )),
+                },
+                coral_api::v1::QueryTestResult {
+                    sql: "SELECT missing".to_string(),
+                    outcome: Some(coral_api::v1::query_test_result::Outcome::Failure(
+                        coral_api::v1::QueryTestFailure {
+                            error_message: "missing".to_string(),
+                        },
+                    )),
+                },
+            ],
         };
 
         assert_eq!(
@@ -507,11 +553,14 @@ mod tests {
         let response = ValidateSourceResponse {
             source: None,
             tables: Vec::new(),
-            query_tests: Vec::new(),
-            declared_query_count: 1,
-            passed_query_count: 0,
-            failed_query_count: 1,
-            all_query_tests_passed: false,
+            query_tests: vec![coral_api::v1::QueryTestResult {
+                sql: "SELECT missing".to_string(),
+                outcome: Some(coral_api::v1::query_test_result::Outcome::Failure(
+                    coral_api::v1::QueryTestFailure {
+                        error_message: "missing".to_string(),
+                    },
+                )),
+            }],
         };
 
         assert_eq!(

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -203,6 +203,11 @@ impl SourceService for MockSourceService {
         Ok(Response::new(ValidateSourceResponse {
             source: Some(mock_source()),
             tables: Vec::new(),
+            query_tests: Vec::new(),
+            declared_query_count: 0,
+            passed_query_count: 0,
+            failed_query_count: 0,
+            all_query_tests_passed: true,
         }))
     }
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -70,10 +70,6 @@ fn default_validate_source_response() -> ValidateSourceResponse {
         source: Some(mock_source()),
         tables: Vec::new(),
         query_tests: Vec::new(),
-        declared_query_count: 0,
-        passed_query_count: 0,
-        failed_query_count: 0,
-        all_query_tests_passed: true,
     }
 }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -61,6 +61,22 @@ fn mock_table() -> Table {
     }
 }
 
+#[allow(
+    dead_code,
+    reason = "shared harness helpers are used by different integration test crates"
+)]
+fn default_validate_source_response() -> ValidateSourceResponse {
+    ValidateSourceResponse {
+        source: Some(mock_source()),
+        tables: Vec::new(),
+        query_tests: Vec::new(),
+        declared_query_count: 0,
+        passed_query_count: 0,
+        failed_query_count: 0,
+        all_query_tests_passed: true,
+    }
+}
+
 fn encode_arrow_ipc_stream(
     schema: &Schema,
     batches: &[RecordBatch],
@@ -129,7 +145,9 @@ impl QueryService for MockQueryService {
 }
 
 #[derive(Clone)]
-struct MockSourceService;
+struct MockSourceService {
+    validate_source_response: ValidateSourceResponse,
+}
 
 #[tonic::async_trait]
 impl SourceService for MockSourceService {
@@ -200,15 +218,7 @@ impl SourceService for MockSourceService {
         &self,
         _request: Request<ValidateSourceRequest>,
     ) -> Result<Response<ValidateSourceResponse>, Status> {
-        Ok(Response::new(ValidateSourceResponse {
-            source: Some(mock_source()),
-            tables: Vec::new(),
-            query_tests: Vec::new(),
-            declared_query_count: 0,
-            passed_query_count: 0,
-            failed_query_count: 0,
-            all_query_tests_passed: true,
-        }))
+        Ok(Response::new(self.validate_source_response.clone()))
     }
 }
 
@@ -219,7 +229,17 @@ pub(crate) struct MockServer {
 }
 
 impl MockServer {
+    #[allow(
+        dead_code,
+        reason = "shared harness helpers are used by different integration test crates"
+    )]
     pub(crate) async fn start() -> Self {
+        Self::start_with_validate_source_response(default_validate_source_response()).await
+    }
+
+    pub(crate) async fn start_with_validate_source_response(
+        validate_source_response: ValidateSourceResponse,
+    ) -> Self {
         let listener = TcpListener::bind(("127.0.0.1", 0))
             .await
             .expect("bind mock server");
@@ -228,7 +248,9 @@ impl MockServer {
         let task = tokio::spawn(async move {
             Server::builder()
                 .add_service(QueryServiceServer::new(MockQueryService))
-                .add_service(SourceServiceServer::new(MockSourceService))
+                .add_service(SourceServiceServer::new(MockSourceService {
+                    validate_source_response,
+                }))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     let _ = shutdown_rx.await;
                 })

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -146,7 +146,103 @@ tables:
         "expected query-test summary in stdout, got: {stdout}"
     );
     assert!(
+        stdout.contains("SELECT * FROM local_messages.missing"),
+        "expected failing query text in stdout, got: {stdout}"
+    );
+    assert!(
         stderr.contains("1 of 1 validation query failed"),
         "expected strict failure in stderr, got: {stderr}"
     );
 }
+
+#[test]
+fn source_test_succeeds_when_query_tests_pass() {
+    let config_dir = tempdir().expect("failed to create temp dir");
+    let source_dir = config_dir
+        .path()
+        .join("workspaces")
+        .join("default")
+        .join("sources")
+        .join("local_messages");
+    std::fs::create_dir_all(source_dir.join("fixture-data")).expect("create source dir");
+    std::fs::write(
+        source_dir.join("fixture-data/messages.jsonl"),
+        r#"{"type":"user","text":"hello"}
+"#,
+    )
+    .expect("write fixture data");
+    std::fs::write(
+        source_dir.join("manifest.yaml"),
+        r#"
+name: local_messages
+version: 0.1.0
+dsl_version: 3
+backend: jsonl
+test_queries:
+  - SELECT COUNT(*) AS n FROM local_messages.messages
+tables:
+  - name: messages
+    description: fixture messages
+    source:
+      location: file://FIXTURE_ROOT/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: text
+        type: Utf8
+"#
+        .replace(
+            "file://FIXTURE_ROOT/",
+            &format!("file://{}/", source_dir.join("fixture-data").display()),
+        ),
+    )
+    .expect("write manifest");
+    std::fs::write(
+        config_dir.path().join("config.toml"),
+        r#"
+        [workspaces.default.sources.local_messages]
+        version = "0.1.0"
+        variables = {}
+        secrets = []
+        origin = "imported"
+    "#,
+    )
+    .expect("failed to write config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_coral"))
+        .arg("source")
+        .arg("test")
+        .arg("local_messages")
+        .env("CORAL_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("failed to run coral source test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "expected zero exit status: {stderr}"
+    );
+    assert!(
+        stdout.contains("Query tests"),
+        "expected query-test summary in stdout, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("SELECT COUNT(*) AS n FROM local_messages.messages"),
+        "expected passing query text in stdout, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("1 declared · 1 passed · 0 failed"),
+        "expected passing query-test counts in stdout, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("1 row"),
+        "expected passing query row count in stdout, got: {stdout}"
+    );
+    assert!(
+        stderr.trim().is_empty(),
+        "expected no stderr output, got: {stderr}"
+    );
+}
+

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -74,3 +74,79 @@ fn source_test_errors_when_required_secret_is_missing() {
         "expected missing secret error in stderr, got: {stderr}"
     );
 }
+
+#[test]
+fn source_test_exits_non_zero_when_query_tests_fail() {
+    let config_dir = tempdir().expect("failed to create temp dir");
+    let source_dir = config_dir
+        .path()
+        .join("workspaces")
+        .join("default")
+        .join("sources")
+        .join("local_messages");
+    std::fs::create_dir_all(source_dir.join("fixture-data")).expect("create source dir");
+    std::fs::write(
+        source_dir.join("fixture-data/messages.jsonl"),
+        r#"{"type":"user","text":"hello"}
+"#,
+    )
+    .expect("write fixture data");
+    std::fs::write(
+        source_dir.join("manifest.yaml"),
+        r#"
+name: local_messages
+version: 0.1.0
+dsl_version: 3
+backend: jsonl
+test_queries:
+  - SELECT * FROM local_messages.missing
+tables:
+  - name: messages
+    description: fixture messages
+    source:
+      location: file://FIXTURE_ROOT/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: text
+        type: Utf8
+"#
+        .replace(
+            "file://FIXTURE_ROOT/",
+            &format!("file://{}/", source_dir.join("fixture-data").display()),
+        ),
+    )
+    .expect("write manifest");
+    std::fs::write(
+        config_dir.path().join("config.toml"),
+        r#"
+        [workspaces.default.sources.local_messages]
+        version = "0.1.0"
+        variables = {}
+        secrets = []
+        origin = "imported"
+    "#,
+    )
+    .expect("failed to write config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_coral"))
+        .arg("source")
+        .arg("test")
+        .arg("local_messages")
+        .env("CORAL_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("failed to run coral source test");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "expected non-zero exit status");
+    assert!(
+        stdout.contains("Query tests"),
+        "expected query-test summary in stdout, got: {stdout}"
+    );
+    assert!(
+        stderr.contains("1 of 1 validation query failed"),
+        "expected strict failure in stderr, got: {stderr}"
+    );
+}

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -4,9 +4,15 @@
     reason = "Integration test crates only use a small subset of the package dependencies."
 )]
 
+mod harness;
+
 use tempfile::tempdir;
 
 use std::process::Command;
+
+use coral_api::v1::{QueryTestResult, Source, SourceOrigin, ValidateSourceResponse, Workspace};
+
+use harness::MockServer;
 
 #[test]
 fn source_test_errors_when_required_secret_is_missing() {
@@ -75,72 +81,42 @@ fn source_test_errors_when_required_secret_is_missing() {
     );
 }
 
-#[test]
-fn source_test_exits_non_zero_when_query_tests_fail() {
-    let config_dir = tempdir().expect("failed to create temp dir");
-    let source_dir = config_dir
-        .path()
-        .join("workspaces")
-        .join("default")
-        .join("sources")
-        .join("local_messages");
-    std::fs::create_dir_all(source_dir.join("fixture-data")).expect("create source dir");
-    std::fs::write(
-        source_dir.join("fixture-data/messages.jsonl"),
-        r#"{"type":"user","text":"hello"}
-"#,
-    )
-    .expect("write fixture data");
-    std::fs::write(
-        source_dir.join("manifest.yaml"),
-        r#"
-name: local_messages
-version: 0.1.0
-dsl_version: 3
-backend: jsonl
-test_queries:
-  - SELECT * FROM local_messages.missing
-tables:
-  - name: messages
-    description: fixture messages
-    source:
-      location: file://FIXTURE_ROOT/
-      glob: "**/*.jsonl"
-    columns:
-      - name: type
-        type: Utf8
-      - name: text
-        type: Utf8
-"#
-        .replace(
-            "file://FIXTURE_ROOT/",
-            &format!("file://{}/", source_dir.join("fixture-data").display()),
-        ),
-    )
-    .expect("write manifest");
-    std::fs::write(
-        config_dir.path().join("config.toml"),
-        r#"
-        [workspaces.default.sources.local_messages]
-        version = "0.1.0"
-        variables = {}
-        secrets = []
-        origin = "imported"
-    "#,
-    )
-    .expect("failed to write config");
+#[tokio::test(flavor = "multi_thread")]
+async fn source_test_exits_non_zero_when_query_tests_fail() {
+    let server = MockServer::start_with_validate_source_response(ValidateSourceResponse {
+        source: Some(Source {
+            workspace: Some(Workspace {
+                name: "default".to_string(),
+            }),
+            name: "local_messages".to_string(),
+            version: "0.1.0".to_string(),
+            secrets: Vec::new(),
+            variables: Vec::new(),
+            origin: SourceOrigin::Imported as i32,
+        }),
+        tables: Vec::new(),
+        query_tests: vec![QueryTestResult {
+            sql: "SELECT * FROM local_messages.missing".to_string(),
+            passed: false,
+            row_count: None,
+            error_message: Some("invalid input: table not found".to_string()),
+        }],
+        declared_query_count: 1,
+        passed_query_count: 0,
+        failed_query_count: 1,
+        all_query_tests_passed: false,
+    })
+    .await;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_coral"))
-        .arg("source")
-        .arg("test")
-        .arg("local_messages")
-        .env("CORAL_CONFIG_DIR", config_dir.path())
-        .output()
-        .expect("failed to run coral source test");
+    let assert = server
+        .cmd()
+        .args(["source", "test", "local_messages"])
+        .assert()
+        .failure();
+    let output = assert.get_output();
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(!output.status.success(), "expected non-zero exit status");
     assert!(
         stdout.contains("Query tests"),
         "expected query-test summary in stdout, got: {stdout}"
@@ -153,77 +129,46 @@ tables:
         stderr.contains("1 of 1 validation query failed"),
         "expected strict failure in stderr, got: {stderr}"
     );
+
+    server.shutdown().await;
 }
 
-#[test]
-fn source_test_succeeds_when_query_tests_pass() {
-    let config_dir = tempdir().expect("failed to create temp dir");
-    let source_dir = config_dir
-        .path()
-        .join("workspaces")
-        .join("default")
-        .join("sources")
-        .join("local_messages");
-    std::fs::create_dir_all(source_dir.join("fixture-data")).expect("create source dir");
-    std::fs::write(
-        source_dir.join("fixture-data/messages.jsonl"),
-        r#"{"type":"user","text":"hello"}
-"#,
-    )
-    .expect("write fixture data");
-    std::fs::write(
-        source_dir.join("manifest.yaml"),
-        r#"
-name: local_messages
-version: 0.1.0
-dsl_version: 3
-backend: jsonl
-test_queries:
-  - SELECT COUNT(*) AS n FROM local_messages.messages
-tables:
-  - name: messages
-    description: fixture messages
-    source:
-      location: file://FIXTURE_ROOT/
-      glob: "**/*.jsonl"
-    columns:
-      - name: type
-        type: Utf8
-      - name: text
-        type: Utf8
-"#
-        .replace(
-            "file://FIXTURE_ROOT/",
-            &format!("file://{}/", source_dir.join("fixture-data").display()),
-        ),
-    )
-    .expect("write manifest");
-    std::fs::write(
-        config_dir.path().join("config.toml"),
-        r#"
-        [workspaces.default.sources.local_messages]
-        version = "0.1.0"
-        variables = {}
-        secrets = []
-        origin = "imported"
-    "#,
-    )
-    .expect("failed to write config");
+#[tokio::test(flavor = "multi_thread")]
+async fn source_test_succeeds_when_query_tests_pass() {
+    let server = MockServer::start_with_validate_source_response(ValidateSourceResponse {
+        source: Some(Source {
+            workspace: Some(Workspace {
+                name: "default".to_string(),
+            }),
+            name: "local_messages".to_string(),
+            version: "0.1.0".to_string(),
+            secrets: Vec::new(),
+            variables: Vec::new(),
+            origin: SourceOrigin::Imported as i32,
+        }),
+        tables: Vec::new(),
+        query_tests: vec![QueryTestResult {
+            sql: "SELECT COUNT(*) AS n FROM local_messages.messages".to_string(),
+            passed: true,
+            row_count: Some(1),
+            error_message: None,
+        }],
+        declared_query_count: 1,
+        passed_query_count: 1,
+        failed_query_count: 0,
+        all_query_tests_passed: true,
+    })
+    .await;
 
-    let output = Command::new(env!("CARGO_BIN_EXE_coral"))
-        .arg("source")
-        .arg("test")
-        .arg("local_messages")
-        .env("CORAL_CONFIG_DIR", config_dir.path())
-        .output()
-        .expect("failed to run coral source test");
+    let assert = server
+        .cmd()
+        .args(["source", "test", "local_messages"])
+        .assert()
+        .success();
+    let output = assert.get_output();
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        output.status.success(),
-        "expected zero exit status: {stderr}"
-    );
     assert!(
         stdout.contains("Query tests"),
         "expected query-test summary in stdout, got: {stdout}"
@@ -244,4 +189,6 @@ tables:
         stderr.trim().is_empty(),
         "expected no stderr output, got: {stderr}"
     );
+
+    server.shutdown().await;
 }

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -104,10 +104,6 @@ async fn source_test_exits_non_zero_when_query_tests_fail() {
                 error_message: "invalid input: table not found".to_string(),
             })),
         }],
-        declared_query_count: 1,
-        passed_query_count: 0,
-        failed_query_count: 1,
-        all_query_tests_passed: false,
     })
     .await;
 
@@ -156,10 +152,6 @@ async fn source_test_succeeds_when_query_tests_pass() {
                 row_count: 1,
             })),
         }],
-        declared_query_count: 1,
-        passed_query_count: 1,
-        failed_query_count: 0,
-        all_query_tests_passed: true,
     })
     .await;
 

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -98,8 +98,8 @@ async fn source_test_exits_non_zero_when_query_tests_fail() {
         query_tests: vec![QueryTestResult {
             sql: "SELECT * FROM local_messages.missing".to_string(),
             passed: false,
-            row_count: None,
-            error_message: Some("invalid input: table not found".to_string()),
+            row_count: 0,
+            error_message: "invalid input: table not found".to_string(),
         }],
         declared_query_count: 1,
         passed_query_count: 0,
@@ -150,8 +150,8 @@ async fn source_test_succeeds_when_query_tests_pass() {
         query_tests: vec![QueryTestResult {
             sql: "SELECT COUNT(*) AS n FROM local_messages.messages".to_string(),
             passed: true,
-            row_count: Some(1),
-            error_message: None,
+            row_count: 1,
+            error_message: String::new(),
         }],
         declared_query_count: 1,
         passed_query_count: 1,

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -245,4 +245,3 @@ tables:
         "expected no stderr output, got: {stderr}"
     );
 }
-

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -10,7 +10,10 @@ use tempfile::tempdir;
 
 use std::process::Command;
 
-use coral_api::v1::{QueryTestResult, Source, SourceOrigin, ValidateSourceResponse, Workspace};
+use coral_api::v1::{
+    QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, SourceOrigin,
+    ValidateSourceResponse, Workspace, query_test_result,
+};
 
 use harness::MockServer;
 
@@ -97,9 +100,9 @@ async fn source_test_exits_non_zero_when_query_tests_fail() {
         tables: Vec::new(),
         query_tests: vec![QueryTestResult {
             sql: "SELECT * FROM local_messages.missing".to_string(),
-            passed: false,
-            row_count: 0,
-            error_message: "invalid input: table not found".to_string(),
+            outcome: Some(query_test_result::Outcome::Failure(QueryTestFailure {
+                error_message: "invalid input: table not found".to_string(),
+            })),
         }],
         declared_query_count: 1,
         passed_query_count: 0,
@@ -149,9 +152,9 @@ async fn source_test_succeeds_when_query_tests_pass() {
         tables: Vec::new(),
         query_tests: vec![QueryTestResult {
             sql: "SELECT COUNT(*) AS n FROM local_messages.messages".to_string(),
-            passed: true,
-            row_count: 1,
-            error_message: String::new(),
+            outcome: Some(query_test_result::Outcome::Success(QueryTestSuccess {
+                row_count: 1,
+            })),
         }],
         declared_query_count: 1,
         passed_query_count: 1,

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -6,19 +6,8 @@ mod query;
 mod query_error;
 
 pub use catalog::{ColumnInfo, TableInfo};
-<<<<<<< HEAD
 pub use error::{CoreError, StatusCode, StructuredQueryError};
-pub use query::{QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};
-||||||| parent of 68e2039 (Make validation-query results explicit success/failure variants)
-pub use error::{CoreError, StatusCode};
 pub use query::{
-    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QueryTestResult,
-    SourceValidationOutcome,
+    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QueryTestFailure,
+    QueryTestResult, QueryTestSuccess, SourceValidationReport,
 };
-=======
-pub use error::{CoreError, StatusCode};
-pub use query::{
-    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QueryTestOutcome,
-    QueryTestResult, SourceValidationOutcome,
-};
->>>>>>> 68e2039 (Make validation-query results explicit success/failure variants)

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -6,5 +6,19 @@ mod query;
 mod query_error;
 
 pub use catalog::{ColumnInfo, TableInfo};
+<<<<<<< HEAD
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};
+||||||| parent of 68e2039 (Make validation-query results explicit success/failure variants)
+pub use error::{CoreError, StatusCode};
+pub use query::{
+    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QueryTestResult,
+    SourceValidationOutcome,
+};
+=======
+pub use error::{CoreError, StatusCode};
+pub use query::{
+    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QueryTestOutcome,
+    QueryTestResult, SourceValidationOutcome,
+};
+>>>>>>> 68e2039 (Make validation-query results explicit success/failure variants)

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -69,25 +69,42 @@ impl QuerySource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryTestResult {
     sql: String,
-    passed: bool,
-    row_count: u64,
-    error_message: String,
+    outcome: QueryTestOutcome,
+}
+
+/// Outcome metadata for one validation query execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryTestOutcome {
+    /// Query executed successfully and produced a row count.
+    Success {
+        /// Row count captured for the successful query.
+        row_count: u64,
+    },
+    /// Query failed and produced an error message.
+    Failure {
+        /// Error message captured for the failed query.
+        error_message: String,
+    },
 }
 
 impl QueryTestResult {
     #[must_use]
-    /// Builds one query-test result entry.
-    pub fn new(
-        sql: impl Into<String>,
-        passed: bool,
-        row_count: u64,
-        error_message: impl Into<String>,
-    ) -> Self {
+    /// Builds one successful query-test result entry.
+    pub fn success(sql: impl Into<String>, row_count: u64) -> Self {
         Self {
             sql: sql.into(),
-            passed,
-            row_count,
-            error_message: error_message.into(),
+            outcome: QueryTestOutcome::Success { row_count },
+        }
+    }
+
+    #[must_use]
+    /// Builds one failed query-test result entry.
+    pub fn failure(sql: impl Into<String>, error_message: impl Into<String>) -> Self {
+        Self {
+            sql: sql.into(),
+            outcome: QueryTestOutcome::Failure {
+                error_message: error_message.into(),
+            },
         }
     }
 
@@ -100,19 +117,31 @@ impl QueryTestResult {
     #[must_use]
     /// Returns whether the query executed successfully.
     pub fn passed(&self) -> bool {
-        self.passed
+        matches!(self.outcome, QueryTestOutcome::Success { .. })
     }
 
     #[must_use]
-    /// Returns the captured row count, or zero when not reported.
-    pub fn row_count(&self) -> u64 {
-        self.row_count
+    /// Returns the captured row count for successful queries.
+    pub fn row_count(&self) -> Option<u64> {
+        match self.outcome {
+            QueryTestOutcome::Success { row_count } => Some(row_count),
+            QueryTestOutcome::Failure { .. } => None,
+        }
     }
 
     #[must_use]
-    /// Returns the error message for failed queries, or an empty string.
-    pub fn error_message(&self) -> &str {
-        &self.error_message
+    /// Returns the error message for failed queries, when present.
+    pub fn error_message(&self) -> Option<&str> {
+        match &self.outcome {
+            QueryTestOutcome::Success { .. } => None,
+            QueryTestOutcome::Failure { error_message } => Some(error_message),
+        }
+    }
+
+    #[must_use]
+    /// Returns the outcome metadata for this query test.
+    pub fn outcome(&self) -> &QueryTestOutcome {
+        &self.outcome
     }
 }
 
@@ -139,7 +168,7 @@ impl SourceValidationOutcome {
     pub fn new(tables: Vec<super::TableInfo>, query_tests: Vec<QueryTestResult>) -> Self {
         let declared_query_count = u64::try_from(query_tests.len()).unwrap_or(u64::MAX);
         let passed_query_count =
-            u64::try_from(query_tests.iter().filter(|test| test.passed).count()).unwrap_or(0);
+            u64::try_from(query_tests.iter().filter(|test| test.passed()).count()).unwrap_or(0);
         let failed_query_count = declared_query_count.saturating_sub(passed_query_count);
         Self {
             tables,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -119,11 +119,17 @@ impl QueryTestResult {
 /// Structured outcome for validating one source and its optional test queries.
 #[derive(Debug, Clone)]
 pub struct SourceValidationOutcome {
+    /// Tables exposed by the validated source.
     pub tables: Vec<super::TableInfo>,
+    /// One result per declared validation query, in manifest order.
     pub query_tests: Vec<QueryTestResult>,
+    /// Total number of declared validation queries.
     pub declared_query_count: u32,
+    /// Number of validation queries that executed successfully.
     pub passed_query_count: u32,
+    /// Number of validation queries that failed.
     pub failed_query_count: u32,
+    /// Whether every declared validation query passed.
     pub all_query_tests_passed: bool,
 }
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -69,22 +69,35 @@ impl QuerySource {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueryTestResult {
     sql: String,
-    outcome: QueryTestOutcome,
+    result: Result<QueryTestSuccess, QueryTestFailure>,
 }
 
-/// Outcome metadata for one validation query execution.
+/// Success metadata for one validation query execution.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum QueryTestOutcome {
-    /// Query executed successfully and produced a row count.
-    Success {
-        /// Row count captured for the successful query.
-        row_count: u64,
-    },
-    /// Query failed and produced an error message.
-    Failure {
-        /// Error message captured for the failed query.
-        error_message: String,
-    },
+pub struct QueryTestSuccess {
+    row_count: u64,
+}
+
+impl QueryTestSuccess {
+    #[must_use]
+    /// Returns the row count captured for the successful query.
+    pub fn row_count(&self) -> u64 {
+        self.row_count
+    }
+}
+
+/// Failure details for one validation query execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryTestFailure {
+    error_message: String,
+}
+
+impl QueryTestFailure {
+    #[must_use]
+    /// Returns the error message captured for the failed query.
+    pub fn error_message(&self) -> &str {
+        &self.error_message
+    }
 }
 
 impl QueryTestResult {
@@ -93,7 +106,7 @@ impl QueryTestResult {
     pub fn success(sql: impl Into<String>, row_count: u64) -> Self {
         Self {
             sql: sql.into(),
-            outcome: QueryTestOutcome::Success { row_count },
+            result: Ok(QueryTestSuccess { row_count }),
         }
     }
 
@@ -102,9 +115,9 @@ impl QueryTestResult {
     pub fn failure(sql: impl Into<String>, error_message: impl Into<String>) -> Self {
         Self {
             sql: sql.into(),
-            outcome: QueryTestOutcome::Failure {
+            result: Err(QueryTestFailure {
                 error_message: error_message.into(),
-            },
+            }),
         }
     }
 
@@ -117,66 +130,46 @@ impl QueryTestResult {
     #[must_use]
     /// Returns whether the query executed successfully.
     pub fn passed(&self) -> bool {
-        matches!(self.outcome, QueryTestOutcome::Success { .. })
+        self.result.is_ok()
     }
 
     #[must_use]
     /// Returns the captured row count for successful queries.
     pub fn row_count(&self) -> Option<u64> {
-        match self.outcome {
-            QueryTestOutcome::Success { row_count } => Some(row_count),
-            QueryTestOutcome::Failure { .. } => None,
-        }
+        self.result.as_ref().ok().map(QueryTestSuccess::row_count)
     }
 
     #[must_use]
     /// Returns the error message for failed queries, when present.
     pub fn error_message(&self) -> Option<&str> {
-        match &self.outcome {
-            QueryTestOutcome::Success { .. } => None,
-            QueryTestOutcome::Failure { error_message } => Some(error_message),
-        }
+        self.result
+            .as_ref()
+            .err()
+            .map(QueryTestFailure::error_message)
     }
 
-    #[must_use]
-    /// Returns the outcome metadata for this query test.
-    pub fn outcome(&self) -> &QueryTestOutcome {
-        &self.outcome
+    /// Returns the execution result metadata for this query test.
+    pub fn result(&self) -> &Result<QueryTestSuccess, QueryTestFailure> {
+        &self.result
     }
 }
 
-/// Structured outcome for validating one source and its optional test queries.
+/// Structured report for validating one source and its optional test queries.
 #[derive(Debug, Clone)]
-pub struct SourceValidationOutcome {
+pub struct SourceValidationReport {
     /// Tables exposed by the validated source.
     pub tables: Vec<super::TableInfo>,
     /// One result per declared validation query, in manifest order.
     pub query_tests: Vec<QueryTestResult>,
-    /// Total number of declared validation queries.
-    pub declared_query_count: u64,
-    /// Number of validation queries that executed successfully.
-    pub passed_query_count: u64,
-    /// Number of validation queries that failed.
-    pub failed_query_count: u64,
-    /// Whether every declared validation query passed.
-    pub all_query_tests_passed: bool,
 }
 
-impl SourceValidationOutcome {
+impl SourceValidationReport {
     #[must_use]
-    /// Builds one structured source-validation outcome.
+    /// Builds one structured source-validation report.
     pub fn new(tables: Vec<super::TableInfo>, query_tests: Vec<QueryTestResult>) -> Self {
-        let declared_query_count = u64::try_from(query_tests.len()).unwrap_or(u64::MAX);
-        let passed_query_count =
-            u64::try_from(query_tests.iter().filter(|test| test.passed()).count()).unwrap_or(0);
-        let failed_query_count = declared_query_count.saturating_sub(passed_query_count);
         Self {
             tables,
             query_tests,
-            declared_query_count,
-            passed_query_count,
-            failed_query_count,
-            all_query_tests_passed: failed_query_count == 0,
         }
     }
 }

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -124,11 +124,11 @@ pub struct SourceValidationOutcome {
     /// One result per declared validation query, in manifest order.
     pub query_tests: Vec<QueryTestResult>,
     /// Total number of declared validation queries.
-    pub declared_query_count: u32,
+    pub declared_query_count: u64,
     /// Number of validation queries that executed successfully.
-    pub passed_query_count: u32,
+    pub passed_query_count: u64,
     /// Number of validation queries that failed.
-    pub failed_query_count: u32,
+    pub failed_query_count: u64,
     /// Whether every declared validation query passed.
     pub all_query_tests_passed: bool,
 }
@@ -137,9 +137,9 @@ impl SourceValidationOutcome {
     #[must_use]
     /// Builds one structured source-validation outcome.
     pub fn new(tables: Vec<super::TableInfo>, query_tests: Vec<QueryTestResult>) -> Self {
-        let declared_query_count = u32::try_from(query_tests.len()).unwrap_or(u32::MAX);
+        let declared_query_count = u64::try_from(query_tests.len()).unwrap_or(u64::MAX);
         let passed_query_count =
-            u32::try_from(query_tests.iter().filter(|test| test.passed).count()).unwrap_or(0);
+            u64::try_from(query_tests.iter().filter(|test| test.passed).count()).unwrap_or(0);
         let failed_query_count = declared_query_count.saturating_sub(passed_query_count);
         Self {
             tables,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -70,8 +70,8 @@ impl QuerySource {
 pub struct QueryTestResult {
     sql: String,
     passed: bool,
-    row_count: Option<u64>,
-    error_message: Option<String>,
+    row_count: u64,
+    error_message: String,
 }
 
 impl QueryTestResult {
@@ -80,14 +80,14 @@ impl QueryTestResult {
     pub fn new(
         sql: impl Into<String>,
         passed: bool,
-        row_count: Option<u64>,
-        error_message: Option<String>,
+        row_count: u64,
+        error_message: impl Into<String>,
     ) -> Self {
         Self {
             sql: sql.into(),
             passed,
             row_count,
-            error_message,
+            error_message: error_message.into(),
         }
     }
 
@@ -104,15 +104,15 @@ impl QueryTestResult {
     }
 
     #[must_use]
-    /// Returns the optional row count captured for successful queries.
-    pub fn row_count(&self) -> Option<u64> {
+    /// Returns the captured row count, or zero when not reported.
+    pub fn row_count(&self) -> u64 {
         self.row_count
     }
 
     #[must_use]
-    /// Returns the error message for failed queries, when present.
-    pub fn error_message(&self) -> Option<&str> {
-        self.error_message.as_deref()
+    /// Returns the error message for failed queries, or an empty string.
+    pub fn error_message(&self) -> &str {
+        &self.error_message
     }
 }
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -65,6 +65,86 @@ impl QuerySource {
     }
 }
 
+/// One source-spec validation query executed during source validation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryTestResult {
+    sql: String,
+    passed: bool,
+    row_count: Option<u64>,
+    error_message: Option<String>,
+}
+
+impl QueryTestResult {
+    #[must_use]
+    /// Builds one query-test result entry.
+    pub fn new(
+        sql: impl Into<String>,
+        passed: bool,
+        row_count: Option<u64>,
+        error_message: Option<String>,
+    ) -> Self {
+        Self {
+            sql: sql.into(),
+            passed,
+            row_count,
+            error_message,
+        }
+    }
+
+    #[must_use]
+    /// Returns the SQL text that was executed.
+    pub fn sql(&self) -> &str {
+        &self.sql
+    }
+
+    #[must_use]
+    /// Returns whether the query executed successfully.
+    pub fn passed(&self) -> bool {
+        self.passed
+    }
+
+    #[must_use]
+    /// Returns the optional row count captured for successful queries.
+    pub fn row_count(&self) -> Option<u64> {
+        self.row_count
+    }
+
+    #[must_use]
+    /// Returns the error message for failed queries, when present.
+    pub fn error_message(&self) -> Option<&str> {
+        self.error_message.as_deref()
+    }
+}
+
+/// Structured outcome for validating one source and its optional test queries.
+#[derive(Debug, Clone)]
+pub struct SourceValidationOutcome {
+    pub tables: Vec<super::TableInfo>,
+    pub query_tests: Vec<QueryTestResult>,
+    pub declared_query_count: u32,
+    pub passed_query_count: u32,
+    pub failed_query_count: u32,
+    pub all_query_tests_passed: bool,
+}
+
+impl SourceValidationOutcome {
+    #[must_use]
+    /// Builds one structured source-validation outcome.
+    pub fn new(tables: Vec<super::TableInfo>, query_tests: Vec<QueryTestResult>) -> Self {
+        let declared_query_count = query_tests.len() as u32;
+        let passed_query_count = query_tests.iter().filter(|test| test.passed).count() as u32;
+        let failed_query_count = declared_query_count.saturating_sub(passed_query_count);
+        Self {
+            tables,
+            query_tests,
+            declared_query_count,
+            passed_query_count,
+            failed_query_count,
+            all_query_tests_passed: failed_query_count == 0,
+        }
+    }
+}
+
 /// App-owned non-secret runtime inputs needed while compiling sources.
 #[derive(Debug, Clone, Default)]
 pub struct QueryRuntimeContext {

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -139,8 +139,7 @@ impl SourceValidationOutcome {
     pub fn new(tables: Vec<super::TableInfo>, query_tests: Vec<QueryTestResult>) -> Self {
         let declared_query_count = u32::try_from(query_tests.len()).unwrap_or(u32::MAX);
         let passed_query_count =
-            u32::try_from(query_tests.iter().filter(|test| test.passed).count())
-                .unwrap_or(declared_query_count);
+            u32::try_from(query_tests.iter().filter(|test| test.passed).count()).unwrap_or(0);
         let failed_query_count = declared_query_count.saturating_sub(passed_query_count);
         Self {
             tables,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -137,8 +137,10 @@ impl SourceValidationOutcome {
     #[must_use]
     /// Builds one structured source-validation outcome.
     pub fn new(tables: Vec<super::TableInfo>, query_tests: Vec<QueryTestResult>) -> Self {
-        let declared_query_count = query_tests.len() as u32;
-        let passed_query_count = query_tests.iter().filter(|test| test.passed).count() as u32;
+        let declared_query_count = u32::try_from(query_tests.len()).unwrap_or(u32::MAX);
+        let passed_query_count =
+            u32::try_from(query_tests.iter().filter(|test| test.passed).count())
+                .unwrap_or(declared_query_count);
         let failed_query_count = declared_query_count.saturating_sub(passed_query_count);
         Self {
             tables,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -94,9 +94,9 @@ impl CoralQuery {
         runtime: &dyn QueryRuntimeProvider,
         schema_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
-        runtime::query::build_runtime(sources, runtime)
+        Ok(runtime::query::build_runtime(sources, runtime)
             .await?
-            .list_tables(schema_filter)
+            .list_tables(schema_filter))
     }
 
     /// Executes one `SQL` statement over the provided source set.

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -71,7 +71,13 @@ mod runtime;
 
 pub use contracts::{
     ColumnInfo, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
+<<<<<<< HEAD
     StatusCode, StructuredQueryError, TableInfo,
+||||||| parent of 68e2039 (Make validation-query results explicit success/failure variants)
+    QueryTestResult, SourceValidationOutcome, StatusCode, TableInfo,
+=======
+    QueryTestOutcome, QueryTestResult, SourceValidationOutcome, StatusCode, TableInfo,
+>>>>>>> 68e2039 (Make validation-query results explicit success/failure variants)
 };
 
 /// High-level query operations for the local query engine.
@@ -235,11 +241,9 @@ impl CoralQuery {
         let mut query_tests = Vec::with_capacity(test_queries.len());
         for sql in test_queries {
             match query_runtime.execute_sql(sql).await {
-                Ok(execution) => query_tests.push(QueryTestResult::new(
+                Ok(execution) => query_tests.push(QueryTestResult::success(
                     sql.clone(),
-                    true,
                     execution.row_count() as u64,
-                    "",
                 )),
                 Err(error) => {
                     let error_message = match &error {
@@ -248,7 +252,7 @@ impl CoralQuery {
                         }
                         _ => error.to_string(),
                     };
-                    query_tests.push(QueryTestResult::new(sql.clone(), false, 0, error_message));
+                    query_tests.push(QueryTestResult::failure(sql.clone(), error_message));
                 }
             }
         }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -243,9 +243,7 @@ impl CoralQuery {
                 )),
                 Err(error) => {
                     let error_message = match &error {
-                        CoreError::InvalidInput(detail)
-                            if runtime::query::is_non_read_only_sql_error(detail) =>
-                        {
+                        CoreError::InvalidInput(detail) if is_non_read_only_sql_error(detail) => {
                             "test query must be read-only SQL".to_string()
                         }
                         _ => error.to_string(),
@@ -263,4 +261,10 @@ impl CoralQuery {
         Ok(SourceValidationOutcome::new(tables, query_tests))
     }
 >>>>>>> a604639 (Preserve source test_queries implementation progress before team relaunch)
+}
+
+fn is_non_read_only_sql_error(detail: &str) -> bool {
+    detail.starts_with("DDL not supported")
+        || detail.starts_with("DML not supported")
+        || detail.starts_with("Statement not supported")
 }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -129,10 +129,138 @@ impl CoralQuery {
         source: &QuerySource,
         runtime: &dyn QueryRuntimeProvider,
     ) -> Result<Vec<TableInfo>, CoreError> {
+<<<<<<< HEAD
         Ok(
             runtime::query::build_runtime(std::slice::from_ref(source), runtime)
                 .await?
                 .list_tables(Some(source.source_name())),
         )
+||||||| parent of a604639 (Preserve source test_queries implementation progress before team relaunch)
+        Ok(
+            Self::validate_source_with_tests(source, runtime, &[])
+                .await?
+                .tables,
+        )
+=======
+        Ok(Self::validate_source_with_tests(source, runtime, &[])
+            .await?
+            .tables)
+>>>>>>> a604639 (Preserve source test_queries implementation progress before team relaunch)
     }
+<<<<<<< HEAD
+||||||| parent of a604639 (Preserve source test_queries implementation progress before team relaunch)
+
+    /// Validates one source and then executes any declared validation queries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the source cannot be initialized or enumerated.
+    /// Query-test failures are reported in the returned outcome instead of
+    /// failing the whole call.
+    pub async fn validate_source_with_tests(
+        source: &QuerySource,
+        runtime: &dyn QueryRuntimeProvider,
+        test_queries: &[String],
+    ) -> Result<SourceValidationOutcome, CoreError> {
+        let query_runtime = runtime::query::build_runtime(std::slice::from_ref(source), runtime)
+            .await?;
+        let tables = query_runtime.list_tables(Some(source.source_name()));
+        if tables.is_empty() {
+            if let Some(failure) = query_runtime.registration_failure(source.source_name()) {
+                return Err(CoreError::FailedPrecondition(failure.detail.clone()));
+            }
+            return Err(CoreError::FailedPrecondition(format!(
+                "source '{}' did not become queryable during validation",
+                source.source_name()
+            )));
+        }
+
+        let mut query_tests = Vec::with_capacity(test_queries.len());
+        for sql in test_queries {
+            match query_runtime.execute_sql(sql).await {
+                Ok(execution) => query_tests.push(QueryTestResult::new(
+                    sql.clone(),
+                    true,
+                    Some(execution.row_count() as u64),
+                    None,
+                )),
+                Err(error) => {
+                    let error_message = match &error {
+                        CoreError::InvalidInput(detail)
+                            if runtime::query::is_non_read_only_sql_error(detail) =>
+                        {
+                            "test query must be read-only SQL".to_string()
+                        }
+                        _ => error.to_string(),
+                    };
+                    query_tests.push(QueryTestResult::new(
+                        sql.clone(),
+                        false,
+                        None,
+                        Some(error_message),
+                    ));
+                }
+            }
+        }
+
+        Ok(SourceValidationOutcome::new(tables, query_tests))
+    }
+=======
+
+    /// Validates one source and then executes any declared validation queries.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the source cannot be initialized or enumerated.
+    /// Query-test failures are reported in the returned outcome instead of
+    /// failing the whole call.
+    pub async fn validate_source_with_tests(
+        source: &QuerySource,
+        runtime: &dyn QueryRuntimeProvider,
+        test_queries: &[String],
+    ) -> Result<SourceValidationOutcome, CoreError> {
+        let query_runtime =
+            runtime::query::build_runtime(std::slice::from_ref(source), runtime).await?;
+        let tables = query_runtime.list_tables(Some(source.source_name()));
+        if tables.is_empty() {
+            if let Some(failure) = query_runtime.registration_failure(source.source_name()) {
+                return Err(CoreError::FailedPrecondition(failure.detail.clone()));
+            }
+            return Err(CoreError::FailedPrecondition(format!(
+                "source '{}' did not become queryable during validation",
+                source.source_name()
+            )));
+        }
+
+        let mut query_tests = Vec::with_capacity(test_queries.len());
+        for sql in test_queries {
+            match query_runtime.execute_sql(sql).await {
+                Ok(execution) => query_tests.push(QueryTestResult::new(
+                    sql.clone(),
+                    true,
+                    Some(execution.row_count() as u64),
+                    None,
+                )),
+                Err(error) => {
+                    let error_message = match &error {
+                        CoreError::InvalidInput(detail)
+                            if runtime::query::is_non_read_only_sql_error(detail) =>
+                        {
+                            "test query must be read-only SQL".to_string()
+                        }
+                        _ => error.to_string(),
+                    };
+                    query_tests.push(QueryTestResult::new(
+                        sql.clone(),
+                        false,
+                        None,
+                        Some(error_message),
+                    ));
+                }
+            }
+        }
+
+        Ok(SourceValidationOutcome::new(tables, query_tests))
+    }
+>>>>>>> a604639 (Preserve source test_queries implementation progress before team relaunch)
 }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -238,8 +238,8 @@ impl CoralQuery {
                 Ok(execution) => query_tests.push(QueryTestResult::new(
                     sql.clone(),
                     true,
-                    Some(execution.row_count() as u64),
-                    None,
+                    execution.row_count() as u64,
+                    "",
                 )),
                 Err(error) => {
                     let error_message = match &error {
@@ -248,12 +248,7 @@ impl CoralQuery {
                         }
                         _ => error.to_string(),
                     };
-                    query_tests.push(QueryTestResult::new(
-                        sql.clone(),
-                        false,
-                        None,
-                        Some(error_message),
-                    ));
+                    query_tests.push(QueryTestResult::new(sql.clone(), false, 0, error_message));
                 }
             }
         }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -71,13 +71,8 @@ mod runtime;
 
 pub use contracts::{
     ColumnInfo, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-<<<<<<< HEAD
-    StatusCode, StructuredQueryError, TableInfo,
-||||||| parent of 68e2039 (Make validation-query results explicit success/failure variants)
-    QueryTestResult, SourceValidationOutcome, StatusCode, TableInfo,
-=======
-    QueryTestOutcome, QueryTestResult, SourceValidationOutcome, StatusCode, TableInfo,
->>>>>>> 68e2039 (Make validation-query results explicit success/failure variants)
+    QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport, StatusCode,
+    StructuredQueryError, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -99,17 +94,17 @@ impl CoralQuery {
         runtime: &dyn QueryRuntimeProvider,
         schema_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
-        Ok(runtime::query::build_runtime(sources, runtime)
+        runtime::query::build_runtime(sources, runtime)
             .await?
-            .list_tables(schema_filter))
+            .list_tables(schema_filter)
     }
 
-    /// Executes one read-only `SQL` statement against the provided sources.
+    /// Executes one `SQL` statement over the provided source set.
     ///
     /// # Errors
     ///
-    /// Returns [`CoreError::InvalidInput`] when `sql` is empty, or another
-    /// [`CoreError`] if runtime construction, planning, or execution fails.
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// or if the runtime cannot execute the statement.
     pub async fn execute_sql(
         sources: &[QuerySource],
         runtime: &dyn QueryRuntimeProvider,
@@ -135,26 +130,8 @@ impl CoralQuery {
         source: &QuerySource,
         runtime: &dyn QueryRuntimeProvider,
     ) -> Result<Vec<TableInfo>, CoreError> {
-<<<<<<< HEAD
-        Ok(
-            runtime::query::build_runtime(std::slice::from_ref(source), runtime)
-                .await?
-                .list_tables(Some(source.source_name())),
-        )
-||||||| parent of a604639 (Preserve source test_queries implementation progress before team relaunch)
-        Ok(
-            Self::validate_source_with_tests(source, runtime, &[])
-                .await?
-                .tables,
-        )
-=======
-        Ok(Self::validate_source_with_tests(source, runtime, &[])
-            .await?
-            .tables)
->>>>>>> a604639 (Preserve source test_queries implementation progress before team relaunch)
+        Ok(Self::validate_source(source, runtime, &[]).await?.tables)
     }
-<<<<<<< HEAD
-||||||| parent of a604639 (Preserve source test_queries implementation progress before team relaunch)
 
     /// Validates one source and then executes any declared validation queries.
     ///
@@ -163,68 +140,11 @@ impl CoralQuery {
     /// Returns [`CoreError`] if the source cannot be initialized or enumerated.
     /// Query-test failures are reported in the returned outcome instead of
     /// failing the whole call.
-    pub async fn validate_source_with_tests(
+    pub async fn validate_source(
         source: &QuerySource,
         runtime: &dyn QueryRuntimeProvider,
         test_queries: &[String],
-    ) -> Result<SourceValidationOutcome, CoreError> {
-        let query_runtime = runtime::query::build_runtime(std::slice::from_ref(source), runtime)
-            .await?;
-        let tables = query_runtime.list_tables(Some(source.source_name()));
-        if tables.is_empty() {
-            if let Some(failure) = query_runtime.registration_failure(source.source_name()) {
-                return Err(CoreError::FailedPrecondition(failure.detail.clone()));
-            }
-            return Err(CoreError::FailedPrecondition(format!(
-                "source '{}' did not become queryable during validation",
-                source.source_name()
-            )));
-        }
-
-        let mut query_tests = Vec::with_capacity(test_queries.len());
-        for sql in test_queries {
-            match query_runtime.execute_sql(sql).await {
-                Ok(execution) => query_tests.push(QueryTestResult::new(
-                    sql.clone(),
-                    true,
-                    Some(execution.row_count() as u64),
-                    None,
-                )),
-                Err(error) => {
-                    let error_message = match &error {
-                        CoreError::InvalidInput(detail)
-                            if runtime::query::is_non_read_only_sql_error(detail) =>
-                        {
-                            "test query must be read-only SQL".to_string()
-                        }
-                        _ => error.to_string(),
-                    };
-                    query_tests.push(QueryTestResult::new(
-                        sql.clone(),
-                        false,
-                        None,
-                        Some(error_message),
-                    ));
-                }
-            }
-        }
-
-        Ok(SourceValidationOutcome::new(tables, query_tests))
-    }
-=======
-
-    /// Validates one source and then executes any declared validation queries.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`CoreError`] if the source cannot be initialized or enumerated.
-    /// Query-test failures are reported in the returned outcome instead of
-    /// failing the whole call.
-    pub async fn validate_source_with_tests(
-        source: &QuerySource,
-        runtime: &dyn QueryRuntimeProvider,
-        test_queries: &[String],
-    ) -> Result<SourceValidationOutcome, CoreError> {
+    ) -> Result<SourceValidationReport, CoreError> {
         let query_runtime =
             runtime::query::build_runtime(std::slice::from_ref(source), runtime).await?;
         let tables = query_runtime.list_tables(Some(source.source_name()));
@@ -257,9 +177,8 @@ impl CoralQuery {
             }
         }
 
-        Ok(SourceValidationOutcome::new(tables, query_tests))
+        Ok(SourceValidationReport::new(tables, query_tests))
     }
->>>>>>> a604639 (Preserve source test_queries implementation progress before team relaunch)
 }
 
 fn is_non_read_only_sql_error(detail: &str) -> bool {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -77,7 +77,10 @@ impl QueryRuntimeAdapter {
             .collect()
     }
 
-    pub(crate) fn registration_failure(&self, source_name: &str) -> Option<&SourceRegistrationFailure> {
+    pub(crate) fn registration_failure(
+        &self,
+        source_name: &str,
+    ) -> Option<&SourceRegistrationFailure> {
         self.failures
             .iter()
             .find(|failure| failure.schema_name == source_name)

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -15,6 +15,7 @@ use crate::{CoreError, QueryExecution, QueryRuntimeProvider, QuerySource, TableI
 pub(crate) struct QueryRuntimeAdapter {
     ctx: Arc<SessionContext>,
     tables: Vec<TableInfo>,
+    failures: Vec<SourceRegistrationFailure>,
 }
 
 pub(crate) async fn build_runtime(
@@ -51,6 +52,7 @@ pub(crate) async fn build_runtime(
     catalog::register(&ctx, &registration.active_sources)
         .map_err(|err| datafusion_to_core(&err))?;
     let tables = catalog::collect_tables(&registration.active_sources);
+    failures.extend(registration.failures);
     for failure in &failures {
         tracing::warn!(
             source = %failure.schema_name,
@@ -59,7 +61,11 @@ pub(crate) async fn build_runtime(
         );
     }
 
-    Ok(QueryRuntimeAdapter { ctx, tables })
+    Ok(QueryRuntimeAdapter {
+        ctx,
+        tables,
+        failures,
+    })
 }
 
 impl QueryRuntimeAdapter {
@@ -69,6 +75,12 @@ impl QueryRuntimeAdapter {
             .filter(|table| source_filter.is_none_or(|value| table.schema_name == value))
             .cloned()
             .collect()
+    }
+
+    pub(crate) fn registration_failure(&self, source_name: &str) -> Option<&SourceRegistrationFailure> {
+        self.failures
+            .iter()
+            .find(|failure| failure.schema_name == source_name)
     }
 
     pub(crate) async fn execute_sql(&self, sql: &str) -> Result<QueryExecution, CoreError> {
@@ -147,4 +159,10 @@ mod tests {
             other => panic!("expected CoreError::InvalidInput, got {other:?}"),
         }
     }
+}
+
+pub(crate) fn is_non_read_only_sql_error(detail: &str) -> bool {
+    detail.starts_with("DDL not supported")
+        || detail.starts_with("DML not supported")
+        || detail.starts_with("Statement not supported")
 }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -135,12 +135,6 @@ fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
     CoreError::QueryFailure(Box::new(error.to_structured()))
 }
 
-pub(crate) fn is_non_read_only_sql_error(detail: &str) -> bool {
-    detail.starts_with("DDL not supported")
-        || detail.starts_with("DML not supported")
-        || detail.starts_with("Statement not supported")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -135,6 +135,12 @@ fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
     CoreError::QueryFailure(Box::new(error.to_structured()))
 }
 
+pub(crate) fn is_non_read_only_sql_error(detail: &str) -> bool {
+    detail.starts_with("DDL not supported")
+        || detail.starts_with("DML not supported")
+        || detail.starts_with("Statement not supported")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -162,10 +168,4 @@ mod tests {
             other => panic!("expected CoreError::InvalidInput, got {other:?}"),
         }
     }
-}
-
-pub(crate) fn is_non_read_only_sql_error(detail: &str) -> bool {
-    detail.starts_with("DDL not supported")
-        || detail.starts_with("DML not supported")
-        || detail.starts_with("Statement not supported")
 }

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -60,18 +60,6 @@ pub(crate) fn assert_row_count(execution: &QueryExecution, expected: usize) {
 
 #[allow(
     dead_code,
-    reason = "retained for engine tests that may assert internal errors"
-)]
-pub(crate) fn assert_internal(error: CoreError, expected_detail: &str) {
-    assert_eq!(error.status_code(), StatusCode::Internal);
-    match error {
-        CoreError::Internal(detail) => assert_eq!(detail, expected_detail),
-        other => panic!("expected CoreError::Internal, got {other:?}"),
-    }
-}
-
-#[allow(
-    dead_code,
     reason = "retained for other engine tests that may assert invalid input"
 )]
 pub(crate) fn assert_invalid_input(error: CoreError, expected_detail: &str) {

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -58,6 +58,10 @@ pub(crate) fn assert_row_count(execution: &QueryExecution, expected: usize) {
     assert_eq!(execution_to_rows(execution).len(), expected);
 }
 
+#[allow(
+    dead_code,
+    reason = "retained for engine tests that may assert internal errors"
+)]
 pub(crate) fn assert_internal(error: CoreError, expected_detail: &str) {
     assert_eq!(error.status_code(), StatusCode::Internal);
     match error {

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -58,6 +58,18 @@ pub(crate) fn assert_row_count(execution: &QueryExecution, expected: usize) {
     assert_eq!(execution_to_rows(execution).len(), expected);
 }
 
+pub(crate) fn assert_internal(error: CoreError, expected_detail: &str) {
+    assert_eq!(error.status_code(), StatusCode::Internal);
+    match error {
+        CoreError::Internal(detail) => assert_eq!(detail, expected_detail),
+        other => panic!("expected CoreError::Internal, got {other:?}"),
+    }
+}
+
+#[allow(
+    dead_code,
+    reason = "retained for other engine tests that may assert invalid input"
+)]
 pub(crate) fn assert_invalid_input(error: CoreError, expected_detail: &str) {
     assert_eq!(error.status_code(), StatusCode::InvalidArgument);
     match error {

--- a/crates/coral-engine/tests/engine/test_source_tests.rs
+++ b/crates/coral-engine/tests/engine/test_source_tests.rs
@@ -4,9 +4,7 @@ use coral_engine::CoralQuery;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use crate::harness::{
-    TestRuntime, assert_invalid_input, build_source, dir_url, users_rows, write_jsonl_file,
-};
+use crate::harness::{TestRuntime, build_source, dir_url, users_rows, write_jsonl_file};
 
 fn jsonl_manifest(name: &str, dir: &Path, glob: &str) -> Value {
     json!({
@@ -63,12 +61,16 @@ async fn test_source_missing_directory_returns_error() {
         .await
         .expect_err("test_source should fail for missing directories");
 
-    assert_invalid_input(
-        error,
-        &format!(
+    assert_eq!(
+        error.status_code(),
+        coral_engine::StatusCode::FailedPrecondition
+    );
+    assert!(
+        error.to_string().contains(&format!(
             "jsonl_test_missing.users source.location '{}' is not a directory",
             dir_url(&missing_dir)
-        ),
+        )),
+        "expected missing-directory detail in error, got: {error}"
     );
 }
 
@@ -103,7 +105,11 @@ async fn validate_source_with_tests_reports_passing_and_failing_queries() {
         outcome.query_tests[1]
             .error_message()
             .expect("failed query should carry an error")
-            .contains("resource not found")
+            .contains("not found")
+            || outcome.query_tests[1]
+                .error_message()
+                .expect("failed query should carry an error")
+                .contains("invalid input")
     );
 }
 

--- a/crates/coral-engine/tests/engine/test_source_tests.rs
+++ b/crates/coral-engine/tests/engine/test_source_tests.rs
@@ -75,6 +75,31 @@ async fn test_source_missing_directory_returns_error() {
 }
 
 #[tokio::test]
+async fn validate_source_with_tests_fails_when_source_never_registers() {
+    let temp = TempDir::new().expect("temp dir");
+    let missing_dir = temp.path().join("missing");
+    let source = build_source(jsonl_manifest(
+        "jsonl_test_missing",
+        &missing_dir,
+        "**/*.jsonl",
+    ));
+    let queries = vec!["SELECT * FROM jsonl_test_missing.users".to_string()];
+
+    let error = CoralQuery::validate_source_with_tests(&source, &TestRuntime, &queries)
+        .await
+        .expect_err("validate_source_with_tests should fail when the source never registers");
+
+    assert_eq!(
+        error.status_code(),
+        coral_engine::StatusCode::FailedPrecondition
+    );
+    assert!(
+        error.to_string().contains("is not a directory"),
+        "expected skipped-registration detail in error, got: {error}"
+    );
+}
+
+#[tokio::test]
 async fn validate_source_with_tests_reports_passing_and_failing_queries() {
     let temp = TempDir::new().expect("temp dir");
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());

--- a/crates/coral-engine/tests/engine/test_source_tests.rs
+++ b/crates/coral-engine/tests/engine/test_source_tests.rs
@@ -50,7 +50,6 @@ async fn test_source_lists_registered_tables() {
 }
 
 #[tokio::test]
-#[ignore = "TODO: re-enable when test_source behavior is aligned with the source lint command"]
 async fn test_source_missing_directory_returns_error() {
     let temp = TempDir::new().expect("temp dir");
     let missing_dir = temp.path().join("missing");
@@ -60,8 +59,6 @@ async fn test_source_missing_directory_returns_error() {
         "**/*.jsonl",
     ));
 
-    // TODO: Re-enable this once source validation semantics are aligned with
-    // the source lint command instead of returning Ok([]) for skipped sources.
     let error = CoralQuery::test_source(&source, &TestRuntime)
         .await
         .expect_err("test_source should fail for missing directories");
@@ -72,5 +69,62 @@ async fn test_source_missing_directory_returns_error() {
             "jsonl_test_missing.users source.location '{}' is not a directory",
             dir_url(&missing_dir)
         ),
+    );
+}
+
+#[tokio::test]
+async fn validate_source_with_tests_reports_passing_and_failing_queries() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest(
+        "jsonl_test_source",
+        temp.path(),
+        "**/*.jsonl",
+    ));
+    let queries = vec![
+        "SELECT * FROM jsonl_test_source.users".to_string(),
+        "SELECT * FROM jsonl_test_source.missing".to_string(),
+    ];
+
+    let outcome = CoralQuery::validate_source_with_tests(&source, &TestRuntime, &queries)
+        .await
+        .expect("validate_source_with_tests should succeed");
+
+    assert_eq!(outcome.tables.len(), 1);
+    assert_eq!(outcome.declared_query_count, 2);
+    assert_eq!(outcome.passed_query_count, 1);
+    assert_eq!(outcome.failed_query_count, 1);
+    assert!(!outcome.all_query_tests_passed);
+    assert_eq!(outcome.query_tests.len(), 2);
+    assert!(outcome.query_tests[0].passed());
+    assert_eq!(outcome.query_tests[0].row_count(), Some(3));
+    assert!(!outcome.query_tests[1].passed());
+    assert!(
+        outcome.query_tests[1]
+            .error_message()
+            .expect("failed query should carry an error")
+            .contains("resource not found")
+    );
+}
+
+#[tokio::test]
+async fn validate_source_with_tests_maps_non_read_only_queries_to_stable_error() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest(
+        "jsonl_test_source",
+        temp.path(),
+        "**/*.jsonl",
+    ));
+    let queries = vec!["SET datafusion.execution.batch_size = 1".to_string()];
+
+    let outcome = CoralQuery::validate_source_with_tests(&source, &TestRuntime, &queries)
+        .await
+        .expect("validate_source_with_tests should succeed");
+
+    assert_eq!(outcome.failed_query_count, 1);
+    assert_eq!(
+        outcome.query_tests[0].error_message(),
+        Some("test query must be read-only SQL")
     );
 }

--- a/crates/coral-engine/tests/engine/test_source_tests.rs
+++ b/crates/coral-engine/tests/engine/test_source_tests.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use coral_engine::{CoralQuery, QueryTestOutcome};
+use coral_engine::CoralQuery;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -75,7 +75,7 @@ async fn test_source_missing_directory_returns_error() {
 }
 
 #[tokio::test]
-async fn validate_source_with_tests_fails_when_source_never_registers() {
+async fn validate_source_fails_when_source_never_registers() {
     let temp = TempDir::new().expect("temp dir");
     let missing_dir = temp.path().join("missing");
     let source = build_source(jsonl_manifest(
@@ -85,9 +85,9 @@ async fn validate_source_with_tests_fails_when_source_never_registers() {
     ));
     let queries = vec!["SELECT * FROM jsonl_test_missing.users".to_string()];
 
-    let error = CoralQuery::validate_source_with_tests(&source, &TestRuntime, &queries)
+    let error = CoralQuery::validate_source(&source, &TestRuntime, &queries)
         .await
-        .expect_err("validate_source_with_tests should fail when the source never registers");
+        .expect_err("validate_source should fail when the source never registers");
 
     assert_eq!(
         error.status_code(),
@@ -100,7 +100,7 @@ async fn validate_source_with_tests_fails_when_source_never_registers() {
 }
 
 #[tokio::test]
-async fn validate_source_with_tests_reports_passing_and_failing_queries() {
+async fn validate_source_reports_passing_and_failing_queries() {
     let temp = TempDir::new().expect("temp dir");
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
     let source = build_source(jsonl_manifest(
@@ -113,37 +113,33 @@ async fn validate_source_with_tests_reports_passing_and_failing_queries() {
         "SELECT * FROM jsonl_test_source.missing".to_string(),
     ];
 
-    let outcome = CoralQuery::validate_source_with_tests(&source, &TestRuntime, &queries)
+    let report = CoralQuery::validate_source(&source, &TestRuntime, &queries)
         .await
-        .expect("validate_source_with_tests should succeed");
+        .expect("validate_source should succeed");
 
-    assert_eq!(outcome.tables.len(), 1);
-    assert_eq!(outcome.declared_query_count, 2);
-    assert_eq!(outcome.passed_query_count, 1);
-    assert_eq!(outcome.failed_query_count, 1);
-    assert!(!outcome.all_query_tests_passed);
-    assert_eq!(outcome.query_tests.len(), 2);
-    assert!(outcome.query_tests[0].passed());
-    assert_eq!(outcome.query_tests[0].row_count(), Some(3));
-    assert!(!outcome.query_tests[1].passed());
+    assert_eq!(report.tables.len(), 1);
+    assert_eq!(report.query_tests.len(), 2);
+    assert!(report.query_tests[0].passed());
+    assert_eq!(report.query_tests[0].row_count(), Some(3));
+    assert!(!report.query_tests[1].passed());
     assert!(
-        outcome.query_tests[1]
+        report.query_tests[1]
             .error_message()
             .expect("failed query should carry an error")
             .contains("not found")
-            || outcome.query_tests[1]
+            || report.query_tests[1]
                 .error_message()
                 .expect("failed query should carry an error")
                 .contains("invalid input")
     );
     assert!(matches!(
-        outcome.query_tests[0].outcome(),
-        QueryTestOutcome::Success { row_count } if *row_count == 3
+        report.query_tests[0].result(),
+        Ok(success) if success.row_count() == 3
     ));
 }
 
 #[tokio::test]
-async fn validate_source_with_tests_maps_non_read_only_queries_to_stable_error() {
+async fn validate_source_maps_non_read_only_queries_to_stable_error() {
     let temp = TempDir::new().expect("temp dir");
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
     let source = build_source(jsonl_manifest(
@@ -153,13 +149,12 @@ async fn validate_source_with_tests_maps_non_read_only_queries_to_stable_error()
     ));
     let queries = vec!["SET datafusion.execution.batch_size = 1".to_string()];
 
-    let outcome = CoralQuery::validate_source_with_tests(&source, &TestRuntime, &queries)
+    let report = CoralQuery::validate_source(&source, &TestRuntime, &queries)
         .await
-        .expect("validate_source_with_tests should succeed");
+        .expect("validate_source should succeed");
 
-    assert_eq!(outcome.failed_query_count, 1);
     assert_eq!(
-        outcome.query_tests[0].error_message(),
+        report.query_tests[0].error_message(),
         Some("test query must be read-only SQL")
     );
 }

--- a/crates/coral-engine/tests/engine/test_source_tests.rs
+++ b/crates/coral-engine/tests/engine/test_source_tests.rs
@@ -124,16 +124,12 @@ async fn validate_source_with_tests_reports_passing_and_failing_queries() {
     assert!(!outcome.all_query_tests_passed);
     assert_eq!(outcome.query_tests.len(), 2);
     assert!(outcome.query_tests[0].passed());
-    assert_eq!(outcome.query_tests[0].row_count(), Some(3));
+    assert_eq!(outcome.query_tests[0].row_count(), 3);
     assert!(!outcome.query_tests[1].passed());
     assert!(
-        outcome.query_tests[1]
-            .error_message()
-            .expect("failed query should carry an error")
-            .contains("not found")
+        outcome.query_tests[1].error_message().contains("not found")
             || outcome.query_tests[1]
                 .error_message()
-                .expect("failed query should carry an error")
                 .contains("invalid input")
     );
 }
@@ -156,6 +152,6 @@ async fn validate_source_with_tests_maps_non_read_only_queries_to_stable_error()
     assert_eq!(outcome.failed_query_count, 1);
     assert_eq!(
         outcome.query_tests[0].error_message(),
-        Some("test query must be read-only SQL")
+        "test query must be read-only SQL"
     );
 }

--- a/crates/coral-engine/tests/engine/test_source_tests.rs
+++ b/crates/coral-engine/tests/engine/test_source_tests.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use coral_engine::CoralQuery;
+use coral_engine::{CoralQuery, QueryTestOutcome};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
@@ -124,14 +124,22 @@ async fn validate_source_with_tests_reports_passing_and_failing_queries() {
     assert!(!outcome.all_query_tests_passed);
     assert_eq!(outcome.query_tests.len(), 2);
     assert!(outcome.query_tests[0].passed());
-    assert_eq!(outcome.query_tests[0].row_count(), 3);
+    assert_eq!(outcome.query_tests[0].row_count(), Some(3));
     assert!(!outcome.query_tests[1].passed());
     assert!(
-        outcome.query_tests[1].error_message().contains("not found")
+        outcome.query_tests[1]
+            .error_message()
+            .expect("failed query should carry an error")
+            .contains("not found")
             || outcome.query_tests[1]
                 .error_message()
+                .expect("failed query should carry an error")
                 .contains("invalid input")
     );
+    assert!(matches!(
+        outcome.query_tests[0].outcome(),
+        QueryTestOutcome::Success { row_count } if *row_count == 3
+    ));
 }
 
 #[tokio::test]
@@ -152,6 +160,6 @@ async fn validate_source_with_tests_maps_non_read_only_queries_to_stable_error()
     assert_eq!(outcome.failed_query_count, 1);
     assert_eq!(
         outcome.query_tests[0].error_message(),
-        "test query must be read-only SQL"
+        Some("test query must be read-only SQL")
     );
 }

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -18,6 +18,7 @@ use crate::common::parse_manifest_data_type;
 use crate::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestError, Result, SourceBackend,
     SourceManifestCommon, TableCommon, validate_columns, validate_filters_and_column_exprs,
+    validate_test_queries,
 };
 
 /// Validated top-level manifest for a `Parquet`-backed source.
@@ -42,6 +43,8 @@ struct RawFileSourceManifest {
     version: String,
     #[serde(default)]
     description: String,
+    #[serde(default)]
+    test_queries: Vec<String>,
     backend: SourceBackend,
     tables: Vec<RawFileTableSpec>,
 }
@@ -262,10 +265,13 @@ impl ParquetSourceManifest {
             name,
             version,
             description,
+            test_queries,
             backend: _backend,
             tables,
         } = raw;
-        let common = SourceManifestCommon::new(dsl_version, name, version, description);
+        validate_test_queries(&name, &test_queries)?;
+        let common =
+            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_parquet(&common.name))
@@ -283,10 +289,13 @@ impl JsonlSourceManifest {
             name,
             version,
             description,
+            test_queries,
             backend: _backend,
             tables,
         } = raw;
-        let common = SourceManifestCommon::new(dsl_version, name, version, description);
+        validate_test_queries(&name, &test_queries)?;
+        let common =
+            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_jsonl(&common.name))

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -19,7 +19,8 @@ use crate::{
     AuthSpec, ColumnSpec, FilterSpec, ManifestError, ManifestInputKind, ManifestInputSpec,
     PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
     SourceBackend, SourceManifestCommon, TableCommon, inputs::collect_source_inputs_value,
-    validate::validate_template, validate_http_table,
+    validate_http_table, validate_test_queries,
+    validate::validate_template,
 };
 
 /// Provider-specific response hints for classifying and delaying rate-limit retries.
@@ -55,6 +56,8 @@ struct RawHttpSourceManifest {
     version: String,
     #[serde(default)]
     description: String,
+    #[serde(default)]
+    test_queries: Vec<String>,
     backend: SourceBackend,
     #[serde(default)]
     base_url: ParsedTemplate,
@@ -203,6 +206,7 @@ impl HttpSourceManifest {
             name,
             version,
             description,
+            test_queries,
             backend: _backend,
             base_url,
             auth,
@@ -210,7 +214,9 @@ impl HttpSourceManifest {
             inputs: _inputs,
             tables,
         } = raw;
-        let common = SourceManifestCommon::new(dsl_version, name, version, description);
+        validate_test_queries(&name, &test_queries)?;
+        let common =
+            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -19,8 +19,7 @@ use crate::{
     AuthSpec, ColumnSpec, FilterSpec, ManifestError, ManifestInputKind, ManifestInputSpec,
     PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
     SourceBackend, SourceManifestCommon, TableCommon, inputs::collect_source_inputs_value,
-    validate_http_table, validate_test_queries,
-    validate::validate_template,
+    validate::validate_template, validate_http_table, validate_test_queries,
 };
 
 /// Provider-specific response hints for classifying and delaying rate-limit retries.

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -23,6 +23,7 @@ pub struct SourceManifestCommon {
     pub name: String,
     pub version: String,
     pub description: String,
+    pub test_queries: Vec<String>,
 }
 
 impl SourceManifestCommon {
@@ -31,14 +32,27 @@ impl SourceManifestCommon {
         name: String,
         version: String,
         description: String,
+        test_queries: Vec<String>,
     ) -> Self {
         Self {
             dsl_version,
             name,
             version,
             description,
+            test_queries,
         }
     }
+}
+
+pub(crate) fn validate_test_queries(source_name: &str, test_queries: &[String]) -> Result<()> {
+    for (index, query) in test_queries.iter().enumerate() {
+        if query.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' test_queries[{index}] must not be empty"
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Supported source-spec backends.

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -85,6 +85,7 @@ mod schema;
 mod template;
 mod validate;
 
+pub(crate) use common::validate_test_queries;
 pub use common::{
     AuthSpec, BodyFieldSpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, HeaderSpec, HttpMethod,
     ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,
@@ -101,4 +102,3 @@ pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToke
 pub(crate) use validate::{
     validate_columns, validate_filters_and_column_exprs, validate_http_table,
 };
-pub(crate) use common::validate_test_queries;

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -101,3 +101,4 @@ pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToke
 pub(crate) use validate::{
     validate_columns, validate_filters_and_column_exprs, validate_http_table,
 };
+pub(crate) use common::validate_test_queries;

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -75,6 +75,16 @@ impl ValidatedSourceManifest {
         }
     }
 
+    #[must_use]
+    /// Returns the optional top-level validation queries declared by the source spec.
+    pub fn test_queries(&self) -> &[String] {
+        match &self.inner {
+            ValidatedManifestKind::Http(manifest) => &manifest.common.test_queries,
+            ValidatedManifestKind::Parquet(manifest) => &manifest.common.test_queries,
+            ValidatedManifestKind::Jsonl(manifest) => &manifest.common.test_queries,
+        }
+    }
+
     /// Returns the set of source secrets required to compile or authenticate
     /// the source spec.
     ///
@@ -173,4 +183,63 @@ fn parse_source_backend(value: &Value) -> Result<SourceBackend> {
     let backend: SourceBackend =
         serde_json::from_value(backend).map_err(ManifestError::deserialize)?;
     Ok(backend)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_source_manifest_yaml;
+
+    #[test]
+    fn parse_source_manifest_preserves_test_query_order() {
+        let manifest = parse_source_manifest_yaml(
+            r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+test_queries:
+  - SELECT 1
+  - SELECT 2
+tables:
+  - name: messages
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+"#,
+        )
+        .expect("manifest should parse");
+
+        assert_eq!(manifest.test_queries(), &["SELECT 1", "SELECT 2"]);
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_whitespace_only_test_query() {
+        let error = parse_source_manifest_yaml(
+            r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+test_queries:
+  - "   "
+tables:
+  - name: messages
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+"#,
+        )
+        .expect_err("whitespace-only query should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'demo' test_queries[0] must not be empty"
+        );
+    }
 }

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -192,7 +192,7 @@ mod tests {
     #[test]
     fn parse_source_manifest_preserves_test_query_order() {
         let manifest = parse_source_manifest_yaml(
-            r#"
+            r"
 name: demo
 version: 1.0.0
 dsl_version: 3
@@ -208,7 +208,7 @@ tables:
     columns:
       - name: kind
         type: Utf8
-"#,
+",
         )
         .expect("manifest should parse");
 

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -10,6 +10,10 @@
     "name": { "type": "string", "minLength": 1 },
     "version": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
+    "test_queries": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
     "backend": { "type": "string", "enum": ["http", "parquet", "jsonl"] },
     "inputs": { "$ref": "#/$defs/inputs" },
     "base_url": { "type": "string", "minLength": 1 },

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -28,6 +28,8 @@ coral source add github
 
 Coral prompts for any required variables or secrets. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
 
+After install, Coral runs a validation pass automatically. If the connection check or any declared `test_queries` fail, Coral keeps the source installed and prints warnings so you can fix the configuration and rerun `coral source test github`.
+
 <Tip>You can re-validate anytime with `coral source test github`.</Tip>
 
 ## 3. Query your data

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -28,10 +28,6 @@ coral source add github
 
 Coral prompts for any required variables or secrets. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
 
-After install, Coral runs a validation pass automatically. If the connection check or any declared `test_queries` fail, Coral keeps the source installed and prints warnings so you can fix the configuration and rerun `coral source test github`.
-
-<Tip>You can re-validate anytime with `coral source test github`.</Tip>
-
 ## 3. Query your data
 
 You can now query any connected source using SQL.

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -85,50 +85,26 @@ coral sql "
 
 When you add `test_queries` to a source spec, treat them as a lightweight validation contract for that source.
 
-1. Run `coral source lint ./my-source.yaml` before installing the source.
+1. Run `coral source lint ./my-source.yaml` first. It catches schema and semantic issues without touching your workspace or asking for secrets.
 2. Add or update the source with `coral source add --file ./my-source.yaml`.
-3. Run `coral source test <source_name>` and confirm:
-   - the source still exposes the expected tables
-<<<<<<< HEAD
-   - each declared `test_queries` entry runs in manifest order
-   - successful queries show a pass status and optional row count
-<<<<<<< HEAD
-   - failing queries surface a readable error message
-4. Run one or two real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
-||||||| parent of 015e4a4 (Trim minor reviewer nits from PR #107)
-   - failing queries surface the SQL text plus a readable error message
-4. Run one or two real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
-5. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
-=======
-   - failing queries surface the SQL text plus a readable error message
-||||||| parent of b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
-   - each declared `test_queries` entry runs in manifest order
-   - successful queries show a pass status and optional row count
-   - failing queries surface the SQL text plus a readable error message
-=======
+3. Confirm the install-time validation output:
+   - the source exposes the expected tables
    - each declared `test_queries` entry runs successfully
    - successful queries show a pass status and row count
    - failing queries surface the SQL text plus an error message
->>>>>>> b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
 4. Run real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
-5. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
->>>>>>> 015e4a4 (Trim minor reviewer nits from PR #107)
+5. If you want a strict rerun later, or you are debugging a failure, run `coral source test <source_name>`.
+6. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
 
 If you are validating a credentialed source end-to-end, it is useful to try both:
 
 - a correctly configured source, which should pass table validation and all declared query tests
-- an intentionally misconfigured source, which should still reach `coral source test` but exit non-zero when its declared query tests fail
+- an intentionally misconfigured source, which should still install but fail `coral source test` with a non-zero exit code
 
 This gives you confidence that the source spec works in the happy path and that `test_queries` catch broken credentials or runtime regressions in a predictable way.
 
-<<<<<<< HEAD
-||||||| parent of b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
-Use read-only SQL in `test_queries`. Coral rejects DDL, DML, and other non-read-only statements as failed validation queries instead of applying them.
-
-=======
 Use read-only SQL in `test_queries`. Prefer bounded checks such as `SELECT * FROM schema.table LIMIT 1` over expensive scans like `SELECT COUNT(*)`, especially for HTTP-backed sources or large datasets. Coral rejects DDL, DML, and other non-read-only statements as failed validation queries instead of applying them.
 
->>>>>>> b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
 ## Example: HTTP API source
 
 To connect an HTTP API, the source spec declares the base URL, auth, endpoints, and response shape.
@@ -182,7 +158,7 @@ For the full set of HTTP response, pagination, auth, and column fields, see [HTT
 
 ## Tips
 
-- **Lint before installing.** Run `coral source lint ./my-source.yaml` to catch schema and semantic errors without touching your workspace.
+- **Lint before installing.** `coral source lint ./my-source.yaml` is a fast local precheck because it does not install the source or require credentials.
 - **Start small.** Begin with one table and a few columns. Validate with `coral source test`, check `coral.columns` and `coral.inputs`, then expand.
 - **Use `coral.tables`, `coral.columns`, and `coral.inputs`.** They show you exactly what Coral sees after adding a source — including required filters and column metadata.
 - **Look at bundled sources for patterns.** The bundled source specs in the repo under `sources/` are working examples of HTTP pagination, response parsing, auth, and inputs.

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -79,6 +79,26 @@ coral sql "
 "
 ```
 
+## How to verify and validate
+
+When you add `test_queries` to a source spec, treat them as a lightweight validation contract for that source.
+
+1. Run `coral source lint ./my-source.yaml` before installing the source.
+2. Add or update the source with `coral source add --file ./my-source.yaml`.
+3. Run `coral source test <source_name>` and confirm:
+   - the source still exposes the expected tables
+   - each declared `test_queries` entry runs in manifest order
+   - successful queries show a pass status and optional row count
+   - failing queries surface a readable error message
+4. Run one or two real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
+
+If you are validating a credentialed source end-to-end, it is useful to try both:
+
+- a correctly configured source, which should pass table validation and all declared query tests
+- an intentionally misconfigured source, which should still reach `coral source test` but exit non-zero when its declared query tests fail
+
+This gives you confidence that the source spec works in the happy path and that `test_queries` catch broken credentials or runtime regressions in a predictable way.
+
 ## Example: HTTP API source
 
 To connect an HTTP API, the source spec declares the base URL, auth, endpoints, and response shape.

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -69,7 +69,7 @@ coral source add --file ./local-messages.yaml
 coral source test local_messages
 ```
 
-`coral source add --file` validates immediately after install, but it treats failing `test_queries` as warnings so the source still lands in your workspace. Use `coral source test <NAME>` when you want strict pass/fail verification.
+`coral source add --file` validates immediately after install. Post-install validation issues, including failing `test_queries`, are printed as warnings so the source still lands in your workspace. Use `coral source test <NAME>` when you want strict pass/fail verification.
 
 ### 4. Query it
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -41,6 +41,8 @@ name: local_messages
 version: 0.1.0
 dsl_version: 3
 backend: jsonl
+test_queries:
+  - SELECT COUNT(*) AS n FROM local_messages.messages
 tables:
   - name: messages
     description: Demo messages
@@ -57,6 +59,8 @@ tables:
 ```
 
 Replace `/absolute/path/to/demo-data/` with the real absolute path on your machine.
+
+The optional top-level `test_queries` field lets you declare read-only SQL checks that Coral runs during `coral source test`. Coral preserves the order you write, allows duplicates, and reports each query result individually.
 
 ### 3. Add and validate
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -69,6 +69,8 @@ coral source add --file ./local-messages.yaml
 coral source test local_messages
 ```
 
+`coral source add --file` validates immediately after install, but it treats failing `test_queries` as warnings so the source still lands in your workspace. Use `coral source test <NAME>` when you want strict pass/fail verification.
+
 ### 4. Query it
 
 ```shellscript

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -42,7 +42,7 @@ version: 0.1.0
 dsl_version: 3
 backend: jsonl
 test_queries:
-  - SELECT COUNT(*) AS n FROM local_messages.messages
+  - SELECT * FROM local_messages.messages LIMIT 1
 tables:
   - name: messages
     description: Demo messages
@@ -60,7 +60,7 @@ tables:
 
 Replace `/absolute/path/to/demo-data/` with the real absolute path on your machine.
 
-The optional top-level `test_queries` field lets you declare read-only SQL checks that Coral runs during `coral source test`. Coral preserves the order you write, allows duplicates, and reports each query result individually.
+The optional top-level `test_queries` field lets you declare read-only SQL checks that Coral runs during `coral source test`. Prefer cheap `SELECT` queries that confirm the source connects correctly and the table mapping looks right.
 
 ### 3. Add and validate
 
@@ -89,6 +89,7 @@ When you add `test_queries` to a source spec, treat them as a lightweight valida
 2. Add or update the source with `coral source add --file ./my-source.yaml`.
 3. Run `coral source test <source_name>` and confirm:
    - the source still exposes the expected tables
+<<<<<<< HEAD
    - each declared `test_queries` entry runs in manifest order
    - successful queries show a pass status and optional row count
 <<<<<<< HEAD
@@ -100,6 +101,15 @@ When you add `test_queries` to a source spec, treat them as a lightweight valida
 5. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
 =======
    - failing queries surface the SQL text plus a readable error message
+||||||| parent of b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
+   - each declared `test_queries` entry runs in manifest order
+   - successful queries show a pass status and optional row count
+   - failing queries surface the SQL text plus a readable error message
+=======
+   - each declared `test_queries` entry runs successfully
+   - successful queries show a pass status and row count
+   - failing queries surface the SQL text plus an error message
+>>>>>>> b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
 4. Run real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
 5. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
 >>>>>>> 015e4a4 (Trim minor reviewer nits from PR #107)
@@ -111,6 +121,14 @@ If you are validating a credentialed source end-to-end, it is useful to try both
 
 This gives you confidence that the source spec works in the happy path and that `test_queries` catch broken credentials or runtime regressions in a predictable way.
 
+<<<<<<< HEAD
+||||||| parent of b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
+Use read-only SQL in `test_queries`. Coral rejects DDL, DML, and other non-read-only statements as failed validation queries instead of applying them.
+
+=======
+Use read-only SQL in `test_queries`. Prefer bounded checks such as `SELECT * FROM schema.table LIMIT 1` over expensive scans like `SELECT COUNT(*)`, especially for HTTP-backed sources or large datasets. Coral rejects DDL, DML, and other non-read-only statements as failed validation queries instead of applying them.
+
+>>>>>>> b880030 (Reduce validation-doc noise and simplify query-test wire semantics)
 ## Example: HTTP API source
 
 To connect an HTTP API, the source spec declares the base URL, auth, endpoints, and response shape.

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -91,8 +91,18 @@ When you add `test_queries` to a source spec, treat them as a lightweight valida
    - the source still exposes the expected tables
    - each declared `test_queries` entry runs in manifest order
    - successful queries show a pass status and optional row count
+<<<<<<< HEAD
    - failing queries surface a readable error message
 4. Run one or two real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
+||||||| parent of 015e4a4 (Trim minor reviewer nits from PR #107)
+   - failing queries surface the SQL text plus a readable error message
+4. Run one or two real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
+5. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
+=======
+   - failing queries surface the SQL text plus a readable error message
+4. Run real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
+5. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
+>>>>>>> 015e4a4 (Trim minor reviewer nits from PR #107)
 
 If you are validating a credentialed source end-to-end, it is useful to try both:
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -81,7 +81,7 @@ coral sql "
 "
 ```
 
-## How to verify and validate
+## How to validate
 
 When you add `test_queries` to a source spec, treat them as a lightweight validation contract for that source.
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -68,7 +68,7 @@ coral source lint ./my-source.yaml
 
 ### `coral source test <NAME>`
 
-Validate that an installed source can initialize, expose tables, and run any optional top-level `test_queries` declared in its source spec. The command exits non-zero when one or more declared query tests fail.
+Validate that an installed source can initialize, expose tables, and run any optional top-level `test_queries` declared in its source spec. The command errors when one or more declared query tests fail.
 
 ```shellscript
 coral source test github

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -48,7 +48,7 @@ coral source add github
 ```
 
 Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
-After installation, it automatically validates the connection, prints the discovered tables, and runs any optional top-level `test_queries` declared in the source spec. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
+After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
 ### `coral source add --file <PATH>`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -70,7 +70,7 @@ coral source lint ./my-source.yaml
 
 ### `coral source test <NAME>`
 
-Validate that an installed source can initialize and expose tables.
+Validate that an installed source can initialize, expose tables, and run any optional top-level `test_queries` declared in its source spec. The command exits non-zero when one or more declared query tests fail.
 
 ```shellscript
 coral source test github

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -48,7 +48,7 @@ coral source add github
 ```
 
 Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
-After installation, it automatically validates the connection and prints the discovered tables.
+After installation, it automatically validates the connection, prints the discovered tables, and runs any optional top-level `test_queries` declared in the source spec. Query-test failures are reported as warnings here so the source remains installed and re-runnable.
 
 ### `coral source add --file <PATH>`
 
@@ -58,7 +58,7 @@ Add a custom source spec from a YAML file.
 coral source add --file ./local-messages.yaml
 ```
 
-Like `source add`, this automatically validates and prints discovered tables after install.
+Like `source add`, this automatically validates, prints discovered tables, and warns if declared `test_queries` fail after install.
 
 ### `coral source lint <FILE>`
 
@@ -76,6 +76,8 @@ Validate that an installed source can initialize, expose tables, and run any opt
 coral source test github
 coral source test local_messages
 ```
+
+Unlike `source add`, this command is strict: it returns a non-zero exit code when any declared query test fails so you can use it in verification and CI workflows.
 
 ### `coral source remove <NAME>`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -58,8 +58,6 @@ Add a custom source spec from a YAML file.
 coral source add --file ./local-messages.yaml
 ```
 
-Like `source add`, this automatically validates, prints discovered tables, and warns about post-install validation issues instead of rolling the source back.
-
 ### `coral source lint <FILE>`
 
 Validate a source spec YAML file without installing it. Checks YAML syntax, JSON schema conformance, and semantic rules such as duplicate columns or references to unknown filters.
@@ -77,8 +75,6 @@ coral source test github
 coral source test local_messages
 ```
 
-Unlike `source add`, this command is strict: it returns a non-zero exit code when any declared query test fails so you can use it in verification and CI workflows.
-
 ### `coral source remove <NAME>`
 
 Remove an installed source.
@@ -94,8 +90,6 @@ Run the guided source setup flow.
 ```shellscript
 coral onboard
 ```
-
-The onboarding wizard uses the same warn-only post-install validation behavior as `coral source add`: Coral validates the source after install, runs any declared `test_queries`, and keeps the source installed if that validation reports warnings. Use the wizard's explicit **Validate** action or `coral source test <NAME>` when you want strict pass/fail validation.
 
 ## `coral mcp-stdio`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -48,7 +48,7 @@ coral source add github
 ```
 
 Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
-After installation, it automatically validates the connection, prints the discovered tables, and runs any optional top-level `test_queries` declared in the source spec. Query-test failures are reported as warnings here so the source remains installed and re-runnable.
+After installation, it automatically validates the connection, prints the discovered tables, and runs any optional top-level `test_queries` declared in the source spec. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
 ### `coral source add --file <PATH>`
 
@@ -58,7 +58,7 @@ Add a custom source spec from a YAML file.
 coral source add --file ./local-messages.yaml
 ```
 
-Like `source add`, this automatically validates, prints discovered tables, and warns if declared `test_queries` fail after install.
+Like `source add`, this automatically validates, prints discovered tables, and warns about post-install validation issues instead of rolling the source back.
 
 ### `coral source lint <FILE>`
 
@@ -94,6 +94,8 @@ Run the guided source setup flow.
 ```shellscript
 coral onboard
 ```
+
+The onboarding wizard uses the same warn-only post-install validation behavior as `coral source add`: Coral validates the source after install, runs any declared `test_queries`, and keeps the source installed if that validation reports warnings. Use the wizard's explicit **Validate** action or `coral source test <NAME>` when you want strict pass/fail validation.
 
 ## `coral mcp-stdio`
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -20,7 +20,7 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 test_queries:
-  - SELECT COUNT(*) AS n FROM my_source.messages
+  - SELECT * FROM my_source.messages LIMIT 1
 ```
 
 | Field         | Description                                        |
@@ -39,16 +39,16 @@ queryable.
 
 ```yaml
 test_queries:
-  - SELECT COUNT(*) AS n FROM my_source.messages
+  - SELECT * FROM my_source.messages LIMIT 1
   - SELECT * FROM my_source.messages LIMIT 1
 ```
 
 Notes:
 
-- Coral preserves the order exactly as you write it.
 - Coral allows duplicate entries.
 - Each query result is reported individually during `coral source test`.
 - `coral source add` and `coral onboard` surface post-install validation issues as warnings; `coral source test` is the strict pass/fail command.
+- Prefer cheap read-only checks that validate connectivity and mapping logic. For example, `SELECT * FROM schema.table LIMIT 1` is usually a better fit than `SELECT COUNT(*)`.
 - Keep these queries read-only. Statements such as `CREATE`, `COPY`, `INSERT`,
   `UPDATE`, `DELETE`, or `SET` are reported as failed validation queries.
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -31,7 +31,7 @@ test_queries:
 | `backend`     | How data is fetched: `http`, `jsonl`, or `parquet` |
 | `test_queries` | Optional read-only SQL checks Coral runs during `coral source test` |
 
-## Validation queries
+## Test queries
 
 Use the optional top-level `test_queries` field when you want Coral to run one
 or more read-only SQL checks after the source validates and its tables become
@@ -40,12 +40,10 @@ queryable.
 ```yaml
 test_queries:
   - SELECT * FROM my_source.messages LIMIT 1
-  - SELECT * FROM my_source.messages LIMIT 1
 ```
 
 Notes:
 
-- Coral allows duplicate entries.
 - Each query result is reported individually during `coral source test`.
 - `coral source add` and `coral onboard` surface post-install validation issues as warnings; `coral source test` is the strict pass/fail command.
 - Prefer cheap read-only checks that validate connectivity and mapping logic. For example, `SELECT * FROM schema.table LIMIT 1` is usually a better fit than `SELECT COUNT(*)`.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -48,6 +48,7 @@ Notes:
 - Coral preserves the order exactly as you write it.
 - Coral allows duplicate entries.
 - Each query result is reported individually during `coral source test`.
+- `coral source add` and `coral onboard` surface post-install validation issues as warnings; `coral source test` is the strict pass/fail command.
 - Keep these queries read-only. Statements such as `CREATE`, `COPY`, `INSERT`,
   `UPDATE`, `DELETE`, or `SET` are reported as failed validation queries.
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -19,6 +19,8 @@ name: my_source
 version: 0.1.0
 dsl_version: 3
 backend: http
+test_queries:
+  - SELECT COUNT(*) AS n FROM my_source.messages
 ```
 
 | Field         | Description                                        |
@@ -27,6 +29,27 @@ backend: http
 | `version`     | Source spec version string                         |
 | `dsl_version` | Coral source spec DSL version (currently `3`)      |
 | `backend`     | How data is fetched: `http`, `jsonl`, or `parquet` |
+| `test_queries` | Optional read-only SQL checks Coral runs during `coral source test` |
+
+## Validation queries
+
+Use the optional top-level `test_queries` field when you want Coral to run one
+or more read-only SQL checks after the source validates and its tables become
+queryable.
+
+```yaml
+test_queries:
+  - SELECT COUNT(*) AS n FROM my_source.messages
+  - SELECT * FROM my_source.messages LIMIT 1
+```
+
+Notes:
+
+- Coral preserves the order exactly as you write it.
+- Coral allows duplicate entries.
+- Each query result is reported individually during `coral source test`.
+- Keep these queries read-only. Statements such as `CREATE`, `COPY`, `INSERT`,
+  `UPDATE`, `DELETE`, or `SET` are reported as failed validation queries.
 
 ## Column types
 

--- a/sources/slack/manifest.yaml
+++ b/sources/slack/manifest.yaml
@@ -13,6 +13,8 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{input.SLACK_TOKEN}}
+test_queries:
+  - SELECT COUNT(*) AS channel_count FROM slack.channels
 tables:
   - name: channels
     description: Slack channels with topic, purpose, and member count

--- a/sources/slack/manifest.yaml
+++ b/sources/slack/manifest.yaml
@@ -14,7 +14,7 @@ auth:
       from: template
       template: Bearer {{input.SLACK_TOKEN}}
 test_queries:
-  - SELECT COUNT(*) AS channel_count FROM slack.channels
+  - SELECT * FROM slack.channels LIMIT 1
 tables:
   - name: channels
     description: Slack channels with topic, purpose, and member count


### PR DESCRIPTION
## Summary

- run top-level `test_queries` during `coral source test` and plumb structured query-test results through the spec, engine, app, API, and CLI layers
- keep `coral source add` / onboarding validation warn-only while `coral source test` stays strict, and add CLI regression coverage for both failing and passing query-test output
- document the warn-vs-strict behavior and add a lightweight `SELECT COUNT(*) AS channel_count FROM slack.channels` test query to the bundled Slack source

## Testing

- `make rust-checks`
- `cargo run --quiet -- source lint sources/slack/manifest.yaml``  
``  
`![CleanShot 2026-04-16 at 09.41.36@2x.png](https://app.graphite.com/user-attachments/assets/a205c4f0-c026-4b63-90ab-8c81e88522dc.png)

    