### PR TITLE
feat(engine): structured TABLE_NOT_FOUND and UNKNOWN_FIELD errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "parquet",
  "reqwest",
  "serde_json",
+ "strsim",
  "tempfile",
  "thiserror",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"
 sqlparser = "0.59.0"
+strsim = "0.11"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -486,7 +486,7 @@ tables:
             status.message().len(),
         );
         assert!(
-            status.message().contains("No field named"),
+            status.message().contains("No column named"),
             "missing expected schema-error head in: {:?}",
             status.message()
         );

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -81,5 +81,5 @@ async fn broken_source_does_not_block_healthy_sources() {
         }))
         .await
         .expect_err("broken source query should fail");
-    assert_eq!(broken.code(), tonic::Code::InvalidArgument);
+    assert_eq!(broken.code(), tonic::Code::NotFound);
 }

--- a/crates/coral-cli/src/query_error.rs
+++ b/crates/coral-cli/src/query_error.rs
@@ -94,7 +94,7 @@ mod tests {
                 ("hint", "Add a constant equality filter on `repo`."),
                 ("schema", "github"),
                 ("table", "issues"),
-                ("field", "repo"),
+                ("column", "repo"),
             ],
             false,
         );

--- a/crates/coral-client/src/status_error.rs
+++ b/crates/coral-client/src/status_error.rs
@@ -168,7 +168,7 @@ mod tests {
             vec![
                 ("schema", "github"),
                 ("table", "issues"),
-                ("field", "repo"),
+                ("column", "repo"),
                 (
                     "summary",
                     "github.issues requires `WHERE repo = <constant>`",
@@ -190,7 +190,7 @@ mod tests {
                 );
                 assert_eq!(err.metadata.get("schema").unwrap(), "github");
                 assert_eq!(err.metadata.get("table").unwrap(), "issues");
-                assert_eq!(err.metadata.get("field").unwrap(), "repo");
+                assert_eq!(err.metadata.get("column").unwrap(), "repo");
                 assert!(
                     !err.metadata.contains_key("summary"),
                     "summary promoted out of metadata"

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -21,6 +21,7 @@ object_store.workspace = true
 parquet.workspace = true
 reqwest.workspace = true
 serde_json.workspace = true
+strsim.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -19,12 +19,12 @@ const TOO_MANY_REQUESTS: u16 = HttpStatus::TOO_MANY_REQUESTS.as_u16();
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ProviderQueryError {
     #[error(
-        "{schema}.{table} table requires a constant equality filter: WHERE {field} = <constant>"
+        "{schema}.{table} table requires a constant equality filter: WHERE {column} = <constant>"
     )]
     MissingRequiredFilter {
         schema: String,
         table: String,
-        field: String,
+        column: String,
     },
 
     #[error("{source_schema}.{table} API error: {detail}")]
@@ -58,18 +58,18 @@ impl ProviderQueryError {
             Self::MissingRequiredFilter {
                 schema,
                 table,
-                field,
+                column,
             } => {
                 let mut metadata = HashMap::new();
                 metadata.insert("schema".to_string(), schema.clone());
                 metadata.insert("table".to_string(), table.clone());
-                metadata.insert("field".to_string(), field.clone());
+                metadata.insert("column".to_string(), column.clone());
                 StructuredQueryError::new(
                     "MISSING_REQUIRED_FILTER",
-                    format!("{schema}.{table} requires `WHERE {field} = <constant>`"),
-                    format!("{schema}.{table} requires a constant equality filter on {field}"),
+                    format!("{schema}.{table} requires `WHERE {column} = <constant>`"),
+                    format!("{schema}.{table} requires a constant equality filter on {column}"),
                     Some(format!(
-                        "Add a constant equality filter on `{field}` or inspect \
+                        "Add a constant equality filter on `{column}` or inspect \
                          `coral.columns` / `coral.tables` first."
                     )),
                     false,
@@ -285,13 +285,13 @@ mod tests {
         let error = ProviderQueryError::MissingRequiredFilter {
             schema: "github".to_string(),
             table: "issues".to_string(),
-            field: "repo".to_string(),
+            column: "repo".to_string(),
         }
         .to_structured();
         assert_eq!(error.reason(), "MISSING_REQUIRED_FILTER");
         assert_eq!(error.metadata().get("schema").unwrap(), "github");
         assert_eq!(error.metadata().get("table").unwrap(), "issues");
-        assert_eq!(error.metadata().get("field").unwrap(), "repo");
+        assert_eq!(error.metadata().get("column").unwrap(), "repo");
         assert!(error.summary().contains("repo"));
         assert!(error.hint().is_some());
         assert_eq!(error.status(), StatusCode::FailedPrecondition);
@@ -389,7 +389,7 @@ mod tests {
         let error = ProviderQueryError::MissingRequiredFilter {
             schema: "github".to_string(),
             table: "issues".to_string(),
-            field: "repo".to_string(),
+            column: "repo".to_string(),
         }
         .to_structured();
         let text = error.to_string();

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -129,7 +129,7 @@ impl TableProvider for HttpSourceTableProvider {
                     ProviderQueryError::MissingRequiredFilter {
                         schema: self.source_schema.clone(),
                         table: self.table.name().to_string(),
-                        field: required.name.clone(),
+                        column: required.name.clone(),
                     },
                 )));
             }

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -11,3 +11,7 @@ pub use query::{
     QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QueryTestFailure,
     QueryTestResult, QueryTestSuccess, SourceValidationReport,
 };
+pub(crate) use query_error::ColumnParts;
+
+#[cfg(test)]
+pub(crate) use query_error::UNKNOWN_COLUMN_REASON;

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -2,7 +2,70 @@
 
 use std::collections::HashMap;
 
+use datafusion::common::utils::quote_identifier;
+
+use super::catalog::TableInfo;
 use super::error::StatusCode;
+
+/// Wire-stable `reason` code for unknown-column errors.
+pub(crate) const UNKNOWN_COLUMN_REASON: &str = "UNKNOWN_COLUMN";
+
+/// Wire-stable `reason` code for table-not-found errors.
+pub(crate) const TABLE_NOT_FOUND_REASON: &str = "TABLE_NOT_FOUND";
+
+/// Structure-preserving column reference used by `unknown_column`.
+///
+/// Keeping the qualifier components separate from the bare name means the
+/// hint builder can render a `"player.id"`-style identifier (literal dot
+/// inside the name) without any downstream logic having to guess whether a
+/// given `.` is a qualifier separator or part of the identifier.
+#[derive(Debug, Clone)]
+pub(crate) struct ColumnParts {
+    /// 0, 1, 2, or 3 qualifier segments (alias / schema.table /
+    /// catalog.schema.table) — each stored as a bare identifier.
+    pub relation: Vec<String>,
+    /// The bare column name, exactly as registered in the schema
+    /// (case-preserving, may contain embedded dots).
+    pub name: String,
+}
+
+impl ColumnParts {
+    /// Renders the reference as SQL, quoting each component individually.
+    fn quoted(&self) -> String {
+        let mut out = String::new();
+        for part in &self.relation {
+            out.push_str(&quote_identifier(part));
+            out.push('.');
+        }
+        out.push_str(&quote_identifier(&self.name));
+        out
+    }
+
+    /// Joins all components with dots, lowercased. Used for
+    /// structure-preserving case-insensitive equality: two references with
+    /// the same dotted form AND the same number of components match.
+    fn joined_lower(&self) -> String {
+        let mut out = String::new();
+        for part in &self.relation {
+            out.push_str(&part.to_lowercase());
+            out.push('.');
+        }
+        out.push_str(&self.name.to_lowercase());
+        out
+    }
+
+    /// Renders without quoting — for the user-facing summary line where
+    /// readability matters more than round-trip SQL safety.
+    fn flat_display(&self) -> String {
+        let mut out = String::new();
+        for part in &self.relation {
+            out.push_str(part);
+            out.push('.');
+        }
+        out.push_str(&self.name);
+        out
+    }
+}
 
 /// Structured query failure with first-class semantic fields.
 #[derive(Debug, Clone)]
@@ -36,6 +99,86 @@ impl StructuredQueryError {
             status,
             metadata,
         }
+    }
+
+    /// Builds a structured `UNKNOWN_COLUMN` error from a missing column and
+    /// its in-scope candidates. Callers pass both the missing reference and
+    /// each candidate as a `ColumnParts` (qualifier segments plus bare
+    /// name) so dotted identifiers round-trip without ambiguity.
+    pub(crate) fn unknown_column(missing: &ColumnParts, valid_columns: &[ColumnParts]) -> Self {
+        let hint = unknown_column_hint(missing, valid_columns);
+
+        let mut metadata = HashMap::new();
+        metadata.insert("column".to_string(), missing.flat_display());
+
+        let display_missing = missing.flat_display();
+        let detail = if valid_columns.is_empty() {
+            format!("No column matching `{display_missing}` is in scope.")
+        } else {
+            let preview: Vec<String> = valid_columns
+                .iter()
+                .take(10)
+                .map(ColumnParts::flat_display)
+                .collect();
+            format!(
+                "No column `{display_missing}` is in scope. Valid columns include: {}.",
+                preview.join(", ")
+            )
+        };
+
+        Self::new(
+            UNKNOWN_COLUMN_REASON,
+            format!("No column named `{display_missing}`"),
+            detail,
+            hint,
+            false,
+            StatusCode::InvalidArgument,
+            metadata,
+        )
+    }
+
+    /// Builds a structured `TABLE_NOT_FOUND` error.
+    ///
+    /// `catalog_qualified_ref` is the raw string `DataFusion` surfaces inside
+    /// `"table 'X' not found"` — always a dotted path under the default
+    /// catalog. `known_tables` is consulted to (a) distinguish `DataFusion`'s
+    /// synthetic `public` schema from a real user source also named `public`,
+    /// and (b) recover a correct `(schema, table)` split when the source
+    /// name itself contains a dot.
+    pub(crate) fn table_not_found(catalog_qualified_ref: &str, known_tables: &[TableInfo]) -> Self {
+        let parsed = parse_table_ref(catalog_qualified_ref, known_tables);
+
+        let (schema, table) = match &parsed {
+            ParsedTableRef::Unqualified { table } => (None, table.clone()),
+            ParsedTableRef::Qualified { schema, table } => (Some(schema.clone()), table.clone()),
+        };
+
+        let display_ref = match &schema {
+            Some(schema) => format!("{schema}.{table}"),
+            None => table.clone(),
+        };
+        let hint = table_not_found_hint(schema.as_deref(), &table, known_tables);
+
+        let mut metadata = HashMap::new();
+        if let Some(schema) = &schema {
+            metadata.insert("schema".to_string(), schema.clone());
+        }
+        metadata.insert("table".to_string(), table.clone());
+
+        let detail = match schema.as_deref() {
+            Some(schema) => format!("No table `{table}` exists in schema `{schema}`."),
+            None => format!("No table `{table}` exists in any registered schema."),
+        };
+
+        Self::new(
+            TABLE_NOT_FOUND_REASON,
+            format!("Table `{display_ref}` not found"),
+            detail,
+            hint,
+            false,
+            StatusCode::NotFound,
+            metadata,
+        )
     }
 
     /// Machine-readable error reason (e.g. `"MISSING_REQUIRED_FILTER"`).
@@ -91,5 +234,578 @@ impl std::fmt::Display for StructuredQueryError {
             write!(f, "\nHint: {hint}")?;
         }
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Hint builders
+// ---------------------------------------------------------------------------
+
+/// Hint template for a case-only mismatch (`Master` vs `master`, `playerID`
+/// vs `playerid`). Keeping this in one place so the wording stays
+/// consistent across column and table hints.
+fn case_sensitive_hint(suggestion: &str) -> String {
+    format!("Unquoted identifiers are lowercased. Try `{suggestion}`.")
+}
+
+/// Hint template for a Levenshtein "closest match" suggestion.
+fn did_you_mean_hint(suggestion: &str) -> String {
+    format!("Did you mean `{suggestion}`?")
+}
+
+fn unknown_column_hint(missing: &ColumnParts, valid_columns: &[ColumnParts]) -> Option<String> {
+    // Prefer a full-reference case-insensitive hit: same qualifier shape and
+    // same name, differing only in case. Reproduces the user's qualifier in
+    // the suggestion (alias vs resolved schema.table), preserving the
+    // literal identifier inside the bare name — so a declared `"player.id"`
+    // column survives round-trip.
+    let missing_key = missing.joined_lower();
+    if let Some(exact) = valid_columns
+        .iter()
+        .find(|candidate| candidate.joined_lower() == missing_key)
+    {
+        return Some(case_sensitive_hint(&exact.quoted()));
+    }
+
+    // Dotted-column case: the declared column name itself contains a dot
+    // (e.g. `"player.id"`). A user who writes `SELECT player.id FROM …`
+    // unquoted reaches us as `relation=[player], name=id`; the candidate
+    // has `relation=[schema, table], name="player.id"`. The user's full
+    // flat form (`player.id`) is what the candidate's bare name actually
+    // is — match on that so the hint quotes the real column.
+    if let Some(exact) = valid_columns
+        .iter()
+        .find(|candidate| candidate.name.to_lowercase() == missing_key)
+    {
+        return Some(case_sensitive_hint(&exact.quoted()));
+    }
+
+    // Bare-name case-insensitive fallback: the user supplied a different
+    // qualifier shape than the valid-columns list does (e.g. unqualified
+    // typo against a schema.table.column candidate). Comparing only the
+    // bare name still picks up a capitalization-only difference.
+    let missing_name_lower = missing.name.to_lowercase();
+    if let Some(exact) = valid_columns
+        .iter()
+        .find(|candidate| candidate.name.to_lowercase() == missing_name_lower)
+    {
+        return Some(case_sensitive_hint(&exact.quoted()));
+    }
+
+    // Levenshtein over bare names for typos. Lowercase both sides: the
+    // missing name arrives pre-lowercased from DataFusion's identifier
+    // normalization, but candidates keep their schema-declared casing, so
+    // a raw comparison against `playerID` would double-count case edits
+    // and reject a genuine typo of `playrID` → `playerID`.
+    let (best, _score) = valid_columns
+        .iter()
+        .filter_map(|candidate| {
+            let score =
+                strsim::normalized_levenshtein(&candidate.name.to_lowercase(), &missing_name_lower);
+            (score >= 0.5).then_some((candidate, score))
+        })
+        .max_by(|left, right| {
+            left.1
+                .partial_cmp(&right.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })?;
+    Some(did_you_mean_hint(&best.quoted()))
+}
+
+fn table_not_found_hint(
+    schema: Option<&str>,
+    table: &str,
+    known_tables: &[TableInfo],
+) -> Option<String> {
+    let Some(schema) = schema else {
+        return Some(
+            "List available tables with `SELECT schema_name, table_name FROM coral.tables`."
+                .to_string(),
+        );
+    };
+
+    let schema_lower = schema.to_lowercase();
+    let tables_in_schema: Vec<&TableInfo> = known_tables
+        .iter()
+        .filter(|info| info.schema_name.to_lowercase() == schema_lower)
+        .collect();
+
+    if tables_in_schema.is_empty() {
+        // `known_tables` only contains successfully-registered sources, so an
+        // empty schema here could mean either "not installed" or "configured
+        // but failed to register". Keep the hint transport-neutral — point
+        // at the SQL catalog so callers (CLI, MCP, gRPC) each render the
+        // action in their native surface; any adapter that wants to
+        // prescribe a specific command (e.g. `coral source list`) can
+        // enrich the hint at their layer.
+        return Some(format!(
+            "Schema `{schema}` is not currently registered. \
+             Query `SELECT DISTINCT schema_name FROM coral.tables` \
+             to see available schemas."
+        ));
+    }
+
+    let table_lower = table.to_lowercase();
+    if let Some(hit) = tables_in_schema
+        .iter()
+        .find(|info| info.table_name.to_lowercase() == table_lower)
+    {
+        return Some(case_sensitive_hint(&format_schema_table(hit)));
+    }
+
+    let (best, _score) = tables_in_schema
+        .iter()
+        .filter_map(|info| {
+            let score =
+                strsim::normalized_levenshtein(&info.table_name.to_lowercase(), &table_lower);
+            (score >= 0.5).then_some((info, score))
+        })
+        .max_by(|left, right| {
+            left.1
+                .partial_cmp(&right.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })?;
+    Some(did_you_mean_hint(&format_schema_table(best)))
+}
+
+/// Renders `schema.table` with per-component SQL quoting (dotted source
+/// names stay one quoted identifier; case-preserving names are quoted
+/// only when they would otherwise round-trip wrong).
+fn format_schema_table(info: &TableInfo) -> String {
+    format!(
+        "{}.{}",
+        quote_dotted_identifier(&info.schema_name),
+        quote_identifier(&info.table_name)
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Table-ref parsing
+// ---------------------------------------------------------------------------
+
+/// Either a truly unqualified `FROM X` or a qualified `FROM schema.table`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ParsedTableRef {
+    Unqualified { table: String },
+    Qualified { schema: String, table: String },
+}
+
+/// Recovers the user's intent from `DataFusion`'s always-3+-part error ref.
+///
+/// Bare `FROM games` surfaces as `datafusion.public.games` (the default
+/// catalog plus the synthetic `public` schema), which we classify as
+/// unqualified unless a real source named `public` exists in the catalog.
+/// For dotted source names, we try increasingly long schema candidates
+/// against the registered set so `datafusion."foo.bar".missing` is not
+/// silently sliced into `bar` / `missing`.
+fn parse_table_ref(raw: &str, known_tables: &[TableInfo]) -> ParsedTableRef {
+    let parts: Vec<&str> = raw.split('.').collect();
+
+    if parts.is_empty() {
+        return ParsedTableRef::Unqualified {
+            table: String::new(),
+        };
+    }
+    if parts.len() == 1 {
+        return ParsedTableRef::Unqualified {
+            table: parts[0].to_string(),
+        };
+    }
+
+    // Strip the default catalog prefix if present.
+    let body: Vec<&str> = if parts[0] == "datafusion" {
+        parts[1..].to_vec()
+    } else {
+        parts
+    };
+
+    match body.len() {
+        0 => ParsedTableRef::Unqualified {
+            table: String::new(),
+        },
+        1 => ParsedTableRef::Unqualified {
+            table: body[0].to_string(),
+        },
+        _ => {
+            // Synthetic `public` schema: `datafusion.public.X` comes from a
+            // bare `FROM X`. Treat as unqualified unless a real source named
+            // `public` exists (so a user who did register `public` as a
+            // schema still gets catalog-aware hints). When the table name
+            // itself contains a dot (manifest permits), the body is longer
+            // than two — `datafusion.public.player.stats` for a table named
+            // `player.stats` — and we collapse everything after `public`
+            // back into the unqualified bare name.
+            if body.len() >= 2
+                && body[0] == "public"
+                && !schema_is_registered("public", known_tables)
+            {
+                return ParsedTableRef::Unqualified {
+                    table: body[1..].join("."),
+                };
+            }
+
+            // Pick the longest contiguous prefix of `body` that matches a
+            // registered schema (case-insensitive). This recovers dotted
+            // source names like `"foo.bar"` from their exploded form.
+            for schema_len in (1..body.len()).rev() {
+                let candidate_schema = body[..schema_len].join(".");
+                if schema_is_registered(&candidate_schema, known_tables) {
+                    return ParsedTableRef::Qualified {
+                        schema: candidate_schema,
+                        table: body[schema_len..].join("."),
+                    };
+                }
+            }
+
+            // No known schema matched any prefix. Fall back to "everything
+            // but the last dot is the schema" — keeps dotted source names
+            // intact even when the source itself is missing from the
+            // catalog (so the remediation hint still names the right
+            // install target).
+            let last = body.len() - 1;
+            ParsedTableRef::Qualified {
+                schema: body[..last].join("."),
+                table: body[last].to_string(),
+            }
+        }
+    }
+}
+
+fn schema_is_registered(candidate: &str, known_tables: &[TableInfo]) -> bool {
+    let lowered = candidate.to_lowercase();
+    known_tables
+        .iter()
+        .any(|info| info.schema_name.to_lowercase() == lowered)
+}
+
+// ---------------------------------------------------------------------------
+// Identifier helpers
+// ---------------------------------------------------------------------------
+
+/// Like `quote_identifier` but accepts identifiers that themselves contain
+/// dots. A literal source name `foo.bar` quotes as `"foo.bar"`, not as
+/// `foo.bar` (which would read as a 2-component path).
+fn quote_dotted_identifier(ident: &str) -> String {
+    if ident.contains('.') {
+        let escaped = ident.replace('"', "\"\"");
+        format!("\"{escaped}\"")
+    } else {
+        quote_identifier(ident).into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table(schema: &str, name: &str) -> TableInfo {
+        TableInfo {
+            schema_name: schema.to_string(),
+            table_name: name.to_string(),
+            description: String::new(),
+            columns: vec![],
+            required_filters: vec![],
+        }
+    }
+
+    fn cp(relation: &[&str], name: &str) -> ColumnParts {
+        ColumnParts {
+            relation: relation.iter().map(ToString::to_string).collect(),
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn reason_consts_match_wire_contract() {
+        // Guard against an accidental rename: these literal values are the
+        // wire contract. Changing them is a breaking change for any consumer
+        // that pattern-matches on reason codes.
+        assert_eq!(UNKNOWN_COLUMN_REASON, "UNKNOWN_COLUMN");
+        assert_eq!(TABLE_NOT_FOUND_REASON, "TABLE_NOT_FOUND");
+    }
+
+    #[test]
+    fn unknown_column_case_insensitive_match_quotes_preserved_name() {
+        let valid = vec![cp(&["g"], "playerID"), cp(&["m"], "playerID")];
+        let err = StructuredQueryError::unknown_column(&cp(&["g"], "playerid"), &valid);
+
+        assert_eq!(err.reason(), UNKNOWN_COLUMN_REASON);
+        assert_eq!(err.status(), StatusCode::InvalidArgument);
+        let hint = err.hint().expect("hint should be present");
+        assert!(
+            hint.contains("g.\"playerID\""),
+            "expected case-preserving quoted hint, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn unknown_column_preserves_dotted_column_name_in_hint() {
+        // Real column is literally named `player.id`. User wrote an
+        // unquoted `demo.users.player.id`, which DataFusion splits into a
+        // 3-part relation (`demo.users.player`) plus the bare name `id`.
+        // The hint must suggest the only valid SQL: `demo.users."player.id"`.
+        let valid = vec![cp(&["demo", "users"], "player.id")];
+        let missing = cp(&["demo", "users", "player"], "id");
+        let err = StructuredQueryError::unknown_column(&missing, &valid);
+
+        let hint = err.hint().expect("hint should be present");
+        assert!(
+            hint.contains("demo.users.\"player.id\""),
+            "hint must quote the literal-dot name, got: {hint}"
+        );
+        assert!(
+            !hint.contains("demo.users.player.id"),
+            "hint must not render the unquoted 4-part form, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn unknown_column_matches_dotted_name_against_unqualified_reference() {
+        // Declared column is literally `player.id` on `hockey.master`.
+        // User writes `SELECT player.id FROM hockey.master`, which
+        // DataFusion parses as `relation=[player], name=id`. Neither
+        // full-flat nor bare-vs-bare match finds a hit (`player.id` !=
+        // `hockey.master.player.id`, `id` != `player.id`), but the
+        // candidate's bare name IS the user's joined form. The hint must
+        // still suggest the correctly-quoted column.
+        let valid = vec![cp(&["hockey", "master"], "player.id")];
+        let missing = cp(&["player"], "id");
+        let err = StructuredQueryError::unknown_column(&missing, &valid);
+
+        let hint = err.hint().expect("hint should be present");
+        assert!(
+            hint.contains("hockey.master.\"player.id\""),
+            "hint must suggest the fully-qualified quoted form, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn unknown_column_levenshtein_suggests_closest() {
+        let valid = vec![cp(&[], "user_login"), cp(&[], "title")];
+        let err = StructuredQueryError::unknown_column(&cp(&[], "user_llogin"), &valid);
+
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("user_login"), "got: {hint}");
+    }
+
+    #[test]
+    fn unknown_column_no_candidates_has_no_hint() {
+        let err = StructuredQueryError::unknown_column(&cp(&[], "anything"), &[]);
+        assert!(err.hint().is_none());
+    }
+
+    #[test]
+    fn unknown_column_too_distant_omits_hint() {
+        let valid = vec![cp(&[], "zzzzz")];
+        let err = StructuredQueryError::unknown_column(&cp(&[], "playerID"), &valid);
+        assert!(err.hint().is_none());
+    }
+
+    #[test]
+    fn table_not_found_missing_schema_points_at_coral_tables_catalog() {
+        let tables = vec![table("github", "issues")];
+        let err = StructuredQueryError::table_not_found("datafusion.hockey.master", &tables);
+
+        assert_eq!(err.reason(), TABLE_NOT_FOUND_REASON);
+        assert_eq!(err.status(), StatusCode::NotFound);
+        let hint = err.hint().expect("hint should be present");
+        // Hint must be transport-neutral: reference the engine's SQL
+        // catalog rather than a specific CLI command, so CLI / MCP / API
+        // consumers all render sensibly.
+        assert!(hint.contains("coral.tables"), "got: {hint}");
+        assert!(
+            !hint.contains("coral source"),
+            "hint must stay transport-neutral, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn table_not_found_case_insensitive_match_quotes_preserved_name() {
+        let tables = vec![table("hockey", "Master")];
+        let err = StructuredQueryError::table_not_found("datafusion.hockey.master", &tables);
+
+        let hint = err.hint().expect("hint should be present");
+        assert!(
+            hint.contains("hockey.\"Master\""),
+            "expected case-preserving quoted hint, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn table_not_found_levenshtein_suggests_similar_table() {
+        let tables = vec![
+            table("hockey", "games"),
+            table("hockey", "players"),
+            table("hockey", "teams"),
+        ];
+        let err = StructuredQueryError::table_not_found("datafusion.hockey.game", &tables);
+
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("hockey.games"), "got: {hint}");
+    }
+
+    #[test]
+    fn table_not_found_strips_datafusion_catalog_prefix_from_display() {
+        let tables = vec![table("hockey", "Master")];
+        let err = StructuredQueryError::table_not_found("datafusion.hockey.master", &tables);
+
+        assert!(
+            err.summary().contains("`hockey.master`"),
+            "summary should strip catalog prefix, got: {}",
+            err.summary()
+        );
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("hockey")
+        );
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("master")
+        );
+    }
+
+    #[test]
+    fn table_not_found_synthetic_public_treated_as_unqualified() {
+        // `FROM games` (bare) surfaces as `datafusion.public.games`. With no
+        // user-registered `public` source, this must collapse to an
+        // unqualified table-not-found whose hint points at `coral.tables`,
+        // not at "schema `public` is not registered".
+        let tables = vec![table("hockey", "games")];
+        let err = StructuredQueryError::table_not_found("datafusion.public.games", &tables);
+
+        assert_eq!(err.metadata().get("schema"), None);
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("games")
+        );
+        assert!(
+            err.summary().contains("`games`"),
+            "summary should show the bare table, got: {}",
+            err.summary()
+        );
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("coral.tables"), "got: {hint}");
+    }
+
+    #[test]
+    fn table_not_found_synthetic_public_preserves_dotted_table_name() {
+        // Manifest permits table names with embedded dots. `FROM
+        // "player.stats"` (bare, quoted) surfaces as
+        // `datafusion.public.player.stats` — a 4-part ref. The public
+        // shortcut must collapse everything after `public` into the bare
+        // name; it must NOT split on the last dot and report a nonexistent
+        // `public.player` schema.
+        let tables = vec![table("hockey", "player.stats")];
+        let err = StructuredQueryError::table_not_found("datafusion.public.player.stats", &tables);
+
+        assert_eq!(err.metadata().get("schema"), None);
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("player.stats")
+        );
+        assert!(
+            err.summary().contains("`player.stats`"),
+            "summary should show the dotted bare table, got: {}",
+            err.summary()
+        );
+        // Hint uses cross-schema Levenshtein (added in SOURCE-456 follow-up
+        // PR #162). On this branch it's the generic catalog pointer — PR
+        // #162 will upgrade it to a `hockey."player.stats"` suggestion.
+        err.hint().expect("hint should be present");
+    }
+
+    #[test]
+    fn table_not_found_real_public_schema_beats_synthetic_shortcut() {
+        // If a user genuinely registered a source named `public`, don't
+        // collapse the 2-part body — resolve against the catalog.
+        let tables = vec![table("public", "Reports")];
+        let err = StructuredQueryError::table_not_found("datafusion.public.reports", &tables);
+
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("public")
+        );
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("public.\"Reports\""), "got: {hint}");
+    }
+
+    #[test]
+    fn table_not_found_preserves_dotted_source_name() {
+        // Source name itself contains a dot: `foo.bar`. DataFusion explodes
+        // this to `datafusion.foo.bar.items`. The parser must recover
+        // schema=`foo.bar`, table=`items` — not schema=`bar`, table=`items`.
+        let tables = vec![table("foo.bar", "Items")];
+        let err = StructuredQueryError::table_not_found("datafusion.foo.bar.items", &tables);
+
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("foo.bar")
+        );
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("items")
+        );
+        let hint = err.hint().expect("hint should be present");
+        // Case-insensitive match surfaces `Items`; the dotted schema stays
+        // one quoted identifier, and the case-preserving table name is
+        // quoted on its own merits.
+        assert!(
+            hint.contains("\"foo.bar\".\"Items\""),
+            "hint should quote dotted schema as one identifier, got: {hint}"
+        );
+    }
+
+    #[test]
+    fn table_not_found_dotted_source_without_matching_table_still_routes_schema() {
+        // Same dotted source but the table name is just wrong. The hint
+        // path falls through to "no close match", but schema/metadata
+        // must still name the real source.
+        let tables = vec![table("foo.bar", "Items")];
+        let err = StructuredQueryError::table_not_found("datafusion.foo.bar.missing", &tables);
+
+        assert_eq!(
+            err.metadata().get("schema").map(String::as_str),
+            Some("foo.bar")
+        );
+        assert_eq!(
+            err.metadata().get("table").map(String::as_str),
+            Some("missing")
+        );
+    }
+
+    #[test]
+    fn table_not_found_unqualified_falls_back_to_catalog_pointer() {
+        // Pure unqualified form (no catalog prefix at all). DataFusion
+        // currently always emits a 3-part path, but the constructor
+        // accepts this shape defensively — if an upstream change ever
+        // drops the catalog prefix, this test still guards the fallback.
+        let tables = vec![table("hockey", "games")];
+        let err = StructuredQueryError::table_not_found("games", &tables);
+
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("coral.tables"), "got: {hint}");
+    }
+
+    #[test]
+    fn quote_dotted_identifier_wraps_names_with_embedded_dots() {
+        assert_eq!(quote_dotted_identifier("foo.bar"), "\"foo.bar\"");
+        assert_eq!(quote_dotted_identifier("hockey"), "hockey");
+        assert_eq!(quote_dotted_identifier("Master"), "\"Master\"");
+    }
+
+    #[test]
+    fn column_parts_quoted_escapes_each_component() {
+        assert_eq!(cp(&["g"], "playerID").quoted(), "g.\"playerID\"");
+        assert_eq!(cp(&[], "playerID").quoted(), "\"playerID\"");
+        assert_eq!(
+            cp(&["hockey", "master"], "playerID").quoted(),
+            "hockey.master.\"playerID\""
+        );
+        // Literal dot inside the bare column name stays inside one set of
+        // quotes — without this, the hint reads as a 4-component reference.
+        assert_eq!(
+            cp(&["demo", "users"], "player.id").quoted(),
+            "demo.users.\"player.id\""
+        );
     }
 }

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -1,11 +1,13 @@
 //! Shared runtime-error normalization for source compilation and registration.
 
+use datafusion::common::{Column, SchemaError, TableReference};
 use datafusion::error::DataFusionError;
 
 use crate::backends::http::ProviderQueryError;
-use crate::{CoreError, SourceDecoratorError};
+use crate::contracts::{ColumnParts, StructuredQueryError};
+use crate::{CoreError, SourceDecoratorError, TableInfo};
 
-pub(crate) fn datafusion_to_core(error: &DataFusionError) -> CoreError {
+pub(crate) fn datafusion_to_core(error: &DataFusionError, tables: &[TableInfo]) -> CoreError {
     // Unwrap Context/Shared/Diagnostic wrappers so wrapped schema errors
     // get classified by their root variant instead of all landing in the
     // `Internal` bucket. Without `find_root()`, `SELECT bogus FROM wide`
@@ -14,10 +16,8 @@ pub(crate) fn datafusion_to_core(error: &DataFusionError) -> CoreError {
     // from the match arms below.
     match error.find_root() {
         DataFusionError::SQL(detail, _) => CoreError::InvalidInput(detail.to_string()),
-        DataFusionError::Plan(detail) => CoreError::InvalidInput(detail.clone()),
-        DataFusionError::SchemaError(schema_error, _) => {
-            CoreError::InvalidInput(schema_error.to_string())
-        }
+        DataFusionError::Plan(detail) => plan_error_to_core(detail, tables),
+        DataFusionError::SchemaError(schema_error, _) => schema_error_to_core(schema_error),
         DataFusionError::NotImplemented(detail) => CoreError::Unimplemented(detail.clone()),
         DataFusionError::External(inner) => {
             if let Some(provider_error) = inner.downcast_ref::<ProviderQueryError>() {
@@ -43,6 +43,127 @@ pub(crate) fn source_decorator_error_to_core(error: &SourceDecoratorError) -> Co
     }
 }
 
+fn plan_error_to_core(detail: &str, tables: &[TableInfo]) -> CoreError {
+    if let Some(table_ref) = extract_table_not_found(detail) {
+        return CoreError::QueryFailure(Box::new(StructuredQueryError::table_not_found(
+            table_ref, tables,
+        )));
+    }
+    CoreError::InvalidInput(detail.to_string())
+}
+
+fn schema_error_to_core(schema_error: &SchemaError) -> CoreError {
+    if let SchemaError::FieldNotFound {
+        field,
+        valid_fields,
+    } = schema_error
+    {
+        let missing = column_to_parts(field);
+        let valid: Vec<ColumnParts> = valid_fields.iter().map(column_to_parts).collect();
+        return CoreError::QueryFailure(Box::new(StructuredQueryError::unknown_column(
+            &missing, &valid,
+        )));
+    }
+    CoreError::InvalidInput(schema_error.to_string())
+}
+
+/// Converts a `DataFusion` `Column` into structure-preserving parts.
+///
+/// `Column` carries its qualifier as a `TableReference` (Bare / Partial /
+/// Full) and the bare name as a plain `String` — literal dots inside the
+/// name stay inside the name. Preserving that separation here is what lets
+/// downstream hint rendering distinguish `.` as a qualifier from `.` as a
+/// character in a quoted identifier.
+fn column_to_parts(column: &Column) -> ColumnParts {
+    let relation: Vec<String> = column
+        .relation
+        .as_ref()
+        .map(|reference| match reference {
+            TableReference::Bare { table } => vec![table.to_string()],
+            TableReference::Partial { schema, table } => {
+                vec![schema.to_string(), table.to_string()]
+            }
+            TableReference::Full {
+                catalog,
+                schema,
+                table,
+            } => vec![catalog.to_string(), schema.to_string(), table.to_string()],
+        })
+        .unwrap_or_default();
+    ColumnParts {
+        relation,
+        name: column.name.clone(),
+    }
+}
+
+/// Extracts the table reference from a `"table 'xxx' not found"` plan error.
+///
+/// `DataFusion` raises this literal form from both the SQL-level relation
+/// resolver and the session-state catalog lookup when a referenced table
+/// isn't in the catalog. `DataFusionError::source` for the `Diagnostic`
+/// variant returns the inner error, so `find_root()` unwraps any
+/// diagnostic decoration before we match on the `Plan` string.
+///
+/// The exact prefix/suffix are load-bearing: the integration tests in
+/// `tests/engine/structured_error_tests.rs` exercise this path end-to-end,
+/// so any upstream wording change surfaces as a concrete test failure
+/// rather than silent mis-classification.
+fn extract_table_not_found(detail: &str) -> Option<&str> {
+    let rest = detail.strip_prefix("table '")?;
+    rest.strip_suffix("' not found")
+}
+
 fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
     CoreError::QueryFailure(Box::new(error.to_structured()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::contracts::UNKNOWN_COLUMN_REASON;
+
+    #[test]
+    fn datafusion_to_core_unwraps_context_wrapped_schema_error_to_structured() {
+        let schema_err = Box::new(SchemaError::FieldNotFound {
+            field: Box::new(Column::new_unqualified("user_login")),
+            valid_fields: vec![
+                Column::new_unqualified("user__login"),
+                Column::new_unqualified("title"),
+            ],
+        });
+        let inner = DataFusionError::SchemaError(schema_err, Box::new(None));
+        let wrapped = DataFusionError::Context("wrapping context".to_string(), Box::new(inner));
+
+        let core = datafusion_to_core(&wrapped, &[]);
+
+        match core {
+            CoreError::QueryFailure(sqe) => {
+                assert_eq!(sqe.reason(), UNKNOWN_COLUMN_REASON);
+                assert!(sqe.summary().contains("user_login"));
+            }
+            other => panic!("expected CoreError::QueryFailure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_table_not_found_matches_datafusion_format() {
+        assert_eq!(
+            extract_table_not_found("table 'hockey.master' not found"),
+            Some("hockey.master")
+        );
+        assert_eq!(
+            extract_table_not_found("table 'foo' not found"),
+            Some("foo")
+        );
+        assert_eq!(extract_table_not_found("something else"), None);
+    }
+
+    #[test]
+    fn plan_error_without_table_prefix_is_invalid_input() {
+        let core = plan_error_to_core("syntax error at position 12", &[]);
+        match core {
+            CoreError::InvalidInput(detail) => assert!(detail.contains("syntax error")),
+            other => panic!("expected CoreError::InvalidInput, got {other:?}"),
+        }
+    }
 }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -30,7 +30,7 @@ pub(crate) async fn build_runtime(
         RuntimeEnvBuilder::new()
             .with_object_list_cache_limit(0)
             .build()
-            .map_err(|err| datafusion_to_core(&err))?,
+            .map_err(|err| datafusion_to_core(&err, &[]))?,
     );
     let ctx = Arc::new(SessionContext::new_with_config_rt(
         session_config,
@@ -63,7 +63,7 @@ pub(crate) async fn build_runtime(
     )
     .await?;
     catalog::register(&ctx, &registration.active_sources)
-        .map_err(|err| datafusion_to_core(&err))?;
+        .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_tables(&registration.active_sources);
     for failure in &registration.failures {
         tracing::warn!(
@@ -103,9 +103,12 @@ impl QueryRuntimeAdapter {
             .ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
-            .map_err(|err| datafusion_to_core(&err))?;
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
-        let batches = df.collect().await.map_err(|err| datafusion_to_core(&err))?;
+        let batches = df
+            .collect()
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
         Ok(QueryExecution::new(arrow_schema, batches))
     }
 }
@@ -115,34 +118,4 @@ fn read_only_sql_options() -> SQLOptions {
         .with_allow_ddl(false)
         .with_allow_dml(false)
         .with_allow_statements(false)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn datafusion_to_core_unwraps_context_wrapped_schema_error_to_invalid_input() {
-        use datafusion::common::{Column, SchemaError};
-        use datafusion::error::DataFusionError;
-
-        let schema_err = Box::new(SchemaError::FieldNotFound {
-            field: Box::new(Column::new_unqualified("user_login")),
-            valid_fields: vec![
-                Column::new_unqualified("user__login"),
-                Column::new_unqualified("title"),
-            ],
-        });
-        let inner = DataFusionError::SchemaError(schema_err, Box::new(None));
-        let wrapped = DataFusionError::Context("wrapping context".to_string(), Box::new(inner));
-
-        let core = datafusion_to_core(&wrapped);
-
-        match core {
-            CoreError::InvalidInput(msg) => {
-                assert!(msg.contains("user_login"), "expected field name in: {msg}");
-            }
-            other => panic!("expected CoreError::InvalidInput, got {other:?}"),
-        }
-    }
 }

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -77,9 +77,8 @@ pub(crate) async fn register_sources(
     source_decorators: &mut [Box<dyn SourceDecorator>],
 ) -> std::result::Result<SourceRegistrationResult, CoreError> {
     let catalog = ctx.catalog("datafusion").ok_or_else(|| {
-        datafusion_to_core(&DataFusionError::Plan(
-            "catalog 'datafusion' not found".to_string(),
-        ))
+        let plan_err = DataFusionError::Plan("catalog 'datafusion' not found".to_string());
+        datafusion_to_core(&plan_err, &[])
     })?;
 
     let selected_sources = sources
@@ -113,7 +112,7 @@ pub(crate) async fn register_sources(
                         ) {
                             Ok(_) => result.active_sources.push(registered_source),
                             Err(error) => {
-                                let core_error = datafusion_to_core(&error);
+                                let core_error = datafusion_to_core(&error, &[]);
                                 if handle_source_registration_failure(
                                     source_decorators,
                                     query_source,
@@ -136,7 +135,7 @@ pub(crate) async fn register_sources(
                         }
                     }
                     Err(error) => {
-                        let core_error = datafusion_to_core(&error);
+                        let core_error = datafusion_to_core(&error, &[]);
                         if handle_source_registration_failure(
                             source_decorators,
                             query_source,

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -15,5 +15,7 @@ mod http_tests;
 mod jsonl_tests;
 #[path = "engine/parquet_tests.rs"]
 mod parquet_tests;
+#[path = "engine/structured_error_tests.rs"]
+mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]
 mod test_source_tests;

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, build_source, build_source_with_inputs, dir_url,
+    TestRuntime, assert_table_not_found, build_source, build_source_with_inputs, dir_url,
     execution_to_rows, write_jsonl_file,
 };
 
@@ -234,7 +234,7 @@ async fn query_nonexistent_schema_returns_error() {
         .await
         .expect_err("missing schema should fail");
 
-    assert_invalid_input(error, "table 'datafusion.missing.users' not found");
+    assert_table_not_found(error, "missing", "users");
 }
 
 fn table_summary(table: &TableInfo) -> (String, String, String) {

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -70,6 +70,28 @@ pub(crate) fn assert_invalid_input(error: CoreError, expected_detail: &str) {
     }
 }
 
+pub(crate) fn assert_table_not_found(
+    error: CoreError,
+    expected_schema: &str,
+    expected_table: &str,
+) {
+    assert_eq!(error.status_code(), StatusCode::NotFound);
+    match error {
+        CoreError::QueryFailure(sqe) => {
+            assert_eq!(sqe.reason(), "TABLE_NOT_FOUND");
+            assert_eq!(
+                sqe.metadata().get("schema").map(String::as_str),
+                Some(expected_schema)
+            );
+            assert_eq!(
+                sqe.metadata().get("table").map(String::as_str),
+                Some(expected_table)
+            );
+        }
+        other => panic!("expected CoreError::QueryFailure, got {other:?}"),
+    }
+}
+
 pub(crate) fn write_jsonl_file(dir: &Path, filename: &str, rows: &[Value]) {
     let path = dir.join(filename);
     if let Some(parent) = path.parent() {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -577,7 +577,7 @@ async fn missing_required_filter_surfaces_structured_error() {
             assert!(!sqe.retryable());
             assert_eq!(sqe.metadata().get("schema").unwrap(), "http_required");
             assert_eq!(sqe.metadata().get("table").unwrap(), "users");
-            assert_eq!(sqe.metadata().get("field").unwrap(), "id");
+            assert_eq!(sqe.metadata().get("column").unwrap(), "id");
             assert!(sqe.summary().contains("WHERE id"));
             assert!(sqe.hint().unwrap().contains("coral.columns"));
         }

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, assert_row_count, build_source, dir_url, execution_to_rows,
-    users_rows, write_jsonl_file,
+    TestRuntime, assert_row_count, assert_table_not_found, build_source, dir_url,
+    execution_to_rows, users_rows, write_jsonl_file,
 };
 
 fn jsonl_manifest(name: &str, dir: &Path, glob: &str) -> Value {
@@ -169,5 +169,5 @@ async fn missing_file_returns_error() {
             .await
             .expect_err("missing jsonl source should fail");
 
-    assert_invalid_input(error, "table 'datafusion.jsonl_missing.users' not found");
+    assert_table_not_found(error, "jsonl_missing", "users");
 }

--- a/crates/coral-engine/tests/engine/parquet_tests.rs
+++ b/crates/coral-engine/tests/engine/parquet_tests.rs
@@ -5,7 +5,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, build_source, build_source_with_secrets, dir_url,
+    TestRuntime, assert_table_not_found, build_source, build_source_with_secrets, dir_url,
     execution_to_rows, users_batch, write_parquet_file,
 };
 
@@ -240,5 +240,5 @@ async fn missing_file_returns_error() {
     .await
     .expect_err("missing parquet source should fail");
 
-    assert_invalid_input(error, "table 'datafusion.parquet_missing.users' not found");
+    assert_table_not_found(error, "parquet_missing", "users");
 }

--- a/crates/coral-engine/tests/engine/structured_error_tests.rs
+++ b/crates/coral-engine/tests/engine/structured_error_tests.rs
@@ -1,0 +1,182 @@
+//! End-to-end coverage for structured `DataFusion` error enrichment.
+//!
+//! Verifies that `coral-engine` promotes `DataFusionError::SchemaError` and
+//! `DataFusionError::Plan` table-not-found variants into
+//! `CoreError::QueryFailure` with case-aware hints.
+
+use std::path::Path;
+
+use coral_engine::{CoralQuery, CoreError, StatusCode, StructuredQueryError};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use crate::harness::{TestRuntime, build_source, dir_url, write_jsonl_file};
+
+fn manifest(name: &str, table: &str, dir: &Path) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "tables": [{
+            "name": table,
+            "description": "Structured-error fixture",
+            "source": {
+                "location": dir_url(dir),
+                "glob": "**/*.jsonl"
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" },
+                { "name": "playerID", "type": "Utf8" }
+            ]
+        }]
+    })
+}
+
+fn structured(error: CoreError) -> StructuredQueryError {
+    match error {
+        CoreError::QueryFailure(sqe) => *sqe,
+        other => panic!("expected CoreError::QueryFailure, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn unknown_table_in_installed_schema_suggests_case_preserved_quoted_name() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "rows.jsonl",
+        &[json!({"id": 1, "playerID": "ov8"})],
+    );
+    let source = build_source(manifest("hockey", "Master", temp.path()));
+
+    // DataFusion lowercases the unquoted `Master` to `master`, which won't
+    // match our case-preserving `Master` table in the catalog.
+    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM hockey.Master")
+        .await
+        .expect_err("unknown table should fail");
+
+    let sqe = structured(error);
+    assert_eq!(sqe.reason(), "TABLE_NOT_FOUND");
+    assert_eq!(sqe.status(), StatusCode::NotFound);
+    let hint = sqe.hint().expect("hint should be present");
+    assert!(
+        hint.contains("hockey.\"Master\""),
+        "hint should suggest case-preserving quoted form, got: {hint}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_table_missing_schema_points_at_coral_tables_catalog() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "rows.jsonl",
+        &[json!({"id": 1, "playerID": "ov8"})],
+    );
+    let source = build_source(manifest("hockey", "games", temp.path()));
+
+    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM nba.games")
+        .await
+        .expect_err("unknown schema should fail");
+
+    let sqe = structured(error);
+    assert_eq!(sqe.reason(), "TABLE_NOT_FOUND");
+    let hint = sqe.hint().expect("hint should be present");
+    // The engine layer is transport-neutral: the hint must not assume a
+    // particular surface (CLI / MCP / API). SQL catalog queries work
+    // uniformly across all of them.
+    assert!(hint.contains("coral.tables"), "got: {hint}");
+    assert!(
+        !hint.contains("coral source"),
+        "engine hint must not embed a CLI command, got: {hint}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_table_similar_name_levenshtein_suggests_closest() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "rows.jsonl",
+        &[json!({"id": 1, "playerID": "ov8"})],
+    );
+    let source = build_source(manifest("hockey", "games", temp.path()));
+
+    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM hockey.gamers")
+        .await
+        .expect_err("unknown table should fail");
+
+    let sqe = structured(error);
+    let hint = sqe.hint().expect("hint should be present");
+    assert!(
+        hint.contains("hockey.games"),
+        "hint should suggest closest table, got: {hint}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_column_on_aliased_join_suggests_case_preserved_quoted_name() {
+    // Real-world shape: an agent discovers `playerID` in `coral.columns`
+    // and writes a self-join `ON g.playerID = m.playerID`. DataFusion
+    // lowercases both unquoted identifiers to `g.playerid` / `m.playerid`,
+    // which don't match the case-preserving `playerID` column in the
+    // schema. Our hint must point at `g."playerID"` (case-preserving
+    // quoted form). DataFusion's own error text suggests `"g.playerid"`
+    // (lowercased, wrong) — our negative assertion below guards against
+    // accidentally regressing to that shape.
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "rows.jsonl",
+        &[json!({"id": 1, "playerID": "ov8"})],
+    );
+    let source = build_source(manifest("hockey", "master", temp.path()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        &TestRuntime,
+        "SELECT g.id FROM hockey.master AS g \
+         JOIN hockey.master AS m ON g.playerID = m.playerID",
+    )
+    .await
+    .expect_err("unknown field should fail");
+
+    let sqe = structured(error);
+    assert_eq!(sqe.reason(), "UNKNOWN_COLUMN");
+    assert_eq!(sqe.status(), StatusCode::InvalidArgument);
+    let hint = sqe.hint().expect("hint should be present");
+    assert!(
+        hint.contains("g.\"playerID\"") || hint.contains("m.\"playerID\""),
+        "hint should suggest case-preserving quoted alias.column, got: {hint}"
+    );
+    assert!(
+        !hint.contains("\"playerid\""),
+        "hint must not suggest the lowercased quoted form, got: {hint}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_column_levenshtein_suggests_closest_field() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "rows.jsonl",
+        &[json!({"id": 1, "playerID": "ov8"})],
+    );
+    let source = build_source(manifest("hockey", "master", temp.path()));
+
+    // `id2` doesn't exist and isn't a case-twin of anything; the closest
+    // candidate by Levenshtein is `id`.
+    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT id2 FROM hockey.master")
+        .await
+        .expect_err("unknown field should fail");
+
+    let sqe = structured(error);
+    assert_eq!(sqe.reason(), "UNKNOWN_COLUMN");
+    let hint = sqe.hint().expect("hint should be present");
+    assert!(
+        hint.contains("id"),
+        "expected did-you-mean hint, got: {hint}"
+    );
+}


### PR DESCRIPTION
## Summary

Promote two DataFusion error shapes into `StructuredQueryError` so agents and CLI users get actionable hints for the most common query-time failures.

| Input | Before | After |
|---|---|---|
| `SELECT * FROM hockey.Master` (table `Master` registered) | `InvalidArgument: table 'datafusion.hockey.master' not found` | `NotFound` / `TABLE_NOT_FOUND` + hint: `Unquoted identifiers are lowercased. Try \`hockey.\"Master\"\`.` |
| `ON g.playerID = m.playerID` on a `playerID` column | `InvalidArgument: No field named g.playerid. Use double quotes: \"g.playerid\"` (wrong case) | `InvalidArgument` / `UNKNOWN_FIELD` + hint: `Unquoted identifiers are lowercased. Try \`g.\"playerID\"\`.` |
| `SELECT * FROM nba.games` (source absent) | `InvalidArgument: table 'datafusion.nba.games' not found` | `NotFound` + hint: `Schema \`nba\` is not currently registered. Run \`coral source list\` ...` |
| `SELECT * FROM hockey.gamers` (typo) | opaque | `NotFound` + Levenshtein hint: `Did you mean \`hockey.games\`?` |

## What changed

- `coral-engine/contracts/query_error.rs` — new `unknown_field` / `table_not_found` constructors on `StructuredQueryError`, with case-aware quoting (via `datafusion::common::utils::quote_identifier`) and Levenshtein fallback via `strsim`.
- `coral-engine/runtime/query.rs` — `datafusion_to_core` threads `&[TableInfo]` through so hint builders can do case-insensitive catalog lookups; extracts `SchemaError::FieldNotFound` and `Plan(\"table '...' not found\")` into the structured path.
- Wire-stable reason-code consts (`UNKNOWN_FIELD_REASON`, `TABLE_NOT_FOUND_REASON`) — crate-private, guarded by a wire-contract test.
- Three pre-existing negative-path tests updated: a missing source is semantically `NotFound`, not `InvalidArgument` (catalog / jsonl / parquet `missing_file_returns_error`, plus `coral-app`'s `broken_source_does_not_block_healthy_sources`).

## Relation to #113 (sauldhernandez)

#113 adds `sql_table_ref` / `sql_column_ref` / `sql_qualified_column_ref` to `coral.tables` / `coral.columns`. Once it lands on main, a follow-up should switch `table_not_found_hint`'s match and Levenshtein branches from reconstructing via `quote_identifier` to reading `hit.sql_table_ref` directly. The unknown-field hint builder should likely stay on reconstruction (see open question below).

## Open questions / assumptions

1. **Alias preservation for unknown-field hints.** DataFusion's `valid_fields` arrive shaped like `[\"g.id\", \"g.playerID\"]` when the query uses an alias, or `[\"hockey.master.id\", ...]` when not. The hint preserves the query's qualifier form rather than always showing the fully-qualified catalog ref, on the theory that it's closer to the code the user wrote and matches DataFusion's own suggestion shape. Flag if you'd prefer always showing the catalog's `sql_qualified_column_ref`.
2. **DataFusion 52.5 message-format coupling.** `extract_table_not_found` matches the literal text `\"table 'X' not found\"`, and `split_table_ref` assumes the 3-part `datafusion.schema.table` form. Both are verified on datafusion 52.5 directly. A DataFusion upgrade that changes these strings needs a matching edit here.
3. **No hint when schema exists but no close match.** Today if `hockey.foo` fails and no table in `hockey` is within Levenshtein 0.5 of `foo`, the hint is omitted. Listing the schema's tables is the alternative; I picked brevity. Flag if the noisier option is preferred.

## Test plan

- [x] `cargo test --workspace --locked` — green (new: 11 unit tests in `query_error.rs`, 3 in `runtime/query.rs`, 5 integration tests in `structured_error_tests.rs`)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- [x] End-to-end wire verified by integration tests: `structured_error_tests::unknown_table_in_installed_schema_suggests_case_preserved_quoted_name` and `unknown_column_on_aliased_join_suggests_case_preserved_quoted_name` assert the plan's exact `hockey."Master"` and `g."playerID"` hint shapes through the real `DataFusion` → `CoreError` → `StructuredQueryError` path.

## History

- #92 (PR2) merged: structured-error plumbing now on main.
- #100 (PR3) merged: CLI renders these hints on stderr via the now-side-effect-free `render_query_error` helper.

## Depends on

Merged: #92.
