### PR TITLE
docs(sources/datadog): correct live events filter guidance

### DIFF
--- a/sources/datadog/manifest.yaml
+++ b/sources/datadog/manifest.yaml
@@ -47,8 +47,8 @@ tables:
   - name: monitors
     description: Datadog monitors with status and alert configuration.
     guide: >
-      No required filters — returns all monitors. Filter by status or type in SQL. Status values: Alert, Warn, No Data, OK,
-      Ignored, Skipped.
+      Use this table for full monitor inventory and current alert state. Start with status for active noise, then narrow by
+      type or name; status values are Alert, Warn, No Data, OK, Ignored, and Skipped.
     request:
       method: GET
       path: /api/v1/monitor
@@ -138,6 +138,11 @@ tables:
             - tags
   - name: monitor_search
     description: Datadog monitor search results
+    guide: >
+      Use this table for targeted monitor lookups when you already know a Datadog search query. Let the required query do
+      the big cut, then narrow the smaller result in SQL by status or type; use monitors instead when you need a full
+      inventory.
+
     request:
       method: GET
       path: /api/v1/monitor/search
@@ -224,8 +229,9 @@ tables:
   - name: events
     description: Datadog events within a time range.
     guide: >
-      Requires start and end filters in ISO 8601 format (e.g. '2024-01-15T00:00:00Z'). date_happened is Unix epoch seconds.
-      Priority values: normal, low.
+      Use this table for event timelines in a bounded window. Keep start and end tight in Unix epoch seconds, then narrow the
+      returned rows by source or priority in SQL; date_happened is Unix epoch seconds and priority only exposes normal or
+      low.
 
     request:
       method: GET
@@ -335,6 +341,10 @@ tables:
         required: true
   - name: incidents
     description: Datadog incidents
+    guide: >
+      Use this table for incident response queues and review. Start with resolved_at IS NULL to focus on live work, then
+      narrow by status or severity; resolved_at stays null until Datadog actually marks the incident resolved.
+
     request:
       method: GET
       path: /api/v2/incidents
@@ -461,6 +471,10 @@ tables:
               value: false
   - name: dashboards
     description: Datadog dashboards
+    guide: >
+      Use this table for dashboard inventory and ownership review. In large orgs, narrow first by author_handle or
+      layout_type before scanning title and url; it only exposes dashboard metadata, not widget contents.
+
     request:
       method: GET
       path: /api/v1/dashboard
@@ -538,7 +552,8 @@ tables:
   - name: hosts
     description: Datadog infrastructure hosts.
     guide: >
-      No required filters — returns all hosts. Use up = true to filter for live hosts. last_reported_time is Unix epoch seconds.
+      Use this table for host inventory and liveness checks. Narrow large result sets with up = true or recent
+      last_reported_time, then inspect the remaining hosts; last_reported_time is Unix epoch seconds.
 
     request:
       method: GET
@@ -627,6 +642,10 @@ tables:
             - last_reported_time
   - name: services
     description: Datadog service catalog definitions
+    guide: >
+      Use this table for service catalog ownership and schema cleanup. Narrow first by team or schema_version, then inspect
+      the smaller set by name; name can fall back to id when the service schema omits a service-name field.
+
     request:
       method: GET
       path: /api/v2/services/definitions
@@ -711,6 +730,11 @@ tables:
             - team
   - name: apm_dependencies
     description: Datadog APM service dependencies for a focal service
+    guide: >
+      Use this table for upstream and downstream dependency edges around one service. The required service filter does the
+      main cut; add env for multi-environment services and a tighter time window only when needed. called_by and calls are
+      comma-separated lists, not one row per edge.
+
     request:
       method: GET
       path: /api/v1/service_dependencies/{{filter.service}}
@@ -870,6 +894,10 @@ tables:
       - name: primary_tag
   - name: downtimes
     description: Datadog scheduled downtimes
+    guide: >
+      Use this table for maintenance-window and alert-suppression review. Start with status or scope to cut large result
+      sets before inspecting monitor_identifier; monitor_identifier can be null when a downtime is scope-only.
+
     request:
       method: GET
       path: /api/v2/downtime
@@ -999,6 +1027,10 @@ tables:
                 - canceled
   - name: slos
     description: Datadog SLO definitions
+    guide: >
+      Use this table for SLO inventory and ownership review. Start with type and timeframe, then narrow by tags for the
+      team or service slice you care about; multi-threshold SLOs are flattened to the first threshold entry.
+
     request:
       method: GET
       path: /api/v1/slo
@@ -1090,6 +1122,10 @@ tables:
             - modified_at
   - name: synthetics_tests
     description: Datadog synthetics tests
+    guide: >
+      Use this table for synthetic check inventory and triage. Start with status and subtype, then narrow by name or
+      public_id; locations and tags are comma-separated lists rather than one row per value.
+
     request:
       method: GET
       path: /api/v1/synthetics/tests
@@ -1166,6 +1202,10 @@ tables:
             - tags
   - name: users
     description: Datadog organization users
+    guide: >
+      Use this table for access reviews and stale-account cleanup. Start with status and disabled, then narrow by handle or
+      email; disabled = false can be a fallback when Datadog omits that field.
+
     request:
       method: GET
       path: /api/v2/users
@@ -1280,9 +1320,8 @@ tables:
   - name: logs
     description: Datadog logs within a time range.
     guide: >
-      Requires start and end filters in ISO 8601 format (e.g. '2024-01-15T00:00:00Z'). Optional query filter uses Datadog
-      log search syntax (e.g. 'service:web status:error'). Severity levels: emergency, alert, critical, error, warn, info,
-      debug, trace. Timestamps are ISO 8601.
+      Use this table for log troubleshooting in a bounded window. Keep the required start and end range tight and let query
+      do the main cut, then narrow the returned rows by service, host, or status in SQL; timestamps are ISO 8601.
 
     fetch_limit_default: 1000
     request:
@@ -1451,9 +1490,8 @@ tables:
   - name: spans
     description: Datadog APM distributed tracing spans within a time range.
     guide: >
-      Requires start and end filters in ISO 8601 format (e.g. '2024-01-15T00:00:00Z'). Optional query filter uses Datadog
-      trace search syntax (e.g. 'service:web resource_name:/api/v1'). Duration is in nanoseconds (/1e6 for ms, /1e9 for seconds).
-      Resource is typically the endpoint path or DB query — use for grouping by operation.
+      Use this table for distributed trace investigation in a bounded window. Keep the required start and end range tight
+      and use query for the main cut, then narrow by service or resource in SQL; duration is stored in nanoseconds.
 
     fetch_limit_default: 1000
     request:
@@ -1622,9 +1660,8 @@ tables:
   - name: metrics
     description: Datadog metrics timeseries data.
     guide: >
-      Requires query, start, and end filters. The query filter uses Datadog metrics query syntax (e.g. 'avg:system.cpu.user{*}',
-      'sum:trace.servlet.request.hits{service:web}.as_count()'). Timestamp is Unix epoch milliseconds (/1000 for seconds).
-      Scope is the tag group (e.g. 'host:web-01').
+      Use this table for timeseries slices from one Datadog metric query. Keep the required time window tight and make the
+      query specific, then narrow the returned series by scope or metric in SQL; timestamp is Unix epoch milliseconds.
 
     request:
       method: GET
@@ -1706,6 +1743,10 @@ tables:
         required: true
   - name: metric_names
     description: Datadog metric names
+    guide: >
+      Use this table for recent metric-name discovery. Add query when you know a prefix such as 'system.' or 'trace.' to
+      keep the result set small; it only returns metrics Datadog has seen recently, not a full historical catalog.
+
     request:
       method: GET
       path: /api/v1/metrics


### PR DESCRIPTION
This PR keeps a manifest-only scope and updates only `sources/datadog/manifest.yaml`.

It rewrites the Datadog table guides so each one:
- says what the table is for
- names only the highest-value filters
- explains how to narrow large result sets
- includes one real caveat or quirk
- stays concise and query-oriented
- avoids the phrase "No required filters"

Follow-up fix from live validation:
- `datadog.events` now correctly says `start` and `end` use Unix epoch seconds, not ISO 8601

Verification:
- `./target/debug/coral sql` live query against `datadog.events` with Unix-second `start`/`end` filters
- `./target/debug/coral sql "SELECT table_name, guide FROM coral.tables WHERE schema_name = 'datadog' AND table_name = 'events'"`
- `cargo run -p coral-cli -- source lint sources/datadog/manifest.yaml`
- `cargo run -p xtask -- --sources-dir sources --index docs/reference/bundled-sources.mdx --docs-json docs/docs.json --check`
- `rg -n "No required filters" sources/datadog/manifest.yaml`
- `git diff --cached --check`
- `git diff --cached --name-only`
- `gh pr diff 172 --name-only`

Constraint: Final branch and PR must remain manifest-only
Constraint: Guides should stay query-oriented and only mention filters or caveats supported by the manifest schema
Rejected: Keep partial wording fixes on only the previously filterless tables | left the Datadog guide set inconsistent
Rejected: Keep the ISO 8601 note for `events` after the live query failure | the endpoint rejects that format with HTTP 400
Rejected: Regenerate or edit docs in this branch | violates the requested manifest-only PR scope
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep Datadog guides purpose-first and prefer the filter format proven by a live query when endpoint conventions differ
Not-tested: `make lint-sources` | `ryl` is unavailable in this environment
