### PR TITLE
docs(sources): add first-half authored table guides

### DIFF
--- a/sources/confluence/manifest.yaml
+++ b/sources/confluence/manifest.yaml
@@ -34,6 +34,10 @@ test_queries:
 tables:
   - name: spaces
     description: Confluence spaces visible to the authenticated user
+    guide: |
+      Use this table to discover `space_id` and `key` values before querying
+      pages or blog posts. The `labels` filter expects label names, not
+      label IDs.
     filters:
       - name: ids
         required: false
@@ -174,6 +178,10 @@ tables:
           key: labels
   - name: pages
     description: Confluence pages visible to the authenticated user
+    guide: |
+      Use `space_id` to keep scans scoped to one space. `body_format`
+      (storage or atlas_doc_format) populates the corresponding `body_*`
+      column; use `confluence.page` for single-page lookups.
     filters:
       - name: space_id
         required: false
@@ -351,6 +359,10 @@ tables:
           key: body_format
   - name: page
     description: A single Confluence page by ID
+    guide: |
+      Fetch a single page when you already know the content ID, including
+      cases where list queries are too broad. `body_format` controls which
+      `body_*` column is populated.
     filters:
       - name: id
         required: true
@@ -522,11 +534,9 @@ tables:
   - name: blog_posts
     description: Confluence blog posts visible to the authenticated user
     guide: |
-      Confluence `GET /api/v2/blogposts` supports status values
-      `current`, `deleted`, and `trashed`. Passing `status='draft'`
-      returns a 400 `INVALID_REQUEST_PARAMETER` from the API.
-      To fetch a specific draft blog post, query `confluence.blog_post`
-      by ID.
+      Supports `current`, `deleted`, and `trashed`. The list API
+      rejects `status='draft'`; use `confluence.blog_post` by ID to
+      fetch specific drafts.
     filters:
       - name: space_id
         required: false
@@ -675,6 +685,10 @@ tables:
           key: body_format
   - name: blog_post
     description: A single Confluence blog post by ID
+    guide: |
+      Use this table for a single blog post by ID, especially for drafts
+      that `confluence.blog_posts` cannot list. `body_format` controls
+      which `body_*` column is populated.
     filters:
       - name: id
         required: true
@@ -821,6 +835,10 @@ tables:
           key: body_format
   - name: page_footer_comments
     description: Footer comments on a specific Confluence page
+    guide: |
+      Requires `page_id` from `confluence.pages` or `confluence.page`. These
+      are page-level comments, not inline annotations; `body_format`
+      controls which `body_*` column is populated.
     filters:
       - name: page_id
         required: true
@@ -928,6 +946,10 @@ tables:
           key: body_format
   - name: page_inline_comments
     description: Inline comments on a specific Confluence page
+    guide: |
+      Requires `page_id` from `confluence.pages` or `confluence.page`. Use
+      `inline_marker_ref` and `inline_original_selection` to locate the
+      commented text; `body_format` controls which `body_*` column is populated.
     filters:
       - name: page_id
         required: true
@@ -1061,6 +1083,10 @@ tables:
           key: body_format
   - name: blog_post_footer_comments
     description: Footer comments on a specific Confluence blog post
+    guide: |
+      Requires `blog_post_id` from `confluence.blog_posts` or
+      `confluence.blog_post`. These are post-level comments; `body_format`
+      controls which `body_*` column is populated.
     filters:
       - name: blog_post_id
         required: true
@@ -1168,6 +1194,10 @@ tables:
           key: body_format
   - name: blog_post_inline_comments
     description: Inline comments on a specific Confluence blog post
+    guide: |
+      Requires `blog_post_id` from `confluence.blog_posts` or
+      `confluence.blog_post`. Use the inline marker columns to map each
+      comment back to the quoted blog post text.
     filters:
       - name: blog_post_id
         required: true
@@ -1301,6 +1331,10 @@ tables:
           key: body_format
   - name: page_attachments
     description: Attachments on a specific Confluence page
+    guide: |
+      Requires `page_id` from `confluence.pages` or `confluence.page`. Use
+      `confluence.attachment` with an attachment `id` when you need one
+      file's full metadata or a specific version.
     filters:
       - name: page_id
         required: true
@@ -1422,6 +1456,10 @@ tables:
             - webuiLink
   - name: blog_post_attachments
     description: Attachments on a specific Confluence blog post
+    guide: |
+      Requires `blog_post_id` from `confluence.blog_posts` or
+      `confluence.blog_post`. Use `confluence.attachment` when you need
+      one file's full metadata or a specific version.
     filters:
       - name: blog_post_id
         required: true
@@ -1543,6 +1581,10 @@ tables:
             - webuiLink
   - name: attachment
     description: A single Confluence attachment by ID
+    guide: |
+      Use attachment IDs from `page_attachments` or `blog_post_attachments`.
+      Set `version` when you need a historical attachment version instead
+      of the current one.
     filters:
       - name: id
         required: true
@@ -1716,6 +1758,10 @@ tables:
           key: version
   - name: labels
     description: Labels defined in Confluence
+    guide: |
+      Use this table to browse available labels and stable label IDs.
+      `sort` and `label_id` are useful for deterministic pagination or
+      resuming large exports.
     filters:
       - name: label_id
         required: false

--- a/sources/intercom/manifest.yaml
+++ b/sources/intercom/manifest.yaml
@@ -30,6 +30,9 @@ test_queries:
 tables:
   - name: contacts
     description: Contacts (users and leads) in the workspace
+    guide: |
+      Start here for person-level analysis. `role` distinguishes users from
+      leads, and `owner_id` joins to `intercom.admins`.
     request:
       method: GET
       path: /contacts
@@ -262,6 +265,10 @@ tables:
             - image_url
   - name: companies
     description: Companies in the workspace
+    guide: |
+      Use for account-level reporting such as plan, spend, and activity.
+      `company_id` is the business identifier Intercom exposes to your
+      workspace.
     request:
       method: POST
       path: /companies/list
@@ -393,6 +400,11 @@ tables:
             - last_request_at
   - name: conversations
     description: Conversations in the workspace
+    guide: |
+      Use `admin_assignee_id` and `team_assignee_id` to join conversations
+      back to `intercom.admins` and `intercom.teams`. Some workspaces may
+      get `403 api_plan_restricted`; source and statistics columns are still
+      useful for routing and SLA analysis when available.
     request:
       method: GET
       path: /conversations
@@ -665,6 +677,9 @@ tables:
             - count_assignments
   - name: admins
     description: Admins and team members in the workspace
+    guide: |
+      Join `id` to contact owners or conversation assignees. `team_ids`
+      shows the admin's team memberships.
     request:
       method: GET
       path: /admins
@@ -755,6 +770,9 @@ tables:
             - avatar
   - name: tags
     description: Tags in the workspace
+    guide: |
+      Small lookup table for tagging dimensions used elsewhere in Intercom.
+      Use it to normalize tag IDs to human-readable names.
     request:
       method: GET
       path: /tags
@@ -780,6 +798,9 @@ tables:
             - name
   - name: teams
     description: Teams in the workspace
+    guide: |
+      Use `id` for conversation assignment joins. `admin_ids` lets you map
+      team membership without an extra API call.
     request:
       method: GET
       path: /teams
@@ -814,6 +835,10 @@ tables:
           separator: ", "
   - name: segments
     description: Segments in the workspace
+    guide: |
+      Useful for saved-audience reporting and counts by person type.
+      `count` is the current segment size returned by Intercom, not a
+      historical trend.
     request:
       method: GET
       path: /segments
@@ -875,6 +900,11 @@ tables:
             - updated_at
   - name: data_attributes
     description: Data attributes for contacts, companies, and conversations
+    guide: |
+      Set `model` to `contact`, `company`, or `conversation` when you only
+      need one attribute family. Use this table to discover attribute
+      keys before querying custom fields in `intercom.contacts` or
+      `intercom.companies`.
     filters:
       - name: model
         required: false
@@ -990,6 +1020,10 @@ tables:
             - updated_at
   - name: collections
     description: Help Center collections
+    guide: |
+      Help Center collections form a hierarchy via `parent_id`. When
+      `articles.parent_type` is `collection`, cast as needed before
+      joining `articles.parent_id` back to collection IDs.
     request:
       method: GET
       path: /help_center/collections
@@ -1088,6 +1122,10 @@ tables:
             - updated_at
   - name: articles
     description: Help Center articles
+    guide: |
+      Use `parent_id` and `parent_type` to place articles under collections.
+      `author_id` maps to admin IDs; cast when joining to
+      `intercom.admins.id`.
     request:
       method: GET
       path: /articles
@@ -1194,6 +1232,10 @@ tables:
             - updated_at
   - name: ticket_types
     description: Ticket types in the workspace
+    guide: |
+      Lookup table for the ticket schema configured in the workspace. Use
+      `category` and `archived` to separate active support flows from
+      retired ones.
     request:
       method: GET
       path: /ticket_types

--- a/sources/jira/manifest.yaml
+++ b/sources/jira/manifest.yaml
@@ -34,6 +34,10 @@ test_queries:
 tables:
   - name: projects
     description: Projects visible to the authenticated Jira user
+    guide: |
+      Start here to discover `project_id` and `project_key` values for
+      project-scoped tables. `query`, `expand`, and `order_by` map directly
+      to Jira search parameters.
     filters:
       - name: query
         required: false
@@ -183,6 +187,11 @@ tables:
           key: order_by
   - name: issues
     description: Issues visible to the authenticated Jira user
+    guide: |
+      This table requires `jql`; always include `project` or `created`
+      filters to prevent timeouts and heavy scans on large Jira
+      instances. Join `project_id` or `project_key` to `jira.projects`
+      for metadata.
     filters:
       - name: jql
         required: true
@@ -403,6 +412,10 @@ tables:
           key: expand
   - name: issue_comments
     description: Comments for a specific Jira issue
+    guide: |
+      Requires `issue_id_or_key` from `jira.issues`. Use `order_by` for
+      deterministic replay and `expand` when Jira comment expansions are
+      needed.
     filters:
       - name: issue_id_or_key
         required: true
@@ -553,6 +566,9 @@ tables:
           key: expand
   - name: project_versions
     description: Versions for a specific Jira project
+    guide: |
+      Requires `project_id_or_key` from `jira.projects`. `status` is useful
+      for separating unreleased, released, and archived versions.
     filters:
       - name: project_id_or_key
         required: true
@@ -722,6 +738,10 @@ tables:
           key: status
   - name: project_components
     description: Components for a specific Jira project
+    guide: |
+      Requires `project_id_or_key` from `jira.projects`. Use this table to
+      resolve component names, leads, and assignee behavior before analyzing
+      tagged issues.
     filters:
       - name: project_id_or_key
         required: true
@@ -882,6 +902,9 @@ tables:
           key: query
   - name: myself
     description: Current authenticated Jira user
+    guide: |
+      Single-row table for the authenticated Jira user. Helpful for checking
+      account scope, locale, and time zone during setup.
     filters:
       - name: expand
         required: false
@@ -969,6 +992,10 @@ tables:
           key: expand
   - name: issue_types
     description: Issue types visible to the authenticated Jira user
+    guide: |
+      Lookup table for issue-type metadata, including hierarchy and
+      project-scoped custom types. Join `name` to
+      `jira.issues.issue_type_name`.
     request:
       method: GET
       path: /rest/api/3/issuetype
@@ -1078,6 +1105,9 @@ tables:
             - key
   - name: priorities
     description: Issue priorities configured in Jira
+    guide: |
+      Lookup table for the priority scheme configured in Jira. Join `name`
+      back to `jira.issues.priority_name`.
     request:
       method: GET
       path: /rest/api/3/priority
@@ -1134,6 +1164,10 @@ tables:
             - statusColor
   - name: project_categories
     description: Project categories configured in Jira
+    guide: |
+      Small lookup table for project grouping metadata. Join
+      `project_categories.id` to `jira.projects.category_id` or
+      `project_categories.name` to `jira.projects.category_name`.
     request:
       method: GET
       path: /rest/api/3/projectCategory
@@ -1174,6 +1208,9 @@ tables:
             - description
   - name: issue_link_types
     description: Issue link types configured in Jira
+    guide: |
+      Use `inward` and `outward` to interpret linked-issue relationships
+      from other Jira exports. This table is usually small and stable.
     request:
       method: GET
       path: /rest/api/3/issueLinkType
@@ -1224,6 +1261,9 @@ tables:
             - outward
   - name: issue_worklogs
     description: Worklogs for a specific Jira issue
+    guide: |
+      Requires `issue_id_or_key` from `jira.issues`. Use `started_after` and
+      `started_before` to keep incremental syncs small and repeatable.
     filters:
       - name: issue_id_or_key
         required: true

--- a/sources/launchdarkly/manifest.yaml
+++ b/sources/launchdarkly/manifest.yaml
@@ -30,6 +30,10 @@ test_queries:
 tables:
   - name: projects
     description: LaunchDarkly projects visible to the authenticated token
+    guide: |
+      Start here to discover `project_key` values for project-scoped tables
+      such as environments and feature flags. Tags are returned as a
+      comma-separated string.
     request:
       method: GET
       path: /api/v2/projects
@@ -88,6 +92,10 @@ tables:
             - tags
   - name: environments
     description: Environments for a LaunchDarkly project
+    guide: |
+      Requires `project_key` from `launchdarkly.projects`. Use it to
+      enumerate valid environment keys before querying segments or flag
+      environments.
     request:
       method: GET
       path: /api/v2/projects/{{filter.project_key}}/environments
@@ -164,6 +172,10 @@ tables:
         required: true
   - name: feature_flags
     description: Feature flags for a LaunchDarkly project
+    guide: |
+      Requires `project_key` from `launchdarkly.projects`. Join `key` to
+      `launchdarkly.flag_environments.flag_key` for environment-specific
+      state.
     request:
       method: GET
       path: /api/v2/flags/{{filter.project_key}}
@@ -264,6 +276,9 @@ tables:
         required: true
   - name: segments
     description: Segments for a LaunchDarkly project and environment
+    guide: |
+      Requires both `project_key` and `environment_key`. Query environments
+      first so you can fan out over valid environment keys.
     request:
       method: GET
       path: /api/v2/segments/{{filter.project_key}}/{{filter.environment_key}}
@@ -349,6 +364,10 @@ tables:
         required: true
   - name: flag_environments
     description: Environment-scoped feature flag status and targeting configuration
+    guide: |
+      Requires both `project_key` and `environment_key`. This is the best
+      table for environment-specific targeting details such as `rules`,
+      `targets`, and `enabled` state.
     request:
       method: GET
       path: /api/v2/flags/{{filter.project_key}}
@@ -524,6 +543,9 @@ tables:
         required: true
   - name: members
     description: Account members visible to the authenticated token
+    guide: |
+      Use for account membership and coarse role auditing. `pending_invite`
+      distinguishes invited users from active members.
     request:
       method: GET
       path: /api/v2/members
@@ -590,6 +612,10 @@ tables:
             - _pendingInvite
   - name: roles
     description: Custom roles
+    guide: |
+      Lookup table for custom LaunchDarkly roles. Join `key` or `name` with
+      membership exports outside Coral if you need finer-grained RBAC
+      analysis.
     request:
       method: GET
       path: /api/v2/roles
@@ -640,6 +666,10 @@ tables:
             - description
   - name: audit_log
     description: Audit log entries in a time window
+    guide: |
+      Requires constant `from` and `to` filters for a bounded time window.
+      Keep the window small (for example, under 30 days); milliseconds
+      since epoch work well for repeatable exports and incremental polling.
     request:
       method: GET
       path: /api/v2/auditlog

--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -24,6 +24,10 @@ test_queries:
 tables:
   - name: teams
     description: Teams in the Linear workspace
+    guide: |
+      Start here to discover `team_id` and `team_key` values for
+      team-scoped tables. `private` can explain why some users cannot see
+      related issues.
     request:
       method: POST
       path: /graphql
@@ -134,6 +138,10 @@ tables:
             - updatedAt
   - name: users
     description: Users in the Linear workspace
+    guide: |
+      Workspace user dimension table. Join `id` to attachment
+      `creator_id`, or use user names and emails to interpret issue
+      assignee fields.
     request:
       method: POST
       path: /graphql
@@ -253,6 +261,10 @@ tables:
             - updatedAt
   - name: projects
     description: Projects in the Linear workspace
+    guide: |
+      Use this table to discover `project_id` values before querying
+      milestones or project updates. Team columns let you group projects
+      without another join.
     request:
       method: POST
       path: /graphql
@@ -396,6 +408,10 @@ tables:
             - name
   - name: project_milestones
     description: Milestones for a specific Linear project
+    guide: |
+      Requires `project_id` from `linear.projects`. Use `status`, `progress`,
+      and `archived_at` to separate active roadmap items from completed
+      ones.
     request:
       method: POST
       path: /graphql
@@ -553,6 +569,10 @@ tables:
         required: true
   - name: cycles
     description: Cycles in the Linear workspace
+    guide: |
+      Optionally filter by `team_id` to keep results scoped to one team.
+      Without a filter, this table returns cycles across the whole
+      workspace.
     request:
       method: POST
       path: /graphql
@@ -679,6 +699,10 @@ tables:
         required: false
   - name: initiatives
     description: Initiatives in the Linear workspace
+    guide: |
+      High-level planning objects that can outlive individual projects. Use
+      alongside `projects` when you need roadmap context beyond a single
+      team.
     request:
       method: POST
       path: /graphql
@@ -771,6 +795,10 @@ tables:
             - updatedAt
   - name: project_updates
     description: Updates for a specific Linear project
+    guide: |
+      Requires `project_id` from `linear.projects`. The `body` field
+      contains the written update; timestamps make this useful for progress
+      reporting.
     request:
       method: POST
       path: /graphql
@@ -874,6 +902,9 @@ tables:
         required: true
   - name: issue_labels
     description: Issue labels in the Linear workspace
+    guide: |
+      Workspace-wide label lookup table. Join by label names from downstream
+      exports when you need consistent color and group metadata.
     request:
       method: POST
       path: /graphql
@@ -968,6 +999,10 @@ tables:
             - isGroup
   - name: issues
     description: Issues in the Linear workspace
+    guide: |
+      Optional project filters are useful for narrowing large workspaces.
+      Join `team_id`, `project_id`, and assignee columns back to `teams`,
+      `projects`, and `users`.
     filters:
       - name: project_id
       - name: project_milestone_id
@@ -1235,6 +1270,9 @@ tables:
             - completedAt
   - name: issue_comments
     description: Comments for a specific Linear issue
+    guide: |
+      Requires `issue_id` from `linear.issues` or `linear.team_issues`. Use
+      it when you need the discussion trail for a specific issue.
     request:
       method: POST
       path: /graphql
@@ -1338,6 +1376,9 @@ tables:
         required: true
   - name: team_issues
     description: Issues for a specific Linear team
+    guide: |
+      Requires `team_id` from `linear.teams`. Prefer this table over
+      `linear.issues` when you want a complete backlog for one team.
     request:
       method: POST
       path: /graphql
@@ -1507,6 +1548,10 @@ tables:
         required: true
   - name: attachments
     description: Attachments (including pull requests) linked to Linear issues
+    guide: |
+      Includes external links such as pull requests attached to issues.
+      Join `issue_id` or `issue_identifier` back to `linear.issues` for
+      issue context.
     request:
       method: POST
       path: /graphql


### PR DESCRIPTION
Add authored table guides for the first-half missing-guide sources: Confluence, Intercom, Jira, LaunchDarkly, and Linear. The guides stay short and table-specific, then tighten a few outliers after comparing them with existing authored guides and a Gemini review.

Constraint: Keep changes limited to the requested bundled source manifests

Rejected: Longer column-by-column guidance | too verbose for existing manifest guide style

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Keep future table guides short, operational, and focused on filters, joins, scoping, or API quirks

Tested: YAML parse check for the five edited manifests; cargo test -p coral-app bundled_sources_load_through_catalog -- --exact

Not-tested: Live source queries against third-party APIs