### PR TITLE
fix(engine): validate regex-style query patterns

### DIFF
--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod catalog;
 pub(crate) mod error;
 pub(crate) mod json;
+pub(crate) mod pattern_validator;
 pub(crate) mod query;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;

--- a/crates/coral-engine/src/runtime/pattern_validator.rs
+++ b/crates/coral-engine/src/runtime/pattern_validator.rs
@@ -1,0 +1,267 @@
+//! Query-pattern validation for regex-style operators with common LIKE-wildcard
+//! mistakes.
+
+use std::sync::Arc;
+
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::tree_node::Transformed;
+use datafusion::common::{DFSchema, Result as DataFusionResult, ScalarValue, plan_err};
+use datafusion::execution::FunctionRegistry;
+use datafusion::logical_expr::Operator;
+use datafusion::logical_expr::expr::{BinaryExpr, Expr, Like};
+use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
+
+pub(crate) fn register_pattern_validator(
+    registry: &mut dyn FunctionRegistry,
+) -> DataFusionResult<()> {
+    registry.register_function_rewrite(Arc::new(PatternValidator))?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct PatternValidator;
+
+impl FunctionRewrite for PatternValidator {
+    fn name(&self) -> &'static str {
+        "PatternValidator"
+    }
+
+    fn rewrite(
+        &self,
+        expr: Expr,
+        _schema: &DFSchema,
+        _config: &ConfigOptions,
+    ) -> DataFusionResult<Transformed<Expr>> {
+        validate_expr(&expr)?;
+        Ok(Transformed::no(expr))
+    }
+}
+
+fn validate_expr(expr: &Expr) -> DataFusionResult<()> {
+    match expr {
+        Expr::SimilarTo(like) => validate_similar_to(like),
+        Expr::BinaryExpr(binary) => validate_regex_binary(binary),
+        _ => Ok(()),
+    }
+}
+
+fn validate_similar_to(like: &Like) -> DataFusionResult<()> {
+    let Some(pattern) = extract_string_literal(&like.pattern) else {
+        return Ok(());
+    };
+
+    if contains_like_wildcards(&pattern) {
+        return plan_err!(
+            "SIMILAR TO pattern '{pattern}' contains `%` or `_` which are literal characters in SIMILAR TO, not wildcards. Use `.*` instead of `%`, `.` instead of `_`, or use LIKE for wildcard matching."
+        );
+    }
+
+    Ok(())
+}
+
+fn validate_regex_binary(binary: &BinaryExpr) -> DataFusionResult<()> {
+    if !is_regex_operator(binary.op) {
+        return Ok(());
+    }
+
+    let Some(pattern) = extract_string_literal(&binary.right) else {
+        return Ok(());
+    };
+
+    if pattern.contains('%') {
+        return plan_err!(
+            "Regex operator `{}` pattern '{}' contains `%` which is a literal character in regex, not a wildcard. Use `.*` instead of `%`, or use LIKE/ILIKE for wildcard matching.",
+            binary.op,
+            pattern
+        );
+    }
+
+    Ok(())
+}
+
+fn extract_string_literal(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::Literal(
+            ScalarValue::Utf8(Some(value))
+            | ScalarValue::Utf8View(Some(value))
+            | ScalarValue::LargeUtf8(Some(value)),
+            _,
+        ) => Some(value.clone()),
+        Expr::Alias(alias) => extract_string_literal(&alias.expr),
+        _ => None,
+    }
+}
+
+fn contains_like_wildcards(pattern: &str) -> bool {
+    pattern.contains('%') || pattern.contains('_')
+}
+
+fn is_regex_operator(op: Operator) -> bool {
+    matches!(
+        op,
+        Operator::RegexMatch
+            | Operator::RegexIMatch
+            | Operator::RegexNotMatch
+            | Operator::RegexNotIMatch
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::common::config::ConfigOptions;
+    use datafusion::common::{Column, DFSchema, ScalarValue};
+    use datafusion::logical_expr::Operator;
+    use datafusion::logical_expr::expr::{BinaryExpr, Expr, Like};
+    use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
+
+    use super::PatternValidator;
+    use crate::runtime::pattern_validator::{
+        contains_like_wildcards, extract_string_literal, validate_expr,
+    };
+
+    #[test]
+    fn similar_to_with_percent_returns_error() {
+        let error = rewrite_err(similar_to_expr("(Slack|Weekly)%"));
+        assert!(error.contains("SIMILAR TO pattern '(Slack|Weekly)%'"));
+        assert!(error.contains("Use `.*` instead of `%`"));
+    }
+
+    #[test]
+    fn similar_to_with_underscore_returns_error() {
+        let error = rewrite_err(similar_to_expr("Slack_Weekly"));
+        assert!(error.contains("SIMILAR TO pattern 'Slack_Weekly'"));
+        assert!(error.contains("Use `.*` instead of `%`"));
+        assert!(error.contains("`.` instead of `_`"));
+    }
+
+    #[test]
+    fn similar_to_with_regex_syntax_passes() {
+        assert_rewrite_passes(&similar_to_expr("(Slack|Weekly).*"));
+    }
+
+    #[test]
+    fn similar_to_exact_match_passes() {
+        assert_rewrite_passes(&similar_to_expr("default"));
+    }
+
+    #[test]
+    fn regex_match_with_percent_returns_error() {
+        let error = rewrite_err(regex_expr(Operator::RegexMatch, "(Slack|Weekly)%"));
+        assert!(error.contains("Regex operator `~` pattern '(Slack|Weekly)%'"));
+        assert!(error.contains("Use `.*` instead of `%`"));
+    }
+
+    #[test]
+    fn regex_match_without_percent_passes() {
+        assert_rewrite_passes(&regex_expr(Operator::RegexMatch, "(Slack|Weekly).*"));
+    }
+
+    #[test]
+    fn regex_imatch_with_percent_returns_error() {
+        let error = rewrite_err(regex_expr(Operator::RegexIMatch, "(Slack|Weekly)%"));
+        assert!(error.contains("Regex operator `~*` pattern '(Slack|Weekly)%'"));
+    }
+
+    #[test]
+    fn negated_regex_with_percent_returns_error() {
+        let error = rewrite_err(regex_expr(Operator::RegexNotIMatch, "(Slack|Weekly)%"));
+        assert!(error.contains("Regex operator `!~*` pattern '(Slack|Weekly)%'"));
+    }
+
+    #[test]
+    fn like_with_percent_passes() {
+        assert_rewrite_passes(&like_expr("%Slack%", false));
+    }
+
+    #[test]
+    fn ilike_with_percent_passes() {
+        assert_rewrite_passes(&like_expr("%SLACK%", true));
+    }
+
+    #[test]
+    fn extract_string_literal_supports_utf8_variants() {
+        assert_eq!(
+            extract_string_literal(&Expr::Literal(ScalarValue::Utf8(Some("a".into())), None)),
+            Some("a".into())
+        );
+        assert_eq!(
+            extract_string_literal(&Expr::Literal(
+                ScalarValue::LargeUtf8(Some("b".into())),
+                None
+            )),
+            Some("b".into())
+        );
+        assert_eq!(
+            extract_string_literal(&Expr::Literal(
+                ScalarValue::Utf8View(Some("c".into())),
+                None
+            )),
+            Some("c".into())
+        );
+    }
+
+    #[test]
+    fn contains_like_wildcards_only_flags_like_syntax() {
+        assert!(contains_like_wildcards("Slack%"));
+        assert!(contains_like_wildcards("Slack_"));
+        assert!(!contains_like_wildcards("Slack.*"));
+    }
+
+    #[test]
+    fn validate_expr_ignores_non_literal_regex_patterns() {
+        let expr = Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(Expr::Column(Column::from_name("name"))),
+            Operator::RegexMatch,
+            Box::new(Expr::Column(Column::from_name("pattern"))),
+        ));
+
+        validate_expr(&expr).expect("column-driven regex should not error");
+    }
+
+    fn similar_to_expr(pattern: &str) -> Expr {
+        Expr::SimilarTo(Like::new(
+            false,
+            Box::new(Expr::Column(Column::from_name("name"))),
+            Box::new(string_literal(pattern)),
+            None,
+            false,
+        ))
+    }
+
+    fn like_expr(pattern: &str, case_insensitive: bool) -> Expr {
+        Expr::Like(Like::new(
+            false,
+            Box::new(Expr::Column(Column::from_name("name"))),
+            Box::new(string_literal(pattern)),
+            None,
+            case_insensitive,
+        ))
+    }
+
+    fn regex_expr(op: Operator, pattern: &str) -> Expr {
+        Expr::BinaryExpr(BinaryExpr::new(
+            Box::new(Expr::Column(Column::from_name("name"))),
+            op,
+            Box::new(string_literal(pattern)),
+        ))
+    }
+
+    fn string_literal(value: &str) -> Expr {
+        Expr::Literal(ScalarValue::Utf8(Some(value.to_string())), None)
+    }
+
+    fn assert_rewrite_passes(expr: &Expr) {
+        let result = PatternValidator
+            .rewrite(expr.clone(), &DFSchema::empty(), &ConfigOptions::new())
+            .expect("rewrite should pass");
+        assert!(!result.transformed);
+        assert_eq!(result.data, *expr);
+    }
+
+    fn rewrite_err(expr: Expr) -> String {
+        PatternValidator
+            .rewrite(expr, &DFSchema::empty(), &ConfigOptions::new())
+            .expect_err("rewrite should fail")
+            .to_string()
+    }
+}

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -9,6 +9,7 @@ use crate::backends::compile_query_source;
 use crate::runtime::catalog;
 use crate::runtime::error::datafusion_to_core;
 use crate::runtime::json::register_json_support;
+use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
@@ -35,6 +36,7 @@ pub(crate) async fn build_runtime(
     );
     let mut ctx = SessionContext::new_with_config_rt(session_config, runtime_env);
     register_json_support(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
+    register_pattern_validator(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
     let ctx = Arc::new(ctx);
 
     let runtime_context = runtime.runtime_context();

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -17,6 +17,8 @@ mod json_tests;
 mod jsonl_tests;
 #[path = "engine/parquet_tests.rs"]
 mod parquet_tests;
+#[path = "engine/pattern_error_tests.rs"]
+mod pattern_error_tests;
 #[path = "engine/structured_error_tests.rs"]
 mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]

--- a/crates/coral-engine/tests/engine/pattern_error_tests.rs
+++ b/crates/coral-engine/tests/engine/pattern_error_tests.rs
@@ -1,0 +1,153 @@
+//! End-to-end coverage for clear errors when LIKE wildcards are used in
+//! regex-style operators.
+
+use std::path::Path;
+
+use coral_engine::{CoralQuery, CoreError, QuerySource};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use crate::harness::{
+    TestRuntime, assert_row_count, build_source, execution_to_rows, write_jsonl_file,
+};
+
+fn manifest(dir: &Path) -> Value {
+    json!({
+        "name": "linear",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "tables": [{
+            "name": "projects",
+            "description": "Pattern validator fixture",
+            "source": {
+                "location": format!("file://{}/", dir.display()),
+                "glob": "**/*.jsonl"
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" },
+                { "name": "name", "type": "Utf8" }
+            ]
+        }]
+    })
+}
+
+fn invalid_input_detail(error: CoreError) -> String {
+    match error {
+        CoreError::InvalidInput(detail) => detail,
+        other => panic!("expected CoreError::InvalidInput, got {other:?}"),
+    }
+}
+
+fn project_names(rows: &[Value]) -> Vec<&str> {
+    rows.iter()
+        .map(|row| {
+            row.get("name")
+                .and_then(Value::as_str)
+                .expect("row should contain project name")
+        })
+        .collect()
+}
+
+fn write_projects_fixture(dir: &Path) -> QuerySource {
+    write_jsonl_file(
+        dir,
+        "projects.jsonl",
+        &[
+            json!({"id": 1, "name": "Slack Planning"}),
+            json!({"id": 2, "name": "Weekly Sync"}),
+            json!({"id": 3, "name": "Backlog Triage"}),
+        ],
+    );
+    build_source(manifest(dir))
+}
+
+#[tokio::test]
+async fn similar_to_with_like_wildcard_returns_clear_error() {
+    let temp = TempDir::new().expect("temp dir");
+    let source = write_projects_fixture(temp.path());
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        &TestRuntime,
+        "SELECT id, name FROM linear.projects WHERE name SIMILAR TO '(Slack|Weekly)%'",
+    )
+    .await
+    .expect_err("SIMILAR TO wildcard mismatch should fail");
+
+    let detail = invalid_input_detail(error);
+    assert!(detail.contains("SIMILAR TO pattern '(Slack|Weekly)%'"));
+    assert!(detail.contains("Use `.*` instead of `%`"));
+}
+
+#[tokio::test]
+async fn regex_match_with_like_wildcard_returns_clear_error() {
+    let temp = TempDir::new().expect("temp dir");
+    let source = write_projects_fixture(temp.path());
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        &TestRuntime,
+        "SELECT id, name FROM linear.projects WHERE name ~ '(Slack|Weekly)%'",
+    )
+    .await
+    .expect_err("regex wildcard mismatch should fail");
+
+    let detail = invalid_input_detail(error);
+    assert!(detail.contains("Regex operator `~` pattern '(Slack|Weekly)%'"));
+    assert!(detail.contains("Use `.*` instead of `%`"));
+}
+
+#[tokio::test]
+async fn similar_to_with_regex_syntax_succeeds() {
+    let temp = TempDir::new().expect("temp dir");
+    let source = write_projects_fixture(temp.path());
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        &TestRuntime,
+        "SELECT id, name FROM linear.projects WHERE name SIMILAR TO '(Slack|Weekly).*' ORDER BY id",
+    )
+    .await
+    .expect("regex-shaped SIMILAR TO should succeed");
+
+    assert_row_count(&execution, 2);
+    let rows = execution_to_rows(&execution);
+    assert_eq!(project_names(&rows), vec!["Slack Planning", "Weekly Sync"]);
+}
+
+#[tokio::test]
+async fn regex_match_with_valid_regex_succeeds() {
+    let temp = TempDir::new().expect("temp dir");
+    let source = write_projects_fixture(temp.path());
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        &TestRuntime,
+        "SELECT id, name FROM linear.projects WHERE name ~ '^(Slack|Weekly)' ORDER BY id",
+    )
+    .await
+    .expect("valid regex should succeed");
+
+    assert_row_count(&execution, 2);
+    let rows = execution_to_rows(&execution);
+    assert_eq!(project_names(&rows), vec!["Slack Planning", "Weekly Sync"]);
+}
+
+#[tokio::test]
+async fn like_with_wildcards_still_works() {
+    let temp = TempDir::new().expect("temp dir");
+    let source = write_projects_fixture(temp.path());
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        &TestRuntime,
+        "SELECT id, name FROM linear.projects WHERE name LIKE 'Slack%' OR name LIKE 'Weekly%' ORDER BY id",
+    )
+    .await
+    .expect("LIKE should remain unaffected");
+
+    assert_row_count(&execution, 2);
+    let rows = execution_to_rows(&execution);
+    assert_eq!(project_names(&rows), vec!["Slack Planning", "Weekly Sync"]);
+}


### PR DESCRIPTION
## Summary
- Add a runtime pattern validator rewrite that rejects `%` and `_` in `SIMILAR TO` and rejects `%` in regex operators with clear guidance to use regex syntax or `LIKE`/`ILIKE`.
- Register the validator when building the DataFusion session so invalid regex-style patterns fail before execution.
- Add unit and end-to-end engine tests covering invalid wildcard usage, valid regex patterns, and unchanged `LIKE` behavior.

Check https://linear.app/withcoral/issue/SOURCE-475/show-an-error-for-unsupported-regex-sql-operators

## Test plan
- [x] Run the `coral-engine` unit tests for `runtime::pattern_validator`.
- [x] Run the `coral-engine` integration tests including `pattern_error_tests`.
- [x] Verify `SIMILAR TO '(Slack|Weekly)%'` and `~ '(Slack|Weekly)%'` return `InvalidInput` errors with the new guidance.
- [x] Verify valid regex-style queries and `LIKE` queries still return the expected matching rows.


<img width="1863" height="1394" alt="image" src="https://github.com/user-attachments/assets/b0ad3408-4bfc-4a4b-8fcc-d11309ec8d45" />
