### PR TITLE
fix(engine): retry github 403 reset-based rate limits

### DIFF
--- a/crates/coral-engine/src/backends/http/rate_limit.rs
+++ b/crates/coral-engine/src/backends/http/rate_limit.rs
@@ -103,6 +103,7 @@ fn classify_rate_limit(
             .or(Some(DEFAULT_FALLBACK_RETRY_AFTER))
     } else {
         parse_retry_after(headers, spec, now)
+            .or_else(|| parse_reset_in(headers, spec, now).filter(|wait| !wait.is_zero()))
     };
     if is_extra && retry_after.is_none() {
         // Extra status without any rate-limit signal — treat as a regular error.
@@ -227,6 +228,22 @@ mod tests {
             classify_rate_limit(reqwest::StatusCode::FORBIDDEN, &throttle, &spec, now),
             RateLimitSignal::Throttle {
                 retry_after: Some(Duration::from_secs(7)),
+            },
+        );
+
+        // 403 with a future reset-header should also throttle for providers
+        // like GitHub that use 403 for rate limiting.
+        let mut reset_throttle_403 = HeaderMap::new();
+        reset_throttle_403.insert("X-RateLimit-Reset", HeaderValue::from_static("1700000108"));
+        assert_eq!(
+            classify_rate_limit(
+                reqwest::StatusCode::FORBIDDEN,
+                &reset_throttle_403,
+                &spec,
+                now
+            ),
+            RateLimitSignal::Throttle {
+                retry_after: Some(Duration::from_secs(8)),
             },
         );
 


### PR DESCRIPTION
## Summary
GitHub can rate-limit requests with `403` plus `X-RateLimit-Reset` instead of `429` or `Retry-After`. The recent rate-limit refactor intended to support that provider behavior, but the extra-status path still only treated `Retry-After` as a throttle signal.

This keeps the HTTP retry logic aligned with the GitHub manifest contract so secondary rate limits back off instead of surfacing as ordinary forbidden errors.

## What changed
- fall back to `X-RateLimit-Reset` for configured extra statuses like GitHub `403`
- keep stale reset epochs from being treated as active throttle signals
- add regression coverage for `403 + X-RateLimit-Reset`

## Testing
- `cargo test -p coral-engine rate_limit -- --nocapture`
- `make rust-checks`
