### PR TITLE
test(sources/sentry): add smoke test query

### DIFF
--- a/sources/sentry/manifest.yaml
+++ b/sources/sentry/manifest.yaml
@@ -22,6 +22,8 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{input.SENTRY_TOKEN}}
+test_queries:
+  - SELECT * FROM sentry.projects LIMIT 1
 tables:
   - name: projects
     description: Sentry projects in the organization


### PR DESCRIPTION
Add a single manifest-level test query against the organization-scoped projects table so the bundled Sentry source has a minimal live validation path without extra filters.

Constraint: Keep the change scoped to sources/sentry/manifest.yaml
Rejected: Use an issue-scoped table | requires an issue_id filter and is less broadly applicable
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep Sentry manifest test queries on broadly available no-filter tables unless a narrower table is required to validate a bug fix
Tested: cargo run -- source test sentry
Not-tested: make rust-checks (no Rust code changed)