### PR TITLE
test(sources/grafana): add smoke test query

### DIFF
--- a/sources/grafana/manifest.yaml
+++ b/sources/grafana/manifest.yaml
@@ -26,6 +26,9 @@ auth:
       from: template
       template: Bearer {{input.GRAFANA_TOKEN}}
 
+test_queries:
+  - SELECT * FROM grafana.datasources LIMIT 1
+
 tables:
   - name: dashboards
     description: Grafana dashboards listed via the search API


### PR DESCRIPTION
Use datasources for source validation because it is broadly available and does not require caller-supplied filters. This keeps the test query cheap while still verifying auth and table mapping through the bundled manifest.

Constraint: Validation should avoid required filters and instance-specific resources
Rejected: dashboards smoke test | dashboards may be empty on minimal instances
Rejected: folders smoke test | folder availability varies by instance shape
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep Grafana test_queries focused on broadly available read endpoints unless the manifest contract changes
Tested: CORAL_CONFIG_DIR=/tmp/coral-grafana-test cargo run -- source test grafana against a temporary local mock Grafana endpoint
Not-tested: Live Grafana Cloud or self-hosted instances