### PR TITLE
feat(cli): friendly not-found error for `coral source remove`

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -69,6 +69,9 @@ pub const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
 /// Canonical default workspace name used across local Coral surfaces.
 pub const DEFAULT_WORKSPACE_ID: &str = "default";
 
+/// Machine-readable reason for a configured source lookup miss.
+pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
+
 /// Reserved `ErrorInfo.metadata` key for a one-line error summary.
 pub const CORAL_ERROR_METADATA_SUMMARY: &str = "summary";
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -2,7 +2,7 @@
 
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
-    CORAL_ERROR_METADATA_SUMMARY,
+    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
 };
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
@@ -88,6 +88,25 @@ fn truncate_status_detail(detail: String) -> String {
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn app_status(error: AppError) -> Status {
+    if matches!(error, AppError::SourceNotFound(_)) {
+        // The `reason` alone discriminates `SOURCE_NOT_FOUND` from other
+        // `Code::NotFound` causes (e.g. `io::ErrorKind::NotFound` raised
+        // when a manifest file is missing). The qualified name already
+        // appears in the truncated status message; we deliberately do
+        // not duplicate it into structured metadata so unbounded
+        // identifiers cannot push the `grpc-status-details-bin` trailer
+        // past the h2 `MAX_HEADER_LIST_SIZE` budget.
+        let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+            CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+            CORAL_ERROR_DOMAIN,
+            std::collections::HashMap::new(),
+        ))];
+        return Status::with_error_details_vec(
+            Code::NotFound,
+            truncate_status_detail(error.to_string()),
+            details,
+        );
+    }
     Status::new(app_code(&error), truncate_status_detail(error.to_string()))
 }
 
@@ -189,6 +208,44 @@ mod tests {
         let out = truncate_status_detail(detail);
         assert!(out.len() <= MAX_STATUS_DETAIL_BYTES);
         assert!(out.ends_with("… (truncated)"), "missing marker: {out:?}");
+    }
+
+    #[test]
+    fn app_status_attaches_structured_reason_for_source_not_found() {
+        let status = app_status(AppError::SourceNotFound("default:hn".to_string()));
+        assert_eq!(status.code(), Code::NotFound);
+
+        let details = status.get_error_details_vec();
+        let info = details
+            .iter()
+            .find_map(|detail| match detail {
+                ErrorDetail::ErrorInfo(info) => Some(info),
+                _ => None,
+            })
+            .expect("source-not-found status must carry an ErrorInfo detail");
+        assert_eq!(info.reason, CORAL_ERROR_REASON_SOURCE_NOT_FOUND);
+        assert_eq!(info.domain, CORAL_ERROR_DOMAIN);
+        // The reason alone is the discriminator; we intentionally do
+        // not echo unbounded identifiers into structured metadata.
+        assert!(
+            info.metadata.is_empty(),
+            "SOURCE_NOT_FOUND must not carry unbounded identifier metadata: {:?}",
+            info.metadata
+        );
+    }
+
+    #[test]
+    fn app_status_does_not_attach_structured_reason_for_io_not_found() {
+        let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "manifest missing");
+        let status = app_status(AppError::Io(io_error));
+        // Same gRPC code as SourceNotFound — but no Coral ErrorInfo, so
+        // clients can't confuse a broken local manifest for a missing
+        // catalog entry.
+        assert_eq!(status.code(), Code::NotFound);
+        assert!(
+            status.get_error_details_vec().is_empty(),
+            "io::NotFound must not carry SOURCE_NOT_FOUND details"
+        );
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -204,6 +204,12 @@ pub enum CliError {
         /// Normalized source name requested by the user.
         source_name: String,
     },
+    /// A requested source was not found while removing an installed source.
+    #[error("source '{source_name}' was not found")]
+    SourceRemoveNotFound {
+        /// Normalized source name requested by the user.
+        source_name: String,
+    },
     /// Any non-renderable internal command failure.
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
@@ -222,6 +228,9 @@ impl CliError {
             )),
             Self::SourceNotFound { source_name } => Some(format!(
                 "source '{source_name}' was not found. Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.\n"
+            )),
+            Self::SourceRemoveNotFound { source_name } => Some(format!(
+                "source '{source_name}' was not found. Run `coral source list` to see installed sources.\n"
             )),
             Self::Internal(_) => None,
         }
@@ -250,7 +259,9 @@ impl coral_app::RunErrorTelemetry for CliError {
         match self {
             Self::Query { error_type, .. } => Cow::Borrowed(error_type.as_str()),
             Self::SourceNotInstalled { .. } => Cow::Borrowed("SOURCE_NOT_INSTALLED"),
-            Self::SourceNotFound { .. } => Cow::Borrowed("SOURCE_NOT_FOUND"),
+            Self::SourceNotFound { .. } | Self::SourceRemoveNotFound { .. } => {
+                Cow::Borrowed("SOURCE_NOT_FOUND")
+            }
             Self::Internal(_) => Cow::Borrowed("INTERNAL"),
         }
     }
@@ -261,7 +272,7 @@ impl coral_app::RunErrorTelemetry for CliError {
             Self::SourceNotInstalled { source_name } => {
                 Cow::Owned(format!("source '{source_name}' is not installed"))
             }
-            Self::SourceNotFound { source_name } => {
+            Self::SourceNotFound { source_name } | Self::SourceRemoveNotFound { source_name } => {
                 Cow::Owned(format!("source '{source_name}' was not found"))
             }
             Self::Internal(error) => Cow::Owned(error.to_string()),
@@ -514,8 +525,7 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
             .await?;
         }
         SourceCommand::Remove { name } => {
-            source_ops::delete_source(app, &name).await?;
-            println!("Removed source {name}");
+            source_ops::remove_and_print(app, &name).await?;
         }
     }
     Ok(())

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -2,13 +2,14 @@ use std::collections::BTreeMap;
 use std::io::{IsTerminal, stdin, stdout};
 use std::path::Path;
 
+use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, GetSourceInfoRequest,
     ImportSourceRequest, ListSourcesRequest, QueryTestFailure, QueryTestSuccess, Source,
     SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, SourceSecret, SourceVariable,
     ValidateSourceRequest, ValidateSourceResponse, query_test_result,
 };
-use coral_client::{AppClient, default_workspace};
+use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::{
     ManifestInputKind, ManifestInputSpec, ValidatedSourceManifest, parse_source_manifest_yaml,
 };
@@ -397,11 +398,12 @@ pub(crate) async fn test_and_print(
     let normalized = source_name_arg(Some(source_name))?;
     let response = match validate_source_request(app, normalized.clone()).await {
         Ok(response) => response,
-        Err(status) if status.code() == tonic::Code::NotFound => {
+        Err(status) if is_source_missing_status(&status) => {
             return source_test_not_found_error(app, &normalized, status).await;
         }
         Err(status) => return Err(anyhow::Error::from(status).into()),
     };
+
     print_validation_pretty(&response, limit)?;
     match validation_follow_up(&response, severity_mode) {
         ValidationFollowUp::None => Ok(()),
@@ -434,6 +436,45 @@ async fn source_test_not_found_error(
     Err(crate::CliError::SourceNotFound {
         source_name: source_name.to_string(),
     })
+}
+
+pub(crate) async fn remove_and_print(
+    app: &AppClient,
+    source_name: &str,
+) -> Result<(), crate::CliError> {
+    let normalized = source_name_arg(Some(source_name))?;
+    match delete_source(app, &normalized).await {
+        Ok(()) => {
+            println!("Removed source {normalized}");
+            Ok(())
+        }
+        Err(err) => {
+            if err
+                .downcast_ref::<tonic::Status>()
+                .is_some_and(is_source_missing_status)
+            {
+                Err(crate::CliError::SourceRemoveNotFound {
+                    source_name: normalized,
+                })
+            } else {
+                Err(err.into())
+            }
+        }
+    }
+}
+
+/// Returns `true` only when the gRPC status carries the server's
+/// `SOURCE_NOT_FOUND` AIP-193 reason. Other `Code::NotFound` causes
+/// (e.g. a missing manifest file mapped from `io::ErrorKind::NotFound`)
+/// have no Coral `ErrorInfo` attached, so they remain diagnosable instead
+/// of being rewritten into the friendly "source not found" message.
+fn is_source_missing_status(status: &tonic::Status) -> bool {
+    match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => {
+            error.reason == CORAL_ERROR_REASON_SOURCE_NOT_FOUND
+        }
+        DecodedStatusError::Plain(_) => false,
+    }
 }
 
 pub(crate) fn print_validation_pretty(

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -774,7 +774,7 @@ async fn source_add_interactive_requires_tty() {
 async fn source_test_suggests_add_for_uninstalled_bundled_source() {
     let server = MockServer::start_with_config(
         MockServerConfig::default()
-            .with_validate_source_error(Code::NotFound, "source 'default:demo_bundled' not found")
+            .with_validate_source_not_found("default:demo_bundled")
             .with_discover_sources(DiscoverSourcesResponse {
                 sources: vec![SourceInfo {
                     name: "demo_bundled".to_string(),
@@ -804,10 +804,6 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
         "expected add suggestion in stderr: {stderr}"
     );
     assert!(
-        stderr.contains("coral source test demo_bundled"),
-        "expected retry suggestion in stderr: {stderr}"
-    );
-    assert!(
         !stderr.contains("default:demo_bundled"),
         "should not expose workspace-qualified source name: {stderr}"
     );
@@ -819,10 +815,7 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
 async fn source_test_normalizes_error_for_unknown_source() {
     let server = MockServer::start_with_config(
         MockServerConfig::default()
-            .with_validate_source_error(
-                Code::NotFound,
-                "source 'default:totally_unknown' not found",
-            )
+            .with_validate_source_not_found("default:totally_unknown")
             .with_discover_sources(DiscoverSourcesResponse {
                 sources: Vec::new(),
             }),
@@ -841,10 +834,6 @@ async fn source_test_normalizes_error_for_unknown_source() {
         "expected normalized not-found error in stderr: {stderr}"
     );
     assert!(
-        stderr.contains("coral source list"),
-        "expected list suggestion in stderr: {stderr}"
-    );
-    assert!(
         stderr.contains("coral source discover"),
         "expected discover suggestion in stderr: {stderr}"
     );
@@ -852,9 +841,66 @@ async fn source_test_normalizes_error_for_unknown_source() {
         !stderr.contains("default:totally_unknown"),
         "should not expose workspace-qualified source name: {stderr}"
     );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_remove_normalizes_error_for_unknown_source() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default().with_delete_source_not_found("default:unknown_source"),
+    )
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "remove", "unknown_source"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        !stderr.contains("coral source add"),
-        "should not contain add suggestion for unknown source: {stderr}"
+        stderr.contains("source 'unknown_source' was not found"),
+        "expected normalized not-found error in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("coral source list"),
+        "expected list suggestion in stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("default:unknown_source"),
+        "should not expose workspace-qualified source name: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_remove_preserves_unrelated_not_found_errors() {
+    // Server can return Code::NotFound for reasons other than a missing
+    // catalog entry (e.g. a missing manifest file mapped from
+    // io::ErrorKind::NotFound). The CLI must not rewrite those into the
+    // friendly "source was not found" message.
+    let raw_message = "manifest file missing: No such file or directory (os error 2)";
+    let server = MockServer::start_with_config(
+        MockServerConfig::default().with_delete_source_error(Code::NotFound, raw_message),
+    )
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "remove", "broken_source"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains(raw_message),
+        "expected raw server error to surface unchanged: {stderr}"
+    );
+    assert!(
+        !stderr.contains("source 'broken_source' was not found"),
+        "should not rewrite non-source-missing NotFound: {stderr}"
     );
 
     server.shutdown().await;

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -23,12 +23,14 @@ use coral_api::v1::{
     SourceInputSpec, SourceOrigin, Table, TableSummary, ValidateSourceRequest,
     ValidateSourceResponse, Workspace,
 };
+use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
 use tonic::{Code, Request, Response, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
 
 fn workspace() -> Workspace {
     Workspace {
@@ -270,6 +272,11 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
 struct MockError {
     code: Code,
     message: String,
+    /// When `Some`, the error carries an AIP-193 `ErrorInfo` matching what
+    /// the real server attaches via `app_status` for the
+    /// `AppError::SourceNotFound` variant. Set via
+    /// `MockError::source_not_found(qualified)`.
+    source_not_found_qualified: Option<String>,
 }
 
 impl MockError {
@@ -277,10 +284,31 @@ impl MockError {
         Self {
             code,
             message: message.into(),
+            source_not_found_qualified: None,
+        }
+    }
+
+    fn source_not_found(qualified: impl Into<String>) -> Self {
+        let qualified = qualified.into();
+        Self {
+            code: Code::NotFound,
+            message: format!("source '{qualified}' not found"),
+            source_not_found_qualified: Some(qualified),
         }
     }
 
     fn status(&self) -> Status {
+        if self.source_not_found_qualified.is_some() {
+            // Mirrors `coral_app::bootstrap::error::app_status`: the
+            // reason alone discriminates the error class — no unbounded
+            // identifier is echoed into structured metadata.
+            let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+                CORAL_ERROR_DOMAIN,
+                std::collections::HashMap::new(),
+            ))];
+            return Status::with_error_details_vec(self.code, self.message.clone(), details);
+        }
         Status::new(self.code, self.message.clone())
     }
 }
@@ -298,6 +326,10 @@ impl<T> MockResult<T> {
 
     fn err(code: Code, message: impl Into<String>) -> Self {
         Self::Err(MockError::new(code, message))
+    }
+
+    fn source_not_found(qualified: impl Into<String>) -> Self {
+        Self::Err(MockError::source_not_found(qualified))
     }
 
     fn into_tonic_result(self) -> Result<T, Status> {
@@ -383,6 +415,31 @@ impl MockServerConfig {
         response: ValidateSourceResponse,
     ) -> Self {
         self.validate_source = MockResult::ok(response);
+        self
+    }
+
+    /// Mirrors what the real server emits for `AppError::SourceNotFound`
+    /// from `validate_source` (a `Code::NotFound` Status carrying an
+    /// AIP-193 `ErrorInfo` with `reason = "SOURCE_NOT_FOUND"`).
+    pub(crate) fn with_validate_source_not_found(mut self, qualified: impl Into<String>) -> Self {
+        self.validate_source = MockResult::source_not_found(qualified);
+        self
+    }
+
+    pub(crate) fn with_delete_source_error(
+        mut self,
+        code: Code,
+        message: impl Into<String>,
+    ) -> Self {
+        self.delete_source = MockResult::err(code, message);
+        self
+    }
+
+    /// Mirrors what the real server emits for `AppError::SourceNotFound`
+    /// from `delete_source` (a `Code::NotFound` Status carrying an
+    /// AIP-193 `ErrorInfo` with `reason = "SOURCE_NOT_FOUND"`).
+    pub(crate) fn with_delete_source_not_found(mut self, qualified: impl Into<String>) -> Self {
+        self.delete_source = MockResult::source_not_found(qualified);
         self
     }
 }

--- a/crates/coral-client/src/status_error.rs
+++ b/crates/coral-client/src/status_error.rs
@@ -108,7 +108,9 @@ mod tests {
     use tonic::{Code, Status};
     use tonic_types::{ErrorDetail, StatusExt as _};
 
-    use super::{CORAL_ERROR_DOMAIN, DecodedStatusError, decode_status_error};
+    use coral_api::CORAL_ERROR_DOMAIN;
+
+    use super::{DecodedStatusError, decode_status_error};
 
     fn build_coral_status(reason: &str, metadata: Vec<(&str, &str)>, retryable: bool) -> Status {
         let meta: std::collections::HashMap<String, String> = metadata


### PR DESCRIPTION
## Summary

- Render `coral source remove <name>` missing-source failures as a friendly CLI error that keeps the user-provided source name and suggests `coral source list`.
- Reuse the same structured source-not-found discriminator for `coral source test <name>` so only AIP-193 `SOURCE_NOT_FOUND` statuses get normalized; unrelated `Code::NotFound` errors continue to surface raw.
- Emit `SOURCE_NOT_FOUND` `ErrorInfo` from `app_status` for `AppError::SourceNotFound` and centralize the Coral structured-error domain/reason/metadata constants in `coral-api`.

## Test plan

When trying to removing a source that's not installed:

Before
Error: code: 'Some requested entity was not found', message: "source 'default:hn' not found"

After
Error: source 'hn' was not found. Run coral source list to see installed sources.
