### PR TITLE
fix(spec): recognize inputs block for parquet and jsonl manifests

### DIFF
--- a/crates/coral-engine/tests/engine/parquet_tests.rs
+++ b/crates/coral-engine/tests/engine/parquet_tests.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_invalid_input, build_source, dir_url, execution_to_rows, users_batch,
-    write_parquet_file,
+    TestRuntime, assert_invalid_input, build_source, build_source_with_secrets, dir_url,
+    execution_to_rows, users_batch, write_parquet_file,
 };
 
 fn parquet_manifest(name: &str, dir: &Path) -> Value {
@@ -140,6 +140,90 @@ async fn select_count_aggregation() {
     );
 
     assert_eq!(rows, vec![json!({"n": 3})]);
+}
+
+#[tokio::test]
+async fn parquet_manifest_with_declared_secret_inputs_registers_and_queries() {
+    // Regression: parquet manifests that declare secrets via the `inputs:`
+    // block must surface those names in `required_secret_names()`, otherwise
+    // `load_query_source` drops the stored secrets and the source silently
+    // fails to register — leaving its schema absent from the catalog.
+    let temp = TempDir::new().expect("temp dir");
+    write_parquet_file(temp.path(), "users.parquet", &users_batch());
+
+    let manifest = json!({
+        "name": "warehouse",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "parquet",
+        "inputs": {
+            "api_token": { "kind": "secret" },
+            "signing_key": { "kind": "secret" },
+        },
+        "tables": [{
+            "name": "users",
+            "description": "Warehouse users",
+            "source": {
+                "location": dir_url(temp.path()),
+                "glob": "**/*.parquet"
+            },
+            "columns": []
+        }]
+    });
+
+    let source = build_source_with_secrets(
+        manifest,
+        [("api_token", "token-value"), ("signing_key", "key-value")],
+    );
+
+    let schemata = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            &TestRuntime,
+            "SELECT schema_name FROM information_schema.schemata \
+             WHERE schema_name = 'warehouse'",
+        )
+        .await
+        .expect("schemata query should succeed"),
+    );
+    assert_eq!(schemata, vec![json!({"schema_name": "warehouse"})]);
+
+    // The table must be queryable end-to-end: declared secret inputs must
+    // not block registration for a local-filesystem-backed source.
+    let temp2 = TempDir::new().expect("temp dir");
+    write_parquet_file(temp2.path(), "users.parquet", &users_batch());
+    let manifest2 = json!({
+        "name": "warehouse2",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "parquet",
+        "inputs": {
+            "api_token": { "kind": "secret" },
+        },
+        "tables": [{
+            "name": "users",
+            "description": "Warehouse users",
+            "source": {
+                "location": dir_url(temp2.path()),
+                "glob": "**/*.parquet"
+            },
+            "columns": []
+        }]
+    });
+    let source2 = build_source_with_secrets(manifest2, [("api_token", "token-value")]);
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source2],
+            &TestRuntime,
+            "SELECT id FROM warehouse2.users ORDER BY id",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+    assert_eq!(
+        rows,
+        vec![json!({"id": 1}), json!({"id": 2}), json!({"id": 3})]
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -11,14 +11,15 @@
 
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use url::Url;
 
 use crate::common::parse_manifest_data_type;
+use crate::inputs::collect_source_inputs_value;
 use crate::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, Result, SourceBackend,
-    SourceManifestCommon, TableCommon, validate_columns, validate_filters_and_column_exprs,
-    validate_test_queries,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ManifestInputKind, ManifestInputSpec,
+    Result, SourceBackend, SourceManifestCommon, TableCommon, validate_columns,
+    validate_filters_and_column_exprs, validate_test_queries,
 };
 
 /// Validated top-level manifest for a `Parquet`-backed source.
@@ -26,6 +27,7 @@ use crate::{
 pub struct ParquetSourceManifest {
     pub common: SourceManifestCommon,
     pub tables: Vec<FileTableSpec>,
+    pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
 /// Validated top-level manifest for a `JSONL`-backed source.
@@ -33,6 +35,32 @@ pub struct ParquetSourceManifest {
 pub struct JsonlSourceManifest {
     pub common: SourceManifestCommon,
     pub tables: Vec<FileTableSpec>,
+    pub declared_inputs: Vec<ManifestInputSpec>,
+}
+
+impl ParquetSourceManifest {
+    /// Returns the source secrets required by this manifest.
+    ///
+    /// Every declared input with `kind: secret` is required; secrets cannot
+    /// carry defaults.
+    pub fn required_secret_names(&self) -> BTreeSet<String> {
+        required_secret_names(&self.declared_inputs)
+    }
+}
+
+impl JsonlSourceManifest {
+    /// Returns the source secrets required by this manifest.
+    pub fn required_secret_names(&self) -> BTreeSet<String> {
+        required_secret_names(&self.declared_inputs)
+    }
+}
+
+fn required_secret_names(inputs: &[ManifestInputSpec]) -> BTreeSet<String> {
+    inputs
+        .iter()
+        .filter(|input| input.kind == ManifestInputKind::Secret)
+        .map(|input| input.key.clone())
+        .collect()
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -46,6 +74,8 @@ struct RawFileSourceManifest {
     #[serde(default)]
     test_queries: Vec<String>,
     backend: SourceBackend,
+    #[serde(default)]
+    inputs: Option<Value>,
     tables: Vec<RawFileTableSpec>,
 }
 
@@ -258,6 +288,7 @@ impl RawFileTableSpec {
 
 impl ParquetSourceManifest {
     pub(crate) fn parse_manifest_value(value: Value) -> Result<Self> {
+        let declared_inputs = collect_source_inputs_value(&value)?;
         let raw: RawFileSourceManifest =
             serde_json::from_value(value).map_err(ManifestError::deserialize)?;
         let RawFileSourceManifest {
@@ -267,6 +298,7 @@ impl ParquetSourceManifest {
             description,
             test_queries,
             backend: _backend,
+            inputs: _inputs,
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
@@ -276,12 +308,17 @@ impl ParquetSourceManifest {
             .into_iter()
             .map(|table| table.into_validated_parquet(&common.name))
             .collect::<Result<Vec<_>>>()?;
-        Ok(Self { common, tables })
+        Ok(Self {
+            common,
+            tables,
+            declared_inputs,
+        })
     }
 }
 
 impl JsonlSourceManifest {
     pub(crate) fn parse_manifest_value(value: Value) -> Result<Self> {
+        let declared_inputs = collect_source_inputs_value(&value)?;
         let raw: RawFileSourceManifest =
             serde_json::from_value(value).map_err(ManifestError::deserialize)?;
         let RawFileSourceManifest {
@@ -291,6 +328,7 @@ impl JsonlSourceManifest {
             description,
             test_queries,
             backend: _backend,
+            inputs: _inputs,
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
@@ -300,6 +338,96 @@ impl JsonlSourceManifest {
             .into_iter()
             .map(|table| table.into_validated_jsonl(&common.name))
             .collect::<Result<Vec<_>>>()?;
-        Ok(Self { common, tables })
+        Ok(Self {
+            common,
+            tables,
+            declared_inputs,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JsonlSourceManifest, ParquetSourceManifest};
+    use crate::ManifestInputKind;
+    use serde_json::json;
+
+    #[test]
+    fn parquet_manifest_surfaces_declared_secret_inputs() {
+        let manifest = ParquetSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "warehouse",
+            "version": "0.1.0",
+            "backend": "parquet",
+            "inputs": {
+                "api_token": { "kind": "secret" },
+                "signing_key": { "kind": "secret" },
+                "region": { "kind": "variable", "default": "us-east-1" },
+            },
+            "tables": [{
+                "name": "events",
+                "description": "Warehouse events",
+                "source": { "location": "s3://example/warehouse/" },
+                "columns": [{ "name": "id", "type": "Int64" }],
+            }],
+        }))
+        .expect("parquet manifest with inputs should parse");
+
+        let required = manifest.required_secret_names();
+        assert!(required.contains("api_token"));
+        assert!(required.contains("signing_key"));
+        assert_eq!(required.len(), 2);
+
+        let kinds: Vec<(&str, ManifestInputKind)> = manifest
+            .declared_inputs
+            .iter()
+            .map(|input| (input.key.as_str(), input.kind))
+            .collect();
+        assert!(kinds.contains(&("api_token", ManifestInputKind::Secret)));
+        assert!(kinds.contains(&("region", ManifestInputKind::Variable)));
+    }
+
+    #[test]
+    fn jsonl_manifest_surfaces_declared_secret_inputs() {
+        let manifest = JsonlSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "logs",
+            "version": "0.1.0",
+            "backend": "jsonl",
+            "inputs": {
+                "access_token": { "kind": "secret" },
+            },
+            "tables": [{
+                "name": "messages",
+                "description": "JSONL messages",
+                "source": { "location": "file:///tmp/logs/" },
+                "columns": [{ "name": "kind", "type": "Utf8" }],
+            }],
+        }))
+        .expect("jsonl manifest with inputs should parse");
+
+        let required = manifest.required_secret_names();
+        assert!(required.contains("access_token"));
+        assert_eq!(required.len(), 1);
+    }
+
+    #[test]
+    fn parquet_manifest_without_inputs_block_has_no_required_secrets() {
+        let manifest = ParquetSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "local",
+            "version": "0.1.0",
+            "backend": "parquet",
+            "tables": [{
+                "name": "events",
+                "description": "Local events",
+                "source": { "location": "file:///tmp/local/" },
+                "columns": [],
+            }],
+        }))
+        .expect("parquet manifest without inputs should parse");
+
+        assert!(manifest.required_secret_names().is_empty());
+        assert!(manifest.declared_inputs.is_empty());
     }
 }

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -87,14 +87,12 @@ impl ValidatedSourceManifest {
 
     /// Returns the set of source secrets required to compile or authenticate
     /// the source spec.
-    ///
-    /// File-backed source specs do not currently declare secret inputs at the
-    /// source level, so they return an empty set here.
     #[must_use]
     pub fn required_secret_names(&self) -> BTreeSet<String> {
         match &self.inner {
             ValidatedManifestKind::Http(manifest) => manifest.required_secret_names(),
-            ValidatedManifestKind::Parquet(_) | ValidatedManifestKind::Jsonl(_) => BTreeSet::new(),
+            ValidatedManifestKind::Parquet(manifest) => manifest.required_secret_names(),
+            ValidatedManifestKind::Jsonl(manifest) => manifest.required_secret_names(),
         }
     }
 
@@ -103,7 +101,8 @@ impl ValidatedSourceManifest {
     pub fn declared_inputs(&self) -> &[ManifestInputSpec] {
         match &self.inner {
             ValidatedManifestKind::Http(manifest) => &manifest.declared_inputs,
-            ValidatedManifestKind::Parquet(_) | ValidatedManifestKind::Jsonl(_) => &[],
+            ValidatedManifestKind::Parquet(manifest) => &manifest.declared_inputs,
+            ValidatedManifestKind::Jsonl(manifest) => &manifest.declared_inputs,
         }
     }
 


### PR DESCRIPTION
## Summary

Parquet- and JSONL-backed source manifests silently ignored any declared `inputs:` block. `ValidatedSourceManifest::required_secret_names()` and `declared_inputs()` were hardcoded to return empty for those backends, so secrets written to `<config>/workspaces/<ws>/sources/<name>/secrets.env` were filtered out of the resolved set in `load_query_source` before ever reaching the backend. For parquet S3 sources, `build_object_store` then failed to find credentials like `aws_access_key_id`, and source registration failed with only a `tracing::warn!` line — leaving the schema missing from the DataFusion catalog.

This PR:

- Teaches `ParquetSourceManifest` and `JsonlSourceManifest` to parse the `inputs:` block via the shared `collect_source_inputs_value` helper (same path HTTP already uses).
- Adds `declared_inputs` + `required_secret_names()` on both file-backed manifests.
- Dispatches `ValidatedSourceManifest::required_secret_names()` / `declared_inputs()` to those methods instead of returning empty.

The fix is backend-agnostic: any secret name declared in `inputs:` now flows into `QuerySource.secrets` → `source_secrets: BTreeMap<String, String>` verbatim. The parquet backend's S3 code was already reading AWS-named keys from that map; it's unchanged.

## Files changed

- `crates/coral-spec/src/backends/file.rs` — parse `inputs:`, expose `declared_inputs` + `required_secret_names()` on both parquet and jsonl manifests; 3 new unit tests.
- `crates/coral-spec/src/parser.rs` — route `required_secret_names()` and `declared_inputs()` through to the per-backend implementations.
- `crates/coral-engine/tests/engine/parquet_tests.rs` — new regression test `parquet_manifest_with_declared_secret_inputs_registers_and_queries`: builds a parquet source that declares two secret inputs, populates the secret map, asserts the schema appears in `information_schema.schemata`, and that rows come back from the registered table.

## Test plan

- [x] `cargo test -p coral-spec` — 44 passed
- [x] `cargo test -p coral-engine` — 46 passed (including the new regression test)
- [x] `cargo test -p coral-app` — 37 passed (no regressions in the query/load path)
- [x] `cargo clippy -p coral-spec -p coral-engine --tests` — clean
- [x] Manual sanity check: author a parquet manifest with `inputs:` declaring secrets, install it, populate `secrets.env`, and confirm the schema is visible via `SELECT schema_name FROM information_schema.schemata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)