### PR TITLE
build: pin Rust 1.95 in workspace toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 edition = "2024"
 version = "0.1.3" # x-release-please-version
 license = "Apache-2.0"
-rust-version = "1.94"
+rust-version = "1.95"
 
 [workspace.lints.rust]
 missing_docs = "warn"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.95"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.95"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

Pin the repo's Rust version in the workspace metadata and checked-in toolchain file without bundling the CI wiring and Clippy cleanup into the same change.

This keeps the version bump reviewable on its own and leaves the CI updates plus Rust 1.95 lint fixes for a follow-up PR.

## Validation

- Ran `make rust-checks`
- Current result: fails under Rust 1.95 on new Clippy `collapsible_match` warnings in `crates/coral-spec/src/validate.rs`
- Those fixes are intentionally deferred to the next PR
