### PR TITLE
docs(sources/github): add authored table guides

### DIFF
--- a/sources/github/manifest.yaml
+++ b/sources/github/manifest.yaml
@@ -45,6 +45,8 @@ test_queries:
 tables:
   - name: accepted_assignments
     description: List accepted assignments for an assignment
+    guide: >
+      Requires assignment_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: assignment_id
         required: true
@@ -431,6 +433,9 @@ tables:
             - submitted
   - name: access
     description: Get the level of access for workflows outside of the repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -477,6 +482,9 @@ tables:
           key: repo
   - name: accounts
     description: List accounts for a plan
+    guide: >
+      Requires plan_id. Most useful optional filters: sort, direction. Use LIMIT for spot checks; large
+      result sets paginate quickly.
     filters:
       - name: plan_id
         required: true
@@ -826,6 +834,9 @@ tables:
             - url
   - name: activity
     description: List repository activities
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref, time_period, actor. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -1176,6 +1187,9 @@ tables:
             - timestamp
   - name: activity_list_repos_starred_by_user
     description: List repositories starred by a user
+    guide: >
+      Requires username. Most useful optional filters: sort, direction. Use LIMIT for spot checks; large
+      result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -1240,6 +1254,8 @@ tables:
           key: username
   - name: activity_list_repos_watched_by_user
     description: List repositories watched by a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -2310,6 +2326,9 @@ tables:
             - web_commit_signoff_required
   - name: advisories
     description: List global security advisories
+    guide: >
+      Works without WHERE filters. Most useful optional filters: type, sort, ghsa_id. Add ghsa_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: ghsa_id
         required: false
@@ -2700,6 +2719,9 @@ tables:
             - withdrawn_at
   - name: alerts
     description: List Dependabot alerts for an organization
+    guide: >
+      Requires org. Most useful optional filters: state, assignee, scope. Large organizations can return
+      many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -4304,6 +4326,9 @@ tables:
           key: enterprise
   - name: analyses
     description: List code scanning analyses for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref, sort, sarif_id. Add analysis_id to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -4601,6 +4626,9 @@ tables:
             - warning
   - name: annotations
     description: List check run annotations
+    guide: >
+      Requires owner, repo, and check_run_id. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -4731,6 +4759,8 @@ tables:
             - title
   - name: app
     description: Get the authenticated app
+    guide: >
+      Works without WHERE filters. Results depend on the authenticated app context.
     request:
       method: GET
       path: /app
@@ -5162,6 +5192,8 @@ tables:
             - updated_at
   - name: app_hook_config
     description: Get a webhook configuration for an app
+    guide: >
+      Works without WHERE filters. Results depend on the authenticated app context.
     request:
       method: GET
       path: /app/hook/config
@@ -5213,6 +5245,9 @@ tables:
             - url
   - name: app_hook_deliveries
     description: List deliveries for an app webhook
+    guide: >
+      Works without WHERE filters. Most useful optional filters: status, delivery_id. Add delivery_id to jump from
+      the default list call to a specific record lookup.
     filters:
       - name: status
         required: false
@@ -5426,6 +5461,9 @@ tables:
             - url
   - name: app_installations
     description: List installations for the authenticated app
+    guide: >
+      Works without WHERE filters. Most useful optional filters: installation_id, outdated. Add installation_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: outdated
         required: false
@@ -6649,6 +6687,9 @@ tables:
             - updated_at
   - name: approvals
     description: Get the review history for a workflow run
+    guide: >
+      Requires owner, repo, and run_id. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -6951,6 +6992,8 @@ tables:
             - user_view_type
   - name: apps
     description: Get an app
+    guide: >
+      Requires app_slug. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: app_slug
         required: true
@@ -7392,6 +7435,10 @@ tables:
             - updated_at
   - name: artifact_and_log_retention
     description: Get artifact and log retention settings for an organization
+    guide: >
+      Use this table to inspect Actions artifact and log retention for an org. Requires org. Add
+      owner and repo to switch to repository-level retention; repository overrides can differ from
+      org defaults.
     filters:
       - name: org
         required: true
@@ -7462,6 +7509,9 @@ tables:
           key: repo
   - name: assignees
     description: List assignees
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -7678,6 +7728,8 @@ tables:
             - user_view_type
   - name: assignments
     description: Get an assignment
+    guide: >
+      Requires assignment_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: assignment_id
         required: true
@@ -8051,6 +8103,10 @@ tables:
             - type
   - name: attempts
     description: Get a workflow run attempt
+    guide: >
+      Requires owner, repo, run_id, and attempt_number. Most useful optional filters:
+      exclude_pull_requests. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -11439,6 +11495,10 @@ tables:
             - workflow_url
   - name: attestations
     description: List attestations
+    guide: >
+      Use this table to list attestations for one subject digest. Requires username and
+      subject_digest. Add owner and repo before paging if the digest appears in multiple
+      repositories; predicate_type is the best content filter.
     filters:
       - name: username
         required: true
@@ -11594,6 +11654,9 @@ tables:
           key: repo
   - name: authors
     description: Get commit authors
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -11686,6 +11749,9 @@ tables:
             - url
   - name: autofix
     description: Get the status of an autofix for a code scanning alert
+    guide: >
+      Requires owner, repo, and alert_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -11759,6 +11825,9 @@ tables:
             - status
   - name: autolinks
     description: Get all autolinks of a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: autolink_id. Add autolink_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -11855,6 +11924,9 @@ tables:
             - url_template
   - name: automated_security_fixes
     description: Check if Dependabot security updates are enabled for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -11909,6 +11981,9 @@ tables:
           key: repo
   - name: billing
     description: Get Copilot seat information and settings for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -12059,6 +12134,9 @@ tables:
             - seat_management_setting
   - name: blobs
     description: Get a blob
+    guide: >
+      Requires owner, repo, and file_sha. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -12160,6 +12238,9 @@ tables:
             - url
   - name: blocked_by
     description: List dependencies an issue is blocked by
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -16158,6 +16239,9 @@ tables:
             - user_view_type
   - name: blocking
     description: List dependencies an issue is blocking
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -20156,6 +20240,9 @@ tables:
             - user_view_type
   - name: branches_where_head
     description: List branches for HEAD commit
+    guide: >
+      Requires owner, repo, and commit_sha. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -20244,6 +20331,9 @@ tables:
           key: repo
   - name: budgets
     description: Get all budgets for an organization
+    guide: >
+      Requires org. Most useful optional filters: scope, budget_id. Add budget_id to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -20398,6 +20488,9 @@ tables:
           key: scope
   - name: builds
     description: List GitHub Pages builds
+    guide: >
+      Requires owner and repo. Most useful optional filters: build_id. Add build_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -20725,6 +20818,9 @@ tables:
             - url
   - name: caches
     description: List GitHub Actions caches for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref, sort, key. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -20861,6 +20957,9 @@ tables:
             - version
   - name: campaigns
     description: List campaigns for an organization
+    guide: >
+      Requires org. Most useful optional filters: state, sort, campaign_number. Add campaign_number to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -21085,6 +21184,9 @@ tables:
             - updated_at
   - name: check_runs
     description: List check runs for a Git reference
+    guide: >
+      Requires owner, repo, and ref. Most useful optional filters: status, app_id, check_suite_id. Add
+      check_suite_id to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -22151,6 +22253,8 @@ tables:
           key: check_suite_id
   - name: classroom_assignments
     description: List assignments for a classroom
+    guide: >
+      Requires classroom_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: classroom_id
         required: true
@@ -22384,6 +22488,9 @@ tables:
             - type
   - name: classrooms
     description: List classrooms
+    guide: >
+      Works without WHERE filters. Most useful optional filters: classroom_id. Add classroom_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: classroom_id
         required: false
@@ -22525,6 +22632,9 @@ tables:
             - url
   - name: clones
     description: Get repository clones
+    guide: >
+      Requires owner and repo. Most useful optional filters: per. Keep queries repository-scoped; fan out
+      across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -22601,6 +22711,9 @@ tables:
             - uniques
   - name: code
     description: Search code
+    guide: >
+      Requires q. Most useful optional filters: sort, order. Use LIMIT for spot checks; large result sets
+      paginate quickly.
     filters:
       - name: q
         required: true
@@ -24022,6 +24135,9 @@ tables:
             - url
   - name: code_frequency
     description: Get the weekly commit activity
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -24065,6 +24181,9 @@ tables:
           key: repo
   - name: code_security_configuration
     description: Get the code security configuration associated with a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -24441,6 +24560,9 @@ tables:
             - status
   - name: codes_of_conduct
     description: Get all codes of conduct
+    guide: >
+      Works without WHERE filters. Most useful optional filters: key. Add key to jump from the default list call
+      to a specific record lookup.
     filters:
       - name: key
         required: false
@@ -24504,6 +24626,9 @@ tables:
             - url
   - name: codespaces
     description: List codespaces for the organization
+    guide: >
+      Use this table to audit codespaces in one org. Requires org. Start with username or owner/repo
+      before paging through large orgs; results only include codespaces your token can see.
     filters:
       - name: org
         required: true
@@ -26674,6 +26799,9 @@ tables:
           key: repo
   - name: collaborators
     description: List repository collaborators
+    guide: >
+      Requires owner and repo. Most useful optional filters: affiliation, permission. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -26970,6 +27098,9 @@ tables:
             - user_view_type
   - name: comments
     description: List commit comments for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: comment_id, commit_sha. Add comment_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -27444,6 +27575,9 @@ tables:
           key: commit_sha
   - name: commit_activity
     description: Get the last year of commit activity
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -27504,6 +27638,9 @@ tables:
             - week
   - name: commits
     description: List commits
+    guide: >
+      Use this table to browse commit history for one repo. Requires owner and repo. Start with ref
+      or path before paging long histories; sha is the fastest way to jump to one commit.
     filters:
       - name: owner
         required: true
@@ -28310,6 +28447,9 @@ tables:
           key: pull_number
   - name: config
     description: Get a webhook configuration for an organization
+    guide: >
+      Use this table to inspect one org webhook config. Requires org and hook_id. Add owner and repo
+      to query the repository webhook config instead; org and repo hooks can differ.
     filters:
       - name: org
         required: true
@@ -28408,6 +28548,9 @@ tables:
           key: repo
   - name: configurations
     description: Get code security configurations for an enterprise
+    guide: >
+      Requires enterprise. Most useful optional filters: org, configuration_id, target_type. Add
+      configuration_id to jump from the default list call to a specific record lookup.
     filters:
       - name: enterprise
         required: true
@@ -28762,6 +28905,9 @@ tables:
           key: org
   - name: conflicts
     description: Get list of conflicting packages during Docker migration for organization
+    guide: >
+      Requires org. Most useful optional filters: username. Add username to narrow the result set before
+      paging.
     filters:
       - name: org
         required: true
@@ -30254,6 +30400,9 @@ tables:
           key: username
   - name: content_exclusion
     description: Get Copilot content exclusion rules for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -30287,6 +30436,9 @@ tables:
           key: org
   - name: contents
     description: Get repository content
+    guide: >
+      Requires owner, repo, and path. Most useful optional filters: ref. Keep queries repository-scoped;
+      fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -30478,6 +30630,9 @@ tables:
             - url
   - name: contexts
     description: Get all status check contexts
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -30530,6 +30685,9 @@ tables:
           key: repo
   - name: copilot
     description: Get Copilot seat assignment details for a user
+    guide: >
+      Requires org and username. Large organizations can return many rows; narrow by one scoping filter
+      before broad scans.
     filters:
       - name: org
         required: true
@@ -31392,6 +31550,9 @@ tables:
           key: username
   - name: custom
     description: List custom images for an organization
+    guide: >
+      Requires org. Most useful optional filters: image_definition_id. Add image_definition_id to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -31508,6 +31669,9 @@ tables:
             - versions_count
   - name: databases
     description: List CodeQL databases for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: language. Keep queries repository-scoped; fan
+      out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -31863,6 +32027,9 @@ tables:
             - url
   - name: default_setup
     description: Get a code scanning default setup configuration
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -31971,6 +32138,9 @@ tables:
             - updated_at
   - name: defaults
     description: Get default code security configurations for an enterprise
+    guide: >
+      Requires enterprise. Most useful optional filters: org. Add org to narrow the result set before
+      paging.
     filters:
       - name: enterprise
         required: true
@@ -32353,6 +32523,9 @@ tables:
           key: org
   - name: deliveries
     description: List deliveries for an organization webhook
+    guide: >
+      Requires org and hook_id. Most useful optional filters: status, owner, repo. Add delivery_id to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -32618,6 +32791,9 @@ tables:
           key: repo
   - name: deployment_branch_policies
     description: List deployment branch policies
+    guide: >
+      Requires owner, repo, and environment_name. Most useful optional filters: branch_policy_id. Add
+      branch_policy_id to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -32724,6 +32900,9 @@ tables:
             - type
   - name: deployment_protection_rules
     description: Get all deployment protection rules for an environment
+    guide: >
+      Requires environment_name, repo, and owner. Most useful optional filters: protection_rule_id. Add
+      protection_rule_id to jump from the default list call to a specific record lookup.
     filters:
       - name: environment_name
         required: true
@@ -32866,6 +33045,9 @@ tables:
           key: repo
   - name: deployment_records
     description: List artifact deployment records
+    guide: >
+      Requires org and subject_digest. Large organizations can return many rows; narrow by one scoping
+      filter before broad scans.
     filters:
       - name: org
         required: true
@@ -32994,6 +33176,9 @@ tables:
             - updated_at
   - name: devcontainers
     description: List devcontainer configurations in a repository for the authenticated user
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -33061,6 +33246,10 @@ tables:
           key: repo
   - name: downloads
     description: List runner applications for an organization
+    guide: >
+      Use this table to list runner application downloads for an org. Requires org. Add owner and
+      repo to query repository-scoped runner downloads instead; repository availability can differ
+      from org defaults.
     filters:
       - name: org
         required: true
@@ -33162,6 +33351,8 @@ tables:
           key: repo
   - name: emails
     description: List email addresses for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/emails
@@ -33213,6 +33404,8 @@ tables:
             - visibility
   - name: emojis
     description: Get emojis
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /emojis
@@ -33234,6 +33427,9 @@ tables:
           kind: current_row
   - name: enforce_admins
     description: Get admin branch protection
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -33296,6 +33492,9 @@ tables:
             - url
   - name: enterprise_1_day
     description: Get Copilot enterprise usage metrics for a specific day
+    guide: >
+      Requires enterprise and day. Enterprise-wide calls can be expensive; narrow by org or time window
+      before broad scans.
     filters:
       - name: enterprise
         required: true
@@ -33355,6 +33554,10 @@ tables:
             - report_day
   - name: enterprise_code_security_configuration_repositories
     description: Get repositories associated with an enterprise code security configuration
+    guide: >
+      Use this table to list repositories attached to one enterprise code security configuration.
+      Requires enterprise and configuration_id. Add org before paging large enterprise rollouts;
+      status is the best filter for attached vs pending repos.
     filters:
       - name: enterprise
         required: true
@@ -34141,6 +34344,9 @@ tables:
           key: org
   - name: enterprise_copilot_metric_report_enterprise_28_day_latest
     description: Get Copilot enterprise usage metrics
+    guide: >
+      Requires enterprise. Enterprise-wide calls can be expensive; narrow by org or time window before
+      broad scans.
     filters:
       - name: enterprise
         required: true
@@ -34194,6 +34400,10 @@ tables:
             - report_start_day
   - name: enterprise_team_memberships
     description: List members in an enterprise team
+    guide: >
+      Use this table to list memberships for one enterprise team. Requires enterprise and
+      enterprise-team. Add username to jump to one member; hidden memberships can still limit what
+      the API returns.
     filters:
       - name: enterprise
         required: true
@@ -34427,6 +34637,9 @@ tables:
           key: username
   - name: enterprise_teams
     description: List enterprise teams
+    guide: >
+      Use this table to browse enterprise teams. Requires enterprise. Add team_slug to jump to one
+      team before paging; team visibility still follows enterprise permissions.
     filters:
       - name: enterprise
         required: true
@@ -34579,6 +34792,9 @@ tables:
             - url
   - name: environments
     description: List environments
+    guide: >
+      Requires owner and repo. Most useful optional filters: environment_name. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -34752,6 +34968,9 @@ tables:
             - wait_timer
   - name: errors
     description: List CODEOWNERS errors
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref. Keep queries repository-scoped; fan out
+      across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -34867,6 +35086,10 @@ tables:
             - suggestion
   - name: events
     description: List public events
+    guide: >
+      Use this table to scan the public GitHub event firehose. Works without WHERE filters. Start
+      with username or org, or pair owner with repo before paging; the feed is time-ordered and
+      changes quickly.
     filters:
       - name: username
         required: false
@@ -38018,6 +38241,9 @@ tables:
           key: owner
   - name: exports
     description: Get details about a codespace export
+    guide: >
+      Requires codespace_name and export_id. Use LIMIT for spot checks; large result sets paginate
+      quickly.
     filters:
       - name: codespace_name
         required: true
@@ -38117,6 +38343,9 @@ tables:
             - state
   - name: failed_invitations
     description: List failed organization invitations
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -38464,6 +38693,8 @@ tables:
             - team_count
   - name: feeds
     description: Get feeds
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /feeds
@@ -38866,6 +39097,9 @@ tables:
             - user_url
   - name: fields
     description: List project fields for organization
+    guide: >
+      Requires project_number and org. Most useful optional filters: username, field_id. Add field_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: project_number
         required: true
@@ -39116,6 +39350,9 @@ tables:
           key: username
   - name: files
     description: List pull requests files
+    guide: >
+      Requires owner, repo, and pull_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -39254,6 +39491,10 @@ tables:
             - status
   - name: fork_pr_contributor_approval
     description: Get fork PR contributor approval permissions for an organization
+    guide: >
+      Use this table to inspect fork-PR contributor approval rules for an org. Requires org. Add
+      owner and repo to query one repository override instead; repo settings can differ from the org
+      default.
     filters:
       - name: org
         required: true
@@ -39315,6 +39556,10 @@ tables:
           key: repo
   - name: fork_pr_workflows_private_repos
     description: Get private repo fork PR workflow settings for an organization
+    guide: >
+      Use this table to inspect private-repo fork workflow settings for an org. Requires org. Add
+      owner and repo to query one repository override instead; repo settings can differ from the org
+      default.
     filters:
       - name: org
         required: true
@@ -39404,6 +39649,8 @@ tables:
           key: repo
   - name: gist
     description: Get a gist revision
+    guide: >
+      Requires gist_id and sha. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: gist_id
         required: true
@@ -39837,6 +40084,9 @@ tables:
             - user
   - name: gist_comments
     description: List gist comments
+    guide: >
+      Requires gist_id. Most useful optional filters: comment_id. Add comment_id to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: gist_id
         required: true
@@ -40147,6 +40397,8 @@ tables:
             - user_view_type
   - name: gist_commits
     description: List gist commits
+    guide: >
+      Requires gist_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: gist_id
         required: true
@@ -40442,6 +40694,8 @@ tables:
             - version
   - name: gist_forks
     description: List gist forks
+    guide: >
+      Requires gist_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: gist_id
         required: true
@@ -40870,6 +41124,8 @@ tables:
             - user
   - name: gist_public
     description: List public gists
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /gists/public
@@ -41477,6 +41733,8 @@ tables:
             - user_view_type
   - name: gist_starred
     description: List starred gists
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /gists/starred
@@ -42083,6 +42341,9 @@ tables:
             - user_view_type
   - name: gists
     description: List gists for the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: username, gist_id. Add gist_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: gist_id
         required: false
@@ -42728,6 +42989,9 @@ tables:
           key: username
   - name: github_owned
     description: Get GitHub-owned images for GitHub-hosted runners in an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -42801,6 +43065,8 @@ tables:
             - source
   - name: grades
     description: Get assignment grades
+    guide: >
+      Requires assignment_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: assignment_id
         required: true
@@ -42926,6 +43192,9 @@ tables:
             - submission_timestamp
   - name: health
     description: Get a DNS health check for GitHub Pages
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -43230,6 +43499,9 @@ tables:
           key: repo
   - name: history
     description: Get organization ruleset history
+    guide: >
+      Requires org and ruleset_id. Most useful optional filters: owner, repo, version_id. Add version_id
+      to jump from the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -43361,6 +43633,9 @@ tables:
           key: repo
   - name: hovercard
     description: Get contextual information for a user
+    guide: >
+      Requires username. Most useful optional filters: subject_id, subject_type. Use LIMIT for spot
+      checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -43422,6 +43697,9 @@ tables:
           key: username
   - name: import
     description: Get an import status
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -43484,6 +43762,10 @@ tables:
             - vcs
   - name: installation
     description: Get an organization installation for the authenticated app
+    guide: >
+      Use this table to inspect an app installation for an org. Requires org. Add username to switch
+      to a user installation, or owner/repo to switch to a repository installation; returned scope
+      depends on the app context.
     filters:
       - name: org
         required: true
@@ -44713,6 +44995,8 @@ tables:
           key: repo
   - name: installation_repositories
     description: List repositories accessible to the app installation
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /installation/repositories
@@ -45893,6 +46177,8 @@ tables:
             - web_commit_signoff_required
   - name: installation_requests
     description: List installation requests for the authenticated app
+    guide: >
+      Works without WHERE filters. Results depend on the authenticated app context.
     request:
       method: GET
       path: /app/installation-requests
@@ -46423,6 +46709,9 @@ tables:
             - user_view_type
   - name: instances
     description: List instances of a code scanning alert
+    guide: >
+      Requires owner, repo, and alert_number. Most useful optional filters: ref, pr. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -46641,6 +46930,10 @@ tables:
             - state
   - name: interaction_limits
     description: Get interaction restrictions for an organization
+    guide: >
+      Use this table to inspect interaction limits for an org. Requires org. Add owner and repo to
+      query one repository override instead; repository restrictions can be stricter than the org
+      default.
     filters:
       - name: org
         required: true
@@ -46719,6 +47012,9 @@ tables:
           key: repo
   - name: invitations
     description: List pending organization invitations
+    guide: >
+      Requires org. Most useful optional filters: team_slug, team_id, role. Add team_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -47107,6 +47403,9 @@ tables:
           key: team_slug
   - name: issue_field_values
     description: List issue field values for an issue
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -47201,6 +47500,9 @@ tables:
             - value
   - name: issue_fields
     description: List issue fields for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -47308,6 +47610,9 @@ tables:
             - visibility
   - name: issue_types
     description: List issue types for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -47406,6 +47711,9 @@ tables:
             - updated_at
   - name: issues
     description: List issues assigned to the authenticated user
+    guide: >
+      Use this table to list issues assigned to the authenticated user. Works without WHERE filters.
+      Start with org or state before paging; the feed is viewer-specific, not a global issue search.
     filters:
       - name: filter
         required: false
@@ -51579,6 +51887,9 @@ tables:
           key: issue_number
   - name: issues_list_comments
     description: List issue comments
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -52741,6 +53052,9 @@ tables:
             - user_view_type
   - name: issues_list_events
     description: List issue events
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -54594,6 +54908,9 @@ tables:
             - url
   - name: items
     description: List items for an organization owned project
+    guide: >
+      Requires project_number and org. Most useful optional filters: username, item_id, view_number. Add
+      item_id to jump from the default list call to a specific record lookup.
     filters:
       - name: project_number
         required: true
@@ -55045,6 +55362,9 @@ tables:
           key: view_number
   - name: jobs
     description: List jobs for a workflow run
+    guide: >
+      Requires owner, repo, and run_id. Most useful optional filters: attempt_number, filter. Add
+      attempt_number to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -55325,6 +55645,9 @@ tables:
           key: attempt_number
   - name: labels
     description: List labels for a self-hosted runner for an organization
+    guide: >
+      Use this table to list labels for one org self-hosted runner. Requires org and runner_id. Add
+      owner and repo to query repository-scoped runner labels instead; runner labels vary by scope.
     filters:
       - name: org
         required: true
@@ -55417,6 +55740,9 @@ tables:
           key: repo
   - name: languages
     description: List repository languages
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -55460,6 +55786,9 @@ tables:
           key: repo
   - name: large_files
     description: Get large files
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -55528,6 +55857,9 @@ tables:
             - size
   - name: latest
     description: Get Copilot users usage metrics
+    guide: >
+      Requires enterprise. Most useful optional filters: org. Add org to narrow the result set before
+      paging.
     filters:
       - name: enterprise
         required: true
@@ -55596,6 +55928,9 @@ tables:
           key: org
   - name: license
     description: Get the license for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref. Keep queries repository-scoped; fan out
+      across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -55831,6 +56166,9 @@ tables:
             - url
   - name: licenses
     description: Get all commonly used licenses
+    guide: >
+      Works without WHERE filters. Most useful optional filters: featured, license. Use LIMIT for spot checks;
+      large result sets paginate quickly.
     filters:
       - name: featured
         required: false
@@ -55975,6 +56313,9 @@ tables:
             - url
   - name: limits
     description: Get limits on GitHub-hosted runners for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -56030,6 +56371,9 @@ tables:
             - maximum
   - name: locations
     description: List locations for a secret scanning alert
+    guide: >
+      Requires owner, repo, and alert_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -56307,6 +56651,9 @@ tables:
             - type
   - name: machine_sizes
     description: Get GitHub-hosted runners machine specs for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -56371,6 +56718,8 @@ tables:
             - storage_gb
   - name: marketplace_listing_accounts
     description: Get a subscription plan for an account
+    guide: >
+      Requires account_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: account_id
         required: true
@@ -56682,6 +57031,8 @@ tables:
             - url
   - name: marketplace_listing_plans
     description: List plans
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /marketplace_listing/plans
@@ -56805,6 +57156,8 @@ tables:
             - yearly_price_in_cents
   - name: marketplace_listing_stubbed_plans
     description: List plans (stubbed)
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /marketplace_listing/stubbed/plans
@@ -56928,6 +57281,8 @@ tables:
             - yearly_price_in_cents
   - name: marketplace_purchases
     description: List subscriptions for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/marketplace_purchases
@@ -57205,6 +57560,9 @@ tables:
             - updated_at
   - name: matching_refs
     description: List matching references
+    guide: >
+      Requires owner, repo, and ref. Keep queries repository-scoped; fan out across repos client-side when
+      you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -57303,6 +57661,9 @@ tables:
             - url
   - name: members
     description: List organization members
+    guide: >
+      Requires org. Most useful optional filters: team_slug, team_id, filter. Add team_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -57574,6 +57935,10 @@ tables:
           key: team_slug
   - name: memberships
     description: Get team membership for a user (Legacy)
+    guide: >
+      Use this table to inspect one team membership. Requires team_id and username. If you only
+      know org and team_slug, resolve team_id from github.teams first; org and team_slug then select
+      the matching org team route instead of the legacy team_id path.
     filters:
       - name: team_id
         required: true
@@ -57663,6 +58028,8 @@ tables:
           key: team_slug
   - name: meta
     description: Get GitHub meta information
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /meta
@@ -57953,6 +58320,8 @@ tables:
             - web
   - name: meta_get_all_versions
     description: Get all API versions
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /versions
@@ -57974,6 +58343,9 @@ tables:
           kind: current_row
   - name: metrics
     description: Get Copilot metrics for an organization
+    guide: >
+      Requires org. Most useful optional filters: team_slug. Add team_slug to narrow the result set before
+      paging.
     filters:
       - name: org
         required: true
@@ -58085,6 +58457,9 @@ tables:
           key: team_slug
   - name: milestones
     description: List milestones
+    guide: >
+      Requires owner and repo. Most useful optional filters: state, sort, milestone_number. Add
+      milestone_number to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -58503,6 +58878,9 @@ tables:
             - url
   - name: network_configurations
     description: List hosted compute network configurations for an organization
+    guide: >
+      Requires org. Most useful optional filters: network_configuration_id. Add network_configuration_id
+      to jump from the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -58614,6 +58992,9 @@ tables:
           key: org
   - name: network_settings
     description: Get a hosted compute network settings resource for an organization
+    guide: >
+      Requires org and network_settings_id. Large organizations can return many rows; narrow by one
+      scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -58695,6 +59076,9 @@ tables:
             - subnet_id
   - name: new
     description: Get default attributes for a codespace
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref, client_ip. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -59013,6 +59397,8 @@ tables:
           key: repo
   - name: notification_thread_subscription
     description: Get a thread subscription for the authenticated user
+    guide: >
+      Requires thread_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: thread_id
         required: true
@@ -59095,6 +59481,10 @@ tables:
             - url
   - name: notifications
     description: List notifications for the authenticated user
+    guide: >
+      Use this table to review the authenticated user's notifications. Works without WHERE filters.
+      Start with owner/repo or all before paging busy inboxes; unread state changes as GitHub
+      updates the inbox.
     filters:
       - name: all
         required: false
@@ -60536,6 +60926,9 @@ tables:
           key: repo
   - name: org_action_cache_usage
     description: Get GitHub Actions cache usage for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -60580,6 +60973,9 @@ tables:
             - total_active_caches_size_in_bytes
   - name: org_action_hosted_runner_image_custom_versions
     description: List image versions of a custom image for an organization
+    guide: >
+      Requires image_definition_id and org. Most useful optional filters: version. Large organizations can
+      return many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: image_definition_id
         required: true
@@ -60672,6 +61068,9 @@ tables:
             - version
   - name: org_action_hosted_runners
     description: List GitHub-hosted runners for an organization
+    guide: >
+      Requires org. Most useful optional filters: hosted_runner_id. Add hosted_runner_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -60944,6 +61343,9 @@ tables:
             - status
   - name: org_action_oidc_customization_sub
     description: Get the customization template for an OIDC subject claim for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -60979,6 +61381,9 @@ tables:
           key: org
   - name: org_action_permission_repositories
     description: List selected repositories enabled for GitHub Actions in an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -62172,6 +62577,9 @@ tables:
             - web_commit_signoff_required
   - name: org_action_permission_self_hosted_runner_repositories
     description: List repositories allowed to use self-hosted runners in an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -63365,6 +63773,9 @@ tables:
             - web_commit_signoff_required
   - name: org_action_permissions
     description: Get GitHub Actions permissions for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -63438,6 +63849,9 @@ tables:
             - sha_pinning_required
   - name: org_action_runner_group_hosted_runners
     description: List GitHub-hosted runners in a group for an organization
+    guide: >
+      Requires org and runner_group_id. Large organizations can return many rows; narrow by one scoping
+      filter before broad scans.
     filters:
       - name: org
         required: true
@@ -63669,6 +64083,9 @@ tables:
             - status
   - name: org_action_runner_group_runners
     description: List self-hosted runners in a group for an organization
+    guide: >
+      Requires org and runner_group_id. Large organizations can return many rows; narrow by one scoping
+      filter before broad scans.
     filters:
       - name: org
         required: true
@@ -63772,6 +64189,9 @@ tables:
             - status
   - name: org_action_secret_public_key
     description: Get an organization public key
+    guide: >
+      Use this table to fetch the public key for org Actions secrets. Requires org. Add owner and
+      repo to fetch the repository key instead; secret writes must use the matching key scope.
     filters:
       - name: org
         required: true
@@ -63874,6 +64294,9 @@ tables:
           key: repo
   - name: org_action_secrets
     description: List organization secrets
+    guide: >
+      Requires org. Most useful optional filters: secret_name. Add secret_name to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -63964,6 +64387,9 @@ tables:
             - visibility
   - name: org_action_variables
     description: List organization variables
+    guide: >
+      Requires org. Most useful optional filters: name. Add name to jump from the default list call to a
+      specific record lookup.
     filters:
       - name: org
         required: true
@@ -64057,6 +64483,9 @@ tables:
             - visibility
   - name: org_attestation_repositories
     description: List attestation repositories
+    guide: >
+      Requires org. Most useful optional filters: predicate_type. Large organizations can return many
+      rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -64118,6 +64547,9 @@ tables:
           key: predicate_type
   - name: org_attestations
     description: List attestations
+    guide: >
+      Requires org and subject_digest. Most useful optional filters: predicate_type. Large organizations
+      can return many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -64209,6 +64641,9 @@ tables:
           key: subject_digest
   - name: org_blocks
     description: List users blocked by an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -64416,6 +64851,9 @@ tables:
             - user_view_type
   - name: org_code_scanning_alerts
     description: List code scanning alerts for an organization
+    guide: >
+      Requires org. Most useful optional filters: state, sort, tool_name. Large organizations can return
+      many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -66073,6 +66511,9 @@ tables:
             - url
   - name: org_codespace_secrets
     description: List organization secrets
+    guide: >
+      Requires org. Most useful optional filters: secret_name. Add secret_name to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -66166,6 +66607,9 @@ tables:
             - visibility
   - name: org_copilot_coding_agent_permission_repositories
     description: List repositories enabled for Copilot coding agent in an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -67239,6 +67683,9 @@ tables:
             - web_commit_signoff_required
   - name: org_copilot_coding_agent_permissions
     description: Get Copilot coding agent permissions for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -67283,6 +67730,9 @@ tables:
             - selected_repositories_url
   - name: org_copilot_metric_report_organization_28_day_latest
     description: Get Copilot organization usage metrics
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -67336,6 +67786,9 @@ tables:
             - report_start_day
   - name: org_dependabot_secret_public_key
     description: Get an organization public key
+    guide: >
+      Use this table to fetch the public key for org Dependabot secrets. Requires org. Add owner and
+      repo to fetch the repository key instead; secret writes must use the matching key scope.
     filters:
       - name: org
         required: true
@@ -67406,6 +67859,9 @@ tables:
           key: repo
   - name: org_dependabot_secrets
     description: List organization secrets
+    guide: >
+      Requires org. Most useful optional filters: secret_name. Add secret_name to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -67496,6 +67952,9 @@ tables:
             - visibility
   - name: org_hooks
     description: List organization webhooks
+    guide: >
+      Requires org. Most useful optional filters: hook_id. Add hook_id to jump from the default list call
+      to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -67666,6 +68125,9 @@ tables:
             - url
   - name: org_insight_summary_stat_users
     description: Get summary stats by user
+    guide: >
+      Requires org, user_id, and min_timestamp. Most useful optional filters: max_timestamp. Large
+      organizations can return many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -67747,6 +68209,9 @@ tables:
           key: user_id
   - name: org_insight_summary_stats
     description: Get summary stats
+    guide: >
+      Requires org and min_timestamp. Most useful optional filters: max_timestamp. Large organizations can
+      return many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -67818,6 +68283,10 @@ tables:
             - total_request_count
   - name: org_insight_time_stat_users
     description: Get time stats by user
+    guide: >
+      Requires org, user_id, min_timestamp, and timestamp_increment. Most useful optional filters:
+      max_timestamp. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -67918,6 +68387,9 @@ tables:
           key: user_id
   - name: org_insight_time_stats
     description: Get time stats
+    guide: >
+      Requires org, min_timestamp, and timestamp_increment. Most useful optional filters: max_timestamp.
+      Large organizations can return many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -68008,6 +68480,9 @@ tables:
             - total_request_count
   - name: org_insights_summary_stat
     description: Get summary stats by actor
+    guide: >
+      Requires org, min_timestamp, actor_type, and actor_id. Most useful optional filters: max_timestamp.
+      Large organizations can return many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -68099,6 +68574,10 @@ tables:
             - total_request_count
   - name: org_insights_time_stat
     description: Get time stats by actor
+    guide: >
+      Requires org, actor_type, actor_id, min_timestamp, and timestamp_increment. Most useful optional
+      filters: max_timestamp. Large organizations can return many rows; narrow by one scoping filter
+      before broad scans.
     filters:
       - name: org
         required: true
@@ -68209,6 +68688,9 @@ tables:
             - total_request_count
   - name: org_installations
     description: List app installations for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -69416,6 +69898,9 @@ tables:
             - updated_at
   - name: org_memberships
     description: Get organization membership for a user
+    guide: >
+      Requires org and username. Large organizations can return many rows; narrow by one scoping filter
+      before broad scans.
     filters:
       - name: org
         required: true
@@ -69856,6 +70341,9 @@ tables:
           key: username
   - name: org_migrations
     description: List organization migrations
+    guide: >
+      Requires org. Most useful optional filters: migration_id, exclude. Add migration_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -71137,6 +71625,9 @@ tables:
             - web_commit_signoff_required
   - name: org_organization_role_teams
     description: List teams that are assigned to an organization role
+    guide: >
+      Requires org and role_id. Large organizations can return many rows; narrow by one scoping filter
+      before broad scans.
     filters:
       - name: org
         required: true
@@ -71525,6 +72016,9 @@ tables:
             - url
   - name: org_organization_role_users
     description: List users that are assigned to an organization role
+    guide: >
+      Requires org and role_id. Large organizations can return many rows; narrow by one scoping filter
+      before broad scans.
     filters:
       - name: org
         required: true
@@ -71759,6 +72253,9 @@ tables:
             - user_view_type
   - name: org_private_registry_public_key
     description: Get private registries public key for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -71803,6 +72300,9 @@ tables:
           key: org
   - name: org_property_values
     description: List custom property values for organization repositories
+    guide: >
+      Requires org. Most useful optional filters: repository_query. Large organizations can return many
+      rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -71881,6 +72381,9 @@ tables:
           key: repository_query
   - name: org_repos
     description: List organization repositories
+    guide: >
+      Use this table to list repositories in one org. Requires org. Start with type or username
+      before paging large orgs; username is best when you need one user's accessible slice.
     filters:
       - name: org
         required: true
@@ -73046,6 +73549,9 @@ tables:
           key: team_slug
   - name: org_secret_scanning_alerts
     description: List secret scanning alerts for an organization
+    guide: >
+      Requires org. Most useful optional filters: state, assignee, sort. Large organizations can return
+      many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -75135,6 +75641,9 @@ tables:
             - validity
   - name: org_setting_immutable_release_repositories
     description: List selected repositories for immutable releases enforcement
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -76209,6 +76718,9 @@ tables:
             - web_commit_signoff_required
   - name: org_setting_immutable_releases
     description: Get immutable releases settings for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -76254,6 +76766,9 @@ tables:
             - selected_repositories_url
   - name: organization_1_day
     description: Get Copilot organization usage metrics for a specific day
+    guide: >
+      Requires org and day. Large organizations can return many rows; narrow by one scoping filter before
+      broad scans.
     filters:
       - name: org
         required: true
@@ -76313,6 +76828,9 @@ tables:
             - report_day
   - name: organization_roles
     description: Get all organization roles for an organization
+    guide: >
+      Requires org. Most useful optional filters: role_id. Add role_id to jump from the default list call
+      to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -76635,6 +77153,9 @@ tables:
             - updated_at
   - name: organization_secrets
     description: List repository organization secrets
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -76702,6 +77223,9 @@ tables:
             - updated_at
   - name: organization_setting_billing_usage
     description: Get billing usage report for an organization
+    guide: >
+      Requires org. Most useful optional filters: year, month, day. Large organizations can return many
+      rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -76871,6 +77395,9 @@ tables:
           key: year
   - name: organization_variables
     description: List repository organization variables
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -76949,6 +77476,9 @@ tables:
             - value
   - name: organizations
     description: List organizations
+    guide: >
+      Works without WHERE filters. Most useful optional filters: org, enterprise, enterprise-team. Use LIMIT for
+      spot checks; large result sets paginate quickly.
     filters:
       - name: enterprise
         required: false
@@ -77103,6 +77633,9 @@ tables:
           key: org
   - name: orgs
     description: Get an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -77729,6 +78262,8 @@ tables:
             - web_commit_signoff_required
   - name: orgs_list_for_user
     description: List organizations for a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -77855,6 +78390,9 @@ tables:
           key: username
   - name: outside_collaborators
     description: List outside collaborators for an organization
+    guide: >
+      Requires org. Most useful optional filters: filter. Large organizations can return many rows; narrow
+      by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -78075,6 +78613,10 @@ tables:
             - user_view_type
   - name: packages
     description: List packages for an organization
+    guide: >
+      Use this table to list packages in one org. Requires package_type and org. Start with
+      visibility or username before paging; package visibility often removes rows you might expect
+      from the full org list.
     filters:
       - name: package_type
         required: true
@@ -79591,6 +80133,9 @@ tables:
           key: username
   - name: packages_list_packages_for_authenticated_user
     description: List packages for the authenticated user's namespace
+    guide: >
+      Requires package_type. Most useful optional filters: visibility. Use LIMIT for spot checks; large
+      result sets paginate quickly.
     filters:
       - name: package_type
         required: true
@@ -81075,6 +81620,9 @@ tables:
             - visibility
   - name: pages
     description: Get a GitHub Pages site
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -81273,6 +81821,9 @@ tables:
             - url
   - name: parent
     description: Get parent issue
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -85268,6 +85819,9 @@ tables:
             - user_view_type
   - name: participation
     description: Get the weekly commit count
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -85312,6 +85866,9 @@ tables:
           key: repo
   - name: partner
     description: Get partner images for GitHub-hosted runners in an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -85385,6 +85942,9 @@ tables:
             - source
   - name: paths
     description: Get top referral paths
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -85453,6 +86013,9 @@ tables:
             - uniques
   - name: pattern_configurations
     description: List organization pattern configurations
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -85506,6 +86069,9 @@ tables:
             - provider_pattern_overrides
   - name: pending_deployments
     description: Get pending deployments for a workflow run
+    guide: >
+      Requires owner, repo, and run_id. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -85644,6 +86210,9 @@ tables:
             - wait_timer_started_at
   - name: permission
     description: Get repository permissions for a user
+    guide: >
+      Requires owner, repo, and username. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -85971,6 +86540,9 @@ tables:
           key: username
   - name: permissions_check
     description: Check if permissions defined by a devcontainer have been accepted by the authenticated user
+    guide: >
+      Requires owner, repo, ref, and devcontainer_path. Keep queries repository-scoped; fan out across
+      repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -86044,6 +86616,9 @@ tables:
           key: repo
   - name: personal_access_token_requests
     description: List requests to access organization resources with fine-grained personal access tokens
+    guide: >
+      Requires org. Most useful optional filters: sort, owner, token_id. Large organizations can return
+      many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -86522,6 +87097,9 @@ tables:
             - token_name
   - name: personal_access_tokens
     description: List fine-grained personal access tokens with access to organization resources
+    guide: >
+      Requires org. Most useful optional filters: sort, owner, token_id. Large organizations can return
+      many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -86991,6 +87569,9 @@ tables:
             - token_name
   - name: platforms
     description: Get platforms for GitHub-hosted runners in an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -87033,6 +87614,9 @@ tables:
             - total_count
   - name: private_registries
     description: List private registries for an organization
+    guide: >
+      Requires org. Most useful optional filters: secret_name. Add secret_name to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -87251,6 +87835,9 @@ tables:
             - visibility
   - name: private_vulnerability_reporting
     description: Check if private vulnerability reporting is enabled for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -87296,6 +87883,9 @@ tables:
           key: repo
   - name: profile
     description: Get community profile metrics
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -87643,6 +88233,9 @@ tables:
             - updated_at
   - name: projects_v2
     description: List projects for organization
+    guide: >
+      Requires org. Most useful optional filters: username, project_number, q. Add project_number to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -88852,6 +89445,9 @@ tables:
           key: username
   - name: protection
     description: Get branch protection
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -89437,6 +90033,8 @@ tables:
             - url
   - name: public_emails
     description: List public email addresses for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/public_emails
@@ -89488,6 +90086,9 @@ tables:
             - visibility
   - name: public_key
     description: Get an organization public key
+    guide: >
+      Use this table to fetch the public key for org secrets. Requires org. Add owner and repo to
+      fetch the repository key instead; secret writes must use the matching key scope.
     filters:
       - name: org
         required: true
@@ -89590,6 +90191,9 @@ tables:
           key: repo
   - name: public_members
     description: List public organization members
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -89796,6 +90400,9 @@ tables:
             - user_view_type
   - name: pulls
     description: List pull requests
+    guide: >
+      Requires owner and repo. Most useful optional filters: state, head, base. Add pull_number to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -94124,6 +94731,9 @@ tables:
           key: commit_sha
   - name: pulls_list_review_comments
     description: List review comments on a pull request
+    guide: >
+      Requires owner, repo, and pull_number. Most useful optional filters: sort, direction. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -94800,6 +95410,9 @@ tables:
             - user_view_type
   - name: punch_card
     description: Get the hourly commit count for each day
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -94843,6 +95456,8 @@ tables:
           key: repo
   - name: rate_limit
     description: Get rate limit status for the authenticated user
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /rate_limit
@@ -95498,6 +96113,9 @@ tables:
             - used
   - name: reactions
     description: List reactions for a commit comment
+    guide: >
+      Requires owner, repo, and comment_id. Most useful optional filters: issue_number, release_id,
+      content. Add issue_number to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -95854,6 +96472,9 @@ tables:
           key: release_id
   - name: readme
     description: Get a repository README
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref, dir. Keep queries repository-scoped; fan
+      out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -96064,6 +96685,8 @@ tables:
             - url
   - name: received_events
     description: List events received by the authenticated user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -99182,6 +99805,9 @@ tables:
           key: username
   - name: ref
     description: Get a reference
+    guide: >
+      Requires owner, repo, and ref. Keep queries repository-scoped; fan out across repos client-side when
+      you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -99280,6 +99906,9 @@ tables:
             - url
   - name: referrers
     description: Get top referral sources
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -99340,6 +99969,9 @@ tables:
             - uniques
   - name: releases
     description: List releases
+    guide: >
+      Requires owner and repo. Most useful optional filters: release_id. Add release_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -100177,6 +100809,9 @@ tables:
             - zipball_url
   - name: repo
     description: List OIDC custom property inclusions for an enterprise
+    guide: >
+      Requires enterprise. Most useful optional filters: org. Add org to narrow the result set before
+      paging.
     filters:
       - name: enterprise
         required: true
@@ -100236,6 +100871,9 @@ tables:
           key: org
   - name: repo_action_artifacts
     description: List artifacts for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: name, artifact_id. Add artifact_id to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -100401,6 +101039,9 @@ tables:
             - workflow_run
   - name: repo_action_cache_usage
     description: Get GitHub Actions cache usage for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -100464,6 +101105,9 @@ tables:
           key: repo
   - name: repo_action_jobs
     description: Get a job for a workflow run
+    guide: >
+      Requires owner, repo, and job_id. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -100565,6 +101209,9 @@ tables:
             - status
   - name: repo_action_oidc_customization_sub
     description: Get the customization template for an OIDC subject claim for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -100619,6 +101266,9 @@ tables:
             - use_default
   - name: repo_action_permissions
     description: Get GitHub Actions permissions for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -100691,6 +101341,9 @@ tables:
             - sha_pinning_required
   - name: repo_action_run_artifacts
     description: List workflow run artifacts
+    guide: >
+      Requires owner, repo, and run_id. Most useful optional filters: name, direction. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -100862,6 +101515,9 @@ tables:
             - workflow_run
   - name: repo_action_run_timing
     description: Get workflow run usage
+    guide: >
+      Requires owner, repo, and run_id. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -101041,6 +101697,9 @@ tables:
           key: run_id
   - name: repo_action_runs
     description: List workflow runs for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: branch, status, check_suite_id. Add run_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -104486,6 +105145,9 @@ tables:
             - workflow_url
   - name: repo_action_secrets
     description: List repository secrets
+    guide: >
+      Requires owner and repo. Most useful optional filters: secret_name. Add secret_name to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -104570,6 +105232,9 @@ tables:
             - updated_at
   - name: repo_action_variables
     description: List repository variables
+    guide: >
+      Requires owner and repo. Most useful optional filters: name. Add name to jump from the default list
+      call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -104657,6 +105322,9 @@ tables:
             - value
   - name: repo_action_workflow_runs
     description: List workflow runs for a workflow
+    guide: >
+      Requires owner, repo, and workflow_id. Most useful optional filters: branch, status, check_suite_id.
+      Keep queries repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -108083,6 +108751,9 @@ tables:
             - workflow_url
   - name: repo_action_workflow_timing
     description: Get workflow usage
+    guide: >
+      Requires owner, repo, and workflow_id. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -108194,6 +108865,9 @@ tables:
           key: workflow_id
   - name: repo_branch_protection_restriction_apps
     description: Get apps with access to the protected branch
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -108648,6 +109322,9 @@ tables:
             - updated_at
   - name: repo_branch_protection_restriction_teams
     description: Get teams with access to the protected branch
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -109033,6 +109710,9 @@ tables:
             - url
   - name: repo_branch_protection_restriction_users
     description: Get users with access to the protected branch
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -109255,6 +109935,9 @@ tables:
             - user_view_type
   - name: repo_branches
     description: List branches
+    guide: >
+      Requires owner and repo. Most useful optional filters: branch, protected. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -110604,6 +111287,9 @@ tables:
             - required_approving_review_count
   - name: repo_check_runs
     description: Get a check run
+    guide: >
+      Requires owner, repo, and check_run_id. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -110806,6 +111492,9 @@ tables:
             - url
   - name: repo_check_suites
     description: Get a check suite
+    guide: >
+      Requires owner, repo, and check_suite_id. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -112782,6 +113471,9 @@ tables:
             - url
   - name: repo_code_scanning_alerts
     description: List code scanning alerts for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref, sort, state. Add alert_number to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -113939,6 +114631,9 @@ tables:
             - user_view_type
   - name: repo_code_scanning_codeql_variant_analyse_repos
     description: Get the analysis status of a repository in a CodeQL variant analysis
+    guide: >
+      Requires owner, repo, codeql_variant_analysis_id, repo_owner, and repo_name. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -114779,6 +115474,9 @@ tables:
             - source_location_prefix
   - name: repo_codespace_machines
     description: List available machine types for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: ref, location, client_ip. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -114920,6 +115618,9 @@ tables:
             - storage_in_bytes
   - name: repo_codespace_secrets
     description: List repository secrets
+    guide: >
+      Requires owner and repo. Most useful optional filters: secret_name. Add secret_name to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -115004,6 +115705,9 @@ tables:
             - updated_at
   - name: repo_commit_check_suites
     description: List check suites for a Git reference
+    guide: >
+      Requires owner, repo, and ref. Most useful optional filters: app_id, check_name. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -117013,6 +117717,9 @@ tables:
             - url
   - name: repo_commit_statuses
     description: List commit statuses for a reference
+    guide: >
+      Requires owner, repo, and ref. Keep queries repository-scoped; fan out across repos client-side when
+      you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -117349,6 +118056,9 @@ tables:
             - url
   - name: repo_compare
     description: Compare two commits
+    guide: >
+      Requires owner, repo, and basehead. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -118909,6 +119619,9 @@ tables:
             - url
   - name: repo_contributors
     description: List repository contributors
+    guide: >
+      Requires owner and repo. Most useful optional filters: anon. Keep queries repository-scoped; fan out
+      across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -119139,6 +119852,9 @@ tables:
             - user_view_type
   - name: repo_dependabot_alerts
     description: List Dependabot alerts for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: state, assignee, scope. Add alert_number to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -120146,6 +120862,9 @@ tables:
             - user_view_type
   - name: repo_dependabot_secrets
     description: List repository secrets
+    guide: >
+      Requires owner and repo. Most useful optional filters: secret_name. Add secret_name to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -120230,6 +120949,9 @@ tables:
             - updated_at
   - name: repo_dependency_graph_compare
     description: Get a diff of the dependencies between commits
+    guide: >
+      Requires owner, repo, and basehead. Most useful optional filters: name. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -120363,6 +121085,9 @@ tables:
             - vulnerabilities
   - name: repo_deployment_statuses
     description: List deployment statuses
+    guide: >
+      Requires owner, repo, and deployment_id. Most useful optional filters: status_id. Add status_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -121216,6 +121941,9 @@ tables:
             - url
   - name: repo_deployments
     description: List deployments
+    guide: >
+      Requires owner and repo. Most useful optional filters: sha, ref, deployment_id. Add deployment_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -122104,6 +122832,9 @@ tables:
             - url
   - name: repo_environment_deployment_protection_rule_apps
     description: List custom deployment rule integrations available for an environment
+    guide: >
+      Requires environment_name, repo, and owner. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: environment_name
         required: true
@@ -122193,6 +122924,9 @@ tables:
             - slug
   - name: repo_environment_secret_public_key
     description: Get an environment public key
+    guide: >
+      Requires owner, repo, and environment_name. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -122289,6 +123023,9 @@ tables:
             - url
   - name: repo_environment_secrets
     description: List environment secrets
+    guide: >
+      Requires owner, repo, and environment_name. Most useful optional filters: secret_name. Add
+      secret_name to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -122384,6 +123121,9 @@ tables:
             - updated_at
   - name: repo_environment_variables
     description: List environment variables
+    guide: >
+      Requires owner, repo, and environment_name. Most useful optional filters: name. Add name to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -122482,6 +123222,9 @@ tables:
             - value
   - name: repo_forks
     description: List forks
+    guide: >
+      Requires owner and repo. Most useful optional filters: sort. Keep queries repository-scoped; fan out
+      across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -123568,6 +124311,9 @@ tables:
             - web_commit_signoff_required
   - name: repo_git_commits
     description: Get a commit object
+    guide: >
+      Requires owner, repo, and commit_sha. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -123641,6 +124387,9 @@ tables:
             - url
   - name: repo_git_tags
     description: Get a tag
+    guide: >
+      Requires owner, repo, and tag_sha. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -123852,6 +124601,9 @@ tables:
             - verified_at
   - name: repo_hooks
     description: List repository webhooks
+    guide: >
+      Requires owner and repo. Most useful optional filters: hook_id. Add hook_id to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -124085,6 +124837,9 @@ tables:
             - url
   - name: repo_immutable_releases
     description: Check if immutable releases are enabled for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -124139,6 +124894,9 @@ tables:
           key: repo
   - name: repo_invitations
     description: List repository invitations
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -125912,6 +126670,9 @@ tables:
             - url
   - name: repo_issue_comments
     description: List issue comments for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: sort, comment_id, direction. Add comment_id
+      to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -127108,6 +127869,9 @@ tables:
             - user_view_type
   - name: repo_issue_events
     description: List issue events for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: event_id. Add event_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -132141,6 +132905,9 @@ tables:
             - url
   - name: repo_keys
     description: List deploy keys
+    guide: >
+      Requires owner and repo. Most useful optional filters: key_id. Add key_id to jump from the default
+      list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -132278,6 +133045,9 @@ tables:
             - verified
   - name: repo_labels
     description: List labels for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: name, issue_number, milestone_number. Add
+      name to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -132421,6 +133191,9 @@ tables:
           key: milestone_number
   - name: repo_page_build_latest
     description: Get latest Pages build
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -132728,6 +133501,9 @@ tables:
             - url
   - name: repo_page_deployments
     description: Get the status of a GitHub Pages deployment
+    guide: >
+      Requires owner, repo, and pages_deployment_id. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -132783,6 +133559,9 @@ tables:
             - status
   - name: repo_property_values
     description: Get all custom property values for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -132837,6 +133616,9 @@ tables:
             - value
   - name: repo_pull_comments
     description: List review comments in a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: sort, comment_id, direction. Add comment_id
+      to jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -133519,6 +134301,9 @@ tables:
             - user_view_type
   - name: repo_pull_review_comments
     description: List comments for a pull request review
+    guide: >
+      Requires owner, repo, pull_number, and review_id. Keep queries repository-scoped; fan out across
+      repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -134170,6 +134955,9 @@ tables:
             - user_view_type
   - name: repo_release_assets
     description: Get a release asset
+    guide: >
+      Requires owner, repo, and asset_id. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -134528,6 +135316,9 @@ tables:
             - url
   - name: repo_release_latest
     description: Get the latest release
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -134878,6 +135669,9 @@ tables:
             - url
   - name: repo_release_tags
     description: Get a release by tag name
+    guide: >
+      Requires owner, repo, and tag. Keep queries repository-scoped; fan out across repos client-side when
+      you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -135238,6 +136032,9 @@ tables:
             - url
   - name: repo_rule_branches
     description: Get rules for a branch
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -135352,6 +136149,9 @@ tables:
             - type
   - name: repo_secret_scanning_alerts
     description: List secret scanning alerts for a repository
+    guide: >
+      Requires owner and repo. Most useful optional filters: state, assignee, sort. Add alert_number to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -136761,6 +137561,9 @@ tables:
             - validity
   - name: repo_stat_contributors
     description: Get all contributor commit activity
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -137019,6 +137822,9 @@ tables:
             - weeks
   - name: repo_subscription
     description: Get a repository subscription
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -137105,6 +137911,9 @@ tables:
             - url
   - name: repo_tags
     description: List repository tags
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -137203,6 +138012,9 @@ tables:
             - zipball_url
   - name: repo_topics
     description: Get all repository topics
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -137247,6 +138059,9 @@ tables:
           key: repo
   - name: repos
     description: Check team permissions for a repository (Legacy)
+    guide: >
+      Requires team_id, owner, and repo. Most useful optional filters: org, team_slug. Add org and
+      team_slug to query the matching organization team route instead of only the legacy team_id path.
     filters:
       - name: team_id
         required: true
@@ -138341,6 +139156,9 @@ tables:
           key: team_slug
   - name: repos_get
     description: Get a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -143814,6 +144632,9 @@ tables:
             - web_commit_signoff_required
   - name: repos_list_release_assets
     description: List release assets
+    guide: >
+      Requires owner, repo, and release_id. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -144176,6 +144997,11 @@ tables:
             - url
   - name: repositories
     description: List public repositories
+    guide: >
+      Use this table to scan public repositories or switch into org-scoped repository lists. Works
+      without WHERE filters. Use LIMIT on the public /repositories feed; add org with one of
+      secret_name, migration_id, runner_group_id, pat_request_id, pat_id, or name to hit the
+      matching org route.
     filters:
       - name: secret_name
         required: false
@@ -145347,6 +146173,9 @@ tables:
           key: pat_id
   - name: repository_access
     description: Lists the repositories Dependabot can access in an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -146014,6 +146843,8 @@ tables:
             - url
   - name: repository_invitations
     description: List repository invitations for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/repository_invitations
@@ -147766,6 +148597,9 @@ tables:
             - url
   - name: requested_reviewers
     description: Get all requested reviewers for a pull request
+    guide: >
+      Requires owner, repo, and pull_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -147828,6 +148662,9 @@ tables:
             - users
   - name: required_pull_request_reviews
     description: Get pull request review protection
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -148019,6 +148856,9 @@ tables:
             - url
   - name: required_signatures
     description: Get commit signature protection
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -148081,6 +148921,9 @@ tables:
             - url
   - name: required_status_checks
     description: Get status checks protection
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -148167,6 +149010,9 @@ tables:
             - url
   - name: restrictions
     description: Get access restrictions
+    guide: >
+      Requires owner, repo, and branch. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -148269,6 +149115,10 @@ tables:
             - users_url
   - name: retention_limit
     description: Get GitHub Actions cache retention limit for an enterprise
+    guide: >
+      Use this table to inspect Actions cache retention limits for an enterprise. Requires
+      enterprise. Add org before paging, then owner/repo if you need repository scope; enterprise,
+      org, and repo limits can differ.
     filters:
       - name: enterprise
         required: true
@@ -148344,6 +149194,9 @@ tables:
           key: repo
   - name: reviews
     description: List reviews for a pull request
+    guide: >
+      Requires owner, repo, and pull_number. Most useful optional filters: review_id. Add review_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: owner
         required: true
@@ -148756,6 +149609,10 @@ tables:
             - user_view_type
   - name: route_stats
     description: Get route stats by actor
+    guide: >
+      Requires org, actor_type, actor_id, and min_timestamp. Most useful optional filters: sort,
+      max_timestamp, api_route_substring. Large organizations can return many rows; narrow by one scoping
+      filter before broad scans.
     filters:
       - name: org
         required: true
@@ -148925,6 +149782,8 @@ tables:
             - total_request_count
   - name: rows
     description: GitHub API Root
+    guide: >
+      Works without WHERE filters. Use LIMIT for spot checks; large result sets paginate quickly.
     request:
       method: GET
       path: /
@@ -149204,6 +150063,9 @@ tables:
             - user_url
   - name: rule_suites
     description: List organization rule suites
+    guide: >
+      Requires org. Most useful optional filters: ref, time_period, owner. Add rule_suite_id to jump from
+      the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -149496,6 +150358,9 @@ tables:
           key: repo
   - name: rulesets
     description: Get all organization repository rulesets
+    guide: >
+      Requires org. Most useful optional filters: owner, repo, ruleset_id. Add ruleset_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -149893,6 +150758,9 @@ tables:
           key: repo
   - name: runner_groups
     description: List self-hosted runner groups for an organization
+    guide: >
+      Requires org. Most useful optional filters: runner_group_id, visible_to_repository. Add
+      runner_group_id to jump from the default list call to a specific record lookup.
     filters:
       - name: org
         required: true
@@ -150073,6 +150941,9 @@ tables:
             - workflow_restrictions_read_only
   - name: runners
     description: List self-hosted runners for an organization
+    guide: >
+      Requires org. Most useful optional filters: owner, repo, name. Add runner_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: name
         required: false
@@ -150234,6 +151105,9 @@ tables:
           key: repo
   - name: sarifs
     description: Get information about a SARIF upload
+    guide: >
+      Requires owner, repo, and sarif_id. Keep queries repository-scoped; fan out across repos client-side
+      when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -150307,6 +151181,9 @@ tables:
           key: sarif_id
   - name: sbom
     description: Export a software bill of materials (SBOM) for a repository.
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -150460,6 +151337,9 @@ tables:
             - spdxVersion
   - name: scan_history
     description: Get secret scanning scan history for a repository
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -150528,6 +151408,9 @@ tables:
           key: repo
   - name: schema
     description: Get all custom properties for an organization
+    guide: >
+      Requires org. Most useful optional filters: custom_property_name. Large organizations can return
+      many rows; narrow by one scoping filter before broad scans.
     filters:
       - name: org
         required: true
@@ -158126,6 +159009,9 @@ tables:
             - user_view_type
   - name: seats
     description: List all Copilot seat assignments for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -158984,6 +159870,10 @@ tables:
             - updated_at
   - name: security_advisories
     description: List repository security advisories for an organization
+    guide: >
+      Use this table to list repository security advisories for an org. Requires org. Start with
+      state or owner before paging; advisories only appear for repositories where the token can read
+      advisory data.
     filters:
       - name: org
         required: true
@@ -160414,6 +161304,9 @@ tables:
           key: repo
   - name: security_managers
     description: List security manager teams
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -160579,6 +161472,10 @@ tables:
             - url
   - name: selected_actions
     description: Get allowed actions and reusable workflows for an organization
+    guide: >
+      Use this table to inspect allowed Actions and reusable workflow policy for an org. Requires
+      org. Add owner and repo to query one repository override instead; repository policy can be
+      more restrictive.
     filters:
       - name: org
         required: true
@@ -160659,6 +161556,9 @@ tables:
           key: repo
   - name: self_hosted_runners
     description: Get self-hosted runners settings for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -160703,6 +161603,9 @@ tables:
             - selected_repositories_url
   - name: stargazers
     description: List stargazers
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -160749,6 +161652,9 @@ tables:
           key: repo
   - name: status
     description: Get the combined status for a specific reference
+    guide: >
+      Requires owner, repo, and ref. Keep queries repository-scoped; fan out across repos client-side when
+      you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -160890,6 +161796,10 @@ tables:
             - url
   - name: storage_limit
     description: Get GitHub Actions cache storage limit for an enterprise
+    guide: >
+      Use this table to inspect Actions cache storage limits for an enterprise. Requires enterprise.
+      Add org before paging, then owner/repo if you need repository scope; enterprise, org, and repo
+      limits can differ.
     filters:
       - name: enterprise
         required: true
@@ -160965,6 +161875,9 @@ tables:
           key: repo
   - name: storage_records
     description: List artifact storage records
+    guide: >
+      Requires org and subject_digest. Large organizations can return many rows; narrow by one scoping
+      filter before broad scans.
     filters:
       - name: org
         required: true
@@ -161075,6 +161988,8 @@ tables:
             - updated_at
   - name: stubbed
     description: List subscriptions for the authenticated user (stubbed)
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/marketplace_purchases/stubbed
@@ -161352,6 +162267,9 @@ tables:
             - updated_at
   - name: sub_issues
     description: List sub-issues
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -165348,6 +166266,10 @@ tables:
             - user_view_type
   - name: subject_stats
     description: Get subject stats
+    guide: >
+      Requires org and min_timestamp. Most useful optional filters: sort, max_timestamp,
+      subject_name_substring. Large organizations can return many rows; narrow by one scoping filter
+      before broad scans.
     filters:
       - name: org
         required: true
@@ -165501,6 +166423,9 @@ tables:
             - total_request_count
   - name: subscribers
     description: List watchers
+    guide: >
+      Requires owner and repo. Keep queries repository-scoped; fan out across repos client-side when you
+      need broader coverage.
     filters:
       - name: owner
         required: true
@@ -165717,6 +166642,9 @@ tables:
             - user_view_type
   - name: summary
     description: Get billing usage summary for an organization
+    guide: >
+      Use this table to summarize org billing usage. Requires org. Start with year, month, or day
+      before paging long histories; username helps isolate one user's spend.
     filters:
       - name: org
         required: true
@@ -165933,6 +166861,8 @@ tables:
           key: username
   - name: team
     description: Get a team (Legacy)
+    guide: >
+      Requires team_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: team_id
         required: true
@@ -166846,6 +167776,9 @@ tables:
             - url
   - name: teams
     description: List teams
+    guide: >
+      Use this table to list teams in one org. Requires org. Start with team_slug before paging,
+      then owner/repo when you need teams tied to one repository; hidden teams may be omitted.
     filters:
       - name: org
         required: true
@@ -167899,6 +168832,9 @@ tables:
           key: repo
   - name: templates
     description: Get all gitignore templates
+    guide: >
+      Works without WHERE filters. Most useful optional filters: name. Add name to jump from the default list call
+      to a specific record lookup.
     filters:
       - name: name
         required: false
@@ -167944,6 +168880,8 @@ tables:
             - source
   - name: threads
     description: Get a thread
+    guide: >
+      Requires thread_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: thread_id
         required: true
@@ -169331,6 +170269,9 @@ tables:
             - url
   - name: timeline
     description: List timeline events for an issue
+    guide: >
+      Requires owner, repo, and issue_number. Keep queries repository-scoped; fan out across repos
+      client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -172784,6 +173725,9 @@ tables:
             - verified_at
   - name: trees
     description: Get a tree
+    guide: >
+      Requires owner, repo, and tree_sha. Most useful optional filters: recursive. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -172894,6 +173838,9 @@ tables:
             - url
   - name: usage
     description: Get billing premium request usage report for an organization
+    guide: >
+      Use this table to inspect premium request usage for an org. Requires org. Start with year,
+      month, or day before paging long histories; username helps isolate one caller.
     filters:
       - name: org
         required: true
@@ -173116,6 +174063,9 @@ tables:
           key: username
   - name: usage_by_repository
     description: List repositories with GitHub Actions cache usage for an organization
+    guide: >
+      Requires org. Large organizations can return many rows; narrow by one scoping filter before broad
+      scans.
     filters:
       - name: org
         required: true
@@ -173175,6 +174125,9 @@ tables:
           key: org
   - name: user
     description: Get the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: account_id. Add account_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: account_id
         required: false
@@ -173586,6 +174539,8 @@ tables:
             - user_view_type
   - name: user_blocks
     description: List users blocked by the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/blocks
@@ -173782,6 +174737,8 @@ tables:
             - user_view_type
   - name: user_codespace_machines
     description: List machine types for a codespace
+    guide: >
+      Requires codespace_name. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: codespace_name
         required: true
@@ -173873,6 +174830,8 @@ tables:
             - storage_in_bytes
   - name: user_codespace_secret_public_key
     description: Get public key for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/codespaces/secrets/public-key
@@ -173906,6 +174865,9 @@ tables:
             - key_id
   - name: user_codespace_secrets
     description: List secrets for the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: secret_name. Add secret_name to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: secret_name
         required: false
@@ -173988,6 +174950,9 @@ tables:
             - visibility
   - name: user_codespaces
     description: List codespaces for the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: repository_id, codespace_name. Add codespace_name
+      to jump from the default list call to a specific record lookup.
     filters:
       - name: repository_id
         required: false
@@ -176145,6 +177110,8 @@ tables:
             - web_url
   - name: user_docker_conflicts
     description: Get list of conflicting packages during Docker migration for authenticated-user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/docker/conflicts
@@ -177611,6 +178578,9 @@ tables:
             - visibility
   - name: user_event_orgs
     description: List organization events for the authenticated user
+    guide: >
+      Requires username and org. Large organizations can return many rows; narrow by one scoping filter
+      before broad scans.
     filters:
       - name: username
         required: true
@@ -180731,6 +181701,8 @@ tables:
           key: username
   - name: user_event_public
     description: List public events for a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -183849,6 +184821,8 @@ tables:
           key: username
   - name: user_followers
     description: List followers of the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/followers
@@ -184044,6 +185018,8 @@ tables:
             - user_view_type
   - name: user_following
     description: List the people the authenticated user follows
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/following
@@ -184239,6 +185215,9 @@ tables:
             - user_view_type
   - name: user_gpg_keys
     description: List GPG keys for the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: gpg_key_id. Add gpg_key_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: gpg_key_id
         required: false
@@ -184394,6 +185373,8 @@ tables:
             - subkeys
   - name: user_installation_repositories
     description: List repositories accessible to the user access token
+    guide: >
+      Requires installation_id. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: installation_id
         required: true
@@ -185586,6 +186567,8 @@ tables:
             - web_commit_signoff_required
   - name: user_installations
     description: List app installations accessible to the user access token
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/installations
@@ -186782,6 +187765,8 @@ tables:
             - updated_at
   - name: user_interaction_limits
     description: Get interaction restrictions for your public repositories
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/interaction-limits
@@ -186823,6 +187808,9 @@ tables:
             - origin
   - name: user_issues
     description: List user account issues assigned to the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: state, labels, sort. Results are limited to
+      resources visible to the authenticated user.
     filters:
       - name: filter
         required: false
@@ -190840,6 +191828,9 @@ tables:
             - user_view_type
   - name: user_keys
     description: List public SSH keys for the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: key_id. Add key_id to jump from the default list
+      call to a specific record lookup.
     filters:
       - name: key_id
         required: false
@@ -190939,6 +191930,10 @@ tables:
             - verified
   - name: user_membership_orgs
     description: List organization memberships for the authenticated user
+    guide: >
+      Use this table to list the authenticated user's organization memberships. Works without WHERE
+      filters. Start with org or state before paging; results are limited to memberships visible to
+      the current user.
     filters:
       - name: state
         required: false
@@ -191385,6 +192380,9 @@ tables:
             - user_view_type
   - name: user_migrations
     description: List user migrations
+    guide: >
+      Works without WHERE filters. Most useful optional filters: migration_id, exclude. Add migration_id to jump
+      from the default list call to a specific record lookup.
     filters:
       - name: migration_id
         required: false
@@ -192653,6 +193651,8 @@ tables:
             - web_commit_signoff_required
   - name: user_orgs
     description: List organizations for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/orgs
@@ -192768,6 +193768,10 @@ tables:
             - url
   - name: user_packages
     description: Get a package for the authenticated user
+    guide: >
+      Use this table to inspect one authenticated-user package. Requires package_type and
+      package_name. Add org or username to switch the package owner scope; package visibility
+      depends on the chosen owner.
     filters:
       - name: package_type
         required: true
@@ -194280,6 +195284,8 @@ tables:
           key: username
   - name: user_received_event_public
     description: List public events received by a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -197398,6 +198404,9 @@ tables:
           key: username
   - name: user_repos
     description: List repositories for the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: visibility, affiliation, type. Results are
+      limited to resources visible to the authenticated user.
     filters:
       - name: visibility
         required: false
@@ -198637,6 +199646,9 @@ tables:
             - web_commit_signoff_required
   - name: user_setting_billing_usage
     description: Get billing usage report for a user
+    guide: >
+      Requires username. Most useful optional filters: year, month, day. Use the time filter for
+      incremental syncs instead of rescanning long history.
     filters:
       - name: username
         required: true
@@ -198796,6 +199808,8 @@ tables:
           key: year
   - name: user_social_accounts
     description: List social accounts for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/social_accounts
@@ -198831,6 +199845,9 @@ tables:
             - url
   - name: user_ssh_signing_keys
     description: List SSH signing keys for the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: ssh_signing_key_id. Add ssh_signing_key_id to
+      jump from the default list call to a specific record lookup.
     filters:
       - name: ssh_signing_key_id
         required: false
@@ -198898,6 +199915,9 @@ tables:
             - title
   - name: user_starred
     description: List repositories starred by the authenticated user
+    guide: >
+      Works without WHERE filters. Most useful optional filters: sort, direction. Results are limited to resources
+      visible to the authenticated user.
     filters:
       - name: sort
         required: false
@@ -200105,6 +201125,10 @@ tables:
             - web_commit_signoff_required
   - name: user_stats
     description: Get user stats
+    guide: >
+      Requires org, user_id, and min_timestamp. Most useful optional filters: sort, max_timestamp,
+      actor_name_substring. Large organizations can return many rows; narrow by one scoping filter before
+      broad scans.
     filters:
       - name: org
         required: true
@@ -200284,6 +201308,8 @@ tables:
           key: user_id
   - name: user_subscriptions
     description: List repositories watched by the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/subscriptions
@@ -201343,6 +202369,8 @@ tables:
             - web_commit_signoff_required
   - name: user_teams
     description: List teams for the authenticated user
+    guide: >
+      Works without WHERE filters. Results are limited to resources visible to the authenticated user.
     request:
       method: GET
       path: /user/teams
@@ -202249,6 +203277,9 @@ tables:
             - url
   - name: users
     description: List users
+    guide: >
+      Use this table to browse public GitHub users. Works without WHERE filters. Add username to
+      jump to one account before paging; broad scans should always start with LIMIT.
     filters:
       - name: username
         required: false
@@ -202673,6 +203704,10 @@ tables:
           key: username
   - name: users_1_day
     description: Get Copilot users usage metrics for a specific day
+    guide: >
+      Use this table to inspect Copilot user metrics for one enterprise day. Requires enterprise and
+      day. Add org before paging multi-org rollups; metrics only cover data available to the
+      enterprise token.
     filters:
       - name: enterprise
         required: true
@@ -202751,6 +203786,8 @@ tables:
           key: org
   - name: users_list_followers_for_user
     description: List followers of a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -202957,6 +203994,8 @@ tables:
           key: username
   - name: users_list_following_for_user
     description: List the people a user follows
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -203163,6 +204202,8 @@ tables:
           key: username
   - name: users_list_gpg_keys_for_user
     description: List GPG keys for a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -203313,6 +204354,8 @@ tables:
           key: username
   - name: users_list_public_keys_for_user
     description: List public keys for a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -203375,6 +204418,8 @@ tables:
           key: username
   - name: users_list_social_accounts_for_user
     description: List social accounts for a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -203421,6 +204466,8 @@ tables:
           key: username
   - name: users_list_ssh_signing_keys_for_user
     description: List SSH signing keys for a user
+    guide: >
+      Requires username. Use LIMIT for spot checks; large result sets paginate quickly.
     filters:
       - name: username
         required: true
@@ -203483,6 +204530,9 @@ tables:
           key: username
   - name: variant_analyses
     description: Get the summary of a CodeQL variant analysis
+    guide: >
+      Requires owner, repo, and codeql_variant_analysis_id. Keep queries repository-scoped; fan out across
+      repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -203636,6 +204686,9 @@ tables:
             - result_count
   - name: versions
     description: List package versions for a package owned by the authenticated user
+    guide: >
+      Requires package_type and package_name. Most useful optional filters: state, org, username. Add
+      package_version_id to jump from the default list call to a specific record lookup.
     filters:
       - name: package_type
         required: true
@@ -203881,6 +204934,9 @@ tables:
           key: username
   - name: views
     description: Get page views
+    guide: >
+      Requires owner and repo. Most useful optional filters: per. Keep queries repository-scoped; fan out
+      across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -203957,6 +205013,9 @@ tables:
             - uniques
   - name: workflow
     description: Get default workflow permissions for an organization
+    guide: >
+      Use this table to inspect default workflow permissions for an org. Requires org. Add owner and
+      repo to query repository permissions instead; repositories can override the org default.
     filters:
       - name: org
         required: true
@@ -204027,6 +205086,9 @@ tables:
           key: repo
   - name: workflows
     description: List repository workflows
+    guide: >
+      Requires owner and repo. Most useful optional filters: workflow_id. Add workflow_id to jump from the
+      default list call to a specific record lookup.
     filters:
       - name: owner
         required: true


### PR DESCRIPTION
## Summary
- tighten `sources/github/manifest.yaml` guide text so GitHub tables read more like query help than filter inventories
- keep the guides focused on what each table is for, the highest-value filters, how to narrow large result sets, and one real API caveat or scope quirk when it matters
- preserve the ban on the generic "No required filters" wording in the GitHub manifest

## Scope
- final diff is manifest-only: `sources/github/manifest.yaml`

## Verification
- `cargo run -p xtask -- --check`
- `make rust-checks`
- `./target/debug/coral sql "SELECT login FROM github.user LIMIT 1"`
- `./target/debug/coral sql "SELECT username, login FROM github.users WHERE username = 'torvalds' LIMIT 1"`
- `./target/debug/coral sql "SELECT id, full_name, visibility FROM github.repositories LIMIT 2"`
- `./target/debug/coral sql "SELECT repository__full_name, subject__title, reason FROM github.notifications WHERE owner = 'withcoral' AND repo = 'coral' LIMIT 5"`
- `./target/debug/coral sql "SELECT org, owner__login, full_name, visibility FROM github.org_repos WHERE org = 'withcoral' LIMIT 5"`
- `./target/debug/coral sql "SELECT id, type, actor__login, repo__name FROM github.events WHERE owner = 'withcoral' AND repo = 'coral' LIMIT 5"`
- confirmed `git diff --name-only main...HEAD` returns only `sources/github/manifest.yaml`
