### PR TITLE
refactor(engine)!: replace runtime provider with config

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -2,11 +2,10 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::Mutex;
 
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryExecution, QueryRuntimeContext,
-    QueryRuntimeProvider, QuerySource, SourceValidationReport, TableInfo,
+    CoralQuery, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    SourceValidationReport, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_source_manifest_yaml};
 
@@ -62,8 +61,8 @@ impl QueryManager {
         let sources = self
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_provider(&sources);
-        CoralQuery::list_tables(&sources, &runtime, None)
+        let runtime = self.runtime_config(&sources);
+        CoralQuery::list_tables(&sources, runtime, None)
             .await
             .map_err(QueryManagerError::Core)
     }
@@ -76,8 +75,8 @@ impl QueryManager {
         let sources = self
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_provider(&sources);
-        CoralQuery::execute_sql(&sources, &runtime, sql)
+        let runtime = self.runtime_config(&sources);
+        CoralQuery::execute_sql(&sources, runtime, sql)
             .await
             .map_err(QueryManagerError::Core)
     }
@@ -94,10 +93,10 @@ impl QueryManager {
         let (query_source, version) = self
             .load_query_source(workspace_name, &source)
             .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_provider(std::slice::from_ref(&query_source));
+        let runtime = self.runtime_config(std::slice::from_ref(&query_source));
         let report = CoralQuery::validate_source(
             &query_source,
-            &runtime,
+            runtime,
             query_source.source_spec().test_queries(),
         )
         .await
@@ -169,33 +168,11 @@ impl QueryManager {
         ))
     }
 
-    fn runtime_provider(&self, sources: &[QuerySource]) -> RuntimeProvider {
-        RuntimeProvider {
-            runtime_context: self.runtime_context.clone(),
-            engine_extensions: Mutex::new(Some(engine_extensions_for_providers(
-                &self.engine_extensions_providers,
-                sources,
-            ))),
-        }
-    }
-}
-
-struct RuntimeProvider {
-    runtime_context: QueryRuntimeContext,
-    engine_extensions: Mutex<Option<EngineExtensions>>,
-}
-
-impl QueryRuntimeProvider for RuntimeProvider {
-    fn runtime_context(&self) -> QueryRuntimeContext {
-        self.runtime_context.clone()
-    }
-
-    fn engine_extensions(&self) -> EngineExtensions {
-        self.engine_extensions
-            .lock()
-            .expect("engine extensions mutex poisoned")
-            .take()
-            .unwrap_or_default()
+    fn runtime_config(&self, selected_sources: &[QuerySource]) -> QueryRuntimeConfig {
+        QueryRuntimeConfig::new(
+            self.runtime_context.clone(),
+            engine_extensions_for_providers(&self.engine_extensions_providers, selected_sources),
+        )
     }
 }
 

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -8,7 +8,7 @@ mod query_error;
 pub use catalog::{ColumnInfo, TableInfo};
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
-    QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, QueryTestFailure,
+    QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
     QueryTestResult, QueryTestSuccess, SourceValidationReport,
 };
 pub(crate) use query_error::ColumnParts;

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -182,16 +182,23 @@ pub struct QueryRuntimeContext {
     pub home_dir: Option<PathBuf>,
 }
 
-/// Resolves app-owned runtime inputs at query time.
-pub trait QueryRuntimeProvider: Send + Sync {
-    /// Returns non-secret runtime inputs owned by the application layer.
-    fn runtime_context(&self) -> QueryRuntimeContext;
+/// Owned runtime-build inputs needed while compiling and registering sources.
+#[derive(Default)]
+pub struct QueryRuntimeConfig {
+    /// Non-secret runtime inputs owned by the application layer.
+    pub context: QueryRuntimeContext,
+    /// Optional engine extensions for this runtime build.
+    pub extensions: EngineExtensions,
+}
 
-    /// Returns optional engine extensions for this runtime build.
-    ///
-    /// The default implementation returns no extensions.
-    fn engine_extensions(&self) -> EngineExtensions {
-        EngineExtensions::default()
+impl QueryRuntimeConfig {
+    /// Builds one runtime config from app-owned context and extension state.
+    #[must_use]
+    pub fn new(context: QueryRuntimeContext, extensions: EngineExtensions) -> Self {
+        Self {
+            context,
+            extensions,
+        }
     }
 }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -25,18 +25,10 @@
 //! ```no_run
 //! use std::collections::BTreeMap;
 //!
-//! use coral_engine::{CoralQuery, QueryRuntimeContext, QueryRuntimeProvider, QuerySource};
+//! use coral_engine::{CoralQuery, QueryRuntimeConfig, QuerySource};
 //! use coral_spec::parse_source_manifest_yaml;
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!
-//! struct EmptyRuntime;
-//!
-//! impl QueryRuntimeProvider for EmptyRuntime {
-//!     fn runtime_context(&self) -> QueryRuntimeContext {
-//!         QueryRuntimeContext::default()
-//!     }
-//! }
 //!
 //! # let source_spec = parse_source_manifest_yaml(
 //! #     "name: demo\nversion: 0.1.0\ndsl_version: 3\nbackend: jsonl\ntables: []",
@@ -46,12 +38,10 @@
 //! #     BTreeMap::new(),
 //! #     BTreeMap::new(),
 //! # )];
-//! # let provider = EmptyRuntime;
 //! # async fn demo(
 //! #     sources: &[QuerySource],
-//! #     provider: &dyn QueryRuntimeProvider,
 //! # ) -> Result<(), Box<dyn std::error::Error>> {
-//! let _ = CoralQuery::list_tables(sources, provider, None).await?;
+//! let _ = CoralQuery::list_tables(sources, QueryRuntimeConfig::default(), None).await?;
 //! # Ok(())
 //! # }
 //! # Ok(())
@@ -75,7 +65,7 @@ pub use composition::{
     SourceDecoratorError, SourceFailurePolicy, SourceTables,
 };
 pub use contracts::{
-    ColumnInfo, CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource,
+    ColumnInfo, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport, StatusCode,
     StructuredQueryError, TableInfo,
 };
@@ -96,7 +86,7 @@ impl CoralQuery {
     /// cannot be built.
     pub async fn list_tables(
         sources: &[QuerySource],
-        runtime: &dyn QueryRuntimeProvider,
+        runtime: QueryRuntimeConfig,
         schema_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
         Ok(runtime::query::build_runtime(sources, runtime)
@@ -112,7 +102,7 @@ impl CoralQuery {
     /// or if the runtime cannot execute the statement.
     pub async fn execute_sql(
         sources: &[QuerySource],
-        runtime: &dyn QueryRuntimeProvider,
+        runtime: QueryRuntimeConfig,
         sql: &str,
     ) -> Result<QueryExecution, CoreError> {
         if sql.trim().is_empty() {
@@ -133,7 +123,7 @@ impl CoralQuery {
     /// cannot be registered or enumerated successfully.
     pub async fn test_source(
         source: &QuerySource,
-        runtime: &dyn QueryRuntimeProvider,
+        runtime: QueryRuntimeConfig,
     ) -> Result<Vec<TableInfo>, CoreError> {
         Ok(Self::validate_source(source, runtime, &[]).await?.tables)
     }
@@ -147,7 +137,7 @@ impl CoralQuery {
     /// failing the whole call.
     pub async fn validate_source(
         source: &QuerySource,
-        runtime: &dyn QueryRuntimeProvider,
+        runtime: QueryRuntimeConfig,
         test_queries: &[String],
     ) -> Result<SourceValidationReport, CoreError> {
         let query_runtime =

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -13,9 +13,7 @@ use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
-use crate::{
-    CoreError, EngineExtensions, QueryExecution, QueryRuntimeProvider, QuerySource, TableInfo,
-};
+use crate::{CoreError, QueryExecution, QueryRuntimeConfig, QuerySource, TableInfo};
 
 pub(crate) struct QueryRuntimeAdapter {
     ctx: Arc<SessionContext>,
@@ -25,7 +23,7 @@ pub(crate) struct QueryRuntimeAdapter {
 
 pub(crate) async fn build_runtime(
     sources: &[QuerySource],
-    runtime: &dyn QueryRuntimeProvider,
+    runtime: QueryRuntimeConfig,
 ) -> Result<QueryRuntimeAdapter, CoreError> {
     let session_config = SessionConfig::new().with_information_schema(true);
     let runtime_env = Arc::new(
@@ -39,15 +37,13 @@ pub(crate) async fn build_runtime(
     register_pattern_validator(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
     let ctx = Arc::new(ctx);
 
-    let runtime_context = runtime.runtime_context();
-    let mut build_options: EngineExtensions = runtime.engine_extensions();
+    let QueryRuntimeConfig {
+        context: runtime_context,
+        mut extensions,
+    } = runtime;
     let mut source_candidates = Vec::new();
     for source in sources {
-        match compile_query_source(
-            source,
-            &runtime_context,
-            &build_options.request_authenticators,
-        ) {
+        match compile_query_source(source, &runtime_context, &extensions.request_authenticators) {
             Ok(compiled) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(
                     CompiledQuerySource {
@@ -65,7 +61,7 @@ pub(crate) async fn build_runtime(
     let registration = register_sources(
         &ctx,
         source_candidates,
-        build_options.source_decorators.as_mut_slice(),
+        extensions.source_decorators.as_mut_slice(),
     )
     .await?;
     catalog::register(&ctx, &registration.active_sources)

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_table_not_found, build_source, build_source_with_inputs, dir_url,
-    execution_to_rows, write_jsonl_file,
+    assert_table_not_found, build_source, build_source_with_inputs, dir_url, execution_to_rows,
+    test_runtime, write_jsonl_file,
 };
 
 fn users_manifest(dir: &std::path::Path) -> Value {
@@ -88,7 +88,7 @@ async fn coral_tables_lists_installed_sources() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT schema_name, table_name FROM coral.tables ORDER BY schema_name, table_name",
         )
         .await
@@ -111,7 +111,7 @@ async fn coral_columns_returns_metadata() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT column_name, data_type, is_virtual, is_required_filter \
              FROM coral.columns WHERE schema_name = 'alpha' AND table_name = 'users' \
              ORDER BY ordinal_position",
@@ -137,7 +137,7 @@ async fn coral_columns_default_row_order_matches_ordinal_position() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT column_name, ordinal_position \
              FROM coral.columns WHERE schema_name = 'alpha' AND table_name = 'users'",
         )
@@ -159,13 +159,13 @@ async fn coral_columns_default_row_order_matches_ordinal_position() {
 async fn list_tables_matches_catalog() {
     let (_temp, sources) = build_catalog_sources();
 
-    let listed = CoralQuery::list_tables(&sources, &TestRuntime, None)
+    let listed = CoralQuery::list_tables(&sources, test_runtime(), None)
         .await
         .expect("list_tables should succeed");
     let catalog_rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT schema_name, table_name, description FROM coral.tables ORDER BY schema_name, table_name",
         )
         .await
@@ -192,7 +192,7 @@ async fn list_tables_matches_catalog() {
 
 #[tokio::test]
 async fn list_tables_empty_when_no_sources() {
-    let tables = CoralQuery::list_tables(&[], &TestRuntime, None)
+    let tables = CoralQuery::list_tables(&[], test_runtime(), None)
         .await
         .expect("empty source list should succeed");
 
@@ -206,7 +206,7 @@ async fn join_across_two_sources() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT u.name, t.team_name \
              FROM alpha.users u \
              JOIN beta.teams t ON u.team_id = t.id \
@@ -230,7 +230,7 @@ async fn join_across_two_sources() {
 async fn query_nonexistent_schema_returns_error() {
     let (_temp, sources) = build_catalog_sources();
 
-    let error = CoralQuery::execute_sql(&sources, &TestRuntime, "SELECT * FROM missing.users")
+    let error = CoralQuery::execute_sql(&sources, test_runtime(), "SELECT * FROM missing.users")
         .await
         .expect_err("missing schema should fail");
 
@@ -320,7 +320,7 @@ async fn coral_inputs_exposes_variable_values_and_defaults() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT key, kind, value, default_value, hint, required, is_set \
              FROM coral.inputs WHERE schema_name = 'demo' ORDER BY key",
         )
@@ -367,7 +367,7 @@ async fn coral_inputs_marks_unset_secrets_and_missing_variables() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT key, value, is_set FROM coral.inputs \
              WHERE schema_name = 'demo' ORDER BY key",
         )
@@ -393,7 +393,7 @@ async fn coral_inputs_never_exposes_secret_values() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT value FROM coral.inputs WHERE kind = 'secret'",
         )
         .await
@@ -419,7 +419,7 @@ async fn coral_inputs_reports_explicit_empty_variable_as_set() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &sources,
-            &TestRuntime,
+            test_runtime(),
             "SELECT key, value, is_set FROM coral.inputs \
              WHERE schema_name = 'demo' AND key = 'ACCOUNT_ID'",
         )
@@ -439,7 +439,7 @@ async fn coral_inputs_empty_for_sources_without_declared_inputs() {
     let (_temp, sources) = build_catalog_sources();
 
     let rows = execution_to_rows(
-        &CoralQuery::execute_sql(&sources, &TestRuntime, "SELECT * FROM coral.inputs")
+        &CoralQuery::execute_sql(&sources, test_runtime(), "SELECT * FROM coral.inputs")
             .await
             .expect("catalog query should succeed"),
     );

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -6,19 +6,13 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use coral_engine::{
-    CoreError, QueryExecution, QueryRuntimeContext, QueryRuntimeProvider, QuerySource, StatusCode,
-};
+use coral_engine::{CoreError, QueryExecution, QueryRuntimeConfig, QuerySource, StatusCode};
 use coral_spec::parse_source_manifest_value;
 use parquet::arrow::ArrowWriter;
 use serde_json::{Value, json};
 
-pub(crate) struct TestRuntime;
-
-impl QueryRuntimeProvider for TestRuntime {
-    fn runtime_context(&self) -> QueryRuntimeContext {
-        QueryRuntimeContext::default()
-    }
+pub(crate) fn test_runtime() -> QueryRuntimeConfig {
+    QueryRuntimeConfig::default()
 }
 
 pub(crate) fn build_source(value: Value) -> QuerySource {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryRuntimeContext, QueryRuntimeProvider,
+    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext,
     RequestAuthenticator, RequestAuthenticatorError, StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
@@ -11,7 +11,7 @@ use wiremock::matchers::{body_json, header, method, path, query_param, query_par
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::{
-    TestRuntime, build_source, build_source_with_secrets, execution_to_rows, users_rows,
+    build_source, build_source_with_secrets, execution_to_rows, test_runtime, users_rows,
 };
 
 fn base_http_manifest(name: &str, base_url: &str) -> Value {
@@ -79,21 +79,13 @@ impl RequestAuthenticator for TestRequestAuthenticator {
     }
 }
 
-struct TestAuthRuntime;
-
-impl QueryRuntimeProvider for TestAuthRuntime {
-    fn runtime_context(&self) -> QueryRuntimeContext {
-        QueryRuntimeContext::default()
-    }
-
-    fn engine_extensions(&self) -> EngineExtensions {
-        let mut extensions = EngineExtensions::default();
-        extensions.request_authenticators.insert(
-            "test_signer".to_string(),
-            Arc::new(TestRequestAuthenticator),
-        );
-        extensions
-    }
+fn test_auth_runtime() -> QueryRuntimeConfig {
+    let mut extensions = EngineExtensions::default();
+    extensions.request_authenticators.insert(
+        "test_signer".to_string(),
+        Arc::new(TestRequestAuthenticator),
+    );
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
 }
 
 #[tokio::test]
@@ -110,7 +102,7 @@ async fn select_all_from_http_source() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name, email FROM http_users.users ORDER BY id",
         )
         .await
@@ -134,7 +126,7 @@ async fn select_with_column_projection() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT name, email FROM http_projection.users ORDER BY name",
         )
         .await
@@ -165,7 +157,7 @@ async fn select_with_order_by() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT name FROM http_order.users ORDER BY name DESC",
         )
         .await
@@ -196,7 +188,7 @@ async fn select_with_limit() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT * FROM http_limit.users LIMIT 2",
         )
         .await
@@ -231,7 +223,7 @@ async fn select_with_where_filter_pushdown() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name FROM http_filter.users WHERE id = 2",
         )
         .await
@@ -280,7 +272,7 @@ async fn boolean_filter_bool_is_predicate_sends_json_bool_body() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, include_archived FROM http_bool_filter.users WHERE include_archived IS FALSE",
         )
         .await
@@ -304,7 +296,7 @@ async fn select_count_aggregation() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT COUNT(*) AS n FROM http_count.users",
         )
         .await
@@ -348,7 +340,7 @@ async fn pagination_page_mode() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name, email FROM http_page.users ORDER BY id",
         )
         .await
@@ -392,7 +384,7 @@ async fn pagination_offset_mode() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name, email FROM http_offset.users ORDER BY id",
         )
         .await
@@ -432,7 +424,7 @@ async fn pagination_link_header() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name, email FROM http_link.users ORDER BY id",
         )
         .await
@@ -470,7 +462,7 @@ async fn auth_headers_sent_correctly() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT COUNT(*) AS n FROM http_auth.users",
         )
         .await
@@ -506,7 +498,7 @@ async fn custom_authenticator_signs_final_request() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestAuthRuntime,
+            test_auth_runtime(),
             "SELECT COUNT(*) AS n FROM http_custom_auth.users",
         )
         .await
@@ -528,7 +520,7 @@ async fn api_returns_500() {
 
     let source = build_source(base_http_manifest("http_500", &server.uri()));
 
-    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM http_500.users")
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM http_500.users")
         .await
         .expect_err("500 should fail");
 
@@ -557,7 +549,7 @@ async fn api_returns_401() {
 
     let source = build_source(base_http_manifest("http_401", &server.uri()));
 
-    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM http_401.users")
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM http_401.users")
         .await
         .expect_err("401 should fail");
 
@@ -676,7 +668,7 @@ async fn slack_messages_have_formatted_ts_and_permalink() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT ts, permalink, user_id, text FROM slack_ts.messages WHERE channel = 'C123456' ORDER BY ts",
         )
         .await
@@ -714,10 +706,13 @@ async fn missing_required_filter_surfaces_structured_error() {
     ]);
     let source = build_source(manifest);
 
-    let error =
-        CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM http_required.users")
-            .await
-            .expect_err("query without the required filter should fail");
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT * FROM http_required.users",
+    )
+    .await
+    .expect_err("query without the required filter should fail");
 
     assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
     match &error {
@@ -746,10 +741,13 @@ async fn api_returns_malformed_json() {
 
     let source = build_source(base_http_manifest("http_bad_json", &server.uri()));
 
-    let error =
-        CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM http_bad_json.users")
-            .await
-            .expect_err("malformed json should fail");
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT * FROM http_bad_json.users",
+    )
+    .await
+    .expect_err("malformed json should fail");
 
     assert_eq!(error.status_code(), StatusCode::Internal);
     match error {

--- a/crates/coral-engine/tests/engine/json_tests.rs
+++ b/crates/coral-engine/tests/engine/json_tests.rs
@@ -10,7 +10,7 @@ use coral_engine::{CoralQuery, CoreError};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use crate::harness::{TestRuntime, build_source, dir_url, execution_to_rows, write_jsonl_file};
+use crate::harness::{build_source, dir_url, execution_to_rows, test_runtime, write_jsonl_file};
 
 fn events_manifest(name: &str, dir: &Path, column_type: &str) -> Value {
     json!({
@@ -65,7 +65,7 @@ async fn query(name: &str, sql: &str) -> Vec<Value> {
     write_jsonl_file(temp.path(), "events.jsonl", &events_fixture());
     let source = build_source(events_manifest(name, temp.path(), "Json"));
     execution_to_rows(
-        &CoralQuery::execute_sql(&[source], &TestRuntime, sql)
+        &CoralQuery::execute_sql(&[source], test_runtime(), sql)
             .await
             .expect("query should succeed"),
     )
@@ -98,7 +98,7 @@ async fn json_functions_also_work_on_utf8_columns() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, json_get_str(properties, '$browser') AS browser \
              FROM json_utf8.events ORDER BY id",
         )
@@ -128,7 +128,7 @@ async fn json_string_scalars_round_trip_as_json_text() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, json_as_text(properties) AS value FROM json_scalar.events",
         )
         .await
@@ -279,7 +279,7 @@ async fn json_operators_are_rejected() {
         "SELECT id FROM json_ops.events WHERE (properties->'count')::bigint > 5",
         "SELECT id FROM json_ops.events WHERE properties ? '$browser'",
     ] {
-        let error = CoralQuery::execute_sql(std::slice::from_ref(&source), &TestRuntime, sql)
+        let error = CoralQuery::execute_sql(std::slice::from_ref(&source), test_runtime(), sql)
             .await
             .expect_err("query should reject JSON operators");
 

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_row_count, assert_table_not_found, build_source, dir_url,
-    execution_to_rows, users_rows, write_jsonl_file,
+    assert_row_count, assert_table_not_found, build_source, dir_url, execution_to_rows,
+    test_runtime, users_rows, write_jsonl_file,
 };
 
 fn jsonl_manifest(name: &str, dir: &Path, glob: &str) -> Value {
@@ -39,7 +39,7 @@ async fn select_all_from_jsonl_source() {
 
     let execution = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT id, name, email FROM jsonl_users.users ORDER BY id",
     )
     .await
@@ -62,7 +62,7 @@ async fn select_with_column_projection() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT name FROM jsonl_projection.users ORDER BY name DESC",
         )
         .await
@@ -88,7 +88,7 @@ async fn select_with_where_filter() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name FROM jsonl_filter.users WHERE id = 2",
         )
         .await
@@ -107,7 +107,7 @@ async fn select_with_order_by_and_limit() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT name FROM jsonl_order.users ORDER BY name DESC LIMIT 2",
         )
         .await
@@ -129,7 +129,7 @@ async fn select_count_aggregation() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT COUNT(*) AS n FROM jsonl_count.users",
         )
         .await
@@ -149,7 +149,7 @@ async fn glob_matches_multiple_files() {
 
     let execution = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT id, name, email FROM jsonl_glob.users ORDER BY id",
     )
     .await
@@ -164,10 +164,13 @@ async fn missing_file_returns_error() {
     let missing_dir = temp.path().join("missing");
     let source = build_source(jsonl_manifest("jsonl_missing", &missing_dir, "**/*.jsonl"));
 
-    let error =
-        CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM jsonl_missing.users")
-            .await
-            .expect_err("missing jsonl source should fail");
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT * FROM jsonl_missing.users",
+    )
+    .await
+    .expect_err("missing jsonl source should fail");
 
     assert_table_not_found(error, "jsonl_missing", "users");
 }

--- a/crates/coral-engine/tests/engine/parquet_tests.rs
+++ b/crates/coral-engine/tests/engine/parquet_tests.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_table_not_found, build_source, build_source_with_secrets, dir_url,
-    execution_to_rows, users_batch, write_parquet_file,
+    assert_table_not_found, build_source, build_source_with_secrets, dir_url, execution_to_rows,
+    test_runtime, users_batch, write_parquet_file,
 };
 
 fn parquet_manifest(name: &str, dir: &Path) -> Value {
@@ -36,7 +36,7 @@ async fn select_all_from_parquet_source() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name, email FROM parquet_users.users ORDER BY id",
         )
         .await
@@ -62,7 +62,7 @@ async fn select_with_column_projection() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT email FROM parquet_projection.users ORDER BY email",
         )
         .await
@@ -88,7 +88,7 @@ async fn select_with_where_filter() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name FROM parquet_filter.users WHERE id = 3",
         )
         .await
@@ -107,7 +107,7 @@ async fn select_with_order_by_and_limit() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id, name FROM parquet_order.users ORDER BY name DESC LIMIT 2",
         )
         .await
@@ -132,7 +132,7 @@ async fn select_count_aggregation() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT COUNT(*) AS n FROM parquet_count.users",
         )
         .await
@@ -179,7 +179,7 @@ async fn parquet_manifest_with_declared_secret_inputs_registers_and_queries() {
     let schemata = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT schema_name FROM information_schema.schemata \
              WHERE schema_name = 'warehouse'",
         )
@@ -214,7 +214,7 @@ async fn parquet_manifest_with_declared_secret_inputs_registers_and_queries() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source2],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id FROM warehouse2.users ORDER BY id",
         )
         .await
@@ -234,7 +234,7 @@ async fn missing_file_returns_error() {
 
     let error = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT * FROM parquet_missing.users",
     )
     .await

--- a/crates/coral-engine/tests/engine/pattern_error_tests.rs
+++ b/crates/coral-engine/tests/engine/pattern_error_tests.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    TestRuntime, assert_row_count, build_source, execution_to_rows, write_jsonl_file,
+    assert_row_count, build_source, execution_to_rows, test_runtime, write_jsonl_file,
 };
 
 fn manifest(dir: &Path) -> Value {
@@ -69,7 +69,7 @@ async fn similar_to_with_like_wildcard_returns_clear_error() {
 
     let error = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT id, name FROM linear.projects WHERE name SIMILAR TO '(Slack|Weekly)%'",
     )
     .await
@@ -87,7 +87,7 @@ async fn regex_match_with_like_wildcard_returns_clear_error() {
 
     let error = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT id, name FROM linear.projects WHERE name ~ '(Slack|Weekly)%'",
     )
     .await
@@ -105,7 +105,7 @@ async fn similar_to_with_regex_syntax_succeeds() {
 
     let execution = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT id, name FROM linear.projects WHERE name SIMILAR TO '(Slack|Weekly).*' ORDER BY id",
     )
     .await
@@ -123,7 +123,7 @@ async fn regex_match_with_valid_regex_succeeds() {
 
     let execution = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT id, name FROM linear.projects WHERE name ~ '^(Slack|Weekly)' ORDER BY id",
     )
     .await
@@ -141,7 +141,7 @@ async fn like_with_wildcards_still_works() {
 
     let execution = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT id, name FROM linear.projects WHERE name LIKE 'Slack%' OR name LIKE 'Weekly%' ORDER BY id",
     )
     .await

--- a/crates/coral-engine/tests/engine/structured_error_tests.rs
+++ b/crates/coral-engine/tests/engine/structured_error_tests.rs
@@ -10,7 +10,7 @@ use coral_engine::{CoralQuery, CoreError, StatusCode, StructuredQueryError};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use crate::harness::{TestRuntime, build_source, dir_url, write_jsonl_file};
+use crate::harness::{build_source, dir_url, test_runtime, write_jsonl_file};
 
 fn manifest(name: &str, table: &str, dir: &Path) -> Value {
     json!({
@@ -52,7 +52,7 @@ async fn unknown_table_in_installed_schema_suggests_case_preserved_quoted_name()
 
     // DataFusion lowercases the unquoted `Master` to `master`, which won't
     // match our case-preserving `Master` table in the catalog.
-    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM hockey.Master")
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM hockey.Master")
         .await
         .expect_err("unknown table should fail");
 
@@ -76,7 +76,7 @@ async fn unknown_table_missing_schema_points_at_coral_tables_catalog() {
     );
     let source = build_source(manifest("hockey", "games", temp.path()));
 
-    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM nba.games")
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM nba.games")
         .await
         .expect_err("unknown schema should fail");
 
@@ -103,7 +103,7 @@ async fn unknown_table_similar_name_levenshtein_suggests_closest() {
     );
     let source = build_source(manifest("hockey", "games", temp.path()));
 
-    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM hockey.gamers")
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM hockey.gamers")
         .await
         .expect_err("unknown table should fail");
 
@@ -130,7 +130,7 @@ async fn unqualified_table_suggests_schema_qualified_name() {
     );
     let source = build_source(manifest("stripe", "accounts", temp.path()));
 
-    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT * FROM account")
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM account")
         .await
         .expect_err("unqualified unknown table should fail");
 
@@ -169,7 +169,7 @@ async fn unknown_column_on_aliased_join_suggests_case_preserved_quoted_name() {
 
     let error = CoralQuery::execute_sql(
         &[source],
-        &TestRuntime,
+        test_runtime(),
         "SELECT g.id FROM hockey.master AS g \
          JOIN hockey.master AS m ON g.playerID = m.playerID",
     )
@@ -202,7 +202,7 @@ async fn unknown_column_levenshtein_suggests_closest_field() {
 
     // `id2` doesn't exist and isn't a case-twin of anything; the closest
     // candidate by Levenshtein is `id`.
-    let error = CoralQuery::execute_sql(&[source], &TestRuntime, "SELECT id2 FROM hockey.master")
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT id2 FROM hockey.master")
         .await
         .expect_err("unknown field should fail");
 

--- a/crates/coral-engine/tests/engine/test_source_tests.rs
+++ b/crates/coral-engine/tests/engine/test_source_tests.rs
@@ -4,7 +4,7 @@ use coral_engine::CoralQuery;
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
-use crate::harness::{TestRuntime, build_source, dir_url, users_rows, write_jsonl_file};
+use crate::harness::{build_source, dir_url, test_runtime, users_rows, write_jsonl_file};
 
 fn jsonl_manifest(name: &str, dir: &Path, glob: &str) -> Value {
     json!({
@@ -38,7 +38,7 @@ async fn test_source_lists_registered_tables() {
         "**/*.jsonl",
     ));
 
-    let tables = CoralQuery::test_source(&source, &TestRuntime)
+    let tables = CoralQuery::test_source(&source, test_runtime())
         .await
         .expect("test_source should succeed");
 
@@ -57,7 +57,7 @@ async fn test_source_missing_directory_returns_error() {
         "**/*.jsonl",
     ));
 
-    let error = CoralQuery::test_source(&source, &TestRuntime)
+    let error = CoralQuery::test_source(&source, test_runtime())
         .await
         .expect_err("test_source should fail for missing directories");
 
@@ -85,7 +85,7 @@ async fn validate_source_fails_when_source_never_registers() {
     ));
     let queries = vec!["SELECT * FROM jsonl_test_missing.users".to_string()];
 
-    let error = CoralQuery::validate_source(&source, &TestRuntime, &queries)
+    let error = CoralQuery::validate_source(&source, test_runtime(), &queries)
         .await
         .expect_err("validate_source should fail when the source never registers");
 
@@ -113,7 +113,7 @@ async fn validate_source_reports_passing_and_failing_queries() {
         "SELECT * FROM jsonl_test_source.missing".to_string(),
     ];
 
-    let report = CoralQuery::validate_source(&source, &TestRuntime, &queries)
+    let report = CoralQuery::validate_source(&source, test_runtime(), &queries)
         .await
         .expect("validate_source should succeed");
 
@@ -149,7 +149,7 @@ async fn validate_source_maps_non_read_only_queries_to_stable_error() {
     ));
     let queries = vec!["SET datafusion.execution.batch_size = 1".to_string()];
 
-    let report = CoralQuery::validate_source(&source, &TestRuntime, &queries)
+    let report = CoralQuery::validate_source(&source, test_runtime(), &queries)
         .await
         .expect("validate_source should succeed");
 


### PR DESCRIPTION
## Summary

Replace the engine-side `QueryRuntimeProvider` trait with an owned `QueryRuntimeConfig` value so runtime construction receives its app-owned context and extension bundle explicitly.

This keeps extension selection in `coral-app`, where selected sources and app composition belong, while making `coral-engine` consume concrete runtime-build inputs without a one-shot provider adapter.

## Changes

- Add `QueryRuntimeConfig { context, extensions }` to the engine contract surface
- Update `CoralQuery` entrypoints to take `QueryRuntimeConfig` by value
- Remove the app-side `RuntimeProvider` and its `Mutex<Option<EngineExtensions>>`
- Update engine tests and public docs to construct runtime configs directly

## Validation

- `make rust-checks`
