### PR TITLE
refactor(spec): lift declared_inputs and required_secret_names to SourceManifestCommon

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -775,7 +775,7 @@ fn build_resolved_inputs(
     source_variables: &BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
     let mut resolved = BTreeMap::new();
-    for input in &manifest.declared_inputs {
+    for input in &manifest.common.declared_inputs {
         let value = match input.kind {
             ManifestInputKind::Secret => source_secrets.get(&input.key).cloned(),
             ManifestInputKind::Variable => source_variables

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -86,7 +86,7 @@ impl CompiledBackendSource for HttpCompiledSource {
 
         let secret_keys = self.source_secrets.keys().cloned().collect();
         let inputs = build_registered_inputs(
-            &self.manifest.declared_inputs,
+            &self.manifest.common.declared_inputs,
             &self.source_variables,
             &secret_keys,
         );

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -11,15 +11,15 @@
 
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 use url::Url;
 
 use crate::common::parse_manifest_data_type;
 use crate::inputs::collect_source_inputs_value;
 use crate::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ManifestInputKind, ManifestInputSpec,
-    Result, SourceBackend, SourceManifestCommon, TableCommon, validate_columns,
-    validate_filters_and_column_exprs, validate_test_queries,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, Result, SourceBackend,
+    SourceManifestCommon, TableCommon, validate_columns, validate_filters_and_column_exprs,
+    validate_test_queries,
 };
 
 /// Validated top-level manifest for a `Parquet`-backed source.
@@ -27,7 +27,6 @@ use crate::{
 pub struct ParquetSourceManifest {
     pub common: SourceManifestCommon,
     pub tables: Vec<FileTableSpec>,
-    pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
 /// Validated top-level manifest for a `JSONL`-backed source.
@@ -35,32 +34,6 @@ pub struct ParquetSourceManifest {
 pub struct JsonlSourceManifest {
     pub common: SourceManifestCommon,
     pub tables: Vec<FileTableSpec>,
-    pub declared_inputs: Vec<ManifestInputSpec>,
-}
-
-impl ParquetSourceManifest {
-    /// Returns the source secrets required by this manifest.
-    ///
-    /// Every declared input with `kind: secret` is required; secrets cannot
-    /// carry defaults.
-    pub fn required_secret_names(&self) -> BTreeSet<String> {
-        required_secret_names(&self.declared_inputs)
-    }
-}
-
-impl JsonlSourceManifest {
-    /// Returns the source secrets required by this manifest.
-    pub fn required_secret_names(&self) -> BTreeSet<String> {
-        required_secret_names(&self.declared_inputs)
-    }
-}
-
-fn required_secret_names(inputs: &[ManifestInputSpec]) -> BTreeSet<String> {
-    inputs
-        .iter()
-        .filter(|input| input.kind == ManifestInputKind::Secret)
-        .map(|input| input.key.clone())
-        .collect()
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -302,17 +275,19 @@ impl ParquetSourceManifest {
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
-        let common =
-            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
+        let common = SourceManifestCommon::new(
+            dsl_version,
+            name,
+            version,
+            description,
+            test_queries,
+            declared_inputs,
+        );
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_parquet(&common.name))
             .collect::<Result<Vec<_>>>()?;
-        Ok(Self {
-            common,
-            tables,
-            declared_inputs,
-        })
+        Ok(Self { common, tables })
     }
 }
 
@@ -332,17 +307,19 @@ impl JsonlSourceManifest {
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
-        let common =
-            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
+        let common = SourceManifestCommon::new(
+            dsl_version,
+            name,
+            version,
+            description,
+            test_queries,
+            declared_inputs,
+        );
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_jsonl(&common.name))
             .collect::<Result<Vec<_>>>()?;
-        Ok(Self {
-            common,
-            tables,
-            declared_inputs,
-        })
+        Ok(Self { common, tables })
     }
 }
 
@@ -373,12 +350,13 @@ mod tests {
         }))
         .expect("parquet manifest with inputs should parse");
 
-        let required = manifest.required_secret_names();
+        let required = manifest.common.required_secret_names();
         assert!(required.contains("api_token"));
         assert!(required.contains("signing_key"));
         assert_eq!(required.len(), 2);
 
         let kinds: Vec<(&str, ManifestInputKind)> = manifest
+            .common
             .declared_inputs
             .iter()
             .map(|input| (input.key.as_str(), input.kind))
@@ -406,7 +384,7 @@ mod tests {
         }))
         .expect("jsonl manifest with inputs should parse");
 
-        let required = manifest.required_secret_names();
+        let required = manifest.common.required_secret_names();
         assert!(required.contains("access_token"));
         assert_eq!(required.len(), 1);
     }
@@ -427,7 +405,7 @@ mod tests {
         }))
         .expect("parquet manifest without inputs should parse");
 
-        assert!(manifest.required_secret_names().is_empty());
-        assert!(manifest.declared_inputs.is_empty());
+        assert!(manifest.common.required_secret_names().is_empty());
+        assert!(manifest.common.declared_inputs.is_empty());
     }
 }

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -10,16 +10,16 @@
 //! they are still engine-neutral; no runtime HTTP client or execution concerns
 //! live in this crate.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::HashSet;
 
 use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    AuthSpec, ColumnSpec, FilterSpec, ManifestError, ManifestInputKind, ManifestInputSpec,
-    PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
-    SourceBackend, SourceManifestCommon, TableCommon, inputs::collect_source_inputs_value,
-    validate::validate_template, validate_http_table, validate_test_queries,
+    AuthSpec, ColumnSpec, FilterSpec, ManifestError, PaginationSpec, ParsedTemplate,
+    RequestRouteSpec, RequestSpec, ResponseSpec, Result, SourceBackend, SourceManifestCommon,
+    TableCommon, inputs::collect_source_inputs_value, validate::validate_template,
+    validate_http_table, validate_test_queries,
 };
 
 /// Provider-specific response hints for classifying and delaying rate-limit retries.
@@ -44,7 +44,6 @@ pub struct HttpSourceManifest {
     pub auth: AuthSpec,
     pub rate_limit: RateLimitSpec,
     pub tables: Vec<HttpTableSpec>,
-    pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -152,20 +151,6 @@ impl HttpTableSpec {
     }
 }
 
-impl HttpSourceManifest {
-    /// Returns the source secrets required by this manifest.
-    ///
-    /// In the new input model, every declared input with `kind: secret` is
-    /// required because secrets cannot carry defaults.
-    pub fn required_secret_names(&self) -> BTreeSet<String> {
-        self.declared_inputs
-            .iter()
-            .filter(|input| input.kind == ManifestInputKind::Secret)
-            .map(|input| input.key.clone())
-            .collect()
-    }
-}
-
 impl RawHttpTableSpec {
     fn into_validated(self, schema: &str) -> Result<HttpTableSpec> {
         validate_http_table(
@@ -214,8 +199,14 @@ impl HttpSourceManifest {
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
-        let common =
-            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
+        let common = SourceManifestCommon::new(
+            dsl_version,
+            name,
+            version,
+            description,
+            test_queries,
+            declared_inputs,
+        );
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))
@@ -238,7 +229,6 @@ impl HttpSourceManifest {
             auth,
             rate_limit,
             tables,
-            declared_inputs,
         })
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -9,12 +9,12 @@
 //! source identity, filters, request templating, response extraction, typed
 //! columns, and pagination.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::{ManifestError, ParsedTemplate, Result};
+use crate::{ManifestError, ManifestInputKind, ManifestInputSpec, ParsedTemplate, Result};
 
 /// Common top-level source metadata shared by every backend source spec.
 #[derive(Debug, Clone)]
@@ -24,6 +24,7 @@ pub struct SourceManifestCommon {
     pub version: String,
     pub description: String,
     pub test_queries: Vec<String>,
+    pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
 impl SourceManifestCommon {
@@ -33,6 +34,7 @@ impl SourceManifestCommon {
         version: String,
         description: String,
         test_queries: Vec<String>,
+        declared_inputs: Vec<ManifestInputSpec>,
     ) -> Self {
         Self {
             dsl_version,
@@ -40,7 +42,20 @@ impl SourceManifestCommon {
             version,
             description,
             test_queries,
+            declared_inputs,
         }
+    }
+
+    /// Returns the source secrets required by this manifest.
+    ///
+    /// Every declared input with `kind: secret` is required; secrets cannot
+    /// carry defaults.
+    pub fn required_secret_names(&self) -> BTreeSet<String> {
+        self.declared_inputs
+            .iter()
+            .filter(|input| input.kind == ManifestInputKind::Secret)
+            .map(|input| input.key.clone())
+            .collect()
     }
 }
 

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 use crate::backends::file::{JsonlSourceManifest, ParquetSourceManifest};
 use crate::backends::http::HttpSourceManifest;
 use crate::schema::validate_manifest_schema;
-use crate::{ManifestError, ManifestInputSpec, Result, SourceBackend};
+use crate::{ManifestError, ManifestInputSpec, Result, SourceBackend, SourceManifestCommon};
 
 /// Validated top-level source spec for one registered source.
 ///
@@ -46,64 +46,50 @@ impl ValidatedSourceManifest {
     }
 
     #[must_use]
+    /// Returns the backend-agnostic source metadata shared by every manifest.
+    pub fn common(&self) -> &SourceManifestCommon {
+        match &self.inner {
+            ValidatedManifestKind::Http(manifest) => &manifest.common,
+            ValidatedManifestKind::Parquet(manifest) => &manifest.common,
+            ValidatedManifestKind::Jsonl(manifest) => &manifest.common,
+        }
+    }
+
+    #[must_use]
     /// Returns the source-spec `name`, which is also the stable SQL schema name.
     pub fn schema_name(&self) -> &str {
-        match &self.inner {
-            ValidatedManifestKind::Http(manifest) => &manifest.common.name,
-            ValidatedManifestKind::Parquet(manifest) => &manifest.common.name,
-            ValidatedManifestKind::Jsonl(manifest) => &manifest.common.name,
-        }
+        &self.common().name
     }
 
     #[must_use]
     /// Returns the source-spec version string for the source.
     pub fn source_version(&self) -> &str {
-        match &self.inner {
-            ValidatedManifestKind::Http(manifest) => &manifest.common.version,
-            ValidatedManifestKind::Parquet(manifest) => &manifest.common.version,
-            ValidatedManifestKind::Jsonl(manifest) => &manifest.common.version,
-        }
+        &self.common().version
     }
 
     #[must_use]
     /// Returns the source-spec description string.
     pub fn description(&self) -> &str {
-        match &self.inner {
-            ValidatedManifestKind::Http(manifest) => &manifest.common.description,
-            ValidatedManifestKind::Parquet(manifest) => &manifest.common.description,
-            ValidatedManifestKind::Jsonl(manifest) => &manifest.common.description,
-        }
+        &self.common().description
     }
 
     #[must_use]
     /// Returns the optional top-level validation queries declared by the source spec.
     pub fn test_queries(&self) -> &[String] {
-        match &self.inner {
-            ValidatedManifestKind::Http(manifest) => &manifest.common.test_queries,
-            ValidatedManifestKind::Parquet(manifest) => &manifest.common.test_queries,
-            ValidatedManifestKind::Jsonl(manifest) => &manifest.common.test_queries,
-        }
+        &self.common().test_queries
     }
 
     /// Returns the set of source secrets required to compile or authenticate
     /// the source spec.
     #[must_use]
     pub fn required_secret_names(&self) -> BTreeSet<String> {
-        match &self.inner {
-            ValidatedManifestKind::Http(manifest) => manifest.required_secret_names(),
-            ValidatedManifestKind::Parquet(manifest) => manifest.required_secret_names(),
-            ValidatedManifestKind::Jsonl(manifest) => manifest.required_secret_names(),
-        }
+        self.common().required_secret_names()
     }
 
     /// Returns the declared top-level inputs for this manifest in authored order.
     #[must_use]
     pub fn declared_inputs(&self) -> &[ManifestInputSpec] {
-        match &self.inner {
-            ValidatedManifestKind::Http(manifest) => &manifest.declared_inputs,
-            ValidatedManifestKind::Parquet(manifest) => &manifest.declared_inputs,
-            ValidatedManifestKind::Jsonl(manifest) => &manifest.declared_inputs,
-        }
+        &self.common().declared_inputs
     }
 
     /// Returns the validated HTTP source spec when `backend: http`.


### PR DESCRIPTION
## Summary
- Lift `declared_inputs: Vec<ManifestInputSpec>` and `required_secret_names()` from each backend manifest (Http / Parquet / Jsonl) into `SourceManifestCommon`, so there is one source of truth.
- Add `ValidatedSourceManifest::common()` and route the existing accessors (`schema_name`, `source_version`, `description`, `test_queries`, `declared_inputs`, `required_secret_names`) through it, collapsing six identical three-arm matches in `parser.rs`.
- Update the two direct consumers of the old field (`coral-engine/src/backends/http/{mod,client}.rs`) to read `manifest.common.declared_inputs`.

Follow-up to #159 — addresses [this review comment](https://github.com/withcoral/coral/pull/159#discussion_r3129998810) on the match arms that got touched incidentally there.

Public API is unchanged: all existing `ValidatedSourceManifest` accessors keep the same signatures. The only removed surface is the per-backend `HttpSourceManifest::required_secret_names` / `ParquetSourceManifest::required_secret_names` / `JsonlSourceManifest::required_secret_names` methods and the public `declared_inputs` fields on those structs; there are no external callers of those methods, and the two field reads in `coral-engine` are updated in this PR.

## Test plan
- [x] `make rust-checks` (fmt + check + clippy -D warnings + tests + doc -D warnings)
- [x] `cargo test -p coral-spec` — 44 passing
- [x] `cargo test -p coral-engine` — passing
- [ ] Two pre-existing flakes in `coral-cli --test source` (`source_test_succeeds_when_query_tests_pass`, `source_test_exits_non_zero_when_query_tests_fail`) also fail on a clean `main` checkout — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)