### PR TITLE
feat(cli): add `source info` command

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -71,8 +71,8 @@ message SourceInputSpec {
   string hint = 5;
 }
 
-// One bundled or imported source available for installation.
-message AvailableSource {
+// One bundled or imported source metadata record.
+message SourceInfo {
   // Canonical source name.
   string name = 1;
   // Human-readable description.
@@ -83,7 +83,7 @@ message AvailableSource {
   repeated SourceInputSpec inputs = 4;
   // Whether a source with this name is already configured in the workspace.
   bool installed = 5;
-  // Where this available source came from.
+  // Where this source came from.
   SourceOrigin origin = 6;
 }
 
@@ -93,10 +93,10 @@ message DiscoverSourcesRequest {
   Workspace workspace = 1;
 }
 
-// Returns all bundled available sources.
+// Returns all bundled source metadata records.
 message DiscoverSourcesResponse {
   // Bundled sources compiled into this Coral build.
-  repeated AvailableSource sources = 1;
+  repeated SourceInfo sources = 1;
 }
 
 // Installs one bundled source by name.
@@ -140,6 +140,14 @@ message GetSourceRequest {
   // Owning workspace resource.
   Workspace workspace = 1;
   // Bare source name to fetch.
+  string name = 2;
+}
+
+// Fetches source metadata by identifier.
+message GetSourceInfoRequest {
+  // Owning workspace resource.
+  Workspace workspace = 1;
+  // Bare source name to fetch metadata for.
   string name = 2;
 }
 
@@ -202,6 +210,8 @@ service SourceService {
   rpc ListSources(ListSourcesRequest) returns (ListSourcesResponse);
   // Fetches one registered source.
   rpc GetSource(GetSourceRequest) returns (Source);
+  // Fetches metadata for one installed or bundled source.
+  rpc GetSourceInfo(GetSourceInfoRequest) returns (SourceInfo);
   // Installs one bundled source.
   rpc CreateBundledSource(CreateBundledSourceRequest) returns (Source);
   // Imports one user-provided source manifest.

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -79,6 +79,30 @@ impl SourceManager {
         ))
     }
 
+    pub(crate) fn get_source_info(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<CandidateSource, AppError> {
+        match self.config_store.get_source(workspace_name, source_name) {
+            Ok(source) => {
+                return Ok(
+                    resolve_installed_manifest(workspace_name, &source, &self.layout)?.candidate,
+                );
+            }
+            Err(AppError::SourceNotFound(_)) => {}
+            Err(error) => return Err(error),
+        }
+
+        match load_bundled_source(source_name) {
+            Ok(bundled) => self.describe_bundled_source(workspace_name, &bundled.manifest_yaml),
+            Err(AppError::InvalidInput(_)) => {
+                Err(AppError::SourceNotFound(source_name.to_string()))
+            }
+            Err(error) => Err(error),
+        }
+    }
+
     pub(crate) fn discover_sources(
         &self,
         workspace_name: &WorkspaceName,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -2,9 +2,9 @@
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
-    AvailableSource, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
-    DiscoverSourcesResponse, GetSourceRequest, ImportSourceRequest, ListSourcesRequest,
-    ListSourcesResponse, Source, SourceInputKind, SourceInputSpec,
+    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
+    DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
+    ListSourcesRequest, ListSourcesResponse, Source, SourceInfo, SourceInputKind, SourceInputSpec,
     SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
     ValidateSourceResponse,
 };
@@ -86,6 +86,20 @@ impl SourceServiceApi for SourceService {
             &workspace_name,
             source,
         )))
+    }
+
+    async fn get_source_info(
+        &self,
+        request: Request<GetSourceInfoRequest>,
+    ) -> Result<Response<SourceInfo>, Status> {
+        let request = request.into_inner();
+        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+        let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+        let source = self
+            .sources
+            .get_source_info(&workspace_name, &source_name)
+            .map_err(app_status)?;
+        Ok(Response::new(candidate_source_to_proto(source)))
     }
 
     async fn create_bundled_source(
@@ -186,8 +200,8 @@ fn proto_source_origin(origin: SourceOrigin) -> ProtoSourceOrigin {
     }
 }
 
-fn candidate_source_to_proto(source: CandidateSource) -> AvailableSource {
-    AvailableSource {
+fn candidate_source_to_proto(source: CandidateSource) -> SourceInfo {
+    SourceInfo {
         name: source.name.as_str().to_string(),
         description: source.description,
         version: source.version,

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -2,9 +2,9 @@ use std::fs;
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
-    GetSourceRequest, ImportSourceRequest, ListTablesRequest, QueryTestFailure, QueryTestSuccess,
-    SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, Workspace,
-    query_test_result,
+    GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest, ListTablesRequest,
+    QueryTestFailure, QueryTestSuccess, SourceOrigin, SourceSecret, SourceVariable,
+    ValidateSourceRequest, Workspace, query_test_result,
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
@@ -631,6 +631,69 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
         .find(|source| source.name == "github")
         .expect("github bundled source after install");
     assert!(github.installed);
+}
+
+#[tokio::test]
+async fn get_source_info_returns_available_bundled_metadata() {
+    let harness = GrpcHarness::new().await;
+
+    let info = harness
+        .source_client()
+        .get_source_info(Request::new(GetSourceInfoRequest {
+            workspace: Some(default_workspace()),
+            name: "github".to_string(),
+        }))
+        .await
+        .expect("get source info")
+        .into_inner();
+
+    assert_eq!(info.name, "github");
+    assert_eq!(info.origin, SourceOrigin::Bundled as i32);
+    assert!(!info.installed);
+    assert!(!info.description.is_empty());
+    assert!(!info.version.is_empty());
+    assert!(
+        info.inputs.iter().any(|input| input.key == "GITHUB_TOKEN"),
+        "expected bundled manifest inputs"
+    );
+}
+
+#[tokio::test]
+async fn get_source_info_uses_effective_installed_imported_manifest() {
+    let harness = GrpcHarness::new().await;
+
+    harness
+        .import_source(
+            fixture_manifest_with_inputs_yaml(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
+            }],
+        )
+        .await;
+
+    let info = harness
+        .source_client()
+        .get_source_info(Request::new(GetSourceInfoRequest {
+            workspace: Some(default_workspace()),
+            name: "secured_messages".to_string(),
+        }))
+        .await
+        .expect("get source info")
+        .into_inner();
+
+    assert_eq!(info.name, "secured_messages");
+    assert_eq!(info.version, "0.1.0");
+    assert_eq!(info.origin, SourceOrigin::Imported as i32);
+    assert!(info.installed);
+    assert_eq!(info.inputs.len(), 2);
+    assert_eq!(info.inputs[0].key, "API_BASE");
+    assert_eq!(info.inputs[0].default_value, "https://example.com");
+    assert_eq!(info.inputs[1].key, "API_TOKEN");
 }
 
 #[tokio::test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -101,6 +101,14 @@ enum SourceCommand {
     Discover,
     /// List configured sources
     List,
+    /// Show metadata for a source
+    Info {
+        /// Name of the source to show info for
+        name: String,
+        /// Show additional details such as input hints
+        #[arg(short, long)]
+        verbose: bool,
+    },
     /// Add a new source
     Add(SourceAddArgs),
     /// Lint manifest file
@@ -205,6 +213,9 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
                     });
                     print_text_table(["Source", "Version", "Origin"], rows);
                 }
+            }
+            SourceCommand::Info { name, verbose } => {
+                source_ops::print_source_info(&app, &name, verbose).await?;
             }
             SourceCommand::Add(args) => run_source_add(&app, args).await?,
             SourceCommand::Lint { file } => {

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -1,4 +1,4 @@
-use coral_api::v1::{AvailableSource, ExecuteSqlRequest, Source};
+use coral_api::v1::{ExecuteSqlRequest, Source, SourceInfo};
 use coral_client::{
     AppClient, decode_execute_sql_response, default_workspace, format_batches_table,
 };
@@ -82,7 +82,7 @@ pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
 
 fn select_top_level(
     theme: &ColorfulTheme,
-    bundled_sources: &[AvailableSource],
+    bundled_sources: &[SourceInfo],
 ) -> Result<TopLevelChoice, anyhow::Error> {
     let name_width = bundled_sources
         .iter()
@@ -121,7 +121,7 @@ fn select_top_level(
     }
 }
 
-fn format_source_list_item(source: &AvailableSource, name_width: usize) -> String {
+fn format_source_list_item(source: &SourceInfo, name_width: usize) -> String {
     let check = if source.installed { "✓ " } else { "  " };
     let preview = if source.description.is_empty() {
         String::new()
@@ -137,7 +137,7 @@ fn format_source_list_item(source: &AvailableSource, name_width: usize) -> Strin
 async fn run_installed_source_menu(
     app: &AppClient,
     theme: &ColorfulTheme,
-    source: &AvailableSource,
+    source: &SourceInfo,
 ) -> Result<(), anyhow::Error> {
     let items = ["Update credentials", "Validate", "Back"];
     let actions = [
@@ -184,10 +184,7 @@ async fn run_installed_source_menu(
     Ok(())
 }
 
-async fn run_add_bundled_source(
-    app: &AppClient,
-    source: &AvailableSource,
-) -> Result<(), anyhow::Error> {
+async fn run_add_bundled_source(app: &AppClient, source: &SourceInfo) -> Result<(), anyhow::Error> {
     let inputs = source
         .inputs
         .iter()
@@ -354,13 +351,13 @@ fn truncate_description(description: &str, max_len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use coral_api::v1::AvailableSource;
+    use coral_api::v1::SourceInfo;
 
     use super::{format_source_list_item, truncate_description};
 
     #[test]
     fn source_list_item_shows_checkmark_for_installed() {
-        let source = AvailableSource {
+        let source = SourceInfo {
             name: "github".to_string(),
             description: "Query repositories and issues".to_string(),
             version: "1.0.0".to_string(),
@@ -376,7 +373,7 @@ mod tests {
 
     #[test]
     fn source_list_item_shows_space_for_uninstalled() {
-        let source = AvailableSource {
+        let source = SourceInfo {
             name: "slack".to_string(),
             description: "Send and receive messages".to_string(),
             version: "1.0.0".to_string(),
@@ -391,7 +388,7 @@ mod tests {
 
     #[test]
     fn source_list_item_aligns_names() {
-        let short = AvailableSource {
+        let short = SourceInfo {
             name: "gh".to_string(),
             description: "GitHub".to_string(),
             version: "1.0.0".to_string(),
@@ -399,7 +396,7 @@ mod tests {
             installed: false,
             origin: 1,
         };
-        let long = AvailableSource {
+        let long = SourceInfo {
             name: "statusgator".to_string(),
             description: "Status pages".to_string(),
             version: "1.0.0".to_string(),

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -3,9 +3,9 @@ use std::io::{IsTerminal, stdin, stdout};
 use std::path::Path;
 
 use coral_api::v1::{
-    AvailableSource, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
+    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, GetSourceInfoRequest,
     ImportSourceRequest, ListSourcesRequest, QueryTestFailure, QueryTestSuccess, Source,
-    SourceInputKind, SourceInputSpec, SourceOrigin, SourceSecret, SourceVariable,
+    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, SourceSecret, SourceVariable,
     ValidateSourceRequest, ValidateSourceResponse, query_test_result,
 };
 use coral_client::{AppClient, default_workspace};
@@ -52,9 +52,7 @@ impl TableDisplayLimit {
     pub(crate) const DEFAULT: Self = Self::Max(MAX_TABLES_PER_SCHEMA);
 }
 
-pub(crate) async fn discover_sources(
-    app: &AppClient,
-) -> Result<Vec<AvailableSource>, anyhow::Error> {
+pub(crate) async fn discover_sources(app: &AppClient) -> Result<Vec<SourceInfo>, anyhow::Error> {
     Ok(app
         .source_client()
         .discover_sources(Request::new(DiscoverSourcesRequest {
@@ -139,27 +137,19 @@ pub(crate) async fn print_source_info(
     name: &str,
     verbose: bool,
 ) -> Result<(), anyhow::Error> {
-    let canonical = source_name_arg(Some(name))?;
-
-    if let Some(available) = discover_sources(app)
+    let source = app
+        .source_client()
+        .get_source_info(Request::new(GetSourceInfoRequest {
+            workspace: Some(default_workspace()),
+            name: source_name_arg(Some(name))?,
+        }))
         .await?
-        .into_iter()
-        .find(|source| source.name == canonical)
-    {
-        print_available_source_info(&available, verbose);
-        return Ok(());
-    }
-
-    let installed = list_sources(app)
-        .await?
-        .into_iter()
-        .find(|source| source.name == canonical)
-        .ok_or_else(|| anyhow::anyhow!("unknown source '{canonical}'"))?;
-    print_installed_source_info(&installed);
+        .into_inner();
+    print_source_info_response(&source, verbose);
     Ok(())
 }
 
-fn print_available_source_info(source: &AvailableSource, verbose: bool) {
+fn print_source_info_response(source: &SourceInfo, verbose: bool) {
     let status = if source.installed {
         style("installed").green().to_string()
     } else {
@@ -202,34 +192,6 @@ fn print_available_source_info(source: &AvailableSource, verbose: bool) {
         if verbose && !input.hint.is_empty() {
             println!("      {}", style(&input.hint).dim());
         }
-    }
-}
-
-fn print_installed_source_info(source: &Source) {
-    println!("{}", style(&source.name).bold());
-    println!("  Status:      {}", style("installed").green());
-    println!("  Origin:      {}", source_origin_label(source.origin));
-    println!("  Version:     {}", source.version);
-
-    if source.variables.is_empty() && source.secrets.is_empty() {
-        return;
-    }
-
-    println!();
-    println!("  {}", style("Configured inputs").bold());
-    for variable in &source.variables {
-        println!(
-            "    {} {}",
-            style(&variable.key).bold(),
-            style("(variable)").dim()
-        );
-    }
-    for secret in &source.secrets {
-        println!(
-            "    {} {}",
-            style(&secret.key).bold(),
-            style("(secret)").dim()
-        );
     }
 }
 

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -140,12 +140,26 @@ pub(crate) async fn print_source_info(
     verbose: bool,
 ) -> Result<(), anyhow::Error> {
     let canonical = source_name_arg(Some(name))?;
-    let sources = discover_sources(app).await?;
-    let source = sources
+
+    if let Some(available) = discover_sources(app)
+        .await?
+        .into_iter()
+        .find(|source| source.name == canonical)
+    {
+        print_available_source_info(&available, verbose);
+        return Ok(());
+    }
+
+    let installed = list_sources(app)
+        .await?
         .into_iter()
         .find(|source| source.name == canonical)
         .ok_or_else(|| anyhow::anyhow!("unknown source '{canonical}'"))?;
+    print_installed_source_info(&installed);
+    Ok(())
+}
 
+fn print_available_source_info(source: &AvailableSource, verbose: bool) {
     let status = if source.installed {
         style("installed").green().to_string()
     } else {
@@ -154,13 +168,14 @@ pub(crate) async fn print_source_info(
 
     println!("{}", style(&source.name).bold());
     println!("  Status:      {status}");
+    println!("  Origin:      {}", source_origin_label(source.origin));
     println!("  Version:     {}", source.version);
     if !source.description.is_empty() {
         println!("  Description: {}", source.description);
     }
 
     if source.inputs.is_empty() {
-        return Ok(());
+        return;
     }
 
     println!();
@@ -188,8 +203,34 @@ pub(crate) async fn print_source_info(
             println!("      {}", style(&input.hint).dim());
         }
     }
+}
 
-    Ok(())
+fn print_installed_source_info(source: &Source) {
+    println!("{}", style(&source.name).bold());
+    println!("  Status:      {}", style("installed").green());
+    println!("  Origin:      {}", source_origin_label(source.origin));
+    println!("  Version:     {}", source.version);
+
+    if source.variables.is_empty() && source.secrets.is_empty() {
+        return;
+    }
+
+    println!();
+    println!("  {}", style("Configured inputs").bold());
+    for variable in &source.variables {
+        println!(
+            "    {} {}",
+            style(&variable.key).bold(),
+            style("(variable)").dim()
+        );
+    }
+    for secret in &source.secrets {
+        println!(
+            "    {} {}",
+            style(&secret.key).bold(),
+            style("(secret)").dim()
+        );
+    }
 }
 
 pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), anyhow::Error> {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -171,7 +171,11 @@ pub(crate) async fn print_source_info(
             Ok(SourceInputKind::Secret) => "secret",
             Ok(SourceInputKind::Unspecified) | Err(_) => "unknown",
         };
-        let requirement = if input.required { "required" } else { "optional" };
+        let requirement = if input.required {
+            "required"
+        } else {
+            "optional"
+        };
         println!(
             "    {} {}",
             style(&input.key).bold(),

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -134,6 +134,60 @@ pub(crate) fn load_validated_manifest_file(
     Ok((manifest_yaml, manifest))
 }
 
+pub(crate) async fn print_source_info(
+    app: &AppClient,
+    name: &str,
+    verbose: bool,
+) -> Result<(), anyhow::Error> {
+    let canonical = source_name_arg(Some(name))?;
+    let sources = discover_sources(app).await?;
+    let source = sources
+        .into_iter()
+        .find(|source| source.name == canonical)
+        .ok_or_else(|| anyhow::anyhow!("unknown source '{canonical}'"))?;
+
+    let status = if source.installed {
+        style("installed").green().to_string()
+    } else {
+        style("not installed").dim().to_string()
+    };
+
+    println!("{}", style(&source.name).bold());
+    println!("  Status:      {status}");
+    println!("  Version:     {}", source.version);
+    if !source.description.is_empty() {
+        println!("  Description: {}", source.description);
+    }
+
+    if source.inputs.is_empty() {
+        return Ok(());
+    }
+
+    println!();
+    println!("  {}", style("Inputs").bold());
+    for input in &source.inputs {
+        let kind_label = match SourceInputKind::try_from(input.kind) {
+            Ok(SourceInputKind::Variable) => "variable",
+            Ok(SourceInputKind::Secret) => "secret",
+            Ok(SourceInputKind::Unspecified) | Err(_) => "unknown",
+        };
+        let requirement = if input.required { "required" } else { "optional" };
+        println!(
+            "    {} {}",
+            style(&input.key).bold(),
+            style(format!("({kind_label}, {requirement})")).dim()
+        );
+        if !input.default_value.is_empty() {
+            println!("      default: {}", input.default_value);
+        }
+        if verbose && !input.hint.is_empty() {
+            println!("      {}", style(&input.hint).dim());
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), anyhow::Error> {
     app.source_client()
         .delete_source(Request::new(DeleteSourceRequest {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -169,10 +169,7 @@ async fn source_info_renders_metadata_for_installed_source() {
         stdout.contains("installed"),
         "expected installed status: {stdout}"
     );
-    assert!(
-        stdout.contains("1.0.0"),
-        "expected version: {stdout}"
-    );
+    assert!(stdout.contains("1.0.0"), "expected version: {stdout}");
     assert!(
         stdout.contains("GitHub data"),
         "expected description: {stdout}"
@@ -181,10 +178,7 @@ async fn source_info_renders_metadata_for_installed_source() {
         stdout.contains("GITHUB_TOKEN"),
         "expected input key: {stdout}"
     );
-    assert!(
-        stdout.contains("secret"),
-        "expected input kind: {stdout}"
-    );
+    assert!(stdout.contains("secret"), "expected input kind: {stdout}");
     assert!(
         stdout.contains("required"),
         "expected input requirement: {stdout}"
@@ -235,10 +229,7 @@ async fn source_info_renders_metadata_for_available_source() {
         stdout.contains("not installed"),
         "expected not-installed status: {stdout}"
     );
-    assert!(
-        stdout.contains("2.1.0"),
-        "expected version: {stdout}"
-    );
+    assert!(stdout.contains("2.1.0"), "expected version: {stdout}");
     assert!(
         stdout.contains("Slack data"),
         "expected description: {stdout}"

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -239,6 +239,31 @@ async fn source_info_renders_metadata_for_available_source() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn source_info_falls_back_to_installed_imported_source() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "info", "jira"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("jira"), "expected source name: {stdout}");
+    assert!(
+        stdout.contains("installed"),
+        "expected installed status: {stdout}"
+    );
+    assert!(
+        stdout.contains("imported"),
+        "expected imported origin: {stdout}"
+    );
+    assert!(stdout.contains("2.0.0"), "expected version: {stdout}");
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_info_errors_for_unknown_source() {
     let server = MockServer::start().await;
 

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -13,7 +13,7 @@ use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use coral_api::v1::{
-    AvailableSource, DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, SourceOrigin,
+    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, SourceInfo, SourceOrigin,
 };
 use tonic::Code;
 
@@ -749,7 +749,7 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
         MockServerConfig::default()
             .with_validate_source_error(Code::NotFound, "source 'default:demo_bundled' not found")
             .with_discover_sources(DiscoverSourcesResponse {
-                sources: vec![AvailableSource {
+                sources: vec![SourceInfo {
                     name: "demo_bundled".to_string(),
                     description: "A demo bundled source for testing".to_string(),
                     version: "1.0.0".to_string(),

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -154,6 +154,119 @@ async fn source_discover_renders_empty_state() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn source_info_renders_metadata_for_installed_source() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "info", "github"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("github"), "expected source name: {stdout}");
+    assert!(
+        stdout.contains("installed"),
+        "expected installed status: {stdout}"
+    );
+    assert!(
+        stdout.contains("1.0.0"),
+        "expected version: {stdout}"
+    );
+    assert!(
+        stdout.contains("GitHub data"),
+        "expected description: {stdout}"
+    );
+    assert!(
+        stdout.contains("GITHUB_TOKEN"),
+        "expected input key: {stdout}"
+    );
+    assert!(
+        stdout.contains("secret"),
+        "expected input kind: {stdout}"
+    );
+    assert!(
+        stdout.contains("required"),
+        "expected input requirement: {stdout}"
+    );
+    assert!(
+        !stdout.contains("github.com/settings/tokens"),
+        "expected hint to be hidden without --verbose: {stdout}"
+    );
+
+    let requests = server.discover_sources_requests();
+    assert_eq!(requests.len(), 1, "expected one discover_sources call");
+    assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_info_verbose_includes_input_hints() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "info", "github", "--verbose"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("github.com/settings/tokens"),
+        "expected hint with --verbose: {stdout}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_info_renders_metadata_for_available_source() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "info", "slack"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("not installed"),
+        "expected not-installed status: {stdout}"
+    );
+    assert!(
+        stdout.contains("2.1.0"),
+        "expected version: {stdout}"
+    );
+    assert!(
+        stdout.contains("Slack data"),
+        "expected description: {stdout}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_info_errors_for_unknown_source() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "info", "nope"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("unknown source 'nope'"),
+        "expected unknown source error: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_list_renders_empty_state() {
     let server = MockServer::start_with_config(MockServerConfig::default().with_list_sources(
         ListSourcesResponse {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -188,8 +188,9 @@ async fn source_info_renders_metadata_for_installed_source() {
         "expected hint to be hidden without --verbose: {stdout}"
     );
 
-    let requests = server.discover_sources_requests();
-    assert_eq!(requests.len(), 1, "expected one discover_sources call");
+    let requests = server.get_source_info_requests();
+    assert_eq!(requests.len(), 1, "expected one get_source_info call");
+    assert_eq!(requests[0].name, "github");
     assert_default_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
@@ -239,7 +240,7 @@ async fn source_info_renders_metadata_for_available_source() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn source_info_falls_back_to_installed_imported_source() {
+async fn source_info_renders_installed_imported_source() {
     let server = MockServer::start().await;
 
     let assert = server
@@ -259,6 +260,11 @@ async fn source_info_falls_back_to_installed_imported_source() {
         "expected imported origin: {stdout}"
     );
     assert!(stdout.contains("2.0.0"), "expected version: {stdout}");
+
+    let requests = server.get_source_info_requests();
+    assert_eq!(requests.len(), 1, "expected one get_source_info call");
+    assert_eq!(requests[0].name, "jira");
+    assert_default_workspace(requests[0].workspace.as_ref());
 
     server.shutdown().await;
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -114,7 +114,7 @@ fn mock_discover_response() -> DiscoverSourcesResponse {
                     kind: SourceInputKind::Secret as i32,
                     required: true,
                     default_value: String::new(),
-                    hint: String::new(),
+                    hint: "Create a token at github.com/settings/tokens".to_string(),
                 }],
                 installed: true,
                 origin: SourceOrigin::Bundled as i32,

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -14,11 +14,11 @@ use assert_cmd::Command;
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
-    AvailableSource, Column, CreateBundledSourceRequest, DeleteSourceRequest,
-    DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse,
+    Column, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
+    DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, GetSourceInfoRequest,
     GetSourceRequest, ImportSourceRequest, ListSourcesRequest, ListSourcesResponse,
-    ListTablesRequest, ListTablesResponse, Source, SourceInputKind, SourceInputSpec, SourceOrigin,
-    Table, ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    ListTablesRequest, ListTablesResponse, Source, SourceInfo, SourceInputKind, SourceInputSpec,
+    SourceOrigin, Table, ValidateSourceRequest, ValidateSourceResponse, Workspace,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -105,7 +105,7 @@ fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
 fn mock_discover_response() -> DiscoverSourcesResponse {
     DiscoverSourcesResponse {
         sources: vec![
-            AvailableSource {
+            SourceInfo {
                 name: "github".to_string(),
                 description: "GitHub data".to_string(),
                 version: "1.0.0".to_string(),
@@ -119,7 +119,7 @@ fn mock_discover_response() -> DiscoverSourcesResponse {
                 installed: true,
                 origin: SourceOrigin::Bundled as i32,
             },
-            AvailableSource {
+            SourceInfo {
                 name: "slack".to_string(),
                 description: "Slack data".to_string(),
                 version: "2.1.0".to_string(),
@@ -139,6 +139,42 @@ fn mock_validate_response() -> ValidateSourceResponse {
             mock_table("github", "pull_requests"),
         ],
         query_tests: Vec::new(),
+    }
+}
+
+fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
+    match name {
+        "github" => Ok(SourceInfo {
+            name: "github".to_string(),
+            description: "GitHub data".to_string(),
+            version: "1.0.0".to_string(),
+            inputs: vec![SourceInputSpec {
+                key: "GITHUB_TOKEN".to_string(),
+                kind: SourceInputKind::Secret as i32,
+                required: true,
+                default_value: String::new(),
+                hint: "Create a token at github.com/settings/tokens".to_string(),
+            }],
+            installed: true,
+            origin: SourceOrigin::Bundled as i32,
+        }),
+        "slack" => Ok(SourceInfo {
+            name: "slack".to_string(),
+            description: "Slack data".to_string(),
+            version: "2.1.0".to_string(),
+            inputs: Vec::new(),
+            installed: false,
+            origin: SourceOrigin::Bundled as i32,
+        }),
+        "jira" => Ok(SourceInfo {
+            name: "jira".to_string(),
+            description: "Jira data".to_string(),
+            version: "2.0.0".to_string(),
+            inputs: Vec::new(),
+            installed: true,
+            origin: SourceOrigin::Imported as i32,
+        }),
+        _ => Err(Status::not_found(format!("unknown source '{name}'"))),
     }
 }
 
@@ -270,6 +306,7 @@ struct Captured {
     discover_sources: Mutex<Vec<DiscoverSourcesRequest>>,
     list_sources: Mutex<Vec<ListSourcesRequest>>,
     get_source: Mutex<Vec<GetSourceRequest>>,
+    get_source_info: Mutex<Vec<GetSourceInfoRequest>>,
     create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
     import_source: Mutex<Vec<ImportSourceRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
@@ -387,6 +424,19 @@ impl SourceService for MockSourceService {
             .expect("get_source capture")
             .push(request.into_inner());
         Ok(Response::new(mock_source()))
+    }
+
+    async fn get_source_info(
+        &self,
+        request: Request<GetSourceInfoRequest>,
+    ) -> Result<Response<SourceInfo>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .get_source_info
+            .lock()
+            .expect("get_source_info capture")
+            .push(request.clone());
+        Ok(Response::new(mock_source_info(&request.name)?))
     }
 
     async fn create_bundled_source(
@@ -535,6 +585,14 @@ impl MockServer {
             .list_sources
             .lock()
             .expect("list_sources capture")
+            .clone()
+    }
+
+    pub(crate) fn get_source_info_requests(&self) -> Vec<GetSourceInfoRequest> {
+        self.captured
+            .get_source_info
+            .lock()
+            .expect("get_source_info capture")
             .clone()
     }
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -41,7 +41,7 @@ coral source list
 
 ### `coral source info <NAME>`
 
-Show metadata for a bundled source: whether it is installed, its version, description, and declared inputs.
+Show metadata for a source: whether it is installed, its origin, version, description, and inputs. Works for bundled sources and imported sources installed via `coral source add --file`.
 
 ```shellscript
 coral source info datadog

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -39,6 +39,20 @@ List sources currently installed.
 coral source list
 ```
 
+### `coral source info <NAME>`
+
+Show metadata for a bundled source: whether it is installed, its version, description, and declared inputs.
+
+```shellscript
+coral source info datadog
+```
+
+Pass `-v/--verbose` to include each input's hint text.
+
+```shellscript
+coral source info datadog --verbose
+```
+
 ### `coral source add <NAME>`
 
 Add a bundled source or update its credentials.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -47,7 +47,7 @@ Show metadata for a bundled source: whether it is installed, its version, descri
 coral source info datadog
 ```
 
-Pass `-v/--verbose` to include each input's hint text.
+Pass `-v/--verbose` for more detailed output.
 
 ```shellscript
 coral source info datadog --verbose


### PR DESCRIPTION
## Summary
- Adds `coral source info <name>` which shows whether a source is installed, along with version, description, and declared inputs.
- `-v/--verbose` reveals each input's hint text; hints are hidden by default to keep output terse.
- Uses the existing `DiscoverSources` RPC; errors cleanly with `unknown source '<name>'` when no match is found.

## Test plan
- [x] `cargo test -p coral-cli --features cli-test-server` (new `source_info_*` integration tests cover installed, available, verbose, and unknown-source cases)
- [x] `cargo clippy -p coral-cli --features cli-test-server --all-targets`

## Example output

### Regular

<img width="1940" height="982" alt="CleanShot 2026-04-24 at 9  40 50@2x" src="https://github.com/user-attachments/assets/de82d655-5f19-4268-8ea9-de38d161dc1a" />

### Verbose

<img width="1940" height="1054" alt="CleanShot 2026-04-24 at 9  41 06@2x" src="https://github.com/user-attachments/assets/3c5411d1-a3a2-4e99-80ac-6c74cb95707f" />
