### PR TITLE
test(sources/pagerduty): add smoke test query

### DIFF
--- a/sources/pagerduty/manifest.yaml
+++ b/sources/pagerduty/manifest.yaml
@@ -13,6 +13,8 @@ auth:
     - name: Authorization
       from: template
       template: Token token={{input.PAGERDUTY_API_TOKEN}}
+test_queries:
+  - SELECT * FROM pagerduty.abilities LIMIT 1
 tables:
   - name: abilities
     description: List abilities


### PR DESCRIPTION
Mirror the existing bundled-source pattern by adding one minimal PagerDuty test query against the broadly available abilities table. This keeps the change scoped to the manifest while giving source validation a smoke-test target.

Constraint: Keep the change limited to sources/pagerduty/manifest.yaml
Constraint: cargo run -- source test pagerduty is currently blocked by an unrelated compile error in crates/coral-engine/src/lib.rs
Rejected: Query a table with required filters | not suitable for a minimal smoke test
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Prefer broadly available no-filter tables for bundled smoke tests when the API allows it
Tested: Manifest diff inspection; attempted cargo run --target-dir /Users/ludo/DEV/worktrees/coral-test-queries/target -- source test pagerduty (blocked by unrelated coral-engine compile error)
Not-tested: End-to-end PagerDuty source validation until the unrelated compile failure is fixed