### PR TITLE
feat(cli): add --interactive flag to `coral source add`

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -76,6 +76,11 @@ struct SourceAddArgs {
     /// Path to a file
     #[arg(long)]
     file: Option<PathBuf>,
+
+    /// Prompt for input values interactively. When unset, values are read from
+    /// environment variables matching each input key.
+    #[arg(long)]
+    interactive: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -227,8 +232,21 @@ fn print_batches(
 }
 
 async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyhow::Error> {
-    source_ops::require_interactive()?;
-    let SourceAddArgs { name, file } = args;
+    let SourceAddArgs {
+        name,
+        file,
+        interactive,
+    } = args;
+    if interactive {
+        source_ops::require_interactive()?;
+    }
+    let collect = |inputs: &[coral_spec::ManifestInputSpec]| {
+        if interactive {
+            source_ops::prompt_for_inputs(inputs)
+        } else {
+            source_ops::collect_inputs_from_env(inputs)
+        }
+    };
     let response = match (name, file) {
         (Some(name), None) => {
             let bundled_name = source_ops::source_name_arg(Some(&name))?;
@@ -242,12 +260,12 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyh
                 .iter()
                 .map(source_ops::manifest_input_from_proto)
                 .collect::<Result<Vec<_>, _>>()?;
-            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            let (variables, secrets) = collect(&inputs)?;
             source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
         }
         (None, Some(file)) => {
             let (manifest_yaml, manifest) = source_ops::load_validated_manifest_file(&file)?;
-            let (variables, secrets) = source_ops::prompt_for_inputs(manifest.declared_inputs())?;
+            let (variables, secrets) = collect(manifest.declared_inputs())?;
             source_ops::import_source(app, manifest_yaml, variables, secrets).await?
         }
         _ => unreachable!("clap enforces exactly one of name or file"),

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -191,6 +191,65 @@ pub(crate) fn prompt_for_inputs(
     Ok((variables, secrets))
 }
 
+pub(crate) fn collect_inputs_from_env(
+    inputs: &[ManifestInputSpec],
+) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
+    collect_inputs_with(inputs, |key| read_env_var(key).unwrap_or_default())
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "Source input keys are user-defined by manifests; this reads each as a process env var."
+)]
+fn read_env_var(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+fn collect_inputs_with(
+    inputs: &[ManifestInputSpec],
+    mut lookup: impl FnMut(&str) -> String,
+) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
+    let mut variables = Vec::new();
+    let mut secrets = Vec::new();
+    let mut missing = Vec::new();
+
+    for input in inputs {
+        let raw = lookup(&input.key);
+        let value = if raw.is_empty() {
+            input.default_value.clone()
+        } else {
+            raw
+        };
+        if value.is_empty() {
+            if input.required {
+                missing.push(input.key.clone());
+            }
+            continue;
+        }
+        match input.kind {
+            ManifestInputKind::Variable => variables.push(SourceVariable {
+                key: input.key.clone(),
+                value,
+            }),
+            ManifestInputKind::Secret => secrets.push(SourceSecret {
+                key: input.key.clone(),
+                value,
+            }),
+        }
+    }
+
+    if !missing.is_empty() {
+        return Err(anyhow::anyhow!(
+            "missing required environment variable{}: {}. Set the variable{} or run with --interactive.",
+            if missing.len() == 1 { "" } else { "s" },
+            missing.join(", "),
+            if missing.len() == 1 { "" } else { "s" },
+        ));
+    }
+
+    Ok((variables, secrets))
+}
+
 pub(crate) fn manifest_input_from_proto(
     input: &SourceInputSpec,
 ) -> Result<ManifestInputSpec, anyhow::Error> {
@@ -466,9 +525,115 @@ mod tests {
     use coral_api::v1::ValidateSourceResponse;
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
+    use std::collections::HashMap;
+
     use super::{
-        ValidationFollowUp, ValidationSeverityMode, finalize_input_value, validation_follow_up,
+        ValidationFollowUp, ValidationSeverityMode, collect_inputs_with, finalize_input_value,
+        validation_follow_up,
     };
+
+    #[test]
+    fn collect_inputs_reads_variables_and_secrets_from_lookup() {
+        let inputs = vec![
+            ManifestInputSpec {
+                key: "LINEAR_API_BASE".to_string(),
+                kind: ManifestInputKind::Variable,
+                required: false,
+                default_value: "https://api.linear.app".to_string(),
+                hint: None,
+            },
+            ManifestInputSpec {
+                key: "LINEAR_API_KEY".to_string(),
+                kind: ManifestInputKind::Secret,
+                required: true,
+                default_value: String::new(),
+                hint: None,
+            },
+        ];
+        let env: HashMap<&str, &str> = [("LINEAR_API_KEY", "lin_token")].into_iter().collect();
+        let (variables, secrets) = collect_inputs_with(&inputs, |key| {
+            env.get(key).map(|v| (*v).to_string()).unwrap_or_default()
+        })
+        .expect("should succeed");
+        assert_eq!(variables.len(), 1);
+        assert_eq!(variables[0].key, "LINEAR_API_BASE");
+        assert_eq!(variables[0].value, "https://api.linear.app");
+        assert_eq!(secrets.len(), 1);
+        assert_eq!(secrets[0].key, "LINEAR_API_KEY");
+        assert_eq!(secrets[0].value, "lin_token");
+    }
+
+    #[test]
+    fn collect_inputs_env_value_overrides_default() {
+        let inputs = vec![ManifestInputSpec {
+            key: "API_BASE".to_string(),
+            kind: ManifestInputKind::Variable,
+            required: false,
+            default_value: "https://example.com".to_string(),
+            hint: None,
+        }];
+        let (variables, _) = collect_inputs_with(&inputs, |_| "https://override.test".to_string())
+            .expect("env should override default");
+        assert_eq!(variables.len(), 1);
+        assert_eq!(variables[0].value, "https://override.test");
+    }
+
+    #[test]
+    fn collect_inputs_uses_default_when_env_empty() {
+        let inputs = vec![ManifestInputSpec {
+            key: "API_BASE".to_string(),
+            kind: ManifestInputKind::Variable,
+            required: true,
+            default_value: "https://example.com".to_string(),
+            hint: None,
+        }];
+        let (variables, secrets) = collect_inputs_with(&inputs, |_| String::new())
+            .expect("default should satisfy required");
+        assert_eq!(secrets.len(), 0);
+        assert_eq!(variables.len(), 1);
+        assert_eq!(variables[0].value, "https://example.com");
+    }
+
+    #[test]
+    fn collect_inputs_errors_on_missing_required() {
+        let inputs = vec![
+            ManifestInputSpec {
+                key: "LINEAR_API_KEY".to_string(),
+                kind: ManifestInputKind::Secret,
+                required: true,
+                default_value: String::new(),
+                hint: None,
+            },
+            ManifestInputSpec {
+                key: "OTHER_KEY".to_string(),
+                kind: ManifestInputKind::Variable,
+                required: true,
+                default_value: String::new(),
+                hint: None,
+            },
+        ];
+        let error = collect_inputs_with(&inputs, |_| String::new())
+            .expect_err("missing required inputs should fail");
+        let message = error.to_string();
+        assert!(message.contains("LINEAR_API_KEY"));
+        assert!(message.contains("OTHER_KEY"));
+        assert!(message.contains("--interactive"));
+    }
+
+    #[test]
+    fn collect_inputs_skips_optional_empty_inputs() {
+        let inputs = vec![ManifestInputSpec {
+            key: "OPTIONAL".to_string(),
+            kind: ManifestInputKind::Variable,
+            required: false,
+            default_value: String::new(),
+            hint: None,
+        }];
+        let (variables, secrets) =
+            collect_inputs_with(&inputs, |_| String::new()).expect("optional should be omitted");
+        assert!(variables.is_empty());
+        assert!(secrets.is_empty());
+    }
 
     #[test]
     fn empty_optional_input_is_omitted_for_server_side_defaults() {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -554,12 +554,36 @@ async fn source_remove_rejects_invalid_name() {
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread")]
-async fn source_add_rejects_non_interactive() {
+async fn source_add_reports_missing_env_vars_without_interactive() {
     let server = MockServer::start().await;
 
     let assert = server
         .cmd()
         .args(["source", "add", "github"])
+        .env_remove("GITHUB_TOKEN")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("missing required environment variable"),
+        "expected missing env var error: {stderr}"
+    );
+    assert!(
+        stderr.contains("GITHUB_TOKEN"),
+        "expected missing env var to name GITHUB_TOKEN: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_interactive_requires_tty() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "add", "--interactive", "github"])
         .assert()
         .failure();
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -20,13 +20,19 @@ This lists the bundled sources available in your build. Coral comes with [bundle
 
 ## 2. Add a source
 
-For example, add GitHub:
+For example, add GitHub. Coral reads each required input from an environment variable of the same name:
 
 ```shellscript
-coral source add github
+GITHUB_TOKEN=ghp_... coral source add github
 ```
 
-Coral prompts for any required variables or secrets. Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
+Prefer to be prompted? Pass `--interactive`:
+
+```shellscript
+coral source add --interactive github
+```
+
+Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
 
 ## 3. Query your data
 

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -20,19 +20,19 @@ This lists the bundled sources available in your build. Coral comes with [bundle
 
 ## 2. Add a source
 
-For example, add GitHub. Coral reads each required input from an environment variable of the same name:
-
-```shellscript
-GITHUB_TOKEN=ghp_... coral source add github
-```
-
-Prefer to be prompted? Pass `--interactive`:
+For example, add GitHub. Pass `--interactive` and Coral will prompt you for each required input:
 
 ```shellscript
 coral source add --interactive github
 ```
 
 Once connected, the source's data is available as SQL tables. To update a source's credentials later, run the same command again.
+
+<Tip>
+  For scripted setups, omit `--interactive` and Coral reads each input from an
+  environment variable of the same name — e.g. `GITHUB_TOKEN=ghp_... coral
+  source add github`.
+</Tip>
 
 ## 3. Query your data
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -158,7 +158,7 @@ tables:
         type: Utf8
 ```
 
-When you run `coral source add --file`, Coral prompts for the declared `inputs` interactively. `kind: variable` values go to source variables; `kind: secret` values go to the secret store.
+When you run `coral source add --file`, Coral reads each declared `input` from an environment variable of the same name, or prompts for them when you pass `--interactive`. `kind: variable` values go to source variables; `kind: secret` values go to the secret store.
 
 For the full set of HTTP response, pagination, auth, and column fields, see [HTTP-backed tables](/reference/source-spec-reference#http-backed-tables).
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -50,7 +50,7 @@ Coral sits between you and your data sources: you (or your agent) write SQL, and
 
 A **source spec** is a YAML file that defines how to reach an API or local dataset and which tables/columns it exposes. A **source** is a data source Coral can query, created from a source spec plus your configured credentials and variables. When you run `coral source add github`, Coral installs the `github` source. At query time, Coral loads that source as the `github` SQL schema, so tables like `github.issues` and `github.pull_requests` are queryable. Start with [bundled sources](/reference/bundled-sources) or [write your own](/guides/write-a-custom-source).
 
-During `source add`, Coral prompts for declared variables and secrets (tokens, workspace IDs, file paths, etc.). These are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
+During `source add`, Coral collects each declared variable and secret (tokens, workspace IDs, file paths, etc.) from environment variables of the same name, or prompts for them interactively when you pass `--interactive`. These values are stored locally in Coral state, with secrets kept separately from non-secret config, and used only at query time. Because each source appears as SQL tables, you can `JOIN` across sources in one statement (for example `github.issues` with `linear.attachments`), and Coral executes that locally on your machine.
 
 ```mermaid actions={false}
 graph LR

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -43,16 +43,23 @@ coral source list
 
 Add a bundled source or update its credentials.
 
+By default, Coral reads each declared input from an environment variable of the same name. If a required input is missing, the command exits with an error listing the missing keys.
+
 ```shellscript
-coral source add github
+GITHUB_TOKEN=ghp_... coral source add github
 ```
 
-Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
-After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
+Pass `--interactive` to be prompted for variables and secrets instead:
+
+```shellscript
+coral source add --interactive github
+```
+
+If the source is already installed, running this command again replaces its stored credentials with the new values you provide. After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
 ### `coral source add --file <PATH>`
 
-Add a custom source spec from a YAML file.
+Add a custom source spec from a YAML file. Input values come from environment variables by default; add `--interactive` to be prompted.
 
 ```shellscript
 coral source add --file ./local-messages.yaml

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -227,7 +227,7 @@ In this minimal example:
 
 - `response: {}` means "use the default response rules" for an HTTP table
 - with the default response rules, Coral treats the selected response value directly as rows unless you configure a different `row_strategy`
-- `inputs` declares the install-time prompts for this source in stable authored order. (At runtime, these are surfaced through `coral.inputs`.)
+- `inputs` declares the install-time variables and secrets for this source in stable authored order. At install time, `coral source add` reads each key from an environment variable of the same name (or prompts for them when run with `--interactive`). At runtime, installed inputs are surfaced through `coral.inputs`.
 - `{{input.API_TOKEN}}` is resolved from the store implied by the declared input kind
 
 ### HTTP rate limiting
@@ -353,7 +353,7 @@ pagination:
 
 ## Source inputs
 
-HTTP source specs can declare install-time inputs under a top-level `inputs` map:
+HTTP source specs can declare the variables and secrets this source needs under a top-level `inputs` map. At install time, `coral source add` collects each input from an environment variable matching the key, or prompts interactively when you pass `--interactive`.
 
 - **Variables**: non-secret configuration like base URLs or organization IDs
 - **Secrets**: API keys or bearer tokens
@@ -381,7 +381,7 @@ Rules:
 - `kind: variable` values are stored with source variables
 - `kind: secret` values are stored with source secrets
 - `default` is allowed only for variables
-- `hint` is optional and shown while Coral prompts for the input
+- `hint` is optional and shown alongside the input during `coral source add --interactive`
 - references elsewhere in the manifest use `{{input.KEY}}` templates or `from: input`
 
 At runtime, installed source inputs are also surfaced through `coral.inputs`.


### PR DESCRIPTION
## Summary

For SOURCE-433: `coral source add` now defaults to non-interactive mode, reading each input value from an environment variable matching the input key. Pass `--interactive` to restore the previous prompt-driven flow. Missing required env vars produce a clear error listing every missing key and suggesting `--interactive`.

## Test plan
- [x] `cargo test -p coral-cli --bin coral` (22 passed, incl. 5 new)
- [x] `cargo clippy -p coral-cli --all-targets`
- [ ] Manual: `LINEAR_API_KEY=foo coral source add linear`
- [ ] Manual: `coral source add --interactive linear`
- [ ] Manual: `coral source add linear` shows missing-var error