### PR TITLE
fix(sources/cloudwatch_metrics): expose metric statistics time filters

### DIFF
--- a/sources/cloudwatch_metrics/manifest.yaml
+++ b/sources/cloudwatch_metrics/manifest.yaml
@@ -207,6 +207,18 @@ tables:
         virtual: true
         description: Metric name filter.
         expr: {kind: from_filter, key: metric_name}
+      - name: start_time
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: CloudWatch start time filter.
+        expr: {kind: from_filter, key: start_time}
+      - name: end_time
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: CloudWatch end time filter.
+        expr: {kind: from_filter, key: end_time}
       - name: timestamp
         type: Timestamp
         nullable: true


### PR DESCRIPTION
## Summary

- Exposes `start_time` and `end_time` as virtual filter columns on `cloudwatch_metrics.metric_statistics`.
- Makes the required CloudWatch metric statistics time filters satisfiable through normal SQL `WHERE` predicates.

## Verification

- `cargo run -q -p coral-cli -- source lint sources/cloudwatch_metrics/manifest.yaml`
- Repo-wide required-filter scan: all required filters are exposed as columns
