### PR TITLE
test(sources/jira): add smoke test query

### DIFF
--- a/sources/jira/manifest.yaml
+++ b/sources/jira/manifest.yaml
@@ -30,6 +30,8 @@ auth:
     - name: Accept
       from: literal
       value: application/json
+test_queries:
+  - SELECT * FROM jira.projects LIMIT 1
 tables:
   - name: projects
     description: Projects visible to the authenticated Jira user


### PR DESCRIPTION
Add a single test_queries entry for jira.projects so source validation exercises a broadly available table without requiring user-supplied filters.

Constraint: Keep the change scoped to the Jira manifest only
Rejected: Query jira.issues | requires the mandatory jql filter
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep Jira test queries on broadly visible tables unless required filters become optional
Tested: cargo run -- source test jira
Tested: repository hooks (fmt/check/clippy/test/doc)
Not-tested: Live Jira tenants with zero visible projects