### PR TITLE
test(sources/launchdarkly): add smoke test query

### DIFF
--- a/sources/launchdarkly/manifest.yaml
+++ b/sources/launchdarkly/manifest.yaml
@@ -20,6 +20,8 @@ auth:
     - name: Content-Type
       from: literal
       value: application/json
+test_queries:
+  - SELECT * FROM launchdarkly.projects LIMIT 1
 tables:
   - name: projects
     description: LaunchDarkly projects visible to the authenticated token


### PR DESCRIPTION
The LaunchDarkly source had no test_queries entry, so source-level
smoke coverage missed even the most basic no-filter table. Add the
smallest broadly available query against projects to match the manifest
pattern used by other sources.

Constraint: Keep the code change scoped to sources/launchdarkly/manifest.yaml
Rejected: Query a filter-dependent table | would require setup-specific filters
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Prefer no-filter smoke queries on broadly available tables when adding manifest test coverage
Tested: coral source add launchdarkly; coral source test launchdarkly; SELECT * FROM launchdarkly.projects LIMIT 1
Not-tested: cargo run -- source test launchdarkly is currently blocked by a pre-existing coral-engine compile error in this branch