### PR TITLE
docs(sources): add guides for incident_io and stripe tables

### DIFF
--- a/sources/incident_io/manifest.yaml
+++ b/sources/incident_io/manifest.yaml
@@ -8907,8 +8907,8 @@ tables:
   - name: openapi_json
     description: OpenAPI
     guide: >-
-      Use this table to open API. Query it directly when you need the full list; it works
-      best as a lookup or dimension table.
+      OpenAPI document. Query this singleton endpoint when you need the raw v2 API
+      specification JSON.
     request:
       method: GET
       path: /v1/openapi.json
@@ -8931,8 +8931,8 @@ tables:
   - name: openapi_v3_json
     description: OpenAPIV3
     guide: >-
-      Use this table to open APIV3. Query it directly when you need the full list; it works
-      best as a lookup or dimension table.
+      OpenAPI v3 document. Query this singleton endpoint when you need the raw v3 API
+      specification JSON.
     request:
       method: GET
       path: /v1/openapiV3.json

--- a/sources/incident_io/manifest.yaml
+++ b/sources/incident_io/manifest.yaml
@@ -21,6 +21,9 @@ auth:
 tables:
   - name: actions
     description: List
+    guide: >-
+      Use this table to list actions. Prefer filtering by `incident_id`, `incident_mode`,
+      `id` to keep result sets small.
     filters:
       - name: incident_id
         required: false
@@ -542,6 +545,9 @@ tables:
             - updated_at
   - name: alert_attributes
     description: List
+    guide: >-
+      Use this table to list alert attributes. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -689,6 +695,9 @@ tables:
             - type
   - name: alert_routes
     description: List
+    guide: >-
+      Use this table to list alert routes. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -1110,6 +1119,9 @@ tables:
             - name
   - name: alert_sources
     description: List
+    guide: >-
+      Use this table to list alert sources. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -1736,6 +1748,9 @@ tables:
             - value
   - name: alerts
     description: List
+    guide: >-
+      Use this table to list alerts. Prefer filtering by `deduplication_key`, `status`,
+      `alert_source`, `created_at` to keep result sets small.
     filters:
       - name: deduplication_key
         required: false
@@ -2026,6 +2041,8 @@ tables:
             - updated_at
   - name: api_keys
     description: List
+    guide: >-
+      Use this table to list api keys. Prefer filtering by `id` to keep result sets small.
     filters:
       - name: id
         required: false
@@ -2347,6 +2364,9 @@ tables:
             - token_last_issued_at
   - name: catalog_entries
     description: ListEntries
+    guide: >-
+      Use this table to list catalog entries. It requires `catalog_type_id`, so start from
+      those IDs before joining outward.
     filters:
       - name: catalog_type_id
         required: true
@@ -2834,6 +2854,9 @@ tables:
             - updated_at
   - name: catalog_resources
     description: ListResources
+    guide: >-
+      Use this table to list catalog resources. Query it directly when you need the full
+      list; it works best as a lookup or dimension table.
     request:
       method: GET
       path: /v3/catalog_resources
@@ -2896,6 +2919,9 @@ tables:
             - value_docstring
   - name: catalog_types
     description: ListTypes
+    guide: >-
+      Use this table to list catalog types. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -3370,6 +3396,9 @@ tables:
             - use_name_as_identifier
   - name: content
     description: ShowContent
+    guide: >-
+      Use this table to show content. It requires `id`, so start from those IDs before
+      joining outward.
     filters:
       - name: id
         required: true
@@ -3405,6 +3434,9 @@ tables:
             - markdown
   - name: custom_field_options
     description: List
+    guide: >-
+      Use this table to list custom field options. It requires `custom_field_id`, so start
+      from those IDs before joining outward.
     filters:
       - name: custom_field_id
         required: true
@@ -3524,6 +3556,9 @@ tables:
             - value
   - name: custom_fields
     description: List
+    guide: >-
+      Use this table to list custom fields. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -3789,6 +3824,9 @@ tables:
             - updated_at
   - name: escalation_paths
     description: ListPaths
+    guide: >-
+      Use this table to list escalation paths. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -3999,6 +4037,9 @@ tables:
             - working_hours
   - name: escalations
     description: List
+    guide: >-
+      Use this table to list escalations. Prefer filtering by `escalation_path`, `status`,
+      `alert`, `created_at` to keep result sets small.
     filters:
       - name: escalation_path
         required: false
@@ -4483,6 +4524,9 @@ tables:
             - updated_at
   - name: follow_ups
     description: List
+    guide: >-
+      Use this table to list follow ups. Prefer filtering by `incident_id`, `incident_mode`,
+      `id` to keep result sets small.
     filters:
       - name: incident_id
         required: false
@@ -5223,6 +5267,9 @@ tables:
             - updated_at
   - name: identity
     description: Identity
+    guide: >-
+      Use this table to get identity details. Query it directly when you need this singleton
+      or config payload.
     request:
       method: GET
       path: /v1/identity
@@ -5296,6 +5343,9 @@ tables:
             - teams
   - name: incident_alerts
     description: ListIncidentAlerts
+    guide: >-
+      Use this table to list Incident Alerts. Prefer filtering by `alert_id`, `incident_id`
+      to keep result sets small.
     filters:
       - name: alert_id
         required: false
@@ -5551,6 +5601,9 @@ tables:
           key: incident_id
   - name: incident_attachments
     description: List
+    guide: >-
+      Use this table to list incident attachments. It requires `incident_id`, so start from
+      those IDs before joining outward.
     filters:
       - name: incident_id
         required: true
@@ -5654,6 +5707,9 @@ tables:
             - title
   - name: incident_relationships
     description: List
+    guide: >-
+      Use this table to list incident relationships. It requires `incident_id`, so start
+      from those IDs before joining outward.
     filters:
       - name: incident_id
         required: true
@@ -5724,6 +5780,9 @@ tables:
             - page_size
   - name: incident_roles
     description: List
+    guide: >-
+      Use this table to list incident roles. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -5909,6 +5968,9 @@ tables:
             - updated_at
   - name: incident_statuses
     description: List
+    guide: >-
+      Use this table to list incident statuses. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -6071,6 +6133,9 @@ tables:
             - updated_at
   - name: incident_timestamps
     description: List
+    guide: >-
+      Use this table to list incident timestamps. Prefer filtering by `id` to keep result
+      sets small.
     filters:
       - name: id
         required: false
@@ -6161,6 +6226,9 @@ tables:
             - rank
   - name: incident_types
     description: List
+    guide: >-
+      Use this table to list incident types. Prefer filtering by `id` to keep result sets
+      small.
     filters:
       - name: id
         required: false
@@ -6346,6 +6414,9 @@ tables:
             - updated_at
   - name: incident_updates
     description: List
+    guide: >-
+      Use this table to list incident updates. Prefer filtering by `incident_id` to keep
+      result sets small.
     filters:
       - name: incident_id
         required: false
@@ -6728,6 +6799,9 @@ tables:
             - name
   - name: incidents
     description: List
+    guide: >-
+      Use this table to list incidents. Prefer filtering by `sort_by`, `filter_mode`,
+      `status`, `status_category` to keep result sets small.
     filters:
       - name: sort_by
         required: false
@@ -8107,6 +8181,9 @@ tables:
             - workload_minutes_working
   - name: ip_allowlists
     description: ShowIPAllowlist
+    guide: >-
+      Use this table to show ip allowlists. Query it directly when you need the full list;
+      it works best as a lookup or dimension table.
     request:
       method: GET
       path: /v1/ip_allowlists
@@ -8170,6 +8247,9 @@ tables:
             - version
   - name: maintenance_windows
     description: List
+    guide: >-
+      Use this table to list maintenance windows. Prefer filtering by `status`, `id` to keep
+      result sets small.
     filters:
       - name: status
         required: false
@@ -8759,6 +8839,9 @@ tables:
             - updated_at
   - name: notification_methods
     description: ListNotificationMethods
+    guide: >-
+      Use this table to list Notification Methods. It requires `user_id`, so start from
+      those IDs before joining outward.
     filters:
       - name: user_id
         required: true
@@ -8823,6 +8906,9 @@ tables:
           key: user_id
   - name: openapi_json
     description: OpenAPI
+    guide: >-
+      Use this table to open API. Query it directly when you need the full list; it works
+      best as a lookup or dimension table.
     request:
       method: GET
       path: /v1/openapi.json
@@ -8844,6 +8930,9 @@ tables:
           kind: current_row
   - name: openapi_v3_json
     description: OpenAPIV3
+    guide: >-
+      Use this table to open APIV3. Query it directly when you need the full list; it works
+      best as a lookup or dimension table.
     request:
       method: GET
       path: /v1/openapiV3.json
@@ -8865,6 +8954,9 @@ tables:
           kind: current_row
   - name: postmortem_documents
     description: List
+    guide: >-
+      Use this table to list postmortem documents. Prefer filtering by `incident_id`,
+      `sort_by`, `id` to keep result sets small.
     filters:
       - name: incident_id
         required: false
@@ -9092,6 +9184,9 @@ tables:
             - updated_at
   - name: replicas
     description: ListScheduleReplicas
+    guide: >-
+      Use this table to list Schedule Replicas. It requires `schedule_id`, so start from
+      those IDs before joining outward.
     filters:
       - name: schedule_id
         required: true
@@ -9333,6 +9428,9 @@ tables:
             - user_statuses
   - name: response_incidents
     description: ListResponseIncidents
+    guide: >-
+      Use this table to list Response Incidents. It requires `status_page_id`,
+      `status_page_incident_id`, so start from those IDs before joining outward.
     filters:
       - name: status_page_id
         required: true
@@ -9377,6 +9475,9 @@ tables:
             - incidents
   - name: schedule_entries
     description: ListScheduleEntries
+    guide: >-
+      Use this table to list Schedule Entries. It requires `schedule_id`, so start from
+      those IDs before joining outward.
     filters:
       - name: schedule_id
         required: true
@@ -9496,6 +9597,8 @@ tables:
           key: schedule_id
   - name: schedules
     description: List
+    guide: >-
+      Use this table to list schedules. Prefer filtering by `id` to keep result sets small.
     filters:
       - name: id
         required: false
@@ -9759,6 +9862,8 @@ tables:
             - updated_at
   - name: severities
     description: List
+    guide: >-
+      Use this table to list severities. Prefer filtering by `id` to keep result sets small.
     filters:
       - name: id
         required: false
@@ -9906,6 +10011,9 @@ tables:
             - updated_at
   - name: status_page_incidents
     description: ListStatusPageIncidents
+    guide: >-
+      Use this table to list Status Page Incidents. It requires `status_page_id`, so start
+      from those IDs before joining outward.
     filters:
       - name: status_page_id
         required: true
@@ -10155,6 +10263,9 @@ tables:
             - updates
   - name: status_page_maintenances
     description: ListStatusPageMaintenances
+    guide: >-
+      Use this table to list Status Page Maintenances. It requires `status_page_id`, so
+      start from those IDs before joining outward.
     filters:
       - name: status_page_id
         required: true
@@ -10404,6 +10515,9 @@ tables:
             - updates
   - name: status_page_structures
     description: ShowStatusPageStructure
+    guide: >-
+      Use this table to show Status Page Structure. It requires `status_page_id`, so start
+      from those IDs before joining outward.
     filters:
       - name: status_page_id
         required: true
@@ -10448,6 +10562,9 @@ tables:
           key: status_page_id
   - name: status_pages
     description: ListStatusPages
+    guide: >-
+      Use this table to list Status Pages. Query it directly when you need the full list; it
+      works best as a lookup or dimension table.
     request:
       method: GET
       path: /v2/status_pages
@@ -10505,6 +10622,8 @@ tables:
             - public_url
   - name: teams
     description: List
+    guide: >-
+      Use this table to list teams. Prefer filtering by `id` to keep result sets small.
     filters:
       - name: id
         required: false
@@ -10658,6 +10777,9 @@ tables:
             - name
   - name: users
     description: List
+    guide: >-
+      Use this table to list users. Prefer filtering by `email`, `slack_user_id`, `id` to
+      keep result sets small.
     filters:
       - name: email
         required: false
@@ -10919,6 +11041,9 @@ tables:
             - slack_user_id
   - name: workflows
     description: ListWorkflows
+    guide: >-
+      Use this table to list workflows. Prefer filtering by `skip_step_upgrades`, `id` to
+      keep result sets small.
     filters:
       - name: skip_step_upgrades
         required: false

--- a/sources/stripe/manifest.yaml
+++ b/sources/stripe/manifest.yaml
@@ -8071,7 +8071,7 @@ tables:
             - updated
   - name: calculations
     description: Retrieve a Tax Calculation
-    guide: "Calculations. Scope with calculation. List endpoint."
+    guide: "Tax calculation breakdown. Scope with calculation to inspect the returned breakdown for that calculation."
     filters:
       - name: calculation
         required: true
@@ -36680,7 +36680,7 @@ tables:
           key: subscription_exposed_id
   - name: dispute
     description: Retrieve a dispute for a specified charge.
-    guide: "Dispute. Scope with charge. List endpoint."
+    guide: "Dispute balance transactions. Scope with charge to inspect the balance transactions attached to that charge's dispute."
     filters:
       - name: charge
         required: true
@@ -40446,7 +40446,7 @@ tables:
             - updated
   - name: get_application_fees_id_refunds
     description: List all application fee refunds
-    guide: "Refunds. Use id to fetch one row."
+    guide: "Application fee refunds. Scope with application fee id to list refunds for that fee."
     filters:
       - name: id
         required: true

--- a/sources/stripe/manifest.yaml
+++ b/sources/stripe/manifest.yaml
@@ -24,6 +24,7 @@ auth:
 tables:
   - name: account
     description: Retrieve account
+    guide: "Account. Singleton endpoint for the authenticated Stripe API key."
     request:
       method: GET
       path: /v1/account
@@ -2380,6 +2381,7 @@ tables:
             - type
   - name: account_bank_accounts
     description: Retrieve an external account
+    guide: "Bank accounts. Scope with account. Returns one row per request."
     filters:
       - name: account
         required: true
@@ -2838,6 +2840,7 @@ tables:
             - tokenization_method
   - name: accounts
     description: List all connected accounts
+    guide: "Accounts. Use account to fetch one row. Useful filter: created."
     filters:
       - name: created
         required: false
@@ -5233,6 +5236,7 @@ tables:
             - type
   - name: active_entitlements
     description: List all active entitlements
+    guide: "Active entitlements. Use id to fetch one row. Useful filter: customer."
     filters:
       - name: customer
         required: true
@@ -5318,6 +5322,7 @@ tables:
             - object
   - name: alerts
     description: List billing alerts
+    guide: "Alerts. Use id to fetch one row. Useful filters: alert_type and meter."
     filters:
       - name: alert_type
         required: false
@@ -5466,6 +5471,7 @@ tables:
             - recurrence
   - name: amount_details_line_items
     description: List all PaymentIntent LineItems
+    guide: "Amount details line items. Scope with intent. List endpoint."
     filters:
       - name: intent
         required: true
@@ -5727,6 +5733,7 @@ tables:
             - unit_of_measure
   - name: app_secret_find
     description: Find a Secret
+    guide: "Secrets find. Returns one row per request. Useful filters: name and scope."
     filters:
       - name: name
         required: true
@@ -5856,6 +5863,7 @@ tables:
             - user
   - name: application_fee_refunds
     description: Retrieve an application fee refund
+    guide: "Refunds. Scope with fee. Returns one row per request."
     filters:
       - name: fee
         required: true
@@ -5948,6 +5956,7 @@ tables:
             - object
   - name: application_fees
     description: List all application fees
+    guide: "Application fees. Use id to fetch one row. Useful filters: charge and created."
     filters:
       - name: charge
         required: false
@@ -6224,6 +6233,7 @@ tables:
             - url
   - name: authorizations
     description: List all authorizations
+    guide: "Authorizations. Use authorization to fetch one row. Useful filters: card and cardholder."
     filters:
       - name: card
         required: false
@@ -7112,6 +7122,7 @@ tables:
             - wallet
   - name: balance
     description: Retrieve balance
+    guide: "Balance. Singleton endpoint for the authenticated Stripe API key."
     request:
       method: GET
       path: /v1/balance
@@ -7231,6 +7242,7 @@ tables:
             - pending
   - name: balance_settings
     description: Retrieve balance settings
+    guide: "Balance settings. Singleton endpoint for the authenticated Stripe API key."
     request:
       method: GET
       path: /v1/balance_settings
@@ -7359,6 +7371,7 @@ tables:
             - delay_days_override
   - name: balance_transactions
     description: List all balance transactions
+    guide: "Balance transactions. Use id to fetch one row. Useful filters: created and currency."
     filters:
       - name: created
         required: false
@@ -7576,6 +7589,7 @@ tables:
             - type
   - name: billing_portal_configurations
     description: List portal configurations
+    guide: "Configurations. Use configuration to fetch one row. Useful filters: active and is_default."
     filters:
       - name: active
         required: false
@@ -8057,6 +8071,7 @@ tables:
             - updated
   - name: calculations
     description: Retrieve a Tax Calculation
+    guide: "Calculations. Scope with calculation. List endpoint."
     filters:
       - name: calculation
         required: true
@@ -8212,6 +8227,7 @@ tables:
             - taxable_amount
   - name: capabilities
     description: List all account capabilities
+    guide: "Capabilities. Scope with account. Use capability to fetch one row."
     filters:
       - name: account
         required: true
@@ -8479,6 +8495,7 @@ tables:
             - status
   - name: cardholders
     description: List all cardholders
+    guide: "Cardholders. Use cardholder to fetch one row. Useful filters: created and email."
     filters:
       - name: created
         required: false
@@ -8944,6 +8961,7 @@ tables:
             - type
   - name: cash_balance
     description: Retrieve a cash balance
+    guide: "Cash balance. Scope with customer. Returns one row per request."
     filters:
       - name: customer
         required: true
@@ -9036,6 +9054,7 @@ tables:
             - using_merchant_default
   - name: cash_balance_transactions
     description: List cash balance transactions
+    guide: "Cash balance transactions. Scope with customer. Use transaction to fetch one row."
     filters:
       - name: customer
         required: true
@@ -9341,6 +9360,7 @@ tables:
             - payment_intent
   - name: charge_refunds
     description: List all refunds
+    guide: "Refunds. Scope with charge. Use refund to fetch one row."
     filters:
       - name: charge
         required: true
@@ -10314,6 +10334,7 @@ tables:
             - transfer_reversal
   - name: charge_search
     description: Search charges
+    guide: "Charges search. Use this search endpoint when list filters are too restrictive. Useful filter: query."
     filters:
       - name: query
         required: true
@@ -14237,6 +14258,7 @@ tables:
             - transfer_group
   - name: charges
     description: List all charges
+    guide: "Charges. Use charge to fetch one row. Useful filters: created and customer."
     filters:
       - name: created
         required: false
@@ -18181,6 +18203,7 @@ tables:
             - transfer_group
   - name: checkout_sessions
     description: List all Checkout Sessions
+    guide: "Sessions. Use session to fetch one row. Useful filters: created and customer."
     filters:
       - name: created
         required: false
@@ -21342,6 +21365,7 @@ tables:
             - display
   - name: climate_products
     description: List products
+    guide: "Products. Use product to fetch one row."
     filters:
       - name: product
         required: false
@@ -21484,6 +21508,7 @@ tables:
             - suppliers
   - name: computed_upfront_line_items
     description: Retrieve a quote's upfront line items
+    guide: "Computed upfront line items. Scope with quote. List endpoint."
     filters:
       - name: quote
         required: true
@@ -21665,6 +21690,7 @@ tables:
             - taxes
   - name: confirmation_tokens
     description: Retrieve a ConfirmationToken
+    guide: "Confirmation tokens. Scope with confirmation_token. Returns one row per request."
     filters:
       - name: confirmation_token
         required: true
@@ -23635,6 +23661,7 @@ tables:
             - use_stripe_sdk
   - name: country_specs
     description: List Country Specs
+    guide: "Country specs. Use country to fetch one row."
     filters:
       - name: country
         required: false
@@ -23803,6 +23830,7 @@ tables:
             - minimum
   - name: coupons
     description: List all coupons
+    guide: "Coupons. Use coupon to fetch one row. Useful filter: created."
     filters:
       - name: created
         required: false
@@ -24011,6 +24039,7 @@ tables:
             - valid
   - name: credit_balance_summary
     description: Retrieve the credit balance summary for a customer
+    guide: "Credit balance summary. Returns one row per request. Useful filters: customer and customer_account."
     filters:
       - name: customer
         required: false
@@ -24099,6 +24128,7 @@ tables:
             - object
   - name: credit_balance_transactions
     description: List credit balance transactions
+    guide: "Credit balance transactions. Use id to fetch one row. Useful filters: credit_grant and customer."
     filters:
       - name: credit_grant
         required: false
@@ -24387,6 +24417,7 @@ tables:
             - type
   - name: credit_grants
     description: List credit grants
+    guide: "Credit grants. Use id to fetch one row. Useful filters: customer and customer_account."
     filters:
       - name: customer
         required: false
@@ -24650,6 +24681,7 @@ tables:
             - voided_at
   - name: credit_note_lines
     description: Retrieve a credit note's line items
+    guide: "Lines. Scope with credit_note. List endpoint."
     filters:
       - name: credit_note
         required: true
@@ -24826,6 +24858,7 @@ tables:
             - unit_amount_decimal
   - name: credit_note_preview_lines
     description: Retrieve a credit note preview's line items
+    guide: "Lines. List endpoint. Useful filters: amount and credit_amount."
     filters:
       - name: amount
         required: false
@@ -25156,6 +25189,7 @@ tables:
             - unit_amount_decimal
   - name: credit_notes
     description: List all credit notes
+    guide: "Credit notes. Use id to fetch one row. Useful filters: created and customer."
     filters:
       - name: created
         required: false
@@ -25611,6 +25645,7 @@ tables:
             - voided_at
   - name: credit_reversals
     description: List all CreditReversals
+    guide: "Credit reversals. Use credit_reversal to fetch one row. Useful filters: financial_account and received_credit."
     filters:
       - name: financial_account
         required: true
@@ -25797,6 +25832,7 @@ tables:
             - transaction
   - name: customer_balance_transactions
     description: List customer balance transactions
+    guide: "Balance transactions. Scope with customer. Use transaction to fetch one row. Useful filters: created and invoice."
     filters:
       - name: created
         required: false
@@ -25984,6 +26020,7 @@ tables:
             - type
   - name: customer_bank_accounts
     description: List all bank accounts
+    guide: "Bank accounts. Scope with customer. Use id to fetch one row."
     filters:
       - name: customer
         required: true
@@ -26274,6 +26311,7 @@ tables:
             - status
   - name: customer_cards
     description: List all cards
+    guide: "Cards. Scope with customer. Use id to fetch one row."
     filters:
       - name: customer
         required: true
@@ -26612,6 +26650,7 @@ tables:
             - tokenization_method
   - name: customer_payment_methods
     description: List a Customer's PaymentMethods
+    guide: "Payment methods. Scope with customer. Use payment_method to fetch one row. Useful filters: allow_redisplay and type."
     filters:
       - name: allow_redisplay
         required: false
@@ -28709,6 +28748,7 @@ tables:
             - zip
   - name: customer_search
     description: Search customers
+    guide: "Customers search. Use this search endpoint when list filters are too restrictive. Useful filter: query."
     filters:
       - name: query
         required: true
@@ -29464,6 +29504,7 @@ tables:
             - test_clock
   - name: customer_sources
     description: List sources for a specified customer.
+    guide: "Sources. Scope with customer. Use id to fetch one row. Useful filter: object."
     filters:
       - name: customer
         required: true
@@ -34222,6 +34263,7 @@ tables:
             - statement_descriptor
   - name: customer_subscriptions
     description: List active subscriptions
+    guide: "Subscriptions. Scope with customer. Use subscription_exposed_id to fetch one row."
     filters:
       - name: customer
         required: true
@@ -35246,6 +35288,7 @@ tables:
             - trial_start
   - name: customer_tax_ids
     description: List all Customer tax IDs
+    guide: "Tax ids. Scope with customer. Use id to fetch one row."
     filters:
       - name: customer
         required: true
@@ -35484,6 +35527,7 @@ tables:
             - verified_name
   - name: customers
     description: List all customers
+    guide: "Customers. Use customer to fetch one row. Useful filters: created and email."
     filters:
       - name: created
         required: false
@@ -36248,6 +36292,7 @@ tables:
             - test_clock
   - name: debit_reversals
     description: List all DebitReversals
+    guide: "Debit reversals. Use debit_reversal to fetch one row. Useful filters: financial_account and received_debit."
     filters:
       - name: financial_account
         required: true
@@ -36463,6 +36508,7 @@ tables:
             - transaction
   - name: discount
     description: customer_discount
+    guide: "Discount. Scope with customer. Returns one row per request. Useful filter: subscription_exposed_id."
     filters:
       - name: customer
         required: true
@@ -36634,6 +36680,7 @@ tables:
           key: subscription_exposed_id
   - name: dispute
     description: Retrieve a dispute for a specified charge.
+    guide: "Dispute. Scope with charge. List endpoint."
     filters:
       - name: charge
         required: true
@@ -36807,6 +36854,7 @@ tables:
             - type
   - name: disputes
     description: List all disputes
+    guide: "Disputes. Use dispute to fetch one row. Useful filters: charge and created."
     filters:
       - name: charge
         required: false
@@ -37608,6 +37656,7 @@ tables:
             - type
   - name: domains
     description: List apple pay domains.
+    guide: "Domains. Use domain to fetch one row. Useful filter: domain_name."
     filters:
       - name: domain_name
         required: false
@@ -37690,6 +37739,7 @@ tables:
             - object
   - name: early_fraud_warnings
     description: List all early fraud warnings
+    guide: "Early fraud warnings. Use early_fraud_warning to fetch one row. Useful filters: charge and created."
     filters:
       - name: charge
         required: false
@@ -37811,6 +37861,7 @@ tables:
             - payment_intent
   - name: entitlement_features
     description: List all features
+    guide: "Features. Use id to fetch one row. Useful filters: archived and lookup_key."
     filters:
       - name: archived
         required: false
@@ -37919,6 +37970,7 @@ tables:
             - object
   - name: event_summaries
     description: List billing meter event summaries
+    guide: "Event summaries. Use id to fetch one row. Useful filters: customer and end_time."
     filters:
       - name: customer
         required: true
@@ -38039,6 +38091,7 @@ tables:
           key: value_grouping_window
   - name: events
     description: List all events
+    guide: "Events. Use id to fetch one row. Useful filters: created and delivery_success."
     filters:
       - name: created
         required: false
@@ -38242,6 +38295,7 @@ tables:
           key: types
   - name: exchange_rates
     description: List all exchange rates
+    guide: "Exchange rates. Use rate_id to fetch one row."
     filters:
       - name: rate_id
         required: false
@@ -38302,6 +38356,7 @@ tables:
             - rates
   - name: external_accounts
     description: List all external accounts
+    guide: "External accounts. Scope with account. Use id to fetch one row. Useful filter: object."
     filters:
       - name: account
         required: true
@@ -38775,6 +38830,7 @@ tables:
             - tokenization_method
   - name: file_links
     description: List all file links
+    guide: "File links. Use link to fetch one row. Useful filters: created and expired."
     filters:
       - name: created
         required: false
@@ -38905,6 +38961,7 @@ tables:
             - url
   - name: files
     description: List all files
+    guide: "Files. Use file to fetch one row. Useful filters: created and purpose."
     filters:
       - name: created
         required: false
@@ -39088,6 +39145,7 @@ tables:
             - url
   - name: financial_accounts
     description: List all FinancialAccounts
+    guide: "Financial accounts. Use financial_account to fetch one row. Useful filters: created and status."
     filters:
       - name: created
         required: false
@@ -39439,6 +39497,7 @@ tables:
             - type
   - name: financial_connection_accounts
     description: List Accounts
+    guide: "Accounts. Use account to fetch one row. Useful filters: account_holder and session."
     filters:
       - name: account_holder
         required: false
@@ -39993,6 +40052,7 @@ tables:
             - status
   - name: financial_connection_sessions
     description: Retrieve a Session
+    guide: "Sessions. Scope with session. Returns one row per request."
     filters:
       - name: session
         required: true
@@ -40208,6 +40268,7 @@ tables:
           key: session
   - name: financial_connection_transactions
     description: List Transactions
+    guide: "Transactions. Use transaction to fetch one row. Useful filters: account and transacted_at."
     filters:
       - name: account
         required: true
@@ -40385,6 +40446,7 @@ tables:
             - updated
   - name: get_application_fees_id_refunds
     description: List all application fee refunds
+    guide: "Refunds. Use id to fetch one row."
     filters:
       - name: id
         required: true
@@ -40477,6 +40539,7 @@ tables:
             - object
   - name: history
     description: List all balance transactions
+    guide: "Balance history. Use id to fetch one row. Useful filters: created and currency."
     filters:
       - name: created
         required: false
@@ -40694,6 +40757,7 @@ tables:
             - type
   - name: inbound_transfers
     description: List all InboundTransfers
+    guide: "Inbound transfers. Use id to fetch one row. Useful filters: financial_account and status."
     filters:
       - name: financial_account
         required: true
@@ -41108,6 +41172,7 @@ tables:
             - transaction
   - name: invoice_lines
     description: Retrieve an invoice's line items
+    guide: "Lines. Scope with invoice. List endpoint."
     filters:
       - name: invoice
         required: true
@@ -41501,6 +41566,7 @@ tables:
             - taxes
   - name: invoice_payments
     description: List all payments for an invoice
+    guide: "Invoice payments. Use invoice_payment to fetch one row. Useful filters: created and invoice."
     filters:
       - name: created
         required: false
@@ -41724,6 +41790,7 @@ tables:
             - paid_at
   - name: invoice_rendering_templates
     description: List all invoice rendering templates
+    guide: "Invoice rendering templates. Use template to fetch one row. Useful filters: status and version."
     filters:
       - name: status
         required: false
@@ -41841,6 +41908,7 @@ tables:
             - version
   - name: invoice_search
     description: Search invoices
+    guide: "Invoices search. Use this search endpoint when list filters are too restrictive. Useful filter: query."
     filters:
       - name: query
         required: true
@@ -43611,6 +43679,7 @@ tables:
             - webhooks_delivered_at
   - name: invoiceitems
     description: List all invoice items
+    guide: "Invoiceitems. Use invoiceitem to fetch one row. Useful filters: created and customer."
     filters:
       - name: created
         required: false
@@ -44013,6 +44082,7 @@ tables:
             - test_clock
   - name: invoices
     description: List all invoices
+    guide: "Invoices. Use invoice to fetch one row. Useful filters: collection_method and created."
     filters:
       - name: collection_method
         required: false
@@ -45819,6 +45889,7 @@ tables:
             - webhooks_delivered_at
   - name: issuing_cards
     description: List all cards
+    guide: "Cards. Use card to fetch one row. Useful filters: cardholder and created."
     filters:
       - name: cardholder
         required: false
@@ -46540,6 +46611,7 @@ tables:
             - primary_account_identifier
   - name: issuing_disputes
     description: List all disputes
+    guide: "Disputes. Use dispute to fetch one row. Useful filters: created and status."
     filters:
       - name: created
         required: false
@@ -47336,6 +47408,7 @@ tables:
             - type
   - name: issuing_tokens
     description: List all issuing tokens for card
+    guide: "Tokens. Use token to fetch one row. Useful filters: card and created."
     filters:
       - name: card
         required: true
@@ -47801,6 +47874,7 @@ tables:
             - wallet_provider
   - name: issuing_transactions
     description: List all transactions
+    guide: "Transactions. Use transaction to fetch one row. Useful filters: card and cardholder."
     filters:
       - name: card
         required: false
@@ -48460,6 +48534,7 @@ tables:
             - wallet
   - name: line_items
     description: Retrieve a Checkout Session's line items
+    guide: "Line items. Scope with session. List endpoint. Useful filters: payment_link and quote."
     filters:
       - name: session
         required: true
@@ -48666,6 +48741,7 @@ tables:
           key: quote
   - name: link_account_sessions
     description: Retrieve a Session
+    guide: "Link account sessions. Scope with session. Returns one row per request."
     filters:
       - name: session
         required: true
@@ -48878,6 +48954,7 @@ tables:
           key: session
   - name: linked_accounts
     description: List Accounts
+    guide: "Linked accounts. Use account to fetch one row. Useful filters: account_holder and session."
     filters:
       - name: account_holder
         required: false
@@ -49429,6 +49506,7 @@ tables:
             - status
   - name: locations
     description: List all Locations
+    guide: "Locations. Use location to fetch one row."
     filters:
       - name: location
         required: false
@@ -49775,6 +49853,7 @@ tables:
             - phone
   - name: mandate_notifications
     description: Retrieve a Source MandateNotification
+    guide: "Mandate notifications. Scope with source and mandate_notification. Returns one row per request."
     filters:
       - name: mandate_notification
         required: true
@@ -49958,6 +50037,7 @@ tables:
             - type
   - name: mandates
     description: Retrieve a Mandate
+    guide: "Mandates. Scope with mandate. Returns one row per request."
     filters:
       - name: mandate
         required: true
@@ -50627,6 +50707,7 @@ tables:
             - type
   - name: meters
     description: List billing meters
+    guide: "Meters. Use id to fetch one row. Useful filter: status."
     filters:
       - name: status
         required: false
@@ -50821,6 +50902,7 @@ tables:
             - event_payload_key
   - name: orders
     description: List orders
+    guide: "Orders. Use order to fetch one row."
     filters:
       - name: order
         required: false
@@ -51138,6 +51220,7 @@ tables:
             - supplier
   - name: outbound_payments
     description: List all OutboundPayments
+    guide: "Outbound payments. Use id to fetch one row. Useful filters: created and customer."
     filters:
       - name: created
         required: false
@@ -51710,6 +51793,7 @@ tables:
             - transaction
   - name: outbound_transfers
     description: List all OutboundTransfers
+    guide: "Outbound transfers. Use outbound_transfer to fetch one row. Useful filters: financial_account and status."
     filters:
       - name: financial_account
         required: true
@@ -52241,6 +52325,7 @@ tables:
             - transaction
   - name: owners
     description: List Account Owners
+    guide: "Owners. Scope with account. List endpoint. Useful filter: ownership."
     filters:
       - name: account
         required: true
@@ -52355,6 +52440,7 @@ tables:
             - refreshed_at
   - name: payment_attempt_records
     description: List Payment Attempt Records
+    guide: "Payment attempt records. Use id to fetch one row. Useful filter: payment_record."
     filters:
       - name: payment_record
         required: true
@@ -55949,6 +56035,7 @@ tables:
             - phone
   - name: payment_intent_search
     description: Search PaymentIntents
+    guide: "Payment intents search. Use this search endpoint when list filters are too restrictive. Useful filter: query."
     filters:
       - name: query
         required: true
@@ -63358,6 +63445,7 @@ tables:
             - transfer_group
   - name: payment_intents
     description: List all PaymentIntents
+    guide: "Payment intents. Use intent to fetch one row. Useful filters: created and customer."
     filters:
       - name: created
         required: false
@@ -70809,6 +70897,7 @@ tables:
             - transfer_group
   - name: payment_links
     description: List all payment links
+    guide: "Payment links. Use payment_link to fetch one row. Useful filter: active."
     filters:
       - name: active
         required: false
@@ -71827,6 +71916,7 @@ tables:
             - url
   - name: payment_method_configurations
     description: List payment method configurations
+    guide: "Payment method configurations. Use configuration to fetch one row. Useful filter: application."
     filters:
       - name: application
         required: false
@@ -75298,6 +75388,7 @@ tables:
             - value
   - name: payment_method_domains
     description: List payment method domains
+    guide: "Payment method domains. Use payment_method_domain to fetch one row. Useful filters: domain_name and enabled."
     filters:
       - name: domain_name
         required: false
@@ -75635,6 +75726,7 @@ tables:
             - error_message
   - name: payment_methods
     description: List PaymentMethods
+    guide: "Payment methods. Use payment_method to fetch one row. Useful filters: allow_redisplay and customer."
     filters:
       - name: allow_redisplay
         required: false
@@ -77711,6 +77803,7 @@ tables:
             - zip
   - name: payment_records
     description: Retrieve a Payment Record
+    guide: "Payment records. Returns one row per request."
     filters:
       - name: id
         required: true
@@ -81291,6 +81384,7 @@ tables:
             - phone
   - name: payouts
     description: List all payouts
+    guide: "Payouts. Use payout to fetch one row. Useful filters: arrival_date and created."
     filters:
       - name: arrival_date
         required: false
@@ -81608,6 +81702,7 @@ tables:
             - type
   - name: pdf
     description: Download quote PDF
+    guide: "Quotes pdf. Scope with quote. Returns one row per request."
     filters:
       - name: quote
         required: true
@@ -81639,6 +81734,7 @@ tables:
           key: quote
   - name: people
     description: List all persons
+    guide: "People. Scope with account. Use person to fetch one row. Useful filter: relationship."
     filters:
       - name: account
         required: true
@@ -82698,6 +82794,7 @@ tables:
             - status
   - name: personalization_designs
     description: List all personalization designs
+    guide: "Personalization designs. Use personalization_design to fetch one row. Useful filters: lookup_keys and preferences."
     filters:
       - name: lookup_keys
         required: false
@@ -82950,6 +83047,7 @@ tables:
             - status
   - name: persons
     description: List all persons
+    guide: "Persons. Scope with account. Use person to fetch one row. Useful filter: relationship."
     filters:
       - name: account
         required: true
@@ -84009,6 +84107,7 @@ tables:
             - status
   - name: physical_bundles
     description: List all physical bundles
+    guide: "Physical bundles. Use physical_bundle to fetch one row. Useful filters: status and type."
     filters:
       - name: status
         required: false
@@ -84144,6 +84243,7 @@ tables:
             - type
   - name: plans
     description: List all plans
+    guide: "Plans. Use plan to fetch one row. Useful filters: active and created."
     filters:
       - name: active
         required: false
@@ -84437,6 +84537,7 @@ tables:
             - usage_type
   - name: preview
     description: Preview a credit note
+    guide: "Credit notes preview. Returns one row per request. Useful filters: amount and credit_amount."
     filters:
       - name: amount
         required: false
@@ -84944,6 +85045,7 @@ tables:
             - voided_at
   - name: price_search
     description: Search prices
+    guide: "Prices search. Use this search endpoint when list filters are too restrictive. Useful filter: query."
     filters:
       - name: query
         required: true
@@ -85253,6 +85355,7 @@ tables:
             - unit_amount_decimal
   - name: prices
     description: List all prices
+    guide: "Prices. Use price to fetch one row. Useful filters: active and created."
     filters:
       - name: active
         required: false
@@ -85635,6 +85738,7 @@ tables:
             - up_to
   - name: product_features
     description: List all features attached to a product
+    guide: "Features. Scope with product. Use id to fetch one row."
     filters:
       - name: product
         required: true
@@ -85707,6 +85811,7 @@ tables:
           key: product
   - name: product_search
     description: Search products
+    guide: "Products search. Use this search endpoint when list filters are too restrictive. Useful filter: query."
     filters:
       - name: query
         required: true
@@ -85941,6 +86046,7 @@ tables:
             - url
   - name: products
     description: List all products
+    guide: "Products. Use id to fetch one row. Useful filters: active and created."
     filters:
       - name: active
         required: false
@@ -86203,6 +86309,7 @@ tables:
             - url
   - name: promotion_codes
     description: List all promotion codes
+    guide: "Promotion codes. Use promotion_code to fetch one row. Useful filters: active and code."
     filters:
       - name: active
         required: false
@@ -86460,6 +86567,7 @@ tables:
             - times_redeemed
   - name: quotes
     description: List all quotes
+    guide: "Quotes. Use quote to fetch one row. Useful filters: customer and customer_account."
     filters:
       - name: customer
         required: false
@@ -87337,6 +87445,7 @@ tables:
             - destination
   - name: readers
     description: List all Readers
+    guide: "Readers. Use reader to fetch one row. Useful filters: device_type and location."
     filters:
       - name: device_type
         required: false
@@ -87879,6 +87988,7 @@ tables:
             - status
   - name: received_credits
     description: List all ReceivedCredits
+    guide: "Received credits. Use id to fetch one row. Useful filters: financial_account and linked_flows."
     filters:
       - name: financial_account
         required: true
@@ -88343,6 +88453,7 @@ tables:
             - transaction
   - name: received_debits
     description: List all ReceivedDebits
+    guide: "Received debits. Use id to fetch one row. Useful filters: financial_account and status."
     filters:
       - name: financial_account
         required: true
@@ -88744,6 +88855,7 @@ tables:
             - transaction
   - name: refunds
     description: List all refunds
+    guide: "Refunds. Use refund to fetch one row. Useful filters: charge and created."
     filters:
       - name: charge
         required: false
@@ -89726,6 +89838,7 @@ tables:
             - transfer_reversal
   - name: registrations
     description: List registrations
+    guide: "Registrations. Use id to fetch one row. Useful filter: status."
     filters:
       - name: status
         required: false
@@ -92258,6 +92371,7 @@ tables:
             - status
   - name: report_runs
     description: List all Report Runs
+    guide: "Report runs. Use report_run to fetch one row. Useful filter: created."
     filters:
       - name: created
         required: false
@@ -92470,6 +92584,7 @@ tables:
             - succeeded_at
   - name: report_types
     description: List all Report Types
+    guide: "Report types. Use report_type to fetch one row."
     filters:
       - name: report_type
         required: false
@@ -92583,6 +92698,7 @@ tables:
             - version
   - name: requests
     description: List all ForwardingRequests
+    guide: "Requests. Use id to fetch one row. Useful filter: created."
     filters:
       - name: created
         required: false
@@ -92791,6 +92907,7 @@ tables:
             - url
   - name: reviews
     description: List all open reviews
+    guide: "Reviews. Use review to fetch one row. Useful filter: created."
     filters:
       - name: created
         required: false
@@ -93046,6 +93163,7 @@ tables:
             - version
   - name: scheduled_query_runs
     description: List all scheduled query runs
+    guide: "Scheduled query runs. Use scheduled_query_run to fetch one row."
     filters:
       - name: scheduled_query_run
         required: false
@@ -93186,6 +93304,7 @@ tables:
             - title
   - name: secrets
     description: List secrets
+    guide: "Secrets. List endpoint. Useful filter: scope."
     filters:
       - name: scope
         required: true
@@ -93311,6 +93430,7 @@ tables:
             - user
   - name: settings
     description: Retrieve settings
+    guide: "Settings. Singleton endpoint for the authenticated Stripe API key."
     request:
       method: GET
       path: /v1/tax/settings
@@ -93511,6 +93631,7 @@ tables:
             - missing_fields
   - name: settlements
     description: Retrieve a settlement
+    guide: "Settlements. Scope with settlement. Returns one row per request."
     filters:
       - name: settlement
         required: true
@@ -93689,6 +93810,7 @@ tables:
             - transaction_count
   - name: setup_attempts
     description: List all SetupAttempts
+    guide: "Setup attempts. List endpoint. Useful filters: created and setup_intent."
     filters:
       - name: created
         required: false
@@ -94674,6 +94796,7 @@ tables:
             - usage
   - name: setup_intents
     description: List all SetupIntents
+    guide: "Setup intents. Use intent to fetch one row. Useful filters: attach_to_self and created."
     filters:
       - name: attach_to_self
         required: false
@@ -95821,6 +95944,7 @@ tables:
             - usage
   - name: shipping_rates
     description: List all shipping rates
+    guide: "Shipping rates. Use shipping_rate_token to fetch one row. Useful filters: active and created."
     filters:
       - name: active
         required: false
@@ -96076,6 +96200,7 @@ tables:
             - type
   - name: source_transactions
     description: List source transactions for a given source.
+    guide: "Source transactions. Scope with source. Use source_transaction to fetch one row."
     filters:
       - name: source
         required: true
@@ -96444,6 +96569,7 @@ tables:
             - type
   - name: sources
     description: Retrieve a source
+    guide: "Sources. Scope with source. Returns one row per request. Useful filter: client_secret."
     filters:
       - name: client_secret
         required: false
@@ -98624,6 +98750,7 @@ tables:
             - statement_descriptor
   - name: subscription_items
     description: List all subscription items
+    guide: "Subscription items. Use item to fetch one row. Useful filter: subscription."
     filters:
       - name: subscription
         required: true
@@ -98780,6 +98907,7 @@ tables:
             - tax_rates
   - name: subscription_schedules
     description: List all schedules
+    guide: "Subscription schedules. Use schedule to fetch one row. Useful filters: canceled_at and completed_at."
     filters:
       - name: canceled_at
         required: false
@@ -99652,6 +99780,7 @@ tables:
             - trial_end
   - name: subscription_search
     description: Search subscriptions
+    guide: "Subscriptions search. Use this search endpoint when list filters are too restrictive. Useful filter: query."
     filters:
       - name: query
         required: true
@@ -100663,6 +100792,7 @@ tables:
             - trial_start
   - name: subscriptions
     description: List subscriptions
+    guide: "Subscriptions. Use subscription_exposed_id to fetch one row. Useful filters: automatic_tax and collection_method."
     filters:
       - name: automatic_tax
         required: false
@@ -101744,6 +101874,7 @@ tables:
             - trial_start
   - name: suppliers
     description: List suppliers
+    guide: "Suppliers. Use supplier to fetch one row."
     filters:
       - name: supplier
         required: false
@@ -101885,6 +102016,7 @@ tables:
           key: supplier
   - name: tax_association_find
     description: Find a Tax Association
+    guide: "Associations find. List endpoint. Useful filter: payment_intent."
     filters:
       - name: payment_intent
         required: true
@@ -101971,6 +102103,7 @@ tables:
             - status
   - name: tax_calculation_line_items
     description: Retrieve a calculation's line items
+    guide: "Line items. Scope with calculation. List endpoint."
     filters:
       - name: calculation
         required: true
@@ -102106,6 +102239,7 @@ tables:
             - tax_code
   - name: tax_codes
     description: List all tax codes
+    guide: "Tax codes. Use id to fetch one row."
     filters:
       - name: id
         required: false
@@ -102167,6 +102301,7 @@ tables:
             - object
   - name: tax_ids
     description: List all tax IDs
+    guide: "Tax ids. Use id to fetch one row. Useful filter: owner."
     filters:
       - name: owner
         required: false
@@ -102408,6 +102543,7 @@ tables:
             - verified_name
   - name: tax_rates
     description: List all tax rates
+    guide: "Tax rates. Use tax_rate to fetch one row. Useful filters: active and created."
     filters:
       - name: active
         required: false
@@ -102639,6 +102775,7 @@ tables:
             - tax_type
   - name: tax_transaction_line_items
     description: Retrieve a transaction's line items
+    guide: "Line items. Scope with transaction. List endpoint."
     filters:
       - name: transaction
         required: true
@@ -102792,6 +102929,7 @@ tables:
             - type
   - name: tax_transactions
     description: Retrieve a transaction
+    guide: "Transactions. Scope with transaction. Returns one row per request."
     filters:
       - name: transaction
         required: true
@@ -103247,6 +103385,7 @@ tables:
             - type
   - name: terminal_configurations
     description: List all Configurations
+    guide: "Configurations. Use configuration to fetch one row. Useful filter: is_account_default."
     filters:
       - name: is_account_default
         required: false
@@ -104549,6 +104688,7 @@ tables:
             - type
   - name: test_clocks
     description: List all test clocks
+    guide: "Test clocks. Use test_clock to fetch one row."
     filters:
       - name: test_clock
         required: false
@@ -104681,6 +104821,7 @@ tables:
           key: test_clock
   - name: tokens
     description: Retrieve a token
+    guide: "Tokens. Scope with token. Returns one row per request."
     filters:
       - name: token
         required: true
@@ -104789,6 +104930,7 @@ tables:
             - used
   - name: topups
     description: List all top-ups
+    guide: "Topups. Use topup to fetch one row. Useful filters: amount and created."
     filters:
       - name: amount
         required: false
@@ -104983,6 +105125,7 @@ tables:
             - transfer_group
   - name: transaction_entries
     description: List all TransactionEntries
+    guide: "Transaction entries. Use id to fetch one row. Useful filters: created and effective_at."
     filters:
       - name: created
         required: false
@@ -105285,6 +105428,7 @@ tables:
             - type
   - name: transfer_reversal
     description: Retrieve a reversal
+    guide: "Reversals. Scope with transfer. Returns one row per request."
     filters:
       - name: id
         required: true
@@ -105395,6 +105539,7 @@ tables:
             - transfer
   - name: transfer_reversals
     description: List all reversals
+    guide: "Reversals. Use id to fetch one row."
     filters:
       - name: id
         required: true
@@ -105505,6 +105650,7 @@ tables:
             - transfer
   - name: transfers
     description: List all transfers
+    guide: "Transfers. Use transfer to fetch one row. Useful filters: created and destination."
     filters:
       - name: created
         required: false
@@ -105747,6 +105893,7 @@ tables:
             - transfer_group
   - name: treasury_financial_account_features
     description: Retrieve FinancialAccount Features
+    guide: "Features. Scope with financial_account. Returns one row per request."
     filters:
       - name: financial_account
         required: true
@@ -106192,6 +106339,7 @@ tables:
             - status_details
   - name: treasury_transactions
     description: List all Transactions
+    guide: "Transactions. Use id to fetch one row. Useful filters: created and financial_account."
     filters:
       - name: created
         required: false
@@ -106571,6 +106719,7 @@ tables:
             - void_at
   - name: value_list_items
     description: List all value list items
+    guide: "Value list items. Use item to fetch one row. Useful filters: created and value."
     filters:
       - name: created
         required: false
@@ -106683,6 +106832,7 @@ tables:
             - value_list
   - name: value_lists
     description: List all value lists
+    guide: "Value lists. Use value_list to fetch one row. Useful filters: alias and contains."
     filters:
       - name: alias
         required: false
@@ -106871,6 +107021,7 @@ tables:
           key: value_list
   - name: verification_reports
     description: List VerificationReports
+    guide: "Verification reports. Use report to fetch one row. Useful filters: client_reference_id and created."
     filters:
       - name: client_reference_id
         required: false
@@ -107740,6 +107891,7 @@ tables:
             - verification_session
   - name: verification_sessions
     description: List VerificationSessions
+    guide: "Verification sessions. Use session to fetch one row. Useful filters: client_reference_id and created."
     filters:
       - name: client_reference_id
         required: false
@@ -108385,6 +108537,7 @@ tables:
             - unparsed_sex
   - name: webhook_endpoints
     description: List all webhook endpoints
+    guide: "Webhook endpoints. Use webhook_endpoint to fetch one row."
     filters:
       - name: webhook_endpoint
         required: false


### PR DESCRIPTION
Only incident_io and stripe were still missing table-level guide text on main, so this commit fills those gaps with concise query-planning hints while leaving other manifests untouched.

Constraint: Main already carried guide coverage for the other bundled sources
Rejected: Add guides for every source missing in the worktree | would drift beyond the true mainline gap
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep future guide-completion changes aligned to mainline gaps, not transient worktree state
Tested: cargo run -p xtask -- detect-missing-guides; YAML parse checks for incident_io and stripe guides
Not-tested: lint-sources (ryl unavailable in this environment)