### PR TITLE
docs: use canonical Discord link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,7 +59,7 @@
       },
       {
         "type": "discord",
-        "href": "https://discord.gg/h9aun8KpFF"
+        "href": "https://withcoral.com/discord"
       }
     ]
   },

--- a/docs/global.css
+++ b/docs/global.css
@@ -28,6 +28,6 @@ pre {
 
 /* Keep only the icon for GitHub and Discord navbar links. */
 a[href="https://github.com/withcoral/coral"] span,
-a[href="https://discord.gg/h9aun8KpFF"] span {
+a[href="https://withcoral.com/discord"] span {
   display: none !important;
 }

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -41,4 +41,4 @@ Supported sources fall into two categories.
 To update bundled sources, upgrade the Coral binary. Coral resolves each bundled manifest from the current binary at validate or query time, so spec fixes and newly required inputs are picked up automatically, you don't need to remove and re-add the source. Your configured variables and secrets stay in local state across upgrades.
 ## Don't see what you need?
 
-The bundled set is growing. If your data source is not listed, [write a custom source](/guides/write-a-custom-source), or reach out to us via [Discord](https://discord.gg/h9aun8KpFF) or [GitHub](https://github.com/withcoral/coral/issues).
+The bundled set is growing. If your data source is not listed, [write a custom source](/guides/write-a-custom-source), or reach out to us via [Discord](https://withcoral.com/discord) or [GitHub](https://github.com/withcoral/coral/issues).


### PR DESCRIPTION
## Summary
Use the canonical `withcoral.com/discord` URL anywhere the docs currently surface the Discord community link.

## Why
The docs should point at the stable branded invite URL instead of embedding a raw Discord invite code in multiple places.

## Testing
- `git diff --check`
- `rg -n "discord\\.gg/h9aun8KpFF|withcoral\\.com/discord" docs`
