### PR TITLE
docs: Mention withcoral/skills

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -73,6 +73,21 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
   </Tab>
 </Tabs>
 
+## Skills
+
+Coral publishes a set of agent skills that teach your coding agent how to use Coral effectively. Install them with:
+
+```shellscript
+npx skills add withcoral/skills
+```
+
+Available skills:
+
+- **`coral`** — teaches your agent the discovery-first workflow for answering data questions with `coral sql`, including how to use `coral.tables`, `coral.columns`, and `coral.inputs`.
+- **`coral-create-source-spec`** — guides your agent through authoring or repairing a custom source spec YAML for `coral source add --file`, or adapting it into a bundled source.
+
+Browse the source at [github.com/withcoral/skills](https://github.com/withcoral/skills).
+
 ## Local state
 
 Coral stores local state in its platform-specific configuration directory. You can override that location with:

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -56,3 +56,4 @@ coral sql "
 
 - **[Use Coral over MCP](/guides/use-coral-over-mcp)** — expose Coral to Claude Code, Cursor, or VS Code over MCP so your agent can query sources directly
 - **[Write a custom source spec](/guides/write-a-custom-source)** — connect any HTTP API or local dataset that isn't bundled yet
+- **[Install Coral skills](/getting-started/installation#skills)** — teach your coding agent how to use Coral

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -7,6 +7,12 @@ Coral ships with [popular data sources](/reference/bundled-sources), but you are
 
 A source spec tells Coral how to connect to an API or read a local dataset, what tables to expose, and what columns each table has. Once added, the source works exactly like a bundled one: same SQL, same `coral.tables`, `coral.columns` and `coral.inputs`, same MCP surface.
 
+<Tip>
+  Install the [Coral source spec authoring
+  skill](/getting-started/installation#skills) with `npx skills add
+  withcoral/skills` to help your coding agent write source specs.
+</Tip>
+
 ## Agent-driven authoring
 
 Source authoring works well as an agent-driven workflow. Point your coding agent at the Coral CLI and the [source spec reference](/reference/source-spec-reference), give it the API docs or describe the endpoints you want, and let it iterate:


### PR DESCRIPTION
## Summary

We ship some `skills`, and we should advertise those in the docs like we do in `onboard`

## Test plan

In the installation page:

<img width="636" height="503" alt="image" src="https://github.com/user-attachments/assets/47924da7-033c-47ec-a966-facde79c5906" />

In the source spec authoring page
<img width="628" height="228" alt="image" src="https://github.com/user-attachments/assets/ffaeb733-d271-4687-9c4c-d49042e6e92d" />

As next steps in quickstart:

<img width="640" height="254" alt="image" src="https://github.com/user-attachments/assets/54b3138b-1979-4370-970a-116af7ffe460" />
