### PR TITLE
feat(cli): add `coral completion` for shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1025,7 @@ dependencies = [
  "arrow",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "coral-api",
  "coral-app",
  "coral-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ base64 = "0.22"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde", "std"] }
 clap = { version = "4.5", features = ["derive", "env"] }
+clap_complete = "4.5"
 datafusion = "53"
 datafusion-functions-json = "0.53"
 dialoguer = "0.12"

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -19,6 +19,7 @@ cli-test-server = []
 anyhow.workspace = true
 arrow.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 dialoguer.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -15,7 +15,8 @@ mod source_ops;
 
 use std::path::PathBuf;
 
-use clap::{ArgGroup, Args, Parser, Subcommand, ValueEnum};
+use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap_complete::{Shell, generate};
 use coral_api::v1::ExecuteSqlRequest;
 use coral_client::{
     AppClient, decode_execute_sql_response, default_workspace, format_batches_json,
@@ -45,6 +46,15 @@ enum Command {
     Onboard,
     /// Start the MCP server over stdio
     McpStdio,
+    /// Generate shell completion scripts
+    Completion(CompletionArgs),
+}
+
+#[derive(Debug, Args)]
+/// Generate shell completion scripts
+struct CompletionArgs {
+    /// Shell to generate completions for
+    shell: Shell,
 }
 
 #[derive(Debug, Args)]
@@ -220,6 +230,11 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
         }
         Command::McpStdio => {
             coral_mcp::run_stdio_with_client(app).await?;
+        }
+        Command::Completion(args) => {
+            let mut cmd = Cli::command();
+            let bin_name = cmd.get_name().to_string();
+            generate(args.shell, &mut cmd, bin_name, &mut std::io::stdout());
         }
     }
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -116,3 +116,17 @@ This server exposes:
 | Tool     | `list_tables`    | List all available tables        |
 | Resource | `coral://guide`  | Usage guide for agents           |
 | Resource | `coral://tables` | Schema for all installed sources |
+
+## `coral completion <SHELL>`
+
+Generate a shell completion script and write it to standard output. Supported shells are `bash`, `zsh`, `fish`, `elvish`, and `powershell`.
+
+```shellscript
+coral completion zsh > ~/.zsh/completions/_coral
+```
+
+To enable completions in the current shell without installing them:
+
+```shellscript
+source <(coral completion bash)
+```


### PR DESCRIPTION
## Summary
- Adds a `coral completion <SHELL>` subcommand that prints a completion script to stdout, using `clap_complete`.
- Supports bash, zsh, fish, elvish, and powershell.
- Documents the new command in `docs/reference/cli-reference.mdx`.

## Test plan
- [x] `cargo build -p coral-cli` succeeds
- [x] `cargo clippy -p coral-cli --all-targets` is clean
- [x] `coral completion bash`, `coral completion zsh`, `coral completion --help` produce expected output