### PR TITLE
docs: align CONTRIBUTING ryl section with actual targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,14 +78,14 @@ Source manifests under `sources/*/manifest.yaml` are checked with
 [`ryl`](https://github.com/owenlamont/ryl), a Rust-native yamllint port.
 Config lives in `.yamllint.yaml` at the repo root.
 
+Install `ryl` once with `cargo install ryl`, then:
+
 ```bash
-make yaml-lint   # check — run this before pushing changes to sources/
-make yaml-fix    # auto-apply safe fixes in place
+make lint-sources   # check — run this before pushing changes to sources/
+make fix-sources    # auto-apply safe fixes in place
 ```
 
-`ryl` is installed automatically on first invocation via
-`cargo install ryl --locked --version <pinned>` (version pinned in the
-`Makefile`). The same pinned version runs in CI.
+CI installs `ryl` the same way and runs `make lint-sources`.
 
 ## Repo layout
 


### PR DESCRIPTION
## Summary

- Rename `make yaml-lint` / `make yaml-fix` in CONTRIBUTING.md to the actual `make lint-sources` / `make fix-sources` Makefile targets.
- Remove the inaccurate claim that `ryl` is auto-installed on first invocation with a version pinned in the Makefile — neither the Makefile nor `.github/workflows/validate.yml` does this. Replace with a one-line `cargo install ryl` step, matching what CI actually runs.

## Why

A reader following CONTRIBUTING.md today hits "make: *** No rule to make target `yaml-lint`" and has no working install path for `ryl`. The fix points them at the real targets and the same install command CI uses.

## Test plan

- [ ] Visual review of the rendered diff in CONTRIBUTING.md.
- [ ] `make lint-sources` and `make fix-sources` resolve against the Makefile.