### PR TITLE
test(sources/incident_io): add smoke test query

### DIFF
--- a/sources/incident_io/manifest.yaml
+++ b/sources/incident_io/manifest.yaml
@@ -18,6 +18,8 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{input.INCIDENT_IO_API_KEY}}
+test_queries:
+  - SELECT * FROM incident_io.actions LIMIT 1
 tables:
   - name: actions
     description: List


### PR DESCRIPTION
Add a single cheap read-only smoke query so coral source test exercises a no-filter table for the bundled incident_io source.

Constraint: Limit the change to the source manifest only
Rejected: Add multiple test queries | unnecessary validation cost for bundled install checks
Confidence: high
Scope-risk: narrow
Directive: Keep bundled source smoke queries cheap and filter-free unless the API requires scoped inputs
Tested: cargo run -q -p coral-cli -- source lint sources/incident_io/manifest.yaml
Not-tested: coral source test against live incident_io credentials