### PR TITLE
docs(docs): add GA4 analytics config

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -75,10 +75,7 @@
       },
       {
         "group": "Guides",
-        "pages": [
-          "guides/use-coral-over-mcp",
-          "guides/write-a-custom-source"
-        ]
+        "pages": ["guides/use-coral-over-mcp", "guides/write-a-custom-source"]
       },
       {
         "group": "Reference",
@@ -105,6 +102,9 @@
       "apiKey": "phc_vgjDFiUbVgKPsKQL3wKPwsG3z7KnH4hgLi6n57PX7HEs",
       "apiHost": "https://eu.posthog.com",
       "sessionRecording": false
+    },
+    "ga4": {
+      "measurementId": "G-MZ1LQREJTK"
     }
   },
   "thumbnails": {


### PR DESCRIPTION
## Summary
Add the Google Analytics 4 measurement ID to the docs site configuration so docs traffic can be tracked in GA4 alongside the existing PostHog setup.

## Testing
- `jq empty docs/docs.json`
