### PR TITLE
docs: Add "how coral works" section to intro

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -46,9 +46,9 @@ With Coral, agents can make fewer, more precise tool calls, as a result it is mo
 
 Coral sits between you and your data sources: you (or your agent) write SQL, and Coral translates it into API calls or file reads, then returns a single query result.
 
-A **source** is a YAML spec that defines how to reach an API or local dataset and which tables/columns it exposes. When you run `coral source add github`, Coral installs the `github` source and its bindings. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pull_requests` are queryable. Start with [bundled sources](/reference/bundled-sources) or [write your own](/guides/write-a-custom-source).
+A **source spec** is a YAML file that defines how to reach an API or local dataset and which tables/columns it exposes. A **source** is a data source Coral can query, created from a source spec plus your configured credentials and variables. When you run `coral source add github`, Coral installs the `github` source. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pull_requests` are queryable. Start with [bundled sources](/reference/bundled-sources) or [write your own](/guides/write-a-custom-source).
 
-During `source add`, Coral prompts for declared variables and secrets (tokens, workspace IDs, file paths). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.tickets` or `slack.messages`), and Coral executes that locally on your machine.
+During `source add`, Coral prompts for declared variables and secrets (tokens, workspace IDs, file paths, etc.). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
 
 ```mermaid actions={false}
 graph LR

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -42,6 +42,42 @@ With Coral, agents can make fewer, more precise tool calls, as a result it is mo
   </Step>
 </Steps>
 
+## How Coral works
+
+Coral sits between you and your data sources: you (or your agent) write SQL, and Coral translates it into API calls or file reads, then returns a single query result.
+
+A **source** is a YAML spec that defines how to reach an API or local dataset and which tables/columns it exposes. When you run `coral source add github`, Coral installs the `github` source and its bindings. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pull_requests` are queryable. Start with [bundled sources](/reference/bundled-sources) or [write your own](/guides/write-a-custom-source).
+
+During `source add`, Coral prompts for declared variables and secrets (tokens, workspace IDs, file paths). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.tickets` or `slack.messages`), and Coral executes that locally on your machine.
+
+```mermaid actions={false}
+graph LR
+    Agent["You / your agent"] -->|SQL query| Coral["Coral (local)"]
+    Coral -->|Result rows| Agent
+
+    subgraph Sources["Installed sources"]
+        GH["github source<br/>(github.* tables)"]
+        LN["linear source<br/>(linear.* tables)"]
+        FS["file source<br/>(your_files.* tables)"]
+    end
+
+    Coral --> GH
+    Coral --> LN
+    Coral --> FS
+
+    subgraph Backing["Backing systems"]
+        GHAPI["GitHub API"]
+        LNAPI["Linear API"]
+        Disk["Local files"]
+    end
+
+    GH -.->|PAT / gh auth token| GHAPI
+    LN -.->|Personal API key| LNAPI
+    FS -.->|File path| Disk
+```
+
+For the full internals, crates, gRPC transport, DataFusion integration, see the [architecture page](/contributors/architecture).
+
 ## Quick links
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary

Addressing some early users' feedback, by adding some text describing how coral works, in the docs landing page.


## Test plan

<img width="607" height="842" alt="image" src="https://github.com/user-attachments/assets/25323046-6d8d-4649-b475-d3a3b50a0feb" />
