### PR TITLE
ci: guard fromJSON against empty release-please pr output

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,7 +39,7 @@ jobs:
         if: steps.rp.outputs.pr
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ fromJSON(steps.rp.outputs.pr).headBranchName }}
+          ref: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
           token: ${{ steps.github-app-token.outputs.token }}
           persist-credentials: true
 
@@ -50,7 +50,7 @@ jobs:
       - name: Sync Cargo.lock to new workspace version
         if: steps.rp.outputs.pr
         env:
-          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr).headBranchName }}
+          PR_BRANCH: ${{ fromJSON(steps.rp.outputs.pr || '{}').headBranchName }}
         run: |
           set -euo pipefail
           cargo update --workspace


### PR DESCRIPTION
## Summary
- When release-please leaves the existing release PR unchanged (e.g. [run 24723529728](https://github.com/withcoral/coral/actions/runs/24723529728/job/72318307835)), `steps.rp.outputs.pr` is empty and `fromJSON('')` errors with `Error reading JToken from JsonReader`.
- Step-level `env:` expressions are evaluated before `if:`, so the `if: steps.rp.outputs.pr` guard on the Sync Cargo.lock step can't rescue it — the template error fires first.
- Fall back to `'{}'` on both `fromJSON(steps.rp.outputs.pr)` references so the expression resolves cleanly; the `if:` guard then correctly skips the step when no PR was created.

## When does release-please leave the PR unchanged?
It skips updating the open release PR whenever the candidate PR it would produce is byte-identical to the existing one. Common triggers:

- **Merges that don't alter the release** — commits of types release-please ignores for version bumps (`chore:`, `docs:`, `test:`, `ci:`, `refactor:`). The failing run above was `47776f9 docs: Add "how coral works" section...`, which fits this.
- **Re-runs with no new commits** — manual re-dispatch, or a push that adds nothing new since release-please last synced the PR.
- **Cosmetic-only commits** — merges whose message body/footer doesn't affect the changelog (e.g. a `feat`/`fix` whose content was already captured in a prior run).
- **Title/body already in sync** — if the open PR's title/body already matches what release-please would generate, subsequent runs see no diff.

In the logs this shows up as `✔ PR https://github.com/withcoral/coral/pull/131 remained the same`, and the action emits no `pr` / `prs_created` outputs on that branch — which is what triggers the `fromJSON('')` error.

## Test plan
- [ ] Merge and confirm the next no-op release-please run on `main` succeeds instead of failing at the Sync Cargo.lock step.
- [ ] Confirm that when release-please *does* create/update a release PR, the Cargo.lock sync still runs and pushes to the PR branch.