### PR TITLE
feat(engine): expose source config via coral.inputs

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -38,7 +38,9 @@ pub(crate) struct RegisteredInput {
     pub(crate) key: String,
     pub(crate) kind: ManifestInputKind,
     pub(crate) required: bool,
-    pub(crate) default_value: Option<String>,
+    /// Mirrors [`ManifestInputSpec::default_value`]: empty string means
+    /// "no default declared". The catalog layer maps empty to SQL `NULL`.
+    pub(crate) default_value: String,
     pub(crate) hint: Option<String>,
     /// Resolved value for variables. Unconditionally `None` for secrets.
     pub(crate) resolved_value: Option<String>,
@@ -132,23 +134,19 @@ pub(crate) fn build_registered_inputs(
     declared
         .iter()
         .map(|input| {
-            let default_value = if input.default_value.is_empty() {
-                None
-            } else {
-                Some(input.default_value.clone())
-            };
             let (resolved_value, is_set) = match input.kind {
                 ManifestInputKind::Variable => {
-                    let resolved = variables
-                        .get(&input.key)
-                        .cloned()
-                        .or_else(|| default_value.clone());
+                    let explicit = variables.get(&input.key).cloned();
+                    let has_default = !input.default_value.is_empty();
+                    let resolved = explicit
+                        .clone()
+                        .or_else(|| has_default.then(|| input.default_value.clone()));
                     // Variable is "set" if the user explicitly configured the
                     // key (even with an empty string — HTTP input resolution
                     // and required-variable validation both treat the key's
                     // presence as authoritative) or the manifest provides a
                     // non-empty default.
-                    let is_set = variables.contains_key(&input.key) || default_value.is_some();
+                    let is_set = explicit.is_some() || has_default;
                     (resolved, is_set)
                 }
                 ManifestInputKind::Secret => (None, secret_keys.contains(&input.key)),
@@ -161,7 +159,7 @@ pub(crate) fn build_registered_inputs(
                 key: input.key.clone(),
                 kind: input.kind,
                 required: input.required,
-                default_value,
+                default_value: input.default_value.clone(),
                 hint: input.hint.clone(),
                 resolved_value,
                 is_set,

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -1,12 +1,14 @@
 //! Shared internal backend contracts and registry-visible metadata.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::Arc;
 
 use crate::QueryRuntimeContext;
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
-use coral_spec::{ColumnSpec, FilterSpec, ManifestDataType, TableCommon};
+use coral_spec::{
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec, TableCommon,
+};
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
@@ -32,9 +34,22 @@ pub(crate) struct RegisteredTable {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct RegisteredInput {
+    pub(crate) key: String,
+    pub(crate) kind: ManifestInputKind,
+    pub(crate) required: bool,
+    pub(crate) default_value: Option<String>,
+    pub(crate) hint: Option<String>,
+    /// Resolved value for variables. Unconditionally `None` for secrets.
+    pub(crate) resolved_value: Option<String>,
+    pub(crate) is_set: bool,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct RegisteredSource {
     pub(crate) schema_name: String,
     pub(crate) tables: Vec<RegisteredTable>,
+    pub(crate) inputs: Vec<RegisteredInput>,
 }
 
 pub(crate) struct BackendRegistration {
@@ -99,6 +114,58 @@ pub(crate) fn registered_columns_from_schema(
             is_virtual: false,
             is_required_filter: required_filters.iter().any(|filter| filter == field.name()),
             description: String::new(),
+        })
+        .collect()
+}
+
+/// Build registry-visible input metadata.
+///
+/// Takes the manifest-declared inputs, the resolved non-secret variables map,
+/// and the set of configured secret keys. Secret *values* are never consumed
+/// here — only their keys — so the catalog layer has no path to leak secret
+/// values.
+pub(crate) fn build_registered_inputs(
+    declared: &[ManifestInputSpec],
+    variables: &BTreeMap<String, String>,
+    secret_keys: &BTreeSet<String>,
+) -> Vec<RegisteredInput> {
+    declared
+        .iter()
+        .map(|input| {
+            let default_value = if input.default_value.is_empty() {
+                None
+            } else {
+                Some(input.default_value.clone())
+            };
+            let (resolved_value, is_set) = match input.kind {
+                ManifestInputKind::Variable => {
+                    let resolved = variables
+                        .get(&input.key)
+                        .cloned()
+                        .or_else(|| default_value.clone());
+                    // Variable is "set" if the user explicitly configured the
+                    // key (even with an empty string — HTTP input resolution
+                    // and required-variable validation both treat the key's
+                    // presence as authoritative) or the manifest provides a
+                    // non-empty default.
+                    let is_set = variables.contains_key(&input.key) || default_value.is_some();
+                    (resolved, is_set)
+                }
+                ManifestInputKind::Secret => (None, secret_keys.contains(&input.key)),
+            };
+            debug_assert!(
+                !(matches!(input.kind, ManifestInputKind::Secret) && resolved_value.is_some()),
+                "secret inputs must never carry a resolved value"
+            );
+            RegisteredInput {
+                key: input.key.clone(),
+                kind: input.kind,
+                required: input.required,
+                default_value,
+                hint: input.hint.clone(),
+                resolved_value,
+                is_set,
+            }
         })
         .collect()
 }

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -11,7 +11,8 @@ use datafusion::prelude::SessionContext;
 
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_table, registered_columns_from_specs, required_filter_names,
+    RegisteredTable, build_registered_inputs, build_registered_table,
+    registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod client;
@@ -83,11 +84,19 @@ impl CompiledBackendSource for HttpCompiledSource {
             table_infos.push(registered_table(table));
         }
 
+        let secret_keys = self.source_secrets.keys().cloned().collect();
+        let inputs = build_registered_inputs(
+            &self.manifest.declared_inputs,
+            &self.source_variables,
+            &secret_keys,
+        );
+
         Ok(BackendRegistration {
             tables,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                inputs,
             },
         })
     }

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -287,6 +287,7 @@ impl CompiledBackendSource for JsonlCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                inputs: Vec::new(),
             },
         })
     }

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -19,8 +19,8 @@ use crate::backends::shared::json_exec::{Converter, Fetcher, JsonExec, RowFetche
 use crate::backends::shared::mapping::convert_items;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_table, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, build_registered_inputs, build_registered_table,
+    registered_columns_from_specs, required_filter_names, schema_from_columns,
 };
 use crate::{CoreError, QueryRuntimeContext};
 use coral_spec::backends::file::{FileTableSpec, JsonlSourceManifest};
@@ -49,10 +49,14 @@ pub(crate) struct CompiledJsonlTable {
 struct JsonlCompiledSource {
     manifest: JsonlSourceManifest,
     tables: Vec<CompiledJsonlTable>,
+    source_secrets: std::collections::BTreeMap<String, String>,
+    source_variables: std::collections::BTreeMap<String, String>,
 }
 
 pub(crate) fn compile_source(
     manifest: JsonlSourceManifest,
+    source_secrets: std::collections::BTreeMap<String, String>,
+    source_variables: std::collections::BTreeMap<String, String>,
     runtime_context: &QueryRuntimeContext,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     let tables = manifest
@@ -68,14 +72,24 @@ pub(crate) fn compile_source(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
-    Ok(Box::new(JsonlCompiledSource { manifest, tables }))
+    Ok(Box::new(JsonlCompiledSource {
+        manifest,
+        tables,
+        source_secrets,
+        source_variables,
+    }))
 }
 
 pub(crate) fn compile_manifest(
     manifest: &JsonlSourceManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
-    compile_source(manifest.clone(), request.runtime_context)
+    compile_source(
+        manifest.clone(),
+        request.source_secrets.clone(),
+        request.source_variables.clone(),
+        request.runtime_context,
+    )
 }
 
 /// A table provider backed by newline-delimited `JSON` (`JSONL`) files on the local
@@ -282,12 +296,15 @@ impl CompiledBackendSource for JsonlCompiledSource {
             table_infos.push(metadata);
         }
 
+        let secret_keys = self.source_secrets.keys().cloned().collect();
+        let inputs = build_registered_inputs(&[], &self.source_variables, &secret_keys);
+
         Ok(BackendRegistration {
             tables,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
-                inputs: Vec::new(),
+                inputs,
             },
         })
     }

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -6,9 +6,9 @@ use coral_spec::ValidatedSourceManifest;
 pub(crate) mod common;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, arrow_type_for_column, build_registered_table, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, arrow_type_for_column, build_registered_inputs, build_registered_table,
+    partition_columns_to_arrow, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod http;

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -28,7 +28,7 @@ use parquet::file::reader::{ChunkReader, Length};
 
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_table, partition_columns_to_arrow,
+    RegisteredTable, build_registered_inputs, build_registered_table, partition_columns_to_arrow,
     registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
     schema_from_columns,
 };
@@ -46,15 +46,18 @@ const PARQUET_FOOTER_SIZE: u64 = 8;
 struct ParquetCompiledSource {
     manifest: ParquetSourceManifest,
     source_secrets: BTreeMap<String, String>,
+    source_variables: BTreeMap<String, String>,
 }
 
 pub(crate) fn compile_source(
     manifest: ParquetSourceManifest,
     source_secrets: BTreeMap<String, String>,
+    source_variables: BTreeMap<String, String>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(ParquetCompiledSource {
         manifest,
         source_secrets,
+        source_variables,
     })
 }
 
@@ -62,7 +65,11 @@ pub(crate) fn compile_manifest(
     manifest: &ParquetSourceManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Box<dyn CompiledBackendSource> {
-    compile_source(manifest.clone(), request.source_secrets.clone())
+    compile_source(
+        manifest.clone(),
+        request.source_secrets.clone(),
+        request.source_variables.clone(),
+    )
 }
 
 #[derive(Debug)]
@@ -234,12 +241,15 @@ impl CompiledBackendSource for ParquetCompiledSource {
             table_infos.push(metadata);
         }
 
+        let secret_keys = self.source_secrets.keys().cloned().collect();
+        let inputs = build_registered_inputs(&[], &self.source_variables, &secret_keys);
+
         Ok(BackendRegistration {
             tables,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
-                inputs: Vec::new(),
+                inputs,
             },
         })
     }

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -239,6 +239,7 @@ impl CompiledBackendSource for ParquetCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                inputs: Vec::new(),
             },
         })
     }

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -124,7 +124,8 @@ struct CatalogInput {
     key: String,
     kind: &'static str,
     value: Option<String>,
-    default_value: Option<String>,
+    /// Empty string (= "no default declared" in the spec) renders as SQL NULL.
+    default_value: String,
     hint: Option<String>,
     required: bool,
     is_set: bool,
@@ -190,7 +191,13 @@ fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
             ),
             Arc::new(
                 rows.iter()
-                    .map(|row| row.default_value.as_deref())
+                    .map(|row| {
+                        if row.default_value.is_empty() {
+                            None
+                        } else {
+                            Some(row.default_value.as_str())
+                        }
+                    })
                     .collect::<StringArray>(),
             ),
             Arc::new(

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -161,7 +161,9 @@ fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
         })
         .collect();
 
-    rows.sort_by(|left, right| (&left.schema_name, &left.key).cmp(&(&right.schema_name, &right.key)));
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.key).cmp(&(&right.schema_name, &right.key))
+    });
 
     let batch = RecordBatch::try_new(
         schema.clone(),

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use coral_spec::ManifestInputKind;
 use datafusion::arrow::array::{BooleanArray, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::datasource::MemTable;
@@ -25,11 +26,13 @@ pub(crate) const SYSTEM_SCHEMA: &str = "coral";
 pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
+    let inputs_table = build_inputs_table(active_sources)?;
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
     meta_tables.insert("columns".to_string(), Arc::new(columns_table));
+    meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
 
     let catalog = ctx
         .catalog("datafusion")
@@ -108,6 +111,100 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
                 rows.iter()
                     .map(|row| Some(row.4.as_str()))
                     .collect::<StringArray>(),
+            ),
+        ],
+    )
+    .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
+
+    MemTable::try_new(schema, vec![vec![batch]])
+}
+
+struct CatalogInput {
+    schema_name: String,
+    key: String,
+    kind: &'static str,
+    value: Option<String>,
+    default_value: Option<String>,
+    hint: Option<String>,
+    required: bool,
+    is_set: bool,
+}
+
+fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("key", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+        Field::new("value", DataType::Utf8, true),
+        Field::new("default_value", DataType::Utf8, true),
+        Field::new("hint", DataType::Utf8, true),
+        Field::new("required", DataType::Boolean, false),
+        Field::new("is_set", DataType::Boolean, false),
+    ]));
+
+    let mut rows: Vec<CatalogInput> = active_sources
+        .iter()
+        .flat_map(|source| {
+            source.inputs.iter().map(move |input| CatalogInput {
+                schema_name: source.schema_name.clone(),
+                key: input.key.clone(),
+                kind: match input.kind {
+                    ManifestInputKind::Variable => "variable",
+                    ManifestInputKind::Secret => "secret",
+                },
+                value: input.resolved_value.clone(),
+                default_value: input.default_value.clone(),
+                hint: input.hint.clone(),
+                required: input.required,
+                is_set: input.is_set,
+            })
+        })
+        .collect();
+
+    rows.sort_by(|left, right| (&left.schema_name, &left.key).cmp(&(&right.schema_name, &right.key)));
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.schema_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.key.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.kind))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.value.as_deref())
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.default_value.as_deref())
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.hint.as_deref())
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.required))
+                    .collect::<BooleanArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.is_set))
+                    .collect::<BooleanArray>(),
             ),
         ],
     )

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -1,9 +1,12 @@
+use std::collections::BTreeMap;
+
 use coral_engine::{ColumnInfo, CoralQuery, QuerySource, TableInfo};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, write_jsonl_file,
+    TestRuntime, assert_invalid_input, build_source, build_source_with_inputs, dir_url,
+    execution_to_rows, write_jsonl_file,
 };
 
 fn users_manifest(dir: &std::path::Path) -> Value {
@@ -252,4 +255,190 @@ fn table_column_names(table: &TableInfo) -> Vec<String> {
         .iter()
         .map(|column: &ColumnInfo| column.name.clone())
         .collect()
+}
+
+fn http_manifest_with_inputs() -> Value {
+    json!({
+        "name": "demo",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "inputs": {
+            "DD_SITE": {
+                "kind": "variable",
+                "default": "datadoghq.com",
+                "hint": "Datadog site host"
+            },
+            "ACCOUNT_ID": {
+                "kind": "variable",
+                "hint": "Numeric account identifier"
+            },
+            "API_TOKEN": {
+                "kind": "secret",
+                "hint": "Bearer token"
+            }
+        },
+        "base_url": "https://api.{{input.DD_SITE}}",
+        "tables": [{
+            "name": "items",
+            "description": "Example items",
+            "request": {
+                "method": "GET",
+                "path": "/api/items"
+            },
+            "response": {
+                "rows_path": ["data"]
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" }
+            ]
+        }]
+    })
+}
+
+fn build_demo_source(
+    variables: &[(&str, &str)],
+    secrets: &[(&str, &str)],
+) -> QuerySource {
+    let to_map = |items: &[(&str, &str)]| -> BTreeMap<String, String> {
+        items
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    };
+    build_source_with_inputs(http_manifest_with_inputs(), to_map(variables), to_map(secrets))
+}
+
+#[tokio::test]
+async fn coral_inputs_exposes_variable_values_and_defaults() {
+    let sources = vec![build_demo_source(
+        &[("ACCOUNT_ID", "123456")],
+        &[("API_TOKEN", "secret-value")],
+    )];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT key, kind, value, default_value, hint, required, is_set \
+             FROM coral.inputs WHERE schema_name = 'demo' ORDER BY key",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+
+    // Arrow's JSON writer omits NULL fields from object output.
+    assert_eq!(
+        rows,
+        vec![
+            json!({
+                "key": "ACCOUNT_ID",
+                "kind": "variable",
+                "value": "123456",
+                "hint": "Numeric account identifier",
+                "required": true,
+                "is_set": true,
+            }),
+            json!({
+                "key": "API_TOKEN",
+                "kind": "secret",
+                "hint": "Bearer token",
+                "required": true,
+                "is_set": true,
+            }),
+            json!({
+                "key": "DD_SITE",
+                "kind": "variable",
+                "value": "datadoghq.com",
+                "default_value": "datadoghq.com",
+                "hint": "Datadog site host",
+                "required": false,
+                "is_set": true,
+            }),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn coral_inputs_marks_unset_secrets_and_missing_variables() {
+    let sources = vec![build_demo_source(&[], &[])];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT key, value, is_set FROM coral.inputs \
+             WHERE schema_name = 'demo' ORDER BY key",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({"key": "ACCOUNT_ID", "is_set": false}),
+            json!({"key": "API_TOKEN", "is_set": false}),
+            json!({"key": "DD_SITE", "value": "datadoghq.com", "is_set": true}),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn coral_inputs_never_exposes_secret_values() {
+    // Canary: secret values must never appear in coral.inputs under any filter.
+    let sources = vec![build_demo_source(&[], &[("API_TOKEN", "ultra-secret")])];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT value FROM coral.inputs WHERE kind = 'secret'",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+
+    assert!(!rows.is_empty(), "expected at least one secret row");
+    for row in &rows {
+        assert!(
+            row["value"].is_null(),
+            "secret value must be NULL, got {row}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn coral_inputs_reports_explicit_empty_variable_as_set() {
+    // A user-configured empty string is still "set" — HTTP input resolution
+    // and required-variable validation both treat the key's presence as
+    // authoritative. See crates/coral-app/src/sources/manager.rs.
+    let sources = vec![build_demo_source(&[("ACCOUNT_ID", "")], &[])];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT key, value, is_set FROM coral.inputs \
+             WHERE schema_name = 'demo' AND key = 'ACCOUNT_ID'",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"key": "ACCOUNT_ID", "value": "", "is_set": true})]);
+}
+
+#[tokio::test]
+async fn coral_inputs_empty_for_sources_without_declared_inputs() {
+    // The JSONL fixtures declare no inputs; coral.inputs should be empty.
+    let (_temp, sources) = build_catalog_sources();
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&sources, &TestRuntime, "SELECT * FROM coral.inputs")
+            .await
+            .expect("catalog query should succeed"),
+    );
+
+    assert!(rows.is_empty(), "expected no inputs, got {rows:?}");
 }

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -296,17 +296,18 @@ fn http_manifest_with_inputs() -> Value {
     })
 }
 
-fn build_demo_source(
-    variables: &[(&str, &str)],
-    secrets: &[(&str, &str)],
-) -> QuerySource {
+fn build_demo_source(variables: &[(&str, &str)], secrets: &[(&str, &str)]) -> QuerySource {
     let to_map = |items: &[(&str, &str)]| -> BTreeMap<String, String> {
         items
             .iter()
             .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
             .collect()
     };
-    build_source_with_inputs(http_manifest_with_inputs(), to_map(variables), to_map(secrets))
+    build_source_with_inputs(
+        http_manifest_with_inputs(),
+        to_map(variables),
+        to_map(secrets),
+    )
 }
 
 #[tokio::test]
@@ -426,7 +427,10 @@ async fn coral_inputs_reports_explicit_empty_variable_as_set() {
         .expect("catalog query should succeed"),
     );
 
-    assert_eq!(rows, vec![json!({"key": "ACCOUNT_ID", "value": "", "is_set": true})]);
+    assert_eq!(
+        rows,
+        vec![json!({"key": "ACCOUNT_ID", "value": "", "is_set": true})]
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -14,9 +14,23 @@ SELECT schema_name, table_name, description, required_filters FROM coral.tables 
 {{COLUMNS_EXAMPLE}}
 ```
 
+## Per-Source Configuration
+
+Per-source config values (e.g. Datadog site, Sentry org slug, GitHub API base URL) are exposed via `coral.inputs`. Use it to compose absolute URLs or account-scoped identifiers from source variables. Secret values are never exposed — secret rows always have `value IS NULL`, but `is_set` tells you whether the secret is configured.
+
+```sql
+-- Look up a variable value
+SELECT value FROM coral.inputs
+WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
+
+-- Check which secrets are configured (without revealing values)
+SELECT schema_name, key FROM coral.inputs
+WHERE kind = 'secret' AND is_set;
+```
+
 ## Query Guidance
 
 - Fully qualify tables in SQL, for example `slack.messages`.
 - Check `coral.tables.required_filters` and `coral.columns.is_required_filter` before querying tables that depend on filter-only inputs.
 - Cross-source joins work with standard SQL after source scans complete.
-- `list_tables` and `coral://tables` show queryable fully qualified tables; `coral.tables` and `coral.columns` provide richer SQL metadata.
+- `list_tables` and `coral://tables` show queryable fully qualified tables; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -202,13 +202,6 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources.
 
-Agents can also read per-source configuration (for example, the Datadog site or Sentry organization slug) from the virtual `coral.inputs` table to compose absolute URLs and account-scoped identifiers. Secret values are never exposed — secret rows always have `value IS NULL`, but `is_set` reports whether the secret is configured.
-
-```sql
-SELECT value FROM coral.inputs
-WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
-```
-
 ## Troubleshooting
 
 - **`coral` not found:** Make sure `coral` is on your `PATH`, or use the full path from `which coral` in your client config.

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -202,6 +202,13 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources.
 
+Agents can also read per-source configuration (for example, the Datadog site or Sentry organization slug) from the virtual `coral.inputs` table to compose absolute URLs and account-scoped identifiers. Secret values are never exposed — secret rows always have `value IS NULL`, but `is_set` reports whether the secret is configured.
+
+```sql
+SELECT value FROM coral.inputs
+WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
+```
+
 ## Troubleshooting
 
 - **`coral` not found:** Make sure `coral` is on your `PATH`, or use the full path from `which coral` in your client config.

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -5,7 +5,7 @@ description: "Extend Coral by adding any API or dataset as a queryable source."
 
 Coral ships with [popular data sources](/reference/bundled-sources), but you are not limited to them. If the data source you need is not available out of the box, you can write a source spec in YAML and import it.
 
-A source spec tells Coral how to connect to an API or read a local dataset, what tables to expose, and what columns each table has. Once added, the source works exactly like a bundled one: same SQL, same `coral.tables` and `coral.columns`, same MCP surface.
+A source spec tells Coral how to connect to an API or read a local dataset, what tables to expose, and what columns each table has. Once added, the source works exactly like a bundled one: same SQL, same `coral.tables`, `coral.columns` and `coral.inputs`, same MCP surface.
 
 ## Agent-driven authoring
 
@@ -15,7 +15,7 @@ Source authoring works well as an agent-driven workflow. Point your coding agent
 2. Lints the file with `coral source lint ./my-source.yaml` to catch errors before installing
 3. Adds it with `coral source add --file ./my-source.yaml`
 4. Validates with `coral source test my_source`
-5. Inspects `coral.tables` and `coral.columns` to check the shape
+5. Inspects `coral.tables`, `coral.columns` and `coral.inputs` to check the shape
 6. Refines and repeats until the tables look right
 
 ## Example: local JSONL source
@@ -129,6 +129,6 @@ For the full set of HTTP response, pagination, auth, and column fields, see [HTT
 ## Tips
 
 - **Lint before installing.** Run `coral source lint ./my-source.yaml` to catch schema and semantic errors without touching your workspace.
-- **Start small.** Begin with one table and a few columns. Validate with `coral source test`, check `coral.columns`, then expand.
-- **Use `coral.tables` and `coral.columns`.** They show you exactly what Coral sees after adding a source — including required filters and column metadata.
+- **Start small.** Begin with one table and a few columns. Validate with `coral source test`, check `coral.columns` and `coral.inputs`, then expand.
+- **Use `coral.tables`, `coral.columns`, and `coral.inputs`.** They show you exactly what Coral sees after adding a source — including required filters and column metadata.
 - **Look at bundled sources for patterns.** The bundled source specs in the repo under `sources/` are working examples of HTTP pagination, response parsing, auth, and inputs.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -205,7 +205,7 @@ In this minimal example:
 
 - `response: {}` means "use the default response rules" for an HTTP table
 - with the default response rules, Coral treats the selected response value directly as rows unless you configure a different `row_strategy`
-- `inputs` declares the install-time prompts for this source in stable authored order
+- `inputs` declares the install-time prompts for this source in stable authored order. (At runtime, these are surfaced through `coral.inputs`.)
 - `{{input.API_TOKEN}}` is resolved from the store implied by the declared input kind
 
 ### HTTP rate limiting


### PR DESCRIPTION
## Summary
- Adds a `coral.inputs` virtual table (`schema_name`, `key`, `kind`, `value`, `default_value`, `hint`, `required`, `is_set`) so agents can introspect per-source config like Datadog's `DD_SITE` or Sentry's `SENTRY_ORG` and compose absolute URLs or account-scoped identifiers.
- Secret values are never exposed — secret rows always have `value IS NULL`, with `is_set` reporting whether the secret is configured; the canary test locks this invariant in.
- `is_set` for variables is derived from key presence (matching the app layer's required-variable validation), so an explicitly-configured empty string is correctly reported as set.
- Updates the MCP `coral://guide` template and the user-facing `docs/guides/use-coral-over-mcp.mdx`.

## Test plan
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [ ] Manual: `coral sql "SELECT * FROM coral.inputs WHERE schema_name='datadog'"` shows `DD_SITE` value and `DD_API_KEY` with NULL value