### PR TITLE
fix(engine): pass tables arg to datafusion_to_core in json registration

### DIFF
--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -34,7 +34,7 @@ pub(crate) async fn build_runtime(
             .map_err(|err| datafusion_to_core(&err, &[]))?,
     );
     let mut ctx = SessionContext::new_with_config_rt(session_config, runtime_env);
-    register_json_support(&mut ctx).map_err(|err| datafusion_to_core(&err))?;
+    register_json_support(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
     let ctx = Arc::new(ctx);
 
     let runtime_context = runtime.runtime_context();


### PR DESCRIPTION
## Summary

One-line fix — \`main\` doesn't currently compile.

\`\`\`
error[E0061]: this function takes 2 arguments but 1 argument was supplied
  --> crates/coral-engine/src/runtime/query.rs:37:51
\`\`\`

## Root cause

Two PRs touched the same call graph on independent schedules:

- **#160** (DataFusion JSON functions, merged 2026-04-22) added a new \`register_json_support(&mut ctx).map_err(|err| datafusion_to_core(&err))\` call to \`build_runtime\`.
- **#120** (structured \`TABLE_NOT_FOUND\` / \`UNKNOWN_COLUMN\`, merged 2026-04-24) changed \`datafusion_to_core\`'s signature to \`(error, tables: &[TableInfo])\` and updated every call site *that existed when its last rebase happened*. Between that rebase and the merge, #160 landed and added a new call site that #120's merge didn't touch.

## Fix

Pass \`&[]\` as the second arg. At session-init time there are no registered tables yet, so the empty slice is the correct value — same as the other \`build_runtime\`-scope callers (line 34).

No behavior change. No tests added — existing engine tests cover the path and were already green before #120 merged; the issue is purely a post-merge arity mismatch.

## Verification

- \`cargo check --workspace\`: now compiles
- \`cargo test -p coral-engine\`: 98 unit + 64 integration passing
- \`cargo fmt --all --check\`, \`cargo clippy --workspace --all-targets --locked -- -D warnings\`: clean