### PR TITLE
feat(cli): improve `source test` error message

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -202,7 +202,7 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
                 println!("Manifest is valid");
             }
             SourceCommand::Test { name } => {
-                source_ops::validate_and_print(
+                source_ops::test_and_print(
                     &app,
                     &name,
                     source_ops::TableDisplayLimit::All,

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -308,6 +308,51 @@ pub(crate) async fn validate_and_warn(
     Ok(())
 }
 
+pub(crate) async fn test_and_print(
+    app: &AppClient,
+    source_name: &str,
+    limit: TableDisplayLimit,
+    severity_mode: ValidationSeverityMode,
+) -> Result<(), anyhow::Error> {
+    let normalized = source_name_arg(Some(source_name))?;
+    let err = match validate_and_print(app, &normalized, limit, severity_mode).await {
+        Ok(()) => return Ok(()),
+        Err(err) => err,
+    };
+
+    let is_not_found = err
+        .downcast_ref::<tonic::Status>()
+        .is_some_and(|status| status.code() == tonic::Code::NotFound);
+    if !is_not_found {
+        return Err(err);
+    }
+
+    // Discovery failure must not mask the original validation error.
+    let Ok(available) = discover_sources(app).await else {
+        return Err(err);
+    };
+    if available
+        .iter()
+        .any(|source| source.name == normalized && !source.installed)
+    {
+        return Err(source_not_installed_error(&normalized));
+    }
+
+    Err(source_not_found_error(&normalized))
+}
+
+fn source_not_installed_error(source_name: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "source '{source_name}' is not installed. Run `coral source add {source_name}` to install it, then retry `coral source test {source_name}`."
+    )
+}
+
+fn source_not_found_error(source_name: &str) -> anyhow::Error {
+    anyhow::anyhow!(
+        "source '{source_name}' was not found. Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install."
+    )
+}
+
 pub(crate) fn print_validation_pretty(
     response: &ValidateSourceResponse,
     limit: TableDisplayLimit,

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use coral_api::v1::{DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse};
+use coral_api::v1::{
+    AvailableSource, DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, SourceOrigin,
+};
 use tonic::Code;
 
 use harness::{MockServer, MockServerConfig, encode_arrow_ipc_stream};
@@ -601,6 +603,96 @@ async fn source_add_interactive_requires_tty() {
     assert!(
         stderr.contains("requires a TTY"),
         "expected TTY requirement error: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_test_suggests_add_for_uninstalled_bundled_source() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_validate_source_error(Code::NotFound, "source 'default:demo_bundled' not found")
+            .with_discover_sources(DiscoverSourcesResponse {
+                sources: vec![AvailableSource {
+                    name: "demo_bundled".to_string(),
+                    description: "A demo bundled source for testing".to_string(),
+                    version: "1.0.0".to_string(),
+                    inputs: Vec::new(),
+                    installed: false,
+                    origin: SourceOrigin::Bundled as i32,
+                }],
+            }),
+    )
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "test", "demo_bundled"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("source 'demo_bundled' is not installed"),
+        "expected not-installed error in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("coral source add demo_bundled"),
+        "expected add suggestion in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("coral source test demo_bundled"),
+        "expected retry suggestion in stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("default:demo_bundled"),
+        "should not expose workspace-qualified source name: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_test_normalizes_error_for_unknown_source() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default()
+            .with_validate_source_error(
+                Code::NotFound,
+                "source 'default:totally_unknown' not found",
+            )
+            .with_discover_sources(DiscoverSourcesResponse {
+                sources: Vec::new(),
+            }),
+    )
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "test", "totally_unknown"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("source 'totally_unknown' was not found"),
+        "expected normalized not-found error in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("coral source list"),
+        "expected list suggestion in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("coral source discover"),
+        "expected discover suggestion in stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("default:totally_unknown"),
+        "should not expose workspace-qualified source name: {stderr}"
+    );
+    assert!(
+        !stderr.contains("coral source add"),
+        "should not contain add suggestion for unknown source: {stderr}"
     );
 
     server.shutdown().await;


### PR DESCRIPTION
## Summary

Says on the tin; making everyone's life slightly easier :P
Thought about prompting users to install (and fuzzy matching source names), but that complexity for this code path wasn't worth IMO

## Test plan

Source exists, but is not installed:

```
$ cargo run -p coral-cli -- source test posthog
Error: source 'posthog' is not installed. Run `coral source add posthog` to install it, then retry `coral source test posthog`.
```

Source doesn't exist:
```
$ cargo run -p coral-cli -- source test cloudwatch
Error: source 'cloudwatch' was not found. Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.
```

Source exists, and is installed (no behaviour change from what we had):
<img width="864" height="241" alt="image" src="https://github.com/user-attachments/assets/762e768b-3ab3-44a9-a200-3b885b3e348d" />
