### PR TITLE
docs: document nested field __ convention

### DIFF
--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -38,6 +38,24 @@ Source authoring works well as an agent-driven workflow. Point your coding agent
 5. Inspects `coral.tables`, `coral.columns` and `coral.inputs` to check the shape
 6. Refines and repeats until the tables look right
 
+## Column naming for nested fields
+
+When a source exposes nested API fields as separate SQL columns, use double underscores (`__`) to flatten the path into a single column name.
+
+- `assignee__name` means "the `name` field under `assignee`"
+- `repository__owner__login` means `repository.owner.login`
+
+This matches the naming convention used across bundled sources and keeps the mapping easy to read in both SQL and `coral.columns`. Treat the full flattened name as the column name in queries; it is not dot notation.
+
+```sql
+SELECT title, assignee__name
+FROM github.issues
+WHERE owner = 'withcoral' AND repo = 'coral'
+LIMIT 5
+```
+
+If you are consuming a source, inspect `coral.columns` to see the exact names Coral exposes. If you are authoring a source, prefer `parent__child` style names for flattened fields so users can recognize related data consistently.
+
 ## Example: local JSONL source
 
 The fastest way to see a custom source working is with a local file.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -68,6 +68,33 @@ Each column also supports:
 - `nullable` (boolean, default `true`): whether the column can contain NULL values
 - `description` (string): human-readable description, surfaced through `coral.columns`
 
+### Nested field naming
+
+Coral uses a double underscore (`__`) naming convention for flattened nested or related fields.
+Treat the full name as the SQL column name:
+
+- `assignee__name` means the `name` field inside the `assignee` object or relation
+- `repository__owner__login` means `repository.owner.login`
+
+This is a naming convention, not special SQL syntax. Query the column exactly as it appears in `coral.columns`:
+
+```sql
+SELECT number, title, assignee__name
+FROM github.issues
+WHERE owner = 'withcoral' AND repo = 'coral'
+ORDER BY number DESC
+LIMIT 10
+```
+
+Do not rewrite these names with dots such as `assignee.name` or `repository.owner.login`. When you are unsure which flattened names a source exposes, inspect them first:
+
+```sql
+SELECT column_name, description
+FROM coral.columns
+WHERE schema_name = 'github' AND table_name = 'issues'
+ORDER BY ordinal_position
+```
+
 ### Querying JSON columns
 
 `Json`-typed columns (and any `Utf8` column whose values happen to be JSON) can be queried with the built-in JSON functions:


### PR DESCRIPTION
Documents Coral's double-underscore naming convention for flattened nested and related fields in the source spec reference and custom source guide. It adds concrete SQL examples for columns like `assignee__name` and `repository__owner__login`, plus guidance to inspect exact names through `coral.columns`. This addresses SOURCE-442 by clarifying that these are literal column names, not dot notation, which should reduce confusion when querying bundled and custom sources. Validation: docs-only change; no tests run.