### PR TITLE
docs: clarify custom source authoring guidance

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -84,7 +84,8 @@ npx skills add withcoral/skills
 Available skills:
 
 - **`coral`** — teaches your agent the discovery-first workflow for answering data questions with `coral sql`, including how to use `coral.tables`, `coral.columns`, and `coral.inputs`.
-- **`coral-create-source-spec`** — guides your agent through authoring or repairing a custom source spec YAML for `coral source add --file`, or adapting it into a bundled source.
+- **`coral-create-source-spec`** — the current source-authoring skill. It guides your agent through drafting or repairing a custom source manifest, validating it with `coral source lint`, installing it with `coral source add --file`, and iterating with `coral source test`. When a source exposes search endpoints, use it alongside source-specific docs that explain search syntax, scoping qualifiers, and common endpoint gotchas.
+- **`create-source-manifest`** — an older alias you may still see in some agent environments. Use the same source-authoring workflow, but prefer the current Coral CLI commands and docs.
 
 Browse the source at [github.com/withcoral/skills](https://github.com/withcoral/skills).
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -3,26 +3,58 @@ title: "Write a custom source spec"
 description: "Extend Coral by adding any API or dataset as a queryable source."
 ---
 
-Coral ships with [popular data sources](/reference/bundled-sources), but you are not limited to them. If the data source you need is not available out of the box, you can write a source spec in YAML and import it.
+Coral ships with [popular data sources](/reference/bundled-sources), but you are not limited to them. If the data source you need is not available out of the box, you can write a source spec in YAML and add it locally.
 
-A source spec tells Coral how to connect to an API or read a local dataset, what tables to expose, and what columns each table has. Once added, the source works exactly like a bundled one: same SQL, same `coral.tables`, `coral.columns` and `coral.inputs`, same MCP surface.
+A **source spec** is the YAML document you author. When that same YAML is stored in a bundled source directory or in Coral's workspace, it is usually named `manifest.yaml`, so you will also see it called a **source manifest**. In practice, they are the same thing: a declarative description of how Coral should connect to an API or local dataset, which tables to expose, and which columns each table has.
+
+Once added, the source works exactly like a bundled one: same SQL, same `coral.tables`, `coral.columns`, and `coral.inputs`, same MCP surface.
 
 <Tip>
-  Install the [Coral source spec authoring
-  skill](/getting-started/installation#skills) with `npx skills add
-  withcoral/skills` to help your coding agent write source specs.
+  Install the [Coral source authoring skills](/getting-started/installation#skills)
+  with `npx skills add withcoral/skills` if you want an agent to draft or
+  repair manifests for you. The current skill is
+  `coral-create-source-spec`. Some environments may also expose an older
+  alias named `create-source-manifest`; use the same authoring loop, but prefer
+  the current CLI commands: `coral source lint`, `coral source add --file`, and
+  `coral source test`.
 </Tip>
 
-## Agent-driven authoring
+## Choose your authoring path
 
-Source authoring works well as an agent-driven workflow. Point your coding agent at the Coral CLI and the [source spec reference](/reference/source-spec-reference), give it the API docs or describe the endpoints you want, and let it iterate:
+Use the same manifest format in both cases, but pick the workflow that matches your goal:
 
-1. The agent writes or updates the source spec YAML
-2. Lints the file with `coral source lint ./my-source.yaml` to catch errors before installing
-3. Adds it with `coral source add --file ./my-source.yaml`
-4. Validates with `coral source test my_source`
-5. Inspects `coral.tables`, `coral.columns` and `coral.inputs` to check the shape
-6. Refines and repeats until the tables look right
+- **Standalone custom source**: author a YAML file such as `./my-source.yaml`, then install it with `coral source add --file ./my-source.yaml`.
+- **Bundled source contribution**: edit `sources/<name>/manifest.yaml` in the Coral repo, then validate it with the repo's normal checks plus `coral source test <name>`.
+
+## Recommended authoring loop
+
+Start small and tighten the loop. A good first pass is one table, a few columns, and a cheap validation query.
+
+1. Inspect the upstream API docs or local dataset and choose one table-worthy endpoint or file shape.
+2. Create a minimal manifest with `name`, `version`, `dsl_version`, `backend`, one table, and a few typed columns.
+3. Run `coral source lint ./my-source.yaml` before installing anything.
+4. Add the source with `coral source add --file ./my-source.yaml`.
+5. Run `coral source test my_source` for strict pass/fail validation.
+6. Inspect the installed shape through Coral's system tables.
+7. Run representative `coral sql` queries against the new tables.
+8. Expand the manifest only after the first table works end to end.
+
+A practical loop looks like this:
+
+```shellscript
+coral source lint ./my-source.yaml
+coral source add --file ./my-source.yaml
+coral source test my_source
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'my_source'"
+coral sql "SELECT table_name, column_name, data_type, is_required_filter FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, column_name"
+coral sql "SELECT * FROM my_source.messages LIMIT 5"
+```
+
+That sequence tells you three different things:
+
+- `lint` catches YAML/schema mistakes before credentials or runtime behavior are involved
+- `add --file` installs the source and shows install-time warnings
+- `test` gives you a strict validation result that is easy to rerun while iterating
 
 ## Example: local JSONL source
 
@@ -87,27 +119,18 @@ coral sql "
 "
 ```
 
-## How to validate
+## Validate and inspect
 
-When you add `test_queries` to a source spec, treat them as a lightweight validation contract for that source.
+Treat `test_queries` as a lightweight validation contract for the manifest.
 
-1. Run `coral source lint ./my-source.yaml` first. It catches schema and semantic issues without touching your workspace or asking for secrets.
+1. Run `coral source lint ./my-source.yaml` first. This catches YAML, schema, and semantic issues without installing the source.
 2. Add or update the source with `coral source add --file ./my-source.yaml`.
-3. Confirm the install-time validation output:
-   - the source exposes the expected tables
-   - each declared `test_queries` entry runs successfully
-   - successful queries show a pass status and row count
-   - failing queries surface the SQL text plus an error message
-4. Run real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
-5. If you want a strict rerun later, or you are debugging a failure, run `coral source test <source_name>`.
-6. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
+3. Review the install-time output to confirm Coral discovered the expected tables and that each declared `test_queries` entry either passed or surfaced a clear error.
+4. Rerun strict validation with `coral source test <source_name>` whenever you want a pass/fail result.
+5. Query `coral.tables`, `coral.columns`, and `coral.inputs` to confirm the installed source shape matches what you intended.
+6. Run one or two real `coral sql` queries that reflect how you expect the source to be used.
 
-If you are validating a credentialed source end-to-end, it is useful to try both:
-
-- a correctly configured source, which should pass table validation and all declared query tests
-- an intentionally misconfigured source, which should still install but fail `coral source test` with a non-zero exit code
-
-This gives you confidence that the source spec works in the happy path and that `test_queries` catch broken credentials or runtime regressions in a predictable way.
+For credentialed sources, it is useful to validate both a happy path and a broken-credential path. A good manifest should install cleanly when configured correctly, and its `test_queries` should fail predictably when credentials or runtime configuration are wrong.
 
 Use read-only SQL in `test_queries`. Prefer bounded checks such as `SELECT * FROM schema.table LIMIT 1` over expensive scans like `SELECT COUNT(*)`, especially for HTTP-backed sources or large datasets. Coral rejects DDL, DML, and other non-read-only statements as failed validation queries instead of applying them.
 
@@ -161,6 +184,26 @@ tables:
 When you run `coral source add --file`, Coral prompts for the declared `inputs` interactively. `kind: variable` values go to source variables; `kind: secret` values go to the secret store.
 
 For the full set of HTTP response, pagination, auth, and column fields, see [HTTP-backed tables](/reference/source-spec-reference#http-backed-tables).
+
+## Search endpoint guidance
+
+If a table is backed by a search endpoint, document the query language as part of the source guide, not just the manifest.
+
+Call out the parts users usually need to get right:
+
+- the query syntax they actually need to type in `WHERE` filters or search parameters
+- common scoping qualifiers such as `repo:`, `org:`, `project:`, `type:`, or provider-specific equivalents
+- surprising defaults, such as broad global search, implicit sort order, or partial-result behavior
+- pagination and rate-limit behavior, especially when broad searches fan out across many results
+- operators or parameters that commonly fail, are ignored, or only work in certain endpoint combinations
+
+A good search-table guide saves users from trial and error. If the upstream API has gotchas around quoting, operator precedence, unsupported combinations, or required qualifiers, include concrete examples and one or two anti-examples.
+
+<Tip>
+  If you are sharing a custom source spec with others, include a `README.md`
+  alongside your YAML file that documents these search patterns, scoping
+  qualifiers, and known endpoint gotchas.
+</Tip>
 
 ## Tips
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -5,10 +5,31 @@ description: "Schema and fields for Coral source spec YAML files."
 
 Coral is extensible through source specs. These are YAML files that describe how to connect to an API or read a local dataset.
 
+A **source spec** is the YAML you author. When that YAML is stored on disk for a bundled source or an installed custom source, it is commonly named `manifest.yaml`, so the terms **source spec** and **source manifest** are interchangeable in the Coral docs and codebase.
+
 <Tip>
   For a guided walkthrough, see [Write a custom
   source](/guides/write-a-custom-source).
 </Tip>
+
+## Authoring workflow
+
+The recommended loop for authoring sources is **Lint → Add → Test**.
+
+- `coral source lint ./my-source.yaml` (Pre-install schema check)
+- `coral source add --file ./my-source.yaml` (Installation and input prompts)
+- `coral source test my_source` (Runtime validation and `test_queries`)
+
+For a detailed walkthrough of this loop, including how to inspect system tables, see [Write a custom source](/guides/write-a-custom-source#recommended-authoring-loop).
+
+If you expose a search-style table, plan to ship companion guide content for it. The manifest can describe the endpoint, but source authors should also document the search syntax, common scoping qualifiers, surprising defaults, pagination or rate-limit behavior, and operators or parameters that commonly fail.
+
+| Command | What it proves |
+| ------- | -------------- |
+| `coral source lint` | The YAML parses and satisfies Coral's schema + semantic validation rules |
+| `coral source add --file` | Coral can install the manifest and prompt for any declared inputs |
+| `coral source test` | The installed source initializes, exposes tables, and passes any `test_queries` |
+| `coral sql` against `coral.tables` / `coral.columns` / `coral.inputs` | The installed shape matches what you intended |
 
 ## Top-level fields
 
@@ -23,13 +44,13 @@ test_queries:
   - SELECT * FROM my_source.messages LIMIT 1
 ```
 
-| Field         | Description                                        |
-| ------------- | -------------------------------------------------- |
-| `name`        | Source name, also used as the SQL schema name      |
-| `version`     | Source spec version string                         |
-| `dsl_version` | Coral source spec DSL version (currently `3`)      |
-| `backend`     | How data is fetched: `http`, `jsonl`, or `parquet` |
-| `test_queries` | Optional read-only SQL checks Coral runs during `coral source test` |
+| Field         | Description |
+| ------------- | ----------- |
+| `name`        | Stable source identifier, also used as the SQL schema name. Prefer lowercase snake_case. |
+| `version`     | Source spec version string that you update as the manifest evolves. |
+| `dsl_version` | Coral source spec DSL version. Current manifests should use `3`. |
+| `backend`     | How data is fetched: `http`, `jsonl`, or `parquet`. |
+| `test_queries` | Optional read-only SQL checks Coral runs during `coral source test`. Keep them cheap and representative. |
 
 ## Test queries
 
@@ -45,7 +66,8 @@ test_queries:
 Notes:
 
 - Each query result is reported individually during `coral source test`.
-- `coral source add` and `coral onboard` surface post-install validation issues as warnings; `coral source test` is the strict pass/fail command.
+- `test_queries` failures are **non-blocking** during `coral source add --file` and `coral onboard`; they surface as warnings so the source still lands in your workspace.
+- `coral source test` is the **strict pass/fail** command where any failing query causes a non-zero exit code.
 - Prefer cheap read-only checks that validate connectivity and mapping logic. For example, `SELECT * FROM schema.table LIMIT 1` is usually a better fit than `SELECT COUNT(*)`.
 - Keep these queries read-only. Statements such as `CREATE`, `COPY`, `INSERT`,
   `UPDATE`, `DELETE`, or `SET` are reported as failed validation queries.
@@ -187,6 +209,7 @@ Notes:
 - `jsonl` currently expects `file://` locations
 - `parquet` supports `file://` and `s3://` locations
 - if you omit `glob`, Coral uses a backend-specific default
+- standalone manifests can be named however you like (for example `./my-source.yaml`), but bundled sources conventionally live at `sources/<name>/manifest.yaml`
 
 ## HTTP-backed tables
 
@@ -378,6 +401,7 @@ auth:
 
 Rules:
 
+- declare inputs in the order you want Coral to prompt for them during `coral source add --file`
 - `kind: variable` values are stored with source variables
 - `kind: secret` values are stored with source secrets
 - `default` is allowed only for variables


### PR DESCRIPTION
The source-authoring docs blurred spec-vs-manifest terminology and left
new authors to infer too much of the lint/add/test loop. This update
makes the authoring path explicit, highlights search-endpoint gotchas,
and points shared custom sources toward nearby usage notes.

Constraint: Keep changes scoped to docs in this worktree
Constraint: External skill definitions were inspected but not edited here
Rejected: Leave search-endpoint guidance implicit | users would keep guessing syntax and scope qualifiers
Rejected: Duplicate the full workflow in both guide and reference | higher maintenance burden
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep source-authoring docs aligned with `coral source lint`, `coral source add --file`, and `coral source test`
Tested: git diff --check; manual review of updated docs; Gemini review artifact at .omx/artifacts/gemini-source-authoring-docs-review-20260423T090628Z.md
Not-tested: full docs site build