### PR TITLE
feat: add cloudwatch source

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -887,29 +887,36 @@ fn set_path_value(root: &mut Value, path: &[String], value: Value) -> Result<()>
         return Ok(());
     }
 
-    let mut cursor = root;
-    for key in &path[..path.len() - 1] {
-        if !cursor.is_object() {
-            *cursor = Value::Object(Map::new());
+    set_path_value_at(root, path, value)
+}
+
+fn set_path_value_at(cursor: &mut Value, path: &[String], value: Value) -> Result<()> {
+    let Some((head, tail)) = path.split_first() else {
+        *cursor = value;
+        return Ok(());
+    };
+
+    if let Ok(index) = head.parse::<usize>() {
+        if !cursor.is_array() {
+            *cursor = Value::Array(Vec::new());
         }
-        let obj = cursor.as_object_mut().ok_or_else(|| {
-            DataFusionError::Execution("failed to create JSON object path".to_string())
+        let array = cursor.as_array_mut().ok_or_else(|| {
+            DataFusionError::Execution("failed to create JSON array path".to_string())
         })?;
-        cursor = obj
-            .entry(key.clone())
-            .or_insert_with(|| Value::Object(Map::new()));
+        if array.len() <= index {
+            array.resize_with(index + 1, || Value::Null);
+        }
+        return set_path_value_at(&mut array[index], tail, value);
     }
 
-    let last = path
-        .last()
-        .cloned()
-        .ok_or_else(|| DataFusionError::Execution("invalid empty JSON path segment".to_string()))?;
-
+    if !cursor.is_object() {
+        *cursor = Value::Object(Map::new());
+    }
     let obj = cursor.as_object_mut().ok_or_else(|| {
-        DataFusionError::Execution("failed to assign JSON path value".to_string())
+        DataFusionError::Execution("failed to create JSON object path".to_string())
     })?;
-    obj.insert(last, value);
-    Ok(())
+    let next = obj.entry(head.clone()).or_insert(Value::Null);
+    set_path_value_at(next, tail, value)
 }
 
 #[allow(
@@ -1061,7 +1068,7 @@ mod tests {
     use super::{
         HttpSourceClient, PageState, RequestSpec as HttpRequestSpec, apply_pagination_query_pairs,
         execute_request, extract_next_link_url, extract_rows, join_url, normalize_base_url,
-        page_is_exhausted, resolve_value_source,
+        page_is_exhausted, resolve_value_source, set_path_value,
     };
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
@@ -1110,6 +1117,49 @@ mod tests {
         .into_iter()
         .next()
         .expect("table should exist")
+    }
+
+    #[test]
+    fn set_path_value_builds_arrays_from_numeric_segments() {
+        let mut root = json!({});
+
+        set_path_value(
+            &mut root,
+            &[
+                "Dimensions".to_string(),
+                "0".to_string(),
+                "Name".to_string(),
+            ],
+            json!("ClusterName"),
+        )
+        .expect("path assignment should succeed");
+        set_path_value(
+            &mut root,
+            &[
+                "Dimensions".to_string(),
+                "0".to_string(),
+                "Value".to_string(),
+            ],
+            json!("titaness"),
+        )
+        .expect("path assignment should succeed");
+        set_path_value(
+            &mut root,
+            &["Statistics".to_string(), "0".to_string()],
+            json!("Average"),
+        )
+        .expect("path assignment should succeed");
+
+        assert_eq!(
+            root,
+            json!({
+                "Dimensions": [{
+                    "Name": "ClusterName",
+                    "Value": "titaness"
+                }],
+                "Statistics": ["Average"]
+            })
+        );
     }
 
     fn request_json(request: &RequestSpec) -> serde_json::Value {

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1203,6 +1203,11 @@ mod tests {
                 "key": key,
                 "default": default,
             }),
+            ValueSourceSpec::FilterBool { key, default } => json!({
+                "from": "filter_bool",
+                "key": key,
+                "default": default,
+            }),
             ValueSourceSpec::Input { key } => json!({
                 "from": "input",
                 "key": key,
@@ -1371,6 +1376,24 @@ mod tests {
                 .to_string()
                 .contains("filter 'start_time' value 'not-a-number' is not a valid i64")
         );
+    }
+
+    #[test]
+    fn resolve_value_source_parses_filter_bools_as_bools() {
+        let filters = HashMap::from([("descending".to_string(), "false".to_string())]);
+
+        let value = resolve_value_source(
+            &ValueSourceSpec::FilterBool {
+                key: "descending".to_string(),
+                default: None,
+            },
+            &filters,
+            &HashMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect("bool filter should resolve");
+
+        assert_eq!(value, Some(json!(false)));
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -904,6 +904,12 @@ fn set_path_value_at(cursor: &mut Value, path: &[String], value: Value) -> Resul
             DataFusionError::Execution("failed to create JSON array path".to_string())
         })?;
         if array.len() <= index {
+            const MAX_JSON_ARRAY_INDEX: usize = 10_000;
+            if index > MAX_JSON_ARRAY_INDEX {
+                return Err(DataFusionError::Execution(format!(
+                    "JSON array index {index} exceeds supported maximum {MAX_JSON_ARRAY_INDEX}"
+                )));
+            }
             array.resize_with(index + 1, || Value::Null);
         }
         return set_path_value_at(&mut array[index], tail, value);

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -167,6 +167,26 @@ fn classify_filter(
     allowed: &HashSet<&str>,
     filter_modes: &HashMap<&str, FilterMode>,
 ) -> TableProviderFilterPushDown {
+    if let Expr::Column(col) = expr
+        && allowed.contains(col.name())
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
+    if let Expr::Not(inner) = expr
+        && let Expr::Column(col) = inner.as_ref()
+        && allowed.contains(col.name())
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
+    if let Expr::IsTrue(inner)
+    | Expr::IsFalse(inner)
+    | Expr::IsNotTrue(inner)
+    | Expr::IsNotFalse(inner) = expr
+        && let Expr::Column(col) = inner.as_ref()
+        && allowed.contains(col.name())
+    {
+        return TableProviderFilterPushDown::Exact;
+    }
     if let Expr::BinaryExpr(binary) = expr
         && binary.op == Operator::Eq
         && let Expr::Column(col) = binary.left.as_ref()
@@ -201,6 +221,7 @@ mod tests {
         Expr, Operator, TableProviderFilterPushDown, binary_expr, expr::Like, lit,
     };
     use std::collections::{HashMap, HashSet};
+    use std::ops::Not;
 
     fn allowed<'a>(names: &'a [&'a str]) -> HashSet<&'a str> {
         names.iter().copied().collect()
@@ -262,5 +283,34 @@ mod tests {
             &modes(&[("query", FilterMode::Search)]),
         );
         assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
+    }
+
+    #[test]
+    fn boolean_column_filter_pushes_down_exactly() {
+        let pushdown = classify_filter(&col("descending"), &allowed(&["descending"]), &modes(&[]));
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn negated_boolean_column_filter_pushes_down_exactly() {
+        let pushdown = classify_filter(
+            &col("descending").not(),
+            &allowed(&["descending"]),
+            &modes(&[]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+    }
+
+    #[test]
+    fn boolean_is_predicates_push_down_exactly() {
+        for expr in [
+            Expr::IsTrue(Box::new(col("descending"))),
+            Expr::IsFalse(Box::new(col("descending"))),
+            Expr::IsNotTrue(Box::new(col("descending"))),
+            Expr::IsNotFalse(Box::new(col("descending"))),
+        ] {
+            let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
+            assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+        }
     }
 }

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -178,10 +178,7 @@ fn classify_filter(
     {
         return TableProviderFilterPushDown::Exact;
     }
-    if let Expr::IsTrue(inner)
-    | Expr::IsFalse(inner)
-    | Expr::IsNotTrue(inner)
-    | Expr::IsNotFalse(inner) = expr
+    if let Expr::IsTrue(inner) | Expr::IsFalse(inner) = expr
         && let Expr::Column(col) = inner.as_ref()
         && allowed.contains(col.name())
     {
@@ -302,15 +299,24 @@ mod tests {
     }
 
     #[test]
-    fn boolean_is_predicates_push_down_exactly() {
+    fn boolean_is_true_and_is_false_push_down_exactly() {
         for expr in [
             Expr::IsTrue(Box::new(col("descending"))),
             Expr::IsFalse(Box::new(col("descending"))),
+        ] {
+            let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
+            assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+        }
+    }
+
+    #[test]
+    fn null_inclusive_boolean_is_predicates_are_not_pushed_down() {
+        for expr in [
             Expr::IsNotTrue(Box::new(col("descending"))),
             Expr::IsNotFalse(Box::new(col("descending"))),
         ] {
             let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
-            assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
+            assert_eq!(pushdown, TableProviderFilterPushDown::Unsupported);
         }
     }
 }

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -40,12 +40,12 @@ fn collect_filter_values(
         Expr::Column(col) => {
             insert_bool_filter(col.name(), true, allowed, filters);
         }
-        Expr::Not(inner) | Expr::IsFalse(inner) | Expr::IsNotTrue(inner) => {
+        Expr::Not(inner) | Expr::IsFalse(inner) => {
             if let Expr::Column(col) = inner.as_ref() {
                 insert_bool_filter(col.name(), false, allowed, filters);
             }
         }
-        Expr::IsTrue(inner) | Expr::IsNotFalse(inner) => {
+        Expr::IsTrue(inner) => {
             if let Expr::Column(col) = inner.as_ref() {
                 insert_bool_filter(col.name(), true, allowed, filters);
             }
@@ -304,7 +304,7 @@ mod tests {
     }
 
     #[test]
-    fn extracts_boolean_values_from_is_predicates() {
+    fn extracts_boolean_values_from_is_true_and_is_false_predicates() {
         let filters = vec![FilterSpec {
             name: "descending".into(),
             required: false,
@@ -314,13 +314,28 @@ mod tests {
         let cases = [
             (Expr::IsTrue(Box::new(col("descending"))), "true"),
             (Expr::IsFalse(Box::new(col("descending"))), "false"),
-            (Expr::IsNotTrue(Box::new(col("descending"))), "false"),
-            (Expr::IsNotFalse(Box::new(col("descending"))), "true"),
         ];
 
         for (expr, expected) in cases {
             let values = extract_filter_values(&[expr], &filters);
             assert_eq!(values.get("descending").map(String::as_str), Some(expected));
+        }
+    }
+
+    #[test]
+    fn ignores_null_inclusive_boolean_is_predicates() {
+        let filters = vec![FilterSpec {
+            name: "descending".into(),
+            required: false,
+            mode: FilterMode::default(),
+        }];
+
+        for expr in [
+            Expr::IsNotTrue(Box::new(col("descending"))),
+            Expr::IsNotFalse(Box::new(col("descending"))),
+        ] {
+            let values = extract_filter_values(&[expr], &filters);
+            assert!(values.is_empty());
         }
     }
 }

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -37,6 +37,19 @@ fn collect_filter_values(
             collect_filter_values(binary.left.as_ref(), allowed, filter_modes, filters);
             collect_filter_values(binary.right.as_ref(), allowed, filter_modes, filters);
         }
+        Expr::Column(col) => {
+            insert_bool_filter(col.name(), true, allowed, filters);
+        }
+        Expr::Not(inner) | Expr::IsFalse(inner) | Expr::IsNotTrue(inner) => {
+            if let Expr::Column(col) = inner.as_ref() {
+                insert_bool_filter(col.name(), false, allowed, filters);
+            }
+        }
+        Expr::IsTrue(inner) | Expr::IsNotFalse(inner) => {
+            if let Expr::Column(col) = inner.as_ref() {
+                insert_bool_filter(col.name(), true, allowed, filters);
+            }
+        }
         Expr::BinaryExpr(binary) if binary.op == Operator::Eq => {
             if let Some((col, val)) =
                 extract_column_equality(binary.left.as_ref(), binary.right.as_ref(), allowed)
@@ -74,6 +87,17 @@ fn collect_filter_values(
             }
         }
         _ => {}
+    }
+}
+
+fn insert_bool_filter(
+    col_name: &str,
+    value: bool,
+    allowed: &HashSet<&str>,
+    filters: &mut HashMap<String, String>,
+) {
+    if allowed.contains(col_name) {
+        filters.insert(col_name.to_string(), value.to_string());
     }
 }
 
@@ -140,6 +164,7 @@ mod tests {
     use super::extract_filter_values;
     use coral_spec::{FilterMode, FilterSpec};
     use datafusion::logical_expr::{Expr, col, lit};
+    use std::ops::Not;
 
     fn equality_expr(filter: &str, value: &str) -> Expr {
         col(filter).eq(lit(value))
@@ -250,5 +275,52 @@ mod tests {
         let values = extract_filter_values(&[expr], &filters);
 
         assert_eq!(values.get("q").map(String::as_str), Some("deploy"));
+    }
+
+    #[test]
+    fn extracts_boolean_true_from_bare_column_filter() {
+        let filters = vec![FilterSpec {
+            name: "descending".into(),
+            required: false,
+            mode: FilterMode::default(),
+        }];
+
+        let values = extract_filter_values(&[col("descending")], &filters);
+
+        assert_eq!(values.get("descending").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn extracts_boolean_false_from_not_column_filter() {
+        let filters = vec![FilterSpec {
+            name: "descending".into(),
+            required: false,
+            mode: FilterMode::default(),
+        }];
+
+        let values = extract_filter_values(&[col("descending").not()], &filters);
+
+        assert_eq!(values.get("descending").map(String::as_str), Some("false"));
+    }
+
+    #[test]
+    fn extracts_boolean_values_from_is_predicates() {
+        let filters = vec![FilterSpec {
+            name: "descending".into(),
+            required: false,
+            mode: FilterMode::default(),
+        }];
+
+        let cases = [
+            (Expr::IsTrue(Box::new(col("descending"))), "true"),
+            (Expr::IsFalse(Box::new(col("descending"))), "false"),
+            (Expr::IsNotTrue(Box::new(col("descending"))), "false"),
+            (Expr::IsNotFalse(Box::new(col("descending"))), "true"),
+        ];
+
+        for (expr, expected) in cases {
+            let values = extract_filter_values(&[expr], &filters);
+            assert_eq!(values.get("descending").map(String::as_str), Some(expected));
+        }
     }
 }

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -41,6 +41,19 @@ pub(crate) fn resolve_value_source(
             };
             Ok(value)
         }
+        ValueSourceSpec::FilterBool { key, default } => {
+            let value = if let Some(filter) = filters.get(key) {
+                let parsed = filter.parse::<bool>().map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "filter '{key}' value '{filter}' is not a valid bool: {error}"
+                    ))
+                })?;
+                Some(json!(parsed))
+            } else {
+                default.map(|value| json!(value))
+            };
+            Ok(value)
+        }
         ValueSourceSpec::Input { key } => Ok(resolved_inputs.get(key).cloned().map(Value::String)),
         ValueSourceSpec::State { key } => Ok(state.get(key).map(|v| Value::String(v.clone()))),
         ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
@@ -177,6 +190,7 @@ pub(crate) fn validate_value_source_inputs(
         ValueSourceSpec::Literal { .. }
         | ValueSourceSpec::Filter { .. }
         | ValueSourceSpec::FilterInt { .. }
+        | ValueSourceSpec::FilterBool { .. }
         | ValueSourceSpec::State { .. }
         | ValueSourceSpec::NowEpochMinusSeconds { .. } => Ok(()),
     }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -7,7 +7,7 @@ use coral_engine::{
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
-use wiremock::matchers::{header, method, path, query_param, query_param_is_missing};
+use wiremock::matchers::{body_json, header, method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::{
@@ -239,6 +239,55 @@ async fn select_with_where_filter_pushdown() {
     );
 
     assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+}
+
+#[tokio::test]
+async fn boolean_filter_bool_is_predicate_sends_json_bool_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/users/search"))
+        .and(body_json(json!({ "includeArchived": false })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(
+            json!({ "data": [json!({"id": 2, "name": "Grace", "email": "grace@example.com"})] }),
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_bool_filter", &server.uri());
+    let table = &mut manifest["tables"][0];
+    table["filters"] = json!([{ "name": "include_archived" }]);
+    table["request"] = json!({
+        "method": "POST",
+        "path": "/api/users/search",
+        "body": [
+            {
+                "path": ["includeArchived"],
+                "from": "filter_bool",
+                "key": "include_archived"
+            }
+        ]
+    });
+    table["columns"].as_array_mut().unwrap().push(json!({
+        "name": "include_archived",
+        "type": "Boolean",
+        "nullable": true,
+        "virtual": true,
+        "expr": { "kind": "from_filter", "key": "include_archived" }
+    }));
+    let source = build_source(manifest);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            &TestRuntime,
+            "SELECT id, include_archived FROM http_bool_filter.users WHERE include_archived IS FALSE",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": 2, "include_archived": false})]);
 }
 
 #[tokio::test]

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -215,6 +215,11 @@ pub enum ValueSourceSpec {
         #[serde(default)]
         default: Option<i64>,
     },
+    FilterBool {
+        key: String,
+        #[serde(default)]
+        default: Option<bool>,
+    },
     Input {
         key: String,
     },

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -323,6 +323,14 @@
         },
         {
           "properties": {
+            "from": { "const": "filter_bool" },
+            "key": { "type": "string", "minLength": 1 },
+            "default": { "type": "boolean" }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
             "from": { "const": "input" },
             "key": { "type": "string", "minLength": 1 }
           },

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -142,7 +142,9 @@ fn validate_value_source(
     context: &str,
 ) -> Result<()> {
     match source {
-        ValueSourceSpec::Filter { key, .. } | ValueSourceSpec::FilterInt { key, .. }
+        ValueSourceSpec::Filter { key, .. }
+        | ValueSourceSpec::FilterInt { key, .. }
+        | ValueSourceSpec::FilterBool { key, .. }
             if !known_filters.contains(key) =>
         {
             return Err(ManifestError::validation(format!(

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -18,6 +18,8 @@ If the source you need is not available, you can extend Coral by [writing a cust
 | Source | Backend | Description |
 | --- | --- | --- |
 | [clickup](#clickup) | `http` | Query tasks, spaces, folders, lists, goals, time entries, comments, views, tags, custom fields, teams, and users from ClickUp. |
+| [cloudwatch_logs](#cloudwatch_logs) | `http` | Query Amazon CloudWatch Logs groups, streams, and events. |
+| [cloudwatch_metrics](#cloudwatch_metrics) | `http` | Query Amazon CloudWatch metrics and monitoring metadata. |
 | [confluence](#confluence) | `http` | Query spaces, pages, blog posts, comments, attachments, labels, and related metadata from Confluence Cloud. |
 | [datadog](#datadog) | `http` | Query monitors, events, incidents, dashboards, hosts, services, APM dependencies, downtimes, SLOs, synthetic tests, users, logs, spans, and metrics from Datadog. |
 | [github](#github) | `http` | Query repositories, issues, pull requests, workflows, organizations, users, teams, and API metadata from GitHub (Cloud or Enterprise). |
@@ -64,6 +66,49 @@ If you're logged in to ClickUp, you can go to
 [App Settings](https://app.clickup.com/settings/apps) to find your token.
 For more details, see the
 [ClickUp authentication guide](https://developer.clickup.com/docs/authentication).
+
+### `cloudwatch_logs`
+
+`AWS_REGION` (optional)<br />
+default `us-east-1`
+
+AWS region for CloudWatch Logs API requests, for example `us-east-1`.
+
+`AWS_ENDPOINT_SUFFIX` (optional)<br />
+default `amazonaws.com`
+
+AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS
+regions. Use the appropriate suffix for other partitions.
+
+`AWS_ACCESS_KEY_ID` (required)
+
+AWS access key ID with CloudWatch Logs read permissions.
+
+`AWS_SECRET_ACCESS_KEY` (required)
+
+AWS secret access key for SigV4 signing.
+
+### `cloudwatch_metrics`
+
+`AWS_REGION` (optional)<br />
+default `us-east-1`
+
+AWS region for CloudWatch API requests, for example `us-east-1`.
+
+`AWS_ENDPOINT_SUFFIX` (optional)<br />
+default `amazonaws.com`
+
+AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS
+regions. Use the appropriate suffix for other partitions.
+
+`AWS_ACCESS_KEY_ID` (required)
+
+AWS access key ID with the CloudWatch read permissions needed for
+the tables you plan to query.
+
+`AWS_SECRET_ACCESS_KEY` (required)
+
+AWS secret access key for SigV4 signing.
 
 ### `confluence`
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -389,9 +389,14 @@ Request query params, body fields, and headers support these `from` values:
 | `template` | Render a string template with `input`, `filter`, or `state` tokens |
 | `filter` | Read a SQL filter as a string |
 | `filter_int` | Read a SQL filter and serialize it as a JSON integer |
+| `filter_bool` | Read a SQL filter and serialize it as a JSON boolean |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
 | `state` | Read pagination/runtime state |
 | `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |
+
+Boolean filters used with `filter_bool` can be written as normal SQL boolean
+predicates, for example `WHERE include_archived IS FALSE` or
+`WHERE include_archived = false`.
 
 ### HTTP response fields
 

--- a/sources/cloudwatch_logs/manifest.yaml
+++ b/sources/cloudwatch_logs/manifest.yaml
@@ -124,7 +124,7 @@ tables:
           key: order_by
           default: LogStreamName
         - path: [descending]
-          from: filter
+          from: filter_bool
           key: descending
           default: true
         - path: [limit]
@@ -157,7 +157,7 @@ tables:
         description: Ordering mode filter.
         expr: {kind: from_filter, key: order_by}
       - name: descending
-        type: Utf8
+        type: Boolean
         nullable: true
         virtual: true
         description: Descending sort filter.

--- a/sources/cloudwatch_logs/manifest.yaml
+++ b/sources/cloudwatch_logs/manifest.yaml
@@ -1,0 +1,294 @@
+dsl_version: 3
+name: cloudwatch_logs
+version: 0.1.0
+backend: http
+description: >-
+  Query Amazon CloudWatch Logs groups, streams, and events.
+inputs:
+  AWS_REGION:
+    kind: variable
+    default: us-east-1
+    hint: |
+      AWS region for CloudWatch Logs API requests, for example `us-east-1`.
+  AWS_ENDPOINT_SUFFIX:
+    kind: variable
+    default: amazonaws.com
+    hint: |
+      AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS
+      regions. Use the appropriate suffix for other partitions.
+  AWS_ACCESS_KEY_ID:
+    kind: secret
+    hint: |
+      AWS access key ID with CloudWatch Logs read permissions.
+  AWS_SECRET_ACCESS_KEY:
+    kind: secret
+    hint: |
+      AWS secret access key for SigV4 signing.
+base_url: https://logs.{{input.AWS_REGION}}.{{input.AWS_ENDPOINT_SUFFIX}}
+auth:
+  type: CustomAuth
+  authenticator: aws_sigv4
+  service: logs
+  region: "{{input.AWS_REGION}}"
+  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
+  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+  - name: Content-Type
+    from: literal
+    value: application/x-amz-json-1.1
+test_queries:
+  - SELECT * FROM cloudwatch_logs.log_groups LIMIT 1
+tables:
+  - name: log_groups
+    description: CloudWatch Logs log groups returned by DescribeLogGroups.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: Logs_20140328.DescribeLogGroups
+      body:
+        - path: [logGroupNamePrefix]
+          from: filter
+          key: log_group_name_prefix
+        - path: [limit]
+          from: literal
+          value: 50
+    response:
+      rows_path: [logGroups]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [nextToken]
+      response_cursor_path: [nextToken]
+      max_pages: 100
+    columns:
+      - name: log_group_name
+        type: Utf8
+        nullable: false
+        description: Log group name.
+        expr: {kind: path, path: [logGroupName]}
+      - name: arn
+        type: Utf8
+        nullable: true
+        description: Log group ARN.
+        expr: {kind: path, path: [arn]}
+      - name: creation_time
+        type: Int64
+        nullable: true
+        description: Creation time in Unix epoch milliseconds.
+        expr: {kind: path, path: [creationTime]}
+      - name: retention_in_days
+        type: Int64
+        nullable: true
+        description: Retention period in days.
+        expr: {kind: path, path: [retentionInDays]}
+      - name: metric_filter_count
+        type: Int64
+        nullable: true
+        description: Number of metric filters.
+        expr: {kind: path, path: [metricFilterCount]}
+      - name: stored_bytes
+        type: Int64
+        nullable: true
+        description: Stored bytes.
+        expr: {kind: path, path: [storedBytes]}
+    filters:
+      - name: log_group_name_prefix
+
+  - name: log_streams
+    description: CloudWatch Logs log streams returned by DescribeLogStreams.
+    guide: >
+      Requires log_group_name. Optional log_stream_name_prefix narrows the
+      returned streams. order_by defaults to LogStreamName because AWS does not
+      allow log_stream_name_prefix together with LastEventTime ordering.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: Logs_20140328.DescribeLogStreams
+      body:
+        - path: [logGroupName]
+          from: filter
+          key: log_group_name
+        - path: [logStreamNamePrefix]
+          from: filter
+          key: log_stream_name_prefix
+        - path: [orderBy]
+          from: filter
+          key: order_by
+          default: LogStreamName
+        - path: [descending]
+          from: filter
+          key: descending
+          default: true
+        - path: [limit]
+          from: literal
+          value: 50
+    response:
+      rows_path: [logStreams]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [nextToken]
+      response_cursor_path: [nextToken]
+      max_pages: 100
+    columns:
+      - name: log_group_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Log group name filter.
+        expr: {kind: from_filter, key: log_group_name}
+      - name: log_stream_name_prefix
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Log stream name prefix filter.
+        expr: {kind: from_filter, key: log_stream_name_prefix}
+      - name: order_by
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Ordering mode filter.
+        expr: {kind: from_filter, key: order_by}
+      - name: descending
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Descending sort filter.
+        expr: {kind: from_filter, key: descending}
+      - name: log_stream_name
+        type: Utf8
+        nullable: false
+        description: Log stream name.
+        expr: {kind: path, path: [logStreamName]}
+      - name: arn
+        type: Utf8
+        nullable: true
+        description: Log stream ARN.
+        expr: {kind: path, path: [arn]}
+      - name: creation_time
+        type: Int64
+        nullable: true
+        description: Creation time in Unix epoch milliseconds.
+        expr: {kind: path, path: [creationTime]}
+      - name: first_event_timestamp
+        type: Int64
+        nullable: true
+        description: First event timestamp in Unix epoch milliseconds.
+        expr: {kind: path, path: [firstEventTimestamp]}
+      - name: last_event_timestamp
+        type: Int64
+        nullable: true
+        description: Last event timestamp in Unix epoch milliseconds.
+        expr: {kind: path, path: [lastEventTimestamp]}
+      - name: last_ingestion_time
+        type: Int64
+        nullable: true
+        description: Last ingestion time in Unix epoch milliseconds.
+        expr: {kind: path, path: [lastIngestionTime]}
+      - name: stored_bytes
+        type: Int64
+        nullable: true
+        description: Stored bytes.
+        expr: {kind: path, path: [storedBytes]}
+    filters:
+      - name: log_group_name
+        required: true
+      - name: log_stream_name_prefix
+      - name: order_by
+      - name: descending
+
+  - name: log_events
+    description: CloudWatch Logs events returned by FilterLogEvents.
+    guide: >
+      Requires log_group_name or log_group_identifier. Optional start_time and
+      end_time are Unix epoch milliseconds. Use filter_pattern for CloudWatch
+      Logs filter syntax and log_stream_name_prefix to narrow streams.
+    fetch_limit_default: 1000
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: Logs_20140328.FilterLogEvents
+      body:
+        - path: [logGroupName]
+          from: filter
+          key: log_group_name
+        - path: [logGroupIdentifier]
+          from: filter
+          key: log_group_identifier
+        - path: [logStreamNamePrefix]
+          from: filter
+          key: log_stream_name_prefix
+        - path: [filterPattern]
+          from: filter
+          key: filter_pattern
+        - path: [startTime]
+          from: filter_int
+          key: start_time
+        - path: [endTime]
+          from: filter_int
+          key: end_time
+        - path: [limit]
+          from: literal
+          value: 1000
+    response:
+      rows_path: [events]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [nextToken]
+      response_cursor_path: [nextToken]
+      max_pages: 100
+    columns:
+      - name: event_id
+        type: Utf8
+        nullable: true
+        description: Event ID.
+        expr: {kind: path, path: [eventId]}
+      - name: timestamp
+        type: Int64
+        nullable: true
+        description: Event timestamp in Unix epoch milliseconds.
+        expr: {kind: path, path: [timestamp]}
+      - name: ingestion_time
+        type: Int64
+        nullable: true
+        description: Ingestion time in Unix epoch milliseconds.
+        expr: {kind: path, path: [ingestionTime]}
+      - name: log_stream_name
+        type: Utf8
+        nullable: true
+        description: Log stream name.
+        expr: {kind: path, path: [logStreamName]}
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Log message.
+        expr: {kind: path, path: [message]}
+      - name: log_group_name
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Log group name filter.
+        expr: {kind: from_filter, key: log_group_name}
+      - name: filter_pattern
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: CloudWatch Logs filter pattern.
+        expr: {kind: from_filter, key: filter_pattern}
+    filters:
+      - name: log_group_name
+      - name: log_group_identifier
+      - name: log_stream_name_prefix
+      - name: filter_pattern
+      - name: start_time
+      - name: end_time

--- a/sources/cloudwatch_metrics/manifest.yaml
+++ b/sources/cloudwatch_metrics/manifest.yaml
@@ -1,0 +1,769 @@
+dsl_version: 3
+name: cloudwatch_metrics
+version: 0.2.0
+backend: http
+description: >-
+  Query Amazon CloudWatch metrics and monitoring metadata.
+inputs:
+  AWS_REGION:
+    kind: variable
+    default: us-east-1
+    hint: |
+      AWS region for CloudWatch API requests, for example `us-east-1`.
+  AWS_ENDPOINT_SUFFIX:
+    kind: variable
+    default: amazonaws.com
+    hint: |
+      AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS
+      regions. Use the appropriate suffix for other partitions.
+  AWS_ACCESS_KEY_ID:
+    kind: secret
+    hint: |
+      AWS access key ID with the CloudWatch read permissions needed for
+      the tables you plan to query.
+  AWS_SECRET_ACCESS_KEY:
+    kind: secret
+    hint: |
+      AWS secret access key for SigV4 signing.
+base_url: https://monitoring.{{input.AWS_REGION}}.{{input.AWS_ENDPOINT_SUFFIX}}
+auth:
+  type: CustomAuth
+  authenticator: aws_sigv4
+  service: monitoring
+  region: "{{input.AWS_REGION}}"
+  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
+  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+  - name: Content-Encoding
+    from: literal
+    value: amz-1.0
+test_queries:
+  - SELECT * FROM cloudwatch_metrics.metrics WHERE namespace = 'AWS/EC2' LIMIT 1
+  - SELECT * FROM cloudwatch_metrics.metric_alarms LIMIT 1
+tables:
+  - name: metrics
+    description: CloudWatch metric identities returned by ListMetrics.
+    guide: >
+      Optional filters: namespace, metric_name, and recently_active. Set
+      recently_active to PT3H to request metrics active in the past three
+      hours. CloudWatch returns only metrics that reported data in the past
+      two weeks.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.ListMetrics
+      body:
+        - path: [Namespace]
+          from: filter
+          key: namespace
+        - path: [MetricName]
+          from: filter
+          key: metric_name
+        - path: [RecentlyActive]
+          from: filter
+          key: recently_active
+        - path: [IncludeLinkedAccounts]
+          from: filter
+          key: include_linked_accounts
+        - path: [OwningAccount]
+          from: filter
+          key: owning_account
+    response:
+      rows_path: [Metrics]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: namespace
+        type: Utf8
+        nullable: true
+        description: Metric namespace.
+        expr: {kind: path, path: [Namespace]}
+      - name: metric_name
+        type: Utf8
+        nullable: true
+        description: Metric name.
+        expr: {kind: path, path: [MetricName]}
+      - name: dimensions
+        type: Utf8
+        nullable: true
+        description: Metric dimensions as JSON objects.
+        expr: {kind: join_array, path: [Dimensions]}
+      - name: recently_active
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Virtual filter. Use PT3H to request recently active metrics.
+        expr: {kind: from_filter, key: recently_active}
+      - name: include_linked_accounts
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Virtual filter for cross-account observability.
+        expr: {kind: from_filter, key: include_linked_accounts}
+      - name: owning_account
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Virtual filter for the owning source account ID.
+        expr: {kind: from_filter, key: owning_account}
+    filters:
+      - name: namespace
+      - name: metric_name
+      - name: recently_active
+      - name: include_linked_accounts
+      - name: owning_account
+
+  - name: metric_statistics
+    description: CloudWatch datapoints returned by GetMetricStatistics.
+    guide: >
+      Requires namespace, metric_name, start_time, and end_time. period defaults
+      to 300 seconds. Up to three dimensions can be supplied with dimension_name,
+      dimension_value, dimension2_name, dimension2_value, dimension3_name, and
+      dimension3_value. The request asks CloudWatch for Average, Minimum,
+      Maximum, Sum, and SampleCount.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.GetMetricStatistics
+      body:
+        - path: [Namespace]
+          from: filter
+          key: namespace
+        - path: [MetricName]
+          from: filter
+          key: metric_name
+        - path: [StartTime]
+          from: filter
+          key: start_time
+        - path: [EndTime]
+          from: filter
+          key: end_time
+        - path: [Period]
+          from: filter_int
+          key: period
+          default: 300
+        - path: [Unit]
+          from: filter
+          key: unit
+        - path: [Statistics, "0"]
+          from: literal
+          value: Average
+        - path: [Statistics, "1"]
+          from: literal
+          value: Minimum
+        - path: [Statistics, "2"]
+          from: literal
+          value: Maximum
+        - path: [Statistics, "3"]
+          from: literal
+          value: Sum
+        - path: [Statistics, "4"]
+          from: literal
+          value: SampleCount
+        - path: [Dimensions, "0", Name]
+          from: filter
+          key: dimension_name
+        - path: [Dimensions, "0", Value]
+          from: filter
+          key: dimension_value
+        - path: [Dimensions, "1", Name]
+          from: filter
+          key: dimension2_name
+        - path: [Dimensions, "1", Value]
+          from: filter
+          key: dimension2_value
+        - path: [Dimensions, "2", Name]
+          from: filter
+          key: dimension3_name
+        - path: [Dimensions, "2", Value]
+          from: filter
+          key: dimension3_value
+    response:
+      rows_path: [Datapoints]
+    pagination:
+      mode: none
+    columns:
+      - name: namespace
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Metric namespace filter.
+        expr: {kind: from_filter, key: namespace}
+      - name: metric_name
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Metric name filter.
+        expr: {kind: from_filter, key: metric_name}
+      - name: timestamp
+        type: Timestamp
+        nullable: true
+        description: Datapoint timestamp.
+        expr: {kind: path, path: [Timestamp]}
+      - name: average
+        type: Float64
+        nullable: true
+        description: Average value.
+        expr: {kind: path, path: [Average]}
+      - name: minimum
+        type: Float64
+        nullable: true
+        description: Minimum value.
+        expr: {kind: path, path: [Minimum]}
+      - name: maximum
+        type: Float64
+        nullable: true
+        description: Maximum value.
+        expr: {kind: path, path: [Maximum]}
+      - name: sum
+        type: Float64
+        nullable: true
+        description: Sum value.
+        expr: {kind: path, path: [Sum]}
+      - name: sample_count
+        type: Float64
+        nullable: true
+        description: Number of samples.
+        expr: {kind: path, path: [SampleCount]}
+      - name: unit
+        type: Utf8
+        nullable: true
+        description: Datapoint unit.
+        expr: {kind: path, path: [Unit]}
+      - name: dimension_name
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: First dimension name filter.
+        expr: {kind: from_filter, key: dimension_name}
+      - name: dimension_value
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: First dimension value filter.
+        expr: {kind: from_filter, key: dimension_value}
+    filters:
+      - name: namespace
+        required: true
+      - name: metric_name
+        required: true
+      - name: start_time
+        required: true
+      - name: end_time
+        required: true
+      - name: period
+      - name: unit
+      - name: dimension_name
+      - name: dimension_value
+      - name: dimension2_name
+      - name: dimension2_value
+      - name: dimension3_name
+      - name: dimension3_value
+
+  - name: metric_alarms
+    description: CloudWatch metric alarms returned by DescribeAlarms.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.DescribeAlarms
+      body:
+        - path: [AlarmNamePrefix]
+          from: filter
+          key: alarm_name_prefix
+        - path: [ActionPrefix]
+          from: filter
+          key: action_prefix
+        - path: [StateValue]
+          from: filter
+          key: state_value
+        - path: [AlarmTypes, "0"]
+          from: literal
+          value: MetricAlarm
+        - path: [MaxRecords]
+          from: literal
+          value: 100
+    response:
+      rows_path: [MetricAlarms]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: alarm_name
+        type: Utf8
+        nullable: false
+        description: Alarm name.
+        expr: {kind: path, path: [AlarmName]}
+      - name: alarm_arn
+        type: Utf8
+        nullable: true
+        description: Alarm ARN.
+        expr: {kind: path, path: [AlarmArn]}
+      - name: state_value
+        type: Utf8
+        nullable: true
+        description: Alarm state.
+        expr: {kind: path, path: [StateValue]}
+      - name: state_reason
+        type: Utf8
+        nullable: true
+        description: Human-readable state reason.
+        expr: {kind: path, path: [StateReason]}
+      - name: metric_name
+        type: Utf8
+        nullable: true
+        description: Metric name watched by the alarm.
+        expr: {kind: path, path: [MetricName]}
+      - name: namespace
+        type: Utf8
+        nullable: true
+        description: Metric namespace watched by the alarm.
+        expr: {kind: path, path: [Namespace]}
+      - name: dimensions
+        type: Utf8
+        nullable: true
+        description: Alarm metric dimensions as JSON objects.
+        expr: {kind: join_array, path: [Dimensions]}
+      - name: comparison_operator
+        type: Utf8
+        nullable: true
+        description: Comparison operator.
+        expr: {kind: path, path: [ComparisonOperator]}
+      - name: threshold
+        type: Float64
+        nullable: true
+        description: Alarm threshold.
+        expr: {kind: path, path: [Threshold]}
+      - name: period
+        type: Int64
+        nullable: true
+        description: Evaluation period in seconds.
+        expr: {kind: path, path: [Period]}
+      - name: evaluation_periods
+        type: Int64
+        nullable: true
+        description: Number of periods evaluated.
+        expr: {kind: path, path: [EvaluationPeriods]}
+      - name: actions_enabled
+        type: Boolean
+        nullable: true
+        description: Whether actions are enabled.
+        expr: {kind: path, path: [ActionsEnabled]}
+      - name: alarm_actions
+        type: Utf8
+        nullable: true
+        description: Alarm action ARNs.
+        expr: {kind: join_array, path: [AlarmActions]}
+      - name: state_updated_timestamp
+        type: Timestamp
+        nullable: true
+        description: Last state update timestamp.
+        expr: {kind: path, path: [StateUpdatedTimestamp]}
+    filters:
+      - name: alarm_name_prefix
+      - name: action_prefix
+      - name: state_value
+
+  - name: composite_alarms
+    description: CloudWatch composite alarms returned by DescribeAlarms.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.DescribeAlarms
+      body:
+        - path: [AlarmNamePrefix]
+          from: filter
+          key: alarm_name_prefix
+        - path: [ActionPrefix]
+          from: filter
+          key: action_prefix
+        - path: [StateValue]
+          from: filter
+          key: state_value
+        - path: [AlarmTypes, "0"]
+          from: literal
+          value: CompositeAlarm
+        - path: [MaxRecords]
+          from: literal
+          value: 100
+    response:
+      rows_path: [CompositeAlarms]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: alarm_name
+        type: Utf8
+        nullable: false
+        description: Alarm name.
+        expr: {kind: path, path: [AlarmName]}
+      - name: alarm_arn
+        type: Utf8
+        nullable: true
+        description: Alarm ARN.
+        expr: {kind: path, path: [AlarmArn]}
+      - name: alarm_rule
+        type: Utf8
+        nullable: true
+        description: Composite alarm rule.
+        expr: {kind: path, path: [AlarmRule]}
+      - name: state_value
+        type: Utf8
+        nullable: true
+        description: Alarm state.
+        expr: {kind: path, path: [StateValue]}
+      - name: state_reason
+        type: Utf8
+        nullable: true
+        description: Human-readable state reason.
+        expr: {kind: path, path: [StateReason]}
+      - name: actions_enabled
+        type: Boolean
+        nullable: true
+        description: Whether actions are enabled.
+        expr: {kind: path, path: [ActionsEnabled]}
+      - name: alarm_actions
+        type: Utf8
+        nullable: true
+        description: Alarm action ARNs.
+        expr: {kind: join_array, path: [AlarmActions]}
+      - name: state_updated_timestamp
+        type: Timestamp
+        nullable: true
+        description: Last state update timestamp.
+        expr: {kind: path, path: [StateUpdatedTimestamp]}
+    filters:
+      - name: alarm_name_prefix
+      - name: action_prefix
+      - name: state_value
+
+  - name: alarm_history
+    description: CloudWatch alarm history items returned by DescribeAlarmHistory.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.DescribeAlarmHistory
+      body:
+        - path: [AlarmName]
+          from: filter
+          key: alarm_name
+        - path: [HistoryItemType]
+          from: filter
+          key: history_item_type
+        - path: [StartDate]
+          from: filter
+          key: start_date
+        - path: [EndDate]
+          from: filter
+          key: end_date
+        - path: [ScanBy]
+          from: filter
+          key: scan_by
+          default: TimestampDescending
+        - path: [MaxRecords]
+          from: literal
+          value: 100
+    response:
+      rows_path: [AlarmHistoryItems]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: alarm_name
+        type: Utf8
+        nullable: true
+        description: Alarm name.
+        expr: {kind: path, path: [AlarmName]}
+      - name: alarm_type
+        type: Utf8
+        nullable: true
+        description: Alarm type.
+        expr: {kind: path, path: [AlarmType]}
+      - name: timestamp
+        type: Timestamp
+        nullable: true
+        description: History item timestamp.
+        expr: {kind: path, path: [Timestamp]}
+      - name: history_item_type
+        type: Utf8
+        nullable: true
+        description: History item type.
+        expr: {kind: path, path: [HistoryItemType]}
+      - name: history_summary
+        type: Utf8
+        nullable: true
+        description: History summary.
+        expr: {kind: path, path: [HistorySummary]}
+      - name: history_data
+        type: Utf8
+        nullable: true
+        description: Raw history data JSON string.
+        expr: {kind: path, path: [HistoryData]}
+    filters:
+      - name: alarm_name
+      - name: history_item_type
+      - name: start_date
+      - name: end_date
+      - name: scan_by
+
+  - name: dashboards
+    description: CloudWatch dashboard entries returned by ListDashboards.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.ListDashboards
+      body:
+        - path: [DashboardNamePrefix]
+          from: filter
+          key: dashboard_name_prefix
+    response:
+      rows_path: [DashboardEntries]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: dashboard_name
+        type: Utf8
+        nullable: false
+        description: Dashboard name.
+        expr: {kind: path, path: [DashboardName]}
+      - name: dashboard_arn
+        type: Utf8
+        nullable: true
+        description: Dashboard ARN.
+        expr: {kind: path, path: [DashboardArn]}
+      - name: last_modified
+        type: Timestamp
+        nullable: true
+        description: Last modified timestamp.
+        expr: {kind: path, path: [LastModified]}
+      - name: size
+        type: Int64
+        nullable: true
+        description: Dashboard body size in bytes.
+        expr: {kind: path, path: [Size]}
+    filters:
+      - name: dashboard_name_prefix
+
+  - name: dashboard
+    description: Details for one CloudWatch dashboard returned by GetDashboard.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.GetDashboard
+      body:
+        - path: [DashboardName]
+          from: filter
+          key: dashboard_name
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: dashboard_name
+        type: Utf8
+        nullable: false
+        description: Dashboard name.
+        expr: {kind: path, path: [DashboardName]}
+      - name: dashboard_arn
+        type: Utf8
+        nullable: true
+        description: Dashboard ARN.
+        expr: {kind: path, path: [DashboardArn]}
+      - name: dashboard_body
+        type: Utf8
+        nullable: true
+        description: Dashboard body JSON.
+        expr: {kind: path, path: [DashboardBody]}
+    filters:
+      - name: dashboard_name
+        required: true
+
+  - name: metric_streams
+    description: CloudWatch metric stream entries returned by ListMetricStreams.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.ListMetricStreams
+      body:
+        - path: [MaxResults]
+          from: literal
+          value: 500
+    response:
+      rows_path: [Entries]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Metric stream name.
+        expr: {kind: path, path: [Name]}
+      - name: arn
+        type: Utf8
+        nullable: true
+        description: Metric stream ARN.
+        expr: {kind: path, path: [Arn]}
+      - name: firehose_arn
+        type: Utf8
+        nullable: true
+        description: Destination Firehose ARN.
+        expr: {kind: path, path: [FirehoseArn]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Metric stream state.
+        expr: {kind: path, path: [State]}
+      - name: output_format
+        type: Utf8
+        nullable: true
+        description: Metric stream output format.
+        expr: {kind: path, path: [OutputFormat]}
+      - name: creation_date
+        type: Timestamp
+        nullable: true
+        description: Creation timestamp.
+        expr: {kind: path, path: [CreationDate]}
+      - name: last_update_date
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp.
+        expr: {kind: path, path: [LastUpdateDate]}
+
+  - name: metric_stream
+    description: Details for one CloudWatch metric stream returned by GetMetricStream.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.GetMetricStream
+      body:
+        - path: [Name]
+          from: filter
+          key: name
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Metric stream name.
+        expr: {kind: path, path: [Name]}
+      - name: arn
+        type: Utf8
+        nullable: true
+        description: Metric stream ARN.
+        expr: {kind: path, path: [Arn]}
+      - name: firehose_arn
+        type: Utf8
+        nullable: true
+        description: Destination Firehose ARN.
+        expr: {kind: path, path: [FirehoseArn]}
+      - name: role_arn
+        type: Utf8
+        nullable: true
+        description: Role ARN used by the metric stream.
+        expr: {kind: path, path: [RoleArn]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Metric stream state.
+        expr: {kind: path, path: [State]}
+      - name: output_format
+        type: Utf8
+        nullable: true
+        description: Metric stream output format.
+        expr: {kind: path, path: [OutputFormat]}
+      - name: include_filters
+        type: Utf8
+        nullable: true
+        description: Included namespace filters as JSON objects.
+        expr: {kind: join_array, path: [IncludeFilters]}
+      - name: exclude_filters
+        type: Utf8
+        nullable: true
+        description: Excluded namespace filters as JSON objects.
+        expr: {kind: join_array, path: [ExcludeFilters]}
+    filters:
+      - name: name
+        required: true
+
+  - name: tags
+    description: Tags for a CloudWatch alarm or Contributor Insights rule.
+    request:
+      method: POST
+      path: /
+      headers:
+        - name: X-Amz-Target
+          from: literal
+          value: GraniteServiceVersion20100801.ListTagsForResource
+      body:
+        - path: [ResourceARN]
+          from: filter
+          key: resource_arn
+    response:
+      rows_path: [Tags]
+    pagination:
+      mode: none
+    columns:
+      - name: resource_arn
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Resource ARN filter.
+        expr: {kind: from_filter, key: resource_arn}
+      - name: key
+        type: Utf8
+        nullable: false
+        description: Tag key.
+        expr: {kind: path, path: [Key]}
+      - name: value
+        type: Utf8
+        nullable: true
+        description: Tag value.
+        expr: {kind: path, path: [Value]}
+    filters:
+      - name: resource_arn
+        required: true

--- a/sources/cloudwatch_metrics/manifest.yaml
+++ b/sources/cloudwatch_metrics/manifest.yaml
@@ -211,7 +211,10 @@ tables:
         type: Timestamp
         nullable: true
         description: Datapoint timestamp.
-        expr: {kind: path, path: [Timestamp]}
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [Timestamp]}
       - name: average
         type: Float64
         nullable: true
@@ -374,7 +377,10 @@ tables:
         type: Timestamp
         nullable: true
         description: Last state update timestamp.
-        expr: {kind: path, path: [StateUpdatedTimestamp]}
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [StateUpdatedTimestamp]}
     filters:
       - name: alarm_name_prefix
       - name: action_prefix
@@ -452,7 +458,10 @@ tables:
         type: Timestamp
         nullable: true
         description: Last state update timestamp.
-        expr: {kind: path, path: [StateUpdatedTimestamp]}
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [StateUpdatedTimestamp]}
     filters:
       - name: alarm_name_prefix
       - name: action_prefix
@@ -509,7 +518,10 @@ tables:
         type: Timestamp
         nullable: true
         description: History item timestamp.
-        expr: {kind: path, path: [Timestamp]}
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [Timestamp]}
       - name: history_item_type
         type: Utf8
         nullable: true
@@ -567,7 +579,10 @@ tables:
         type: Timestamp
         nullable: true
         description: Last modified timestamp.
-        expr: {kind: path, path: [LastModified]}
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [LastModified]}
       - name: size
         type: Int64
         nullable: true
@@ -662,12 +677,18 @@ tables:
         type: Timestamp
         nullable: true
         description: Creation timestamp.
-        expr: {kind: path, path: [CreationDate]}
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [CreationDate]}
       - name: last_update_date
         type: Timestamp
         nullable: true
         description: Last update timestamp.
-        expr: {kind: path, path: [LastUpdateDate]}
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [LastUpdateDate]}
 
   - name: metric_stream
     description: Details for one CloudWatch metric stream returned by GetMetricStream.

--- a/sources/cloudwatch_metrics/manifest.yaml
+++ b/sources/cloudwatch_metrics/manifest.yaml
@@ -69,7 +69,7 @@ tables:
           from: filter
           key: recently_active
         - path: [IncludeLinkedAccounts]
-          from: filter
+          from: filter_bool
           key: include_linked_accounts
         - path: [OwningAccount]
           from: filter
@@ -104,7 +104,7 @@ tables:
         description: Virtual filter. Use PT3H to request recently active metrics.
         expr: {kind: from_filter, key: recently_active}
       - name: include_linked_accounts
-        type: Utf8
+        type: Boolean
         nullable: true
         virtual: true
         description: Virtual filter for cross-account observability.


### PR DESCRIPTION
## Summary

Adds two new sources `cloudwatch_logs` and `cloudwatch_metrics`

To support the CloudWatch metrics API, the HTTP client now builds JSON request bodies from manifest paths that include array indexes. That lets a manifest express requests like:
```
  body:
    - path: [Statistics, "0"]
      from: literal
      value: Average
    - path: [Statistics, "1"]
      from: literal
      value: Minimum
    - path: [Dimensions, "0", Name]
      from: filter
      key: dimension_name
    - path: [Dimensions, "0", Value]
      from: filter
      key: dimension_value
```
  which now render to the AWS-compatible JSON body:
```
  {
    "Statistics": ["Average", "Minimum"],
    "Dimensions": [
      {
        "Name": "ClusterName",
        "Value": "titaness"
      }
    ]
  }
```
Before this change, numeric path segments were treated like object keys, so the same manifest would have produced invalid object-shaped JSON instead of arrays.


## Validation:

- cargo build
- cargo test -p coral-spec --locked
- live queries with ./target/debug/coral against a configured cloudwatch_logs source for log_groups, log_streams, log_events, and prefix-filtered log_streams