### PR TITLE
test(sources/stripe): add smoke test query

### DIFF
--- a/sources/stripe/manifest.yaml
+++ b/sources/stripe/manifest.yaml
@@ -21,6 +21,8 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{input.STRIPE_API_KEY}}
+test_queries:
+  - SELECT * FROM stripe.account LIMIT 1
 tables:
   - name: account
     description: Retrieve account


### PR DESCRIPTION
Add a single cheap read-only smoke query so coral source test exercises a no-filter table for the bundled stripe source.

Constraint: Limit the change to the source manifest only
Rejected: Add multiple test queries | unnecessary validation cost for bundled install checks
Confidence: high
Scope-risk: narrow
Directive: Keep bundled source smoke queries cheap and filter-free unless the API requires scoped inputs
Tested: cargo run -q -p coral-cli -- source lint sources/stripe/manifest.yaml
Not-tested: coral source test against live stripe credentials