### PR TITLE
test(sources/posthog): add smoke test query

### DIFF
--- a/sources/posthog/manifest.yaml
+++ b/sources/posthog/manifest.yaml
@@ -26,6 +26,8 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{input.POSTHOG_API_KEY}}
+test_queries:
+  - SELECT * FROM posthog.organizations LIMIT 1
 tables:
   - name: actions
     description: project_actions


### PR DESCRIPTION
Add a single cheap read-only smoke query so coral source test exercises a no-filter table for the bundled posthog source.

Constraint: Limit the change to the source manifest only
Rejected: Add multiple test queries | unnecessary validation cost for bundled install checks
Confidence: high
Scope-risk: narrow
Directive: Keep bundled source smoke queries cheap and filter-free unless the API requires scoped inputs
Tested: cargo run -q -p coral-cli -- source lint sources/posthog/manifest.yaml
Not-tested: coral source test against live posthog credentials