### PR TITLE
test(cli): add MCP stdio e2e coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,8 @@ dependencies = [
  "coral-mcp",
  "coral-spec",
  "dialoguer",
+ "rmcp",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2739,6 +2741,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3129,6 +3143,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap",
+ "nix",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -3552,6 +3580,7 @@ dependencies = [
  "futures",
  "pastey",
  "pin-project-lite",
+ "process-wrap",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -4730,6 +4759,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4740,6 +4790,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4769,6 +4830,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4866,6 +4937,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -31,5 +31,7 @@ coral-mcp.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true
+rmcp = { workspace = true, features = ["transport-child-process"] }
+serde_json.workspace = true
 tempfile.workspace = true
 tokio-stream.workspace = true

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use arrow::array::Int64Array;
+use arrow::array::StringArray;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
@@ -8,10 +9,10 @@ use assert_cmd::Command;
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
-    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
+    Column, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
     DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, GetSourceRequest,
     ImportSourceRequest, ListSourcesRequest, ListSourcesResponse, ListTablesRequest,
-    ListTablesResponse, Source, SourceOrigin, ValidateSourceRequest, ValidateSourceResponse,
+    ListTablesResponse, Source, SourceOrigin, Table, ValidateSourceRequest, ValidateSourceResponse,
     Workspace,
 };
 use tokio::net::TcpListener;
@@ -35,6 +36,28 @@ fn mock_source() -> Source {
         secrets: Vec::new(),
         variables: Vec::new(),
         origin: SourceOrigin::Bundled as i32,
+    }
+}
+
+fn mock_table() -> Table {
+    Table {
+        workspace: Some(workspace()),
+        schema_name: "local_messages".to_string(),
+        name: "messages".to_string(),
+        description: "Fixture messages".to_string(),
+        columns: vec![
+            Column {
+                name: "type".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: false,
+            },
+            Column {
+                name: "text".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: false,
+            },
+        ],
+        required_filters: Vec::new(),
     }
 }
 
@@ -62,23 +85,45 @@ impl QueryService for MockQueryService {
         &self,
         _request: Request<ListTablesRequest>,
     ) -> Result<Response<ListTablesResponse>, Status> {
-        Ok(Response::new(ListTablesResponse { tables: Vec::new() }))
+        Ok(Response::new(ListTablesResponse {
+            tables: vec![mock_table()],
+        }))
     }
 
     async fn execute_sql(
         &self,
-        _request: Request<ExecuteSqlRequest>,
+        request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
-        let schema = Schema::new(vec![Field::new("value", DataType::Int64, false)]);
-        let batch = RecordBatch::try_new(
-            Arc::new(schema.clone()),
-            vec![Arc::new(Int64Array::from(vec![1_i64]))],
-        )
-        .expect("build record batch");
+        let sql = request.into_inner().sql;
+        if sql
+            .trim_start()
+            .to_ascii_uppercase()
+            .starts_with("DELETE FROM")
+        {
+            return Err(Status::invalid_argument("DML not supported: DELETE"));
+        }
+
+        let (schema, batch, row_count) = if sql.contains("local_messages.messages") {
+            let schema = Schema::new(vec![Field::new("text", DataType::Utf8, false)]);
+            let batch = RecordBatch::try_new(
+                Arc::new(schema.clone()),
+                vec![Arc::new(StringArray::from(vec!["hello", "world"]))],
+            )
+            .expect("build text batch");
+            (schema, batch, 2)
+        } else {
+            let schema = Schema::new(vec![Field::new("value", DataType::Int64, false)]);
+            let batch = RecordBatch::try_new(
+                Arc::new(schema.clone()),
+                vec![Arc::new(Int64Array::from(vec![1_i64]))],
+            )
+            .expect("build value batch");
+            (schema, batch, 1)
+        };
 
         Ok(Response::new(ExecuteSqlResponse {
             arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
-            row_count: 1,
+            row_count,
         }))
     }
 }
@@ -191,10 +236,22 @@ impl MockServer {
         }
     }
 
+    #[allow(
+        dead_code,
+        reason = "Integration test crates share this harness, but each target only uses the helpers it needs."
+    )]
     pub(crate) fn cmd(&self) -> Command {
         let mut cmd = Command::cargo_bin("coral").expect("cargo bin");
         cmd.env("CORAL_ENDPOINT", &self.endpoint_uri);
         cmd
+    }
+
+    #[allow(
+        dead_code,
+        reason = "Integration test crates share this harness, but each target only uses the helpers it needs."
+    )]
+    pub(crate) fn endpoint_uri(&self) -> &str {
+        &self.endpoint_uri
     }
 
     pub(crate) async fn shutdown(mut self) {

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -1,0 +1,166 @@
+#![allow(
+    missing_docs,
+    unused_crate_dependencies,
+    reason = "Integration tests only use a subset of the package dependency graph."
+)]
+#![cfg(feature = "cli-test-server")]
+
+mod harness;
+
+use harness::MockServer;
+use rmcp::{
+    RoleClient, ServiceExt,
+    model::{CallToolRequestParams, ReadResourceRequestParams},
+    service::RunningService,
+    transport::{ConfigureCommandExt, TokioChildProcess},
+};
+use serde_json::{Map, Value, json};
+
+fn json_object(value: &Value) -> Map<String, Value> {
+    value.as_object().cloned().expect("json object")
+}
+
+async fn start_mcp_client(
+    server: &MockServer,
+) -> Result<RunningService<RoleClient, ()>, Box<dyn std::error::Error>> {
+    let transport = TokioChildProcess::new(
+        tokio::process::Command::new(env!("CARGO_BIN_EXE_coral")).configure(|cmd| {
+            cmd.arg("mcp-stdio")
+                .env("CORAL_ENDPOINT", server.endpoint_uri());
+        }),
+    )?;
+    let client = ().serve(transport).await?;
+    Ok(client)
+}
+
+fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
+    match &result.contents[0] {
+        rmcp::model::ResourceContents::TextResourceContents { text, .. } => text,
+        other @ rmcp::model::ResourceContents::BlobResourceContents { .. } => {
+            panic!("unexpected resource contents: {other:?}")
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client(&server).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["sql", "list_tables"]
+    );
+    assert!(
+        tools[0]
+            .description
+            .as_deref()
+            .expect("sql description")
+            .contains("1 visible SQL schema(s) are currently available")
+    );
+    assert!(
+        tools[1]
+            .description
+            .as_deref()
+            .expect("list_tables description")
+            .contains("1 table(s) are currently visible")
+    );
+
+    let resources = client.list_all_resources().await?;
+    assert_eq!(
+        resources
+            .iter()
+            .map(|resource| resource.uri.as_str())
+            .collect::<Vec<_>>(),
+        vec!["coral://guide", "coral://tables"]
+    );
+
+    let guide = client
+        .read_resource(ReadResourceRequestParams::new("coral://guide"))
+        .await?;
+    let guide_text = text_content(&guide);
+    assert!(guide_text.contains("## Available Schemas"));
+    assert!(guide_text.contains("- local_messages"));
+    assert!(guide_text.contains(
+        "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'messages'"
+    ));
+
+    let tables = client
+        .read_resource(ReadResourceRequestParams::new("coral://tables"))
+        .await?;
+    let tables_json: Value = serde_json::from_str(text_content(&tables))?;
+    assert_eq!(tables_json["tables"][0]["name"], "local_messages.messages");
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_sql_and_list_tables_return_structured_content()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client(&server).await?;
+
+    let tables = client
+        .call_tool(CallToolRequestParams::new("list_tables"))
+        .await?;
+    assert_eq!(tables.is_error, Some(false));
+    assert_eq!(
+        tables.structured_content.expect("structured content")["tables"][0]["name"],
+        "local_messages.messages"
+    );
+
+    let sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "SELECT text FROM local_messages.messages ORDER BY text"
+            }))),
+        )
+        .await?;
+    assert_eq!(sql.is_error, Some(false));
+    assert_eq!(
+        sql.structured_content.expect("structured content")["rows"][0]["text"],
+        "hello"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client(&server).await?;
+
+    let invalid_sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "DELETE FROM local_messages.messages"
+            }))),
+        )
+        .await?;
+    assert_eq!(invalid_sql.is_error, Some(true));
+    assert_eq!(
+        invalid_sql.structured_content.expect("structured content")["error"]["summary"],
+        "Query request is invalid"
+    );
+
+    let tables = client
+        .call_tool(CallToolRequestParams::new("list_tables"))
+        .await?;
+    assert_eq!(tables.is_error, Some(false));
+    assert_eq!(
+        tables.structured_content.expect("structured content")["tables"][0]["name"],
+        "local_messages.messages"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -2,8 +2,15 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use coral_api::v1::ImportSourceRequest;
-use coral_client::{AppClient, SourceClient, default_workspace, local::ServerBuilder};
-use rmcp::{ServiceExt, model::CallToolRequestParams};
+use coral_client::{
+    AppClient, SourceClient, default_workspace,
+    local::{RunningServer, ServerBuilder},
+};
+use rmcp::{
+    RoleClient, ServiceExt,
+    model::{CallToolRequestParams, ReadResourceRequestParams},
+    service::RunningService,
+};
 use serde_json::{Map, Value, json};
 use tempfile::TempDir;
 use tonic::Request;
@@ -65,15 +72,31 @@ async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String
         .expect("add source");
 }
 
-#[tokio::test]
-#[allow(
-    clippy::too_many_lines,
-    reason = "This end-to-end MCP test intentionally verifies discovery refresh, guide rendering, success, and failure recovery in one session."
-)]
-async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
-    let temp = TempDir::new().expect("temp dir");
-    let manifest_path = write_fixture_manifest(temp.path());
-    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+struct TestSession {
+    source_client: SourceClient,
+    client: RunningService<RoleClient, ()>,
+    app_server: RunningServer,
+    mcp_server_task: tokio::task::JoinHandle<Result<(), Box<dyn std::error::Error + Send + Sync>>>,
+}
+
+impl TestSession {
+    async fn shutdown(self) {
+        let Self {
+            client,
+            app_server,
+            mcp_server_task,
+            ..
+        } = self;
+        client.cancel().await.expect("cancel client");
+        mcp_server_task
+            .await
+            .expect("join mcp task")
+            .expect("mcp server result");
+        app_server.shutdown().await.expect("shutdown app server");
+    }
+}
+
+async fn start_session(temp: &TempDir) -> TestSession {
     let server = ServerBuilder::new()
         .with_config_dir(temp.path().join("coral-config"))
         .start()
@@ -82,15 +105,43 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     let app = AppClient::connect(server.endpoint_uri())
         .await
         .expect("connect client");
-    let mut source_client = app.source_client();
+    let source_client = app.source_client();
 
     let (server_transport, client_transport) = tokio::io::duplex(4096);
-    let server_handle = tokio::spawn(async move {
+    let mcp_server_task = tokio::spawn(async move {
         let server = CoralMcpServer::new(&app).serve(server_transport).await?;
         server.waiting().await?;
         Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     });
     let client = ().serve(client_transport).await.expect("start rmcp client");
+    TestSession {
+        source_client,
+        client,
+        app_server: server,
+        mcp_server_task,
+    }
+}
+
+fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
+    match &result.contents[0] {
+        rmcp::model::ResourceContents::TextResourceContents { text, .. } => text,
+        other @ rmcp::model::ResourceContents::BlobResourceContents { .. } => {
+            panic!("unexpected resource contents: {other:?}")
+        }
+    }
+}
+
+#[tokio::test]
+#[allow(
+    clippy::too_many_lines,
+    reason = "This focused session test still verifies multiple discovery and resource refresh assertions in one end-to-end flow."
+)]
+async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
 
     let initial_tools = client.list_all_tools().await.expect("initial tools");
     assert_eq!(
@@ -128,21 +179,16 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     );
 
     let initial_guide = client
-        .read_resource(rmcp::model::ReadResourceRequestParams::new("coral://guide"))
+        .read_resource(ReadResourceRequestParams::new("coral://guide"))
         .await
         .expect("initial guide");
-    let initial_guide_text = match &initial_guide.contents[0] {
-        rmcp::model::ResourceContents::TextResourceContents { text, .. } => text,
-        other @ rmcp::model::ResourceContents::BlobResourceContents { .. } => {
-            panic!("unexpected guide contents: {other:?}")
-        }
-    };
+    let initial_guide_text = text_content(&initial_guide);
     assert!(initial_guide_text.contains("## Available Schemas"));
     assert!(initial_guide_text.contains("- coral: System metadata schema."));
     assert!(initial_guide_text.contains("No source schemas are currently configured."));
     assert!(initial_guide_text.contains("schema_name = '<schema>'"));
 
-    add_demo_source(&mut source_client, manifest_yaml).await;
+    add_demo_source(&mut session.source_client, manifest_yaml).await;
 
     let updated_tools = client.list_all_tools().await.expect("updated tools");
     assert!(
@@ -173,31 +219,19 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     );
 
     let tables_resource = client
-        .read_resource(rmcp::model::ReadResourceRequestParams::new(
-            "coral://tables",
-        ))
+        .read_resource(ReadResourceRequestParams::new("coral://tables"))
         .await
         .expect("read tables resource");
-    let tables_text = match &tables_resource.contents[0] {
-        rmcp::model::ResourceContents::TextResourceContents { text, .. } => text,
-        other @ rmcp::model::ResourceContents::BlobResourceContents { .. } => {
-            panic!("unexpected resource contents: {other:?}")
-        }
-    };
+    let tables_text = text_content(&tables_resource);
     let tables_json =
         serde_json::from_str::<serde_json::Value>(tables_text).expect("parse tables resource");
     assert_eq!(tables_json["tables"][0]["name"], "local_messages.messages");
 
     let updated_guide = client
-        .read_resource(rmcp::model::ReadResourceRequestParams::new("coral://guide"))
+        .read_resource(ReadResourceRequestParams::new("coral://guide"))
         .await
         .expect("updated guide");
-    let updated_guide_text = match &updated_guide.contents[0] {
-        rmcp::model::ResourceContents::TextResourceContents { text, .. } => text,
-        other @ rmcp::model::ResourceContents::BlobResourceContents { .. } => {
-            panic!("unexpected guide contents: {other:?}")
-        }
-    };
+    let updated_guide_text = text_content(&updated_guide);
     assert!(updated_guide_text.contains("## Available Schemas"));
     assert!(updated_guide_text.contains("- coral: System metadata schema."));
     assert!(updated_guide_text.contains("- local_messages"));
@@ -215,6 +249,19 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         "local_messages.messages"
     );
     assert_eq!(tables.is_error, Some(false));
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_tool_error_does_not_end_session() {
+    let temp = TempDir::new().expect("temp dir");
+    let manifest_path = write_fixture_manifest(temp.path());
+    let manifest_yaml = fs::read_to_string(&manifest_path).expect("read manifest");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
+
+    add_demo_source(&mut session.source_client, manifest_yaml).await;
 
     let sql = client
         .call_tool(
@@ -263,9 +310,5 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     );
     assert_eq!(tables_after_error.is_error, Some(false));
 
-    client.cancel().await.expect("cancel client");
-    server_handle
-        .await
-        .expect("join server")
-        .expect("server result");
+    session.shutdown().await;
 }


### PR DESCRIPTION
## Summary
- add `coral-cli` MCP stdio binary e2e tests that drive `coral mcp-stdio` over RMCP child-process transport against the existing mock gRPC harness
- extend the CLI test harness to expose visible tables, query rows, and tool-error cases needed for MCP coverage
- keep `coral-mcp` with a smaller real-app session layer by splitting the old monolithic test into focused refresh and error-recovery coverage

## Validation
- `make rust-checks`