### PR TITLE
refactor(cli): format source listings

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -20,6 +20,7 @@ use coral_client::{
     AppClient, decode_execute_sql_response, default_workspace, format_batches_json,
     format_batches_table,
 };
+use dialoguer::console::measure_text_width;
 use tonic::Request;
 
 #[cfg(test)]
@@ -163,14 +164,15 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
                 if sources.is_empty() {
                     println!("No bundled sources available.");
                 } else {
-                    for source in sources {
+                    let rows = sources.into_iter().map(|source| {
                         let status = if source.installed {
-                            "installed"
+                            "installed".to_string()
                         } else {
-                            "available"
+                            "available".to_string()
                         };
-                        println!("{}\t{}\t{}", source.name, source.version, status);
-                    }
+                        [source.name, source.version, status]
+                    });
+                    print_text_table(["Source", "Version", "Status"], rows);
                 }
             }
             SourceCommand::List => {
@@ -178,10 +180,14 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
                 if sources.is_empty() {
                     println!("No sources configured.");
                 } else {
-                    for source in sources {
-                        let origin = source_ops::source_origin_label(source.origin);
-                        println!("{}\t{}\t{}", source.name, source.version, origin);
-                    }
+                    let rows = sources.into_iter().map(|source| {
+                        [
+                            source.name,
+                            source.version,
+                            source_ops::source_origin_label(source.origin).to_string(),
+                        ]
+                    });
+                    print_text_table(["Source", "Version", "Origin"], rows);
                 }
             }
             SourceCommand::Add(args) => run_source_add(&app, args).await?,
@@ -224,6 +230,67 @@ fn print_batches(
     };
     println!("{output}");
     Ok(())
+}
+
+fn print_text_table<const COLUMNS: usize>(
+    headers: [&str; COLUMNS],
+    rows: impl IntoIterator<Item = [String; COLUMNS]>,
+) {
+    let rows = rows.into_iter().collect::<Vec<_>>();
+    let widths = compute_column_widths(headers, &rows);
+
+    println!("{}", format_table_row(headers, &widths));
+    println!("{}", format_separator_row(&widths));
+    for row in rows {
+        println!("{}", format_table_row(row.each_ref(), &widths));
+    }
+}
+
+fn compute_column_widths<const COLUMNS: usize>(
+    headers: [&str; COLUMNS],
+    rows: &[[String; COLUMNS]],
+) -> [usize; COLUMNS] {
+    std::array::from_fn(|idx| {
+        let header_width = measure_text_width(headers[idx]);
+        let row_width = rows
+            .iter()
+            .map(|row| measure_text_width(&row[idx]))
+            .max()
+            .unwrap_or(0);
+        header_width.max(row_width)
+    })
+}
+
+fn format_table_row<const COLUMNS: usize, T>(
+    cells: [T; COLUMNS],
+    widths: &[usize; COLUMNS],
+) -> String
+where
+    T: AsRef<str>,
+{
+    cells
+        .into_iter()
+        .enumerate()
+        .map(|(idx, cell)| pad_cell(cell.as_ref(), widths[idx], idx + 1 < COLUMNS))
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
+fn format_separator_row<const COLUMNS: usize>(widths: &[usize; COLUMNS]) -> String {
+    widths
+        .iter()
+        .map(|width| "-".repeat(*width))
+        .collect::<Vec<_>>()
+        .join("  ")
+}
+
+fn pad_cell(value: &str, width: usize, pad: bool) -> String {
+    if !pad {
+        return value.to_string();
+    }
+
+    let padding = width.saturating_sub(measure_text_width(value));
+    format!("{value}{}", " ".repeat(padding))
 }
 
 async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyhow::Error> {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -64,7 +64,12 @@ async fn source_list_renders_configured_sources() {
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert_eq!(
         nonempty_lines(&stdout),
-        vec!["github\t1.0.0\tbundled", "jira\t2.0.0\timported"],
+        vec![
+            "Source  Version  Origin",
+            "------  -------  --------",
+            "github  1.0.0    bundled",
+            "jira    2.0.0    imported",
+        ],
         "expected configured source list"
     );
 
@@ -105,7 +110,12 @@ async fn source_discover_renders_available_sources() {
     let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
     assert_eq!(
         nonempty_lines(&stdout),
-        vec!["github\t1.0.0\tinstalled", "slack\t2.1.0\tavailable"],
+        vec![
+            "Source  Version  Status",
+            "------  -------  ---------",
+            "github  1.0.0    installed",
+            "slack   2.1.0    available",
+        ],
         "expected discover source list"
     );
 


### PR DESCRIPTION
## Summary
- render `coral source list` and `coral source discover` as aligned text tables with headers
- share a small width-aware formatter across both commands
- update CLI end-to-end tests for the new layout

## Intent
Improve the readability of source listing commands in interactive terminals so the output scans cleanly without relying on terminal tab stops.

## Validation
- `cargo test -p coral-cli --features cli-test-server`
- `make rust-checks`

## Before

<img width="1040" height="834" alt="CleanShot 2026-04-22 at 21 51 11@2x" src="https://github.com/user-attachments/assets/afaabe1c-6afb-4b1d-aa52-70d5fc7f8019" />

## After

<img width="1044" height="964" alt="CleanShot 2026-04-22 at 21 48 47@2x" src="https://github.com/user-attachments/assets/d057ae80-353f-40a0-8d37-447fb591798d" />

