### PR TITLE
chore: remove .claude/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../.agents/skills


### PR DESCRIPTION
.agents/skills was removed in #124 but this symlink was left in place