### PR TITLE
feat(engine): add coral.source_variables table

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    TableInfo,
+    QuerySourceOrigin, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_manifest_and_inputs};
 
@@ -154,7 +154,13 @@ impl QueryManager {
             resolved_secrets.insert(secret_name, value);
         }
         Ok((
-            QuerySource::new(source_spec, source.variables.clone(), resolved_secrets),
+            QuerySource::new(
+                source_spec,
+                source.variables.clone(),
+                resolved_secrets,
+                inputs,
+                query_source_origin(source.origin),
+            ),
             installed.candidate.version,
         ))
     }
@@ -201,4 +207,11 @@ fn validate_required_variables(
         )));
     }
     Ok(())
+}
+
+fn query_source_origin(origin: crate::sources::model::SourceOrigin) -> QuerySourceOrigin {
+    match origin {
+        crate::sources::model::SourceOrigin::Bundled => QuerySourceOrigin::Bundled,
+        crate::sources::model::SourceOrigin::Imported => QuerySourceOrigin::Imported,
+    }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeMap;
 
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    QuerySourceOrigin, TableInfo,
+    TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_manifest_and_inputs};
 
@@ -159,7 +159,6 @@ impl QueryManager {
                 source.variables.clone(),
                 resolved_secrets,
                 inputs,
-                query_source_origin(source.origin),
             ),
             installed.candidate.version,
         ))
@@ -207,11 +206,4 @@ fn validate_required_variables(
         )));
     }
     Ok(())
-}
-
-fn query_source_origin(origin: crate::sources::model::SourceOrigin) -> QuerySourceOrigin {
-    match origin {
-        crate::sources::model::SourceOrigin::Bundled => QuerySourceOrigin::Bundled,
-        crate::sources::model::SourceOrigin::Imported => QuerySourceOrigin::Imported,
-    }
 }

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -3,10 +3,12 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-use crate::QueryRuntimeContext;
+use crate::{QueryRuntimeContext, QuerySourceOrigin};
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
-use coral_spec::{ColumnSpec, FilterSpec, ManifestDataType, TableCommon};
+use coral_spec::{
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec, TableCommon,
+};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
@@ -35,6 +37,18 @@ pub(crate) struct RegisteredTable {
 pub(crate) struct RegisteredSource {
     pub(crate) schema_name: String,
     pub(crate) tables: Vec<RegisteredTable>,
+    pub(crate) variables: Vec<RegisteredSourceVariable>,
+    pub(crate) source_origin: String,
+    pub(crate) manifest_version: String,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RegisteredSourceVariable {
+    pub(crate) variable_key: String,
+    pub(crate) variable_value: String,
+    pub(crate) is_defaulted: bool,
+    pub(crate) is_required: bool,
+    pub(crate) default_value: String,
 }
 
 pub(crate) struct BackendRegistration {
@@ -46,6 +60,8 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) runtime_context: &'a QueryRuntimeContext,
     pub(crate) source_secrets: BTreeMap<String, String>,
     pub(crate) source_variables: BTreeMap<String, String>,
+    pub(crate) source_inputs: Vec<ManifestInputSpec>,
+    pub(crate) source_origin: QuerySourceOrigin,
 }
 
 #[async_trait]
@@ -115,6 +131,38 @@ pub(crate) fn build_registered_table(
         columns,
         required_filters,
     }
+}
+
+pub(crate) fn build_registered_source_variables(
+    input_specs: &[ManifestInputSpec],
+    source_variables: &BTreeMap<String, String>,
+) -> Vec<RegisteredSourceVariable> {
+    let mut rows = input_specs
+        .iter()
+        .filter(|input| input.kind == ManifestInputKind::Variable)
+        .filter_map(|input| {
+            source_variables
+                .get(&input.key)
+                .map(|value| RegisteredSourceVariable {
+                    variable_key: input.key.clone(),
+                    variable_value: value.clone(),
+                    is_defaulted: false,
+                    is_required: input.required,
+                    default_value: input.default_value.clone(),
+                })
+                .or_else(|| {
+                    (!input.required).then(|| RegisteredSourceVariable {
+                        variable_key: input.key.clone(),
+                        variable_value: input.default_value.clone(),
+                        is_defaulted: true,
+                        is_required: false,
+                        default_value: input.default_value.clone(),
+                    })
+                })
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| left.variable_key.cmp(&right.variable_key));
+    rows
 }
 
 pub(crate) fn manifest_data_type_to_arrow(data_type: ManifestDataType) -> DataType {

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -3,7 +3,7 @@
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
-use crate::{QueryRuntimeContext, QuerySourceOrigin};
+use crate::QueryRuntimeContext;
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
@@ -38,7 +38,6 @@ pub(crate) struct RegisteredSource {
     pub(crate) schema_name: String,
     pub(crate) tables: Vec<RegisteredTable>,
     pub(crate) variables: Vec<RegisteredSourceVariable>,
-    pub(crate) source_origin: String,
     pub(crate) manifest_version: String,
 }
 
@@ -61,7 +60,6 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_secrets: BTreeMap<String, String>,
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) source_inputs: Vec<ManifestInputSpec>,
-    pub(crate) source_origin: QuerySourceOrigin,
 }
 
 #[async_trait]

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -9,7 +9,6 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
-use crate::QuerySourceOrigin;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
     RegisteredTable, build_registered_source_variables, build_registered_table,
@@ -32,7 +31,6 @@ struct HttpCompiledSource {
     source_secrets: std::collections::BTreeMap<String, String>,
     source_variables: std::collections::BTreeMap<String, String>,
     source_inputs: Vec<ManifestInputSpec>,
-    source_origin: QuerySourceOrigin,
 }
 
 pub(crate) fn compile_source(
@@ -40,14 +38,12 @@ pub(crate) fn compile_source(
     source_secrets: std::collections::BTreeMap<String, String>,
     source_variables: std::collections::BTreeMap<String, String>,
     source_inputs: Vec<ManifestInputSpec>,
-    source_origin: QuerySourceOrigin,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
         source_secrets,
         source_variables,
         source_inputs,
-        source_origin,
     })
 }
 
@@ -61,7 +57,6 @@ pub(crate) fn compile_manifest(
         request.source_secrets.clone(),
         request.source_variables.clone(),
         request.source_inputs.clone(),
-        request.source_origin,
     )
 }
 
@@ -103,7 +98,6 @@ impl CompiledBackendSource for HttpCompiledSource {
                     &self.source_inputs,
                     &self.source_variables,
                 ),
-                source_origin: self.source_origin.as_str().to_string(),
                 manifest_version: self.manifest.common.version.clone(),
             },
         })

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -9,10 +9,13 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
+use crate::QuerySourceOrigin;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_table, registered_columns_from_specs, required_filter_names,
+    RegisteredTable, build_registered_source_variables, build_registered_table,
+    registered_columns_from_specs, required_filter_names,
 };
+use coral_spec::ManifestInputSpec;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod client;
 pub(crate) mod error;
@@ -28,17 +31,23 @@ struct HttpCompiledSource {
     manifest: HttpSourceManifest,
     source_secrets: std::collections::BTreeMap<String, String>,
     source_variables: std::collections::BTreeMap<String, String>,
+    source_inputs: Vec<ManifestInputSpec>,
+    source_origin: QuerySourceOrigin,
 }
 
 pub(crate) fn compile_source(
     manifest: HttpSourceManifest,
     source_secrets: std::collections::BTreeMap<String, String>,
     source_variables: std::collections::BTreeMap<String, String>,
+    source_inputs: Vec<ManifestInputSpec>,
+    source_origin: QuerySourceOrigin,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
         source_secrets,
         source_variables,
+        source_inputs,
+        source_origin,
     })
 }
 
@@ -51,6 +60,8 @@ pub(crate) fn compile_manifest(
         manifest.clone(),
         request.source_secrets.clone(),
         request.source_variables.clone(),
+        request.source_inputs.clone(),
+        request.source_origin,
     )
 }
 
@@ -88,6 +99,12 @@ impl CompiledBackendSource for HttpCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                variables: build_registered_source_variables(
+                    &self.source_inputs,
+                    &self.source_variables,
+                ),
+                source_origin: self.source_origin.as_str().to_string(),
+                manifest_version: self.manifest.common.version.clone(),
             },
         })
     }

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -22,7 +22,7 @@ use crate::backends::{
     RegisteredTable, build_registered_source_variables, build_registered_table,
     registered_columns_from_specs, required_filter_names, schema_from_columns,
 };
-use crate::{CoreError, QueryRuntimeContext, QuerySourceOrigin};
+use crate::{CoreError, QueryRuntimeContext};
 use coral_spec::ManifestInputSpec;
 use coral_spec::backends::file::{FileTableSpec, JsonlSourceManifest};
 
@@ -52,7 +52,6 @@ struct JsonlCompiledSource {
     tables: Vec<CompiledJsonlTable>,
     source_inputs: Vec<ManifestInputSpec>,
     source_variables: std::collections::BTreeMap<String, String>,
-    source_origin: QuerySourceOrigin,
 }
 
 pub(crate) fn compile_source(
@@ -60,7 +59,6 @@ pub(crate) fn compile_source(
     runtime_context: &QueryRuntimeContext,
     source_inputs: Vec<ManifestInputSpec>,
     source_variables: std::collections::BTreeMap<String, String>,
-    source_origin: QuerySourceOrigin,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     let tables = manifest
         .tables
@@ -80,7 +78,6 @@ pub(crate) fn compile_source(
         tables,
         source_inputs,
         source_variables,
-        source_origin,
     }))
 }
 
@@ -93,7 +90,6 @@ pub(crate) fn compile_manifest(
         request.runtime_context,
         request.source_inputs.clone(),
         request.source_variables.clone(),
-        request.source_origin,
     )
 }
 
@@ -310,7 +306,6 @@ impl CompiledBackendSource for JsonlCompiledSource {
                     &self.source_inputs,
                     &self.source_variables,
                 ),
-                source_origin: self.source_origin.as_str().to_string(),
                 manifest_version: self.manifest.common.version.clone(),
             },
         })

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -19,10 +19,11 @@ use crate::backends::shared::json_exec::{Converter, Fetcher, JsonExec, RowFetche
 use crate::backends::shared::mapping::convert_items;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_table, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, build_registered_source_variables, build_registered_table,
+    registered_columns_from_specs, required_filter_names, schema_from_columns,
 };
-use crate::{CoreError, QueryRuntimeContext};
+use crate::{CoreError, QueryRuntimeContext, QuerySourceOrigin};
+use coral_spec::ManifestInputSpec;
 use coral_spec::backends::file::{FileTableSpec, JsonlSourceManifest};
 
 /// Maximum directory recursion depth to prevent stack overflow from symlink
@@ -49,11 +50,17 @@ pub(crate) struct CompiledJsonlTable {
 struct JsonlCompiledSource {
     manifest: JsonlSourceManifest,
     tables: Vec<CompiledJsonlTable>,
+    source_inputs: Vec<ManifestInputSpec>,
+    source_variables: std::collections::BTreeMap<String, String>,
+    source_origin: QuerySourceOrigin,
 }
 
 pub(crate) fn compile_source(
     manifest: JsonlSourceManifest,
     runtime_context: &QueryRuntimeContext,
+    source_inputs: Vec<ManifestInputSpec>,
+    source_variables: std::collections::BTreeMap<String, String>,
+    source_origin: QuerySourceOrigin,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     let tables = manifest
         .tables
@@ -68,14 +75,26 @@ pub(crate) fn compile_source(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(Box::new(JsonlCompiledSource { manifest, tables }))
+    Ok(Box::new(JsonlCompiledSource {
+        manifest,
+        tables,
+        source_inputs,
+        source_variables,
+        source_origin,
+    }))
 }
 
 pub(crate) fn compile_manifest(
     manifest: &JsonlSourceManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
-    compile_source(manifest.clone(), request.runtime_context)
+    compile_source(
+        manifest.clone(),
+        request.runtime_context,
+        request.source_inputs.clone(),
+        request.source_variables.clone(),
+        request.source_origin,
+    )
 }
 
 /// A table provider backed by newline-delimited `JSON` (`JSONL`) files on the local
@@ -287,6 +306,12 @@ impl CompiledBackendSource for JsonlCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                variables: build_registered_source_variables(
+                    &self.source_inputs,
+                    &self.source_variables,
+                ),
+                source_origin: self.source_origin.as_str().to_string(),
+                manifest_version: self.manifest.common.version.clone(),
             },
         })
     }

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -27,7 +27,6 @@ pub(crate) fn compile_query_source(
             source_secrets: source.secrets().clone(),
             source_variables: source.variables().clone(),
             source_inputs: source.inputs().to_vec(),
-            source_origin: source.source_origin(),
         },
     )
 }
@@ -46,7 +45,6 @@ pub(crate) fn compile_source_manifest(
             source_secrets,
             source_variables,
             source_inputs: Vec::new(),
-            source_origin: crate::QuerySourceOrigin::Imported,
         },
     )
 }

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -6,9 +6,9 @@ use coral_spec::ValidatedSourceManifest;
 pub(crate) mod common;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, arrow_type_for_column, build_registered_table, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, arrow_type_for_column, build_registered_source_variables,
+    build_registered_table, partition_columns_to_arrow, registered_columns_from_schema,
+    registered_columns_from_specs, required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod http;
@@ -26,6 +26,8 @@ pub(crate) fn compile_query_source(
             runtime_context,
             source_secrets: source.secrets().clone(),
             source_variables: source.variables().clone(),
+            source_inputs: source.inputs().to_vec(),
+            source_origin: source.source_origin(),
         },
     )
 }
@@ -43,6 +45,8 @@ pub(crate) fn compile_source_manifest(
             runtime_context,
             source_secrets,
             source_variables,
+            source_inputs: Vec::new(),
+            source_origin: crate::QuerySourceOrigin::Imported,
         },
     )
 }

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -26,7 +26,6 @@ use object_store::local::LocalFileSystem;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::reader::{ChunkReader, Length};
 
-use crate::QuerySourceOrigin;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
     RegisteredTable, build_registered_source_variables, build_registered_table,
@@ -50,7 +49,6 @@ struct ParquetCompiledSource {
     source_secrets: BTreeMap<String, String>,
     source_inputs: Vec<ManifestInputSpec>,
     source_variables: BTreeMap<String, String>,
-    source_origin: QuerySourceOrigin,
 }
 
 pub(crate) fn compile_source(
@@ -58,14 +56,12 @@ pub(crate) fn compile_source(
     source_secrets: BTreeMap<String, String>,
     source_inputs: Vec<ManifestInputSpec>,
     source_variables: BTreeMap<String, String>,
-    source_origin: QuerySourceOrigin,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(ParquetCompiledSource {
         manifest,
         source_secrets,
         source_inputs,
         source_variables,
-        source_origin,
     })
 }
 
@@ -78,7 +74,6 @@ pub(crate) fn compile_manifest(
         request.source_secrets.clone(),
         request.source_inputs.clone(),
         request.source_variables.clone(),
-        request.source_origin,
     )
 }
 
@@ -260,7 +255,6 @@ impl CompiledBackendSource for ParquetCompiledSource {
                     &self.source_inputs,
                     &self.source_variables,
                 ),
-                source_origin: self.source_origin.as_str().to_string(),
                 manifest_version: self.manifest.common.version.clone(),
             },
         })

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -26,12 +26,14 @@ use object_store::local::LocalFileSystem;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::reader::{ChunkReader, Length};
 
+use crate::QuerySourceOrigin;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_table, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, build_registered_source_variables, build_registered_table,
+    partition_columns_to_arrow, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
+use coral_spec::ManifestInputSpec;
 use coral_spec::backends::file::{FileTableSpec, ParquetSourceManifest};
 
 const DEFAULT_PARQUET_EXTENSION: &str = ".parquet";
@@ -46,15 +48,24 @@ const PARQUET_FOOTER_SIZE: u64 = 8;
 struct ParquetCompiledSource {
     manifest: ParquetSourceManifest,
     source_secrets: BTreeMap<String, String>,
+    source_inputs: Vec<ManifestInputSpec>,
+    source_variables: BTreeMap<String, String>,
+    source_origin: QuerySourceOrigin,
 }
 
 pub(crate) fn compile_source(
     manifest: ParquetSourceManifest,
     source_secrets: BTreeMap<String, String>,
+    source_inputs: Vec<ManifestInputSpec>,
+    source_variables: BTreeMap<String, String>,
+    source_origin: QuerySourceOrigin,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(ParquetCompiledSource {
         manifest,
         source_secrets,
+        source_inputs,
+        source_variables,
+        source_origin,
     })
 }
 
@@ -62,7 +73,13 @@ pub(crate) fn compile_manifest(
     manifest: &ParquetSourceManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Box<dyn CompiledBackendSource> {
-    compile_source(manifest.clone(), request.source_secrets.clone())
+    compile_source(
+        manifest.clone(),
+        request.source_secrets.clone(),
+        request.source_inputs.clone(),
+        request.source_variables.clone(),
+        request.source_origin,
+    )
 }
 
 #[derive(Debug)]
@@ -239,6 +256,12 @@ impl CompiledBackendSource for ParquetCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                variables: build_registered_source_variables(
+                    &self.source_inputs,
+                    &self.source_variables,
+                ),
+                source_origin: self.source_origin.as_str().to_string(),
+                manifest_version: self.manifest.common.version.clone(),
             },
         })
     }

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -6,6 +6,4 @@ mod query;
 
 pub use catalog::{ColumnInfo, TableInfo};
 pub use error::{CoreError, StatusCode};
-pub use query::{
-    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QuerySourceOrigin,
-};
+pub use query::{QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -6,4 +6,6 @@ mod query;
 
 pub use catalog::{ColumnInfo, TableInfo};
 pub use error::{CoreError, StatusCode};
-pub use query::{QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};
+pub use query::{
+    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QuerySourceOrigin,
+};

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -10,26 +10,6 @@ use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
 
 use super::ColumnInfo;
 
-/// Where one query-visible source was installed from.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum QuerySourceOrigin {
-    /// Source came from Coral's bundled source catalog.
-    Bundled,
-    /// Source was imported from user-supplied manifest content.
-    Imported,
-}
-
-impl QuerySourceOrigin {
-    #[must_use]
-    /// Returns the stable system-catalog string representation.
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Bundled => "bundled",
-            Self::Imported => "imported",
-        }
-    }
-}
-
 /// One managed source selected into the current query runtime.
 #[derive(Debug, Clone)]
 pub struct QuerySource {
@@ -37,7 +17,6 @@ pub struct QuerySource {
     variables: BTreeMap<String, String>,
     secrets: BTreeMap<String, String>,
     inputs: Vec<ManifestInputSpec>,
-    source_origin: QuerySourceOrigin,
 }
 
 impl QuerySource {
@@ -49,14 +28,12 @@ impl QuerySource {
         variables: BTreeMap<String, String>,
         secrets: BTreeMap<String, String>,
         inputs: Vec<ManifestInputSpec>,
-        source_origin: QuerySourceOrigin,
     ) -> Self {
         Self {
             source_spec,
             variables,
             secrets,
             inputs,
-            source_origin,
         }
     }
 
@@ -94,12 +71,6 @@ impl QuerySource {
     /// Returns manifest-declared install-time inputs in manifest order.
     pub fn inputs(&self) -> &[ManifestInputSpec] {
         &self.inputs
-    }
-
-    #[must_use]
-    /// Returns where this source was installed from.
-    pub fn source_origin(&self) -> QuerySourceOrigin {
-        self.source_origin
     }
 }
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -6,9 +6,29 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
-use coral_spec::ValidatedSourceManifest;
+use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
 
 use super::ColumnInfo;
+
+/// Where one query-visible source was installed from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuerySourceOrigin {
+    /// Source came from Coral's bundled source catalog.
+    Bundled,
+    /// Source was imported from user-supplied manifest content.
+    Imported,
+}
+
+impl QuerySourceOrigin {
+    #[must_use]
+    /// Returns the stable system-catalog string representation.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Bundled => "bundled",
+            Self::Imported => "imported",
+        }
+    }
+}
 
 /// One managed source selected into the current query runtime.
 #[derive(Debug, Clone)]
@@ -16,6 +36,8 @@ pub struct QuerySource {
     source_spec: ValidatedSourceManifest,
     variables: BTreeMap<String, String>,
     secrets: BTreeMap<String, String>,
+    inputs: Vec<ManifestInputSpec>,
+    source_origin: QuerySourceOrigin,
 }
 
 impl QuerySource {
@@ -26,11 +48,15 @@ impl QuerySource {
         source_spec: ValidatedSourceManifest,
         variables: BTreeMap<String, String>,
         secrets: BTreeMap<String, String>,
+        inputs: Vec<ManifestInputSpec>,
+        source_origin: QuerySourceOrigin,
     ) -> Self {
         Self {
             source_spec,
             variables,
             secrets,
+            inputs,
+            source_origin,
         }
     }
 
@@ -62,6 +88,18 @@ impl QuerySource {
     /// Returns resolved source secrets required by the manifest.
     pub fn secrets(&self) -> &BTreeMap<String, String> {
         &self.secrets
+    }
+
+    #[must_use]
+    /// Returns manifest-declared install-time inputs in manifest order.
+    pub fn inputs(&self) -> &[ManifestInputSpec] {
+        &self.inputs
+    }
+
+    #[must_use]
+    /// Returns where this source was installed from.
+    pub fn source_origin(&self) -> QuerySourceOrigin {
+        self.source_origin
     }
 }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -46,7 +46,6 @@
 //! #     BTreeMap::new(),
 //! #     BTreeMap::new(),
 //! #     Vec::new(),
-//! #     coral_engine::QuerySourceOrigin::Imported,
 //! # )];
 //! # let provider = EmptyRuntime;
 //! # async fn demo(
@@ -73,7 +72,7 @@ mod runtime;
 
 pub use contracts::{
     ColumnInfo, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    QuerySourceOrigin, StatusCode, TableInfo,
+    StatusCode, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -45,6 +45,8 @@
 //! #     source_spec,
 //! #     BTreeMap::new(),
 //! #     BTreeMap::new(),
+//! #     Vec::new(),
+//! #     coral_engine::QuerySourceOrigin::Imported,
 //! # )];
 //! # let provider = EmptyRuntime;
 //! # async fn demo(
@@ -71,7 +73,7 @@ mod runtime;
 
 pub use contracts::{
     ColumnInfo, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    StatusCode, TableInfo,
+    QuerySourceOrigin, StatusCode, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -139,7 +139,6 @@ struct CatalogSourceVariable {
     is_defaulted: bool,
     is_required: bool,
     default_value: String,
-    source_origin: String,
     manifest_version: String,
 }
 
@@ -247,7 +246,6 @@ fn build_source_variables_table(active_sources: &[RegisteredSource]) -> Result<M
         Field::new("is_defaulted", DataType::Boolean, false),
         Field::new("is_required", DataType::Boolean, false),
         Field::new("default_value", DataType::Utf8, false),
-        Field::new("source_origin", DataType::Utf8, false),
         Field::new("manifest_version", DataType::Utf8, false),
     ]));
 
@@ -264,7 +262,6 @@ fn build_source_variables_table(active_sources: &[RegisteredSource]) -> Result<M
                     is_defaulted: variable.is_defaulted,
                     is_required: variable.is_required,
                     default_value: variable.default_value.clone(),
-                    source_origin: source.source_origin.clone(),
                     manifest_version: source.manifest_version.clone(),
                 })
         })
@@ -305,11 +302,6 @@ fn build_source_variables_table(active_sources: &[RegisteredSource]) -> Result<M
             Arc::new(
                 rows.iter()
                     .map(|row| Some(row.default_value.as_str()))
-                    .collect::<StringArray>(),
-            ),
-            Arc::new(
-                rows.iter()
-                    .map(|row| Some(row.source_origin.as_str()))
                     .collect::<StringArray>(),
             ),
             Arc::new(

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -25,11 +25,16 @@ pub(crate) const SYSTEM_SCHEMA: &str = "coral";
 pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
+    let source_variables_table = build_source_variables_table(active_sources)?;
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
     meta_tables.insert("columns".to_string(), Arc::new(columns_table));
+    meta_tables.insert(
+        "source_variables".to_string(),
+        Arc::new(source_variables_table),
+    );
 
     let catalog = ctx
         .catalog("datafusion")
@@ -127,6 +132,17 @@ struct CatalogColumn {
     ordinal_position: usize,
 }
 
+struct CatalogSourceVariable {
+    schema_name: String,
+    variable_key: String,
+    variable_value: String,
+    is_defaulted: bool,
+    is_required: bool,
+    default_value: String,
+    source_origin: String,
+    manifest_version: String,
+}
+
 #[allow(
     clippy::too_many_lines,
     reason = "The metadata batch builder keeps the fixed coral.columns layout in one place."
@@ -214,6 +230,91 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
             Arc::new(
                 rows.iter()
                     .map(|row| Some(row.description.as_str()))
+                    .collect::<StringArray>(),
+            ),
+        ],
+    )
+    .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
+
+    MemTable::try_new(schema, vec![vec![batch]])
+}
+
+fn build_source_variables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("variable_key", DataType::Utf8, false),
+        Field::new("variable_value", DataType::Utf8, false),
+        Field::new("is_defaulted", DataType::Boolean, false),
+        Field::new("is_required", DataType::Boolean, false),
+        Field::new("default_value", DataType::Utf8, false),
+        Field::new("source_origin", DataType::Utf8, false),
+        Field::new("manifest_version", DataType::Utf8, false),
+    ]));
+
+    let mut rows = active_sources
+        .iter()
+        .flat_map(|source| {
+            source
+                .variables
+                .iter()
+                .map(move |variable| CatalogSourceVariable {
+                    schema_name: source.schema_name.clone(),
+                    variable_key: variable.variable_key.clone(),
+                    variable_value: variable.variable_value.clone(),
+                    is_defaulted: variable.is_defaulted,
+                    is_required: variable.is_required,
+                    default_value: variable.default_value.clone(),
+                    source_origin: source.source_origin.clone(),
+                    manifest_version: source.manifest_version.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
+
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.variable_key).cmp(&(&right.schema_name, &right.variable_key))
+    });
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.schema_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.variable_key.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.variable_value.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.is_defaulted))
+                    .collect::<BooleanArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.is_required))
+                    .collect::<BooleanArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.default_value.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.source_origin.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.manifest_version.as_str()))
                     .collect::<StringArray>(),
             ),
         ],

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use coral_engine::{ColumnInfo, CoralQuery, QuerySource, TableInfo};
 use serde_json::{Value, json};
 use tempfile::TempDir;
@@ -78,6 +80,61 @@ fn build_catalog_sources() -> (TempDir, Vec<QuerySource>) {
     (temp, sources)
 }
 
+fn build_source_variable_sources() -> Vec<QuerySource> {
+    vec![
+        crate::harness::build_source_with_inputs(
+            json!({
+                "name": "datadog",
+                "version": "2.1.0",
+                "dsl_version": 3,
+                "backend": "http",
+                "base_url": "https://api.{{variable.DD_SITE|datadoghq.com}}",
+                "auth": {
+                    "headers": [{
+                        "name": "DD-API-KEY",
+                        "from": "secret",
+                        "key": "DD_API_KEY"
+                    }]
+                },
+                "tables": [{
+                    "name": "dashboards",
+                    "description": "Datadog dashboards",
+                    "request": { "path": "/api/v1/dashboard" },
+                    "columns": [{ "name": "id", "type": "Utf8" }]
+                }]
+            }),
+            BTreeMap::from([("DD_SITE".to_string(), "datadoghq.eu".to_string())]),
+            BTreeMap::from([("DD_API_KEY".to_string(), "secret".to_string())]),
+        ),
+        crate::harness::build_source_with_inputs(
+            json!({
+                "name": "sentry",
+                "version": "3.4.5",
+                "dsl_version": 3,
+                "backend": "http",
+                "base_url": "{{variable.SENTRY_BASE|https://sentry.io/api/0}}",
+                "auth": {
+                    "headers": [{
+                        "name": "Authorization",
+                        "from": "secret",
+                        "key": "SENTRY_TOKEN"
+                    }]
+                },
+                "tables": [{
+                    "name": "issues",
+                    "description": "Sentry issues",
+                    "request": {
+                        "path": "/organizations/{{variable.SENTRY_ORG}}/issues/"
+                    },
+                    "columns": [{ "name": "id", "type": "Utf8" }]
+                }]
+            }),
+            BTreeMap::from([("SENTRY_ORG".to_string(), "withcoral".to_string())]),
+            BTreeMap::from([("SENTRY_TOKEN".to_string(), "secret".to_string())]),
+        ),
+    ]
+}
+
 #[tokio::test]
 async fn coral_tables_lists_installed_sources() {
     let (_temp, sources) = build_catalog_sources();
@@ -123,6 +180,86 @@ async fn coral_columns_returns_metadata() {
             json!({"column_name": "id", "data_type": "Int64", "is_virtual": false, "is_required_filter": false}),
             json!({"column_name": "team_id", "data_type": "Int64", "is_virtual": false, "is_required_filter": false}),
             json!({"column_name": "name", "data_type": "Utf8", "is_virtual": false, "is_required_filter": false}),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn coral_source_variables_returns_effective_values_without_secrets() {
+    let sources = build_source_variable_sources();
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT schema_name, variable_key, variable_value, is_defaulted, is_required, \
+             default_value, source_origin, manifest_version \
+             FROM coral.source_variables ORDER BY schema_name, variable_key",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({
+                "schema_name": "datadog",
+                "variable_key": "DD_SITE",
+                "variable_value": "datadoghq.eu",
+                "is_defaulted": false,
+                "is_required": false,
+                "default_value": "datadoghq.com",
+                "source_origin": "imported",
+                "manifest_version": "2.1.0"
+            }),
+            json!({
+                "schema_name": "sentry",
+                "variable_key": "SENTRY_BASE",
+                "variable_value": "https://sentry.io/api/0",
+                "is_defaulted": true,
+                "is_required": false,
+                "default_value": "https://sentry.io/api/0",
+                "source_origin": "imported",
+                "manifest_version": "3.4.5"
+            }),
+            json!({
+                "schema_name": "sentry",
+                "variable_key": "SENTRY_ORG",
+                "variable_value": "withcoral",
+                "is_defaulted": false,
+                "is_required": true,
+                "default_value": "",
+                "source_origin": "imported",
+                "manifest_version": "3.4.5"
+            }),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn coral_source_variables_joins_cleanly_with_coral_tables() {
+    let sources = build_source_variable_sources();
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT sv.schema_name, sv.variable_key, t.table_name \
+             FROM coral.source_variables sv \
+             JOIN coral.tables t ON t.schema_name = sv.schema_name \
+             WHERE sv.variable_key IN ('DD_SITE', 'SENTRY_ORG') \
+             ORDER BY sv.schema_name, sv.variable_key",
+        )
+        .await
+        .expect("join should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({"schema_name": "datadog", "variable_key": "DD_SITE", "table_name": "dashboards"}),
+            json!({"schema_name": "sentry", "variable_key": "SENTRY_ORG", "table_name": "issues"}),
         ]
     );
 }

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -193,7 +193,7 @@ async fn coral_source_variables_returns_effective_values_without_secrets() {
             &sources,
             &TestRuntime,
             "SELECT schema_name, variable_key, variable_value, is_defaulted, is_required, \
-             default_value, source_origin, manifest_version \
+             default_value, manifest_version \
              FROM coral.source_variables ORDER BY schema_name, variable_key",
         )
         .await
@@ -210,7 +210,6 @@ async fn coral_source_variables_returns_effective_values_without_secrets() {
                 "is_defaulted": false,
                 "is_required": false,
                 "default_value": "datadoghq.com",
-                "source_origin": "imported",
                 "manifest_version": "2.1.0"
             }),
             json!({
@@ -220,7 +219,6 @@ async fn coral_source_variables_returns_effective_values_without_secrets() {
                 "is_defaulted": true,
                 "is_required": false,
                 "default_value": "https://sentry.io/api/0",
-                "source_origin": "imported",
                 "manifest_version": "3.4.5"
             }),
             json!({
@@ -230,7 +228,6 @@ async fn coral_source_variables_returns_effective_values_without_secrets() {
                 "is_defaulted": false,
                 "is_required": true,
                 "default_value": "",
-                "source_origin": "imported",
                 "manifest_version": "3.4.5"
             }),
         ]

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -7,8 +7,7 @@ use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use coral_engine::{
-    CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
-    QuerySourceOrigin, StatusCode,
+    CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, StatusCode,
 };
 use coral_spec::parse_manifest_and_inputs;
 use parquet::arrow::ArrowWriter;
@@ -41,13 +40,7 @@ pub(crate) fn build_source_with_inputs(
     let raw = value.to_string();
     std::mem::drop(value);
     let (manifest, inputs) = parse_manifest_and_inputs(&raw).expect("manifest should parse");
-    QuerySource::new(
-        manifest,
-        variables,
-        secrets,
-        inputs,
-        QuerySourceOrigin::Imported,
-    )
+    QuerySource::new(manifest, variables, secrets, inputs)
 }
 
 pub(crate) fn execution_to_rows(execution: &QueryExecution) -> Vec<Value> {

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -7,9 +7,10 @@ use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use coral_engine::{
-    CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, StatusCode,
+    CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
+    QuerySourceOrigin, StatusCode,
 };
-use coral_spec::parse_source_manifest_value;
+use coral_spec::parse_manifest_and_inputs;
 use parquet::arrow::ArrowWriter;
 use serde_json::{Value, json};
 
@@ -37,8 +38,16 @@ pub(crate) fn build_source_with_inputs(
     variables: BTreeMap<String, String>,
     secrets: BTreeMap<String, String>,
 ) -> QuerySource {
-    let manifest = parse_source_manifest_value(value).expect("manifest should parse");
-    QuerySource::new(manifest, variables, secrets)
+    let raw = value.to_string();
+    std::mem::drop(value);
+    let (manifest, inputs) = parse_manifest_and_inputs(&raw).expect("manifest should parse");
+    QuerySource::new(
+        manifest,
+        variables,
+        secrets,
+        inputs,
+        QuerySourceOrigin::Imported,
+    )
 }
 
 pub(crate) fn execution_to_rows(execution: &QueryExecution) -> Vec<Value> {

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -12,11 +12,17 @@ SELECT schema_name, table_name, description, required_filters FROM coral.tables 
 
 -- Inspect columns for one visible table
 {{COLUMNS_EXAMPLE}}
+
+-- Discover visible source variables and effective values
+SELECT schema_name, variable_key, variable_value FROM coral.source_variables ORDER BY schema_name, variable_key;
 ```
+
+Use `coral.source_variables` when you need source-level context such as site domains, org slugs, or other non-secret config values. Secrets are not exposed there.
 
 ## Query Guidance
 
 - Fully qualify tables in SQL, for example `slack.messages`.
 - Check `coral.tables.required_filters` and `coral.columns.is_required_filter` before querying tables that depend on filter-only inputs.
+- Use `coral.source_variables` to find effective non-secret source variables before constructing source-specific URLs or API paths.
 - Cross-source joins work with standard SQL after source scans complete.
-- `list_tables` and `coral://tables` show queryable fully qualified tables; `coral.tables` and `coral.columns` provide richer SQL metadata.
+- `list_tables` and `coral://tables` show queryable fully qualified tables; `coral.tables`, `coral.columns`, and `coral.source_variables` provide richer SQL metadata.

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{Source, Table};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables` to inspect queryable tables, and use `sql` against `coral.tables` and `coral.columns` for discovery.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables` to inspect queryable tables, and use `sql` against `coral.tables`, `coral.columns`, and `coral.source_variables` for discovery.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {
@@ -29,7 +29,7 @@ pub(crate) fn tables_resource(tables: &[Table]) -> Resource {
 pub(crate) fn guide_resource_content(sources: &[Source], tables: &[Table]) -> String {
     let mut sources_section = String::from("## Available Schemas\n\n");
     sources_section.push_str(
-        "- coral: System metadata schema. Use `coral.tables` and `coral.columns` to discover queryable tables, columns, descriptions, and required filters.\n",
+        "- coral: System metadata schema. Use `coral.tables`, `coral.columns`, and `coral.source_variables` to discover queryable tables, columns, required filters, and visible source variables.\n",
     );
     let schemas = tables
         .iter()
@@ -169,6 +169,7 @@ mod tests {
         let content = guide_resource_content(&[source("demo")], &[]);
         assert!(content.contains("## Available Schemas"));
         assert!(content.contains("- coral: System metadata schema."));
+        assert!(content.contains("coral.source_variables"));
         assert!(content.contains("No query-visible source schemas are currently available."));
         assert!(content.contains("schema_name = '<schema>'"));
     }
@@ -181,6 +182,7 @@ mod tests {
         );
         assert!(content.contains("## Available Schemas"));
         assert!(content.contains("- coral: System metadata schema."));
+        assert!(content.contains("coral.source_variables"));
         assert!(content.contains("Visible source schemas:"));
         assert!(content.contains("- slack"));
         assert!(content.contains("Fully qualify tables in SQL, for example `slack.messages`."));

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -139,6 +139,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     };
     assert!(initial_guide_text.contains("## Available Schemas"));
     assert!(initial_guide_text.contains("- coral: System metadata schema."));
+    assert!(initial_guide_text.contains("coral.source_variables"));
     assert!(initial_guide_text.contains("No source schemas are currently configured."));
     assert!(initial_guide_text.contains("schema_name = '<schema>'"));
 
@@ -200,6 +201,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     };
     assert!(updated_guide_text.contains("## Available Schemas"));
     assert!(updated_guide_text.contains("- coral: System metadata schema."));
+    assert!(updated_guide_text.contains("coral.source_variables"));
     assert!(updated_guide_text.contains("- local_messages"));
     assert!(!updated_guide_text.contains("## Visible SQL Schemas"));
     assert!(updated_guide_text.contains(


### PR DESCRIPTION
## Summary

- add `coral.source_variables`, a new system catalog table that exposes effective non-secret source variables alongside defaulting, required-ness, and manifest version metadata
- thread manifest input specs through `QuerySource` and backend registration so HTTP, JSONL, and Parquet sources all populate the new catalog metadata consistently
- cover the new catalog surface with engine tests and update MCP guide text and initial instructions so clients discover `coral.source_variables` with the existing `coral.tables` and `coral.columns` metadata tables

## Why

`coral.tables` and `coral.columns` expose table- and column-level metadata, but there was no catalog view for source-level configuration. This makes it hard to discover effective values like site domains or org slugs when constructing source-specific queries. `coral.source_variables` fills that gap without exposing secrets.

## Testing

- existing GitHub PR checks are passing
