### PR TITLE
docs(nav): better github/discord links

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -59,7 +59,8 @@
       },
       {
         "type": "discord",
-        "href": "https://withcoral.com/discord"
+        "_comment": "Mintlify only supports discord.gg link, so we can't use the canonical discord link here https://withcoral.com/discord",
+        "href": "https://discord.gg/h9aun8KpFF"
       }
     ]
   },

--- a/docs/global.css
+++ b/docs/global.css
@@ -25,9 +25,3 @@ code,
 pre {
   font-family: "Gustan Mono", ui-monospace, monospace;
 }
-
-/* Keep only the icon for GitHub and Discord navbar links. */
-a[href="https://github.com/withcoral/coral"] span,
-a[href="https://withcoral.com/discord"] span {
-  display: none !important;
-}


### PR DESCRIPTION
## Summary

Using Mintlify buttons, and removing the silly CSS override I added a while ago to make them look "cleaner" (ie icon only). The icon only version didn't work well in the mobile/responsive version of the docs.

## Test plan

<img width="567" height="91" alt="image" src="https://github.com/user-attachments/assets/1d4afb0f-f0e7-4399-bb1e-6c80c17fd81e" />
<img width="682" height="197" alt="image" src="https://github.com/user-attachments/assets/aeaed859-a407-4aa0-bcd9-2a33817d0626" />
