### PR TITLE
fix(sources/jira): align Jira ID column types

### DIFF
--- a/sources/jira/manifest.yaml
+++ b/sources/jira/manifest.yaml
@@ -55,7 +55,7 @@ tables:
         query_param: maxResults
     columns:
       - name: id
-        type: Int64
+        type: Utf8
         nullable: false
         description: Project ID
         expr:
@@ -128,7 +128,7 @@ tables:
             - avatarUrls
             - 48x48
       - name: category_id
-        type: Int64
+        type: Utf8
         nullable: true
         description: Project category ID
         expr:
@@ -645,9 +645,9 @@ tables:
           path:
             - overdue
       - name: project_id
-        type: Int64
+        type: Utf8
         nullable: true
-        description: Numeric project ID for the version
+        description: Project ID for the version
         expr:
           kind: path
           path:


### PR DESCRIPTION
## Summary
Jira source tables should expose related identifier columns with consistent SQL types so users can join them without extra casts.

This change normalizes the bundled Jira manifest so project and category identifiers are all surfaced as `Utf8`, matching the API payload shape used elsewhere in the source.

## Verification
- `target/debug/coral source lint sources/jira/manifest.yaml`
