### PR TITLE
feat(cli): support non-interactive source add

### DIFF
--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -77,13 +77,9 @@ struct SourceAddArgs {
     #[arg(long)]
     file: Option<PathBuf>,
 
-    /// Set a non-secret source variable
-    #[arg(long = "var", value_name = "KEY=VALUE")]
-    vars: Vec<String>,
-
-    /// Set a source secret
-    #[arg(long = "secret", value_name = "KEY=VALUE")]
-    secrets: Vec<String>,
+    /// Set a source input
+    #[arg(long = "input", value_name = "KEY=VALUE")]
+    inputs: Vec<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -212,14 +208,12 @@ async fn run_source_add(
     app: &coral_client::AppClient,
     args: SourceAddArgs,
 ) -> Result<(), anyhow::Error> {
-    let SourceAddArgs {
-        name,
-        file,
-        vars,
-        secrets,
-    } = args;
-    let explicit_bindings = source_ops::collect_explicit_bindings(&vars, &secrets)?;
-    let interactive_allowed = source_ops::is_interactive();
+    let SourceAddArgs { name, file, inputs } = args;
+    let explicit_bindings = source_ops::collect_explicit_bindings(&inputs)?;
+    let interactive_allowed = source_ops::interactive_resolution_allowed(
+        source_ops::is_interactive(),
+        &explicit_bindings,
+    );
     let response = match (name, file) {
         (Some(name), None) => {
             let bundled_name = source_ops::source_name_arg(Some(&name))?;

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -76,6 +76,14 @@ struct SourceAddArgs {
     /// Path to a file
     #[arg(long)]
     file: Option<PathBuf>,
+
+    /// Set a non-secret source variable
+    #[arg(long = "var", value_name = "KEY=VALUE")]
+    vars: Vec<String>,
+
+    /// Set a source secret
+    #[arg(long = "secret", value_name = "KEY=VALUE")]
+    secrets: Vec<String>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -204,8 +212,14 @@ async fn run_source_add(
     app: &coral_client::AppClient,
     args: SourceAddArgs,
 ) -> Result<(), anyhow::Error> {
-    source_ops::require_interactive()?;
-    let SourceAddArgs { name, file } = args;
+    let SourceAddArgs {
+        name,
+        file,
+        vars,
+        secrets,
+    } = args;
+    let explicit_bindings = source_ops::collect_explicit_bindings(&vars, &secrets)?;
+    let interactive_allowed = source_ops::is_interactive();
     let response = match (name, file) {
         (Some(name), None) => {
             let bundled_name = source_ops::source_name_arg(Some(&name))?;
@@ -219,12 +233,17 @@ async fn run_source_add(
                 .iter()
                 .map(source_ops::manifest_input_from_proto)
                 .collect::<Result<Vec<_>, _>>()?;
-            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            let (variables, secrets) =
+                source_ops::resolve_inputs(&inputs, &explicit_bindings, interactive_allowed)?;
             source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
         }
         (None, Some(file)) => {
             let (manifest_yaml, manifest) = source_ops::load_validated_manifest_file(&file)?;
-            let (variables, secrets) = source_ops::prompt_for_inputs(manifest.declared_inputs())?;
+            let (variables, secrets) = source_ops::resolve_inputs(
+                manifest.declared_inputs(),
+                &explicit_bindings,
+                interactive_allowed,
+            )?;
             source_ops::import_source(app, manifest_yaml, variables, secrets).await?
         }
         _ => unreachable!("clap enforces exactly one of name or file"),

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -1,4 +1,5 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, btree_map::Entry};
+use std::env;
 use std::io::{IsTerminal, stdin, stdout};
 use std::path::Path;
 
@@ -17,6 +18,12 @@ use dialoguer::{Input, Password, theme::ColorfulTheme};
 use tonic::Request;
 
 const MAX_TABLES_PER_SCHEMA: usize = 9;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct ExplicitBindings {
+    variables: BTreeMap<String, String>,
+    secrets: BTreeMap<String, String>,
+}
 
 /// How many tables to show per schema when pretty-printing validation results.
 #[derive(Debug, Clone, Copy)]
@@ -145,10 +152,14 @@ pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), any
 }
 
 pub(crate) fn require_interactive() -> Result<(), anyhow::Error> {
-    if !stdin().is_terminal() || !stdout().is_terminal() {
+    if !is_interactive() {
         return Err(anyhow::anyhow!("interactive source install requires a TTY"));
     }
     Ok(())
+}
+
+pub(crate) fn is_interactive() -> bool {
+    stdin().is_terminal() && stdout().is_terminal()
 }
 
 pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Error> {
@@ -170,25 +181,30 @@ pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Erro
 pub(crate) fn prompt_for_inputs(
     inputs: &[ManifestInputSpec],
 ) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
-    let mut variables = Vec::new();
-    let mut secrets = Vec::new();
+    resolve_inputs(inputs, &ExplicitBindings::default(), true)
+}
 
-    for input in inputs {
-        match input.kind {
-            ManifestInputKind::Variable => {
-                if let Some(variable) = prompt_variable(input)? {
-                    variables.push(variable);
-                }
-            }
-            ManifestInputKind::Secret => {
-                if let Some(secret) = prompt_secret(input)? {
-                    secrets.push(secret);
-                }
-            }
-        }
-    }
+pub(crate) fn collect_explicit_bindings(
+    variable_args: &[String],
+    secret_args: &[String],
+) -> Result<ExplicitBindings, anyhow::Error> {
+    Ok(ExplicitBindings {
+        variables: collect_binding_args(variable_args, "source variable", "source variable key")?,
+        secrets: collect_binding_args(secret_args, "source secret", "source secret key")?,
+    })
+}
 
-    Ok((variables, secrets))
+pub(crate) fn resolve_inputs(
+    inputs: &[ManifestInputSpec],
+    explicit_bindings: &ExplicitBindings,
+    interactive_allowed: bool,
+) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
+    resolve_inputs_with_lookup(
+        inputs,
+        explicit_bindings,
+        interactive_allowed,
+        env_input_value,
+    )
 }
 
 pub(crate) fn manifest_input_from_proto(
@@ -394,6 +410,54 @@ fn query_test_counts(response: &ValidateSourceResponse) -> QueryTestCounts {
     }
 }
 
+fn resolve_inputs_with_lookup<F>(
+    inputs: &[ManifestInputSpec],
+    explicit_bindings: &ExplicitBindings,
+    interactive_allowed: bool,
+    env_lookup: F,
+) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut variables = Vec::new();
+    let mut secrets = Vec::new();
+
+    for input in inputs {
+        let explicit_value = match input.kind {
+            ManifestInputKind::Variable => explicit_bindings.variables.get(&input.key),
+            ManifestInputKind::Secret => explicit_bindings.secrets.get(&input.key),
+        };
+        let value = if let Some(value) = explicit_value {
+            finalize_input_value(input, value.clone(), input_kind_label(input.kind))?
+        } else if let Some(value) = env_lookup(&input.key) {
+            finalize_input_value(input, value, input_kind_label(input.kind))?
+        } else if interactive_allowed {
+            match input.kind {
+                ManifestInputKind::Variable => {
+                    prompt_variable(input)?.map(|variable| variable.value)
+                }
+                ManifestInputKind::Secret => prompt_secret(input)?.map(|secret| secret.value),
+            }
+        } else {
+            finalize_input_value(input, String::new(), input_kind_label(input.kind))?
+        };
+
+        match (input.kind, value) {
+            (ManifestInputKind::Variable, Some(value)) => variables.push(SourceVariable {
+                key: input.key.clone(),
+                value,
+            }),
+            (ManifestInputKind::Secret, Some(value)) => secrets.push(SourceSecret {
+                key: input.key.clone(),
+                value,
+            }),
+            (_, None) => {}
+        }
+    }
+
+    Ok((variables, secrets))
+}
+
 fn prompt_variable(input: &ManifestInputSpec) -> Result<Option<SourceVariable>, anyhow::Error> {
     let theme = ColorfulTheme::default();
     print_input_hint(input);
@@ -444,6 +508,72 @@ fn print_input_hint(input: &ManifestInputSpec) {
     }
 }
 
+fn collect_binding_args(
+    args: &[String],
+    kind_label: &str,
+    key_label: &str,
+) -> Result<BTreeMap<String, String>, anyhow::Error> {
+    let mut values = BTreeMap::new();
+    for raw in args {
+        let (key, value) = parse_binding_arg(key_label, raw)?;
+        match values.entry(key.clone()) {
+            Entry::Vacant(entry) => {
+                entry.insert(value);
+            }
+            Entry::Occupied(_) => {
+                return Err(anyhow::anyhow!("{kind_label} '{key}' is repeated"));
+            }
+        }
+    }
+    Ok(values)
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "source add intentionally resolves manifest-declared inputs from the process environment."
+)]
+fn env_input_value(key: &str) -> Option<String> {
+    env::var_os(key).and_then(|value| value.into_string().ok())
+}
+
+fn parse_binding_arg(key_label: &str, raw: &str) -> Result<(String, String), anyhow::Error> {
+    let Some((raw_key, value)) = raw.split_once('=') else {
+        return Err(anyhow::anyhow!(
+            "expected KEY=VALUE for {key_label}, got '{raw}'"
+        ));
+    };
+    let key = normalize_binding_key(key_label, raw_key)?;
+    Ok((key, value.to_string()))
+}
+
+fn normalize_binding_key(key_label: &str, value: &str) -> Result<String, anyhow::Error> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow::anyhow!("missing {key_label}"));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(anyhow::anyhow!(
+            "{key_label} must not contain '/' or '\\\\'"
+        ));
+    }
+    if trimmed.contains('=') || trimmed.contains('\n') || trimmed.contains('\r') {
+        return Err(anyhow::anyhow!(
+            "{key_label} must not contain '=', '\\n', or '\\r'"
+        ));
+    }
+    if trimmed.starts_with('#') {
+        return Err(anyhow::anyhow!("{key_label} must not start with '#'"));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn input_kind_label(kind: ManifestInputKind) -> &'static str {
+    match kind {
+        ManifestInputKind::Variable => "source variable",
+        ManifestInputKind::Secret => "source secret",
+    }
+}
+
 pub(crate) fn finalize_input_value(
     input: &ManifestInputSpec,
     value: String,
@@ -463,22 +593,39 @@ pub(crate) fn finalize_input_value(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use coral_api::v1::ValidateSourceResponse;
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
     use super::{
-        ValidationFollowUp, ValidationSeverityMode, finalize_input_value, validation_follow_up,
+        ExplicitBindings, ValidationFollowUp, ValidationSeverityMode, collect_explicit_bindings,
+        finalize_input_value, parse_binding_arg, resolve_inputs_with_lookup, validation_follow_up,
     };
+
+    fn variable_input(key: &str, required: bool, default_value: &str) -> ManifestInputSpec {
+        ManifestInputSpec {
+            key: key.to_string(),
+            kind: ManifestInputKind::Variable,
+            required,
+            default_value: default_value.to_string(),
+            hint: None,
+        }
+    }
+
+    fn secret_input(key: &str, required: bool) -> ManifestInputSpec {
+        ManifestInputSpec {
+            key: key.to_string(),
+            kind: ManifestInputKind::Secret,
+            required,
+            default_value: String::new(),
+            hint: None,
+        }
+    }
 
     #[test]
     fn empty_optional_input_is_omitted_for_server_side_defaults() {
-        let input = ManifestInputSpec {
-            key: "API_BASE".to_string(),
-            kind: ManifestInputKind::Variable,
-            required: false,
-            default_value: "https://example.com".to_string(),
-            hint: None,
-        };
+        let input = variable_input("API_BASE", false, "https://example.com");
         assert_eq!(
             finalize_input_value(&input, String::new(), "source variable")
                 .expect("empty optional input should be omitted"),
@@ -488,16 +635,123 @@ mod tests {
 
     #[test]
     fn empty_required_input_without_default_is_rejected() {
-        let input = ManifestInputSpec {
-            key: "API_TOKEN".to_string(),
-            kind: ManifestInputKind::Secret,
-            required: true,
-            default_value: String::new(),
-            hint: None,
-        };
+        let input = secret_input("API_TOKEN", true);
         let error = finalize_input_value(&input, String::new(), "source secret")
             .expect_err("required empty input should fail");
         assert!(error.to_string().contains("missing required source secret"));
+    }
+
+    #[test]
+    fn parse_binding_arg_accepts_key_value_pairs() {
+        let (key, value) = parse_binding_arg("source variable key", "API_BASE=https://example.com")
+            .expect("binding should parse");
+        assert_eq!(key, "API_BASE");
+        assert_eq!(value, "https://example.com");
+    }
+
+    #[test]
+    fn parse_binding_arg_rejects_missing_equals() {
+        let error = parse_binding_arg("source variable key", "API_BASE")
+            .expect_err("missing equals should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("expected KEY=VALUE for source variable key")
+        );
+    }
+
+    #[test]
+    fn duplicate_variable_flags_are_rejected() {
+        let error = collect_explicit_bindings(
+            &[
+                "API_BASE=https://example.com".to_string(),
+                "API_BASE=https://override.example.com".to_string(),
+            ],
+            &[],
+        )
+        .expect_err("duplicate variable flags should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("source variable 'API_BASE' is repeated")
+        );
+    }
+
+    #[test]
+    fn duplicate_secret_flags_are_rejected() {
+        let error = collect_explicit_bindings(
+            &[],
+            &[
+                "API_TOKEN=first".to_string(),
+                "API_TOKEN=second".to_string(),
+            ],
+        )
+        .expect_err("duplicate secret flags should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("source secret 'API_TOKEN' is repeated")
+        );
+    }
+
+    #[test]
+    fn explicit_binding_beats_env_value() {
+        let inputs = vec![secret_input("API_TOKEN", true)];
+        let explicit = ExplicitBindings {
+            variables: BTreeMap::default(),
+            secrets: [("API_TOKEN".to_string(), "flag-token".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let (_, secrets) = resolve_inputs_with_lookup(&inputs, &explicit, false, |_| {
+            Some("env-token".to_string())
+        })
+        .expect("explicit binding should resolve");
+
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].value, "flag-token");
+    }
+
+    #[test]
+    fn env_value_is_used_when_no_explicit_binding_exists() {
+        let inputs = vec![variable_input("API_BASE", true, "")];
+        let explicit = ExplicitBindings::default();
+
+        let (variables, _) = resolve_inputs_with_lookup(&inputs, &explicit, false, |key| {
+            (key == "API_BASE").then(|| "https://env.example.com".to_string())
+        })
+        .expect("env binding should resolve");
+
+        assert_eq!(variables.len(), 1);
+        assert_eq!(variables[0].value, "https://env.example.com");
+    }
+
+    #[test]
+    fn optional_input_with_empty_env_value_is_omitted() {
+        let inputs = vec![variable_input("API_BASE", false, "https://example.com")];
+        let explicit = ExplicitBindings::default();
+
+        let (variables, _) =
+            resolve_inputs_with_lookup(&inputs, &explicit, false, |_| Some(String::new()))
+                .expect("empty optional env value should be omitted");
+
+        assert!(variables.is_empty());
+    }
+
+    #[test]
+    fn required_input_with_empty_env_value_is_rejected() {
+        let inputs = vec![secret_input("API_TOKEN", true)];
+        let explicit = ExplicitBindings::default();
+
+        let error = resolve_inputs_with_lookup(&inputs, &explicit, false, |_| Some(String::new()))
+            .expect_err("empty required env value should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing required source secret 'API_TOKEN'")
+        );
     }
 
     #[test]

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -21,8 +21,7 @@ const MAX_TABLES_PER_SCHEMA: usize = 9;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub(crate) struct ExplicitBindings {
-    variables: BTreeMap<String, String>,
-    secrets: BTreeMap<String, String>,
+    inputs: BTreeMap<String, String>,
 }
 
 /// How many tables to show per schema when pretty-printing validation results.
@@ -185,13 +184,18 @@ pub(crate) fn prompt_for_inputs(
 }
 
 pub(crate) fn collect_explicit_bindings(
-    variable_args: &[String],
-    secret_args: &[String],
+    input_args: &[String],
 ) -> Result<ExplicitBindings, anyhow::Error> {
     Ok(ExplicitBindings {
-        variables: collect_binding_args(variable_args, "source variable", "source variable key")?,
-        secrets: collect_binding_args(secret_args, "source secret", "source secret key")?,
+        inputs: collect_binding_args(input_args)?,
     })
+}
+
+pub(crate) fn interactive_resolution_allowed(
+    interactive_terminal: bool,
+    explicit_bindings: &ExplicitBindings,
+) -> bool {
+    interactive_terminal && explicit_bindings.is_empty()
 }
 
 pub(crate) fn resolve_inputs(
@@ -421,12 +425,21 @@ where
 {
     let mut variables = Vec::new();
     let mut secrets = Vec::new();
+    let declared_keys = inputs
+        .iter()
+        .map(|input| input.key.as_str())
+        .collect::<Vec<_>>();
+
+    if let Some((unknown_key, _)) = explicit_bindings.inputs.iter().find(|(key, _)| {
+        !declared_keys
+            .iter()
+            .any(|declared| declared == &key.as_str())
+    }) {
+        return Err(anyhow::anyhow!("unknown source input '{unknown_key}'"));
+    }
 
     for input in inputs {
-        let explicit_value = match input.kind {
-            ManifestInputKind::Variable => explicit_bindings.variables.get(&input.key),
-            ManifestInputKind::Secret => explicit_bindings.secrets.get(&input.key),
-        };
+        let explicit_value = explicit_bindings.inputs.get(&input.key);
         let value = if let Some(value) = explicit_value {
             finalize_input_value(input, value.clone(), input_kind_label(input.kind))?
         } else if let Some(value) = env_lookup(&input.key) {
@@ -508,20 +521,16 @@ fn print_input_hint(input: &ManifestInputSpec) {
     }
 }
 
-fn collect_binding_args(
-    args: &[String],
-    kind_label: &str,
-    key_label: &str,
-) -> Result<BTreeMap<String, String>, anyhow::Error> {
+fn collect_binding_args(args: &[String]) -> Result<BTreeMap<String, String>, anyhow::Error> {
     let mut values = BTreeMap::new();
     for raw in args {
-        let (key, value) = parse_binding_arg(key_label, raw)?;
+        let (key, value) = parse_binding_arg("source input key", raw)?;
         match values.entry(key.clone()) {
             Entry::Vacant(entry) => {
                 entry.insert(value);
             }
             Entry::Occupied(_) => {
-                return Err(anyhow::anyhow!("{kind_label} '{key}' is repeated"));
+                return Err(anyhow::anyhow!("source input '{key}' is repeated"));
             }
         }
     }
@@ -574,6 +583,12 @@ fn input_kind_label(kind: ManifestInputKind) -> &'static str {
     }
 }
 
+impl ExplicitBindings {
+    fn is_empty(&self) -> bool {
+        self.inputs.is_empty()
+    }
+}
+
 pub(crate) fn finalize_input_value(
     input: &ManifestInputSpec,
     value: String,
@@ -593,14 +608,13 @@ pub(crate) fn finalize_input_value(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
-
     use coral_api::v1::ValidateSourceResponse;
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
     use super::{
         ExplicitBindings, ValidationFollowUp, ValidationSeverityMode, collect_explicit_bindings,
-        finalize_input_value, parse_binding_arg, resolve_inputs_with_lookup, validation_follow_up,
+        finalize_input_value, interactive_resolution_allowed, parse_binding_arg,
+        resolve_inputs_with_lookup, validation_follow_up,
     };
 
     fn variable_input(key: &str, required: bool, default_value: &str) -> ManifestInputSpec {
@@ -643,7 +657,7 @@ mod tests {
 
     #[test]
     fn parse_binding_arg_accepts_key_value_pairs() {
-        let (key, value) = parse_binding_arg("source variable key", "API_BASE=https://example.com")
+        let (key, value) = parse_binding_arg("source input key", "API_BASE=https://example.com")
             .expect("binding should parse");
         assert_eq!(key, "API_BASE");
         assert_eq!(value, "https://example.com");
@@ -651,46 +665,26 @@ mod tests {
 
     #[test]
     fn parse_binding_arg_rejects_missing_equals() {
-        let error = parse_binding_arg("source variable key", "API_BASE")
+        let error = parse_binding_arg("source input key", "API_BASE")
             .expect_err("missing equals should fail");
         assert!(
             error
                 .to_string()
-                .contains("expected KEY=VALUE for source variable key")
+                .contains("expected KEY=VALUE for source input key")
         );
     }
 
     #[test]
-    fn duplicate_variable_flags_are_rejected() {
-        let error = collect_explicit_bindings(
-            &[
-                "API_BASE=https://example.com".to_string(),
-                "API_BASE=https://override.example.com".to_string(),
-            ],
-            &[],
-        )
+    fn duplicate_input_flags_are_rejected() {
+        let error = collect_explicit_bindings(&[
+            "API_BASE=https://example.com".to_string(),
+            "API_BASE=https://override.example.com".to_string(),
+        ])
         .expect_err("duplicate variable flags should fail");
         assert!(
             error
                 .to_string()
-                .contains("source variable 'API_BASE' is repeated")
-        );
-    }
-
-    #[test]
-    fn duplicate_secret_flags_are_rejected() {
-        let error = collect_explicit_bindings(
-            &[],
-            &[
-                "API_TOKEN=first".to_string(),
-                "API_TOKEN=second".to_string(),
-            ],
-        )
-        .expect_err("duplicate secret flags should fail");
-        assert!(
-            error
-                .to_string()
-                .contains("source secret 'API_TOKEN' is repeated")
+                .contains("source input 'API_BASE' is repeated")
         );
     }
 
@@ -698,8 +692,7 @@ mod tests {
     fn explicit_binding_beats_env_value() {
         let inputs = vec![secret_input("API_TOKEN", true)];
         let explicit = ExplicitBindings {
-            variables: BTreeMap::default(),
-            secrets: [("API_TOKEN".to_string(), "flag-token".to_string())]
+            inputs: [("API_TOKEN".to_string(), "flag-token".to_string())]
                 .into_iter()
                 .collect(),
         };
@@ -752,6 +745,41 @@ mod tests {
                 .to_string()
                 .contains("missing required source secret 'API_TOKEN'")
         );
+    }
+
+    #[test]
+    fn unknown_explicit_input_is_rejected() {
+        let inputs = vec![secret_input("API_TOKEN", true)];
+        let explicit = ExplicitBindings {
+            inputs: [("UNUSED".to_string(), "value".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        let error = resolve_inputs_with_lookup(&inputs, &explicit, false, |_| None)
+            .expect_err("unknown explicit input should fail");
+
+        assert!(error.to_string().contains("unknown source input 'UNUSED'"));
+    }
+
+    #[test]
+    fn interactive_resolution_is_disabled_when_any_input_is_provided() {
+        let explicit = ExplicitBindings {
+            inputs: [("API_TOKEN".to_string(), "value".to_string())]
+                .into_iter()
+                .collect(),
+        };
+
+        assert!(!interactive_resolution_allowed(true, &explicit));
+        assert!(!interactive_resolution_allowed(false, &explicit));
+        assert!(interactive_resolution_allowed(
+            true,
+            &ExplicitBindings::default()
+        ));
+        assert!(!interactive_resolution_allowed(
+            false,
+            &ExplicitBindings::default()
+        ));
     }
 
     #[test]

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -554,7 +554,7 @@ async fn source_remove_rejects_invalid_name() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
-async fn source_add_rejects_non_interactive() {
+async fn source_add_non_interactive_fails_only_when_required_input_is_missing() {
     let server = MockServer::start().await;
 
     let assert = server
@@ -565,8 +565,12 @@ async fn source_add_rejects_non_interactive() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("requires a TTY"),
-        "expected TTY requirement error: {stderr}"
+        stderr.contains("missing required source secret 'GITHUB_TOKEN'"),
+        "expected missing input error: {stderr}"
+    );
+    assert!(
+        server.create_bundled_source_requests().is_empty(),
+        "expected no create_bundled_source RPC when required inputs are unresolved"
     );
 
     server.shutdown().await;

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -546,6 +546,22 @@ impl MockServer {
             .clone()
     }
 
+    pub(crate) fn create_bundled_source_requests(&self) -> Vec<CreateBundledSourceRequest> {
+        self.captured
+            .create_bundled_source
+            .lock()
+            .expect("create_bundled_source capture")
+            .clone()
+    }
+
+    pub(crate) fn import_source_requests(&self) -> Vec<ImportSourceRequest> {
+        self.captured
+            .import_source
+            .lock()
+            .expect("import_source capture")
+            .clone()
+    }
+
     pub(crate) fn delete_source_requests(&self) -> Vec<DeleteSourceRequest> {
         self.captured
             .delete_source

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -276,7 +276,7 @@ async fn source_add_bundled_secret_flag_succeeds_without_tty() {
             "source",
             "add",
             "github",
-            "--secret",
+            "--input",
             "GITHUB_TOKEN=test-token",
         ])
         .assert()
@@ -322,7 +322,7 @@ async fn source_add_flag_overrides_env_value() {
             "source",
             "add",
             "github",
-            "--secret",
+            "--input",
             "GITHUB_TOKEN=flag-token",
         ])
         .env("GITHUB_TOKEN", "env-token")
@@ -353,6 +353,42 @@ async fn source_add_missing_required_input_without_tty_fails_locally() {
     );
     assert!(
         server.create_bundled_source_requests().is_empty(),
+        "request should not reach the server"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_partial_input_still_fails_without_prompting() {
+    let server = MockServer::start().await;
+    let dir = tempdir().expect("manifest dir");
+    let manifest_path = write_manifest(
+        dir.path(),
+        "secured_messages.yaml",
+        manifest_with_bindings(),
+    );
+
+    let assert = server
+        .cmd()
+        .args([
+            "source",
+            "add",
+            "--file",
+            manifest_path.to_str().expect("utf-8 manifest path"),
+            "--input",
+            "API_BASE=https://flag.example.com",
+        ])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    assert!(
+        stderr.contains("missing required source secret 'API_TOKEN'"),
+        "expected missing secret error, got: {stderr}"
+    );
+    assert!(
+        server.import_source_requests().is_empty(),
         "request should not reach the server"
     );
 
@@ -401,7 +437,7 @@ async fn source_add_import_uses_flags_and_env_without_tty() {
             "add",
             "--file",
             manifest_path.to_str().expect("utf-8 manifest path"),
-            "--var",
+            "--input",
             "API_BASE=https://flag.example.com",
         ])
         .env("API_TOKEN", "env-secret")

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -8,6 +8,7 @@ mod harness;
 
 use tempfile::tempdir;
 
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use coral_api::v1::{
@@ -16,6 +17,64 @@ use coral_api::v1::{
 };
 
 use harness::MockServer;
+
+fn write_manifest(dir: &Path, name: &str, manifest: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, manifest).expect("failed to write manifest");
+    path
+}
+
+fn zero_input_manifest() -> &'static str {
+    r"
+name: local_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Messages
+    request:
+      method: GET
+      path: /messages
+      query: []
+    columns:
+      - name: id
+        type: Utf8
+        description: Message ID
+"
+}
+
+fn manifest_with_bindings() -> &'static str {
+    r#"
+name: secured_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_BASE:
+    kind: variable
+  API_TOKEN:
+    kind: secret
+base_url: "{{input.API_BASE}}"
+auth:
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.API_TOKEN}}"
+tables:
+  - name: messages
+    description: Messages
+    request:
+      method: GET
+      path: /messages
+      query: []
+    columns:
+      - name: id
+        type: Utf8
+        description: Message ID
+"#
+}
 
 #[test]
 fn source_test_errors_when_required_secret_is_missing() {
@@ -184,6 +243,179 @@ async fn source_test_succeeds_when_query_tests_pass() {
         stderr.trim().is_empty(),
         "expected no stderr output, got: {stderr}"
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_bundled_zero_input_succeeds_without_tty() {
+    let server = MockServer::start().await;
+
+    server
+        .cmd()
+        .args(["source", "add", "slack"])
+        .assert()
+        .success();
+
+    let requests = server.create_bundled_source_requests();
+    assert_eq!(requests.len(), 1, "expected one create_bundled_source call");
+    assert_eq!(requests[0].name, "slack");
+    assert!(requests[0].variables.is_empty(), "expected no variables");
+    assert!(requests[0].secrets.is_empty(), "expected no secrets");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_bundled_secret_flag_succeeds_without_tty() {
+    let server = MockServer::start().await;
+
+    server
+        .cmd()
+        .args([
+            "source",
+            "add",
+            "github",
+            "--secret",
+            "GITHUB_TOKEN=test-token",
+        ])
+        .assert()
+        .success();
+
+    let requests = server.create_bundled_source_requests();
+    assert_eq!(requests.len(), 1, "expected one create_bundled_source call");
+    assert_eq!(requests[0].name, "github");
+    assert!(requests[0].variables.is_empty(), "expected no variables");
+    assert_eq!(requests[0].secrets.len(), 1, "expected one secret");
+    assert_eq!(requests[0].secrets[0].key, "GITHUB_TOKEN");
+    assert_eq!(requests[0].secrets[0].value, "test-token");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_bundled_secret_env_succeeds_without_tty() {
+    let server = MockServer::start().await;
+
+    server
+        .cmd()
+        .args(["source", "add", "github"])
+        .env("GITHUB_TOKEN", "env-token")
+        .assert()
+        .success();
+
+    let requests = server.create_bundled_source_requests();
+    assert_eq!(requests.len(), 1, "expected one create_bundled_source call");
+    assert_eq!(requests[0].secrets.len(), 1, "expected one secret");
+    assert_eq!(requests[0].secrets[0].value, "env-token");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_flag_overrides_env_value() {
+    let server = MockServer::start().await;
+
+    server
+        .cmd()
+        .args([
+            "source",
+            "add",
+            "github",
+            "--secret",
+            "GITHUB_TOKEN=flag-token",
+        ])
+        .env("GITHUB_TOKEN", "env-token")
+        .assert()
+        .success();
+
+    let requests = server.create_bundled_source_requests();
+    assert_eq!(requests.len(), 1, "expected one create_bundled_source call");
+    assert_eq!(requests[0].secrets[0].value, "flag-token");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_missing_required_input_without_tty_fails_locally() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "add", "github"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+
+    assert!(
+        stderr.contains("missing required source secret 'GITHUB_TOKEN'"),
+        "expected missing secret error, got: {stderr}"
+    );
+    assert!(
+        server.create_bundled_source_requests().is_empty(),
+        "request should not reach the server"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_import_zero_input_succeeds_without_tty() {
+    let server = MockServer::start().await;
+    let dir = tempdir().expect("manifest dir");
+    let manifest_path = write_manifest(dir.path(), "local_messages.yaml", zero_input_manifest());
+
+    server
+        .cmd()
+        .args([
+            "source",
+            "add",
+            "--file",
+            manifest_path.to_str().expect("utf-8 manifest path"),
+        ])
+        .assert()
+        .success();
+
+    let requests = server.import_source_requests();
+    assert_eq!(requests.len(), 1, "expected one import_source call");
+    assert!(requests[0].variables.is_empty(), "expected no variables");
+    assert!(requests[0].secrets.is_empty(), "expected no secrets");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_import_uses_flags_and_env_without_tty() {
+    let server = MockServer::start().await;
+    let dir = tempdir().expect("manifest dir");
+    let manifest_path = write_manifest(
+        dir.path(),
+        "secured_messages.yaml",
+        manifest_with_bindings(),
+    );
+
+    server
+        .cmd()
+        .args([
+            "source",
+            "add",
+            "--file",
+            manifest_path.to_str().expect("utf-8 manifest path"),
+            "--var",
+            "API_BASE=https://flag.example.com",
+        ])
+        .env("API_TOKEN", "env-secret")
+        .assert()
+        .success();
+
+    let requests = server.import_source_requests();
+    assert_eq!(requests.len(), 1, "expected one import_source call");
+    assert_eq!(requests[0].variables.len(), 1, "expected one variable");
+    assert_eq!(requests[0].variables[0].key, "API_BASE");
+    assert_eq!(requests[0].variables[0].value, "https://flag.example.com");
+    assert_eq!(requests[0].secrets.len(), 1, "expected one secret");
+    assert_eq!(requests[0].secrets[0].key, "API_TOKEN");
+    assert_eq!(requests[0].secrets[0].value, "env-secret");
 
     server.shutdown().await;
 }

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -26,7 +26,7 @@ For example, add GitHub:
 coral source add github
 ```
 
-Coral prompts for any required variables or secrets by default, and you can also provide them non-interactively with `--var`, `--secret`, or matching environment variables such as `GITHUB_TOKEN=...`. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
+Coral prompts for any required variables or secrets by default, and you can also provide them non-interactively with repeatable `--input KEY=VALUE` flags or matching environment variables such as `GITHUB_TOKEN=...`. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
 
 ## 3. Query your data
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -26,7 +26,7 @@ For example, add GitHub:
 coral source add github
 ```
 
-Coral prompts for any required variables or secrets. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
+Coral prompts for any required variables or secrets by default, and you can also provide them non-interactively with `--var`, `--secret`, or matching environment variables such as `GITHUB_TOKEN=...`. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
 
 ## 3. Query your data
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -50,7 +50,7 @@ Coral sits between you and your data sources: you (or your agent) write SQL, and
 
 A **source spec** is a YAML file that defines how to reach an API or local dataset and which tables/columns it exposes. A **source** is a data source Coral can query, created from a source spec plus your configured credentials and variables. When you run `coral source add github`, Coral installs the `github` source. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pull_requests` are queryable. Start with [bundled sources](/reference/bundled-sources) or [write your own](/guides/write-a-custom-source).
 
-During `source add`, Coral prompts for declared variables and secrets (tokens, workspace IDs, file paths, etc.). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
+During `source add`, Coral can collect declared variables and secrets interactively or read them from `--var`, `--secret`, and matching environment variables (tokens, workspace IDs, file paths, etc.). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
 
 ```mermaid actions={false}
 graph LR

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -50,7 +50,7 @@ Coral sits between you and your data sources: you (or your agent) write SQL, and
 
 A **source spec** is a YAML file that defines how to reach an API or local dataset and which tables/columns it exposes. A **source** is a data source Coral can query, created from a source spec plus your configured credentials and variables. When you run `coral source add github`, Coral installs the `github` source. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pull_requests` are queryable. Start with [bundled sources](/reference/bundled-sources) or [write your own](/guides/write-a-custom-source).
 
-During `source add`, Coral can collect declared variables and secrets interactively or read them from `--var`, `--secret`, and matching environment variables (tokens, workspace IDs, file paths, etc.). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
+During `source add`, Coral can collect declared variables and secrets interactively or read them from repeatable `--input KEY=VALUE` flags and matching environment variables (tokens, workspace IDs, file paths, etc.). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
 
 ```mermaid actions={false}
 graph LR

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -45,11 +45,11 @@ Add a bundled source or update its credentials.
 
 ```shellscript
 coral source add github
-coral source add github --secret GITHUB_TOKEN=ghp_xxx
+coral source add github --input GITHUB_TOKEN=ghp_xxx
 GITHUB_TOKEN=ghp_xxx coral source add github
 ```
 
-Use repeatable `--var KEY=VALUE` and `--secret KEY=VALUE` flags to supply inputs non-interactively. When a declared input is not set by a flag, Coral looks for an environment variable with the exact same key. If required inputs are still missing and `stdin`/`stdout` are attached to a TTY, Coral prompts for the remaining values interactively. The precedence order is: flags, then matching environment variables, then prompts.
+Use repeatable `--input KEY=VALUE` flags to supply inputs non-interactively. Coral determines whether each input is a variable or secret from the source's declared inputs at runtime. When a declared input is not set by a flag, Coral looks for an environment variable with the exact same key. Coral only prompts interactively when no `--input` flags are used and `stdin`/`stdout` are attached to a TTY. The precedence order is: `--input`, then matching environment variables, then prompts when prompting is allowed.
 
 If the source is already installed, running this command again replaces its stored credentials with the new values you provide. Non-interactive `source add` works when the source has no declared inputs, or when all required inputs are satisfied by flags or environment variables.
 After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
@@ -60,7 +60,7 @@ Add a custom source spec from a YAML file.
 
 ```shellscript
 coral source add --file ./local-messages.yaml
-coral source add --file ./local-messages.yaml --var API_BASE=https://example.com
+coral source add --file ./local-messages.yaml --input API_BASE=https://example.com
 ```
 
 ### `coral source lint <FILE>`

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -45,9 +45,13 @@ Add a bundled source or update its credentials.
 
 ```shellscript
 coral source add github
+coral source add github --secret GITHUB_TOKEN=ghp_xxx
+GITHUB_TOKEN=ghp_xxx coral source add github
 ```
 
-Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
+Use repeatable `--var KEY=VALUE` and `--secret KEY=VALUE` flags to supply inputs non-interactively. When a declared input is not set by a flag, Coral looks for an environment variable with the exact same key. If required inputs are still missing and `stdin`/`stdout` are attached to a TTY, Coral prompts for the remaining values interactively. The precedence order is: flags, then matching environment variables, then prompts.
+
+If the source is already installed, running this command again replaces its stored credentials with the new values you provide. Non-interactive `source add` works when the source has no declared inputs, or when all required inputs are satisfied by flags or environment variables.
 After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
 ### `coral source add --file <PATH>`
@@ -56,6 +60,7 @@ Add a custom source spec from a YAML file.
 
 ```shellscript
 coral source add --file ./local-messages.yaml
+coral source add --file ./local-messages.yaml --var API_BASE=https://example.com
 ```
 
 ### `coral source lint <FILE>`
@@ -90,6 +95,8 @@ Run the guided source setup flow.
 ```shellscript
 coral onboard
 ```
+
+This command remains interactive-only and requires a TTY.
 
 ## `coral mcp-stdio`
 


### PR DESCRIPTION
Updates `coral source add` to add a (repeatable) `--input KEY=VALUE` flag. Coral resolves whether each provided value is a variable or secret from the manifest input definition at runtime, still falls back to exact-name environment variables, and still allows zero-input `source add` flows without a TTY. 

Prompting is now stricter: Coral only prompts when no `--input` flags are present and stdin/stdout are TTYs; once any `--input` is provided, unresolved required inputs fail instead of prompting. The change includes unit and integration coverage for precedence, unknown input handling, and non-interactive failure cases, plus CLI, quickstart, and index doc updates. 

### Usage examples

All inputs passed on the command line:

```sh
coral source add sentry --input SENTRY_ORG=my-org --input SENTRY_TOKEN=sntrys_xxx
```

All inputs passed as environment variables:

```sh
SENTRY_ORG=my-org SENTRY_TOKEN=sntrys_xxx coral source add sentry
```

Some inputs passed as env vars and others as args:

```sh
SENTRY_TOKEN=sntrys_xxx coral source add sentry --input SENTRY_ORG=my-org
```

Some inputs provided on the command line and some omitted:

```sh
coral source add sentry --input SENTRY_ORG=my-org
# If SENTRY_TOKEN is not set in the environment, Coral errors instead of prompting.
```

For comparison, if no `--input` flags are used and the command is running on a TTY, Coral can still prompt interactively for the remaining required inputs.
