### PR TITLE
test(sources/openobserve): add smoke test query

### DIFF
--- a/sources/openobserve/manifest.yaml
+++ b/sources/openobserve/manifest.yaml
@@ -29,6 +29,8 @@ auth:
       from: template
       template: "Basic {{input.OPENOBSERVE_BASIC_AUTH}}"
 
+test_queries:
+  - SELECT * FROM openobserve.streams LIMIT 1
 tables:
   - name: streams
     description: List available OpenObserve streams.


### PR DESCRIPTION
Add a single cheap read-only smoke query so coral source test exercises a no-filter table for the bundled openobserve source.

Constraint: Limit the change to the source manifest only
Rejected: Add multiple test queries | unnecessary validation cost for bundled install checks
Confidence: high
Scope-risk: narrow
Directive: Keep bundled source smoke queries cheap and filter-free unless the API requires scoped inputs
Tested: cargo run -q -p coral-cli -- source lint sources/openobserve/manifest.yaml
Not-tested: coral source test against live openobserve credentials