### PR TITLE
docs: prettify bundled source table links

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Coral gives agents one query interface instead:
 
 We benchmarked Coral with direct provider MCPs (Datadog, Sentry, Linear, Slack and Github) for a diverse set of 82 real-world AI tasks using Claude Opus 4.6. Key findings:
 
-1. *Widespread impact on performance*. Across all tasks, Claude was 20% more accurate and 2x more cost efficient using Coral than using direct provider MCPs. With Coral, Claude also had 42% lower latency.
+1. **Widespread impact on performance**. Across all tasks, Claude was 20% more accurate and 2x more cost efficient using Coral than using direct provider MCPs. With Coral, Claude also had 42% lower latency.
 
-2. *Highest impact on coding agent tasks*. Across the more complex tasks that typify coding agent workloads (multi-hop, higher post-processing), Claude was 31% more accurate and 3.4x more cost efficient with Coral.
+2. **Highest impact on coding agent tasks**. Across the more complex tasks that typify coding agent workloads (multi-hop, higher post-processing), Claude was 31% more accurate and 3.4x more cost efficient with Coral.
 
-3. *More neutral impact on simpler tasks*. For simpler AI tasks, such as raw fact retrieval from knowledge bases, the results were closer, with Claude 6% more accurate and 2% more cost efficient with Coral.
+3. **More neutral impact on simpler tasks**. For simpler AI tasks, such as raw fact retrieval from knowledge bases, the results were closer, with Claude 6% more accurate and 2% more cost efficient with Coral.
 
 Full [benchmark report](https://withcoral.com/benchmarks).
 

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -17,24 +17,24 @@ If the source you need is not available, you can extend Coral by [writing a cust
 
 | Source | Backend | Description |
 | --- | --- | --- |
-| [`clickup`](#clickup) | `http` | Query tasks, spaces, folders, lists, goals, time entries, comments, views, tags, custom fields, teams, and users from ClickUp. |
-| [`confluence`](#confluence) | `http` | Query spaces, pages, blog posts, comments, attachments, labels, and related metadata from Confluence Cloud. |
-| [`datadog`](#datadog) | `http` | Query monitors, events, incidents, dashboards, hosts, services, APM dependencies, downtimes, SLOs, synthetic tests, users, logs, spans, and metrics from Datadog. |
-| [`github`](#github) | `http` | Query repositories, issues, pull requests, workflows, organizations, users, teams, and API metadata from GitHub (Cloud or Enterprise). |
-| [`gitlab`](#gitlab) | `http` | Query projects, groups, issues, merge requests, pipelines, deployments, packages, users, and instance metadata from GitLab (Cloud or self-hosted). |
-| [`grafana`](#grafana) | `http` | Query dashboards, folders, datasources, alert rules, annotations, contact points, teams, users, and dashboard panels from Grafana (Cloud or self-hosted). |
-| [`incident_io`](#incident_io) | `http` | Query incidents, alerts, escalations, schedules, status pages, workflows, teams, users, and catalog resources from incident.io. |
-| [`intercom`](#intercom) | `http` | Query contacts, companies, conversations, admins, tags, teams, segments, data attributes, collections, articles, and ticket types from Intercom. |
-| [`jira`](#jira) | `http` | Query projects, issues, comments, worklogs, versions, components, issue types, priorities, and related metadata from Jira Cloud. |
-| [`launchdarkly`](#launchdarkly) | `http` | Query projects, feature flags, environments, segments, members, roles, and audit logs from LaunchDarkly. |
-| [`linear`](#linear) | `http` | Query issues, projects, cycles, initiatives, teams, users, comments, project milestones, labels, and attachments from Linear. |
-| [`openobserve`](#openobserve) | `http` | Query streams, logs, metrics, and traces from OpenObserve (Cloud or self-hosted). |
-| [`pagerduty`](#pagerduty) | `http` | Query incidents, services, teams, users, schedules, oncalls, escalation policies, log entries, change events, status pages, and workflows from PagerDuty. |
-| [`posthog`](#posthog) | `http` | Query events, persons, sessions, feature flags, experiments, insights, dashboards, cohorts, projects, organizations, and related PostHog resources. |
-| [`sentry`](#sentry) | `http` | Query issues, events, projects, releases, deployments, teams, and members from Sentry. |
-| [`slack`](#slack) | `http` | Query channels, messages, and users from your Slack workspace. |
-| [`statusgator`](#statusgator) | `http` | Query status boards, monitors, incidents, history, service components, subscribers, users, and monitoring regions from StatusGator. |
-| [`stripe`](#stripe) | `http` | Query customers, charges, subscriptions, invoices, payments, products, prices, refunds, disputes, payouts, balance transactions, and events from Stripe. |
+| [clickup](#clickup) | `http` | Query tasks, spaces, folders, lists, goals, time entries, comments, views, tags, custom fields, teams, and users from ClickUp. |
+| [confluence](#confluence) | `http` | Query spaces, pages, blog posts, comments, attachments, labels, and related metadata from Confluence Cloud. |
+| [datadog](#datadog) | `http` | Query monitors, events, incidents, dashboards, hosts, services, APM dependencies, downtimes, SLOs, synthetic tests, users, logs, spans, and metrics from Datadog. |
+| [github](#github) | `http` | Query repositories, issues, pull requests, workflows, organizations, users, teams, and API metadata from GitHub (Cloud or Enterprise). |
+| [gitlab](#gitlab) | `http` | Query projects, groups, issues, merge requests, pipelines, deployments, packages, users, and instance metadata from GitLab (Cloud or self-hosted). |
+| [grafana](#grafana) | `http` | Query dashboards, folders, datasources, alert rules, annotations, contact points, teams, users, and dashboard panels from Grafana (Cloud or self-hosted). |
+| [incident_io](#incident_io) | `http` | Query incidents, alerts, escalations, schedules, status pages, workflows, teams, users, and catalog resources from incident.io. |
+| [intercom](#intercom) | `http` | Query contacts, companies, conversations, admins, tags, teams, segments, data attributes, collections, articles, and ticket types from Intercom. |
+| [jira](#jira) | `http` | Query projects, issues, comments, worklogs, versions, components, issue types, priorities, and related metadata from Jira Cloud. |
+| [launchdarkly](#launchdarkly) | `http` | Query projects, feature flags, environments, segments, members, roles, and audit logs from LaunchDarkly. |
+| [linear](#linear) | `http` | Query issues, projects, cycles, initiatives, teams, users, comments, project milestones, labels, and attachments from Linear. |
+| [openobserve](#openobserve) | `http` | Query streams, logs, metrics, and traces from OpenObserve (Cloud or self-hosted). |
+| [pagerduty](#pagerduty) | `http` | Query incidents, services, teams, users, schedules, oncalls, escalation policies, log entries, change events, status pages, and workflows from PagerDuty. |
+| [posthog](#posthog) | `http` | Query events, persons, sessions, feature flags, experiments, insights, dashboards, cohorts, projects, organizations, and related PostHog resources. |
+| [sentry](#sentry) | `http` | Query issues, events, projects, releases, deployments, teams, and members from Sentry. |
+| [slack](#slack) | `http` | Query channels, messages, and users from your Slack workspace. |
+| [statusgator](#statusgator) | `http` | Query status boards, monitors, incidents, history, service components, subscribers, users, and monitoring regions from StatusGator. |
+| [stripe](#stripe) | `http` | Query customers, charges, subscriptions, invoices, payments, products, prices, refunds, disputes, payouts, balance transactions, and events from Stripe. |
 
 ## Supported data source types
 

--- a/sources/confluence/manifest.yaml
+++ b/sources/confluence/manifest.yaml
@@ -1,7 +1,7 @@
 dsl_version: 3
 name: confluence
 version: 0.1.0
-description: |
+description: >-
   Query spaces, pages, blog posts, comments, attachments, labels, and
   related metadata from Confluence Cloud.
 backend: http

--- a/sources/jira/manifest.yaml
+++ b/sources/jira/manifest.yaml
@@ -1,7 +1,7 @@
 dsl_version: 3
 name: jira
 version: 0.1.0
-description: |
+description: >-
   Query projects, issues, comments, worklogs, versions, components,
   issue types, priorities, and related metadata from Jira Cloud.
 backend: http

--- a/xtask/src/render.rs
+++ b/xtask/src/render.rs
@@ -33,7 +33,7 @@ pub(crate) fn index_page(manifests: &[ValidatedSourceManifest]) -> String {
         };
         let _ = writeln!(
             out,
-            "| [`{name}`](#{name}) | `{}` | {description} |",
+            "| [{name}](#{name}) | `{}` | {description} |",
             backend_label(manifest),
         );
     }

--- a/xtask/src/snapshots/xtask__render__tests__index_page_renders_rows.snap
+++ b/xtask/src/snapshots/xtask__render__tests__index_page_renders_rows.snap
@@ -1,6 +1,6 @@
 ---
 source: xtask/src/render.rs
-assertion_line: 357
+assertion_line: 440
 expression: "index_page(&[demo, minimal])"
 ---
 ---
@@ -22,8 +22,8 @@ If the source you need is not available, you can extend Coral by [writing a cust
 
 | Source | Backend | Description |
 | --- | --- | --- |
-| [`demo`](#demo) | `http` | A small demo source used in snapshot tests |
-| [`minimal`](#minimal) | `http` | Coral bundled source: minimal |
+| [demo](#demo) | `http` | A small demo source used in snapshot tests |
+| [minimal](#minimal) | `http` | Coral bundled source: minimal |
 
 ## Supported data source types
 


### PR DESCRIPTION
## Summary

Says on the tin. 
- Tiny tweak to the README too whilst at it.
- Switched from `|` to `>` because `|` preserves `\n`, and when running `onboard`, those sources took more than one line, and it did not look good.

## Test plan

<img width="593" height="370" alt="image" src="https://github.com/user-attachments/assets/123a17a6-092d-4b1d-a92d-6df318a81025" />
