### PR TITLE
refactor(sources): keep protobuf out of source manager

### DIFF
--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -55,6 +55,11 @@ root.
 - `manager.rs` files own app-level orchestration. They coordinate installed
   state, secrets, manifests, rollback, runtime setup, and engine calls. They
   should not know about tonic request or response types.
+- For all service calls, keep protobuf request/response types confined to the
+  service edge. Convert request data into small app-local command, query, or
+  binding structs before calling managers; do not pass `coral_api::v1`
+  request/response/message types into managers, state helpers, or other
+  app-owned domain code.
 - `workspaces/name.rs` and `sources/name.rs` own the checked app-local identity
   types. Parse `WorkspaceName` and `SourceName` at persistence and service
   boundaries so managers and state/layout code stay transport-free and do not

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -2,11 +2,6 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use coral_api::v1::{
-    CreateBundledSourceRequest, ImportSourceRequest, SourceSecret, SourceVariable,
-};
-use coral_spec::ManifestInputKind;
-
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::catalog::{
@@ -16,12 +11,34 @@ use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
+use coral_spec::ManifestInputKind;
 
 #[derive(Clone)]
 pub(crate) struct SourceManager {
     config_store: ConfigStore,
     secret_store: SecretStore,
     layout: AppStateLayout,
+}
+
+pub(crate) struct CreateBundledSourceCommand {
+    pub(crate) name: SourceName,
+    pub(crate) bindings: SourceBindings,
+}
+
+pub(crate) struct ImportSourceCommand {
+    pub(crate) manifest_yaml: String,
+    pub(crate) bindings: SourceBindings,
+}
+
+#[derive(Default)]
+pub(crate) struct SourceBindings {
+    pub(crate) variables: Vec<SourceBinding>,
+    pub(crate) secrets: Vec<SourceBinding>,
+}
+
+pub(crate) struct SourceBinding {
+    pub(crate) key: String,
+    pub(crate) value: String,
 }
 
 struct ValidatedBindings {
@@ -118,12 +135,11 @@ impl SourceManager {
     pub(crate) fn create_bundled_source(
         &self,
         workspace_name: &WorkspaceName,
-        bundled_name: &SourceName,
-        request: &CreateBundledSourceRequest,
+        command: &CreateBundledSourceCommand,
     ) -> Result<InstalledSource, AppError> {
-        let bundled = load_bundled_source(bundled_name)?;
+        let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
-        let bindings = validate_bindings(&candidate, &request.variables, &request.secrets)?;
+        let bindings = validate_bindings(&candidate, &command.bindings)?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -138,17 +154,17 @@ impl SourceManager {
     pub(crate) fn import_source(
         &self,
         workspace_name: &WorkspaceName,
-        request: &ImportSourceRequest,
+        command: &ImportSourceCommand,
     ) -> Result<InstalledSource, AppError> {
         let mut candidate =
-            describe_manifest(&request.manifest_yaml, SourceOrigin::Imported, false)?;
+            describe_manifest(&command.manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
-        let bindings = validate_bindings(&candidate, &request.variables, &request.secrets)?;
+        let bindings = validate_bindings(&candidate, &command.bindings)?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
                 candidate: &candidate,
-                manifest_yaml: Some(&request.manifest_yaml),
+                manifest_yaml: Some(&command.manifest_yaml),
                 bindings,
                 origin: SourceOrigin::Imported,
             },
@@ -372,11 +388,10 @@ impl SourceManager {
 
 fn validate_bindings(
     candidate: &CandidateSource,
-    variables: &[SourceVariable],
-    secrets: &[SourceSecret],
+    bindings: &SourceBindings,
 ) -> Result<ValidatedBindings, AppError> {
-    let mut variable_values = collect_unique_variables(variables)?;
-    let secret_values = collect_unique_secrets(secrets)?;
+    let mut variable_values = collect_unique_variables(&bindings.variables)?;
+    let secret_values = collect_unique_secrets(&bindings.secrets)?;
     let expected_variables = candidate
         .inputs
         .iter()
@@ -443,7 +458,7 @@ fn validate_bindings(
 }
 
 fn collect_unique_variables(
-    variables: &[SourceVariable],
+    variables: &[SourceBinding],
 ) -> Result<BTreeMap<String, String>, AppError> {
     let mut values = BTreeMap::new();
     for variable in variables {
@@ -457,7 +472,7 @@ fn collect_unique_variables(
     Ok(values)
 }
 
-fn collect_unique_secrets(secrets: &[SourceSecret]) -> Result<BTreeMap<String, String>, AppError> {
+fn collect_unique_secrets(secrets: &[SourceBinding]) -> Result<BTreeMap<String, String>, AppError> {
     let mut values = BTreeMap::new();
     for secret in secrets {
         let key = normalize_binding_key("source secret key", &secret.key)?;
@@ -514,13 +529,13 @@ fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) 
 
 #[cfg(test)]
 mod tests {
-    use coral_api::v1::{ImportSourceRequest, SourceSecret, SourceVariable};
     use tempfile::TempDir;
 
-    use super::{SourceManager, normalize_binding_key};
+    use super::{
+        ImportSourceCommand, SourceBinding, SourceBindings, SourceManager, normalize_binding_key,
+    };
     use crate::sources::SourceName;
     use crate::state::{AppStateLayout, ConfigStore, SecretStore};
-    use crate::transport::workspace_to_proto;
     use crate::workspaces::WorkspaceName;
 
     fn default_workspace() -> WorkspaceName {
@@ -581,17 +596,18 @@ tables:
         let error = manager
             .import_source(
                 &default_workspace(),
-                &ImportSourceRequest {
-                    workspace: Some(workspace_to_proto(&default_workspace())),
+                &ImportSourceCommand {
                     manifest_yaml: manifest_with_secret(),
-                    variables: vec![SourceVariable {
-                        key: "API_BASE".to_string(),
-                        value: "https://example.com".to_string(),
-                    }],
-                    secrets: vec![SourceSecret {
-                        key: "API_TOKEN".to_string(),
-                        value: "secret-token".to_string(),
-                    }],
+                    bindings: SourceBindings {
+                        variables: vec![SourceBinding {
+                            key: "API_BASE".to_string(),
+                            value: "https://example.com".to_string(),
+                        }],
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
                 },
             )
             .expect_err("secret persistence should fail");
@@ -664,14 +680,15 @@ tables:
         let source = manager
             .import_source(
                 &default_workspace(),
-                &ImportSourceRequest {
-                    workspace: Some(workspace_to_proto(&default_workspace())),
+                &ImportSourceCommand {
                     manifest_yaml: manifest_with_secret(),
-                    variables: vec![],
-                    secrets: vec![SourceSecret {
-                        key: "API_TOKEN".to_string(),
-                        value: "secret-token".to_string(),
-                    }],
+                    bindings: SourceBindings {
+                        variables: vec![],
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
                 },
             )
             .expect("import source");

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -14,7 +14,9 @@ use tonic::{Request, Response, Status};
 use crate::bootstrap::app_status;
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
-use crate::sources::manager::SourceManager;
+use crate::sources::manager::{
+    CreateBundledSourceCommand, ImportSourceCommand, SourceBinding, SourceBindings, SourceManager,
+};
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
     grpc_span, instrument_grpc, query_status, validate_source_response_to_proto,
@@ -128,8 +130,12 @@ impl SourceServiceApi for SourceService {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let command = CreateBundledSourceCommand {
+                name: bundled_name,
+                bindings: source_bindings_from_proto(request.variables, request.secrets),
+            };
             let installed = sources
-                .create_bundled_source(&workspace_name, &bundled_name, &request)
+                .create_bundled_source(&workspace_name, &command)
                 .map_err(app_status)?;
             Ok(Response::new(installed_source_to_proto(
                 &workspace_name,
@@ -148,8 +154,12 @@ impl SourceServiceApi for SourceService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let command = ImportSourceCommand {
+                manifest_yaml: request.manifest_yaml,
+                bindings: source_bindings_from_proto(request.variables, request.secrets),
+            };
             let installed = sources
-                .import_source(&workspace_name, &request)
+                .import_source(&workspace_name, &command)
                 .map_err(app_status)?;
             Ok(Response::new(installed_source_to_proto(
                 &workspace_name,
@@ -200,6 +210,33 @@ impl SourceServiceApi for SourceService {
             )))
         })
         .await
+    }
+}
+
+fn source_bindings_from_proto(
+    variables: Vec<SourceVariable>,
+    secrets: Vec<SourceSecret>,
+) -> SourceBindings {
+    SourceBindings {
+        variables: variables
+            .into_iter()
+            .map(source_variable_from_proto)
+            .collect(),
+        secrets: secrets.into_iter().map(source_secret_from_proto).collect(),
+    }
+}
+
+fn source_variable_from_proto(variable: SourceVariable) -> SourceBinding {
+    SourceBinding {
+        key: variable.key,
+        value: variable.value,
+    }
+}
+
+fn source_secret_from_proto(secret: SourceSecret) -> SourceBinding {
+    SourceBinding {
+        key: secret.key,
+        value: secret.value,
     }
 }
 


### PR DESCRIPTION
## Intent

Keep the source lifecycle manager focused on app-domain commands instead of protobuf request shapes. The gRPC service now owns the transport-to-app mapping before handing work to SourceManager.

## Changes

- Add app-local source command and binding structs for bundled source creation and imported source installation.
- Convert protobuf source variables and secrets in SourceService before calling SourceManager.
- Update SourceManager unit tests to exercise the app-local command API directly.

## Verification

- make rust-checks
