### PR TITLE
test(sources/linear): add smoke test query

### DIFF
--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -19,6 +19,8 @@ auth:
     - name: Authorization
       from: template
       template: "{{input.LINEAR_API_KEY}}"
+test_queries:
+  - SELECT * FROM linear.users LIMIT 1
 tables:
   - name: teams
     description: Teams in the Linear workspace


### PR DESCRIPTION
The Linear manifest did not have a test_queries entry, so source testing was not exercising a minimal end-to-end query. Use linear.users because it is a broadly available workspace-level table, requires no filters, and matches the existing LIMIT 1 smoke-check pattern used by other source manifests.

Constraint: Keep the change scoped to the manifest and avoid required filters
Rejected: linear.team_issues | requires team_id filter
Rejected: linear.project_updates | requires project_id filter
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Prefer broadly available unfiltered tables for source smoke queries unless narrower coverage is required
Tested: cargo run -- source test linear
Not-tested: Workspaces with atypical permissions that omit users from the API