### PR TITLE
ci: add Discord notification on release

### DIFF
--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -25,8 +25,14 @@ jobs:
             BODY="${BODY:0:$MAX_LEN}..."
           fi
 
+          TITLE_MAX_LEN=256
+          TITLE="🪸 ${RELEASE_NAME:-$TAG_NAME}"
+          if [ ${#TITLE} -gt $TITLE_MAX_LEN ]; then
+            TITLE="${TITLE:0:$((TITLE_MAX_LEN - 3))}..."
+          fi
+
           jq -n \
-            --arg title "🪸 ${RELEASE_NAME:-$TAG_NAME}" \
+            --arg title "$TITLE" \
             --arg desc "$BODY" \
             --arg url "$RELEASE_URL" \
             '{

--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -1,0 +1,37 @@
+name: Post release to Discord
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_CHANGELOG_WEBHOOK }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          RELEASE_NAME: ${{ github.event.release.name }}
+          RELEASE_BODY: ${{ github.event.release.body }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          MAX_LEN=3500
+          BODY="$RELEASE_BODY"
+          if [ ${#BODY} -gt $MAX_LEN ]; then
+            BODY="${BODY:0:$MAX_LEN}..."
+          fi
+
+          jq -n \
+            --arg title "🪸 ${RELEASE_NAME:-$TAG_NAME}" \
+            --arg desc "$BODY" \
+            --arg url "$RELEASE_URL" \
+            '{
+              embeds: [{
+                title: $title,
+                description: $desc,
+                url: $url,
+                color: 16744272,
+                footer: { text: "Fresh from the reef" }
+              }]
+            }' | curl -sf -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"

--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   notify-discord:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Post to Discord
         env:

--- a/.github/workflows/discord-changelog.yml
+++ b/.github/workflows/discord-changelog.yml
@@ -4,6 +4,8 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   notify-discord:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a new workflow that listens for `release: published` events
- Posts a formatted Discord embed to the `#changelog` channel via webhook
- Truncates release body to 3500 chars to stay within Discord's embed limit

## Setup required
Add `DISCORD_CHANGELOG_WEBHOOK` as a repo secret (the webhook URL for the #changelog channel).