### PR TITLE
test(sources/clickup): add smoke test query

### DIFF
--- a/sources/clickup/manifest.yaml
+++ b/sources/clickup/manifest.yaml
@@ -23,6 +23,8 @@ auth:
     - name: Authorization
       from: input
       key: CLICKUP_API_TOKEN
+test_queries:
+  - SELECT * FROM clickup.team LIMIT 1
 tables:
   - name: current
     description: Get running time entry


### PR DESCRIPTION
Add a single cheap read-only smoke query so coral source test exercises a no-filter table for the bundled clickup source.

Constraint: Limit the change to the source manifest only
Rejected: Add multiple test queries | unnecessary validation cost for bundled install checks
Confidence: high
Scope-risk: narrow
Directive: Keep bundled source smoke queries cheap and filter-free unless the API requires scoped inputs
Tested: cargo run -q -p coral-cli -- source lint sources/clickup/manifest.yaml
Not-tested: coral source test against live clickup credentials