### PR TITLE
chore: show git SHA in output of --version

### DIFF
--- a/crates/coral-cli/build.rs
+++ b/crates/coral-cli/build.rs
@@ -1,0 +1,40 @@
+//! Embed the git commit SHA into the binary so `coral --version` reports which
+//! commit a build came from. Falls back to `unknown` when git is unavailable,
+//! (e.g. building from a source tarball).
+
+#![allow(
+    clippy::print_stdout,
+    reason = "Build scripts communicate with cargo via stdout."
+)]
+
+use std::process::Command;
+
+fn main() {
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map_or_else(
+            || "unknown".to_owned(),
+            |out| String::from_utf8_lossy(&out.stdout).trim().to_owned(),
+        );
+    println!("cargo:rustc-env=CORAL_GIT_SHA={sha}");
+
+    // Trigger rebuilds when HEAD or the checked-out branch's ref moves so the
+    // embedded SHA stays current.
+    if let Ok(output) = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        && output.status.success()
+    {
+        let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+        println!("cargo:rerun-if-changed={git_dir}/HEAD");
+        println!("cargo:rerun-if-changed={git_dir}/packed-refs");
+        if let Ok(head) = std::fs::read_to_string(format!("{git_dir}/HEAD"))
+            && let Some(reference) = head.trim().strip_prefix("ref: ")
+        {
+            println!("cargo:rerun-if-changed={git_dir}/{reference}");
+        }
+    }
+}

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -26,7 +26,11 @@ use tonic::Request;
 use tempfile as _;
 
 #[derive(Debug, Parser)]
-#[command(name = "coral", version, arg_required_else_help = true)]
+#[command(
+    name = "coral",
+    version = concat!(env!("CARGO_PKG_VERSION"), "-", env!("CORAL_GIT_SHA")),
+    arg_required_else_help = true
+)]
 /// A local-first SQL interface for APIs, files, and other data sources.
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary
- `coral --version` now prints the short git SHA alongside the crate version (e.g. `coral 0.1.3-62bb4cf`), so a local or release build can be traced back to the exact commit it was built from.
- Adds a `build.rs` to `coral-cli` that captures the short SHA via `git rev-parse --short HEAD`, emits it as `CORAL_GIT_SHA`, and sets `rerun-if-changed` on `HEAD`, `packed-refs`, and the current branch ref so rebuilds pick up new SHAs.
- Falls back to `unknown` when git isn't available (e.g. building from a crates.io source tarball).

## Test plan
- [x] `cargo build -p coral-cli && ./target/debug/coral --version` prints `coral <pkg-version>-<short-sha>`
- [x] `cargo clippy -p coral-cli --all-targets` is clean
- [ ] Release build on CI still produces a working binary; artifact shows `coral <pkg-version>-<sha>`