### PR TITLE
test(sources/datadog): add monitor smoke query

### DIFF
--- a/sources/datadog/manifest.yaml
+++ b/sources/datadog/manifest.yaml
@@ -23,6 +23,8 @@ auth:
     - name: DD-APPLICATION-KEY
       from: input
       key: DD_APPLICATION_KEY
+test_queries:
+  - SELECT * FROM datadog.monitors LIMIT 1
 tables:
   - name: monitors
     description: Datadog monitors with status and alert configuration.


### PR DESCRIPTION
The Datadog source lacked a manifest-level test query, so this adds the smallest smoke query patterned after the Slack source: selecting from monitors with LIMIT 1 and no required filters.

Constraint: Keep the change scoped to sources/datadog/manifest.yaml only
Constraint: cargo run -- source test datadog is currently blocked by an unrelated compile error in crates/coral-engine/src/lib.rs
Rejected: Add a test query for a filter-required table | would not be a minimal smoke test
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Prefer broadly available tables without required filters for source smoke tests unless the API requires parameters
Tested: YAML parse of sources/datadog/manifest.yaml; attempted cargo run -- source test datadog
Not-tested: End-to-end datadog source test execution remains blocked by unrelated repo compile failure