### PR TITLE
feat: typed auth system with AWS SigV4 signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,8 +558,8 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "matchit",
@@ -464,8 +582,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -479,6 +597,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bigdecimal"
@@ -601,6 +729,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bzip2"
@@ -851,6 +989,8 @@ version = "0.1.3"
 dependencies = [
  "arrow",
  "async-trait",
+ "aws-credential-types",
+ "aws-sigv4",
  "base64",
  "bytes",
  "coral-spec",
@@ -2078,7 +2218,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -2149,6 +2289,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,12 +2320,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -2176,8 +2347,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2210,8 +2381,8 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2227,7 +2398,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2260,8 +2431,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "hyper",
  "ipnet",
  "libc",
@@ -2879,7 +3050,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "humantime",
  "hyper",
@@ -2935,6 +3106,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -3069,6 +3246,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -3523,8 +3706,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -4299,8 +4482,8 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "hyper",
  "hyper-timeout",
@@ -4395,8 +4578,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -4553,6 +4736,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"
@@ -5070,7 +5259,7 @@ dependencies = [
  "base64",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
  "hyper",
  "hyper-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ assert_cmd = "2"
 anyhow = "1"
 arrow = "57.3.0"
 async-trait = "0.1"
+aws-credential-types = "1.2"
+aws-sigv4 = "1.4"
 base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -166,9 +166,11 @@ inputs:
     kind: secret
 base_url: "{{input.API_BASE}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.API_TOKEN}}"
 tables:
   - name: messages
     description: Demo messages

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -516,9 +516,11 @@ inputs:
     kind: secret
 base_url: "{{input.API_BASE}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.API_TOKEN}}"
 tables:
   - name: messages
     description: Secured messages

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -232,9 +232,12 @@ pub(crate) fn fixture_manifest_with_inputs_yaml() -> String {
         },
         "base_url": "{{input.API_BASE}}",
         "auth": {
-            "type": "ApiKeyAuth",
-            "header": "Authorization",
-            "api_token": "Bearer {{input.API_TOKEN}}",
+            "type": "HeaderAuth",
+            "headers": [{
+                "name": "Authorization",
+                "from": "template",
+                "template": "Bearer {{input.API_TOKEN}}",
+            }],
         },
         "tables": [{
             "name": "messages",
@@ -263,9 +266,12 @@ pub(crate) fn fixture_manifest_with_required_inputs_yaml() -> String {
         },
         "base_url": "{{input.API_BASE}}",
         "auth": {
-            "type": "ApiKeyAuth",
-            "header": "Authorization",
-            "api_token": "Bearer {{input.API_TOKEN}}",
+            "type": "HeaderAuth",
+            "headers": [{
+                "name": "Authorization",
+                "from": "template",
+                "template": "Bearer {{input.API_TOKEN}}",
+            }],
         },
         "tables": [{
             "name": "messages",

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -22,9 +22,11 @@ fn source_test_errors_when_required_secret_is_missing() {
       TEST_API_KEY:
         kind: secret
     auth:
-      type: ApiKeyAuth
-      header: Authorization
-      api_token: "{{input.TEST_API_KEY}}"
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: template
+          template: "{{input.TEST_API_KEY}}"
     tables:
       - name: dummy
         description: dummy table

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -12,6 +12,8 @@ workspace = true
 [dependencies]
 async-trait.workspace = true
 arrow.workspace = true
+aws-credential-types.workspace = true
+aws-sigv4.workspace = true
 base64.workspace = true
 bytes.workspace = true
 datafusion.workspace = true

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -6,8 +6,7 @@
 //! [`AuthContext`]; dynamic variants (AWS `SigV4` and future signers) sign over
 //! them.
 
-use std::collections::{BTreeMap, HashMap};
-use std::sync::LazyLock;
+use std::collections::BTreeMap;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -16,12 +15,9 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use coral_spec::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 
-use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
-
-/// Empty filter and state maps — auth is source-scoped and has no per-request
-/// context. Shared by every [`Authenticator`] impl so each doesn't allocate
-/// its own empty maps.
-pub(crate) static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
+use crate::backends::shared::template::{
+    EMPTY_MAP, render_template, resolve_value_source, value_to_string,
+};
 
 /// Context passed to [`Authenticator::auth`]. Wraps the fully-built
 /// `reqwest::Request` so authenticators can read whatever parts they need

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -1,15 +1,18 @@
 //! Authentication header resolution for HTTP source manifests.
 //!
 //! Each [`AuthSpec`] variant implements [`Authenticator::auth`], returning the
-//! list of headers to attach to an outbound request. Static variants (API keys,
-//! Basic, raw headers) ignore the request-shaped fields on [`AuthContext`];
-//! dynamic variants (AWS SigV4 and future signers) sign over them.
+//! list of typed headers to attach to an outbound request. Static variants
+//! (API keys, Basic, raw headers) ignore the request-shaped fields on
+//! [`AuthContext`]; dynamic variants (AWS `SigV4` and future signers) sign over
+//! them.
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::LazyLock;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use datafusion::error::{DataFusionError, Result};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
 use coral_spec::{
     ApiKeyAuthSpec, AuthSpec, BasicHttpAuthSpec, CustomAuthSpec, CustomHeadersAuthSpec,
@@ -17,85 +20,118 @@ use coral_spec::{
 
 use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
 
-/// Context passed to [`Authenticator::auth`]. Populated just before a request
-/// is sent, so dynamic authenticators can sign over the final method, URL,
-/// headers, and body.
+/// Empty filter and state maps — auth is source-scoped and has no per-request
+/// context. Shared by every [`Authenticator`] impl so each doesn't allocate
+/// its own empty maps.
+pub(crate) static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
+
+/// Context passed to [`Authenticator::auth`]. Wraps the fully-built
+/// `reqwest::Request` so authenticators can read whatever parts they need
+/// (method, URL, headers, body) without the caller pre-extracting each field.
 pub(crate) struct AuthContext<'a> {
-    pub(crate) method: &'a reqwest::Method,
-    pub(crate) url: &'a str,
-    pub(crate) headers: &'a [(String, String)],
-    pub(crate) body: Option<&'a [u8]>,
+    pub(crate) request: &'a reqwest::Request,
     pub(crate) resolved_inputs: &'a BTreeMap<String, String>,
 }
 
-pub(crate) trait Authenticator {
-    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>>;
+impl<'a> AuthContext<'a> {
+    pub(crate) fn method(&self) -> &reqwest::Method {
+        self.request.method()
+    }
+
+    pub(crate) fn url(&self) -> &reqwest::Url {
+        self.request.url()
+    }
+
+    pub(crate) fn headers(&self) -> &HeaderMap {
+        self.request.headers()
+    }
+
+    pub(crate) fn body(&self) -> Option<&'a [u8]> {
+        self.request.body().and_then(|b| b.as_bytes())
+    }
 }
 
-// AWS SigV4 impl lives in `super::custom::aws`; referencing the module here
-// ensures its `impl Authenticator for AwsSigV4Spec` block is linked into the
-// crate even though the module is only used via trait dispatch.
-use super::custom::aws as _;
+pub(crate) trait Authenticator {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>>;
+}
 
 impl Authenticator for ApiKeyAuthSpec {
-    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
-        let empty_filters: HashMap<String, String> = HashMap::new();
-        let empty_state: HashMap<String, String> = HashMap::new();
-        let token = render_template(
-            &self.api_token,
-            &empty_filters,
-            &empty_state,
-            ctx.resolved_inputs,
-        )?;
-        Ok(vec![(self.header.clone(), token)])
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        let token = render_template(&self.api_token, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs)?;
+        let name = HeaderName::try_from(self.header.as_str()).map_err(|e| {
+            DataFusionError::Execution(format!("invalid auth header name '{}': {e}", self.header))
+        })?;
+        let value = HeaderValue::try_from(token.as_str()).map_err(|e| {
+            DataFusionError::Execution(format!(
+                "invalid auth header value for '{}': {e}",
+                self.header
+            ))
+        })?;
+        Ok(vec![(name, value)])
     }
 }
 
 impl Authenticator for BasicHttpAuthSpec {
-    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
-        let empty_filters: HashMap<String, String> = HashMap::new();
-        let empty_state: HashMap<String, String> = HashMap::new();
-        let username = render_template(
-            &self.username,
-            &empty_filters,
-            &empty_state,
-            ctx.resolved_inputs,
-        )?;
-        let password = render_template(
-            &self.password,
-            &empty_filters,
-            &empty_state,
-            ctx.resolved_inputs,
-        )?;
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        let username =
+            render_template(&self.username, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs)?;
+        let password =
+            render_template(&self.password, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs)?;
         let encoded = BASE64_STANDARD.encode(format!("{username}:{password}"));
-        Ok(vec![(
-            "Authorization".to_string(),
-            format!("Basic {encoded}"),
-        )])
+        let value = HeaderValue::try_from(format!("Basic {encoded}").as_str()).map_err(|e| {
+            DataFusionError::Execution(format!("invalid Basic auth header value: {e}"))
+        })?;
+        Ok(vec![(reqwest::header::AUTHORIZATION, value)])
     }
 }
 
 impl Authenticator for CustomHeadersAuthSpec {
-    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
-        let empty_filters: HashMap<String, String> = HashMap::new();
-        let empty_state: HashMap<String, String> = HashMap::new();
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let mut out = Vec::with_capacity(self.headers.len());
         for header in &self.headers {
-            let resolved = resolve_value_source(
-                &header.value,
-                &empty_filters,
-                &empty_state,
-                ctx.resolved_inputs,
-            )?
-            .ok_or_else(|| {
+            let resolved =
+                resolve_value_source(&header.value, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs)?
+                    .ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "missing value for auth header '{}'",
+                        header.name
+                    ))
+                })?;
+            let name = HeaderName::try_from(header.name.as_str()).map_err(|e| {
                 DataFusionError::Execution(format!(
-                    "missing value for auth header '{}'",
+                    "invalid auth header name '{}': {e}",
                     header.name
                 ))
             })?;
-            out.push((header.name.clone(), value_to_string(&resolved)));
+            let value =
+                HeaderValue::try_from(value_to_string(&resolved).as_str()).map_err(|e| {
+                    DataFusionError::Execution(format!(
+                        "invalid auth header value for '{}': {e}",
+                        header.name
+                    ))
+                })?;
+            out.push((name, value));
         }
         Ok(out)
+    }
+}
+
+impl Authenticator for CustomAuthSpec {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        match self {
+            CustomAuthSpec::AwsSigV4(spec) => spec.auth(ctx),
+        }
+    }
+}
+
+impl Authenticator for AuthSpec {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        match self {
+            AuthSpec::ApiKeyAuth(spec) => spec.auth(ctx),
+            AuthSpec::BasicHttpAuth(spec) => spec.auth(ctx),
+            AuthSpec::CustomHeadersAuth(spec) => spec.auth(ctx),
+            AuthSpec::CustomAuth(spec) => spec.auth(ctx),
+        }
     }
 }
 
@@ -110,41 +146,12 @@ pub(crate) fn resolve_auth_headers(
     let mut built = request.build().map_err(|error| {
         DataFusionError::Execution(format!("failed to build HTTP request: {error}"))
     })?;
-    let header_snapshot: Vec<(String, String)> = built
-        .headers()
-        .iter()
-        .map(|(name, value)| {
-            (
-                name.as_str().to_string(),
-                value.to_str().unwrap_or("").to_string(),
-            )
-        })
-        .collect();
-    let body_bytes: Option<&[u8]> = built.body().and_then(|b| b.as_bytes());
-    let ctx = AuthContext {
-        method: built.method(),
-        url: built.url().as_str(),
-        headers: &header_snapshot,
-        body: body_bytes,
+    let headers = auth.auth(&AuthContext {
+        request: &built,
         resolved_inputs,
-    };
-
-    let headers = match auth {
-        AuthSpec::ApiKeyAuth(spec) => spec.auth(&ctx),
-        AuthSpec::BasicHttpAuth(spec) => spec.auth(&ctx),
-        AuthSpec::CustomHeadersAuth(spec) => spec.auth(&ctx),
-        AuthSpec::CustomAuth(custom) => match custom {
-            CustomAuthSpec::AwsSigV4(spec) => spec.auth(&ctx),
-        },
-    }?;
-
+    })?;
     for (name, value) in headers {
-        let header_name = reqwest::header::HeaderName::try_from(name.as_str()).map_err(|e| {
-            DataFusionError::Execution(format!("invalid auth header name '{name}': {e}"))
-        })?;
-        let header_value = reqwest::header::HeaderValue::try_from(value.as_str())
-            .map_err(|e| DataFusionError::Execution(format!("invalid auth header value: {e}")))?;
-        built.headers_mut().append(header_name, header_value);
+        built.headers_mut().append(name, value);
     }
     Ok(built)
 }

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -150,8 +150,12 @@ pub(crate) fn resolve_auth_headers(
         request: &built,
         resolved_inputs,
     })?;
+    // `insert` (not `append`) so the computed auth value is authoritative —
+    // any header already attached to the built request under the same name
+    // (from `request_headers:`, per-request headers, or reqwest defaults) is
+    // replaced rather than duplicated.
     for (name, value) in headers {
-        built.headers_mut().append(name, value);
+        built.headers_mut().insert(name, value);
     }
     Ok(built)
 }

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -16,8 +16,7 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use coral_spec::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 
 use crate::backends::shared::template::{
-    EMPTY_MAP, render_template, resolve_value_source, validate_input_dependencies,
-    validate_value_source_inputs, value_to_string,
+    EMPTY_MAP, render_template, resolve_value_source, value_to_string,
 };
 
 /// Context passed to [`Authenticator::auth`]. Wraps the fully-built
@@ -70,8 +69,8 @@ impl Authenticator for BasicAuthSpec {
     }
 
     fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
-        validate_input_dependencies(&self.username, resolved_inputs)?;
-        validate_input_dependencies(&self.password, resolved_inputs)?;
+        render_template(&self.username, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
+        render_template(&self.password, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
         Ok(())
     }
 }
@@ -108,7 +107,26 @@ impl Authenticator for HeaderAuthSpec {
 
     fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
         for header in &self.headers {
-            validate_value_source_inputs(&header.value, resolved_inputs)?;
+            let resolved =
+                resolve_value_source(&header.value, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "missing value for auth header '{}'",
+                            header.name
+                        ))
+                    })?;
+            HeaderName::try_from(header.name.as_str()).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "invalid auth header name '{}': {e}",
+                    header.name
+                ))
+            })?;
+            let _ = HeaderValue::try_from(value_to_string(&resolved).as_str()).map_err(|e| {
+                DataFusionError::Execution(format!(
+                    "invalid auth header value for '{}': {e}",
+                    header.name
+                ))
+            })?;
         }
         Ok(())
     }

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -2,7 +2,7 @@
 //!
 //! Each [`AuthSpec`] variant implements [`Authenticator::auth`], returning the
 //! list of typed headers to attach to an outbound request. Static variants
-//! (API keys, Basic, raw headers) ignore the request-shaped fields on
+//! (Basic, declarative headers) ignore the request-shaped fields on
 //! [`AuthContext`]; dynamic variants (AWS `SigV4` and future signers) sign over
 //! them.
 
@@ -14,9 +14,7 @@ use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use datafusion::error::{DataFusionError, Result};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 
-use coral_spec::{
-    ApiKeyAuthSpec, AuthSpec, BasicHttpAuthSpec, CustomAuthSpec, CustomHeadersAuthSpec,
-};
+use coral_spec::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 
 use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
 
@@ -55,23 +53,7 @@ pub(crate) trait Authenticator {
     fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>>;
 }
 
-impl Authenticator for ApiKeyAuthSpec {
-    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
-        let token = render_template(&self.api_token, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs)?;
-        let name = HeaderName::try_from(self.header.as_str()).map_err(|e| {
-            DataFusionError::Execution(format!("invalid auth header name '{}': {e}", self.header))
-        })?;
-        let value = HeaderValue::try_from(token.as_str()).map_err(|e| {
-            DataFusionError::Execution(format!(
-                "invalid auth header value for '{}': {e}",
-                self.header
-            ))
-        })?;
-        Ok(vec![(name, value)])
-    }
-}
-
-impl Authenticator for BasicHttpAuthSpec {
+impl Authenticator for BasicAuthSpec {
     fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let username =
             render_template(&self.username, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs)?;
@@ -85,7 +67,7 @@ impl Authenticator for BasicHttpAuthSpec {
     }
 }
 
-impl Authenticator for CustomHeadersAuthSpec {
+impl Authenticator for HeaderAuthSpec {
     fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let mut out = Vec::with_capacity(self.headers.len());
         for header in &self.headers {
@@ -127,9 +109,8 @@ impl Authenticator for CustomAuthSpec {
 impl Authenticator for AuthSpec {
     fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
         match self {
-            AuthSpec::ApiKeyAuth(spec) => spec.auth(ctx),
-            AuthSpec::BasicHttpAuth(spec) => spec.auth(ctx),
-            AuthSpec::CustomHeadersAuth(spec) => spec.auth(ctx),
+            AuthSpec::BasicAuth(spec) => spec.auth(ctx),
+            AuthSpec::HeaderAuth(spec) => spec.auth(ctx),
             AuthSpec::CustomAuth(spec) => spec.auth(ctx),
         }
     }

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -16,7 +16,8 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use coral_spec::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 
 use crate::backends::shared::template::{
-    EMPTY_MAP, render_template, resolve_value_source, value_to_string,
+    EMPTY_MAP, render_template, resolve_value_source, validate_input_dependencies,
+    validate_value_source_inputs, value_to_string,
 };
 
 /// Context passed to [`Authenticator::auth`]. Wraps the fully-built
@@ -47,6 +48,12 @@ impl<'a> AuthContext<'a> {
 
 pub(crate) trait Authenticator {
     fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>>;
+
+    /// Registration-time check: every template / value source this
+    /// authenticator depends on must resolve from `resolved_inputs` (or a
+    /// token-level default). Called before any request is issued so invalid
+    /// source configs fail import instead of first fetch.
+    fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()>;
 }
 
 impl Authenticator for BasicAuthSpec {
@@ -60,6 +67,12 @@ impl Authenticator for BasicAuthSpec {
             DataFusionError::Execution(format!("invalid Basic auth header value: {e}"))
         })?;
         Ok(vec![(reqwest::header::AUTHORIZATION, value)])
+    }
+
+    fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
+        validate_input_dependencies(&self.username, resolved_inputs)?;
+        validate_input_dependencies(&self.password, resolved_inputs)?;
+        Ok(())
     }
 }
 
@@ -92,12 +105,25 @@ impl Authenticator for HeaderAuthSpec {
         }
         Ok(out)
     }
+
+    fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
+        for header in &self.headers {
+            validate_value_source_inputs(&header.value, resolved_inputs)?;
+        }
+        Ok(())
+    }
 }
 
 impl Authenticator for CustomAuthSpec {
     fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
         match self {
             CustomAuthSpec::AwsSigV4(spec) => spec.auth(ctx),
+        }
+    }
+
+    fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
+        match self {
+            CustomAuthSpec::AwsSigV4(spec) => spec.validate_inputs(resolved_inputs),
         }
     }
 }
@@ -108,6 +134,14 @@ impl Authenticator for AuthSpec {
             AuthSpec::BasicAuth(spec) => spec.auth(ctx),
             AuthSpec::HeaderAuth(spec) => spec.auth(ctx),
             AuthSpec::CustomAuth(spec) => spec.auth(ctx),
+        }
+    }
+
+    fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
+        match self {
+            AuthSpec::BasicAuth(spec) => spec.validate_inputs(resolved_inputs),
+            AuthSpec::HeaderAuth(spec) => spec.validate_inputs(resolved_inputs),
+            AuthSpec::CustomAuth(spec) => spec.validate_inputs(resolved_inputs),
         }
     }
 }

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -1,0 +1,150 @@
+//! Authentication header resolution for HTTP source manifests.
+//!
+//! Each [`AuthSpec`] variant implements [`Authenticator::auth`], returning the
+//! list of headers to attach to an outbound request. Static variants (API keys,
+//! Basic, raw headers) ignore the request-shaped fields on [`AuthContext`];
+//! dynamic variants (AWS SigV4 and future signers) sign over them.
+
+use std::collections::{BTreeMap, HashMap};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use datafusion::error::{DataFusionError, Result};
+
+use coral_spec::{
+    ApiKeyAuthSpec, AuthSpec, BasicHttpAuthSpec, CustomAuthSpec, CustomHeadersAuthSpec,
+};
+
+use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
+
+/// Context passed to [`Authenticator::auth`]. Populated just before a request
+/// is sent, so dynamic authenticators can sign over the final method, URL,
+/// headers, and body.
+pub(crate) struct AuthContext<'a> {
+    pub(crate) method: &'a reqwest::Method,
+    pub(crate) url: &'a str,
+    pub(crate) headers: &'a [(String, String)],
+    pub(crate) body: Option<&'a [u8]>,
+    pub(crate) resolved_inputs: &'a BTreeMap<String, String>,
+}
+
+pub(crate) trait Authenticator {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>>;
+}
+
+// AWS SigV4 impl lives in `super::custom::aws`; referencing the module here
+// ensures its `impl Authenticator for AwsSigV4Spec` block is linked into the
+// crate even though the module is only used via trait dispatch.
+use super::custom::aws as _;
+
+impl Authenticator for ApiKeyAuthSpec {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
+        let empty_filters: HashMap<String, String> = HashMap::new();
+        let empty_state: HashMap<String, String> = HashMap::new();
+        let token = render_template(
+            &self.api_token,
+            &empty_filters,
+            &empty_state,
+            ctx.resolved_inputs,
+        )?;
+        Ok(vec![(self.header.clone(), token)])
+    }
+}
+
+impl Authenticator for BasicHttpAuthSpec {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
+        let empty_filters: HashMap<String, String> = HashMap::new();
+        let empty_state: HashMap<String, String> = HashMap::new();
+        let username = render_template(
+            &self.username,
+            &empty_filters,
+            &empty_state,
+            ctx.resolved_inputs,
+        )?;
+        let password = render_template(
+            &self.password,
+            &empty_filters,
+            &empty_state,
+            ctx.resolved_inputs,
+        )?;
+        let encoded = BASE64_STANDARD.encode(format!("{username}:{password}"));
+        Ok(vec![(
+            "Authorization".to_string(),
+            format!("Basic {encoded}"),
+        )])
+    }
+}
+
+impl Authenticator for CustomHeadersAuthSpec {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
+        let empty_filters: HashMap<String, String> = HashMap::new();
+        let empty_state: HashMap<String, String> = HashMap::new();
+        let mut out = Vec::with_capacity(self.headers.len());
+        for header in &self.headers {
+            let resolved = resolve_value_source(
+                &header.value,
+                &empty_filters,
+                &empty_state,
+                ctx.resolved_inputs,
+            )?
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "missing value for auth header '{}'",
+                    header.name
+                ))
+            })?;
+            out.push((header.name.clone(), value_to_string(&resolved)));
+        }
+        Ok(out)
+    }
+}
+
+/// Materialize the request, run the variant-specific [`Authenticator`] over
+/// its final shape, and attach the returned headers. Takes ownership of the
+/// builder and returns the ready-to-send [`reqwest::Request`].
+pub(crate) fn resolve_auth_headers(
+    auth: &AuthSpec,
+    request: reqwest::RequestBuilder,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<reqwest::Request> {
+    let mut built = request.build().map_err(|error| {
+        DataFusionError::Execution(format!("failed to build HTTP request: {error}"))
+    })?;
+    let header_snapshot: Vec<(String, String)> = built
+        .headers()
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                value.to_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+    let body_bytes: Option<&[u8]> = built.body().and_then(|b| b.as_bytes());
+    let ctx = AuthContext {
+        method: built.method(),
+        url: built.url().as_str(),
+        headers: &header_snapshot,
+        body: body_bytes,
+        resolved_inputs,
+    };
+
+    let headers = match auth {
+        AuthSpec::ApiKeyAuth(spec) => spec.auth(&ctx),
+        AuthSpec::BasicHttpAuth(spec) => spec.auth(&ctx),
+        AuthSpec::CustomHeadersAuth(spec) => spec.auth(&ctx),
+        AuthSpec::CustomAuth(custom) => match custom {
+            CustomAuthSpec::AwsSigV4(spec) => spec.auth(&ctx),
+        },
+    }?;
+
+    for (name, value) in headers {
+        let header_name = reqwest::header::HeaderName::try_from(name.as_str()).map_err(|e| {
+            DataFusionError::Execution(format!("invalid auth header name '{name}': {e}"))
+        })?;
+        let header_value = reqwest::header::HeaderValue::try_from(value.as_str())
+            .map_err(|e| DataFusionError::Execution(format!("invalid auth header value: {e}")))?;
+        built.headers_mut().append(header_name, header_value);
+    }
+    Ok(built)
+}

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -9,7 +9,7 @@ use reqwest::header::HeaderMap;
 use serde_json::{Map, Value, json};
 
 use crate::backends::http::ProviderQueryError;
-use crate::backends::http::auth::{AuthContext, Authenticator, resolve_auth_headers};
+use crate::backends::http::auth::{Authenticator, resolve_auth_headers};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::template::{
@@ -352,22 +352,15 @@ fn validate_source_scoped_http_config(
         })?;
     }
 
-    // Auth is source-scoped — `Authenticator::auth` always runs against
-    // empty filters/state at runtime too, so signing a synthetic request
-    // here exercises the same template-resolution contract as real fetches.
-    let validation_url = reqwest::Url::parse("http://preflight.invalid/")
-        .expect("static preflight URL must parse");
-    let request = reqwest::Request::new(reqwest::Method::GET, validation_url);
-    let ctx = AuthContext {
-        request: &request,
-        resolved_inputs,
-    };
-    let _ = manifest.auth.auth(&ctx).map_err(|error| {
-        DataFusionError::Execution(format!(
-            "{} source auth could not be resolved: {error}",
-            manifest.common.name
-        ))
-    })?;
+    manifest
+        .auth
+        .validate_inputs(resolved_inputs)
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "{} source auth could not be resolved: {error}",
+                manifest.common.name
+            ))
+        })?;
     Ok(())
 }
 

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -15,7 +15,7 @@ use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
 use coral_spec::{
-    AuthSpec, HeaderSpec, HttpMethod, ManifestInputKind, PageSizeSpec, ParsedTemplate, RowStrategy,
+    AuthSpec, HeaderSpec, HttpMethod, PageSizeSpec, ParsedTemplate, RowStrategy,
     ValidatedPagination, ValidatedPaginationMode,
 };
 
@@ -86,7 +86,8 @@ impl HttpSourceClient {
         source_secrets: &BTreeMap<String, String>,
         source_variables: &BTreeMap<String, String>,
     ) -> Result<Self> {
-        let resolved_inputs = build_resolved_inputs(manifest, source_secrets, source_variables);
+        let resolved_inputs =
+            coral_spec::resolve_inputs(&manifest.declared_inputs, source_secrets, source_variables);
 
         let request_timeout = Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS);
         let http = reqwest::Client::builder()
@@ -641,7 +642,6 @@ fn page_is_exhausted(rows_on_page: usize, page_size: Option<usize>) -> bool {
     rows_on_page == 0 || page_size.is_some_and(|requested| rows_on_page < requested)
 }
 
-
 fn pagination_state_values(state: &PageState) -> HashMap<String, String> {
     let mut values = HashMap::new();
     values.insert("page".to_string(), state.page.to_string());
@@ -650,27 +650,6 @@ fn pagination_state_values(state: &PageState) -> HashMap<String, String> {
         values.insert("cursor".to_string(), cursor.clone());
     }
     values
-}
-
-fn build_resolved_inputs(
-    manifest: &HttpSourceManifest,
-    source_secrets: &BTreeMap<String, String>,
-    source_variables: &BTreeMap<String, String>,
-) -> BTreeMap<String, String> {
-    let mut resolved = BTreeMap::new();
-    for input in &manifest.declared_inputs {
-        let value = match input.kind {
-            ManifestInputKind::Secret => source_secrets.get(&input.key).cloned(),
-            ManifestInputKind::Variable => source_variables
-                .get(&input.key)
-                .cloned()
-                .or_else(|| (!input.default_value.is_empty()).then(|| input.default_value.clone())),
-        };
-        if let Some(value) = value {
-            resolved.insert(input.key.clone(), value);
-        }
-    }
-    resolved
 }
 
 fn build_logged_url(url: &str, query_pairs: &[(String, String)]) -> String {

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -9,7 +9,7 @@ use reqwest::header::HeaderMap;
 use serde_json::{Map, Value, json};
 
 use crate::backends::http::ProviderQueryError;
-use crate::backends::http::auth::resolve_auth_headers;
+use crate::backends::http::auth::{AuthContext, Authenticator, EMPTY_MAP, resolve_auth_headers};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
@@ -88,6 +88,7 @@ impl HttpSourceClient {
     ) -> Result<Self> {
         let resolved_inputs =
             coral_spec::resolve_inputs(&manifest.declared_inputs, source_secrets, source_variables);
+        validate_source_scoped_http_config(manifest, &resolved_inputs)?;
 
         let request_timeout = Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS);
         let http = reqwest::Client::builder()
@@ -324,6 +325,64 @@ impl HttpSourceClient {
 
         Ok(all_rows)
     }
+}
+
+fn validate_source_scoped_http_config(
+    manifest: &HttpSourceManifest,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<()> {
+    let base_url = render_template(&manifest.base_url, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "{} source base_url could not be resolved: {error}",
+                manifest.common.name
+            ))
+        })?;
+    let url = reqwest::Url::parse(&normalize_base_url(&base_url)).map_err(|error| {
+        DataFusionError::Execution(format!(
+            "{} source base_url '{base_url}' is not a valid URL: {error}",
+            manifest.common.name
+        ))
+    })?;
+    let mut request = reqwest::Request::new(reqwest::Method::GET, url);
+
+    for header in &manifest.request_headers {
+        let resolved =
+            resolve_value_source(&header.value, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
+        let Some(value) = resolved else {
+            return Err(DataFusionError::Execution(format!(
+                "{} source request header '{}' could not be resolved",
+                manifest.common.name, header.name
+            )));
+        };
+        let name =
+            reqwest::header::HeaderName::try_from(header.name.as_str()).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "{} source request header name '{}' is invalid: {error}",
+                    manifest.common.name, header.name
+                ))
+            })?;
+        let header_value = reqwest::header::HeaderValue::try_from(value_to_string(&value).as_str())
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "{} source request header '{}' value is invalid: {error}",
+                    manifest.common.name, header.name
+                ))
+            })?;
+        request.headers_mut().append(name, header_value);
+    }
+
+    let ctx = AuthContext {
+        request: &request,
+        resolved_inputs,
+    };
+    let _ = manifest.auth.auth(&ctx).map_err(|error| {
+        DataFusionError::Execution(format!(
+            "{} source auth could not be resolved: {error}",
+            manifest.common.name
+        ))
+    })?;
+    Ok(())
 }
 
 #[allow(
@@ -875,9 +934,9 @@ mod tests {
     use tokio::task::JoinHandle;
 
     use super::{
-        AuthSpec, PageState, RequestSpec as HttpRequestSpec, apply_pagination_query_pairs,
-        execute_request, extract_next_link_url, extract_rows, join_url, normalize_base_url,
-        page_is_exhausted, resolve_value_source,
+        AuthSpec, HttpSourceClient, PageState, RequestSpec as HttpRequestSpec,
+        apply_pagination_query_pairs, execute_request, extract_next_link_url, extract_rows,
+        join_url, normalize_base_url, page_is_exhausted, resolve_value_source,
     };
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
@@ -1130,6 +1189,48 @@ mod tests {
             error
                 .to_string()
                 .contains("filter 'start_time' value 'not-a-number' is not a valid i64")
+        );
+    }
+
+    #[test]
+    fn backend_client_requires_source_scoped_inputs_during_registration() {
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "alpha",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": "https://api.example.com",
+            "auth": {
+                "type": "ApiKeyAuth",
+                "header": "Authorization",
+                "api_token": "Bearer {{input.API_KEY}}"
+            },
+            "request_headers": [{
+                "name": "X-Api-Key",
+                "from": "input",
+                "key": "API_KEY"
+            }],
+            "inputs": {
+                "API_KEY": { "kind": "secret" }
+            },
+            "tables": [{
+                "name": "items",
+                "description": "items",
+                "request": { "path": "/items" },
+                "columns": [{
+                    "name": "id",
+                    "type": "Utf8"
+                }]
+            }]
+        }));
+
+        let error = HttpSourceClient::from_manifest(&manifest, &BTreeMap::new(), &BTreeMap::new())
+            .expect_err("missing source-scoped input must fail during registration");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing source input 'API_KEY' for template token")
         );
     }
 

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1194,7 +1194,7 @@ mod tests {
 
     #[test]
     fn backend_client_requires_source_scoped_inputs_during_registration() {
-        let manifest = parse_http_manifest(json!({
+        let auth_manifest = parse_http_manifest(json!({
             "dsl_version": 3,
             "name": "alpha",
             "version": "0.1.0",
@@ -1205,6 +1205,25 @@ mod tests {
                 "header": "Authorization",
                 "api_token": "Bearer {{input.API_KEY}}"
             },
+            "inputs": {
+                "API_KEY": { "kind": "secret" }
+            },
+            "tables": [{
+                "name": "items",
+                "description": "items",
+                "request": { "path": "/items" },
+                "columns": [{
+                    "name": "id",
+                    "type": "Utf8"
+                }]
+            }]
+        }));
+        let header_manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "alpha",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": "https://api.example.com",
             "request_headers": [{
                 "name": "X-Api-Key",
                 "from": "input",
@@ -1224,14 +1243,25 @@ mod tests {
             }]
         }));
 
-        let error = HttpSourceClient::from_manifest(&manifest, &BTreeMap::new(), &BTreeMap::new())
-            .expect_err("missing source-scoped input must fail during registration");
+        for (manifest, expected_detail) in [
+            (
+                auth_manifest,
+                "missing source input 'API_KEY' for template token",
+            ),
+            (
+                header_manifest,
+                "alpha source request header 'X-Api-Key' could not be resolved",
+            ),
+        ] {
+            let error =
+                HttpSourceClient::from_manifest(&manifest, &BTreeMap::new(), &BTreeMap::new())
+                    .expect_err("missing source-scoped input must fail during registration");
 
-        assert!(
-            error
-                .to_string()
-                .contains("missing source input 'API_KEY' for template token")
-        );
+            assert!(
+                error.to_string().contains(expected_detail),
+                "expected error to contain '{expected_detail}', got: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -334,34 +334,55 @@ fn validate_source_scoped_http_config(
     manifest: &HttpSourceManifest,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<()> {
-    // `base_url` and `request_headers` may legitimately reference
-    // `{{filter.X}}` / `{{state.X}}` tokens that only resolve per-request.
-    // Validate input dependencies only — runtime will handle the rest.
-    validate_input_dependencies(&manifest.base_url, resolved_inputs).map_err(|error| {
-        DataFusionError::Execution(format!(
-            "{} source base_url could not be resolved: {error}",
-            manifest.common.name
-        ))
-    })?;
+    check_base_url_inputs(manifest, resolved_inputs)?;
+    check_request_header_inputs(manifest, resolved_inputs)?;
+    check_auth_inputs(manifest, resolved_inputs)?;
+    Ok(())
+}
+
+/// `base_url` may reference `{{filter.*}}` / `{{state.*}}` that only resolve
+/// per-request. Check input-token deps only — runtime renders the rest.
+fn check_base_url_inputs(
+    manifest: &HttpSourceManifest,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<()> {
+    validate_input_dependencies(&manifest.base_url, resolved_inputs)
+        .map_err(|e| registration_error(&manifest.common.name, "base_url", &e))
+}
+
+/// Same tolerance for filter/state tokens as `base_url`.
+fn check_request_header_inputs(
+    manifest: &HttpSourceManifest,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<()> {
     for header in &manifest.request_headers {
-        validate_value_source_inputs(&header.value, resolved_inputs).map_err(|error| {
-            DataFusionError::Execution(format!(
-                "{} source request header '{}' could not be resolved: {error}",
-                manifest.common.name, header.name
-            ))
+        validate_value_source_inputs(&header.value, resolved_inputs).map_err(|e| {
+            registration_error(
+                &manifest.common.name,
+                &format!("request header '{}'", header.name),
+                &e,
+            )
         })?;
     }
+    Ok(())
+}
 
+/// Auth is source-scoped — no filter/state context at runtime either, so every
+/// template dep must resolve from inputs at registration.
+fn check_auth_inputs(
+    manifest: &HttpSourceManifest,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<()> {
     manifest
         .auth
         .validate_inputs(resolved_inputs)
-        .map_err(|error| {
-            DataFusionError::Execution(format!(
-                "{} source auth could not be resolved: {error}",
-                manifest.common.name
-            ))
-        })?;
-    Ok(())
+        .map_err(|e| registration_error(&manifest.common.name, "auth", &e))
+}
+
+fn registration_error(source: &str, field: &str, error: &DataFusionError) -> DataFusionError {
+    DataFusionError::Execution(format!(
+        "source '{source}' {field} could not be resolved: {error}"
+    ))
 }
 
 #[allow(
@@ -1232,7 +1253,7 @@ mod tests {
             ),
             (
                 header_manifest,
-                "alpha source request header 'X-Api-Key' could not be resolved",
+                "source 'alpha' request header 'X-Api-Key' could not be resolved",
             ),
         ] {
             let error =

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1201,9 +1201,12 @@ mod tests {
             "backend": "http",
             "base_url": "https://api.example.com",
             "auth": {
-                "type": "ApiKeyAuth",
-                "header": "Authorization",
-                "api_token": "Bearer {{input.API_KEY}}"
+                "type": "HeaderAuth",
+                "headers": [{
+                    "name": "Authorization",
+                    "from": "template",
+                    "template": "Bearer {{input.API_KEY}}"
+                }]
             },
             "inputs": {
                 "API_KEY": { "kind": "secret" }

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -9,10 +9,13 @@ use reqwest::header::HeaderMap;
 use serde_json::{Map, Value, json};
 
 use crate::backends::http::ProviderQueryError;
-use crate::backends::http::auth::{AuthContext, Authenticator, EMPTY_MAP, resolve_auth_headers};
+use crate::backends::http::auth::{AuthContext, Authenticator, resolve_auth_headers};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::shared::json_path::get_path_value;
-use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
+use crate::backends::shared::template::{
+    render_template, resolve_value_source, validate_input_dependencies,
+    validate_value_source_inputs, value_to_string,
+};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
 use coral_spec::{
     AuthSpec, HeaderSpec, HttpMethod, PageSizeSpec, ParsedTemplate, RowStrategy,
@@ -331,47 +334,30 @@ fn validate_source_scoped_http_config(
     manifest: &HttpSourceManifest,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<()> {
-    let base_url = render_template(&manifest.base_url, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)
-        .map_err(|error| {
-            DataFusionError::Execution(format!(
-                "{} source base_url could not be resolved: {error}",
-                manifest.common.name
-            ))
-        })?;
-    let url = reqwest::Url::parse(&normalize_base_url(&base_url)).map_err(|error| {
+    // `base_url` and `request_headers` may legitimately reference
+    // `{{filter.X}}` / `{{state.X}}` tokens that only resolve per-request.
+    // Validate input dependencies only — runtime will handle the rest.
+    validate_input_dependencies(&manifest.base_url, resolved_inputs).map_err(|error| {
         DataFusionError::Execution(format!(
-            "{} source base_url '{base_url}' is not a valid URL: {error}",
+            "{} source base_url could not be resolved: {error}",
             manifest.common.name
         ))
     })?;
-    let mut request = reqwest::Request::new(reqwest::Method::GET, url);
-
     for header in &manifest.request_headers {
-        let resolved =
-            resolve_value_source(&header.value, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
-        let Some(value) = resolved else {
-            return Err(DataFusionError::Execution(format!(
-                "{} source request header '{}' could not be resolved",
+        validate_value_source_inputs(&header.value, resolved_inputs).map_err(|error| {
+            DataFusionError::Execution(format!(
+                "{} source request header '{}' could not be resolved: {error}",
                 manifest.common.name, header.name
-            )));
-        };
-        let name =
-            reqwest::header::HeaderName::try_from(header.name.as_str()).map_err(|error| {
-                DataFusionError::Execution(format!(
-                    "{} source request header name '{}' is invalid: {error}",
-                    manifest.common.name, header.name
-                ))
-            })?;
-        let header_value = reqwest::header::HeaderValue::try_from(value_to_string(&value).as_str())
-            .map_err(|error| {
-                DataFusionError::Execution(format!(
-                    "{} source request header '{}' value is invalid: {error}",
-                    manifest.common.name, header.name
-                ))
-            })?;
-        request.headers_mut().append(name, header_value);
+            ))
+        })?;
     }
 
+    // Auth is source-scoped — `Authenticator::auth` always runs against
+    // empty filters/state at runtime too, so signing a synthetic request
+    // here exercises the same template-resolution contract as real fetches.
+    let validation_url = reqwest::Url::parse("http://preflight.invalid/")
+        .expect("static preflight URL must parse");
+    let request = reqwest::Request::new(reqwest::Method::GET, validation_url);
     let ctx = AuthContext {
         request: &request,
         resolved_inputs,

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -4,19 +4,19 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use base64::Engine as _;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use datafusion::error::{DataFusionError, Result};
 use reqwest::header::HeaderMap;
 use serde_json::{Map, Value, json};
 
 use crate::backends::http::ProviderQueryError;
+use crate::backends::http::auth::resolve_auth_headers;
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::shared::json_path::get_path_value;
+use crate::backends::shared::template::{render_template, resolve_value_source, value_to_string};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
 use coral_spec::{
     AuthSpec, HeaderSpec, HttpMethod, ManifestInputKind, PageSizeSpec, ParsedTemplate, RowStrategy,
-    TemplateNamespace, TemplatePart, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
+    ValidatedPagination, ValidatedPaginationMode,
 };
 
 const DEFAULT_MAX_PAGES: usize = 10_000;
@@ -87,28 +87,6 @@ impl HttpSourceClient {
         source_variables: &BTreeMap<String, String>,
     ) -> Result<Self> {
         let resolved_inputs = build_resolved_inputs(manifest, source_secrets, source_variables);
-
-        resolve_auth_headers(&manifest.auth, &resolved_inputs).map_err(|error| {
-            DataFusionError::Execution(format!(
-                "{} source auth could not be resolved: {error}",
-                manifest.common.name
-            ))
-        })?;
-
-        for header in &manifest.request_headers {
-            let resolved = resolve_value_source(
-                &header.value,
-                &HashMap::new(),
-                &HashMap::new(),
-                &resolved_inputs,
-            )?;
-            if resolved.is_none() {
-                return Err(DataFusionError::Execution(format!(
-                    "{} source request header '{}' could not be resolved",
-                    manifest.common.name, header.name
-                )));
-            }
-        }
 
         let request_timeout = Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS);
         let http = reqwest::Client::builder()
@@ -380,10 +358,6 @@ async fn execute_request(
         let method_label = http_method_label(method);
         let mut request = build_http_request(http, method, url);
 
-        for (name, value) in resolve_auth_headers(auth, resolved_inputs)? {
-            request = request.header(name, value);
-        }
-
         for header in request_headers {
             if let Some(value) =
                 resolve_value_source(&header.value, filters, state, resolved_inputs)?
@@ -413,7 +387,9 @@ async fn execute_request(
             .and_then(|b| serde_json::to_string_pretty(b).ok())
             .filter(|s| !s.is_empty());
 
-        let response = request.send().await.map_err(|error| {
+        let built = resolve_auth_headers(auth, request, resolved_inputs)?;
+
+        let response = http.execute(built).await.map_err(|error| {
             request_error(
                 "request",
                 method_label,
@@ -665,108 +641,6 @@ fn page_is_exhausted(rows_on_page: usize, page_size: Option<usize>) -> bool {
     rows_on_page == 0 || page_size.is_some_and(|requested| rows_on_page < requested)
 }
 
-fn resolve_auth_headers(
-    auth: &AuthSpec,
-    resolved_inputs: &BTreeMap<String, String>,
-) -> Result<Vec<(String, String)>> {
-    let empty_filters: HashMap<String, String> = HashMap::new();
-    let empty_state: HashMap<String, String> = HashMap::new();
-    match auth {
-        AuthSpec::ApiKeyAuth(spec) => {
-            let token = render_template(
-                &spec.api_token,
-                &empty_filters,
-                &empty_state,
-                resolved_inputs,
-            )?;
-            Ok(vec![(spec.header.clone(), token)])
-        }
-        AuthSpec::BasicHttpAuth(spec) => {
-            let username = render_template(
-                &spec.username,
-                &empty_filters,
-                &empty_state,
-                resolved_inputs,
-            )?;
-            let password = render_template(
-                &spec.password,
-                &empty_filters,
-                &empty_state,
-                resolved_inputs,
-            )?;
-            let encoded = BASE64_STANDARD.encode(format!("{username}:{password}"));
-            Ok(vec![(
-                "Authorization".to_string(),
-                format!("Basic {encoded}"),
-            )])
-        }
-        AuthSpec::CustomHeadersAuth(spec) => {
-            let mut out = Vec::with_capacity(spec.headers.len());
-            for header in &spec.headers {
-                let resolved = resolve_value_source(
-                    &header.value,
-                    &empty_filters,
-                    &empty_state,
-                    resolved_inputs,
-                )?
-                .ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "missing value for auth header '{}'",
-                        header.name
-                    ))
-                })?;
-                out.push((header.name.clone(), value_to_string(&resolved)));
-            }
-            Ok(out)
-        }
-    }
-}
-
-fn resolve_value_source(
-    value: &ValueSourceSpec,
-    filters: &HashMap<String, String>,
-    state: &HashMap<String, String>,
-    resolved_inputs: &BTreeMap<String, String>,
-) -> Result<Option<Value>> {
-    match value {
-        ValueSourceSpec::Template { template } => {
-            let rendered = render_template(template, filters, state, resolved_inputs)?;
-            Ok(Some(Value::String(rendered)))
-        }
-        ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
-        ValueSourceSpec::Filter { key, default } => Ok(filters
-            .get(key)
-            .map(|v| Value::String(v.clone()))
-            .or_else(|| default.clone())),
-        ValueSourceSpec::FilterInt { key, default } => {
-            let value = if let Some(filter) = filters.get(key) {
-                let parsed = filter.parse::<i64>().map_err(|error| {
-                    DataFusionError::Execution(format!(
-                        "filter '{key}' value '{filter}' is not a valid i64: {error}"
-                    ))
-                })?;
-                Some(json!(parsed))
-            } else {
-                default.map(|value| json!(value))
-            };
-            Ok(value)
-        }
-        ValueSourceSpec::Input { key } => Ok(resolved_inputs.get(key).cloned().map(Value::String)),
-        ValueSourceSpec::State { key } => Ok(state.get(key).map(|v| Value::String(v.clone()))),
-        ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
-            #[allow(
-                clippy::cast_possible_wrap,
-                reason = "Current Unix epoch seconds fit within i64 for centuries"
-            )]
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs() as i64;
-            let value = now.saturating_sub(*seconds);
-            Ok(Some(json!(value)))
-        }
-    }
-}
 
 fn pagination_state_values(state: &PageState) -> HashMap<String, String> {
     let mut values = HashMap::new();
@@ -776,70 +650,6 @@ fn pagination_state_values(state: &PageState) -> HashMap<String, String> {
         values.insert("cursor".to_string(), cursor.clone());
     }
     values
-}
-
-fn render_template(
-    template: &ParsedTemplate,
-    filters: &HashMap<String, String>,
-    state: &HashMap<String, String>,
-    resolved_inputs: &BTreeMap<String, String>,
-) -> Result<String> {
-    let mut out = String::with_capacity(template.raw().len());
-    for part in template.parts() {
-        match part {
-            TemplatePart::Literal(part) => out.push_str(part),
-            TemplatePart::Token(token) => out.push_str(&resolve_template_token(
-                token,
-                filters,
-                state,
-                resolved_inputs,
-            )?),
-        }
-    }
-    Ok(out)
-}
-
-fn resolve_template_token(
-    token: &coral_spec::TemplateToken,
-    filters: &HashMap<String, String>,
-    state: &HashMap<String, String>,
-    resolved_inputs: &BTreeMap<String, String>,
-) -> Result<String> {
-    let default = token.default_value().map(ToString::to_string);
-
-    if token.namespace() == &TemplateNamespace::Input {
-        return resolved_inputs
-            .get(token.key())
-            .cloned()
-            .or(default)
-            .ok_or_else(|| {
-                DataFusionError::Execution(format!(
-                    "missing source input '{}' for template token",
-                    token.key()
-                ))
-            });
-    }
-
-    if token.namespace() == &TemplateNamespace::Filter {
-        return filters
-            .get(token.key())
-            .cloned()
-            .or(default)
-            .ok_or_else(|| {
-                DataFusionError::Execution(format!("missing filter '{}'", token.key()))
-            });
-    }
-
-    if token.namespace() == &TemplateNamespace::State {
-        return state.get(token.key()).cloned().or(default).ok_or_else(|| {
-            DataFusionError::Execution(format!("missing state value '{}'", token.key()))
-        });
-    }
-
-    Err(DataFusionError::Execution(format!(
-        "unsupported template token '{}'",
-        token.raw()
-    )))
 }
 
 fn build_resolved_inputs(
@@ -861,16 +671,6 @@ fn build_resolved_inputs(
         }
     }
     resolved
-}
-
-fn value_to_string(value: &Value) -> String {
-    match value {
-        Value::Null => String::new(),
-        Value::Bool(v) => v.to_string(),
-        Value::Number(v) => v.to_string(),
-        Value::String(v) => v.clone(),
-        Value::Array(_) | Value::Object(_) => serde_json::to_string(value).unwrap_or_default(),
-    }
 }
 
 fn build_logged_url(url: &str, query_pairs: &[(String, String)]) -> String {
@@ -1096,9 +896,9 @@ mod tests {
     use tokio::task::JoinHandle;
 
     use super::{
-        AuthSpec, HttpSourceClient, PageState, RequestSpec as HttpRequestSpec,
-        apply_pagination_query_pairs, execute_request, extract_next_link_url, extract_rows,
-        join_url, normalize_base_url, page_is_exhausted, resolve_value_source,
+        AuthSpec, PageState, RequestSpec as HttpRequestSpec, apply_pagination_query_pairs,
+        execute_request, extract_next_link_url, extract_rows, join_url, normalize_base_url,
+        page_is_exhausted, resolve_value_source,
     };
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
@@ -1351,44 +1151,6 @@ mod tests {
             error
                 .to_string()
                 .contains("filter 'start_time' value 'not-a-number' is not a valid i64")
-        );
-    }
-
-    #[test]
-    fn backend_client_requires_source_scoped_credentials() {
-        let manifest = parse_http_manifest(json!({
-            "dsl_version": 3,
-            "name": "alpha",
-            "version": "0.1.0",
-            "backend": "http",
-            "base_url": "https://api.example.com",
-            "auth": {
-                "type": "ApiKeyAuth",
-                "header": "Authorization",
-                "api_token": "Bearer {{input.API_KEY}}"
-            },
-            "inputs": {
-                "API_KEY": { "kind": "secret" }
-            },
-            "tables": [{
-                "name": "items",
-                "description": "items",
-                "request": { "path": "/items" },
-                "columns": [{
-                    "name": "id",
-                    "type": "Utf8"
-                }]
-            }]
-        }));
-        let source_secrets = BTreeMap::new();
-
-        let error = HttpSourceClient::from_manifest(&manifest, &source_secrets, &BTreeMap::new())
-            .expect_err("missing source-scoped credentials must fail");
-
-        assert!(
-            error
-                .to_string()
-                .contains("missing source input 'API_KEY' for template token")
         );
     }
 

--- a/crates/coral-engine/src/backends/http/custom/aws.rs
+++ b/crates/coral-engine/src/backends/http/custom/aws.rs
@@ -7,7 +7,10 @@
 use std::time::SystemTime;
 
 use aws_credential_types::Credentials;
-use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, sign as sigv4_sign};
+use aws_sigv4::http_request::{
+    PayloadChecksumKind, PercentEncodingMode, SignableBody, SignableRequest, SigningSettings,
+    UriPathNormalizationMode, sign as sigv4_sign,
+};
 use aws_sigv4::sign::v4;
 use datafusion::error::{DataFusionError, Result};
 use reqwest::header::{HeaderName, HeaderValue};
@@ -16,6 +19,19 @@ use coral_spec::AwsSigV4Spec;
 
 use crate::backends::http::auth::{AuthContext, Authenticator, EMPTY_MAP};
 use crate::backends::shared::template::render_template;
+
+/// Per-service SigV4 settings. Most AWS APIs accept the library defaults,
+/// but S3 needs path normalization disabled, single percent-encoding, and the
+/// `X-Amz-Content-Sha256` header enabled to avoid `SignatureDoesNotMatch`.
+fn signing_settings_for(service: &str) -> SigningSettings {
+    let mut settings = SigningSettings::default();
+    if matches!(service, "s3" | "s3-outposts") {
+        settings.percent_encoding_mode = PercentEncodingMode::Single;
+        settings.uri_path_normalization_mode = UriPathNormalizationMode::Disabled;
+        settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+    }
+    settings
+}
 
 impl Authenticator for AwsSigV4Spec {
     fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
@@ -53,7 +69,7 @@ impl Authenticator for AwsSigV4Spec {
             .region(&region)
             .name(&self.service)
             .time(SystemTime::now())
-            .settings(SigningSettings::default())
+            .settings(signing_settings_for(&self.service))
             .build()
             .map_err(|error| {
                 DataFusionError::Execution(format!("failed to build SigV4 signing params: {error}"))

--- a/crates/coral-engine/src/backends/http/custom/aws.rs
+++ b/crates/coral-engine/src/backends/http/custom/aws.rs
@@ -20,7 +20,7 @@ use coral_spec::AwsSigV4Spec;
 use crate::backends::http::auth::{AuthContext, Authenticator, EMPTY_MAP};
 use crate::backends::shared::template::render_template;
 
-/// Per-service SigV4 settings. Most AWS APIs accept the library defaults,
+/// Per-service `SigV4` settings. Most AWS APIs accept the library defaults,
 /// but S3 needs path normalization disabled, single percent-encoding, and the
 /// `X-Amz-Content-Sha256` header enabled to avoid `SignatureDoesNotMatch`.
 fn signing_settings_for(service: &str) -> SigningSettings {

--- a/crates/coral-engine/src/backends/http/custom/aws.rs
+++ b/crates/coral-engine/src/backends/http/custom/aws.rs
@@ -17,8 +17,8 @@ use reqwest::header::{HeaderName, HeaderValue};
 
 use coral_spec::AwsSigV4Spec;
 
-use crate::backends::http::auth::{AuthContext, Authenticator, EMPTY_MAP};
-use crate::backends::shared::template::render_template;
+use crate::backends::http::auth::{AuthContext, Authenticator};
+use crate::backends::shared::template::{EMPTY_MAP, render_template};
 
 /// Per-service `SigV4` settings. Most AWS APIs accept the library defaults,
 /// but S3 needs path normalization disabled, single percent-encoding, and the

--- a/crates/coral-engine/src/backends/http/custom/aws.rs
+++ b/crates/coral-engine/src/backends/http/custom/aws.rs
@@ -4,45 +4,38 @@
 //! requests using the `aws-sigv4` crate. Configured from [`AwsSigV4Spec`]
 //! and signs over the live request via [`AuthContext`].
 
-use std::collections::HashMap;
 use std::time::SystemTime;
 
 use aws_credential_types::Credentials;
-use aws_sigv4::http_request::{
-    SignableBody, SignableRequest, SigningSettings, sign as sigv4_sign,
-};
+use aws_sigv4::http_request::{SignableBody, SignableRequest, SigningSettings, sign as sigv4_sign};
 use aws_sigv4::sign::v4;
 use datafusion::error::{DataFusionError, Result};
+use reqwest::header::{HeaderName, HeaderValue};
 
 use coral_spec::AwsSigV4Spec;
 
-use crate::backends::http::auth::{AuthContext, Authenticator};
+use crate::backends::http::auth::{AuthContext, Authenticator, EMPTY_MAP};
 use crate::backends::shared::template::render_template;
 
 impl Authenticator for AwsSigV4Spec {
-    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
-        let empty_filters: HashMap<String, String> = HashMap::new();
-        let empty_state: HashMap<String, String> = HashMap::new();
-        let region =
-            render_template(&self.region, &empty_filters, &empty_state, ctx.resolved_inputs)?;
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(HeaderName, HeaderValue)>> {
+        let region = render_template(&self.region, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs)?;
         let access_key_id = render_template(
             &self.access_key_id,
-            &empty_filters,
-            &empty_state,
+            &EMPTY_MAP,
+            &EMPTY_MAP,
             ctx.resolved_inputs,
         )?;
         let secret_access_key = render_template(
             &self.secret_access_key,
-            &empty_filters,
-            &empty_state,
+            &EMPTY_MAP,
+            &EMPTY_MAP,
             ctx.resolved_inputs,
         )?;
         let session_token = self
             .session_token
             .as_ref()
-            .map(|template| {
-                render_template(template, &empty_filters, &empty_state, ctx.resolved_inputs)
-            })
+            .map(|template| render_template(template, &EMPTY_MAP, &EMPTY_MAP, ctx.resolved_inputs))
             .transpose()?
             .filter(|value| !value.is_empty());
 
@@ -63,34 +56,52 @@ impl Authenticator for AwsSigV4Spec {
             .settings(SigningSettings::default())
             .build()
             .map_err(|error| {
-                DataFusionError::Execution(format!(
-                    "failed to build SigV4 signing params: {error}"
-                ))
+                DataFusionError::Execution(format!("failed to build SigV4 signing params: {error}"))
             })?
             .into();
 
-        let header_refs = ctx
-            .headers
-            .iter()
-            .map(|(name, value)| (name.as_str(), value.as_str()));
-        let body = SignableBody::Bytes(ctx.body.unwrap_or(&[]));
-        let signable = SignableRequest::new(ctx.method.as_str(), ctx.url, header_refs, body)
-            .map_err(|error| {
+        let headers = ctx.headers();
+        let mut header_refs = Vec::with_capacity(headers.len());
+        for (name, value) in headers {
+            let value_str = value.to_str().map_err(|error| {
                 DataFusionError::Execution(format!(
-                    "failed to build SigV4 signable request: {error}"
+                    "header '{name}' is not valid ASCII, cannot sign with SigV4: {error}"
                 ))
             })?;
+            header_refs.push((name.as_str(), value_str));
+        }
+        let body = SignableBody::Bytes(ctx.body().unwrap_or(&[]));
+        let signable = SignableRequest::new(
+            ctx.method().as_str(),
+            ctx.url().as_str(),
+            header_refs.iter().copied(),
+            body,
+        )
+        .map_err(|error| {
+            DataFusionError::Execution(format!("failed to build SigV4 signable request: {error}"))
+        })?;
 
         let (instructions, _signature) = sigv4_sign(signable, &signing_params)
-            .map_err(|error| {
-                DataFusionError::Execution(format!("SigV4 signing failed: {error}"))
-            })?
+            .map_err(|error| DataFusionError::Execution(format!("SigV4 signing failed: {error}")))?
             .into_parts();
 
         let (headers, _params) = instructions.into_parts();
-        Ok(headers
-            .into_iter()
-            .map(|header| (header.name().to_string(), header.value().to_string()))
-            .collect())
+        let mut out = Vec::with_capacity(headers.len());
+        for header in headers {
+            let name = HeaderName::try_from(header.name()).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "SigV4 returned invalid header name '{}': {error}",
+                    header.name()
+                ))
+            })?;
+            let value = HeaderValue::try_from(header.value()).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "SigV4 returned invalid header value for '{}': {error}",
+                    header.name()
+                ))
+            })?;
+            out.push((name, value));
+        }
+        Ok(out)
     }
 }

--- a/crates/coral-engine/src/backends/http/custom/aws.rs
+++ b/crates/coral-engine/src/backends/http/custom/aws.rs
@@ -17,8 +17,10 @@ use reqwest::header::{HeaderName, HeaderValue};
 
 use coral_spec::AwsSigV4Spec;
 
+use std::collections::BTreeMap;
+
 use crate::backends::http::auth::{AuthContext, Authenticator};
-use crate::backends::shared::template::{EMPTY_MAP, render_template};
+use crate::backends::shared::template::{EMPTY_MAP, render_template, validate_input_dependencies};
 
 /// Per-service `SigV4` settings. Most AWS APIs accept the library defaults,
 /// but S3 needs path normalization disabled, single percent-encoding, and the
@@ -119,5 +121,15 @@ impl Authenticator for AwsSigV4Spec {
             out.push((name, value));
         }
         Ok(out)
+    }
+
+    fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
+        validate_input_dependencies(&self.region, resolved_inputs)?;
+        validate_input_dependencies(&self.access_key_id, resolved_inputs)?;
+        validate_input_dependencies(&self.secret_access_key, resolved_inputs)?;
+        if let Some(session_token) = &self.session_token {
+            validate_input_dependencies(session_token, resolved_inputs)?;
+        }
+        Ok(())
     }
 }

--- a/crates/coral-engine/src/backends/http/custom/aws.rs
+++ b/crates/coral-engine/src/backends/http/custom/aws.rs
@@ -20,7 +20,7 @@ use coral_spec::AwsSigV4Spec;
 use std::collections::BTreeMap;
 
 use crate::backends::http::auth::{AuthContext, Authenticator};
-use crate::backends::shared::template::{EMPTY_MAP, render_template, validate_input_dependencies};
+use crate::backends::shared::template::{EMPTY_MAP, render_template};
 
 /// Per-service `SigV4` settings. Most AWS APIs accept the library defaults,
 /// but S3 needs path normalization disabled, single percent-encoding, and the
@@ -124,11 +124,16 @@ impl Authenticator for AwsSigV4Spec {
     }
 
     fn validate_inputs(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
-        validate_input_dependencies(&self.region, resolved_inputs)?;
-        validate_input_dependencies(&self.access_key_id, resolved_inputs)?;
-        validate_input_dependencies(&self.secret_access_key, resolved_inputs)?;
+        render_template(&self.region, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
+        render_template(&self.access_key_id, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
+        render_template(
+            &self.secret_access_key,
+            &EMPTY_MAP,
+            &EMPTY_MAP,
+            resolved_inputs,
+        )?;
         if let Some(session_token) = &self.session_token {
-            validate_input_dependencies(session_token, resolved_inputs)?;
+            render_template(session_token, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
         }
         Ok(())
     }

--- a/crates/coral-engine/src/backends/http/custom/aws.rs
+++ b/crates/coral-engine/src/backends/http/custom/aws.rs
@@ -1,0 +1,96 @@
+//! AWS Signature Version 4 signer.
+//!
+//! Produces `Authorization`, `X-Amz-Date`, and related headers for outbound
+//! requests using the `aws-sigv4` crate. Configured from [`AwsSigV4Spec`]
+//! and signs over the live request via [`AuthContext`].
+
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use aws_credential_types::Credentials;
+use aws_sigv4::http_request::{
+    SignableBody, SignableRequest, SigningSettings, sign as sigv4_sign,
+};
+use aws_sigv4::sign::v4;
+use datafusion::error::{DataFusionError, Result};
+
+use coral_spec::AwsSigV4Spec;
+
+use crate::backends::http::auth::{AuthContext, Authenticator};
+use crate::backends::shared::template::render_template;
+
+impl Authenticator for AwsSigV4Spec {
+    fn auth(&self, ctx: &AuthContext<'_>) -> Result<Vec<(String, String)>> {
+        let empty_filters: HashMap<String, String> = HashMap::new();
+        let empty_state: HashMap<String, String> = HashMap::new();
+        let region =
+            render_template(&self.region, &empty_filters, &empty_state, ctx.resolved_inputs)?;
+        let access_key_id = render_template(
+            &self.access_key_id,
+            &empty_filters,
+            &empty_state,
+            ctx.resolved_inputs,
+        )?;
+        let secret_access_key = render_template(
+            &self.secret_access_key,
+            &empty_filters,
+            &empty_state,
+            ctx.resolved_inputs,
+        )?;
+        let session_token = self
+            .session_token
+            .as_ref()
+            .map(|template| {
+                render_template(template, &empty_filters, &empty_state, ctx.resolved_inputs)
+            })
+            .transpose()?
+            .filter(|value| !value.is_empty());
+
+        let credentials = Credentials::new(
+            access_key_id,
+            secret_access_key,
+            session_token,
+            None,
+            "coral",
+        );
+        let identity = credentials.into();
+
+        let signing_params = v4::SigningParams::builder()
+            .identity(&identity)
+            .region(&region)
+            .name(&self.service)
+            .time(SystemTime::now())
+            .settings(SigningSettings::default())
+            .build()
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "failed to build SigV4 signing params: {error}"
+                ))
+            })?
+            .into();
+
+        let header_refs = ctx
+            .headers
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()));
+        let body = SignableBody::Bytes(ctx.body.unwrap_or(&[]));
+        let signable = SignableRequest::new(ctx.method.as_str(), ctx.url, header_refs, body)
+            .map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "failed to build SigV4 signable request: {error}"
+                ))
+            })?;
+
+        let (instructions, _signature) = sigv4_sign(signable, &signing_params)
+            .map_err(|error| {
+                DataFusionError::Execution(format!("SigV4 signing failed: {error}"))
+            })?
+            .into_parts();
+
+        let (headers, _params) = instructions.into_parts();
+        Ok(headers
+            .into_iter()
+            .map(|header| (header.name().to_string(), header.value().to_string()))
+            .collect())
+    }
+}

--- a/crates/coral-engine/src/backends/http/custom/mod.rs
+++ b/crates/coral-engine/src/backends/http/custom/mod.rs
@@ -1,0 +1,6 @@
+//! Custom authenticators — compiled-in implementations dispatched from
+//! [`AuthSpec::CustomAuth`](coral_spec::AuthSpec). Each submodule implements
+//! the [`Authenticator`](super::auth::Authenticator) trait for one
+//! [`CustomAuthSpec`](coral_spec::CustomAuthSpec) variant.
+
+pub(crate) mod aws;

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -14,7 +14,9 @@ use crate::backends::{
     RegisteredTable, build_registered_table, registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
+pub(crate) mod auth;
 pub(crate) mod client;
+pub(crate) mod custom;
 pub(crate) mod error;
 pub(crate) mod provider;
 mod rate_limit;

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -120,9 +120,12 @@ mod tests {
                 "GITHUB_TOKEN": { "kind": "secret" }
             },
             "auth": {
-                "type": "ApiKeyAuth",
-                "header": "Authorization",
-                "api_token": "Bearer {{input.GITHUB_TOKEN}}"
+                "type": "HeaderAuth",
+                "headers": [{
+                    "name": "Authorization",
+                    "from": "template",
+                    "template": "Bearer {{input.GITHUB_TOKEN}}"
+                }]
             },
             "tables": [{
                 "name": "repos",

--- a/crates/coral-engine/src/backends/shared/mod.rs
+++ b/crates/coral-engine/src/backends/shared/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod filter_expr;
 pub(crate) mod json_exec;
 pub(crate) mod json_path;
 pub(crate) mod mapping;
+pub(crate) mod template;

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -1,0 +1,141 @@
+//! Backend-agnostic template and value-source rendering.
+//!
+//! Source manifests use `ParsedTemplate` strings and `ValueSourceSpec` values
+//! to describe how request parts (headers, query params, bodies, URLs, auth
+//! tokens) pull their runtime data. The helpers here turn those declarative
+//! shapes into concrete strings / JSON values given a set of filters,
+//! pagination state, and resolved input values. They have no HTTP-specific
+//! behavior and can be reused across any backend that wants the same
+//! interpolation semantics.
+
+use std::collections::{BTreeMap, HashMap};
+
+use datafusion::error::{DataFusionError, Result};
+use serde_json::{Value, json};
+
+use coral_spec::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken, ValueSourceSpec};
+
+/// Resolve one declarative value source into an optional JSON value.
+pub(crate) fn resolve_value_source(
+    value: &ValueSourceSpec,
+    filters: &HashMap<String, String>,
+    state: &HashMap<String, String>,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<Option<Value>> {
+    match value {
+        ValueSourceSpec::Template { template } => {
+            let rendered = render_template(template, filters, state, resolved_inputs)?;
+            Ok(Some(Value::String(rendered)))
+        }
+        ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
+        ValueSourceSpec::Filter { key, default } => Ok(filters
+            .get(key)
+            .map(|v| Value::String(v.clone()))
+            .or_else(|| default.clone())),
+        ValueSourceSpec::FilterInt { key, default } => {
+            let value = if let Some(filter) = filters.get(key) {
+                let parsed = filter.parse::<i64>().map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "filter '{key}' value '{filter}' is not a valid i64: {error}"
+                    ))
+                })?;
+                Some(json!(parsed))
+            } else {
+                default.map(|value| json!(value))
+            };
+            Ok(value)
+        }
+        ValueSourceSpec::Input { key } => Ok(resolved_inputs.get(key).cloned().map(Value::String)),
+        ValueSourceSpec::State { key } => Ok(state.get(key).map(|v| Value::String(v.clone()))),
+        ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
+            #[allow(
+                clippy::cast_possible_wrap,
+                reason = "Current Unix epoch seconds fit within i64 for centuries"
+            )]
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
+            let value = now.saturating_sub(*seconds);
+            Ok(Some(json!(value)))
+        }
+    }
+}
+
+/// Render a parsed template into a concrete string.
+pub(crate) fn render_template(
+    template: &ParsedTemplate,
+    filters: &HashMap<String, String>,
+    state: &HashMap<String, String>,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<String> {
+    let mut out = String::with_capacity(template.raw().len());
+    for part in template.parts() {
+        match part {
+            TemplatePart::Literal(part) => out.push_str(part),
+            TemplatePart::Token(token) => {
+                out.push_str(&resolve_template_token(
+                    token,
+                    filters,
+                    state,
+                    resolved_inputs,
+                )?);
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn resolve_template_token(
+    token: &TemplateToken,
+    filters: &HashMap<String, String>,
+    state: &HashMap<String, String>,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<String> {
+    let default = token.default_value().map(ToString::to_string);
+
+    if token.namespace() == &TemplateNamespace::Input {
+        return resolved_inputs
+            .get(token.key())
+            .cloned()
+            .or(default)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "missing source input '{}' for template token",
+                    token.key()
+                ))
+            });
+    }
+
+    if token.namespace() == &TemplateNamespace::Filter {
+        return filters
+            .get(token.key())
+            .cloned()
+            .or(default)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!("missing filter '{}'", token.key()))
+            });
+    }
+
+    if token.namespace() == &TemplateNamespace::State {
+        return state.get(token.key()).cloned().or(default).ok_or_else(|| {
+            DataFusionError::Execution(format!("missing state value '{}'", token.key()))
+        });
+    }
+
+    Err(DataFusionError::Execution(format!(
+        "unsupported template token '{}'",
+        token.raw()
+    )))
+}
+
+/// Flatten a JSON value into a plain string suitable for header/query use.
+pub(crate) fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::Bool(v) => v.to_string(),
+        Value::Number(v) => v.to_string(),
+        Value::String(v) => v.clone(),
+        Value::Array(_) | Value::Object(_) => serde_json::to_string(value).unwrap_or_default(),
+    }
+}

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -173,8 +173,8 @@ pub(crate) fn validate_input_dependencies(
 }
 
 /// Same input-only validation as [`validate_input_dependencies`], but applied
-/// to a [`ValueSourceSpec`]. Literal / filter / state / filter_int /
-/// now_epoch_minus_seconds variants have no input dependencies and are
+/// to a [`ValueSourceSpec`]. Literal / filter / state / `filter_int` /
+/// `now_epoch_minus_seconds` variants have no input dependencies and are
 /// short-circuited.
 pub(crate) fn validate_value_source_inputs(
     value: &ValueSourceSpec,

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -9,11 +9,17 @@
 //! interpolation semantics.
 
 use std::collections::{BTreeMap, HashMap};
+use std::sync::LazyLock;
 
 use datafusion::error::{DataFusionError, Result};
 use serde_json::{Value, json};
 
 use coral_spec::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken, ValueSourceSpec};
+
+/// Shared empty filter/state map for source-scoped rendering (auth,
+/// registration-time validation). Lives next to [`render_template`] /
+/// [`resolve_value_source`] so each call site doesn't allocate its own.
+pub(crate) static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
 
 /// Resolve one declarative value source into an optional JSON value.
 pub(crate) fn resolve_value_source(
@@ -137,5 +143,60 @@ pub(crate) fn value_to_string(value: &Value) -> String {
         Value::Number(v) => v.to_string(),
         Value::String(v) => v.clone(),
         Value::Array(_) | Value::Object(_) => serde_json::to_string(value).unwrap_or_default(),
+    }
+}
+
+/// Verify every `{{input.X}}` token referenced by `template` has a usable
+/// value in `resolved_inputs` (or a token-level default). Filter / state
+/// tokens are tolerated — those resolve at request time, not registration.
+///
+/// Used for source-registration preflight of templates that may reference
+/// per-request context, so the check is deliberately narrower than
+/// [`render_template`].
+pub(crate) fn validate_input_dependencies(
+    template: &ParsedTemplate,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<()> {
+    for part in template.parts() {
+        if let TemplatePart::Token(token) = part
+            && token.namespace() == &TemplateNamespace::Input
+            && token.default_value().is_none()
+            && !resolved_inputs.contains_key(token.key())
+        {
+            return Err(DataFusionError::Execution(format!(
+                "missing source input '{}' for template token",
+                token.key()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Same input-only validation as [`validate_input_dependencies`], but applied
+/// to a [`ValueSourceSpec`]. Literal / filter / state / filter_int /
+/// now_epoch_minus_seconds variants have no input dependencies and are
+/// short-circuited.
+pub(crate) fn validate_value_source_inputs(
+    value: &ValueSourceSpec,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<()> {
+    match value {
+        ValueSourceSpec::Template { template } => {
+            validate_input_dependencies(template, resolved_inputs)
+        }
+        ValueSourceSpec::Input { key } => {
+            if resolved_inputs.contains_key(key) {
+                Ok(())
+            } else {
+                Err(DataFusionError::Execution(format!(
+                    "missing source input '{key}' for `from: input` value source"
+                )))
+            }
+        }
+        ValueSourceSpec::Literal { .. }
+        | ValueSourceSpec::Filter { .. }
+        | ValueSourceSpec::FilterInt { .. }
+        | ValueSourceSpec::State { .. }
+        | ValueSourceSpec::NowEpochMinusSeconds { .. } => Ok(()),
     }
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -346,9 +346,12 @@ async fn auth_headers_sent_correctly() {
         "API_TOKEN": { "kind": "secret" }
     });
     manifest["auth"] = json!({
-        "type": "ApiKeyAuth",
-        "header": "Authorization",
-        "api_token": "Bearer {{input.API_TOKEN}}"
+        "type": "HeaderAuth",
+        "headers": [{
+            "name": "Authorization",
+            "from": "template",
+            "template": "Bearer {{input.API_TOKEN}}"
+        }]
     });
     let source = build_source_with_secrets(manifest, [("API_TOKEN", "secret-token")]);
 

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -33,7 +33,7 @@ pub enum AuthSpec {
     /// Freeform list of auth headers for sources that don't fit the
     /// single-token shape (e.g. dual-key providers).
     CustomHeadersAuth(CustomHeadersAuthSpec),
-    /// Authenticator that needs compiled-in signing logic (e.g. AWS SigV4).
+    /// Authenticator that needs compiled-in signing logic (e.g. AWS `SigV4`).
     /// The `authenticator` tag selects which built-in impl runs.
     CustomAuth(CustomAuthSpec),
 }
@@ -46,6 +46,7 @@ impl Default for AuthSpec {
 
 /// Strict single-header API-key authenticator.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ApiKeyAuthSpec {
     pub header: String,
     pub api_token: ParsedTemplate,
@@ -53,6 +54,7 @@ pub struct ApiKeyAuthSpec {
 
 /// HTTP Basic authenticator with separate username and password templates.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BasicHttpAuthSpec {
     pub username: ParsedTemplate,
     pub password: ParsedTemplate,
@@ -60,6 +62,7 @@ pub struct BasicHttpAuthSpec {
 
 /// Freeform authenticator that injects an arbitrary list of headers.
 #[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CustomHeadersAuthSpec {
     #[serde(default)]
     pub headers: Vec<HeaderSpec>,
@@ -74,8 +77,9 @@ pub enum CustomAuthSpec {
     AwsSigV4(AwsSigV4Spec),
 }
 
-/// AWS SigV4 request signer configuration.
+/// AWS `SigV4` request signer configuration.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct AwsSigV4Spec {
     /// AWS service code used in the signing scope (e.g. `logs`, `s3`, `cloudtrail`).
     pub service: String,
@@ -85,7 +89,7 @@ pub struct AwsSigV4Spec {
     pub access_key_id: ParsedTemplate,
     /// IAM secret access key.
     pub secret_access_key: ParsedTemplate,
-    /// Optional STS session token for temporary credentials.
+    /// Optional STS session token for temporary (STS-issued) credentials.
     #[serde(default)]
     pub session_token: Option<ParsedTemplate>,
 }

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -26,13 +26,12 @@ use crate::{
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type")]
 pub enum AuthSpec {
-    /// Single auth header carrying an API token.
-    ApiKeyAuth(ApiKeyAuthSpec),
     /// HTTP Basic authentication; runtime base64-encodes `username:password`.
-    BasicHttpAuth(BasicHttpAuthSpec),
-    /// Freeform list of auth headers for sources that don't fit the
-    /// single-token shape (e.g. dual-key providers).
-    CustomHeadersAuth(CustomHeadersAuthSpec),
+    #[serde(rename = "BasicAuth")]
+    BasicAuth(BasicAuthSpec),
+    /// Declarative list of auth headers to attach to the request.
+    #[serde(rename = "HeaderAuth")]
+    HeaderAuth(HeaderAuthSpec),
     /// Authenticator that needs compiled-in signing logic (e.g. AWS `SigV4`).
     /// The `authenticator` tag selects which built-in impl runs.
     CustomAuth(CustomAuthSpec),
@@ -40,30 +39,22 @@ pub enum AuthSpec {
 
 impl Default for AuthSpec {
     fn default() -> Self {
-        Self::CustomHeadersAuth(CustomHeadersAuthSpec::default())
+        Self::HeaderAuth(HeaderAuthSpec::default())
     }
-}
-
-/// Strict single-header API-key authenticator.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct ApiKeyAuthSpec {
-    pub header: String,
-    pub api_token: ParsedTemplate,
 }
 
 /// HTTP Basic authenticator with separate username and password templates.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
-pub struct BasicHttpAuthSpec {
+pub struct BasicAuthSpec {
     pub username: ParsedTemplate,
     pub password: ParsedTemplate,
 }
 
-/// Freeform authenticator that injects an arbitrary list of headers.
+/// Declarative authenticator that injects one or more headers.
 #[derive(Debug, Clone, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
-pub struct CustomHeadersAuthSpec {
+pub struct HeaderAuthSpec {
     #[serde(default)]
     pub headers: Vec<HeaderSpec>,
 }

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -33,6 +33,9 @@ pub enum AuthSpec {
     /// Freeform list of auth headers for sources that don't fit the
     /// single-token shape (e.g. dual-key providers).
     CustomHeadersAuth(CustomHeadersAuthSpec),
+    /// Authenticator that needs compiled-in signing logic (e.g. AWS SigV4).
+    /// The `authenticator` tag selects which built-in impl runs.
+    CustomAuth(CustomAuthSpec),
 }
 
 impl Default for AuthSpec {
@@ -60,6 +63,31 @@ pub struct BasicHttpAuthSpec {
 pub struct CustomHeadersAuthSpec {
     #[serde(default)]
     pub headers: Vec<HeaderSpec>,
+}
+
+/// Dispatches to a compiled-in authenticator impl by name.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "authenticator")]
+pub enum CustomAuthSpec {
+    /// AWS Signature Version 4 signing for AWS APIs.
+    #[serde(rename = "aws_sigv4")]
+    AwsSigV4(AwsSigV4Spec),
+}
+
+/// AWS SigV4 request signer configuration.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AwsSigV4Spec {
+    /// AWS service code used in the signing scope (e.g. `logs`, `s3`, `cloudtrail`).
+    pub service: String,
+    /// AWS region (e.g. `us-east-1`).
+    pub region: ParsedTemplate,
+    /// IAM access key ID.
+    pub access_key_id: ParsedTemplate,
+    /// IAM secret access key.
+    pub secret_access_key: ParsedTemplate,
+    /// Optional STS session token for temporary credentials.
+    #[serde(default)]
+    pub session_token: Option<ParsedTemplate>,
 }
 
 /// Provider-specific response hints for classifying and delaying rate-limit retries.

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -8,7 +8,7 @@
 //! the variable or secret store. Manifests that take no interactive inputs
 //! may omit the block entirely.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::{Map, Value};
 
@@ -39,6 +39,38 @@ pub struct ManifestInputSpec {
     pub default_value: String,
     /// Optional authored hint shown to the user when collecting the input.
     pub hint: Option<String>,
+}
+
+/// Merge user-provided source secrets and variables with declared input
+/// defaults into one runtime-ready input map.
+///
+/// The map that comes out is what `{{input.KEY}}` template tokens and
+/// `from: input` value sources resolve against at render time. A declared
+/// input is present in the result only if the caller supplied a value
+/// (secrets via `source_secrets`, variables via `source_variables`) or — for
+/// variables — the manifest itself declared a non-empty default. Required
+/// inputs without a supplied value remain absent, so later template rendering
+/// surfaces the gap as a clear missing-input error.
+#[must_use]
+pub fn resolve_inputs(
+    declared: &[ManifestInputSpec],
+    source_secrets: &BTreeMap<String, String>,
+    source_variables: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut resolved = BTreeMap::new();
+    for input in declared {
+        let value = match input.kind {
+            ManifestInputKind::Secret => source_secrets.get(&input.key).cloned(),
+            ManifestInputKind::Variable => source_variables
+                .get(&input.key)
+                .cloned()
+                .or_else(|| (!input.default_value.is_empty()).then(|| input.default_value.clone())),
+        };
+        if let Some(value) = value {
+            resolved.insert(input.key.clone(), value);
+        }
+    }
+    resolved
 }
 
 /// Collect interactive source inputs from an already-parsed manifest value.

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -64,7 +64,7 @@ pub fn resolve_inputs(
             ManifestInputKind::Variable => source_variables
                 .get(&input.key)
                 .cloned()
-                .or_else(|| (!input.default_value.is_empty()).then(|| input.default_value.clone())),
+                .or_else(|| (!input.required).then(|| input.default_value.clone())),
         };
         if let Some(value) = value {
             resolved.insert(input.key.clone(), value);

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -96,7 +96,7 @@ pub use common::{
     TableCommon, TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
 };
 pub use error::{ManifestError, Result};
-pub use inputs::{ManifestInputKind, ManifestInputSpec};
+pub use inputs::{ManifestInputKind, ManifestInputSpec, resolve_inputs};
 pub use loader::load_manifest_path;
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -85,7 +85,10 @@ mod schema;
 mod template;
 mod validate;
 
-pub use backends::http::{ApiKeyAuthSpec, AuthSpec, BasicHttpAuthSpec, CustomHeadersAuthSpec};
+pub use backends::http::{
+    ApiKeyAuthSpec, AuthSpec, AwsSigV4Spec, BasicHttpAuthSpec, CustomAuthSpec,
+    CustomHeadersAuthSpec,
+};
 pub use common::{
     BodyFieldSpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, HeaderSpec, HttpMethod,
     ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -85,10 +85,7 @@ mod schema;
 mod template;
 mod validate;
 
-pub use backends::http::{
-    ApiKeyAuthSpec, AuthSpec, AwsSigV4Spec, BasicHttpAuthSpec, CustomAuthSpec,
-    CustomHeadersAuthSpec,
-};
+pub use backends::http::{AuthSpec, AwsSigV4Spec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 pub use common::{
     BodyFieldSpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, HeaderSpec, HttpMethod,
     ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -103,11 +103,23 @@
         },
         {
           "type": "object",
-          "additionalProperties": true,
-          "required": ["type", "authenticator"],
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "authenticator",
+            "service",
+            "region",
+            "access_key_id",
+            "secret_access_key"
+          ],
           "properties": {
             "type": { "const": "CustomAuth" },
-            "authenticator": { "type": "string", "minLength": 1 }
+            "authenticator": { "const": "aws_sigv4" },
+            "service": { "type": "string", "minLength": 1 },
+            "region": { "type": "string", "minLength": 1 },
+            "access_key_id": { "type": "string", "minLength": 1 },
+            "secret_access_key": { "type": "string", "minLength": 1 },
+            "session_token": { "type": "string", "minLength": 1 }
           }
         }
       ]

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -100,6 +100,15 @@
               "items": { "$ref": "#/$defs/header" }
             }
           }
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["type", "authenticator"],
+          "properties": {
+            "type": { "const": "CustomAuth" },
+            "authenticator": { "type": "string", "minLength": 1 }
+          }
         }
       ]
     },

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -72,19 +72,9 @@
         {
           "type": "object",
           "additionalProperties": false,
-          "required": ["type", "header", "api_token"],
-          "properties": {
-            "type": { "const": "ApiKeyAuth" },
-            "header": { "type": "string", "minLength": 1 },
-            "api_token": { "type": "string", "minLength": 1 }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
           "required": ["type", "username", "password"],
           "properties": {
-            "type": { "const": "BasicHttpAuth" },
+            "type": { "const": "BasicAuth" },
             "username": { "type": "string", "minLength": 1 },
             "password": { "type": "string", "minLength": 1 }
           }
@@ -94,7 +84,7 @@
           "additionalProperties": false,
           "required": ["type"],
           "properties": {
-            "type": { "const": "CustomHeadersAuth" },
+            "type": { "const": "HeaderAuth" },
             "headers": {
               "type": "array",
               "items": { "$ref": "#/$defs/header" }

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -94,9 +94,11 @@ inputs:
     hint: Bearer token for the API
 base_url: "{{input.API_BASE}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.API_TOKEN}}"
 tables:
   - name: messages
     description: Messages from the API

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -94,10 +94,9 @@ inputs:
     hint: Bearer token for the API
 base_url: "{{input.API_BASE}}"
 auth:
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
+  type: ApiKeyAuth
+  header: Authorization
+  api_token: "Bearer {{input.API_TOKEN}}"
 tables:
   - name: messages
     description: Messages from the API

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -183,10 +183,9 @@ inputs:
     kind: secret
 base_url: "{{input.API_BASE}}"
 auth:
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
+  type: ApiKeyAuth
+  header: Authorization
+  api_token: "Bearer {{input.API_TOKEN}}"
 tables:
   - name: messages
     description: Messages from the demo API
@@ -207,6 +206,91 @@ In this minimal example:
 - with the default response rules, Coral treats the selected response value directly as rows unless you configure a different `row_strategy`
 - `inputs` declares the install-time prompts for this source in stable authored order
 - `{{input.API_TOKEN}}` is resolved from the store implied by the declared input kind
+
+### HTTP authentication
+
+The top-level `auth:` block on an HTTP source is a tagged union — pick one shape via `type:`. Four built-in variants cover the common cases.
+
+#### `ApiKeyAuth` — single token in a single header
+
+Most APIs fall here (Bearer tokens, `Token <x>`, simple API keys, etc.).
+
+```yaml
+auth:
+  type: ApiKeyAuth
+  header: Authorization
+  api_token: "Bearer {{input.API_TOKEN}}"
+```
+
+The `api_token` field is a templated string; interpolate the token from an input. The header name itself is a literal.
+
+#### `BasicHttpAuth` — user + password, base64-encoded at runtime
+
+Coral computes `Basic <base64(user:pass)>` from plaintext inputs. Do **not** pre-encode — supply the raw values.
+
+```yaml
+auth:
+  type: BasicHttpAuth
+  username: "{{input.ACCOUNT_EMAIL}}"
+  password: "{{input.ACCOUNT_PASSWORD}}"
+```
+
+#### `CustomHeadersAuth` — freeform list of auth headers
+
+Use when one token + one header isn't enough (dual API keys, proprietary header schemes, etc.). Values use the same `ValueSourceSpec` shape as other header fields.
+
+```yaml
+auth:
+  type: CustomHeadersAuth
+  headers:
+    - name: DD-API-KEY
+      from: input
+      key: DD_API_KEY
+    - name: DD-APPLICATION-KEY
+      from: input
+      key: DD_APPLICATION_KEY
+```
+
+#### `CustomAuth` — compiled-in signers for schemes that need dynamic logic
+
+For authenticators that can't be expressed as templated headers — e.g. AWS SigV4 signatures that depend on the full request body and timestamp. Pick the impl with `authenticator:`.
+
+```yaml
+auth:
+  type: CustomAuth
+  authenticator: aws_sigv4
+  service: logs
+  region: "{{input.AWS_REGION}}"
+  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
+  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
+  session_token: "{{input.AWS_SESSION_TOKEN}}"   # optional, for STS credentials
+```
+
+Currently available authenticators:
+
+| `authenticator:` | Purpose | Required fields |
+|------------------|---------|-----------------|
+| `aws_sigv4` | AWS Signature Version 4 | `service`, `region`, `access_key_id`, `secret_access_key` (+ optional `session_token`) |
+
+### Request headers
+
+Generic per-source HTTP headers — declare them at the top level under `request_headers:` and Coral attaches them to every outbound request for the source. Typical uses: content negotiation (`Accept`), API version pinning (`X-API-Version`), feature flags, tracing hints, or anything the upstream API requires that isn't conveyed by `auth`.
+
+```yaml
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/vnd.github+json
+  - name: X-GitHub-Api-Version
+    from: literal
+    value: "2022-11-28"
+```
+
+Values use the same `from:` shapes as other manifest fields (`literal`, `template`, `input`, etc.), so you can also thread secrets or variables through a request header when needed.
+
+<Note>
+Coral always sets a `User-Agent` header identifying itself on every outbound request. Do not declare `User-Agent` in `request_headers:` — it is managed by the HTTP client and your entry would collide with Coral's own value.
+</Note>
 
 ### HTTP rate limiting
 
@@ -348,10 +432,9 @@ inputs:
 
 base_url: "{{input.API_BASE}}"
 auth:
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
+  type: ApiKeyAuth
+  header: Authorization
+  api_token: "Bearer {{input.API_TOKEN}}"
 ```
 
 Rules:

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -268,9 +268,44 @@ auth:
 
 Currently available authenticators:
 
-| `authenticator:` | Purpose | Required fields |
-|------------------|---------|-----------------|
-| `aws_sigv4` | AWS Signature Version 4 | `service`, `region`, `access_key_id`, `secret_access_key` (+ optional `session_token`) |
+| `authenticator:` | Purpose |
+|------------------|---------|
+| `aws_sigv4` | AWS Signature Version 4 — signs every outbound request over the canonical method, URL, headers, and body |
+
+##### `aws_sigv4` fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `service` | yes | AWS service code used in the signing scope. Not metadata — SigV4 derives the signing key from `HMAC(region, service)`, and AWS validates that the scope matches the endpoint being called. Wrong code → `403 SignatureDoesNotMatch`. Common values: `s3`, `logs` (CloudWatch Logs), `cloudtrail`, `ce` (Cost Explorer), `sts`, `ec2`, `lambda`, `dynamodb`, `monitoring` (CloudWatch Metrics), `events` (EventBridge). Each source manifest sets the value matching its target API. |
+| `region` | yes | AWS region in the standard short form (`us-east-1`, `eu-west-2`, …). Templated string — typically `{{input.AWS_REGION}}` so the same manifest can serve multiple regions. |
+| `access_key_id` | yes | IAM access key ID. Accepts both long-lived user keys and STS-issued temporary keys. Templated — usually sourced from a secret input. |
+| `secret_access_key` | yes | IAM secret access key paired with `access_key_id`. Templated — usually sourced from a secret input. |
+| `session_token` | no | STS session token. Include when `access_key_id` / `secret_access_key` are temporary credentials (AssumeRole, MFA, federated sessions, etc.). Coral emits it as the `X-Amz-Security-Token` header. Omit for long-lived IAM user keys. |
+
+Example — signing requests against CloudWatch Logs with temporary STS credentials:
+
+```yaml
+inputs:
+  AWS_REGION:
+    kind: variable
+    default: us-east-1
+  AWS_ACCESS_KEY_ID:
+    kind: secret
+  AWS_SECRET_ACCESS_KEY:
+    kind: secret
+  AWS_SESSION_TOKEN:
+    kind: secret
+auth:
+  type: CustomAuth
+  authenticator: aws_sigv4
+  service: logs
+  region: "{{input.AWS_REGION}}"
+  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
+  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
+  session_token: "{{input.AWS_SESSION_TOKEN}}"
+```
+
+Coral does not fetch credentials dynamically (IMDS, EC2 instance profile, `~/.aws/credentials`, SSO, etc.) — static values must flow in through inputs.
 
 ### Request headers
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -183,9 +183,11 @@ inputs:
     kind: secret
 base_url: "{{input.API_BASE}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.API_TOKEN}}"
 tables:
   - name: messages
     description: Messages from the demo API
@@ -209,39 +211,26 @@ In this minimal example:
 
 ### HTTP authentication
 
-The top-level `auth:` block on an HTTP source is a tagged union — pick one shape via `type:`. Four built-in variants cover the common cases.
+The top-level `auth:` block on an HTTP source is a tagged union — pick one shape via `type:`. Three built-in variants cover the common cases.
 
-#### `ApiKeyAuth` — single token in a single header
+#### `HeaderAuth` — one or more auth headers
 
-Most APIs fall here (Bearer tokens, `Token <x>`, simple API keys, etc.).
+Most APIs fall here (Bearer tokens, `Token <x>`, simple API keys, dual keys, proprietary header schemes, etc.). Values use the same `ValueSourceSpec` shape as other header fields.
 
 ```yaml
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.API_TOKEN}}"
 ```
 
-The `api_token` field is a templated string; interpolate the token from an input. The header name itself is a literal.
-
-#### `BasicHttpAuth` — user + password, base64-encoded at runtime
-
-Coral computes `Basic <base64(user:pass)>` from plaintext inputs. Do **not** pre-encode — supply the raw values.
+Use multiple entries when the provider needs more than one auth header.
 
 ```yaml
 auth:
-  type: BasicHttpAuth
-  username: "{{input.ACCOUNT_EMAIL}}"
-  password: "{{input.ACCOUNT_PASSWORD}}"
-```
-
-#### `CustomHeadersAuth` — freeform list of auth headers
-
-Use when one token + one header isn't enough (dual API keys, proprietary header schemes, etc.). Values use the same `ValueSourceSpec` shape as other header fields.
-
-```yaml
-auth:
-  type: CustomHeadersAuth
+  type: HeaderAuth
   headers:
     - name: DD-API-KEY
       from: input
@@ -249,6 +238,17 @@ auth:
     - name: DD-APPLICATION-KEY
       from: input
       key: DD_APPLICATION_KEY
+```
+
+#### `BasicAuth` — user + password, base64-encoded at runtime
+
+Coral computes `Basic <base64(user:pass)>` from plaintext inputs. Do **not** pre-encode — supply the raw values.
+
+```yaml
+auth:
+  type: BasicAuth
+  username: "{{input.ACCOUNT_EMAIL}}"
+  password: "{{input.ACCOUNT_PASSWORD}}"
 ```
 
 #### `CustomAuth` — compiled-in signers for schemes that need dynamic logic
@@ -467,9 +467,11 @@ inputs:
 
 base_url: "{{input.API_BASE}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.API_TOKEN}}"
 ```
 
 Rules:

--- a/sources/clickup/manifest.yaml
+++ b/sources/clickup/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Create a personal token in ClickUp → Settings → Apps
 base_url: https://api.clickup.com/api
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "{{input.CLICKUP_API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "{{input.CLICKUP_API_TOKEN}}"
 tables:
   - name: current
     description: Get running time entry

--- a/sources/datadog/manifest.yaml
+++ b/sources/datadog/manifest.yaml
@@ -16,7 +16,7 @@ inputs:
     hint: Create an application key in Datadog → Organization Settings → Application Keys
 base_url: https://api.{{input.DD_SITE}}
 auth:
-  type: CustomHeadersAuth
+  type: HeaderAuth
   headers:
     - name: DD-API-KEY
       from: input

--- a/sources/github/manifest.yaml
+++ b/sources/github/manifest.yaml
@@ -17,9 +17,11 @@ inputs:
     kind: secret
     hint: Run `gh auth token` or create a PAT
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.GITHUB_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.GITHUB_TOKEN}}"
 request_headers:
   - name: Accept
     from: literal

--- a/sources/gitlab/manifest.yaml
+++ b/sources/gitlab/manifest.yaml
@@ -13,9 +13,11 @@ inputs:
     hint: Create a personal access token with `read_api` scope in GitLab → User Settings → Access Tokens
 base_url: '{{input.GITLAB_API_BASE}}'
 auth:
-  type: ApiKeyAuth
-  header: PRIVATE-TOKEN
-  api_token: "{{input.GITLAB_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: PRIVATE-TOKEN
+      from: template
+      template: "{{input.GITLAB_TOKEN}}"
 tables:
   - name: access_requests
     description: Gets a list of access requests for a group.

--- a/sources/grafana/manifest.yaml
+++ b/sources/grafana/manifest.yaml
@@ -18,9 +18,11 @@ inputs:
     hint: Create a service-account token with the required read scopes
 base_url: "{{input.GRAFANA_URL}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.GRAFANA_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.GRAFANA_TOKEN}}"
 
 tables:
   - name: dashboards

--- a/sources/incident_io/manifest.yaml
+++ b/sources/incident_io/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Create an API key in incident.io → Settings → API keys
 base_url: https://api.incident.io
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.INCIDENT_IO_API_KEY}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.INCIDENT_IO_API_KEY}}"
 tables:
   - name: actions
     description: List

--- a/sources/intercom/manifest.yaml
+++ b/sources/intercom/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Create an access token in Intercom → Settings → Developers → Developer Hub
 base_url: https://api.intercom.io
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.INTERCOM_ACCESS_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.INTERCOM_ACCESS_TOKEN}}"
 request_headers:
   - name: Intercom-Version
     from: literal

--- a/sources/launchdarkly/manifest.yaml
+++ b/sources/launchdarkly/manifest.yaml
@@ -13,9 +13,11 @@ inputs:
     hint: Create an API access token in LaunchDarkly → Account settings → Authorization
 base_url: "{{input.LAUNCHDARKLY_API_BASE}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "{{input.LAUNCHDARKLY_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "{{input.LAUNCHDARKLY_TOKEN}}"
 request_headers:
   - name: Content-Type
     from: literal

--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Create a personal API key in Linear → Settings → API
 base_url: https://api.linear.app
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "{{input.LINEAR_API_KEY}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "{{input.LINEAR_API_KEY}}"
 tables:
   - name: teams
     description: Teams in the Linear workspace

--- a/sources/openobserve/manifest.yaml
+++ b/sources/openobserve/manifest.yaml
@@ -19,7 +19,7 @@ inputs:
     hint: OpenObserve account password
 base_url: "{{input.OPENOBSERVE_URL}}"
 auth:
-  type: BasicHttpAuth
+  type: BasicAuth
   username: "{{input.OPENOBSERVE_USERNAME}}"
   password: "{{input.OPENOBSERVE_PASSWORD}}"
 

--- a/sources/pagerduty/manifest.yaml
+++ b/sources/pagerduty/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Create an API token in PagerDuty → Integrations → API Access Keys
 base_url: https://api.pagerduty.com
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Token token={{input.PAGERDUTY_API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Token token={{input.PAGERDUTY_API_TOKEN}}"
 tables:
   - name: abilities
     description: List abilities

--- a/sources/posthog/manifest.yaml
+++ b/sources/posthog/manifest.yaml
@@ -13,9 +13,11 @@ inputs:
     hint: Create a personal API key in PostHog → Account → Personal API keys
 base_url: "{{input.POSTHOG_API_BASE}}"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.POSTHOG_API_KEY}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.POSTHOG_API_KEY}}"
 tables:
   - name: actions
     description: project_actions

--- a/sources/sentry/manifest.yaml
+++ b/sources/sentry/manifest.yaml
@@ -12,9 +12,11 @@ inputs:
     hint: Create an auth token in Sentry → User Settings → Auth Tokens
 base_url: https://sentry.io
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.SENTRY_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.SENTRY_TOKEN}}"
 tables:
   - name: projects
     description: Sentry projects in the organization

--- a/sources/slack/manifest.yaml
+++ b/sources/slack/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Create a user or bot token in a Slack app (https://api.slack.com/apps)
 base_url: https://slack.com
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.SLACK_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.SLACK_TOKEN}}"
 tables:
   - name: channels
     description: Slack channels with topic, purpose, and member count

--- a/sources/statusgator/manifest.yaml
+++ b/sources/statusgator/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Copy your API token from StatusGator → Account Settings
 base_url: "https://statusgator.com/api/v3"
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.STATUSGATOR_API_TOKEN}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.STATUSGATOR_API_TOKEN}}"
 request_headers:
   - name: Accept
     from: literal

--- a/sources/stripe/manifest.yaml
+++ b/sources/stripe/manifest.yaml
@@ -9,9 +9,11 @@ inputs:
     hint: Create a restricted or secret API key in the Stripe Dashboard → Developers → API keys
 base_url: https://api.stripe.com
 auth:
-  type: ApiKeyAuth
-  header: Authorization
-  api_token: "Bearer {{input.STRIPE_API_KEY}}"
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.STRIPE_API_KEY}}"
 tables:
   - name: account
     description: Retrieve account


### PR DESCRIPTION
## Summary

Rework HTTP-backed source authentication from a single freeform headers into new AuthSpec shape:
  - BasicAuthSpec — username + password templates, base64-encoded at runtime  
  - HeaderAuthSpec — freeform list of headers for sources that don't fit a single-token shape (e.g. Datadog's dual API keys)
  - CustomAuth — dispatches to a compiled-in signer via authenticator: tag; first impl is aws_sigv4

New top-level request_headers: — generic per-source HTTP headers not conveyed by auth (Accept, X-API-Version, etc.). Applied to every outbound request.

Runtime User-Agent — set once on the reqwest client in HttpSourceClient::from_manifest.

## Test plan

  | Check | Status |
  |-------|--------|
  | `cargo test --workspace` | PASS|
  | `make rust-checks` | PASS |
  | Manual End-to-end verification against GitHub + OpenObserve during development | PASS |
  | Manual check: SigV4 against a live AWS endpoint | PASS |

Breaking changes
- OpenObserve source config: users must re-enter credentials as `OPENOBSERVE_USERNAME` + `OPENOBSERVE_PASSWORD` (plaintext) instead of pre-encoded `OPENOBSERVE_BASIC_AUTH`.