### PR TITLE
docs(sources): add missing table guides for remaining bundled sources

### DIFF
--- a/sources/pagerduty/manifest.yaml
+++ b/sources/pagerduty/manifest.yaml
@@ -26,6 +26,8 @@ test_queries:
 tables:
   - name: abilities
     description: List abilities
+    guide: |
+      Use this table to list abilities.
     request:
       method: GET
       path: /abilities
@@ -50,6 +52,10 @@ tables:
             - abilities
   - name: active
     description: Get the Service Orchestration active status for a Service
+    guide: |
+      Use this table to get the Service Orchestration active status for
+      a Service. Requires `service_id`, usually from
+      `pagerduty.services`.
     filters:
       - name: service_id
         required: true
@@ -85,6 +91,9 @@ tables:
           key: service_id
   - name: addons
     description: List installed Add-ons
+    guide: |
+      Use this table to list installed Add-ons. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -296,6 +305,9 @@ tables:
             - type
   - name: alert_grouping_settings
     description: List alert grouping settings
+    guide: |
+      Use this table to list alert grouping settings. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -674,6 +686,11 @@ tables:
             - updated_at
   - name: analytic_raw_incidents
     description: Get raw data - single incident
+    guide: |
+      Use this table to get raw data - single incident. Pass `id` to hit
+      the single-record endpoint when you need details for one row. Use
+      it after inventory tables identify the entities worth
+      investigating in detail.
     filters:
       - name: id
         required: true
@@ -1150,6 +1167,10 @@ tables:
             - user_defined_effort_seconds
   - name: automation_action_action_services
     description: Get all service references associated with an Automation Action
+    guide: |
+      Use this table to list service references for an Automation
+      Action. Requires `id` for the parent automation action; add
+      `service_id` when you want one specific referenced service.
     filters:
       - name: id
         required: true
@@ -1289,6 +1310,9 @@ tables:
             - type
   - name: automation_action_actions
     description: List Automation Actions
+    guide: |
+      Use this table to list Automation Actions. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: name
         required: false
@@ -2013,6 +2037,10 @@ tables:
             - type
   - name: business_service_subscribers
     description: List Business Service Subscribers
+    guide: |
+      Use this table to list Business Service Subscribers. Requires
+      `id` from `pagerduty.business_services` to choose the parent
+      business service.
     filters:
       - name: id
         required: true
@@ -2092,6 +2120,10 @@ tables:
             - total
   - name: business_service_supporting_service_impacts
     description: List the supporting Business Services for the given Business Service Id, sorted by impacted status.
+    guide: |
+      Use this table to list the supporting Business Services for the
+      given Business Service Id, sorted by impacted status. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -2215,6 +2247,9 @@ tables:
             - type
   - name: business_services
     description: List Business Services
+    guide: |
+      Start here to inventory business services. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -2508,6 +2543,10 @@ tables:
       List Cache Variables for a Service Event Orchestration. Cache Variables allow you to store event data on an Event Orchestration, which can then
       be used in Event Orchestration rules as part of conditions or actions. For more information see the [API Concepts
       Document](../../api-reference/a47605517c19a-api-concepts#event-orchestrations) Scoped OAuth requires: `services.read`
+    guide: |
+      Use this table to inspect cache variables. Requires `service_id`,
+      usually from `pagerduty.services`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: service_id
         required: true
@@ -2959,6 +2998,9 @@ tables:
             - type
   - name: change_events
     description: List Change Events
+    guide: |
+      Use this table to list Change Events. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -3408,6 +3450,9 @@ tables:
             - type
   - name: contact_methods
     description: List a user's contact methods
+    guide: |
+      Use this table to list a user's contact methods. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -3716,6 +3761,8 @@ tables:
             - type
   - name: counts
     description: Get Paused Incident Reporting counts
+    guide: |
+      Use this table to get Paused Incident Reporting counts.
     filters:
       - name: service_id
         required: false
@@ -3819,6 +3866,9 @@ tables:
           key: suspended_by
   - name: custom_shifts
     description: List custom shifts
+    guide: |
+      Use this table to list custom shifts. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -4025,6 +4075,11 @@ tables:
             - type
   - name: data
     description: Get Data for an External Data Cache Variable on a Global Event Orchestration
+    guide: |
+      Use this table to get Data for an External Data Cache Variable on
+      a Global Event Orchestration. Pass `id` to hit the single-record
+      endpoint when you need details for one row. Requires
+      `cache_variable_id` from `pagerduty.cache_variables`.
     filters:
       - name: id
         required: true
@@ -4095,6 +4150,9 @@ tables:
           key: service_id
   - name: enablements
     description: List Enablements for an Event Orchestration
+    guide: |
+      Use this table to list enablements for an Event Orchestration.
+      Requires `id` for the parent event orchestration.
     filters:
       - name: id
         required: true
@@ -4164,6 +4222,9 @@ tables:
             - warnings
   - name: escalation_policies
     description: List escalation policies
+    guide: |
+      Start here to inventory escalation policies. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -4499,6 +4560,10 @@ tables:
           key: user_ids[]
   - name: event_orchestration_integrations
     description: List Integrations for an Event Orchestration
+    guide: |
+      Use this table to list integrations for an Event Orchestration.
+      Requires `id` for the parent event orchestration; add
+      `integration_id` when you want one specific integration.
     filters:
       - name: id
         required: true
@@ -4638,6 +4703,9 @@ tables:
             - type
   - name: event_orchestration_services
     description: Get the Service Orchestration for a Service
+    guide: |
+      Use this table to get the Service Orchestration for a Service.
+      Requires `service_id`, usually from `pagerduty.services`.
     filters:
       - name: service_id
         required: true
@@ -4846,6 +4914,9 @@ tables:
           key: service_id
   - name: event_orchestrations
     description: List Event Orchestrations
+    guide: |
+      Use this table to list Event Orchestrations. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: sort_by
         required: false
@@ -5300,6 +5371,10 @@ tables:
             - version
   - name: events
     description: List events
+    guide: |
+      Use this table to list events. Pass `id` to hit the single-record
+      endpoint when you need details for one row. Requires `rotation_id`
+      from `pagerduty.rotations`.
     filters:
       - name: id
         required: true
@@ -5793,6 +5868,9 @@ tables:
             - type
   - name: extension_schemas
     description: List extension schemas
+    guide: |
+      Use this table to list extension schemas. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -6003,6 +6081,9 @@ tables:
             - url
   - name: extensions
     description: List extensions
+    guide: |
+      Use this table to list extensions. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -6408,6 +6489,9 @@ tables:
             - type
   - name: field_options
     description: List Field Options
+    guide: |
+      Use this table to list Field Options. Requires `field_id` from the
+      relevant custom-field catalog table.
     filters:
       - name: field_id
         required: true
@@ -6524,6 +6608,8 @@ tables:
           key: field_option_id
   - name: fields
     description: List template fields
+    guide: |
+      Use this table to list template fields.
     request:
       method: GET
       path: /templates/fields
@@ -6633,6 +6719,9 @@ tables:
       evaluate against all Events sent to an Event Orchestration. When a matching rule is found, it can modify and enhance the event and can route the
       event to another set of Global Rules within this Orchestration for further processing. For more information see the [API Concepts
       Document](../../api-reference/a47605517c19a-api-concepts#event-orchestrations) Scoped OAuth requires: `event_orchestrations.read`
+    guide: |
+      Use this table to inspect global. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -6667,6 +6756,8 @@ tables:
             - orchestration_path
   - name: impactors
     description: List Impactors affecting Business Services
+    guide: |
+      Use this table to list Impactors affecting Business Services.
     filters:
       - name: ids[]
         required: false
@@ -6724,6 +6815,10 @@ tables:
             - more
   - name: impacts
     description: List Business Services sorted by impacted status
+    guide: |
+      Use this table to list Business Services sorted by impacted
+      status. Pass `id` to hit the single-record endpoint when you need
+      details for one row.
     filters:
       - name: additional_fields[]
         required: false
@@ -6852,6 +6947,11 @@ tables:
             - type
   - name: incident_alerts
     description: List alerts for an incident
+    guide: |
+      Use this table to list alerts for an incident. Pass `id` to hit
+      the single-record endpoint when you need details for one row. Use
+      it after inventory tables identify the entities worth
+      investigating in detail.
     filters:
       - name: total
         required: false
@@ -7711,6 +7811,9 @@ tables:
             - type
   - name: incident_custom_field_values
     description: Get Custom Field Values
+    guide: |
+      Use this table to get Custom Field Values. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -7813,6 +7916,8 @@ tables:
             - value
   - name: incident_custom_fields
     description: List Fields
+    guide: |
+      Use this table to list Fields.
     filters:
       - name: field_id
         required: false
@@ -8124,6 +8229,9 @@ tables:
             - updated_at
   - name: incident_status_update_subscribers
     description: List Notification Subscribers
+    guide: |
+      Use this table to list Notification Subscribers. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -8187,6 +8295,10 @@ tables:
             - subscriber_type
   - name: incident_type_custom_fields
     description: List Incident Type Custom Fields
+    guide: |
+      Use this table to list Incident Type Custom Fields. Use
+      `type_id_or_name` to scope this endpoint to the records you
+      actually want.
     filters:
       - name: type_id_or_name
         required: true
@@ -8551,6 +8663,9 @@ tables:
             - updated_at
   - name: incident_workflow_actions
     description: List Actions
+    guide: |
+      Use this table to list Actions. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: keyword
         required: false
@@ -8997,6 +9112,9 @@ tables:
             - version
   - name: incident_workflows
     description: List Incident Workflows
+    guide: |
+      Use this table to list Incident Workflows. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -9315,6 +9433,9 @@ tables:
             - type
   - name: incidents
     description: List incidents
+    guide: |
+      Start here to inventory incidents. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -13442,6 +13563,9 @@ tables:
           key: user_ids[]
   - name: invocations
     description: List Invocations
+    guide: |
+      Use this table to list Invocations. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: invocation_state
         required: false
@@ -14024,6 +14148,10 @@ tables:
             - type
   - name: license
     description: Get the License allocated to a User
+    guide: |
+      Use this table to get the License allocated to a User. Pass `id`
+      to hit the single-record endpoint when you need details for one
+      row.
     filters:
       - name: id
         required: true
@@ -14151,6 +14279,8 @@ tables:
             - valid_roles
   - name: license_allocations
     description: List License Allocations
+    guide: |
+      Use this table to list License Allocations.
     request:
       method: GET
       path: /license_allocations
@@ -14336,6 +14466,9 @@ tables:
             - type
   - name: licenses
     description: List Licenses
+    guide: |
+      Start here to inventory licenses. Use `id` values from here in
+      related tables and drill-down queries.
     request:
       method: GET
       path: /licenses
@@ -14457,6 +14590,9 @@ tables:
             - valid_roles
   - name: list_overrides
     description: List overrides
+    guide: |
+      Use this table to list overrides. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -14833,6 +14969,9 @@ tables:
             - type
   - name: list_schedules_v3
     description: List schedules
+    guide: |
+      Use this table to list schedules. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: id
         required: false
@@ -15118,6 +15257,9 @@ tables:
             - type
   - name: list_teams
     description: List teams
+    guide: |
+      Use this table to list teams. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -15339,6 +15481,9 @@ tables:
             - type
   - name: log_entries
     description: List log entries
+    guide: |
+      Use this table to list log entries. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -16601,6 +16746,9 @@ tables:
             - type
   - name: maintenance_windows
     description: List maintenance windows
+    guide: |
+      Use this table to list maintenance windows. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: query
         required: false
@@ -17043,6 +17191,8 @@ tables:
             - type
   - name: me
     description: Get the current user
+    guide: |
+      Use this table to get the current user.
     request:
       method: GET
       path: /users/me
@@ -17249,6 +17399,9 @@ tables:
             - type
   - name: members
     description: List members of a team
+    guide: |
+      Use this table to list members of a team. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -17360,6 +17513,8 @@ tables:
             - type
   - name: memories
     description: List SRE Agent memories
+    guide: |
+      Use this table to list SRE Agent memories.
     filters:
       - name: service_id
         required: false
@@ -17503,6 +17658,9 @@ tables:
             - updated_at
   - name: notes
     description: List notes for an incident
+    guide: |
+      Use this table to list notes for an incident. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -17675,6 +17833,9 @@ tables:
             - type
   - name: notification_rules
     description: List a user's notification rules
+    guide: |
+      Use this table to list a user's notification rules. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -17983,6 +18144,10 @@ tables:
             - urgency
   - name: notification_subscriptions
     description: List Team Notification Subscriptions
+    guide: |
+      Use this table to list Team Notification Subscriptions. Pass `id`
+      to hit the single-record endpoint when you need details for one
+      row.
     filters:
       - name: id
         required: true
@@ -18058,6 +18223,8 @@ tables:
             - total
   - name: notifications
     description: List notifications
+    guide: |
+      Use this table to list notifications.
     filters:
       - name: total
         required: false
@@ -18229,6 +18396,9 @@ tables:
             - type
   - name: oauth_clients
     description: List OAuth clients
+    guide: |
+      Use this table to list OAuth clients. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: id
         required: false
@@ -18414,6 +18584,9 @@ tables:
             - type
   - name: oauth_delegations
     description: List a user's delegations
+    guide: |
+      Use this table to list a user's delegations. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -18533,6 +18706,10 @@ tables:
             - status
   - name: oncall_handoff_notification_rules
     description: List a User's Handoff Notification Rules
+    guide: |
+      Use this table to list a User's Handoff Notification Rules. Pass
+      `id` to hit the single-record endpoint when you need details for
+      one row.
     filters:
       - name: id
         required: true
@@ -18759,6 +18936,8 @@ tables:
           key: oncall_handoff_notification_rule_id
   - name: oncalls
     description: List all of the on-calls
+    guide: |
+      Use this table to list all of the on-calls.
     filters:
       - name: time_zone
         required: false
@@ -19063,6 +19242,9 @@ tables:
           key: user_ids[]
   - name: outlier_incident
     description: Get Outlier Incident
+    guide: |
+      Use this table to get Outlier Incident. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -19548,6 +19730,11 @@ tables:
             - mined_text
   - name: past_incidents
     description: Get Past Incidents
+    guide: |
+      Use this table to get Past Incidents. Pass `id` to hit the single-
+      record endpoint when you need details for one row. Use it after
+      inventory tables identify the entities worth investigating in
+      detail.
     filters:
       - name: id
         required: true
@@ -19607,6 +19794,10 @@ tables:
             - total
   - name: paused_incident_report_alerts
     description: Get Paused Incident Reporting on Alerts
+    guide: |
+      Use this table to get Paused Incident Reporting on Alerts. Use it
+      after inventory tables identify the entities worth investigating
+      in detail.
     filters:
       - name: service_id
         required: false
@@ -19700,6 +19891,11 @@ tables:
           key: suspended_by
   - name: post_updates
     description: List Status Page Post Updates
+    guide: |
+      Use this table to list Status Page Post Updates. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
+      Requires `post_id`; fetch candidate values from `pagerduty.posts`
+      when available.
     filters:
       - name: id
         required: true
@@ -20116,6 +20312,11 @@ tables:
             - update_frequency_ms
   - name: postmortem
     description: Get a Post Postmortem
+    guide: |
+      Use this table to get a Post Postmortem. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Requires
+      `post_id`; fetch candidate values from `pagerduty.posts` when
+      available.
     filters:
       - name: id
         required: true
@@ -20253,6 +20454,9 @@ tables:
             - type
   - name: posts
     description: List Status Page Posts
+    guide: |
+      Use this table to list Status Page Posts. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -20665,6 +20869,9 @@ tables:
             - updates
   - name: priorities
     description: List priorities
+    guide: |
+      Start here to inventory priorities. Use `id` values from here in
+      related tables and drill-down queries.
     filters:
       - name: total
         required: false
@@ -20766,6 +20973,9 @@ tables:
             - type
   - name: priority_thresholds
     description: Get the global priority threshold for a Business Service to be considered impacted by an Incident
+    guide: |
+      Use this table to get the global priority threshold for a Business
+      Service to be considered impacted by an Incident.
     request:
       method: GET
       path: /business_services/priority_thresholds
@@ -20807,6 +21017,9 @@ tables:
             - order
   - name: records
     description: List audit records
+    guide: |
+      Use this table to list audit records. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: root_resource_types[]
         required: false
@@ -21221,6 +21434,11 @@ tables:
       feature provides incident responders with recent change events that are most relevant to that incident. Change Correlation informs the responder
       why a particular change event was surfaced and correlated to an incident based on three key factors which include time, related service, or
       intelligence (machine learning). Scoped OAuth requires: `incidents.read`
+    guide: |
+      Use this table to inspect related change events. Pass `id` to hit
+      the single-record endpoint when you need details for one row. Best
+      used after inventory tables identify the entity or time range you
+      want to investigate.
     filters:
       - name: id
         required: true
@@ -21427,6 +21645,11 @@ tables:
             - type
   - name: related_incidents
     description: Get Related Incidents
+    guide: |
+      Use this table to get Related Incidents. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Use it
+      after inventory tables identify the entities worth investigating
+      in detail.
     filters:
       - name: id
         required: true
@@ -21477,6 +21700,10 @@ tables:
             - related_incidents
   - name: responses
     description: Get raw responses from a single incident
+    guide: |
+      Use this table to get raw responses from a single incident. Pass
+      `id` to hit the single-record endpoint when you need details for
+      one row.
     filters:
       - name: id
         required: true
@@ -21571,6 +21798,9 @@ tables:
             - time_to_respond_seconds
   - name: rotations
     description: List rotations
+    guide: |
+      Use this table to list rotations. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -21722,6 +21952,10 @@ tables:
             - type
   - name: router
     description: Get the Router for an Event Orchestration
+    guide: |
+      Use this table to get the Router for an Event Orchestration. Pass
+      `id` to hit the single-record endpoint when you need details for
+      one row.
     filters:
       - name: id
         required: true
@@ -21756,6 +21990,9 @@ tables:
             - orchestration_path
   - name: ruleset_rules
     description: List Event Rules
+    guide: |
+      Use this table to list Event Rules. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -22436,6 +22673,9 @@ tables:
             - variables
   - name: rulesets
     description: List Rulesets
+    guide: |
+      Use this table to list Rulesets. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -22863,6 +23103,9 @@ tables:
             - type
   - name: runners
     description: List Automation Action runners
+    guide: |
+      Use this table to list Automation Action runners. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: name
         required: false
@@ -23263,6 +23506,9 @@ tables:
             - type
   - name: schedules
     description: List schedules
+    guide: |
+      Start here to inventory schedules. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -23904,6 +24150,9 @@ tables:
             - users
   - name: service_custom_field_field_options
     description: List Field Options
+    guide: |
+      Use this table to list Field Options. Requires `field_id` from the
+      relevant custom-field catalog table.
     filters:
       - name: field_id
         required: true
@@ -24087,6 +24336,9 @@ tables:
             - updated_at
   - name: service_custom_field_values
     description: Get Custom Field Values
+    guide: |
+      Use this table to get Custom Field Values. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -24189,6 +24441,8 @@ tables:
             - value
   - name: service_custom_fields
     description: List Fields
+    guide: |
+      Use this table to list Fields.
     filters:
       - name: field_id
         required: false
@@ -24489,6 +24743,9 @@ tables:
             - updated_at
   - name: service_dependency_business_services
     description: Get Business Service dependencies
+    guide: |
+      Use this table to get Business Service dependencies. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -24588,6 +24845,10 @@ tables:
       by Impact, secondarily by most recently impacted, and finally by name. To get Impact information about a specific Business Service on the Status
       Dashboard that does not appear in the Impact-sorted response, use the `ids[]` parameter on the `/business_services/impacts` endpoint. Scoped
       OAuth requires: `status_dashboards.read`
+    guide: |
+      Use this table to inspect service impacts. Requires `url_slug`
+      from the related status page configuration. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: url_slug
         required: true
@@ -24717,6 +24978,10 @@ tables:
           key: url_slug
   - name: service_integrations
     description: View an integration
+    guide: |
+      Use this table for View an integration. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Requires
+      `integration_id` from the matching integration table.
     filters:
       - name: id
         required: true
@@ -25019,6 +25284,9 @@ tables:
           key: integration_id
   - name: service_rules
     description: List Service's Event Rules
+    guide: |
+      Use this table to list Service's Event Rules. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -25642,6 +25910,9 @@ tables:
             - variables
   - name: services
     description: List services
+    guide: |
+      Start here to inventory services. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: query
         required: false
@@ -26885,6 +27156,8 @@ tables:
             - type
   - name: session_configurations
     description: Get an account's session configurations
+    guide: |
+      Use this table to get an account's session configurations.
     filters:
       - name: type
         required: false
@@ -26936,6 +27209,10 @@ tables:
             - type
   - name: severities
     description: List Status Page Severities
+    guide: |
+      Start here to inventory severities. Pass `id` to hit the single-
+      record endpoint when you need details for one row. Use `id` values
+      from here in related tables and drill-down queries.
     filters:
       - name: id
         required: true
@@ -27143,6 +27420,11 @@ tables:
             - type
   - name: standard_scores
     description: List resources' standards scores
+    guide: |
+      Use this table to list resources' standards scores. Use `ids` to
+      scope this endpoint to the records you actually want. Use
+      `resource_type` to scope this endpoint to the records you actually
+      want.
     filters:
       - name: ids
         required: true
@@ -27227,6 +27509,8 @@ tables:
             - standards
   - name: standards
     description: List Standards
+    guide: |
+      Use this table to list Standards.
     filters:
       - name: active
         required: false
@@ -27320,6 +27604,11 @@ tables:
             - type
   - name: standards_score
     description: List a resource's standards scores
+    guide: |
+      Use this table to list a resource's standards scores. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
+      Use `resource_type` to scope this endpoint to the records you
+      actually want.
     filters:
       - name: id
         required: true
@@ -27397,6 +27686,9 @@ tables:
             - type
   - name: status_dashboards
     description: List Status Dashboards
+    guide: |
+      Start here to inventory status dashboards. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: false
@@ -27481,6 +27773,9 @@ tables:
             - url_slug
   - name: status_page_impacts
     description: List Status Page Impacts
+    guide: |
+      Use this table to list Status Page Impacts. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -27688,6 +27983,9 @@ tables:
             - type
   - name: status_page_services
     description: List Status Page Services
+    guide: |
+      Use this table to list Status Page Services. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -27889,6 +28187,9 @@ tables:
             - type
   - name: status_pages
     description: List Status Pages
+    guide: |
+      Start here to inventory status pages. Use `id` values from here in
+      related tables and drill-down queries.
     filters:
       - name: status_page_type
         required: false
@@ -27971,6 +28272,11 @@ tables:
             - url
   - name: status_update_notification_rules
     description: List a user's status update notification rules.
+    guide: |
+      Use this table to list a user's status update notification rules.
+      Requires `id` from `pagerduty.users`; add
+      `status_update_notification_rule_id` when you want one specific
+      rule.
     filters:
       - name: id
         required: true
@@ -28097,6 +28403,9 @@ tables:
             - status_update_notification_rules
   - name: statuses
     description: List Status Page Statuses
+    guide: |
+      Use this table to list Status Page Statuses. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -28304,6 +28613,9 @@ tables:
             - type
   - name: subscriptions
     description: List Status Page Subscriptions
+    guide: |
+      Use this table to list Status Page Subscriptions. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -28596,6 +28908,11 @@ tables:
             - type
   - name: tag
     description: Get connected entities
+    guide: |
+      Use this table to get connected entities. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Use
+      `entity_type` to scope this endpoint to the records you actually
+      want.
     filters:
       - name: total
         required: false
@@ -28698,6 +29015,9 @@ tables:
             - users
   - name: tags
     description: List tags
+    guide: |
+      Start here to inventory tags. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -28896,6 +29216,10 @@ tables:
           key: entity_type
   - name: teams
     description: Get all team references associated with an Automation Action
+    guide: |
+      Start here to inventory teams. Pass `id` to hit the single-record
+      endpoint when you need details for one row. Use `id` values from
+      here in related tables and drill-down queries.
     filters:
       - name: id
         required: true
@@ -29039,6 +29363,10 @@ tables:
             - type
   - name: technical_services
     description: Get technical service dependencies
+    guide: |
+      Start here to inventory technical services. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Use `id`
+      values from here in related tables and drill-down queries.
     filters:
       - name: id
         required: true
@@ -29133,6 +29461,9 @@ tables:
             - type
   - name: templates
     description: List templates
+    guide: |
+      Use this table to list templates. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -29697,6 +30028,9 @@ tables:
             - type
   - name: triggers
     description: List Triggers
+    guide: |
+      Use this table to list Triggers. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: workflow_id
         required: false
@@ -30265,6 +30599,8 @@ tables:
           key: workflow_name_contains
   - name: types
     description: List incident types
+    guide: |
+      Use this table to list incident types.
     filters:
       - name: filter
         required: false
@@ -30539,6 +30875,9 @@ tables:
             - updated_at
   - name: unrouted
     description: Get the Unrouted Orchestration for an Event Orchestration
+    guide: |
+      Use this table to inspect the unrouted orchestration for an Event
+      Orchestration. Requires `id` for the parent event orchestration.
     filters:
       - name: id
         required: true
@@ -30573,6 +30912,9 @@ tables:
             - orchestration_path
   - name: url_slugs
     description: Get a single Status Dashboard by `url_slug`
+    guide: |
+      Use this table to get a single Status Dashboard by `url_slug`.
+      Requires `url_slug` from the related status page configuration.
     filters:
       - name: url_slug
         required: true
@@ -30634,6 +30976,10 @@ tables:
           key: url_slug
   - name: user_session
     description: Get a user's session
+    guide: |
+      Use this table to get a user's session. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Use
+      `type` to scope this endpoint to the records you actually want.
     filters:
       - name: id
         required: true
@@ -30736,6 +31082,9 @@ tables:
             - user_id
   - name: user_sessions
     description: List a user's active sessions
+    guide: |
+      Use this table to list a user's active sessions. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: true
@@ -30799,6 +31148,9 @@ tables:
             - user_id
   - name: users
     description: List users
+    guide: |
+      Start here to inventory users. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: query
         required: false
@@ -31229,6 +31581,9 @@ tables:
             - type
   - name: vendors
     description: List vendors
+    guide: |
+      Start here to inventory vendors. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -31373,6 +31728,9 @@ tables:
             - website_url
   - name: webhook_subscriptions
     description: List webhook subscriptions
+    guide: |
+      Use this table to list webhook subscriptions. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: total
         required: false
@@ -31836,6 +32194,8 @@ tables:
             - type
   - name: workflow_integration_connections
     description: 'List all Workflow Integration Connections. Scoped OAuth requires: `workflow_integrations:connections.read`'
+    guide: |
+      Use this table to inspect workflow integration connections.
     filters:
       - name: name
         required: false
@@ -32061,6 +32421,9 @@ tables:
             - type
   - name: workflow_integrations
     description: List Workflow Integrations
+    guide: |
+      Use this table to list Workflow Integrations. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: include_deprecated
         required: false
@@ -32273,6 +32636,10 @@ tables:
             - type
   - name: workflows_integration_connections
     description: List Workflow Integration Connections
+    guide: |
+      Use this table to list Workflow Integration Connections. Requires
+      `integration_id` from the matching integration table. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: integration_id
         required: true

--- a/sources/posthog/manifest.yaml
+++ b/sources/posthog/manifest.yaml
@@ -31,6 +31,10 @@ test_queries:
 tables:
   - name: actions
     description: project_actions
+    guide: |
+      Use this table to inspect saved action definitions. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: format
         required: false
@@ -442,6 +446,9 @@ tables:
             - user_access_level
   - name: active
     description: Get active breakpoints (External API)
+    guide: |
+      Use this table to inspect active. Requires `project_id`, typically
+      from `posthog.projects`.
     filters:
       - name: enabled
         required: false
@@ -542,6 +549,11 @@ tables:
             - repository
   - name: activity
     description: Create, Read, Update and Delete Warehouse Tables.
+    guide: |
+      Use this table to review warehouse activity records. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -841,6 +853,11 @@ tables:
           key: project_id
   - name: activity_log
     description: project_activity_log
+    guide: |
+      Use this table to review project activity log entries. Requires
+      `project_id`, typically from `posthog.projects`. Best used after
+      inventory tables identify the entity or time range you want to
+      investigate.
     filters:
       - name: item_id
         required: false
@@ -1072,6 +1089,11 @@ tables:
             - was_impersonated
   - name: advanced_activity_logs
     description: project_advanced_activity_logs
+    guide: |
+      Use this table to review advanced activity log entries. Requires
+      `project_id`, typically from `posthog.projects`. Best used after
+      inventory tables identify the entity or time range you want to
+      investigate.
     filters:
       - name: project_id
         required: true
@@ -1268,6 +1290,11 @@ tables:
             - was_impersonated
   - name: alerts
     description: environment_alerts
+    guide: |
+      Use this table to inspect alert configurations. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -1950,6 +1977,10 @@ tables:
   - name: annotations
     description: Create, Read, Update and Delete annotations. [See docs](https://posthog.com/docs/data/annotations) for more
       information on annotations.
+    guide: |
+      Use this table to inspect annotations. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -2217,6 +2248,10 @@ tables:
             - updated_at
   - name: assignment_rules
     description: environment_error_tracking_assignment_rules
+    guide: |
+      Use this table to inspect assignment rules. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -2327,6 +2362,9 @@ tables:
             - updated_at
   - name: available_filters
     description: project_advanced_activity_logs_available_filters
+    guide: |
+      Use this table to inspect available filters for a query surface.
+      Requires `project_id`, typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -2526,6 +2564,11 @@ tables:
       ViewSet for BatchExportBackfill models.
 
       Allows creating and reading backfills, but not updating or deleting them.
+    guide: |
+      Use this table to inspect backfill runs. Requires
+      `batch_export_id`; fetch candidate values from
+      `posthog.batch_exports` when available. Requires `environment_id`
+      from the related PostHog environment or API response.
     filters:
       - name: batch_export_id
         required: true
@@ -2750,6 +2793,10 @@ tables:
           key: project_id
   - name: batch_exports
     description: environment_batch_exports
+    guide: |
+      Use this table to inspect batch exports. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -3150,6 +3197,10 @@ tables:
           key: project_id
   - name: batch_jobs
     description: environment_hog_flow_batch_jobs
+    guide: |
+      Use this table to inspect batch jobs. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -3357,6 +3408,9 @@ tables:
           key: project_id
   - name: breakpoint_hits
     description: Get breakpoint hits
+    guide: |
+      Use this table to inspect live debugger breakpoint hits. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: breakpoint_ids
         required: false
@@ -3471,6 +3525,10 @@ tables:
             - variables
   - name: by_name
     description: Get event definition by exact name
+    guide: |
+      Use this table to inspect by name. Use `name` to narrow the result
+      set before doing heavier joins or exports. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: name
         required: true
@@ -3535,6 +3593,10 @@ tables:
             - properties
   - name: cohorts
     description: project_cohorts
+    guide: |
+      Start here to inventory cohorts. Requires `project_id`, typically
+      from `posthog.projects`. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -3868,6 +3930,10 @@ tables:
             - version
   - name: collaborators
     description: environment_dashboard_collaborators
+    guide: |
+      Use this table to inspect dashboard collaborators. Requires
+      `dashboard_id` from the relevant dashboard listing. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: dashboard_id
         required: true
@@ -4039,6 +4105,10 @@ tables:
             - user_uuid
   - name: connection_token
     description: Get sandbox connection token
+    guide: |
+      Use this table to inspect connection token. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -4093,6 +4163,10 @@ tables:
             - token
   - name: connections
     description: Create, Read, Update and Delete External data Sources.
+    guide: |
+      Use this table to inspect external data connections. Requires
+      `environment_id` from the related PostHog environment or API
+      response.
     filters:
       - name: environment_id
         required: true
@@ -4183,6 +4257,9 @@ tables:
           key: project_id
   - name: conversations
     description: environment_conversations
+    guide: |
+      Use this table to inspect conversations. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -4438,6 +4515,9 @@ tables:
             - uuid
   - name: counts
     description: Review state counts for the runs list.
+    guide: |
+      Use this table to inspect counts. Requires `project_id`, typically
+      from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -4496,6 +4576,10 @@ tables:
             - stale
   - name: customer_profile_configs
     description: environment_customer_profile_configs
+    guide: |
+      Use this table to inspect customer profile configs. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -4587,6 +4671,10 @@ tables:
             - updated_at
   - name: dashboard_templates
     description: project_dashboard_templates
+    guide: |
+      Use this table to inspect dashboard templates. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: is_featured
         required: false
@@ -4764,6 +4852,11 @@ tables:
             - variables
   - name: data_color_themes
     description: environment_data_color_themes
+    guide: |
+      Use this table to inspect data color themes. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -4943,6 +5036,10 @@ tables:
           key: project_id
   - name: dataset_items
     description: environment_dataset_items
+    guide: |
+      Use this table to inspect dataset items. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: dataset
         required: false
@@ -5188,6 +5285,10 @@ tables:
           key: project_id
   - name: datasets
     description: environment_datasets
+    guide: |
+      Use this table to inspect datasets. Requires `environment_id` from
+      the related PostHog environment or API response. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -5451,6 +5552,11 @@ tables:
           key: project_id
   - name: dependencies
     description: Return the count of immediate upstream and downstream dependencies for this saved query.
+    guide: |
+      Use this table to inspect dependency counts between configs.
+      Requires `environment_id` from the related PostHog environment or
+      API response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -5750,6 +5856,10 @@ tables:
           key: project_id
   - name: dependent_configs
     description: Get evaluations using this key and alternative keys for replacement.
+    guide: |
+      Use this table to inspect dependent configs. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -5953,6 +6063,10 @@ tables:
             - state
   - name: dependent_flags
     description: Get other active flags that depend on this flag.
+    guide: |
+      Use this table to inspect dependent flags. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -6011,6 +6125,10 @@ tables:
       RESTful API for managing desktop meeting recordings.
 
       Standard CRUD operations plus transcript management as a subresource.
+    guide: |
+      Use this table to inspect desktop recordings. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -6262,6 +6380,10 @@ tables:
             - video_url
   - name: domains
     description: domains
+    guide: |
+      Use this table to inspect verified domains. Requires
+      `organization_id` from `posthog.organizations`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: organization_id
         required: true
@@ -6421,6 +6543,10 @@ tables:
             - verified_at
   - name: draft_status
     description: Lightweight polling endpoint for draft change detection.
+    guide: |
+      Use this table to inspect draft status for a pending change. Pass
+      `id` to hit the single-record endpoint when you need details for
+      one row. Requires `project_id`, typically from `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -6473,6 +6599,10 @@ tables:
             - updated_at
   - name: early_access_feature
     description: project_early_access_feature
+    guide: |
+      Use this table to inspect early access feature. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -6707,6 +6837,11 @@ tables:
             - stage
   - name: elements
     description: environment_elements
+    guide: |
+      Use this table to inspect event elements. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -6837,6 +6972,9 @@ tables:
           key: project_id
   - name: endpoints
     description: List all endpoints for the team.
+    guide: |
+      Use this table to inspect endpoints. Requires `environment_id`
+      from the related PostHog environment or API response.
     filters:
       - name: created_by
         required: false
@@ -7290,6 +7428,11 @@ tables:
           key: project_id
   - name: environment_llm_prompt_name
     description: environment_llm_prompts_name
+    guide: |
+      Use this table to inspect environment llm prompt name. Requires
+      `project_id`, typically from `posthog.projects`. Use `prompt_name`
+      from `posthog.llm_prompts` when drilling into prompt-specific
+      endpoints.
     filters:
       - name: project_id
         required: true
@@ -7419,6 +7562,11 @@ tables:
             - version_count
   - name: environment_llm_prompt_resolve_name
     description: environment_llm_prompts_resolve_name
+    guide: |
+      Use this table to inspect environment llm prompt resolve name.
+      Requires `project_id`, typically from `posthog.projects`. Use
+      `prompt_name` from `posthog.llm_prompts` when drilling into
+      prompt-specific endpoints.
     filters:
       - name: before_version
         required: false
@@ -7614,6 +7762,11 @@ tables:
           key: version_id
   - name: environment_log_alerts
     description: environment_logs_alerts
+    guide: |
+      Use this table to inspect environment log alerts. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -7914,6 +8067,10 @@ tables:
           key: project_id
   - name: evaluations
     description: environment_evaluations
+    guide: |
+      Use this table to inspect feature flag evaluations. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: enabled
         required: false
@@ -8244,6 +8401,10 @@ tables:
             - updated_at
   - name: event_definitions
     description: project_event_definitions
+    guide: |
+      Use this table to inspect event definitions. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -8710,6 +8871,9 @@ tables:
             - uuid
   - name: event_schemas
     description: project_event_schemas
+    guide: |
+      Use this table to inspect event schemas. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -8789,6 +8953,11 @@ tables:
       is kept only for backwards compatibility.\n        If you ever ask about it you will be advised to not use it...\n        If
       you want to ad-hoc list or aggregate events, use the Query endpoint instead.\n        If you want to export all events
       or many pages of events you should use our CDP/Batch Exports products instead.\n        "
+    guide: |
+      Use this table to inspect raw event rows. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: distinct_id
         required: false
@@ -9070,6 +9239,10 @@ tables:
           key: project_id
   - name: experiment_holdouts
     description: project_experiment_holdouts
+    guide: |
+      Use this table to inspect experiment holdouts. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -9243,6 +9416,10 @@ tables:
             - updated_at
   - name: experiment_saved_metrics
     description: project_experiment_saved_metrics
+    guide: |
+      Use this table to inspect experiment saved metrics. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -9433,6 +9610,10 @@ tables:
             - user_access_level
   - name: experiments
     description: List experiments for the current project. Supports filtering by status and archival state.
+    guide: |
+      Start here to inventory experiments. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -9991,6 +10172,10 @@ tables:
             - user_access_level
   - name: exports
     description: environment_exports
+    guide: |
+      Use this table to inspect export jobs. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -10130,6 +10315,11 @@ tables:
           key: project_id
   - name: external_data_sources
     description: Create, Read, Update and Delete External data Sources.
+    guide: |
+      Use this table to inspect external data sources. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -10366,6 +10556,10 @@ tables:
           key: project_id
   - name: feature_flags
     description: Create, read, update, and delete feature flags.
+    guide: |
+      Start here to inventory feature flags. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: active
         required: false
@@ -10942,6 +11136,11 @@ tables:
             - version
   - name: file_system
     description: environment_file_system
+    guide: |
+      Use this table to inspect the file system view. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -11090,6 +11289,11 @@ tables:
           key: project_id
   - name: file_system_shortcut
     description: environment_file_system_shortcut
+    guide: |
+      Use this table to inspect file system shortcuts. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -11188,6 +11392,10 @@ tables:
           key: project_id
   - name: fingerprints
     description: environment_error_tracking_fingerprints
+    guide: |
+      Use this table to inspect error-tracking fingerprints. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -11256,6 +11464,11 @@ tables:
           key: project_id
   - name: github_branches
     description: environment_integration_github_branches
+    guide: |
+      Use this table to inspect connected GitHub branches. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -11344,6 +11557,11 @@ tables:
           key: project_id
   - name: github_repos
     description: environment_integration_github_repos
+    guide: |
+      Use this table to inspect connected GitHub repositories. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -11414,6 +11632,10 @@ tables:
           key: project_id
   - name: grouping_rules
     description: environment_error_tracking_grouping_rules
+    guide: |
+      Use this table to inspect grouping rules. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -11534,6 +11756,11 @@ tables:
   - name: groups
     description: List all groups of a specific group type. You must pass ?group_type_index= in the URL. To get a list of valid
       group types, call /api/:project_id/groups_types/
+    guide: |
+      Use this table to inspect groups. Requires `environment_id` from
+      the related PostHog environment or API response. Use
+      `group_type_index` to scope this endpoint to the records you
+      actually want.
     filters:
       - name: environment_id
         required: true
@@ -11635,6 +11862,9 @@ tables:
           key: project_id
   - name: groups_types
     description: project_groups_types
+    guide: |
+      Use this table to inspect group types. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -11717,6 +11947,10 @@ tables:
           key: project_id
   - name: health_issues
     description: environment_health_issues
+    guide: |
+      Use this table to inspect health issues. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -11825,6 +12059,9 @@ tables:
             - updated_at
   - name: heatmaps
     description: environment_heatmaps
+    guide: |
+      Use this table to inspect heatmaps. Requires `environment_id` from
+      the related PostHog environment or API response.
     filters:
       - name: environment_id
         required: true
@@ -11876,6 +12113,10 @@ tables:
           key: project_id
   - name: hog_flows
     description: environment_hog_flows
+    guide: |
+      Use this table to inspect hog flows. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: created_at
         required: false
@@ -12296,6 +12537,9 @@ tables:
           key: project_id
   - name: hog_function_templates
     description: project_hog_function_templates
+    guide: |
+      Use this table to inspect hog function templates. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -12518,6 +12762,10 @@ tables:
             - use_all_events_by_default
   - name: hog_functions
     description: environment_hog_functions
+    guide: |
+      Use this table to inspect hog functions. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: created_at
         required: false
@@ -13058,6 +13306,11 @@ tables:
           key: project_id
   - name: insight_variables
     description: environment_insight_variables
+    guide: |
+      Use this table to inspect insight variables. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -13185,6 +13438,10 @@ tables:
       request.META["_coalesced_response"] for followers. This mixin runs DRF's
       initial() (auth + permissions + throttling) before returning the
       cached response, ensuring the request is authorized.
+    guide: |
+      Start here to inventory insights. Requires `environment_id` from
+      the related PostHog environment or API response. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: basic
         required: false
@@ -15034,6 +15291,10 @@ tables:
           key: project_id
   - name: integrations
     description: environment_integrations
+    guide: |
+      Use this table to inspect integrations. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -15250,6 +15511,9 @@ tables:
           key: project_id
   - name: invites
     description: invites
+    guide: |
+      Use this table to inspect organization invites. Requires
+      `organization_id` from `posthog.organizations`.
     filters:
       - name: organization_id
         required: true
@@ -15464,6 +15728,10 @@ tables:
             - updated_at
   - name: is_generating_demo_data
     description: Projects for the current organization.
+    guide: |
+      Use this table to inspect is generating demo data. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
+      Requires `organization_id` from `posthog.organizations`.
     filters:
       - name: id
         required: true
@@ -15533,6 +15801,10 @@ tables:
             - updated_at
   - name: issues
     description: environment_error_tracking_issues
+    guide: |
+      Use this table to inspect issue records. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -15718,6 +15990,10 @@ tables:
             - status
   - name: live_debugger_breakpoints
     description: Create, Read, Update and Delete breakpoints for live debugging.
+    guide: |
+      Use this table to inspect live debugger breakpoints. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: filename
         required: false
@@ -15829,6 +16105,9 @@ tables:
             - updated_at
   - name: llm_prompts
     description: environment_llm_prompts
+    guide: |
+      Use this table to inspect LLM prompts. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -16050,6 +16329,9 @@ tables:
             - version_count
   - name: local_evaluation
     description: Create, read, update, and delete feature flags.
+    guide: |
+      Use this table to inspect local evaluation. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -16208,6 +16490,10 @@ tables:
   - name: log
     description: Get query log details from query_log_archive table for a specific query_id, the query must have been issued
       in last 24 hours.
+    guide: |
+      Use this table to inspect log. Requires `environment_id` from the
+      related PostHog environment or API response. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -16266,6 +16552,11 @@ tables:
           key: project_id
   - name: logs
     description: environment_plugin_config_logs
+    guide: |
+      Use this table to inspect logs. Requires `environment_id` from the
+      related PostHog environment or API response. Requires
+      `plugin_config_id`; fetch candidate values from
+      `posthog.plugin_configs` when available.
     filters:
       - name: environment_id
         required: true
@@ -16394,6 +16685,11 @@ tables:
           key: project_id
   - name: materialization_status
     description: Get materialization status for an endpoint. Supports ?version=N query param.
+    guide: |
+      Use this table to inspect materialization status. Supports
+      ?version=N query param. Requires `environment_id` from the related
+      PostHog environment or API response. Use `name` to narrow the
+      result set before doing heavier joins or exports.
     filters:
       - name: environment_id
         required: true
@@ -16499,6 +16795,10 @@ tables:
           key: project_id
   - name: mcp_server_installations
     description: environment_mcp_server_installations
+    guide: |
+      Use this table to inspect mcp server installations. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -16642,6 +16942,9 @@ tables:
             - url
   - name: mcp_servers
     description: environment_mcp_servers
+    guide: |
+      Use this table to inspect mcp servers. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -16706,6 +17009,10 @@ tables:
             - url
   - name: members
     description: members
+    guide: |
+      Start here to inventory members. Requires `organization_id` from
+      `posthog.organizations`. Use `id` values from here in related
+      tables and drill-down queries.
     filters:
       - name: organization_id
         required: true
@@ -16878,6 +17185,10 @@ tables:
             - uuid
   - name: metrics
     description: project_groups_type_metrics
+    guide: |
+      Start here to inventory metrics. Use `group_type_index` to scope
+      this endpoint to the records you actually want. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: group_type_index
         required: true
@@ -16979,6 +17290,9 @@ tables:
           key: project_id
   - name: my_flags
     description: Create, read, update, and delete feature flags.
+    guide: |
+      Use this table to inspect my flags. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: groups
         required: false
@@ -17164,6 +17478,10 @@ tables:
   - name: notebooks
     description: The API for interacting with Notebooks. This feature is in early access and the API can have breaking changes
       without announcement.
+    guide: |
+      Use this table to inspect notebooks. Requires `project_id`,
+      typically from `posthog.projects`. Keep time filters tight so the
+      endpoint stays fast and the results stay interpretable.
     filters:
       - name: contains
         required: false
@@ -17535,6 +17853,9 @@ tables:
             - version
   - name: oauth_applications
     description: ViewSet for listing OAuth applications at the organization level (read-only).
+    guide: |
+      Use this table to inspect oauth applications. Requires
+      `organization_id` from `posthog.organizations`.
     filters:
       - name: organization_id
         required: true
@@ -17619,6 +17940,10 @@ tables:
             - updated
   - name: object_media_previews
     description: project_object_media_previews
+    guide: |
+      Use this table to inspect object media previews. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -17736,6 +18061,10 @@ tables:
       This is read-only. Creation is handled by the integration installation flows
       (e.g., Vercel marketplace installation). Deletion requires contacting support
       due to billing implications.
+    guide: |
+      Use this table to inspect organization integrations. Requires
+      `organization_id` from `posthog.organizations`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: organization_id
         required: true
@@ -17908,6 +18237,10 @@ tables:
             - updated_at
   - name: organization_project_activity
     description: Projects for the current organization.
+    guide: |
+      Use this table to inspect organization project activity. Pass `id`
+      to hit the single-record endpoint when you need details for one
+      row. Requires `organization_id` from `posthog.organizations`.
     filters:
       - name: id
         required: true
@@ -17977,6 +18310,9 @@ tables:
             - updated_at
   - name: organizations
     description: organizations
+    guide: |
+      Start here to inventory organizations. Pass `id` to hit the
+      single-record endpoint when you need details for one row.
     filters:
       - name: id
         required: false
@@ -18212,6 +18548,11 @@ tables:
             - updated_at
   - name: persisted_folder
     description: environment_persisted_folder
+    guide: |
+      Use this table to inspect persisted folder. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -18314,6 +18655,10 @@ tables:
           key: project_id
   - name: persons
     description: Read and delete PostHog persons; create or update via the capture API, $set/$unset properties, or SDKs.
+    guide: |
+      Start here to inventory persons. Requires `environment_id` from
+      the related PostHog environment or API response. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: distinct_id
         required: false
@@ -18507,6 +18852,9 @@ tables:
       Get the preferred media preview for an event definition.
       Most recent user-uploaded, then most recent exported asset.
       Requires event_definition (query param).
+    guide: |
+      Use this table to inspect preferred for event. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -18606,6 +18954,10 @@ tables:
             - uploaded_media_id
   - name: product_tours
     description: project_product_tours
+    guide: |
+      Use this table to inspect product tours. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -19122,6 +19474,10 @@ tables:
             - updated_at
   - name: project_feature_flag_activity
     description: Create, read, update, and delete feature flags.
+    guide: |
+      Use this table to inspect project feature flag activity. Pass `id`
+      to hit the single-record endpoint when you need details for one
+      row. Requires `project_id`, typically from `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -19336,6 +19692,11 @@ tables:
             - user
   - name: project_feature_flags_activity
     description: Create, read, update, and delete feature flags.
+    guide: |
+      Use this table to inspect project feature flags activity. Requires
+      `project_id`, typically from `posthog.projects`. Best used after
+      inventory tables identify the entity or time range you want to
+      investigate.
     filters:
       - name: project_id
         required: true
@@ -19548,6 +19909,11 @@ tables:
             - user
   - name: project_secret_api_keys
     description: environment_project_secret_api_keys
+    guide: |
+      Use this table to inspect project secret api keys. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -19679,6 +20045,10 @@ tables:
 
       Returns:
           Survey statistics including event counts, unique respondents, and conversion rates
+    guide: |
+      Use this table to inspect project survey stats. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
+      Requires `project_id`, typically from `posthog.projects`.
     filters:
       - name: date_from
         required: false
@@ -19795,6 +20165,11 @@ tables:
 
       Returns:
           Aggregated statistics across all surveys including total counts and rates
+    guide: |
+      Use this table to inspect project surveys stats. Requires
+      `project_id`, typically from `posthog.projects`. Keep time filters
+      tight so the endpoint stays fast and the results stay
+      interpretable.
     filters:
       - name: date_from
         required: false
@@ -19866,6 +20241,10 @@ tables:
             - stats
   - name: project_task_runs
     description: List task runs
+    guide: |
+      Use this table to inspect project task runs. Requires
+      `project_id`, typically from `posthog.projects`. Requires
+      `task_id` from `posthog.tasks`.
     filters:
       - name: project_id
         required: true
@@ -20096,6 +20475,10 @@ tables:
             - uploaded_at
   - name: project_visual_review_runs
     description: List runs for the team, optionally filtered by review state.
+    guide: |
+      Use this table to inspect project visual review runs. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -20311,6 +20694,10 @@ tables:
             - unchanged
   - name: projects
     description: Projects for the current organization.
+    guide: |
+      Start here to inventory projects. Requires `organization_id` from
+      `posthog.organizations`. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: organization_id
         required: true
@@ -20490,6 +20877,11 @@ tables:
       - timestamp: ISO datetime string for the point in time (e.g., "2023-06-15T14:30:00Z")
       - include_set_once: Whether to handle $set_once operations (default: false)
       - debug: Whether to include debug information with raw events (default: false)
+    guide: |
+      Use this table to inspect properties at time. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Use `timestamp` to scope this endpoint to the records
+      you actually want.
     filters:
       - name: debug
         required: false
@@ -20819,6 +21211,10 @@ tables:
           key: project_id
   - name: property_definitions
     description: project_property_definitions
+    guide: |
+      Start here to inventory property definitions. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: event_names
         required: false
@@ -21268,6 +21664,10 @@ tables:
             - uuid
   - name: provider_keys
     description: environment_llm_analytics_provider_keys
+    guide: |
+      Use this table to inspect provider keys. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -21480,6 +21880,10 @@ tables:
   - name: proxy_records
     description: List all reverse proxies configured for the organization. Returns proxy records along with the maximum number
       allowed by the current plan.
+    guide: |
+      Use this table to inspect proxy records. Requires
+      `organization_id` from `posthog.organizations`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: organization_id
         required: true
@@ -21602,6 +22006,8 @@ tables:
             - updated_at
   - name: public_hog_function_templates
     description: public_hog_function_templates
+    guide: |
+      Use this table to inspect public hog function templates.
     filters:
       - name: template_id
         required: false
@@ -21781,6 +22187,10 @@ tables:
           key: types
   - name: query
     description: (Experimental)
+    guide: |
+      Use this table to inspect query results. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -22041,6 +22451,10 @@ tables:
           key: project_id
   - name: queue
     description: environment_conversation_queue
+    guide: |
+      Use this table to inspect queue. Use `conversation` to scope this
+      endpoint to the records you actually want. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: conversation
         required: true
@@ -22288,6 +22702,10 @@ tables:
             - uuid
   - name: releases
     description: environment_error_tracking_releases
+    guide: |
+      Use this table to inspect releases. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -22384,6 +22802,10 @@ tables:
             - version
   - name: repos
     description: List all projects for the team.
+    guide: |
+      Use this table to inspect repos. Requires `project_id`, typically
+      from `posthog.projects`. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -22476,6 +22898,10 @@ tables:
             - team_id
   - name: repository_readiness
     description: Get repository readiness
+    guide: |
+      Use this table to inspect repository readiness. Requires
+      `project_id`, typically from `posthog.projects`. Use `repository`
+      to scope this endpoint to the records you actually want.
     filters:
       - name: project_id
         required: true
@@ -22840,6 +23266,10 @@ tables:
           key: window_days
   - name: review_queue_items
     description: environment_llm_analytics_review_queue_items
+    guide: |
+      Use this table to inspect review queue items. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: order_by
         required: false
@@ -23074,6 +23504,10 @@ tables:
             - updated_at
   - name: review_queues
     description: environment_llm_analytics_review_queues
+    guide: |
+      Use this table to inspect review queues. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: name
         required: false
@@ -23281,6 +23715,11 @@ tables:
             - updated_at
   - name: role_memberships
     description: role_role_memberships
+    guide: |
+      Use this table to inspect role memberships. Requires
+      `organization_id` from `posthog.organizations`. Requires
+      `role_id`; fetch candidate values from `posthog.roles` when
+      available.
     filters:
       - name: organization_id
         required: true
@@ -23456,6 +23895,10 @@ tables:
             - user_uuid
   - name: roles
     description: roles
+    guide: |
+      Start here to inventory roles. Requires `organization_id` from
+      `posthog.organizations`. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: organization_id
         required: true
@@ -23627,6 +24070,10 @@ tables:
           key: organization_id
   - name: run_history
     description: Return the recent run history (up to 5 most recent) for this materialized view.
+    guide: |
+      Use this table to inspect run history. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -23926,6 +24373,11 @@ tables:
           key: project_id
   - name: runs
     description: environment_batch_export_runs
+    guide: |
+      Use this table to inspect runs. Requires `batch_export_id`; fetch
+      candidate values from `posthog.batch_exports` when available.
+      Requires `environment_id` from the related PostHog environment or
+      API response.
     filters:
       - name: batch_export_id
         required: true
@@ -24142,6 +24594,10 @@ tables:
           key: project_id
   - name: sandbox_environments
     description: API for managing sandbox environments that control network access for task runs.
+    guide: |
+      Use this table to inspect sandbox environments. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -24374,6 +24830,9 @@ tables:
             - updated_at
   - name: saved
     description: environment_saved
+    guide: |
+      Use this table to inspect saved items. Requires `environment_id`
+      from the related PostHog environment or API response.
     filters:
       - name: environment_id
         required: true
@@ -24630,6 +25089,10 @@ tables:
           key: project_id
   - name: schedules
     description: environment_hog_flow_schedules
+    guide: |
+      Use this table to inspect schedules. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: created_at
         required: false
@@ -24781,6 +25244,10 @@ tables:
           key: project_id
   - name: schema_property_groups
     description: project_schema_property_groups
+    guide: |
+      Use this table to inspect schema property groups. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -24992,6 +25459,10 @@ tables:
             - updated_at
   - name: scoped_api_keys
     description: member_scoped_api_keys
+    guide: |
+      Use this table to inspect scoped api keys. Requires
+      `organization_id` from `posthog.organizations`. Use `user__uuid`
+      to scope this endpoint to the records you actually want.
     filters:
       - name: organization_id
         required: true
@@ -25164,6 +25635,10 @@ tables:
             - uuid
   - name: score_definitions
     description: environment_llm_analytics_score_definitions
+    guide: |
+      Use this table to inspect score definitions. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: archived
         required: false
@@ -25501,6 +25976,10 @@ tables:
             - updated_at
   - name: session_group_summaries
     description: API for retrieving and managing stored group session summaries.
+    guide: |
+      Use this table to inspect session group summaries. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -25703,6 +26182,10 @@ tables:
             - title
   - name: session_recording_playlists
     description: Override list to include synthetic playlists
+    guide: |
+      Use this table to inspect session recording playlists. Requires
+      `environment_id` from the related PostHog environment or API
+      response.
     filters:
       - name: created_by
         required: false
@@ -26060,6 +26543,11 @@ tables:
           key: project_id
   - name: session_recordings
     description: environment_session_recordings
+    guide: |
+      Use this table to inspect session recordings. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -26388,6 +26876,10 @@ tables:
           key: project_id
   - name: sharing
     description: environment_dashboard_sharing
+    guide: |
+      Use this table to inspect sharing. Requires `dashboard_id` from
+      the relevant dashboard listing. Requires `environment_id` from the
+      related PostHog environment or API response.
     filters:
       - name: dashboard_id
         required: true
@@ -26525,6 +27017,10 @@ tables:
           key: project_id
   - name: signal_source_configs
     description: project_signal_source_configs
+    guide: |
+      Use this table to inspect signal source configs. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -26640,6 +27136,11 @@ tables:
             - updated_at
   - name: snapshot_history
     description: Recent change history for a snapshot identifier across runs.
+    guide: |
+      Use this table to inspect snapshot history. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Use
+      `identifier` to scope this endpoint to the records you actually
+      want.
     filters:
       - name: id
         required: true
@@ -26731,6 +27232,10 @@ tables:
             - run_id
   - name: snapshots
     description: Get all snapshots for a run with diff results.
+    guide: |
+      Use this table to inspect snapshots. Pass `id` to hit the single-
+      record endpoint when you need details for one row. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -26992,6 +27497,10 @@ tables:
             - reviewed_at
   - name: spike_events
     description: environment_error_tracking_spike_events
+    guide: |
+      Use this table to inspect spike events. Requires `project_id`,
+      typically from `posthog.projects`. Best used after inventory
+      tables identify the entity or time range you want to investigate.
     filters:
       - name: project_id
         required: true
@@ -27087,6 +27596,10 @@ tables:
           key: project_id
   - name: status
     description: Create, read, update, and delete feature flags.
+    guide: |
+      Use this table to inspect status details. Pass `id` to hit the
+      single-record endpoint when you need details for one row. Requires
+      `project_id`, typically from `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -27141,6 +27654,11 @@ tables:
             - status
   - name: stream
     description: API for managing task runs. Each run represents an execution of a task.
+    guide: |
+      Use this table to inspect stream. Each run represents an execution
+      of a task. Pass `id` to hit the single-record endpoint when you
+      need details for one row. Requires `project_id`, typically from
+      `posthog.projects`.
     filters:
       - name: id
         required: true
@@ -27242,6 +27760,10 @@ tables:
             - uploaded_at
   - name: subscriptions
     description: environment_subscriptions
+    guide: |
+      Use this table to inspect subscriptions. Requires `environment_id`
+      from the related PostHog environment or API response. Pass `id` to
+      hit the single-record endpoint when you need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -27550,6 +28072,9 @@ tables:
           key: project_id
   - name: summary
     description: environment_health_issues_summary
+    guide: |
+      Use this table to inspect summary results. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -27648,6 +28173,10 @@ tables:
             - updated_at
   - name: suppression_rules
     description: environment_error_tracking_suppression_rules
+    guide: |
+      Use this table to inspect suppression rules. Requires
+      `project_id`, typically from `posthog.projects`. Pass `id` to hit
+      the single-record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -27740,6 +28269,10 @@ tables:
             - updated_at
   - name: surveys
     description: project_surveys
+    guide: |
+      Start here to inventory surveys. Requires `project_id`, typically
+      from `posthog.projects`. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: archived
         required: false
@@ -28547,6 +29080,10 @@ tables:
             - user_access_level
   - name: symbol_sets
     description: environment_error_tracking_symbol_sets
+    guide: |
+      Use this table to inspect symbol sets. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -28652,6 +29189,10 @@ tables:
             - team_id
   - name: tasks
     description: List tasks
+    guide: |
+      Use this table to inspect tasks. Requires `project_id`, typically
+      from `posthog.projects`. Pass `id` to hit the single-record
+      endpoint when you need details for one row.
     filters:
       - name: created_by
         required: false
@@ -28799,6 +29340,10 @@ tables:
             - title
   - name: thresholds
     description: environment_insight_thresholds
+    guide: |
+      Use this table to inspect thresholds. Requires `environment_id`
+      from the related PostHog environment or API response. Requires
+      `insight_id` from `posthog.insights`.
     filters:
       - name: environment_id
         required: true
@@ -29449,6 +29994,10 @@ tables:
           key: project_id
   - name: tickets
     description: List tickets with person data attached.
+    guide: |
+      Use this table to inspect tickets. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -29813,6 +30362,10 @@ tables:
             - updated_at
   - name: trace_reviews
     description: environment_llm_analytics_trace_reviews
+    guide: |
+      Use this table to inspect trace reviews. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: definition_id
         required: false
@@ -30333,6 +30886,9 @@ tables:
 
       Returns the sum of unread_team_count for all non-resolved tickets.
       Cached in Redis for 30 seconds, invalidated on changes.
+    guide: |
+      Use this table to inspect unread count. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -30687,6 +31243,9 @@ tables:
             - updated_at
   - name: user_home_settings
     description: user_home_setting
+    guide: |
+      Use this table to inspect user home settings. Use `uuid` to scope
+      this endpoint to the records you actually want.
     filters:
       - name: uuid
         required: true
@@ -30802,6 +31361,10 @@ tables:
           key: uuid
   - name: user_interviews
     description: environment_user_interviews
+    guide: |
+      Use this table to inspect user interviews. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true
@@ -30975,6 +31538,9 @@ tables:
             - transcript
   - name: users
     description: users
+    guide: |
+      Start here to inventory users. Use `id`, `slug` values from here
+      in related tables and drill-down queries.
     filters:
       - name: email
         required: false
@@ -31393,6 +31959,9 @@ tables:
       Returns:
 
       - Array of objects with 'name' field containing possible values
+    guide: |
+      Use this table to inspect property values. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: key
         required: false
@@ -31443,6 +32012,10 @@ tables:
           key: project_id
   - name: versions
     description: List all versions for an endpoint.
+    guide: |
+      Use this table to inspect versions. Requires `environment_id` from
+      the related PostHog environment or API response. Use `name` to
+      narrow the result set before doing heavier joins or exports.
     filters:
       - name: created_by
         required: false
@@ -31892,6 +32465,9 @@ tables:
           key: project_id
   - name: views
     description: environment_logs_views
+    guide: |
+      Use this table to inspect saved views. Requires `project_id`,
+      typically from `posthog.projects`.
     filters:
       - name: project_id
         required: true
@@ -32075,6 +32651,11 @@ tables:
             - updated_at
   - name: warehouse_saved_queries
     description: Create, Read, Update and Delete Warehouse Tables.
+    guide: |
+      Use this table to inspect saved warehouse queries. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -32397,6 +32978,11 @@ tables:
           key: project_id
   - name: warehouse_tables
     description: Create, Read, Update and Delete Warehouse Tables.
+    guide: |
+      Start here to inventory warehouse tables. Requires
+      `environment_id` from the related PostHog environment or API
+      response. Pass `id` to hit the single-record endpoint when you
+      need details for one row.
     filters:
       - name: environment_id
         required: true
@@ -32829,6 +33415,10 @@ tables:
           key: project_id
   - name: web_experiments
     description: project_web_experiments
+    guide: |
+      Use this table to inspect web experiments. Requires `project_id`,
+      typically from `posthog.projects`. Pass `id` to hit the single-
+      record endpoint when you need details for one row.
     filters:
       - name: project_id
         required: true

--- a/sources/sentry/manifest.yaml
+++ b/sources/sentry/manifest.yaml
@@ -27,6 +27,9 @@ test_queries:
 tables:
   - name: projects
     description: Sentry projects in the organization
+    guide: |
+      Start here to inventory projects. Use `id`, `slug` values from
+      here in related tables and drill-down queries.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/projects/
@@ -86,6 +89,9 @@ tables:
             - dateCreated
   - name: issues
     description: Sentry issues across projects
+    guide: |
+      Start here to inventory issues. Use `id` values from here in
+      related tables and drill-down queries.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/issues/
@@ -180,6 +186,11 @@ tables:
       - name: project
   - name: events
     description: Individual events for a specific issue
+    guide: |
+      Use this table for Individual events for a specific issue.
+      Requires `issue_id` from `sentry.issues`. Best used after
+      inventory tables identify the entity or time range you want to
+      investigate.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/issues/{{filter.issue_id}}/events/
@@ -277,6 +288,9 @@ tables:
         required: true
   - name: issue_tags
     description: Tags for a specific issue
+    guide: |
+      Use this table for Tags for a specific issue. Requires `issue_id`
+      from `sentry.issues`.
     request:
       method: GET
       path: /api/0/issues/{{filter.issue_id}}/tags/
@@ -324,6 +338,9 @@ tables:
         required: true
   - name: issue_participants
     description: Participants for a specific issue
+    guide: |
+      Use this table for Participants for a specific issue. Requires
+      `issue_id` from `sentry.issues`.
     request:
       method: GET
       path: /api/0/issues/{{filter.issue_id}}/participants/
@@ -387,6 +404,9 @@ tables:
         required: true
   - name: teams
     description: Teams in the organization
+    guide: |
+      Start here to inventory teams. Use `id`, `slug` values from here
+      in related tables and drill-down queries.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/teams/
@@ -454,6 +474,9 @@ tables:
             - hasAccess
   - name: members
     description: Organization members
+    guide: |
+      Start here to inventory members. Use `id` values from here in
+      related tables and drill-down queries.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/members/
@@ -541,6 +564,9 @@ tables:
             - inviteStatus
   - name: releases
     description: Organization releases
+    guide: |
+      Start here to inventory releases. Use `version` values from here
+      in related tables and drill-down queries.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/releases/
@@ -624,6 +650,10 @@ tables:
             - lastEvent
   - name: deployments
     description: Deployments for a release version
+    guide: |
+      Use this table for Deployments for a release version. Requires
+      `version` from `sentry.releases`. Use it after inventory tables
+      identify the entities worth investigating in detail.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/releases/{{filter.version}}/deploys/
@@ -693,6 +723,9 @@ tables:
         required: true
   - name: release_files
     description: Files for a release version
+    guide: |
+      Use this table for Files for a release version. Requires `version`
+      from `sentry.releases`.
     request:
       method: GET
       path: /api/0/organizations/{{input.SENTRY_ORG}}/releases/{{filter.version}}/files/
@@ -743,6 +776,11 @@ tables:
         required: true
   - name: project_events
     description: Recent events for a specific project
+    guide: |
+      Use this table for Recent events for a specific project. Use
+      `project` with a slug from `sentry.projects` to scope results to
+      one project. Best used after inventory tables identify the entity
+      or time range you want to investigate.
     request:
       method: GET
       path: /api/0/projects/{{input.SENTRY_ORG}}/{{filter.project}}/events/
@@ -844,6 +882,10 @@ tables:
         required: true
   - name: discover
     description: Sentry discover query interface
+    guide: |
+      Use this table for Sentry discover query interface. Keep time
+      filters tight so the endpoint stays fast and the results stay
+      interpretable.
     fetch_limit_default: 1000
     request:
       method: GET

--- a/sources/slack/manifest.yaml
+++ b/sources/slack/manifest.yaml
@@ -31,6 +31,9 @@ test_queries:
 tables:
   - name: channels
     description: Slack channels with topic, purpose, and member count
+    guide: |
+      Start here to inventory channels. Use `id` values from here in
+      related tables and drill-down queries.
     request:
       method: GET
       path: /api/conversations.list
@@ -116,6 +119,11 @@ tables:
             - created
   - name: messages
     description: Messages in a Slack channel (requires channel filter)
+    guide: |
+      Use this table for Messages in a Slack channel (requires channel
+      filter). Requires `channel` from `slack.channels`. Keep time
+      filters tight so the endpoint stays fast and the results stay
+      interpretable.
     request:
       method: GET
       path: /api/conversations.history
@@ -242,6 +250,9 @@ tables:
       - name: latest
   - name: users
     description: Slack workspace users with profile info (email requires users:read.email scope)
+    guide: |
+      Start here to inventory users. Use `id` values from here in
+      related tables and drill-down queries.
     request:
       method: GET
       path: /api/users.list

--- a/sources/statusgator/manifest.yaml
+++ b/sources/statusgator/manifest.yaml
@@ -28,6 +28,9 @@ test_queries:
 tables:
   - name: boards
     description: StatusGator monitoring boards
+    guide: |
+      Start here to inventory boards. Use `id`, `public_token` values
+      from here in related tables and drill-down queries.
     request:
       method: GET
       path: /boards
@@ -86,6 +89,9 @@ tables:
             - updated_at
   - name: monitors
     description: Service monitors on a board
+    guide: |
+      Use this table for Service monitors on a board. Requires
+      `board_id` from `statusgator.boards`.
     request:
       method: GET
       path: /boards/{{filter.board_id}}/monitors
@@ -237,6 +243,10 @@ tables:
         required: true
   - name: history
     description: Status history for a board
+    guide: |
+      Use this table for Status history for a board. Requires `board_id`
+      from `statusgator.boards`. Keep time filters tight so the endpoint
+      stays fast and the results stay interpretable.
     request:
       method: GET
       path: /boards/{{filter.board_id}}/history
@@ -345,6 +355,10 @@ tables:
       - name: end_date
   - name: incidents
     description: Incidents for a board
+    guide: |
+      Use this table for Incidents for a board. Requires `board_id` from
+      `statusgator.boards`. Use it after inventory tables identify the
+      entities worth investigating in detail.
     request:
       method: GET
       path: /boards/{{filter.board_id}}/incidents
@@ -461,6 +475,10 @@ tables:
         required: true
   - name: monitor_components
     description: Components for a specific monitor
+    guide: |
+      Use this table for Components for a specific monitor. Requires
+      `board_id` from `statusgator.boards`. Requires `monitor_id` from
+      `statusgator.monitors`.
     request:
       method: GET
       path: /boards/{{filter.board_id}}/monitors/{{filter.monitor_id}}/components
@@ -546,6 +564,10 @@ tables:
         required: true
   - name: service_search
     description: Search for services by name
+    guide: |
+      Start here to inventory service search. Use `q` to narrow the
+      result set before doing heavier joins or exports. Use `id` values
+      from here in related tables and drill-down queries.
     request:
       method: GET
       path: /services/search
@@ -617,6 +639,9 @@ tables:
         required: true
   - name: service_components
     description: Components for a service
+    guide: |
+      Use this table for Components for a service. Requires `service_id`
+      from `statusgator.service_search`.
     request:
       method: GET
       path: /services/{{filter.service_id}}/components
@@ -685,6 +710,9 @@ tables:
         required: true
   - name: status_page_subscribers
     description: Subscribers to a board's status page
+    guide: |
+      Use this table for Subscribers to a board's status page. Requires
+      `board_id` from `statusgator.boards`.
     request:
       method: GET
       path: /boards/{{filter.board_id}}/status_page_subscribers
@@ -761,6 +789,9 @@ tables:
         required: true
   - name: users
     description: Users in the StatusGator account
+    guide: |
+      Start here to inventory users. Use `id` values from here in
+      related tables and drill-down queries.
     request:
       method: GET
       path: /users
@@ -843,6 +874,8 @@ tables:
             - last_sign_in_at
   - name: monitoring_regions
     description: Available monitoring regions
+    guide: |
+      Start here to inventory monitoring regions.
     request:
       method: GET
       path: /monitoring_regions
@@ -909,6 +942,9 @@ tables:
             - desc
   - name: board_detail
     description: Detailed information about a single board
+    guide: |
+      Use this table for Detailed information about a single board.
+      Requires `board_id` from `statusgator.boards`.
     request:
       method: GET
       path: /boards/{{filter.board_id}}
@@ -969,6 +1005,10 @@ tables:
         required: true
   - name: ping
     description: Health check endpoint
+    guide: |
+      Use this table for Health check endpoint. Useful as a quick auth
+      and connectivity check before you troubleshoot other StatusGator
+      tables.
     request:
       method: GET
       path: /ping


### PR DESCRIPTION
Add missing table-level guides for the remaining half of the source manifests that were identified as lacking them. The new guidance focuses on discovery order, required filters, and drill-down paths, and PostHog wording was hand-polished after live query validation to keep the copy readable.

Constraint: Limit the change to pagerduty, posthog, sentry, slack, and statusgator manifests only
Rejected: Add generic placeholder guides with no filter guidance | too little value for agent-driven query discovery
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep guide text aligned with real discovery paths when table filters or upstream API behavior change
Tested: YAML parse checks for modified manifests; live coral sql queries for PagerDuty services->active, PostHog organizations->projects->actions, Sentry issues->events, Slack channels->messages, and StatusGator boards->monitors; Gemini final review
Not-tested: Exhaustive live query validation for every newly documented table