### PR TITLE
feat(mcp): expose schema filter on list_tables

### DIFF
--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -303,14 +303,19 @@ impl QueryService for MockQueryService {
         &self,
         request: Request<ListTablesRequest>,
     ) -> Result<Response<ListTablesResponse>, Status> {
+        let request = request.into_inner();
+        let schema_filter = request.schema_filter.clone();
         self.captured
             .list_tables
             .lock()
             .expect("list_tables capture")
-            .push(request.into_inner());
-        Ok(Response::new(ListTablesResponse {
-            tables: vec![mock_visible_table()],
-        }))
+            .push(request);
+        let tables = if schema_filter.is_empty() || schema_filter == "local_messages" {
+            vec![mock_visible_table()]
+        } else {
+            Vec::new()
+        };
+        Ok(Response::new(ListTablesResponse { tables }))
     }
 
     async fn execute_sql(
@@ -519,6 +524,14 @@ impl MockServer {
             .execute_sql
             .lock()
             .expect("execute_sql capture")
+            .clone()
+    }
+
+    pub(crate) fn list_tables_requests(&self) -> Vec<ListTablesRequest> {
+        self.captured
+            .list_tables
+            .lock()
+            .expect("list_tables capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -69,6 +69,17 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .expect("list_tables description")
             .contains("1 table(s) are currently visible")
     );
+    let list_tables_properties = tools[1]
+        .input_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("list_tables properties");
+    assert_eq!(list_tables_properties["schema"]["type"], "string");
+    let list_tables_description = tools[1]
+        .description
+        .as_deref()
+        .expect("list_tables description");
+    assert!(list_tables_description.contains("exact schema"));
 
     let resources = client.list_all_resources().await?;
     assert_eq!(
@@ -113,6 +124,30 @@ async fn mcp_stdio_sql_and_list_tables_return_structured_content()
     assert_eq!(
         tables.structured_content.expect("structured content")["tables"][0]["name"],
         "local_messages.messages"
+    );
+
+    let filtered_tables = client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "schema": "local_messages"
+            }))),
+        )
+        .await?;
+    assert_eq!(filtered_tables.is_error, Some(false));
+    assert_eq!(
+        filtered_tables
+            .structured_content
+            .expect("structured content")["tables"][0]["name"],
+        "local_messages.messages"
+    );
+    let captured_list_tables = server.list_tables_requests();
+    assert_eq!(
+        captured_list_tables
+            .last()
+            .expect("captured list_tables request")
+            .schema_filter
+            .as_str(),
+        "local_messages"
     );
 
     let sql = client

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -19,9 +19,9 @@ use tonic::Request;
 
 use crate::surface::{
     build_tool_result, guide_resource, guide_resource_content, initial_instructions,
-    internal_status, list_tables_tool, list_tables_value, required_string_argument, sql_tool,
-    status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
-    tool_error_result,
+    internal_status, list_tables_tool, list_tables_value, optional_string_argument,
+    required_string_argument, sql_tool, status_to_error_data, tables_resource,
+    tables_resource_content, tool_error_from_status, tool_error_result,
 };
 
 #[derive(Clone)]
@@ -49,12 +49,13 @@ impl CoralMcpServer {
             .sources)
     }
 
-    async fn load_tables(&self) -> Result<Vec<Table>, tonic::Status> {
+    async fn load_tables(&self, schema: Option<&str>) -> Result<Vec<Table>, tonic::Status> {
         let mut query_client = self.query_client.clone();
         Ok(query_client
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
-                schema_filter: String::new(),
+                // MCP exposes this as `schema`; the local API names the exact-match field `schema_filter`.
+                schema_filter: schema.unwrap_or_default().to_string(),
             }))
             .await?
             .into_inner()
@@ -62,7 +63,7 @@ impl CoralMcpServer {
     }
 
     async fn load_sources_and_tables(&self) -> Result<(Vec<Source>, Vec<Table>), tonic::Status> {
-        tokio::try_join!(self.load_sources(), self.load_tables())
+        tokio::try_join!(self.load_sources(), self.load_tables(None))
     }
 
     async fn query_rows(&self, sql: &str) -> Result<Vec<Value>, tonic::Status> {
@@ -127,13 +128,16 @@ impl ServerHandler for CoralMcpServer {
                     Err(status) => Ok(tool_error_result(tool_error_from_status("Query", &status))),
                 }
             }
-            "list_tables" => match self.load_tables().await {
-                Ok(tables) => build_tool_result(list_tables_value(&tables)),
-                Err(status) => Ok(tool_error_result(tool_error_from_status(
-                    "Table listing",
-                    &status,
-                ))),
-            },
+            "list_tables" => {
+                let schema = optional_string_argument(request.arguments.as_ref(), "schema")?;
+                match self.load_tables(schema.as_deref()).await {
+                    Ok(tables) => build_tool_result(list_tables_value(&tables)),
+                    Err(status) => Ok(tool_error_result(tool_error_from_status(
+                        "Table listing",
+                        &status,
+                    ))),
+                }
+            }
             _ => Err(ErrorData::invalid_params(
                 format!("tool '{}' not found", request.name),
                 None,
@@ -174,7 +178,7 @@ impl ServerHandler for CoralMcpServer {
             }
             "coral://tables" => {
                 let tables = self
-                    .load_tables()
+                    .load_tables(None)
                     .await
                     .map_err(|status| status_to_error_data(&status))?;
                 let text = tables_resource_content(&tables)

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -11,4 +11,7 @@ pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, list_tables_value,
     tables_resource, tables_resource_content,
 };
-pub(crate) use tools::{build_tool_result, list_tables_tool, required_string_argument, sql_tool};
+pub(crate) use tools::{
+    build_tool_result, list_tables_tool, optional_string_argument, required_string_argument,
+    sql_tool,
+};

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -39,7 +39,12 @@ pub(crate) fn list_tables_tool(tables: &[Table]) -> Tool {
         list_tables_description(tables),
         json_object_schema(&json!({
             "type": "object",
-            "properties": {}
+            "properties": {
+                "schema": {
+                    "type": "string",
+                    "description": "Exact SQL schema name to list, such as github or stripe. Omit to list all visible schemas."
+                }
+            }
         })),
     )
     .with_annotations(
@@ -66,6 +71,27 @@ pub(crate) fn required_string_argument(
     Ok(value.to_string())
 }
 
+pub(crate) fn optional_string_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<Option<String>, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(None);
+    };
+    let Some(value) = value.as_str() else {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be a string"),
+            None,
+        ));
+    };
+    let value = value.trim();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
     let pretty = serde_json::to_string_pretty(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
@@ -90,7 +116,7 @@ fn sql_tool_description(sources: &[Source], tables: &[Table]) -> String {
 
 fn list_tables_description(tables: &[Table]) -> String {
     format!(
-        "List queryable fully qualified tables. {} table(s) are currently visible.",
+        "List queryable fully qualified tables, optionally narrowed by exact schema. {} table(s) are currently visible.",
         visible_table_count(tables)
     )
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -8,8 +8,8 @@ use coral_client::{
 };
 use rmcp::{
     RoleClient, ServiceExt,
-    model::{CallToolRequestParams, ReadResourceRequestParams},
-    service::RunningService,
+    model::{CallToolRequestParams, ErrorCode, ReadResourceRequestParams},
+    service::{RunningService, ServiceError},
 };
 use serde_json::{Map, Value, json};
 use tempfile::TempDir;
@@ -158,6 +158,18 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .expect("sql description")
             .contains("0 configured source")
     );
+    let list_tables_tool = &initial_tools[1];
+    let list_tables_properties = list_tables_tool
+        .input_schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .expect("list_tables properties");
+    assert_eq!(list_tables_properties["schema"]["type"], "string");
+    let list_tables_description = list_tables_tool
+        .description
+        .as_deref()
+        .expect("list_tables description");
+    assert!(list_tables_description.contains("exact schema"));
 
     let initial_resources = client
         .list_all_resources()
@@ -249,6 +261,53 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         "local_messages.messages"
     );
     assert_eq!(tables.is_error, Some(false));
+
+    let filtered_tables = client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "schema": "local_messages"
+            }))),
+        )
+        .await
+        .expect("list filtered tables");
+    assert_eq!(
+        filtered_tables
+            .structured_content
+            .expect("structured content")["tables"][0]["name"],
+        "local_messages.messages"
+    );
+    assert_eq!(filtered_tables.is_error, Some(false));
+
+    let missing_tables = client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "schema": "missing"
+            }))),
+        )
+        .await
+        .expect("list missing schema tables");
+    assert!(
+        missing_tables
+            .structured_content
+            .expect("structured content")["tables"]
+            .as_array()
+            .expect("tables array")
+            .is_empty()
+    );
+    assert_eq!(missing_tables.is_error, Some(false));
+
+    let invalid_schema_error = client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "schema": 123
+            }))),
+        )
+        .await
+        .expect_err("non-string schema should be invalid params");
+    match invalid_schema_error {
+        ServiceError::McpError(error) => assert_eq!(error.code, ErrorCode::INVALID_PARAMS),
+        other => panic!("expected MCP invalid params error, got {other:?}"),
+    }
 
     session.shutdown().await;
 }

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -15,12 +15,12 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
-| Tool     | `list_tables`    | List queryable fully qualified tables                   |
+| Tool     | `list_tables`    | List queryable fully qualified tables; accepts optional exact `schema` narrowing |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
+For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`. `list_tables` accepts an optional `schema` argument that performs exact schema matching only.
 
 ## Client setup
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -113,6 +113,8 @@ This server exposes:
 | Type     | Name             | Description                      |
 | -------- | ---------------- | -------------------------------- |
 | Tool     | `sql`            | Run a SQL query                  |
-| Tool     | `list_tables`    | List all available tables        |
+| Tool     | `list_tables`    | List all available tables, optionally narrowed by exact `schema` |
 | Resource | `coral://guide`  | Usage guide for agents           |
 | Resource | `coral://tables` | Schema for all installed sources |
+
+MCP `list_tables` accepts an optional `schema` argument. The filter is an exact schema-name match.


### PR DESCRIPTION
Stack: 2 of 3 for SOURCE-459. Base: `pawel/source-459-list-tables-schema-filter`.

## Summary
- add optional MCP `list_tables.schema` input with exact-match semantics
- map MCP `schema` to proto `schema_filter` explicitly in the adapter
- update MCP/CLI docs and tests for the new argument

## Tests
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --test mcp --features cli-test-server`
- `make rust-checks` on the final stacked branch