### PR TITLE
test(sources/gitlab): add manifest smoke query

### DIFF
--- a/sources/gitlab/manifest.yaml
+++ b/sources/gitlab/manifest.yaml
@@ -18,7 +18,7 @@ auth:
       from: template
       template: '{{input.GITLAB_TOKEN}}'
 test_queries:
-  - SELECT * FROM gitlab.projects LIMIT 1
+  - SELECT * FROM gitlab.all_projects LIMIT 1
 tables:
   - name: access_requests
     description: Gets a list of access requests for a group.

--- a/sources/gitlab/manifest.yaml
+++ b/sources/gitlab/manifest.yaml
@@ -17,6 +17,8 @@ auth:
     - name: PRIVATE-TOKEN
       from: template
       template: '{{input.GITLAB_TOKEN}}'
+test_queries:
+  - SELECT * FROM gitlab.projects LIMIT 1
 tables:
   - name: access_requests
     description: Gets a list of access requests for a group.


### PR DESCRIPTION
Mirror the existing source manifest pattern by adding a minimal test_queries entry that hits the broadly available top-level projects table without requiring filters.

Constraint: Keep the change scoped to sources/gitlab/manifest.yaml
Constraint: cargo run -- source test gitlab is currently blocked by an unrelated coral-engine compile error in crates/coral-engine/src/lib.rs
Rejected: Add a query for a filtered table | would require repo-specific IDs or extra setup
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep GitLab smoke tests on top-level tables that do not require filters unless the manifest gains a more reliable universal target
Tested: YAML parse of sources/gitlab/manifest.yaml; attempted cargo run -- source test gitlab (blocked by unrelated compile failure)
Not-tested: End-to-end source test execution until the existing coral-engine compile error is fixed