### PR TITLE
fix: centralize local name validation invariants

### DIFF
--- a/crates/coral-app/src/identity.rs
+++ b/crates/coral-app/src/identity.rs
@@ -1,0 +1,52 @@
+//! Shared validation helpers for app-owned identifiers.
+
+use crate::bootstrap::AppError;
+
+pub(crate) fn parse_path_segment(kind: &str, value: &str) -> Result<String, AppError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(AppError::InvalidInput(format!("missing {kind} name")));
+    }
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(AppError::InvalidInput(format!(
+            "{kind} name must not contain '/' or '\\\\'"
+        )));
+    }
+    if trimmed == "." || trimmed == ".." {
+        return Err(AppError::InvalidInput(format!(
+            "{kind} name must not be '.' or '..'"
+        )));
+    }
+    Ok(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_path_segment;
+
+    #[test]
+    fn rejects_empty_names() {
+        let error = parse_path_segment("source", "   ").expect_err("empty name should fail");
+        assert!(error.to_string().contains("missing source name"));
+    }
+
+    #[test]
+    fn rejects_path_separators() {
+        let error = parse_path_segment("workspace", r"bad\name").expect_err("slash should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("workspace name must not contain '/' or '\\\\'")
+        );
+    }
+
+    #[test]
+    fn rejects_dot_segments() {
+        let error = parse_path_segment("source", "..").expect_err("dot segment should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("source name must not be '.' or '..'")
+        );
+    }
+}

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -32,6 +32,7 @@
 //!
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
+mod identity;
 mod query;
 mod sources;
 mod state;

--- a/crates/coral-app/src/sources/name.rs
+++ b/crates/coral-app/src/sources/name.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::bootstrap::AppError;
+use crate::identity::parse_path_segment;
 
 /// App-owned identity for one installed or installable source name.
 ///
@@ -18,21 +19,7 @@ pub(crate) struct SourceName(String);
 impl SourceName {
     /// Parse and validate a source name for app-internal use.
     pub(crate) fn parse(name: &str) -> Result<Self, AppError> {
-        let trimmed = name.trim();
-        if trimmed.is_empty() {
-            return Err(AppError::InvalidInput("missing source name".to_string()));
-        }
-        if trimmed.contains('/') || trimmed.contains('\\') {
-            return Err(AppError::InvalidInput(
-                "source name must not contain '/' or '\\\\'".to_string(),
-            ));
-        }
-        if trimmed == "." || trimmed == ".." {
-            return Err(AppError::InvalidInput(
-                "source name must not be '.' or '..'".to_string(),
-            ));
-        }
-        Ok(Self(trimmed.to_string()))
+        parse_path_segment("source", name).map(Self)
     }
 
     /// Borrow the normalized source name at string boundaries such as paths,
@@ -73,28 +60,5 @@ impl FromStr for SourceName {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::parse(s)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::SourceName;
-
-    #[test]
-    fn rejects_forward_and_backward_slashes() {
-        let error = SourceName::parse(r"bad\source").expect_err("source should fail");
-        assert!(error.to_string().contains("'/' or '\\\\'"));
-
-        let error = SourceName::parse("bad/source").expect_err("source should fail");
-        assert!(error.to_string().contains("'/' or '\\\\'"));
-    }
-
-    #[test]
-    fn rejects_path_traversal() {
-        let error = SourceName::parse("..").expect_err("'..' should be rejected");
-        assert!(error.to_string().contains("'.' or '..'"));
-
-        let error = SourceName::parse(" . ").expect_err("'.' should be rejected");
-        assert!(error.to_string().contains("'.' or '..'"));
     }
 }

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
 use crate::bootstrap::AppError;
+use crate::identity::parse_path_segment;
 
 /// Canonical default workspace name used across local Coral surfaces.
 pub const DEFAULT_WORKSPACE_ID: &str = "default";
@@ -17,21 +18,7 @@ pub(crate) struct WorkspaceName(String);
 impl WorkspaceName {
     /// Parse and validate a workspace name for app-internal use.
     pub(crate) fn parse(name: &str) -> Result<Self, AppError> {
-        let trimmed = name.trim();
-        if trimmed.is_empty() {
-            return Err(AppError::InvalidInput("missing workspace name".to_string()));
-        }
-        if trimmed.contains('/') || trimmed.contains('\\') {
-            return Err(AppError::InvalidInput(
-                "workspace name must not contain '/' or '\\\\'".to_string(),
-            ));
-        }
-        if trimmed == "." || trimmed == ".." {
-            return Err(AppError::InvalidInput(
-                "workspace name must not be '.' or '..'".to_string(),
-            ));
-        }
-        Ok(Self(trimmed.to_string()))
+        parse_path_segment("workspace", name).map(Self)
     }
 
     /// Borrow the normalized workspace name for filesystem and persistence
@@ -61,23 +48,5 @@ mod tests {
     #[test]
     fn parses_default_workspace_name() {
         assert_eq!(WorkspaceName::default().as_str(), DEFAULT_WORKSPACE_ID);
-    }
-
-    #[test]
-    fn rejects_forward_and_backward_slashes() {
-        let error = WorkspaceName::parse(r"bad\workspace").expect_err("workspace should fail");
-        assert!(error.to_string().contains("'/' or '\\\\'"));
-
-        let error = WorkspaceName::parse("bad/workspace").expect_err("workspace should fail");
-        assert!(error.to_string().contains("'/' or '\\\\'"));
-    }
-
-    #[test]
-    fn rejects_path_traversal() {
-        let error = WorkspaceName::parse("..").expect_err("'..' should be rejected");
-        assert!(error.to_string().contains("'.' or '..'"));
-
-        let error = WorkspaceName::parse(" . ").expect_err("'.' should be rejected");
-        assert!(error.to_string().contains("'.' or '..'"));
     }
 }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -164,6 +164,9 @@ pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Erro
             "source name must not contain '/' or '\\\\'"
         ));
     }
+    if name == "." || name == ".." {
+        return Err(anyhow::anyhow!("source name must not be '.' or '..'"));
+    }
     Ok(name.to_string())
 }
 
@@ -529,7 +532,7 @@ mod tests {
 
     use super::{
         ValidationFollowUp, ValidationSeverityMode, collect_inputs_with, finalize_input_value,
-        validation_follow_up,
+        source_name_arg, validation_follow_up,
     };
 
     #[test]
@@ -618,6 +621,15 @@ mod tests {
         assert!(message.contains("LINEAR_API_KEY"));
         assert!(message.contains("OTHER_KEY"));
         assert!(message.contains("--interactive"));
+    }
+
+    #[test]
+    fn source_name_arg_rejects_dot_segments() {
+        let error = source_name_arg(Some("..")).expect_err("dot segment should fail");
+        assert!(error.to_string().contains("must not be '.' or '..'"));
+
+        let error = source_name_arg(Some(" . ")).expect_err("dot segment should fail");
+        assert!(error.to_string().contains("must not be '.' or '..'"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Keep local source and workspace name validation in one app-owned place so the same invariants are enforced consistently across Coral surfaces.

## Why
The app already owns `SourceName` and `WorkspaceName`, but their validation logic had drifted into duplicate implementations. That made small rule changes easy to miss and let the CLI reject some invalid names later than necessary.

## Validation
- `make rust-checks docs-check`
