### PR TITLE
test(sources/intercom): add smoke test query

### DIFF
--- a/sources/intercom/manifest.yaml
+++ b/sources/intercom/manifest.yaml
@@ -25,6 +25,8 @@ auth:
     - name: Accept
       from: literal
       value: application/json
+test_queries:
+  - SELECT * FROM intercom.admins LIMIT 1
 tables:
   - name: contacts
     description: Contacts (users and leads) in the workspace


### PR DESCRIPTION
The Intercom source did not exercise any declared table during source validation, so add one bounded query against a broadly available endpoint. admins is a good fit because it should exist in normal workspaces and does not require filters or customer data assumptions.

Constraint: Query tests should remain read-only and cheap for HTTP-backed sources
Rejected: contacts smoke query | may fail in empty workspaces with no contact data
Rejected: conversations smoke query | depends more heavily on workspace activity
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Prefer unfiltered workspace-metadata tables for source smoke tests unless broader coverage is needed
Tested: cargo run -- source test intercom
Not-tested: Intercom workspaces with unusual admin endpoint permissions