### PR TITLE
test(sources/github): add smoke test query

### DIFF
--- a/sources/github/manifest.yaml
+++ b/sources/github/manifest.yaml
@@ -30,6 +30,8 @@ auth:
     - name: User-Agent
       from: literal
       value: coral
+test_queries:
+  - SELECT * FROM github.meta LIMIT 1
 tables:
   - name: accepted_assignments
     description: List accepted assignments for an assignment


### PR DESCRIPTION
GitHub did not yet define a manifest-level smoke query, so source testing had no minimal filter-free path to exercise. Add a single test_queries entry that targets the broadly available meta table and keeps validation scoped to the manifest.

Constraint: Keep the source change scoped to sources/github/manifest.yaml
Rejected: Use github.rate_limit for the smoke query | meta is broader and avoids depending on authenticated rate-limit shape
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep GitHub smoke queries filter-free and broadly available unless the source contract requires scoped inputs
Tested: /Users/ludo/DEV/worktrees/coral-test-queries/target/debug/coral source test github
Not-tested: cargo run -- source test github (blocked in this branch by a pre-existing coral-engine compile error and local disk pressure)