### PR TITLE
docs: reframe intro subtitle around agent use case

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Introduction to Coral"
-description: "Coral is a local-first SQL interface for APIs, files, and other data sources."
+description: "Coral is a single SQL interface for APIs, files, and other data sources."
 ---
 
-Coral gives agents and developers one local-first SQL interface over APIs, files, and other data sources. It has support for a number of [popular data sources](/reference/bundled-sources) bundled in, and you can easily extend it to accommodate others by writing your own [source specs](/reference/source-spec-reference). You can run SQL from the [CLI](/reference/cli-reference) or through [MCP](/guides/use-coral-over-mcp). And everything is local; your data, credentials and usage history never leave your machine.
+With Coral, agents can make fewer, more precise tool calls, as a result it is more efficient than using individual MCP servers, CLI tools or API wrappers. It has support for a number of [popular data sources](/reference/bundled-sources) bundled in, and you can easily extend it to accommodate others by writing your own [source specs](/reference/source-spec-reference). You can run SQL from the [CLI](/reference/cli-reference) or through [MCP](/guides/use-coral-over-mcp). And everything is local; your data, credentials and usage history never leave your machine.
 
 ## Get started
 


### PR DESCRIPTION
## Summary
- Update the docs landing page subtitle to frame Coral as an SQL interface for agents, positioned against direct MCP/CLI/API-wrapper usage.

## Test plan
- [x] Docs site preview renders the new subtitle under the "Introduction to Coral" header.