### PR TITLE
test(sources/statusgator): add smoke test query

### DIFF
--- a/sources/statusgator/manifest.yaml
+++ b/sources/statusgator/manifest.yaml
@@ -23,6 +23,8 @@ auth:
     - name: Accept
       from: literal
       value: application/json
+test_queries:
+  - SELECT * FROM statusgator.boards LIMIT 1
 tables:
   - name: boards
     description: StatusGator monitoring boards


### PR DESCRIPTION
Add a single cheap read-only smoke query so coral source test exercises a no-filter table for the bundled statusgator source.

Constraint: Limit the change to the source manifest only
Rejected: Add multiple test queries | unnecessary validation cost for bundled install checks
Confidence: high
Scope-risk: narrow
Directive: Keep bundled source smoke queries cheap and filter-free unless the API requires scoped inputs
Tested: cargo run -q -p coral-cli -- source lint sources/statusgator/manifest.yaml
Not-tested: coral source test against live statusgator credentials