### PR TITLE
docs(mcp): steer discovery through SQL metadata

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -80,6 +80,8 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
         .as_deref()
         .expect("list_tables description");
     assert!(list_tables_description.contains("exact schema"));
+    assert!(list_tables_description.contains("coral.tables"));
+    assert!(list_tables_description.contains("coral.columns"));
 
     let resources = client.list_all_resources().await?;
     assert_eq!(
@@ -96,6 +98,9 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
     let guide_text = text_content(&guide);
     assert!(guide_text.contains("## Available Schemas"));
     assert!(guide_text.contains("- local_messages"));
+    assert!(guide_text.contains("FROM coral.tables"));
+    assert!(guide_text.contains("LIKE"));
+    assert!(guide_text.contains("DESCRIBE local_messages.messages"));
     assert!(guide_text.contains(
         "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'messages'"
     ));

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -7,10 +7,18 @@
 Always inspect queryable tables and table metadata before writing queries:
 
 ```sql
--- List visible tables, descriptions, and required filters
-SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
+-- List visible tables, descriptions, guides, and required filters
+SELECT schema_name, table_name, description, required_filters
+FROM coral.tables
+ORDER BY schema_name, table_name;
 
--- Inspect columns for one visible table
+-- Find tables by substring within one schema
+{{TABLE_SEARCH_EXAMPLE}}
+
+-- Quick table shape shortcut
+{{DESCRIBE_EXAMPLE}}
+
+-- Canonical column inspection with required-filter metadata
 {{COLUMNS_EXAMPLE}}
 ```
 

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{Source, Table};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables` to inspect queryable tables, and use `sql` against `coral.tables` and `coral.columns` for discovery.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Use the `sql` tool against `coral.tables` to discover visible tables, descriptions, guides, and required filters, then query `coral.columns` for column types, descriptions, virtual columns, and `is_required_filter`. Use `list_tables` only as a flat fully qualified table index, optionally narrowed by exact schema. `DESCRIBE <schema>.<table>` and `SHOW COLUMNS FROM <schema>.<table>` are quick-shape shortcuts.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {
@@ -49,23 +49,29 @@ pub(crate) fn guide_resource_content(sources: &[Source], tables: &[Table]) -> St
         }
     }
 
-    let columns_example = first_visible_table(tables).map_or_else(
-        || {
-            "SELECT column_name, data_type, is_required_filter, description \
-FROM coral.columns WHERE schema_name = '<schema>' AND table_name = '<table>' ORDER BY ordinal_position;"
-                .to_string()
-        },
-        |(schema_name, table_name)| {
-            format!(
-                "SELECT column_name, data_type, is_required_filter, description \
+    let (schema_name, table_name) = first_visible_table(tables).unwrap_or(("<schema>", "<table>"));
+    let search_fragment = if table_name == "<table>" {
+        "pull"
+    } else {
+        table_name
+    };
+    let columns_example = format!(
+        "SELECT column_name, data_type, is_required_filter, description \
 FROM coral.columns WHERE schema_name = '{schema_name}' AND table_name = '{table_name}' ORDER BY ordinal_position;"
-            )
-        },
     );
+    let table_search_example = format!(
+        "SELECT schema_name, table_name, description, required_filters \
+FROM coral.tables \
+WHERE schema_name = '{schema_name}' AND table_name LIKE '%{search_fragment}%' \
+ORDER BY schema_name, table_name;"
+    );
+    let describe_example = format!("DESCRIBE {schema_name}.{table_name};");
 
     GUIDE_TEMPLATE
         .replace("{{SOURCES_SECTION}}", &sources_section)
         .replace("{{COLUMNS_EXAMPLE}}", &columns_example)
+        .replace("{{DESCRIBE_EXAMPLE}}", &describe_example)
+        .replace("{{TABLE_SEARCH_EXAMPLE}}", &table_search_example)
 }
 
 pub(crate) fn tables_resource_content(tables: &[Table]) -> Result<String, serde_json::Error> {
@@ -171,6 +177,8 @@ mod tests {
         assert!(content.contains("- coral: System metadata schema."));
         assert!(content.contains("No query-visible source schemas are currently available."));
         assert!(content.contains("schema_name = '<schema>'"));
+        assert!(content.contains("table_name LIKE '%pull%'"));
+        assert!(content.contains("DESCRIBE <schema>.<table>"));
     }
 
     #[test]
@@ -184,5 +192,9 @@ mod tests {
         assert!(content.contains("Visible source schemas:"));
         assert!(content.contains("- slack"));
         assert!(content.contains("Fully qualify tables in SQL, for example `slack.messages`."));
+        assert!(content.contains(
+            "FROM coral.tables WHERE schema_name = 'slack' AND table_name LIKE '%channels%'"
+        ));
+        assert!(content.contains("DESCRIBE slack.channels"));
     }
 }

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -116,7 +116,7 @@ fn sql_tool_description(sources: &[Source], tables: &[Table]) -> String {
 
 fn list_tables_description(tables: &[Table]) -> String {
     format!(
-        "List queryable fully qualified tables, optionally narrowed by exact schema. {} table(s) are currently visible.",
+        "List queryable fully qualified tables, optionally narrowed by exact schema. Query `coral.tables` and `coral.columns` with the `sql` tool for richer metadata and table search. {} table(s) are currently visible.",
         visible_table_count(tables)
     )
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -170,6 +170,8 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .as_deref()
         .expect("list_tables description");
     assert!(list_tables_description.contains("exact schema"));
+    assert!(list_tables_description.contains("coral.tables"));
+    assert!(list_tables_description.contains("coral.columns"));
 
     let initial_resources = client
         .list_all_resources()
@@ -248,6 +250,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert!(updated_guide_text.contains("- coral: System metadata schema."));
     assert!(updated_guide_text.contains("- local_messages"));
     assert!(!updated_guide_text.contains("## Visible SQL Schemas"));
+    assert!(
+        updated_guide_text
+            .contains("SELECT schema_name, table_name, description, required_filters")
+    );
+    assert!(updated_guide_text.contains("FROM coral.tables"));
+    assert!(updated_guide_text.contains("LIKE"));
+    assert!(updated_guide_text.contains("DESCRIBE local_messages.messages"));
+    assert!(updated_guide_text.contains("is_required_filter"));
     assert!(updated_guide_text.contains(
         "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'messages'"
     ));

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -20,7 +20,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`. `list_tables` accepts an optional `schema` argument that performs exact schema matching only.
+For discovery, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool. `coral.columns` is the canonical column metadata surface because it includes column descriptions and `is_required_filter`. `list_tables` is useful as a flat fully qualified table index, and its optional `schema` argument performs exact schema matching only. For quick table shape checks, agents can also run `DESCRIBE <schema>.<table>` or `SHOW COLUMNS FROM <schema>.<table>`.
 
 ## Client setup
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -117,4 +117,4 @@ This server exposes:
 | Resource | `coral://guide`  | Usage guide for agents           |
 | Resource | `coral://tables` | Schema for all installed sources |
 
-MCP `list_tables` accepts an optional `schema` argument. The filter is an exact schema-name match.
+MCP `list_tables` accepts an optional `schema` argument. The filter is an exact schema-name match. For substring table search, use SQL `LIKE` against `coral.tables` through the `sql` tool.


### PR DESCRIPTION
Stack: 3 of 3 for SOURCE-459. Base: `pawel/source-459-mcp-list-tables-schema`.

## Summary
- rewrite MCP initial instructions and guide workflow around `coral.tables` and `coral.columns`
- keep `DESCRIBE` and `SHOW COLUMNS` positioned as quick-shape shortcuts
- update MCP docs/tests for SQL metadata discovery and substring search via `coral.tables`

## Tests
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --test mcp --features cli-test-server`
- `make rust-checks`