### PR TITLE
fix(app): make bundled source versions explicit in config state

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -97,7 +97,7 @@ impl QueryManager {
         .await
         .map_err(QueryManagerError::Core)?;
         let mut source = source;
-        source.version = version;
+        source.version = Some(version);
 
         Ok(ValidatedSource { source, report })
     }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -207,8 +207,8 @@ impl SourceManager {
         };
 
         let persisted_version = match request.origin {
-            SourceOrigin::Bundled => String::new(),
-            SourceOrigin::Imported => request.candidate.version.clone(),
+            SourceOrigin::Bundled => None,
+            SourceOrigin::Imported => Some(request.candidate.version.clone()),
         };
         let stored = InstalledSource {
             name: source_name.clone(),
@@ -225,7 +225,7 @@ impl SourceManager {
             return Err(error);
         }
         let mut resolved = stored;
-        resolved.version.clone_from(&request.candidate.version);
+        resolved.version = Some(request.candidate.version.clone());
         Ok(resolved)
     }
 
@@ -329,9 +329,11 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         mut source: InstalledSource,
     ) -> Result<InstalledSource, AppError> {
-        source.version = resolve_installed_manifest(workspace_name, &source, &self.layout)?
-            .candidate
-            .version;
+        source.version = Some(
+            resolve_installed_manifest(workspace_name, &source, &self.layout)?
+                .candidate
+                .version,
+        );
         Ok(source)
     }
 

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -37,9 +37,12 @@ pub(crate) enum CandidateSourceInputKind {
 pub(crate) struct InstalledSource {
     /// Bare source name. This is also the visible SQL schema name.
     pub(crate) name: SourceName,
-    /// Manifest version from the installed source spec.
+    /// Persisted manifest version when it should live in app state.
+    ///
+    /// Bundled sources resolve their manifest directly from the compiled-in
+    /// catalog, so they do not persist a duplicate version string in config.
     #[serde(default)]
-    pub(crate) version: String,
+    pub(crate) version: Option<String>,
     /// Configured non-secret variable bindings.
     #[serde(default)]
     pub(crate) variables: BTreeMap<String, String>,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -194,7 +194,7 @@ fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSo
     Source {
         workspace: Some(workspace_to_proto(workspace_name)),
         name: source.name.as_str().to_string(),
-        version: source.version,
+        version: source.version.unwrap_or_default(),
         secrets: source
             .secrets
             .into_iter()

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -48,7 +48,7 @@ struct PersistedWorkspaceConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct PersistedInstalledSource {
     #[serde(default)]
-    version: String,
+    version: Option<String>,
     #[serde(default)]
     variables: BTreeMap<String, String>,
     #[serde(default)]
@@ -248,13 +248,13 @@ fn render_config(config: &PersistedAppConfig) -> String {
                 *source_item = toml_edit::table();
             }
 
-            if source.version.is_empty() {
+            if let Some(version) = &source.version {
+                source_item["version"] = value(version.clone());
+            } else {
                 let source_table = source_item
                     .as_table_mut()
                     .expect("source config entry should be a table after initialization");
                 source_table.remove("version");
-            } else {
-                source_item["version"] = value(source.version.clone());
             }
             source_item["variables"] = Item::Value(render_inline_table(&source.variables));
             source_item["secrets"] = Item::Value(render_string_array(&source.secrets));
@@ -343,7 +343,7 @@ mod tests {
     fn installed_source(name: &str) -> InstalledSource {
         InstalledSource {
             name: SourceName::parse(name).expect("source"),
-            version: "1.1.4".to_string(),
+            version: Some("1.1.4".to_string()),
             variables: BTreeMap::from([(
                 "GITHUB_API_BASE".to_string(),
                 "https://api.github.com".to_string(),
@@ -382,7 +382,7 @@ mod tests {
     fn omits_empty_versions_from_rendered_source_entries() {
         let workspace_name = default_workspace();
         let mut source = installed_source("github");
-        source.version.clear();
+        source.version = None;
         source.origin = SourceOrigin::Bundled;
         let mut catalog = SourceCatalog::default();
         catalog.upsert_source(&workspace_name, source);
@@ -415,7 +415,7 @@ origin = "bundled"
         let sources = config.catalog.workspace_sources(&default_workspace());
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].name.as_str(), "github");
-        assert_eq!(sources[0].version, "1.1.4");
+        assert_eq!(sources[0].version.as_deref(), Some("1.1.4"));
         assert_eq!(
             sources[0].variables.get("GITHUB_API_BASE"),
             Some(&"https://api.github.com".to_string())
@@ -430,7 +430,7 @@ origin = "bundled"
         catalog.upsert_source(&workspace_name, installed_source("github"));
 
         let mut updated = installed_source("github");
-        updated.version = "2.0.0".to_string();
+        updated.version = Some("2.0.0".to_string());
         updated.origin = SourceOrigin::Imported;
         catalog.upsert_source(&workspace_name, updated);
 
@@ -440,7 +440,7 @@ origin = "bundled"
                 &SourceName::parse("github").expect("source"),
             )
             .expect("source should be present");
-        assert_eq!(stored.version, "2.0.0");
+        assert_eq!(stored.version.as_deref(), Some("2.0.0"));
         assert_eq!(stored.origin, SourceOrigin::Imported);
         assert_eq!(catalog.workspace_sources(&workspace_name).len(), 1);
     }


### PR DESCRIPTION
## Summary
- replace the bundled-source version sentinel in app state with `Option<String>`
- keep the gRPC/source service surface unchanged by defaulting missing persisted versions at the transport edge
- update config serialization and tests so bundled sources explicitly omit the duplicated version field

## Why
Bundled sources resolve their manifest from the compiled-in catalog, so persisting an empty-string version in config was a hidden invariant. Making that state explicit in the `coral-app` model removes sentinel behavior and makes the source lifecycle path easier to evolve safely.

## Validation
- `cargo test -p coral-app --all-features`
- `make rust-checks`
