### PR TITLE
fix(engine): normalize HTTP provider transport errors

### DIFF
--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -386,7 +386,7 @@ async fn validate_source_skipped_registration_returns_unary_failed_precondition(
 }
 
 #[tokio::test]
-async fn execute_sql_with_unreachable_api_returns_internal_error() {
+async fn execute_sql_with_unreachable_api_returns_unavailable_error() {
     let harness = GrpcHarness::new().await;
     let failing_http = FailingHttpFixture::new().await;
     harness
@@ -401,7 +401,7 @@ async fn execute_sql_with_unreachable_api_returns_internal_error() {
         }))
         .await
         .expect_err("unreachable source query should fail");
-    assert_eq!(error.code(), tonic::Code::Internal);
+    assert_eq!(error.code(), tonic::Code::Unavailable);
 }
 
 #[tokio::test]

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -154,7 +154,15 @@ impl HttpSourceClient {
         let pagination = table
             .pagination
             .validated(&self.source_schema, table.name())
-            .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            .map_err(|error| {
+                provider_error(ProviderQueryError::Pagination {
+                    source_schema: self.source_schema.clone(),
+                    table: table.name().to_string(),
+                    method: None,
+                    url: None,
+                    detail: error.to_string(),
+                })
+            })?;
         let page_size = resolve_page_size(pagination.page_size.as_ref(), sql_limit);
 
         let filter_keys: HashSet<String> = filters.keys().cloned().collect();
@@ -175,11 +183,13 @@ impl HttpSourceClient {
         loop {
             page_count += 1;
             if page_count > max_pages {
-                return Err(DataFusionError::Execution(format!(
-                    "source '{}' table '{}' exceeded pagination max_pages={max_pages}",
-                    self.source_schema,
-                    table.name()
-                )));
+                return Err(provider_error(ProviderQueryError::Pagination {
+                    source_schema: self.source_schema.clone(),
+                    table: table.name().to_string(),
+                    method: None,
+                    url: None,
+                    detail: format!("exceeded pagination max_pages={max_pages}"),
+                }));
             }
 
             let base_url = render_template(
@@ -225,7 +235,10 @@ impl HttpSourceClient {
                     &pagination,
                     &state,
                     page_size,
-                )?;
+                )
+                .map_err(|error| {
+                    pagination_error(&self.source_schema, table.name(), None, Some(&url), &error)
+                })?;
 
                 let mut body = build_request_body(
                     active_request,
@@ -240,7 +253,10 @@ impl HttpSourceClient {
                     &pagination,
                     &state,
                     page_size,
-                )?;
+                )
+                .map_err(|error| {
+                    pagination_error(&self.source_schema, table.name(), None, Some(&url), &error)
+                })?;
                 (query_pairs, body)
             };
 
@@ -338,7 +354,15 @@ impl HttpSourceClient {
                     }
                     let step = offset
                         .resolve_step(page_size, &self.source_schema, table.name())
-                        .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+                        .map_err(|error| {
+                            provider_error(ProviderQueryError::Pagination {
+                                source_schema: self.source_schema.clone(),
+                                table: table.name().to_string(),
+                                method: None,
+                                url: None,
+                                detail: error.to_string(),
+                            })
+                        })?;
                     state.offset = state.offset.saturating_add(step);
                 }
                 ValidatedPaginationMode::LinkHeader | ValidatedPaginationMode::Auto => {
@@ -622,7 +646,8 @@ async fn execute_request(
 
         let response = http.execute(built).await.map_err(|error| {
             request_error(
-                "request",
+                source_schema,
+                table_name,
                 method_label,
                 &logged_url,
                 request_timeout,
@@ -665,9 +690,6 @@ async fn execute_request(
             return Ok(None);
         }
 
-        let next_url =
-            extract_next_link_url(response.headers(), base_url, link_header_require_results)?;
-
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
@@ -683,12 +705,25 @@ async fn execute_request(
             )));
         }
 
+        let next_url =
+            extract_next_link_url(response.headers(), base_url, link_header_require_results)
+                .map_err(|error| {
+                    pagination_error(
+                        source_schema,
+                        table_name,
+                        Some(method_label),
+                        Some(&logged_url),
+                        &error,
+                    )
+                })?;
+
         let payload = decode_response_body(
             response,
             response_format,
+            source_schema,
+            table_name,
             method_label,
             &logged_url,
-            request_timeout,
         )
         .await?;
         return Ok(Some((payload, next_url)));
@@ -698,29 +733,18 @@ async fn execute_request(
 async fn decode_response_body(
     response: reqwest::Response,
     format: ResponseBodyFormat,
+    source_schema: &str,
+    table_name: &str,
     method_label: &str,
     logged_url: &str,
-    request_timeout: Duration,
 ) -> Result<Value> {
     match format {
         ResponseBodyFormat::Json => response.json().await.map_err(|error| {
-            request_error(
-                "response decoding",
-                method_label,
-                logged_url,
-                request_timeout,
-                &error,
-            )
+            decode_error(source_schema, table_name, method_label, logged_url, &error)
         }),
         ResponseBodyFormat::JsonEachRow => {
             let text = response.text().await.map_err(|error| {
-                request_error(
-                    "response decoding",
-                    method_label,
-                    logged_url,
-                    request_timeout,
-                    &error,
-                )
+                decode_error(source_schema, table_name, method_label, logged_url, &error)
             })?;
             let mut rows = Vec::new();
             for (index, line) in text.lines().enumerate() {
@@ -729,11 +753,16 @@ async fn decode_response_body(
                     continue;
                 }
                 let row: Value = serde_json::from_str(trimmed).map_err(|error| {
-                    DataFusionError::Execution(format!(
-                        "response decoding failed for {method_label} {logged_url}: \
-                         json_each_row line {} is not valid JSON: {error}",
-                        index + 1
-                    ))
+                    provider_error(ProviderQueryError::Decode {
+                        source_schema: source_schema.to_string(),
+                        table: table_name.to_string(),
+                        method: Some(method_label.to_string()),
+                        url: Some(logged_url.to_string()),
+                        detail: format!(
+                            "source API response decoding failed: json_each_row line {} is not valid JSON: {error}",
+                            index + 1
+                        ),
+                    })
                 })?;
                 rows.push(row);
             }
@@ -743,22 +772,73 @@ async fn decode_response_body(
 }
 
 fn request_error(
-    stage: &str,
+    source_schema: &str,
+    table_name: &str,
     method_label: &str,
     logged_url: &str,
     request_timeout: Duration,
     error: &reqwest::Error,
 ) -> DataFusionError {
-    if error.is_timeout() {
-        return DataFusionError::Execution(format!(
-            "source API {stage} timed out for {method_label} {logged_url} after {}s",
+    let detail = if error.is_timeout() {
+        format!(
+            "source API request timed out for {method_label} {logged_url} after {}s",
             request_timeout.as_secs_f64()
-        ));
-    }
+        )
+    } else {
+        format!("source API request failed for {method_label} {logged_url}: {error}")
+    };
 
-    DataFusionError::Execution(format!(
-        "source API {stage} failed for {method_label} {logged_url}: {error}"
-    ))
+    provider_error(ProviderQueryError::Request {
+        source_schema: source_schema.to_string(),
+        table: table_name.to_string(),
+        method: Some(method_label.to_string()),
+        url: Some(logged_url.to_string()),
+        detail,
+        timed_out: error.is_timeout(),
+    })
+}
+
+fn decode_error(
+    source_schema: &str,
+    table_name: &str,
+    method_label: &str,
+    logged_url: &str,
+    error: &reqwest::Error,
+) -> DataFusionError {
+    provider_error(ProviderQueryError::Decode {
+        source_schema: source_schema.to_string(),
+        table: table_name.to_string(),
+        method: Some(method_label.to_string()),
+        url: Some(logged_url.to_string()),
+        detail: format!("source API response decoding failed: {error}"),
+    })
+}
+
+fn pagination_error(
+    source_schema: &str,
+    table_name: &str,
+    method_label: Option<&str>,
+    logged_url: Option<&str>,
+    error: &DataFusionError,
+) -> DataFusionError {
+    provider_error(ProviderQueryError::Pagination {
+        source_schema: source_schema.to_string(),
+        table: table_name.to_string(),
+        method: method_label.map(ToOwned::to_owned),
+        url: logged_url.map(ToOwned::to_owned),
+        detail: datafusion_detail(error),
+    })
+}
+
+fn provider_error(error: ProviderQueryError) -> DataFusionError {
+    DataFusionError::External(Box::new(error))
+}
+
+fn datafusion_detail(error: &DataFusionError) -> String {
+    match error {
+        DataFusionError::Execution(detail) => detail.clone(),
+        other => other.to_string(),
+    }
 }
 
 fn http_method_label(method: HttpMethod) -> &'static str {
@@ -1176,6 +1256,7 @@ mod tests {
     use std::collections::{BTreeMap, HashMap};
     use std::time::Duration;
 
+    use datafusion::error::DataFusionError;
     use reqwest::header::{HeaderMap, HeaderValue};
     use serde_json::json;
     use tokio::net::TcpListener;
@@ -1186,6 +1267,7 @@ mod tests {
         apply_pagination_query_pairs, execute_request, extract_next_link_url, extract_rows,
         join_url, normalize_base_url, page_is_exhausted, resolve_value_source, set_path_value,
     };
+    use crate::backends::http::ProviderQueryError;
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
     use coral_spec::{
@@ -2089,7 +2171,29 @@ mod tests {
         .await
         .expect_err("hung upstream should time out");
 
-        assert!(error.to_string().contains("timed out"));
+        match error {
+            DataFusionError::External(inner) => {
+                let provider_error = inner
+                    .downcast_ref::<ProviderQueryError>()
+                    .expect("timeout should be a provider query error");
+                match provider_error {
+                    ProviderQueryError::Request {
+                        source_schema,
+                        table,
+                        detail,
+                        timed_out,
+                        ..
+                    } => {
+                        assert_eq!(source_schema, "demo");
+                        assert_eq!(table, "items");
+                        assert!(*timed_out);
+                        assert!(detail.contains("timed out"));
+                    }
+                    other => panic!("expected request provider error, got {other:?}"),
+                }
+            }
+            other => panic!("expected external provider error, got {other:?}"),
+        }
         task.abort();
     }
 

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -37,6 +37,34 @@ pub(crate) enum ProviderQueryError {
         detail: String,
     },
 
+    #[error("{source_schema}.{table} request failed: {detail}")]
+    Request {
+        source_schema: String,
+        table: String,
+        method: Option<String>,
+        url: Option<String>,
+        detail: String,
+        timed_out: bool,
+    },
+
+    #[error("{source_schema}.{table} response decode failed: {detail}")]
+    Decode {
+        source_schema: String,
+        table: String,
+        method: Option<String>,
+        url: Option<String>,
+        detail: String,
+    },
+
+    #[error("{source_schema}.{table} pagination failed: {detail}")]
+    Pagination {
+        source_schema: String,
+        table: String,
+        method: Option<String>,
+        url: Option<String>,
+        detail: String,
+    },
+
     #[error("{source_schema}.{table}: {detail}")]
     RateLimited {
         source_schema: String,
@@ -92,6 +120,47 @@ impl ProviderQueryError {
                 url.as_deref(),
                 detail,
             ),
+            Self::Request {
+                source_schema,
+                table,
+                method,
+                url,
+                detail,
+                timed_out,
+            } => provider_stage_failure_to_structured(provider_request_failure(
+                source_schema,
+                table,
+                method.as_deref(),
+                url.as_deref(),
+                detail,
+                *timed_out,
+            )),
+            Self::Decode {
+                source_schema,
+                table,
+                method,
+                url,
+                detail,
+            } => provider_stage_failure_to_structured(provider_decode_failure(
+                source_schema,
+                table,
+                method.as_deref(),
+                url.as_deref(),
+                detail,
+            )),
+            Self::Pagination {
+                source_schema,
+                table,
+                method,
+                url,
+                detail,
+            } => provider_stage_failure_to_structured(provider_pagination_failure(
+                source_schema,
+                table,
+                method.as_deref(),
+                url.as_deref(),
+                detail,
+            )),
             Self::RateLimited {
                 source_schema,
                 table,
@@ -220,6 +289,131 @@ fn http_request_to_structured(
     )
 }
 
+struct ProviderStageFailure<'a> {
+    source: &'a str,
+    table: &'a str,
+    stage: &'a str,
+    summary: &'a str,
+    detail: &'a str,
+    method: Option<&'a str>,
+    url: Option<&'a str>,
+    hint: Option<String>,
+    retryable: bool,
+    status: StatusCode,
+    timed_out: bool,
+}
+
+fn provider_request_failure<'a>(
+    source: &'a str,
+    table: &'a str,
+    method: Option<&'a str>,
+    url: Option<&'a str>,
+    detail: &'a str,
+    timed_out: bool,
+) -> ProviderStageFailure<'a> {
+    ProviderStageFailure {
+        source,
+        table,
+        stage: "request",
+        summary: if timed_out {
+            "Source request timed out"
+        } else {
+            "Source request failed"
+        },
+        detail,
+        method,
+        url,
+        hint: Some(
+            "The upstream API could not be reached. Check connectivity and retry.".to_string(),
+        ),
+        retryable: true,
+        status: StatusCode::Unavailable,
+        timed_out,
+    }
+}
+
+fn provider_decode_failure<'a>(
+    source: &'a str,
+    table: &'a str,
+    method: Option<&'a str>,
+    url: Option<&'a str>,
+    detail: &'a str,
+) -> ProviderStageFailure<'a> {
+    ProviderStageFailure {
+        source,
+        table,
+        stage: "decode",
+        summary: "Source response decode failed",
+        detail,
+        method,
+        url,
+        hint: Some(
+            "The upstream API returned a response that does not match the source manifest."
+                .to_string(),
+        ),
+        retryable: false,
+        status: StatusCode::FailedPrecondition,
+        timed_out: false,
+    }
+}
+
+fn provider_pagination_failure<'a>(
+    source: &'a str,
+    table: &'a str,
+    method: Option<&'a str>,
+    url: Option<&'a str>,
+    detail: &'a str,
+) -> ProviderStageFailure<'a> {
+    ProviderStageFailure {
+        source,
+        table,
+        stage: "pagination",
+        summary: "Source pagination failed",
+        detail,
+        method,
+        url,
+        hint: Some(
+            "The source pagination configuration or upstream pagination link is invalid."
+                .to_string(),
+        ),
+        retryable: false,
+        status: StatusCode::FailedPrecondition,
+        timed_out: false,
+    }
+}
+
+fn provider_stage_failure_to_structured(failure: ProviderStageFailure<'_>) -> StructuredQueryError {
+    let sanitized_url = failure.url.and_then(sanitize_request_url);
+    let detail = enrich_provider_detail(failure.detail, failure.method, sanitized_url.as_deref());
+
+    let mut metadata = HashMap::new();
+    metadata.insert("source".to_string(), failure.source.to_string());
+    metadata.insert("table".to_string(), failure.table.to_string());
+    metadata.insert(
+        "provider_failure_stage".to_string(),
+        failure.stage.to_string(),
+    );
+    if failure.timed_out {
+        metadata.insert("timeout".to_string(), "true".to_string());
+    }
+    if let Some(method) = failure.method {
+        metadata.insert("http_method".to_string(), method.to_string());
+    }
+    if let Some(url) = &sanitized_url {
+        metadata.insert("url".to_string(), url.clone());
+    }
+
+    StructuredQueryError::new(
+        "PROVIDER_REQUEST_FAILED",
+        failure.summary,
+        detail,
+        failure.hint,
+        failure.retryable,
+        failure.status,
+        metadata,
+    )
+}
+
 /// Returns `true` when the given status belongs to the 5xx server-error class.
 fn is_server_error(status: u16) -> bool {
     HttpStatus::from_u16(status).is_ok_and(|code| code.is_server_error())
@@ -329,6 +523,68 @@ mod tests {
         .to_structured();
         assert_eq!(error.reason(), "INVALID_QUERY_SHAPE");
         assert_eq!(error.status(), StatusCode::InvalidArgument);
+    }
+
+    #[test]
+    fn request_timeout_maps_to_unavailable_provider_failure() {
+        let error = ProviderQueryError::Request {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            method: Some("GET".to_string()),
+            url: Some("https://api.github.com/issues?token=secret".to_string()),
+            detail: "source API request timed out after 30s".to_string(),
+            timed_out: true,
+        }
+        .to_structured();
+        assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.summary(), "Source request timed out");
+        assert_eq!(error.status(), StatusCode::Unavailable);
+        assert!(error.retryable());
+        assert_eq!(
+            error.metadata().get("provider_failure_stage").unwrap(),
+            "request"
+        );
+        assert_eq!(error.metadata().get("timeout").unwrap(), "true");
+        assert!(!error.detail().contains("token=secret"));
+    }
+
+    #[test]
+    fn decode_failure_maps_to_failed_precondition_provider_failure() {
+        let error = ProviderQueryError::Decode {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            method: Some("GET".to_string()),
+            url: Some("https://api.github.com/issues".to_string()),
+            detail: "expected value at line 1 column 1".to_string(),
+        }
+        .to_structured();
+        assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.summary(), "Source response decode failed");
+        assert_eq!(error.status(), StatusCode::FailedPrecondition);
+        assert!(!error.retryable());
+        assert_eq!(
+            error.metadata().get("provider_failure_stage").unwrap(),
+            "decode"
+        );
+    }
+
+    #[test]
+    fn pagination_failure_maps_to_failed_precondition_provider_failure() {
+        let error = ProviderQueryError::Pagination {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            method: Some("GET".to_string()),
+            url: Some("https://api.github.com/issues".to_string()),
+            detail: "invalid pagination Link header item".to_string(),
+        }
+        .to_structured();
+        assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.summary(), "Source pagination failed");
+        assert_eq!(error.status(), StatusCode::FailedPrecondition);
+        assert_eq!(
+            error.metadata().get("provider_failure_stage").unwrap(),
+            "pagination"
+        );
     }
 
     #[test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -540,6 +540,50 @@ async fn api_returns_500() {
 }
 
 #[tokio::test]
+async fn api_returns_500_with_bad_link_header_still_reports_api_failure() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(
+            ResponseTemplate::new(500)
+                .append_header(
+                    "Link",
+                    "<https://example.invalid/api/users?page=2>; rel=\"next\"",
+                )
+                .set_body_string("boom"),
+        )
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_500_bad_link", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "link_header"
+    });
+    let source = build_source(manifest);
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT * FROM http_500_bad_link.users",
+    )
+    .await
+    .expect_err("500 should fail as an API request error");
+
+    assert_eq!(error.status_code(), StatusCode::Unavailable);
+    match &error {
+        CoreError::QueryFailure(sqe) => {
+            assert_eq!(sqe.reason(), "PROVIDER_REQUEST_FAILED");
+            assert!(sqe.retryable());
+            assert_eq!(sqe.metadata().get("http_status").unwrap(), "500");
+            assert_eq!(sqe.metadata().get("source").unwrap(), "http_500_bad_link");
+            assert_eq!(sqe.metadata().get("provider_failure_stage"), None);
+        }
+        other => panic!("unexpected 500 error variant: {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn api_returns_401() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -751,10 +795,73 @@ async fn api_returns_malformed_json() {
     .await
     .expect_err("malformed json should fail");
 
-    assert_eq!(error.status_code(), StatusCode::Internal);
+    assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
     match error {
-        CoreError::Internal(detail) => assert!(detail.contains("response decoding failed")),
+        CoreError::QueryFailure(sqe) => {
+            assert_eq!(sqe.reason(), "PROVIDER_REQUEST_FAILED");
+            assert_eq!(sqe.summary(), "Source response decode failed");
+            assert!(!sqe.retryable());
+            assert_eq!(sqe.metadata().get("source").unwrap(), "http_bad_json");
+            assert_eq!(sqe.metadata().get("table").unwrap(), "users");
+            assert_eq!(
+                sqe.metadata().get("provider_failure_stage").unwrap(),
+                "decode"
+            );
+            assert!(sqe.detail().contains("response decoding failed"));
+        }
         other => panic!("unexpected malformed-json error variant: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn pagination_link_header_cross_origin_surfaces_structured_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header(
+                    "Link",
+                    "<https://example.invalid/api/users?page=2>; rel=\"next\"",
+                )
+                .set_body_json(json!({ "data": [] })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_bad_pagination", &server.uri());
+    manifest["tables"][0]["pagination"] = json!({
+        "mode": "link_header"
+    });
+    let source = build_source(manifest);
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT * FROM http_bad_pagination.users",
+    )
+    .await
+    .expect_err("cross-origin pagination link should fail");
+
+    assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
+    match error {
+        CoreError::QueryFailure(sqe) => {
+            assert_eq!(sqe.reason(), "PROVIDER_REQUEST_FAILED");
+            assert_eq!(sqe.summary(), "Source pagination failed");
+            assert!(!sqe.retryable());
+            assert_eq!(sqe.metadata().get("source").unwrap(), "http_bad_pagination");
+            assert_eq!(sqe.metadata().get("table").unwrap(), "users");
+            assert_eq!(
+                sqe.metadata().get("provider_failure_stage").unwrap(),
+                "pagination"
+            );
+            assert!(
+                sqe.detail()
+                    .contains("pagination next link must stay on origin")
+            );
+        }
+        other => panic!("unexpected pagination error variant: {other:?}"),
     }
 }
 


### PR DESCRIPTION
## Why

HTTP-backed sources already surfaced non-2xx provider responses as structured query failures, but lower-level request, response decode, and pagination failures could still collapse into generic execution errors. That made caller behavior inconsistent for the same provider query path and hid retryability/status information from CLI, MCP, and gRPC surfaces.

## What changed

- Added typed `ProviderQueryError` variants for request, decode, and pagination failures.
- Routed HTTP transport errors, malformed JSON responses, and pagination validation/link failures through structured query errors.
- Preserved API response classification by checking non-2xx status before parsing pagination links.
- Updated integration coverage for malformed JSON, cross-origin pagination links, bad Link headers on 500s, and unreachable HTTP sources.

## Verification

- `make rust-checks`
