### PR TITLE
docs: sync Jira source and coral.inputs guidance

### DIFF
--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -21,6 +21,24 @@ Before setting up a client, make sure you have [connected at least one source](/
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
 
+## Per-source configuration
+
+Agents can inspect non-secret source configuration through `coral.inputs`.
+This is useful for composing absolute URLs or account-scoped identifiers from
+saved source variables such as a Datadog site or Jira base URL. Secret values
+are never exposed: secret rows always return `value = NULL`, while `is_set`
+shows whether a secret has been configured.
+
+```sql
+-- Look up a variable value
+SELECT value FROM coral.inputs
+WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
+
+-- Check which secrets are configured without revealing them
+SELECT schema_name, key FROM coral.inputs
+WHERE kind = 'secret' AND is_set;
+```
+
 ## Client setup
 
 Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`. If a client needs a full path, run `which coral` and use that path in the config instead of `coral`.

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -21,24 +21,6 @@ Before setting up a client, make sure you have [connected at least one source](/
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
 
-## Per-source configuration
-
-Agents can inspect non-secret source configuration through `coral.inputs`.
-This is useful for composing absolute URLs or account-scoped identifiers from
-saved source variables such as a Datadog site or Jira base URL. Secret values
-are never exposed: secret rows always return `value = NULL`, while `is_set`
-shows whether a secret has been configured.
-
-```sql
--- Look up a variable value
-SELECT value FROM coral.inputs
-WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
-
--- Check which secrets are configured without revealing them
-SELECT schema_name, key FROM coral.inputs
-WHERE kind = 'secret' AND is_set;
-```
-
 ## Client setup
 
 Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`. If a client needs a full path, run `which coral` and use that path in the config instead of `coral`.
@@ -193,6 +175,23 @@ Once your client is connected, ask the agent to list available tables or run a s
 > "Run a small Coral query against `coral.tables`."
 
 The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources.
+
+If you need to inspect saved source configuration, query `coral.inputs`. This
+is useful for composing absolute URLs or account-scoped identifiers from
+non-secret source variables such as a Datadog site or Jira base URL. Secret
+values are never exposed: secret rows always return `value IS NULL`, while
+`is_set` shows whether a secret has been configured. For the underlying source
+input model, see the [source inputs reference](/reference/source-spec-reference#source-inputs).
+
+```sql
+-- Look up a variable value
+SELECT value FROM coral.inputs
+WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
+
+-- Check which secrets are configured without revealing them
+SELECT schema_name, key FROM coral.inputs
+WHERE kind = 'secret' AND is_set;
+```
 
 ## Troubleshooting
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -176,23 +176,6 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources.
 
-If you need to inspect saved source configuration, query `coral.inputs`. This
-is useful for composing absolute URLs or account-scoped identifiers from
-non-secret source variables such as a Datadog site or Jira base URL. Secret
-values are never exposed: secret rows always return `value IS NULL`, while
-`is_set` shows whether a secret has been configured. For the underlying source
-input model, see the [source inputs reference](/reference/source-spec-reference#source-inputs).
-
-```sql
--- Look up a variable value
-SELECT value FROM coral.inputs
-WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
-
--- Check which secrets are configured without revealing them
-SELECT schema_name, key FROM coral.inputs
-WHERE kind = 'secret' AND is_set;
-```
-
 ## Troubleshooting
 
 - **`coral` not found:** Make sure `coral` is on your `PATH`, or use the full path from `which coral` in your client config.

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -20,6 +20,7 @@ If the source you need is not available, you can extend Coral by [writing a cust
 | `github`       | `http`    | Repositories, issues, pull requests, Actions, releases, and more |
 | `grafana`      | `http`    | Dashboards, panels, folders, datasources, alerts, teams, users   |
 | `incident_io`  | `http`    | Incidents, alerts, schedules, catalog, and status data           |
+| `jira`         | `http`    | Projects, issues, comments, worklogs, versions, and priorities   |
 | `launchdarkly` | `http`    | Projects, flags, environments, segments, and audit surfaces      |
 | `linear`       | `http`    | Teams, issues, projects, cycles, and initiatives                 |
 | `otel`         | `parquet` | OpenTelemetry logs and metrics exported as Parquet               |
@@ -39,6 +40,7 @@ Supported sources fall into two categories.
 ## Upgrading bundled sources
 
 To update bundled sources, upgrade the Coral binary. Coral resolves each bundled manifest from the current binary at validate or query time, so spec fixes and newly required inputs are picked up automatically, you don't need to remove and re-add the source. Your configured variables and secrets stay in local state across upgrades.
+
 ## Don't see what you need?
 
 The bundled set is growing. If your data source is not listed, [write a custom source](/guides/write-a-custom-source), or reach out to us via [Discord](https://withcoral.com/discord) or [GitHub](https://github.com/withcoral/coral/issues).

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -361,3 +361,35 @@ Rules:
 - `default` is allowed only for variables
 - `hint` is optional and shown while Coral prompts for the input
 - references elsewhere in the manifest use `{{input.KEY}}` templates or `from: input`
+
+At runtime, installed source inputs are also surfaced through `coral.inputs`.
+This is useful when agents or scripts need to inspect non-secret source config
+such as a Datadog site or Jira base URL and compose absolute URLs or
+account-scoped identifiers from it. Secret values are never exposed there:
+secret rows always return `value IS NULL`, while `is_set` shows whether the
+secret has been configured.
+
+`coral.inputs` includes these columns:
+
+| Column | Description |
+| ------ | ----------- |
+| `schema_name` | Source schema that owns the input |
+| `key` | Input key from the manifest |
+| `kind` | `variable` or `secret` |
+| `value` | Variable value when available; `NULL` for secrets |
+| `default_value` | Manifest-authored default for variables |
+| `hint` | Prompt hint from the manifest, if any |
+| `required` | Whether the input must be configured |
+| `is_set` | Whether Coral has a saved value for that input |
+
+Example queries:
+
+```sql
+-- Look up a variable value
+SELECT value FROM coral.inputs
+WHERE schema_name = 'datadog' AND kind = 'variable' AND key = 'DD_SITE';
+
+-- Check which secrets are configured without revealing them
+SELECT schema_name, key FROM coral.inputs
+WHERE kind = 'secret' AND is_set;
+```


### PR DESCRIPTION
## Summary

Keep the public docs aligned with the current product surface after the recent Jira source and `coral.inputs` additions.

- add Jira to the canonical bundled-sources reference page
- document `coral.inputs` in the MCP guide so agents can inspect non-secret source config safely
- keep the examples and wording grounded in the current source manifests and MCP guide template

## Validation

- verified the Jira source docs against `sources/jira/manifest.yaml` and `sources/jira/README.md`
- verified `coral.inputs` guidance against `crates/coral-mcp/src/guide_template.md`
- no dedicated docs validation command exists in the repo beyond local `npx mint dev`
