### PR TITLE
feat(spec): add table namespaces

### DIFF
--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -11,15 +11,16 @@
 
 use serde::Deserialize;
 use serde_json::Value;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use url::Url;
 
 use crate::common::parse_manifest_data_type;
 use crate::inputs::collect_source_inputs_value;
 use crate::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ManifestInputKind, ManifestInputSpec,
-    Result, SourceBackend, SourceManifestCommon, TableCommon, validate_columns,
-    validate_filters_and_column_exprs, validate_test_queries,
+    Result, SourceBackend, SourceManifestCommon, TableCommon,
+    common::{DEFAULT_NAMESPACE, RawNamespaceSpec, build_source_manifest_common},
+    validate_columns, validate_filters_and_column_exprs,
 };
 
 /// Validated top-level manifest for a `Parquet`-backed source.
@@ -76,6 +77,8 @@ struct RawFileSourceManifest {
     backend: SourceBackend,
     #[serde(default)]
     inputs: Option<Value>,
+    #[serde(default)]
+    namespaces: BTreeMap<String, RawNamespaceSpec>,
     tables: Vec<RawFileTableSpec>,
 }
 
@@ -83,6 +86,8 @@ struct RawFileSourceManifest {
 #[serde(deny_unknown_fields)]
 struct RawFileTableSpec {
     name: String,
+    #[serde(default)]
+    namespace: Option<String>,
     description: String,
     #[serde(default)]
     guide: String,
@@ -229,6 +234,9 @@ impl PartitionColumnSpec {
 
 impl RawFileTableSpec {
     fn into_validated_parquet(self, schema: &str) -> Result<FileTableSpec> {
+        let namespace = self
+            .namespace
+            .unwrap_or_else(|| DEFAULT_NAMESPACE.to_string());
         self.source.validate_for_parquet(schema, &self.name)?;
         validate_columns(&self.columns, schema, &self.name)?;
 
@@ -251,6 +259,7 @@ impl RawFileTableSpec {
         Ok(FileTableSpec {
             common: TableCommon::new(
                 self.name,
+                namespace,
                 self.description,
                 self.guide,
                 self.filters,
@@ -262,6 +271,9 @@ impl RawFileTableSpec {
     }
 
     fn into_validated_jsonl(self, schema: &str) -> Result<FileTableSpec> {
+        let namespace = self
+            .namespace
+            .unwrap_or_else(|| DEFAULT_NAMESPACE.to_string());
         if self.columns.is_empty() {
             return Err(ManifestError::validation(format!(
                 "{schema}.{} uses backend=jsonl and must define columns",
@@ -275,6 +287,7 @@ impl RawFileTableSpec {
         Ok(FileTableSpec {
             common: TableCommon::new(
                 self.name,
+                namespace,
                 self.description,
                 self.guide,
                 self.filters,
@@ -299,11 +312,20 @@ impl ParquetSourceManifest {
             test_queries,
             backend: _backend,
             inputs: _inputs,
+            namespaces,
             tables,
         } = raw;
-        validate_test_queries(&name, &test_queries)?;
-        let common =
-            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
+        let common = build_source_manifest_common(
+            dsl_version,
+            name,
+            version,
+            description,
+            test_queries,
+            namespaces,
+            tables
+                .iter()
+                .map(|table| (table.name.as_str(), table.namespace.as_deref())),
+        )?;
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_parquet(&common.name))
@@ -329,11 +351,20 @@ impl JsonlSourceManifest {
             test_queries,
             backend: _backend,
             inputs: _inputs,
+            namespaces,
             tables,
         } = raw;
-        validate_test_queries(&name, &test_queries)?;
-        let common =
-            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
+        let common = build_source_manifest_common(
+            dsl_version,
+            name,
+            version,
+            description,
+            test_queries,
+            namespaces,
+            tables
+                .iter()
+                .map(|table| (table.name.as_str(), table.namespace.as_deref())),
+        )?;
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated_jsonl(&common.name))

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -10,7 +10,7 @@
 //! they are still engine-neutral; no runtime HTTP client or execution concerns
 //! live in this crate.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use serde::Deserialize;
 use serde_json::{Map, Value};
@@ -18,8 +18,11 @@ use serde_json::{Map, Value};
 use crate::{
     ColumnSpec, FilterSpec, HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec,
     PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
-    SourceBackend, SourceManifestCommon, TableCommon, inputs::collect_source_inputs_value,
-    validate::validate_template, validate_http_table, validate_test_queries,
+    SourceBackend, SourceManifestCommon, TableCommon,
+    common::{DEFAULT_NAMESPACE, RawNamespaceSpec, build_source_manifest_common},
+    inputs::collect_source_inputs_value,
+    validate::validate_template,
+    validate_http_table,
 };
 
 /// Source-level authentication requirements for HTTP-backed source specs.
@@ -114,6 +117,8 @@ struct RawHttpSourceManifest {
     rate_limit: RateLimitSpec,
     #[serde(default)]
     inputs: Option<Value>,
+    #[serde(default)]
+    namespaces: BTreeMap<String, RawNamespaceSpec>,
     tables: Vec<RawHttpTableSpec>,
 }
 
@@ -121,6 +126,8 @@ struct RawHttpSourceManifest {
 #[serde(deny_unknown_fields)]
 struct RawHttpTableSpec {
     name: String,
+    #[serde(default)]
+    namespace: Option<String>,
     description: String,
     #[serde(default)]
     guide: String,
@@ -216,6 +223,9 @@ impl HttpSourceManifest {
 
 impl RawHttpTableSpec {
     fn into_validated(self, schema: &str) -> Result<HttpTableSpec> {
+        let namespace = self
+            .namespace
+            .unwrap_or_else(|| DEFAULT_NAMESPACE.to_string());
         validate_http_table(
             schema,
             &self.name,
@@ -229,6 +239,7 @@ impl RawHttpTableSpec {
         Ok(HttpTableSpec {
             common: TableCommon::new(
                 self.name,
+                namespace,
                 self.description,
                 self.guide,
                 self.filters,
@@ -260,11 +271,20 @@ impl HttpSourceManifest {
             request_headers,
             rate_limit,
             inputs: _inputs,
+            namespaces,
             tables,
         } = raw;
-        validate_test_queries(&name, &test_queries)?;
-        let common =
-            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
+        let common = build_source_manifest_common(
+            dsl_version,
+            name,
+            version,
+            description,
+            test_queries,
+            namespaces,
+            tables
+                .iter()
+                .map(|table| (table.name.as_str(), table.namespace.as_deref())),
+        )?;
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))
@@ -303,6 +323,7 @@ pub(crate) fn test_http_table_spec(
     HttpTableSpec {
         common: TableCommon::new(
             name.to_string(),
+            DEFAULT_NAMESPACE.to_string(),
             "test".to_string(),
             String::new(),
             filters,

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -9,12 +9,26 @@
 //! source identity, filters, request templating, response extraction, typed
 //! columns, and pagination.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{ManifestError, ParsedTemplate, Result};
+
+/// Default table namespace used when a source spec does not declare one.
+pub const DEFAULT_NAMESPACE: &str = "core";
+
+/// Default description for the implicit `core` namespace.
+const DEFAULT_NAMESPACE_DESCRIPTION: &str = "Default tables";
+
+const RESERVED_NAMESPACE_NAMES: &[&str] = &["coral", "datafusion", "information_schema"];
+
+/// Return whether a namespace is the implicit default namespace.
+#[must_use]
+fn is_core_namespace(namespace: &str) -> bool {
+    namespace == DEFAULT_NAMESPACE
+}
 
 /// Common top-level source metadata shared by every backend source spec.
 #[derive(Debug, Clone)]
@@ -24,6 +38,7 @@ pub struct SourceManifestCommon {
     pub version: String,
     pub description: String,
     pub test_queries: Vec<String>,
+    pub namespaces: Vec<NamespaceSpec>,
 }
 
 impl SourceManifestCommon {
@@ -33,6 +48,7 @@ impl SourceManifestCommon {
         version: String,
         description: String,
         test_queries: Vec<String>,
+        namespaces: Vec<NamespaceSpec>,
     ) -> Self {
         Self {
             dsl_version,
@@ -40,8 +56,16 @@ impl SourceManifestCommon {
             version,
             description,
             test_queries,
+            namespaces,
         }
     }
+}
+
+/// Raw source-level table namespace declaration from a manifest.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RawNamespaceSpec {
+    pub description: String,
 }
 
 pub(crate) fn validate_test_queries(source_name: &str, test_queries: &[String]) -> Result<()> {
@@ -53,6 +77,150 @@ pub(crate) fn validate_test_queries(source_name: &str, test_queries: &[String]) 
         }
     }
     Ok(())
+}
+
+fn validate_identifier(label: &str, value: &str) -> Result<()> {
+    if value.is_empty() {
+        return Err(ManifestError::validation(format!(
+            "{label} must not be empty"
+        )));
+    }
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err(ManifestError::validation(format!(
+            "{label} must not be empty"
+        )));
+    };
+    let valid_first = first == '_' || first.is_ascii_alphabetic();
+    let valid_rest = chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric());
+    if !valid_first || !valid_rest {
+        return Err(ManifestError::validation(format!(
+            "{label} '{value}' must match [A-Za-z_][A-Za-z0-9_]*"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_namespace_identifier(value: &str) -> Result<()> {
+    validate_identifier("namespace", value)?;
+    if value != value.to_ascii_lowercase() {
+        return Err(ManifestError::validation(format!(
+            "namespace '{value}' must be lowercase"
+        )));
+    }
+    if value.eq_ignore_ascii_case(DEFAULT_NAMESPACE) && value != DEFAULT_NAMESPACE {
+        return Err(ManifestError::validation(format!(
+            "namespace '{value}' must be written as '{DEFAULT_NAMESPACE}'"
+        )));
+    }
+    if RESERVED_NAMESPACE_NAMES
+        .iter()
+        .any(|reserved| value.eq_ignore_ascii_case(reserved))
+    {
+        return Err(ManifestError::validation(format!(
+            "namespace '{value}' is reserved"
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) fn build_source_manifest_common<'a>(
+    dsl_version: u32,
+    name: String,
+    version: String,
+    description: String,
+    test_queries: Vec<String>,
+    namespaces: BTreeMap<String, RawNamespaceSpec>,
+    tables: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+) -> Result<SourceManifestCommon> {
+    // Keep backend-agnostic source checks here so HTTP, JSONL, and Parquet
+    // apply the same test-query, table-name, and namespace rules.
+    validate_test_queries(&name, &test_queries)?;
+
+    let tables = tables.into_iter().collect::<Vec<_>>();
+    validate_unique_table_names(&name, tables.iter().map(|(table_name, _)| *table_name))?;
+    let table_namespaces = tables
+        .iter()
+        .map(|(_, namespace)| namespace.unwrap_or(DEFAULT_NAMESPACE).to_string())
+        .collect::<Vec<_>>();
+    let namespaces = normalize_namespaces(&name, namespaces, &table_namespaces)?;
+
+    Ok(SourceManifestCommon::new(
+        dsl_version,
+        name,
+        version,
+        description,
+        test_queries,
+        namespaces,
+    ))
+}
+
+pub(crate) fn normalize_namespaces(
+    source_name: &str,
+    declared: BTreeMap<String, RawNamespaceSpec>,
+    table_namespaces: &[String],
+) -> Result<Vec<NamespaceSpec>> {
+    let mut namespaces = BTreeMap::new();
+    let mut used = BTreeSet::new();
+
+    for (name, spec) in declared {
+        validate_namespace_identifier(&name)?;
+        if spec.description.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "{source_name}.{name} namespace description must not be empty"
+            )));
+        }
+        namespaces.insert(name, spec.description);
+    }
+
+    for namespace in table_namespaces {
+        validate_namespace_identifier(namespace)?;
+        used.insert(namespace.clone());
+        if !is_core_namespace(namespace) && !namespaces.contains_key(namespace) {
+            return Err(ManifestError::validation(format!(
+                "{source_name}.{namespace} namespace is used by a table but is not declared"
+            )));
+        }
+    }
+
+    if used.contains(DEFAULT_NAMESPACE) {
+        namespaces
+            .entry(DEFAULT_NAMESPACE.to_string())
+            .or_insert_with(|| DEFAULT_NAMESPACE_DESCRIPTION.to_string());
+    }
+
+    let entries = namespaces
+        .into_iter()
+        .map(|(name, description)| NamespaceSpec { name, description })
+        .collect::<Vec<_>>();
+    Ok(entries)
+}
+
+pub(crate) fn validate_unique_table_names<'a>(
+    source_name: &str,
+    table_names: impl IntoIterator<Item = &'a str>,
+) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for table_name in table_names {
+        if table_name.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "{source_name} has an empty table name"
+            )));
+        }
+        if !seen.insert(table_name.to_string()) {
+            return Err(ManifestError::validation(format!(
+                "{source_name} has duplicate table '{table_name}'"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Normalized source-level namespace metadata.
+#[derive(Debug, Clone)]
+pub struct NamespaceSpec {
+    pub name: String,
+    pub description: String,
 }
 
 /// Supported source-spec backends.
@@ -93,6 +261,7 @@ pub struct HeaderSpec {
 #[derive(Debug, Clone)]
 pub struct TableCommon {
     pub name: String,
+    pub namespace: String,
     pub description: String,
     pub guide: String,
     pub filters: Vec<FilterSpec>,
@@ -103,6 +272,7 @@ pub struct TableCommon {
 impl TableCommon {
     pub(crate) fn new(
         name: String,
+        namespace: String,
         description: String,
         guide: String,
         filters: Vec<FilterSpec>,
@@ -111,6 +281,7 @@ impl TableCommon {
     ) -> Self {
         Self {
             name,
+            namespace,
             description,
             guide,
             filters,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -86,12 +86,12 @@ mod template;
 mod validate;
 
 pub use backends::http::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
-pub(crate) use common::validate_test_queries;
 pub use common::{
-    BodyFieldSpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, HeaderSpec, HttpMethod,
-    ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,
-    RequestRouteSpec, RequestSpec, ResponseSpec, RowStrategy, SourceBackend, SourceManifestCommon,
-    TableCommon, TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
+    BodyFieldSpec, ColumnSpec, DEFAULT_NAMESPACE, ExprSpec, FilterMode, FilterSpec, HeaderSpec,
+    HttpMethod, ManifestDataType, NamespaceSpec, PageSizeSpec, PaginationMode, PaginationSpec,
+    QueryParamSpec, RequestRouteSpec, RequestSpec, ResponseSpec, RowStrategy, SourceBackend,
+    SourceManifestCommon, TableCommon, TimestampInput, ValidatedPagination,
+    ValidatedPaginationMode, ValueSourceSpec,
 };
 pub use error::{ManifestError, Result};
 pub use inputs::{ManifestInputKind, ManifestInputSpec, resolve_inputs};

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -241,4 +241,248 @@ tables:
             "source 'demo' test_queries[0] must not be empty"
         );
     }
+
+    #[test]
+    fn parse_source_manifest_defaults_table_namespace_to_core() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+tables:
+  - name: messages
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect("manifest should parse");
+
+        let jsonl = manifest.as_jsonl().expect("jsonl manifest");
+        assert_eq!(jsonl.tables[0].common.namespace, "core");
+        assert_eq!(jsonl.common.namespaces[0].name, "core");
+    }
+
+    #[test]
+    fn parse_source_manifest_preserves_declared_unused_namespace() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+namespaces:
+  archive:
+    description: Historical records
+tables:
+  - name: messages
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect("manifest should parse");
+
+        let jsonl = manifest.as_jsonl().expect("jsonl manifest");
+        assert!(
+            jsonl
+                .common
+                .namespaces
+                .iter()
+                .any(|namespace| namespace.name == "archive")
+        );
+    }
+
+    #[test]
+    fn parse_source_manifest_does_not_add_unused_core_namespace() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+namespaces:
+  archive:
+    description: Historical records
+tables:
+  - name: messages
+    namespace: archive
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect("manifest should parse");
+
+        let jsonl = manifest.as_jsonl().expect("jsonl manifest");
+        assert_eq!(jsonl.common.namespaces.len(), 1);
+        assert_eq!(jsonl.common.namespaces[0].name, "archive");
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_undeclared_non_core_namespace() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+tables:
+  - name: messages
+    namespace: archive
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect_err("undeclared namespace should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "demo.archive namespace is used by a table but is not declared"
+        );
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_duplicate_table_name_across_namespaces() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+namespaces:
+  archive:
+    description: Historical records
+tables:
+  - name: messages
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+  - name: messages
+    namespace: archive
+    description: Archived messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect_err("duplicate table name should fail");
+
+        assert_eq!(error.to_string(), "demo has duplicate table 'messages'");
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_invalid_namespace_identifier() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+namespaces:
+  bad.name:
+    description: Bad namespace
+tables:
+  - name: messages
+    namespace: bad.name
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect_err("invalid namespace should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not match \"^[a-z_][a-z0-9_]*$\""),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_uppercase_namespace_identifier() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+namespaces:
+  Core:
+    description: Wrong casing
+tables:
+  - name: messages
+    namespace: Core
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect_err("uppercase namespace should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not match \"^[a-z_][a-z0-9_]*$\""),
+            "got: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_reserved_namespace_identifier() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+namespaces:
+  datafusion:
+    description: Reserved namespace
+tables:
+  - name: messages
+    namespace: datafusion
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+",
+        )
+        .expect_err("reserved namespace should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("is not allowed for \"datafusion\""),
+            "got: {error}"
+        );
+    }
 }

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -67,6 +67,30 @@ tables:
     }
 
     #[test]
+    fn validate_manifest_schema_accepts_table_namespaces() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+namespaces:
+  actions:
+    description: Action data
+tables:
+  - name: runs
+    namespace: actions
+    description: Demo runs
+    request:
+      method: GET
+      path: /runs
+",
+        );
+        validate_manifest_schema(&manifest).expect("valid manifest should pass schema validation");
+    }
+
+    #[test]
     fn validate_manifest_schema_rejects_unknown_top_level_field() {
         let manifest = manifest_json(&format!("schema: legacy\n{}", valid_http_manifest()));
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -23,6 +23,11 @@
       "items": { "$ref": "#/$defs/header" }
     },
     "rate_limit": { "$ref": "#/$defs/rate_limit" },
+    "namespaces": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/namespace" },
+      "propertyNames": { "$ref": "#/$defs/namespaceIdentifier" }
+    },
     "tables": {
       "type": "array",
       "minItems": 1,
@@ -41,6 +46,19 @@
     }
   },
   "$defs": {
+    "namespaceIdentifier": {
+      "type": "string",
+      "pattern": "^[a-z_][a-z0-9_]*$",
+      "not": { "enum": ["coral", "datafusion", "information_schema"] }
+    },
+    "namespace": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description"],
+      "properties": {
+        "description": { "type": "string", "minLength": 1 }
+      }
+    },
     "inputs": {
       "type": "object",
       "additionalProperties": { "$ref": "#/$defs/input" },
@@ -126,6 +144,7 @@
       "required": ["name", "description"],
       "properties": {
         "name": { "type": "string", "minLength": 1 },
+        "namespace": { "$ref": "#/$defs/namespaceIdentifier" },
         "description": { "type": "string", "minLength": 1 },
         "guide": { "type": "string" },
         "filters": {

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -23,12 +23,13 @@ test_queries:
   - SELECT * FROM my_source.messages LIMIT 1
 ```
 
-| Field         | Description                                        |
-| ------------- | -------------------------------------------------- |
-| `name`        | Source name, also used as the SQL schema name      |
-| `version`     | Source spec version string                         |
-| `dsl_version` | Coral source spec DSL version (currently `3`)      |
-| `backend`     | How data is fetched: `http`, `jsonl`, or `parquet` |
+| Field          | Description                                          |
+| -------------- | ---------------------------------------------------- |
+| `name`         | Source name, also used as the SQL schema name        |
+| `version`      | Source spec version string                           |
+| `dsl_version`  | Coral source spec DSL version (currently `3`)        |
+| `backend`      | How data is fetched: `http`, `jsonl`, or `parquet`   |
+| `namespaces`   | Optional table namespace descriptions for large sources |
 | `test_queries` | Optional read-only SQL checks Coral runs during `coral source test` |
 
 ## Test queries
@@ -49,6 +50,28 @@ Notes:
 - Prefer cheap read-only checks that validate connectivity and mapping logic. For example, `SELECT * FROM schema.table LIMIT 1` is usually a better fit than `SELECT COUNT(*)`.
 - Keep these queries read-only. Statements such as `CREATE`, `COPY`, `INSERT`,
   `UPDATE`, `DELETE`, or `SET` are reported as failed validation queries.
+
+## Table namespaces
+
+Tables belong to the `core` namespace by default. Larger sources can declare
+additional namespaces to keep discovery focused:
+
+```yaml
+namespaces:
+  actions:
+    description: GitHub Actions workflows, runs, jobs, and artifacts
+
+tables:
+  - name: repo_action_runs
+    namespace: actions
+    description: GitHub Actions workflow runs
+    request:
+      method: GET
+      path: /repos/{{filter.owner}}/{{filter.repo}}/actions/runs
+```
+
+Namespace names must be lowercase identifiers. A table using a non-core
+namespace must reference a declared namespace.
 
 ## Column types
 


### PR DESCRIPTION
### TL;DR

Adds namespace support to source manifests, allowing tables to be grouped into named namespaces beyond the default `core` namespace.

### What changed?

- Source manifests now accept an optional top-level `namespaces` map, where each entry declares a namespace name and description.
- Individual tables accept an optional `namespace` field. Tables without an explicit namespace default to `core`.
- The `core` namespace is implicit and does not need to be declared; it is only included in the resolved namespace list if at least one table uses it.
- Non-`core` namespaces referenced by a table must be explicitly declared in the `namespaces` map, otherwise validation fails.
- Namespace names must be lowercase identifiers matching `[a-z_][a-z0-9_]*` and must not use reserved names (`coral`, `datafusion`, `information_schema`).
- Table name uniqueness is now validated globally across all namespaces during manifest parsing.
- `SourceManifestCommon` now carries a `namespaces: Vec<NamespaceSpec>` field, and `TableCommon` carries a `namespace: String` field.
- A shared `build_source_manifest_common` helper centralizes namespace normalization, table name deduplication, and test query validation across the HTTP, JSONL, and Parquet backends.
- The JSON schema for source manifests is updated to enforce namespace identifier patterns and reserved name restrictions.
- Documentation is updated to describe the `namespaces` top-level field and the per-table `namespace` field.

### How to test?

- Run the existing test suite; new parser tests cover the following scenarios:
  - Tables default to the `core` namespace when none is specified.
  - Declared but unused non-`core` namespaces are preserved in the resolved list.
  - The `core` namespace is omitted from the resolved list when no table uses it.
  - A table referencing an undeclared non-`core` namespace produces a validation error.
  - Duplicate table names across namespaces produce a validation error.
  - Invalid namespace identifiers (containing dots, uppercase letters, or reserved words) are rejected.
- The schema validation test `validate_manifest_schema_accepts_table_namespaces` confirms the JSON schema accepts manifests with namespaces and per-table namespace fields.

### Why make this change?

Large sources with many tables benefit from logical grouping to improve discoverability. Namespaces provide a lightweight, validated mechanism for organizing tables within a single source spec without requiring separate source manifests.