### PR TITLE
fix(sources): strip HTML tags from bundled source descriptions

### DIFF
--- a/sources/pagerduty/manifest.yaml
+++ b/sources/pagerduty/manifest.yaml
@@ -5489,7 +5489,7 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
-        description: 'RFC 5545 recurrence rules defining the repeating pattern. This must be an array containing:  <br> - Exactly one <b>RRULE</b>'
+        description: RFC 5545 recurrence rules defining the repeating pattern. This must be an array containing exactly one RRULE.
         expr:
           kind: path
           path:
@@ -5595,7 +5595,7 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
-        description: 'RFC 5545 recurrence rules defining the repeating pattern. This must be an array containing:  <br> - Exactly one <b>RRULE</b>'
+        description: RFC 5545 recurrence rules defining the repeating pattern. This must be an array containing exactly one RRULE.
         expr:
           kind: path
           path:
@@ -13388,7 +13388,7 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
-        description: prepared -- the invocation exists and can be referenced, but is NOT available to a Runner <br> created -- the invocation exists
+        description: prepared -- the invocation exists and can be referenced, but is not available to a Runner. created -- the invocation exists
         expr:
           kind: path
           path:
@@ -13593,7 +13593,7 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
-        description: prepared -- the invocation exists and can be referenced, but is NOT available to a Runner <br> created -- the invocation exists
+        description: prepared -- the invocation exists and can be referenced, but is not available to a Runner. created -- the invocation exists
         expr:
           kind: path
           path:

--- a/sources/stripe/manifest.yaml
+++ b/sources/stripe/manifest.yaml
@@ -29460,7 +29460,7 @@ tables:
           path:
             - test_clock
   - name: customer_sources
-    description: <p>List sources for a specified customer.</p>
+    description: List sources for a specified customer.
     filters:
       - name: customer
         required: true
@@ -36626,7 +36626,7 @@ tables:
           kind: from_filter
           key: subscription_exposed_id
   - name: dispute
-    description: <p>Retrieve a dispute for a specified charge.</p>
+    description: Retrieve a dispute for a specified charge.
     filters:
       - name: charge
         required: true
@@ -37600,7 +37600,7 @@ tables:
           path:
             - type
   - name: domains
-    description: <p>List apple pay domains.</p>
+    description: List apple pay domains.
     filters:
       - name: domain_name
         required: false
@@ -96066,7 +96066,7 @@ tables:
           path:
             - type
   - name: source_transactions
-    description: <p>List source transactions for a given source.</p>
+    description: List source transactions for a given source.
     filters:
       - name: source
         required: true


### PR DESCRIPTION
## Summary
This change removes raw HTML tags from bundled source manifest descriptions so source metadata reads cleanly in Coral surfaces that expose column and table descriptions.

The cleanup stays manifest-local for now and updates every bundled source manifest that still used HTML markup in description fields.

## Testing
- `cargo run -p coral-cli -- source lint sources/stripe/manifest.yaml`
- `cargo run -p coral-cli -- source lint sources/pagerduty/manifest.yaml`
