### PR TITLE
feat(api): filter listed tables by schema

### DIFF
--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -25,6 +25,16 @@ message ExecuteSqlResponse {
 message ListTablesRequest {
   // Workspace whose current query-visible tables should be listed.
   Workspace workspace = 1;
+  // Restrict results to this SQL schema. Exact match.
+  // Empty string (default) or whitespace-only strings mean no filter.
+  //
+  // INVARIANT: this message must not carry matching primitives beyond
+  // exact `schema_filter`. Substring / prefix / fuzzy / multi-field
+  // predicates go through the `sql` RPC against `coral.tables`. This
+  // caps what agents have to learn about ListTables semantics and
+  // keeps `sql`-against-`coral.tables` as the canonical richer-predicate
+  // path. See SOURCE-459 design notes.
+  string schema_filter = 2;
 }
 
 // Returns the query-visible tables in one workspace.

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -58,12 +58,13 @@ impl QueryManager {
     pub(crate) async fn list_tables(
         &self,
         workspace_name: &WorkspaceName,
+        schema_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
         let sources = self
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_provider(&sources);
-        CoralQuery::list_tables(&sources, &runtime, None)
+        CoralQuery::list_tables(&sources, &runtime, schema_filter)
             .await
             .map_err(QueryManagerError::Core)
     }

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -32,9 +32,11 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ListTablesResponse>, Status> {
         let request = request.into_inner();
         let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+        let schema_filter = request.schema_filter.trim();
+        let schema_filter = (!schema_filter.is_empty()).then_some(schema_filter);
         let tables = self
             .queries
-            .list_tables(&workspace_name)
+            .list_tables(&workspace_name, schema_filter)
             .await
             .map_err(query_status)?
             .into_iter()

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -104,6 +104,7 @@ impl GrpcHarness {
         self.query_client()
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
+                schema_filter: String::new(),
             }))
             .await
             .expect("list tables")

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -208,6 +208,55 @@ async fn validate_source_returns_tables() {
 }
 
 #[tokio::test]
+async fn list_tables_filters_by_schema() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_yaml(harness.temp_path());
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    let local_messages = harness
+        .query_client()
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+            schema_filter: "local_messages".to_string(),
+        }))
+        .await
+        .expect("schema-filtered list tables")
+        .into_inner()
+        .tables;
+    assert_eq!(local_messages.len(), 1);
+    assert_eq!(local_messages[0].schema_name, "local_messages");
+    assert_eq!(local_messages[0].name, "messages");
+
+    let missing = harness
+        .query_client()
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+            schema_filter: "missing".to_string(),
+        }))
+        .await
+        .expect("missing schema should list as empty")
+        .into_inner()
+        .tables;
+    assert!(missing.is_empty());
+
+    let unfiltered = harness
+        .query_client()
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+            schema_filter: String::new(),
+        }))
+        .await
+        .expect("unfiltered list tables")
+        .into_inner()
+        .tables;
+    assert_eq!(unfiltered.len(), 1);
+    assert_eq!(unfiltered[0].schema_name, "local_messages");
+    assert_eq!(unfiltered[0].name, "messages");
+}
+
+#[tokio::test]
 async fn validate_source_returns_query_test_results_without_unary_error() {
     let harness = GrpcHarness::new().await;
     let manifest_yaml = fixture_manifest_with_test_queries_yaml(
@@ -1108,6 +1157,7 @@ async fn rejects_invalid_workspace_and_source_names() {
             workspace: Some(Workspace {
                 name: r"bad\workspace".to_string(),
             }),
+            schema_filter: String::new(),
         }))
         .await
         .expect_err("workspace with backslash should fail");

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -191,6 +191,45 @@ async fn list_tables_matches_catalog() {
 }
 
 #[tokio::test]
+async fn list_tables_filters_by_schema() {
+    let (_temp, sources) = build_catalog_sources();
+
+    let alpha = CoralQuery::list_tables(&sources, &TestRuntime, Some("alpha"))
+        .await
+        .expect("alpha schema should list");
+    assert_eq!(
+        alpha.iter().map(table_summary).collect::<Vec<_>>(),
+        vec![(
+            "alpha".to_string(),
+            "users".to_string(),
+            "Alpha users".to_string()
+        )]
+    );
+
+    let beta = CoralQuery::list_tables(&sources, &TestRuntime, Some("beta"))
+        .await
+        .expect("beta schema should list");
+    assert_eq!(
+        beta.iter().map(table_summary).collect::<Vec<_>>(),
+        vec![(
+            "beta".to_string(),
+            "teams".to_string(),
+            "Beta teams".to_string()
+        )]
+    );
+
+    let missing = CoralQuery::list_tables(&sources, &TestRuntime, Some("missing"))
+        .await
+        .expect("missing schema should list as empty");
+    assert!(missing.is_empty());
+
+    let unfiltered = CoralQuery::list_tables(&sources, &TestRuntime, None)
+        .await
+        .expect("unfiltered list should succeed");
+    assert_eq!(unfiltered.len(), 2);
+}
+
+#[tokio::test]
 async fn list_tables_empty_when_no_sources() {
     let tables = CoralQuery::list_tables(&[], &TestRuntime, None)
         .await

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -54,6 +54,7 @@ impl CoralMcpServer {
         Ok(query_client
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
+                schema_filter: String::new(),
             }))
             .await?
             .into_inner()


### PR DESCRIPTION
Stack: 1 of 3 for SOURCE-459.

## Summary
- add exact `schema_filter` to `ListTablesRequest`
- normalize the filter at the app service edge and pass it through the query manager
- add engine and app gRPC coverage for filtered, missing, and unfiltered table listing

## Tests
- `cargo test -p coral-engine --test engine catalog_tests::list_tables_filters_by_schema`
- `cargo test -p coral-app --test grpc -- list_tables_filters_by_schema`
- `make rust-checks` on the final stacked branch