### PR TITLE
docs(source-authoring): document authored table guide metadata

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -84,7 +84,8 @@ npx skills add withcoral/skills
 Available skills:
 
 - **`coral`** — teaches your agent the discovery-first workflow for answering data questions with `coral sql`, including how to use `coral.tables`, `coral.columns`, and `coral.inputs`.
-- **`coral-create-source-spec`** — guides your agent through authoring or repairing a custom source spec YAML for `coral source add --file`, or adapting it into a bundled source.
+- **`coral-create-source-spec`** — the current source-authoring skill. It guides your agent through drafting or repairing a custom source manifest, validating it with `coral source lint`, installing it with `coral source add --file`, and iterating with `coral source test`. When a source exposes search endpoints, use it alongside source-specific docs that explain search syntax, scoping qualifiers, and common endpoint gotchas.
+- **`create-source-manifest`** — an older alias you may still see in some agent environments. Use the same source-authoring workflow, but prefer the current Coral CLI commands and docs.
 
 Browse the source at [github.com/withcoral/skills](https://github.com/withcoral/skills).
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -19,20 +19,6 @@ Once added, the source works exactly like a bundled one: same SQL, same `coral.t
   `coral source test`.
 </Tip>
 
-## Will this work for my source?
-
-How much effort a custom source takes depends on what you are connecting to.
-
-File-based sources (JSONL, CSV, Parquet) are the simplest case — define the file location and columns, and the source is ready to query.
-
-API-backed sources vary in difficulty. The source spec model is designed for APIs that have:
-
-- **Long-lived, non-SSO API credentials** — an API key, personal access token, or service account that does not require a browser-based login flow
-- **Structured, accessible documentation** — an OpenAPI spec, GraphQL schema, or clearly organized REST docs that describe endpoints and response shapes
-- **Real data to validate against** — actual records in the account so you can confirm the source is returning the expected results during development
-
-If you are unsure whether your API is a good candidate, ask us in [Discord](https://withcoral.com/discord) before getting started.
-
 ## Choose your authoring path
 
 Use the same manifest format in both cases, but pick the workflow that matches your goal:
@@ -69,17 +55,6 @@ That sequence tells you three different things:
 - `lint` catches YAML/schema mistakes before credentials or runtime behavior are involved
 - `add --file` installs the source and shows install-time warnings
 - `test` gives you a strict validation result that is easy to rerun while iterating
-
-## Agent-driven authoring
-
-Source authoring works well as an agent-driven workflow. Point your coding agent at the Coral CLI and the [source spec reference](/reference/source-spec-reference), give it the API docs or describe the endpoints you want, and let it iterate:
-
-1. The agent writes or updates the source spec YAML.
-2. Lints the file with `coral source lint ./my-source.yaml` to catch errors before installing.
-3. Adds it with `coral source add --file ./my-source.yaml`.
-4. Validates with `coral source test my_source`.
-5. Inspects `coral.tables`, `coral.columns`, and `coral.inputs` to check the shape.
-6. Refines and repeats until the tables look right.
 
 ## Example: local JSONL source
 
@@ -144,35 +119,28 @@ coral sql "
 "
 ```
 
-## How to validate
+## Validate and inspect
 
-When you add `test_queries` to a source spec, treat them as a lightweight validation contract for that source.
+Treat `test_queries` as a lightweight validation contract for the manifest.
 
-1. Run `coral source lint ./my-source.yaml` first. It catches schema and semantic issues without touching your workspace or asking for secrets.
+1. Run `coral source lint ./my-source.yaml` first. This catches YAML, schema, and semantic issues without installing the source.
 2. Add or update the source with `coral source add --file ./my-source.yaml`.
-3. Confirm the install-time validation output:
-   - the source exposes the expected tables
-   - each declared `test_queries` entry runs successfully
-   - successful queries show a pass status and row count
-   - failing queries surface the SQL text plus an error message
-4. Run real `coral sql` queries against the new tables to confirm the shape is useful beyond the validation checks.
-5. If you want a strict rerun later, or you are debugging a failure, run `coral source test <source_name>`.
-6. If a query fails, fix either the source spec or the upstream credentials/configuration, then rerun `coral source test <source_name>`.
+3. Review the install-time output to confirm Coral discovered the expected tables and that each declared `test_queries` entry either passed or surfaced a clear error.
+4. Rerun strict validation with `coral source test <source_name>` whenever you want a pass/fail result.
+5. Query `coral.tables`, `coral.columns`, and `coral.inputs` to confirm the installed source shape matches what you intended.
+6. Run one or two real `coral sql` queries that reflect how you expect the source to be used.
 
-If you are validating a credentialed source end-to-end, it is useful to try both:
-
-- a correctly configured source, which should pass table validation and all declared query tests
-- an intentionally misconfigured source, which should still install but fail `coral source test` with a non-zero exit code
-
-This gives you confidence that the source spec works in the happy path and that `test_queries` catch broken credentials or runtime regressions in a predictable way.
+For credentialed sources, it is useful to validate both a happy path and a broken-credential path. A good manifest should install cleanly when configured correctly, and its `test_queries` should fail predictably when credentials or runtime configuration are wrong.
 
 Use read-only SQL in `test_queries`. Prefer bounded checks such as `SELECT * FROM schema.table LIMIT 1` over expensive scans like `SELECT COUNT(*)`, especially for HTTP-backed sources or large datasets. Coral rejects DDL, DML, and other non-read-only statements as failed validation queries instead of applying them.
 
 ## Document table usage with `guide`
 
-If a table needs query-writing help beyond a short description, add a `guide` field to that table in the source spec.
+If a table needs query-writing help beyond a short description, add a `guide`
+field to that table in the source spec.
 
-This is especially useful for search-style endpoints or APIs with easy-to-miss constraints:
+This is especially useful for search-style endpoints or APIs with easy-to-miss
+constraints:
 
 - required scoping filters
 - provider-specific search syntax or qualifiers
@@ -186,10 +154,12 @@ tables:
     description: Search commits
     guide: >
       Requires q. Always scope with repo:OWNER/NAME or org:NAME.
-      Common qualifiers: author:LOGIN, path:DIR, committer-date:>=YYYY-MM-DD.
+      Common qualifiers: author:LOGIN, path:DIR,
+      committer-date:>=YYYY-MM-DD.
 ```
 
-Coral stores this authored text on the installed table and exposes it through `coral.tables.guide`, so both humans and agents can read it during discovery:
+Coral stores this authored text on the installed table and exposes it through
+`coral.tables.guide`, so both humans and agents can read it during discovery:
 
 ```shellscript
 coral sql "
@@ -200,13 +170,9 @@ coral sql "
 "
 ```
 
-For MCP clients, this table-level `guide` complements `coral://guide`: agents should read `coral://guide` for the general Coral discovery workflow, then inspect `coral.tables.guide` for table-specific query advice.
-
 ## Example: HTTP API source
 
 To connect an HTTP API, the source spec declares the base URL, auth, endpoints, and response shape.
-
-For authentication, Coral supports three top-level `auth.type` modes. Use `HeaderAuth` for declarative headers such as bearer tokens or API keys, `BasicAuth` for username/password HTTP Basic authentication, and `CustomAuth` for named request authenticators that need runtime logic such as AWS SigV4 signing. The example below uses `HeaderAuth`; for the full auth field reference and additional examples, see [HTTP-backed tables](/reference/source-spec-reference#http-backed-tables).
 
 ```yaml
 name: demo_api
@@ -223,7 +189,6 @@ inputs:
     hint: Bearer token for the API
 base_url: "{{input.API_BASE}}"
 auth:
-  type: HeaderAuth
   headers:
     - name: Authorization
       from: template
@@ -252,7 +217,7 @@ tables:
         type: Utf8
 ```
 
-When you run `coral source add --file`, Coral reads each declared `input` from an environment variable of the same name, or prompts for them when you pass `--interactive`. `kind: variable` values go to source variables; `kind: secret` values go to the secret store.
+When you run `coral source add --file`, Coral prompts for the declared `inputs` interactively. `kind: variable` values go to source variables; `kind: secret` values go to the secret store.
 
 For the full set of HTTP response, pagination, auth, and column fields, see [HTTP-backed tables](/reference/source-spec-reference#http-backed-tables).
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -3,14 +3,20 @@ title: "Write a custom source spec"
 description: "Extend Coral by adding any API or dataset as a queryable source."
 ---
 
-Coral ships with [popular data sources](/reference/bundled-sources), but you are not limited to them. If the data source you need is not available out of the box, you can write a source spec in YAML and import it.
+Coral ships with [popular data sources](/reference/bundled-sources), but you are not limited to them. If the data source you need is not available out of the box, you can write a source spec in YAML and add it locally.
 
-A source spec tells Coral how to connect to an API or read a local dataset, what tables to expose, and what columns each table has. Once added, the source works exactly like a bundled one: same SQL, same `coral.tables`, `coral.columns` and `coral.inputs`, same MCP surface.
+A **source spec** is the YAML document you author. When that same YAML is stored in a bundled source directory or in Coral's workspace, it is usually named `manifest.yaml`, so you will also see it called a **source manifest**. In practice, they are the same thing: a declarative description of how Coral should connect to an API or local dataset, which tables to expose, and which columns each table has.
+
+Once added, the source works exactly like a bundled one: same SQL, same `coral.tables`, `coral.columns`, and `coral.inputs`, same MCP surface.
 
 <Tip>
-  Install the [Coral source spec authoring
-  skill](/getting-started/installation#skills) with `npx skills add
-  withcoral/skills` to help your coding agent write source specs.
+  Install the [Coral source authoring skills](/getting-started/installation#skills)
+  with `npx skills add withcoral/skills` if you want an agent to draft or
+  repair manifests for you. The current skill is
+  `coral-create-source-spec`. Some environments may also expose an older
+  alias named `create-source-manifest`; use the same authoring loop, but prefer
+  the current CLI commands: `coral source lint`, `coral source add --file`, and
+  `coral source test`.
 </Tip>
 
 ## Will this work for my source?
@@ -27,16 +33,53 @@ API-backed sources vary in difficulty. The source spec model is designed for API
 
 If you are unsure whether your API is a good candidate, ask us in [Discord](https://withcoral.com/discord) before getting started.
 
+## Choose your authoring path
+
+Use the same manifest format in both cases, but pick the workflow that matches your goal:
+
+- **Standalone custom source**: author a YAML file such as `./my-source.yaml`, then install it with `coral source add --file ./my-source.yaml`.
+- **Bundled source contribution**: edit `sources/<name>/manifest.yaml` in the Coral repo, then validate it with the repo's normal checks plus `coral source test <name>`.
+
+## Recommended authoring loop
+
+Start small and tighten the loop. A good first pass is one table, a few columns, and a cheap validation query.
+
+1. Inspect the upstream API docs or local dataset and choose one table-worthy endpoint or file shape.
+2. Create a minimal manifest with `name`, `version`, `dsl_version`, `backend`, one table, and a few typed columns.
+3. Run `coral source lint ./my-source.yaml` before installing anything.
+4. Add the source with `coral source add --file ./my-source.yaml`.
+5. Run `coral source test my_source` for strict pass/fail validation.
+6. Inspect the installed shape through Coral's system tables.
+7. Run representative `coral sql` queries against the new tables.
+8. Expand the manifest only after the first table works end to end.
+
+A practical loop looks like this:
+
+```shellscript
+coral source lint ./my-source.yaml
+coral source add --file ./my-source.yaml
+coral source test my_source
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'my_source'"
+coral sql "SELECT table_name, column_name, data_type, is_required_filter FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, column_name"
+coral sql "SELECT * FROM my_source.messages LIMIT 5"
+```
+
+That sequence tells you three different things:
+
+- `lint` catches YAML/schema mistakes before credentials or runtime behavior are involved
+- `add --file` installs the source and shows install-time warnings
+- `test` gives you a strict validation result that is easy to rerun while iterating
+
 ## Agent-driven authoring
 
 Source authoring works well as an agent-driven workflow. Point your coding agent at the Coral CLI and the [source spec reference](/reference/source-spec-reference), give it the API docs or describe the endpoints you want, and let it iterate:
 
-1. The agent writes or updates the source spec YAML
-2. Lints the file with `coral source lint ./my-source.yaml` to catch errors before installing
-3. Adds it with `coral source add --file ./my-source.yaml`
-4. Validates with `coral source test my_source`
-5. Inspects `coral.tables`, `coral.columns` and `coral.inputs` to check the shape
-6. Refines and repeats until the tables look right
+1. The agent writes or updates the source spec YAML.
+2. Lints the file with `coral source lint ./my-source.yaml` to catch errors before installing.
+3. Adds it with `coral source add --file ./my-source.yaml`.
+4. Validates with `coral source test my_source`.
+5. Inspects `coral.tables`, `coral.columns`, and `coral.inputs` to check the shape.
+6. Refines and repeats until the tables look right.
 
 ## Example: local JSONL source
 
@@ -124,6 +167,40 @@ If you are validating a credentialed source end-to-end, it is useful to try both
 This gives you confidence that the source spec works in the happy path and that `test_queries` catch broken credentials or runtime regressions in a predictable way.
 
 Use read-only SQL in `test_queries`. Prefer bounded checks such as `SELECT * FROM schema.table LIMIT 1` over expensive scans like `SELECT COUNT(*)`, especially for HTTP-backed sources or large datasets. Coral rejects DDL, DML, and other non-read-only statements as failed validation queries instead of applying them.
+
+## Document table usage with `guide`
+
+If a table needs query-writing help beyond a short description, add a `guide` field to that table in the source spec.
+
+This is especially useful for search-style endpoints or APIs with easy-to-miss constraints:
+
+- required scoping filters
+- provider-specific search syntax or qualifiers
+- defaults that change result order or breadth
+- pagination or rate-limit caveats
+- examples of the query shape users or agents should prefer
+
+```yaml
+tables:
+  - name: search_commits
+    description: Search commits
+    guide: >
+      Requires q. Always scope with repo:OWNER/NAME or org:NAME.
+      Common qualifiers: author:LOGIN, path:DIR, committer-date:>=YYYY-MM-DD.
+```
+
+Coral stores this authored text on the installed table and exposes it through `coral.tables.guide`, so both humans and agents can read it during discovery:
+
+```shellscript
+coral sql "
+  SELECT schema_name, table_name, guide
+  FROM coral.tables
+  WHERE guide <> ''
+  ORDER BY schema_name, table_name
+"
+```
+
+For MCP clients, this table-level `guide` complements `coral://guide`: agents should read `coral://guide` for the general Coral discovery workflow, then inspect `coral.tables.guide` for table-specific query advice.
 
 ## Example: HTTP API source
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -43,23 +43,16 @@ coral source list
 
 Add a bundled source or update its credentials.
 
-By default, Coral reads each declared input from an environment variable of the same name. If a required input is missing, the command exits with an error listing the missing keys.
-
 ```shellscript
-GITHUB_TOKEN=ghp_... coral source add github
+coral source add github
 ```
 
-Pass `--interactive` to be prompted for variables and secrets instead:
-
-```shellscript
-coral source add --interactive github
-```
-
-If the source is already installed, running this command again replaces its stored credentials with the new values you provide. After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
+Coral prompts for required variables or secrets interactively. If the source is already installed, running this command again replaces its stored credentials with the new values you provide.
+After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
 
 ### `coral source add --file <PATH>`
 
-Add a custom source spec from a YAML file. Input values come from environment variables by default; add `--interactive` to be prompted.
+Add a custom source spec from a YAML file.
 
 ```shellscript
 coral source add --file ./local-messages.yaml

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -76,33 +76,18 @@ Notes:
 
 The `type` field on each column accepts:
 
-| Type        | Description                                                                                        |
-| ----------- | -------------------------------------------------------------------------------------------------- |
-| `Utf8`      | UTF-8 string                                                                                       |
-| `Int64`     | 64-bit signed integer                                                                              |
-| `Float64`   | 64-bit floating point                                                                              |
-| `Boolean`   | Boolean true/false                                                                                 |
-| `Timestamp` | UTC timestamp (microsecond precision)                                                              |
-| `Json`      | UTF-8 string containing JSON. Hint that the column is queryable with JSON accessors. See "Querying JSON columns" below. |
+| Type        | Description                              |
+| ----------- | ---------------------------------------- |
+| `Utf8`      | UTF-8 string                             |
+| `Int64`     | 64-bit signed integer                    |
+| `Float64`   | 64-bit floating point                    |
+| `Boolean`   | Boolean true/false                       |
+| `Timestamp` | UTC timestamp (microsecond precision)    |
 
 Each column also supports:
 
 - `nullable` (boolean, default `true`): whether the column can contain NULL values
 - `description` (string): human-readable description, surfaced through `coral.columns`
-
-### Querying JSON columns
-
-`Json`-typed columns (and any `Utf8` column whose values happen to be JSON) can be queried with the built-in JSON functions:
-
-```sql
-SELECT id, json_get_str(properties, '$browser') AS browser
-FROM posthog.events
-WHERE json_get_int(properties, 'count') > 5
-```
-
-Available: `json_get`, `json_get_str`, `json_get_int`, `json_get_float`, `json_get_bool`, `json_get_array`, `json_get_json`, `json_contains`, `json_length`, `json_as_text`. For detailed function behavior, see the [datafusion-functions-json reference](https://github.com/datafusion-contrib/datafusion-functions-json/blob/main/README.md).
-
-Use plain object keys or array indexes with these functions. They do not accept JSONPath syntax such as `$.browser`. For example, `json_get_str(properties, 'browser')` looks up the `browser` key. Some sources, including PostHog, use literal keys that start with `$`, so `json_get_str(properties, '$browser')` looks up the exact key name `$browser`.
 
 ## Column expressions
 
@@ -195,6 +180,39 @@ Column-expression templates do not support `secret`, `variable`, or `state` name
 | `template` | string | —       | Parsed Coral template string using `{{expr.*}}` and `{{filter.*}}` |
 | `values`   | object | —       | Named sub-expressions referenced from `{{expr.name}}` tokens       |
 
+## Table `guide` field
+
+Each table can declare an optional `guide` string with table-specific usage
+notes.
+
+```yaml
+tables:
+  - name: search_commits
+    description: Search commits
+    guide: >
+      Requires q. Always scope with repo:OWNER/NAME or org:NAME.
+      Common qualifiers: author:LOGIN, path:DIR,
+      committer-date:>=YYYY-MM-DD.
+```
+
+Use `guide` for the advice a query author needs after they discover the table:
+
+- required or strongly recommended filters
+- search syntax, scoping qualifiers, and operator gotchas
+- surprising defaults or result-order behavior
+- rate-limit or pagination caveats that affect query shape
+- one or two concrete examples when the endpoint is easy to misuse
+
+Notes:
+
+- `guide` is optional. If omitted, Coral stores an empty string for the table.
+- `guide` supplements `description`; keep `description` short and use `guide`
+  for actionable query help.
+- Coral exposes the authored value through `coral.tables.guide`, so agents and
+  users can inspect it during table discovery.
+- YAML block scalars such as `>` and `|` work well for longer multi-line
+  guidance.
+
 ## File-backed tables
 
 For `jsonl` and `parquet`, each table points at a file location:
@@ -243,7 +261,6 @@ inputs:
     kind: secret
 base_url: "{{input.API_BASE}}"
 auth:
-  type: HeaderAuth
   headers:
     - name: Authorization
       from: template
@@ -266,119 +283,8 @@ In this minimal example:
 
 - `response: {}` means "use the default response rules" for an HTTP table
 - with the default response rules, Coral treats the selected response value directly as rows unless you configure a different `row_strategy`
-- `inputs` declares the install-time variables and secrets for this source in stable authored order. At install time, `coral source add` reads each key from an environment variable of the same name (or prompts for them when run with `--interactive`). At runtime, installed inputs are surfaced through `coral.inputs`.
+- `inputs` declares the install-time prompts for this source in stable authored order. (At runtime, these are surfaced through `coral.inputs`.)
 - `{{input.API_TOKEN}}` is resolved from the store implied by the declared input kind
-
-### HTTP authentication
-
-The top-level `auth` block declares how Coral authenticates outgoing requests. Pick one of three `type` values:
-
-| `type` | Purpose |
-| ------ | ------- |
-| `HeaderAuth` | Attach one or more declarative auth headers (Bearer tokens, API keys, pre-signed headers). |
-| `BasicAuth` | HTTP Basic. Coral base64-encodes `username:password` into `Authorization: Basic ...`. |
-| `CustomAuth` | Use a named authenticator for auth schemes that need request signing, such as AWS SigV4. |
-
-Credentials for authentication are declared in [Source inputs](/reference/source-spec-reference#source-inputs).
-
-#### `HeaderAuth`
-
-```yaml
-auth:
-  type: HeaderAuth
-  headers:
-    - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
-```
-
-`headers` entries share the same shape as request/table headers, but only `from: literal`, `from: template`, and `from: input` are meaningful here — filter and state tokens have no value at auth time.
-
-#### `BasicAuth`
-
-```yaml
-auth:
-  type: BasicAuth
-  username: "{{input.API_USER}}"
-  password: "{{input.API_TOKEN}}"
-```
-
-`username` and `password` are templates; `{{input.KEY}}` tokens are honored. Coral encodes them as `Authorization: Basic base64(user:pass)`.
-
-#### `CustomAuth`
-
-```yaml
-auth:
-  type: CustomAuth
-  authenticator: aws_sigv4
-  # ...authenticator-specific fields, see below
-```
-
-The `authenticator` key names a runtime-provided authenticator. All other fields under `auth` are passed through as that authenticator's config. Use this type when signing depends on the final request contents.
-
-##### `aws_sigv4`
-
-Signs outgoing requests with AWS Signature Version 4. Useful for querying AWS monitoring services via CloudWatch, CloudTrail, or any other SigV4-protected API.
-
-Example against CloudWatch Logs:
-
-```yaml
-auth:
-  type: CustomAuth
-  authenticator: aws_sigv4
-  service: logs
-  region: "{{input.AWS_REGION}}"
-  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
-  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
-```
-
-| Field | Required | Notes |
-| ----- | -------- | ----- |
-| `service` | yes | AWS service code (`logs`, `monitoring`, `cloudtrail`, `execute-api`, …) |
-| `region` | yes | AWS region; templated from inputs |
-| `access_key_id` | yes | AWS access key ID |
-| `secret_access_key` | yes | AWS secret access key |
-| `session_token` | no | Omit for long-term credentials; include for STS/assumed-role sessions |
-
-For STS or assumed-role temporary credentials, also declare `AWS_SESSION_TOKEN` in the source's `inputs` block and include it in the authenticator config:
-
-```yaml
-inputs:
-  # ...existing AWS_REGION, AWS_ACCESS_KEY_ID, and AWS_SECRET_ACCESS_KEY inputs
-  AWS_SESSION_TOKEN:
-    kind: secret
-    hint: AWS session token for temporary credentials.
-
-auth:
-  # ...existing aws_sigv4 config
-  type: CustomAuth
-  authenticator: aws_sigv4
-  service: logs
-  region: "{{input.AWS_REGION}}"
-  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
-  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
-  session_token: "{{input.AWS_SESSION_TOKEN}}"
-```
-
-**S3 note:** `service: s3` and `service: s3-outposts` switch to S3-specific signing (single percent-encoding, path normalization disabled, `X-Amz-Content-Sha256` enabled). This is required to avoid `SignatureDoesNotMatch` on bucket operations and is handled automatically.
-
-#### Non-auth request headers
-
-Headers required on every request but not used for auth (Accept, API version, etc.) go in a top-level `request_headers:` block (sibling of `auth:`), not inside `auth.headers`:
-
-```yaml
-request_headers:
-  - name: Accept
-    from: literal
-    value: application/json
-  - name: X-Api-Version
-    from: literal
-    value: "2024-10-01"
-```
-
-`request_headers` resolves before auth on each request. If an auth header has the same name, it overwrites the value from `request_headers`.
-
-Coral sets `User-Agent: coral` on every outgoing request automatically — do not declare it in manifests.
 
 ### HTTP rate limiting
 
@@ -503,7 +409,7 @@ pagination:
 
 ## Source inputs
 
-HTTP source specs can declare the variables and secrets this source needs under a top-level `inputs` map. At install time, `coral source add` collects each input from an environment variable matching the key, or prompts interactively when you pass `--interactive`.
+HTTP source specs can declare install-time inputs under a top-level `inputs` map:
 
 - **Variables**: non-secret configuration like base URLs or organization IDs
 - **Secrets**: API keys or bearer tokens
@@ -520,7 +426,6 @@ inputs:
 
 base_url: "{{input.API_BASE}}"
 auth:
-  type: HeaderAuth
   headers:
     - name: Authorization
       from: template
@@ -533,7 +438,7 @@ Rules:
 - `kind: variable` values are stored with source variables
 - `kind: secret` values are stored with source secrets
 - `default` is allowed only for variables
-- `hint` is optional and shown alongside the input during `coral source add --interactive`
+- `hint` is optional and shown while Coral prompts for the input
 - references elsewhere in the manifest use `{{input.KEY}}` templates or `from: input`
 
 At runtime, installed source inputs are also surfaced through `coral.inputs`.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -5,10 +5,31 @@ description: "Schema and fields for Coral source spec YAML files."
 
 Coral is extensible through source specs. These are YAML files that describe how to connect to an API or read a local dataset.
 
+A **source spec** is the YAML you author. When that YAML is stored on disk for a bundled source or an installed custom source, it is commonly named `manifest.yaml`, so the terms **source spec** and **source manifest** are interchangeable in the Coral docs and codebase.
+
 <Tip>
   For a guided walkthrough, see [Write a custom
   source](/guides/write-a-custom-source).
 </Tip>
+
+## Authoring workflow
+
+The recommended loop for authoring sources is **Lint → Add → Test**.
+
+- `coral source lint ./my-source.yaml` (Pre-install schema check)
+- `coral source add --file ./my-source.yaml` (Installation and input prompts)
+- `coral source test my_source` (Runtime validation and `test_queries`)
+
+For a detailed walkthrough of this loop, including how to inspect system tables, see [Write a custom source](/guides/write-a-custom-source#recommended-authoring-loop).
+
+If you expose a search-style table, plan to ship companion guide content for it. The manifest can describe the endpoint, but source authors should also document the search syntax, common scoping qualifiers, surprising defaults, pagination or rate-limit behavior, and operators or parameters that commonly fail.
+
+| Command | What it proves |
+| ------- | -------------- |
+| `coral source lint` | The YAML parses and satisfies Coral's schema + semantic validation rules |
+| `coral source add --file` | Coral can install the manifest and prompt for any declared inputs |
+| `coral source test` | The installed source initializes, exposes tables, and passes any `test_queries` |
+| `coral sql` against `coral.tables` / `coral.columns` / `coral.inputs` | The installed shape matches what you intended |
 
 ## Top-level fields
 
@@ -23,13 +44,13 @@ test_queries:
   - SELECT * FROM my_source.messages LIMIT 1
 ```
 
-| Field         | Description                                        |
-| ------------- | -------------------------------------------------- |
-| `name`        | Source name, also used as the SQL schema name      |
-| `version`     | Source spec version string                         |
-| `dsl_version` | Coral source spec DSL version (currently `3`)      |
-| `backend`     | How data is fetched: `http`, `jsonl`, or `parquet` |
-| `test_queries` | Optional read-only SQL checks Coral runs during `coral source test` |
+| Field         | Description |
+| ------------- | ----------- |
+| `name`        | Stable source identifier, also used as the SQL schema name. Prefer lowercase snake_case. |
+| `version`     | Source spec version string that you update as the manifest evolves. |
+| `dsl_version` | Coral source spec DSL version. Current manifests should use `3`. |
+| `backend`     | How data is fetched: `http`, `jsonl`, or `parquet`. |
+| `test_queries` | Optional read-only SQL checks Coral runs during `coral source test`. Keep them cheap and representative. |
 
 ## Test queries
 
@@ -45,7 +66,8 @@ test_queries:
 Notes:
 
 - Each query result is reported individually during `coral source test`.
-- `coral source add` and `coral onboard` surface post-install validation issues as warnings; `coral source test` is the strict pass/fail command.
+- `test_queries` failures are **non-blocking** during `coral source add --file` and `coral onboard`; they surface as warnings so the source still lands in your workspace.
+- `coral source test` is the **strict pass/fail** command where any failing query causes a non-zero exit code.
 - Prefer cheap read-only checks that validate connectivity and mapping logic. For example, `SELECT * FROM schema.table LIMIT 1` is usually a better fit than `SELECT COUNT(*)`.
 - Keep these queries read-only. Statements such as `CREATE`, `COPY`, `INSERT`,
   `UPDATE`, `DELETE`, or `SET` are reported as failed validation queries.
@@ -202,6 +224,7 @@ Notes:
 - `jsonl` currently expects `file://` locations
 - `parquet` supports `file://` and `s3://` locations
 - if you omit `glob`, Coral uses a backend-specific default
+- standalone manifests can be named however you like (for example `./my-source.yaml`), but bundled sources conventionally live at `sources/<name>/manifest.yaml`
 
 ## HTTP-backed tables
 
@@ -506,6 +529,7 @@ auth:
 
 Rules:
 
+- declare inputs in the order you want Coral to prompt for them during `coral source add --file`
 - `kind: variable` values are stored with source variables
 - `kind: secret` values are stored with source secrets
 - `default` is allowed only for variables


### PR DESCRIPTION
docs(source-authoring): help authors validate custom manifests correctly

The source-authoring docs blurred spec-vs-manifest terminology and left
new authors to infer too much of the lint/add/test loop. This update
makes the authoring path explicit, highlights search-endpoint gotchas,
and points shared custom sources toward nearby usage notes.

Constraint: Keep changes scoped to docs in this worktree
Constraint: External skill definitions were inspected but not edited here
Rejected: Leave search-endpoint guidance implicit | users would keep guessing syntax and scope qualifiers
Rejected: Duplicate the full workflow in both guide and reference | higher maintenance burden
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep source-authoring docs aligned with `coral source lint`, `coral source add --file`, and `coral source test`
Tested: git diff --check; manual review of updated docs; Gemini review artifact at .omx/artifacts/gemini-source-authoring-docs-review-20260423T090628Z.md
Not-tested: full docs site build

Clarify how table guide metadata should be discovered

The docs now distinguish the workspace-level coral://guide MCP resource from per-table guide text authored in source specs. This closes the gap that left source authors and agents unsure where query-writing help belongs and how to discover it after installation.

Constraint: The docs need to match the existing Coral surfaces without introducing new commands or metadata APIs
Rejected: Put table-specific guidance into coral://guide alone | it hides authored help behind a generic workspace resource instead of the installed table metadata
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: Keep coral://guide focused on discovery workflow and keep table-specific query advice documented through coral.tables.guide
Tested: Reviewed updated doc sections via git diff and targeted file inspection
Not-tested: Full docs build/lint