### PR TITLE
fix(engine): allow literal regex patterns and escaped SIMILAR TO wildcards

### DIFF
--- a/crates/coral-engine/src/runtime/pattern_validator.rs
+++ b/crates/coral-engine/src/runtime/pattern_validator.rs
@@ -7,11 +7,14 @@
 //!
 //! See: <https://github.com/apache/datafusion/blob/eae7bf4/datafusion/physical-expr/src/expressions/binary.rs#L970-L983>
 //!
-//! This module registers a `FunctionRewrite` that detects unescaped `%` or `_`
-//! in `SIMILAR TO` and regex operator (`~`, `~*`, `!~`, `!~*`) patterns and
-//! returns a clear error suggesting regex syntax, LIKE, or escaping with `\`.
-//! Escaped forms (`\%`, `\_`) are allowed through since they work as literal
-//! matches in the underlying regex engine.
+//! This module registers a `FunctionRewrite` that returns a clear error when
+//! `SIMILAR TO` patterns contain unescaped `%` or `_`. Escaped forms (`\%`,
+//! `\_`) are allowed through since they work as literal matches in the
+//! underlying regex engine.
+//!
+//! Regex operators (`~`, `~*`, `!~`, `!~*`) are not validated because `%` and
+//! `_` are ordinary literal characters in regex and have legitimate uses
+//! (e.g. matching "50%" or "`user_name`").
 
 use std::sync::Arc;
 
@@ -19,8 +22,7 @@ use datafusion::common::config::ConfigOptions;
 use datafusion::common::tree_node::Transformed;
 use datafusion::common::{DFSchema, Result as DataFusionResult, ScalarValue, plan_err};
 use datafusion::execution::FunctionRegistry;
-use datafusion::logical_expr::Operator;
-use datafusion::logical_expr::expr::{BinaryExpr, Expr, Like};
+use datafusion::logical_expr::expr::{Expr, Like};
 use datafusion::logical_expr::expr_rewriter::FunctionRewrite;
 
 pub(crate) fn register_pattern_validator(
@@ -52,7 +54,6 @@ impl FunctionRewrite for PatternValidator {
 fn validate_expr(expr: &Expr) -> DataFusionResult<()> {
     match expr {
         Expr::SimilarTo(like) => validate_similar_to(like),
-        Expr::BinaryExpr(binary) => validate_regex_binary(binary),
         _ => Ok(()),
     }
 }
@@ -65,26 +66,6 @@ fn validate_similar_to(like: &Like) -> DataFusionResult<()> {
     if contains_unescaped_like_wildcards(&pattern) {
         return plan_err!(
             "SIMILAR TO pattern '{pattern}' contains `%` or `_` which are literal characters in SIMILAR TO, not wildcards. Use `.*` instead of `%`, `.` instead of `_`, use LIKE for wildcard matching, or escape with `\\%` / `\\_` if you want the literal character."
-        );
-    }
-
-    Ok(())
-}
-
-fn validate_regex_binary(binary: &BinaryExpr) -> DataFusionResult<()> {
-    if !is_regex_operator(binary.op) {
-        return Ok(());
-    }
-
-    let Some(pattern) = extract_string_literal(&binary.right) else {
-        return Ok(());
-    };
-
-    if has_unescaped_char(&pattern, '%') {
-        return plan_err!(
-            "Regex operator `{}` pattern '{}' contains `%` which is a literal character in regex, not a wildcard. Use `.*` instead of `%`, use LIKE/ILIKE for wildcard matching, or escape with `\\%` if you want the literal character.",
-            binary.op,
-            pattern
         );
     }
 
@@ -124,16 +105,6 @@ fn has_unescaped_char(pattern: &str, ch: char) -> bool {
     false
 }
 
-fn is_regex_operator(op: Operator) -> bool {
-    matches!(
-        op,
-        Operator::RegexMatch
-            | Operator::RegexIMatch
-            | Operator::RegexNotMatch
-            | Operator::RegexNotIMatch
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use datafusion::common::config::ConfigOptions;
@@ -144,7 +115,7 @@ mod tests {
 
     use super::PatternValidator;
     use crate::runtime::pattern_validator::{
-        contains_unescaped_like_wildcards, extract_string_literal, validate_expr,
+        contains_unescaped_like_wildcards, extract_string_literal,
     };
 
     #[test]
@@ -183,32 +154,14 @@ mod tests {
     }
 
     #[test]
-    fn regex_match_with_percent_returns_error() {
-        let error = rewrite_err(regex_expr(Operator::RegexMatch, "(Slack|Weekly)%"));
-        assert!(error.contains("Regex operator `~` pattern '(Slack|Weekly)%'"));
-        assert!(error.contains("Use `.*` instead of `%`"));
+    fn regex_match_with_percent_passes() {
+        // % is a valid literal character in regex — no error
+        assert_rewrite_passes(&regex_expr(Operator::RegexMatch, "(Slack|Weekly)%"));
     }
 
     #[test]
-    fn regex_match_without_percent_passes() {
-        assert_rewrite_passes(&regex_expr(Operator::RegexMatch, "(Slack|Weekly).*"));
-    }
-
-    #[test]
-    fn regex_match_with_escaped_percent_passes() {
-        assert_rewrite_passes(&regex_expr(Operator::RegexMatch, r"100\%"));
-    }
-
-    #[test]
-    fn regex_imatch_with_percent_returns_error() {
-        let error = rewrite_err(regex_expr(Operator::RegexIMatch, "(Slack|Weekly)%"));
-        assert!(error.contains("Regex operator `~*` pattern '(Slack|Weekly)%'"));
-    }
-
-    #[test]
-    fn negated_regex_with_percent_returns_error() {
-        let error = rewrite_err(regex_expr(Operator::RegexNotIMatch, "(Slack|Weekly)%"));
-        assert!(error.contains("Regex operator `!~*` pattern '(Slack|Weekly)%'"));
+    fn regex_match_with_underscore_passes() {
+        assert_rewrite_passes(&regex_expr(Operator::RegexMatch, "user_name"));
     }
 
     #[test]
@@ -254,17 +207,6 @@ mod tests {
         assert!(contains_unescaped_like_wildcards(r"incident_io"));
         assert!(!contains_unescaped_like_wildcards(r"100\%"));
         assert!(contains_unescaped_like_wildcards(r"100%"));
-    }
-
-    #[test]
-    fn validate_expr_ignores_non_literal_regex_patterns() {
-        let expr = Expr::BinaryExpr(BinaryExpr::new(
-            Box::new(Expr::Column(Column::from_name("name"))),
-            Operator::RegexMatch,
-            Box::new(Expr::Column(Column::from_name("pattern"))),
-        ));
-
-        validate_expr(&expr).expect("column-driven regex should not error");
     }
 
     fn similar_to_expr(pattern: &str) -> Expr {

--- a/crates/coral-engine/src/runtime/pattern_validator.rs
+++ b/crates/coral-engine/src/runtime/pattern_validator.rs
@@ -1,5 +1,17 @@
-//! Query-pattern validation for regex-style operators with common LIKE-wildcard
-//! mistakes.
+//! Validates regex-style query patterns to catch common LIKE-wildcard mistakes.
+//!
+//! `DataFusion`'s `SIMILAR TO` is implemented as a pure regex match — it maps
+//! directly to `RegexMatch` without converting SQL-standard wildcards (`%`, `_`)
+//! to their regex equivalents (`.*`, `.`). This means `WHERE name SIMILAR TO
+//! 'Slack%'` silently matches nothing instead of behaving like `PostgreSQL`.
+//!
+//! See: <https://github.com/apache/datafusion/blob/eae7bf4/datafusion/physical-expr/src/expressions/binary.rs#L970-L983>
+//!
+//! This module registers a `FunctionRewrite` that detects unescaped `%` or `_`
+//! in `SIMILAR TO` and regex operator (`~`, `~*`, `!~`, `!~*`) patterns and
+//! returns a clear error suggesting regex syntax, LIKE, or escaping with `\`.
+//! Escaped forms (`\%`, `\_`) are allowed through since they work as literal
+//! matches in the underlying regex engine.
 
 use std::sync::Arc;
 
@@ -50,9 +62,9 @@ fn validate_similar_to(like: &Like) -> DataFusionResult<()> {
         return Ok(());
     };
 
-    if contains_like_wildcards(&pattern) {
+    if contains_unescaped_like_wildcards(&pattern) {
         return plan_err!(
-            "SIMILAR TO pattern '{pattern}' contains `%` or `_` which are literal characters in SIMILAR TO, not wildcards. Use `.*` instead of `%`, `.` instead of `_`, or use LIKE for wildcard matching."
+            "SIMILAR TO pattern '{pattern}' contains `%` or `_` which are literal characters in SIMILAR TO, not wildcards. Use `.*` instead of `%`, `.` instead of `_`, use LIKE for wildcard matching, or escape with `\\%` / `\\_` if you want the literal character."
         );
     }
 
@@ -68,9 +80,9 @@ fn validate_regex_binary(binary: &BinaryExpr) -> DataFusionResult<()> {
         return Ok(());
     };
 
-    if pattern.contains('%') {
+    if has_unescaped_char(&pattern, '%') {
         return plan_err!(
-            "Regex operator `{}` pattern '{}' contains `%` which is a literal character in regex, not a wildcard. Use `.*` instead of `%`, or use LIKE/ILIKE for wildcard matching.",
+            "Regex operator `{}` pattern '{}' contains `%` which is a literal character in regex, not a wildcard. Use `.*` instead of `%`, use LIKE/ILIKE for wildcard matching, or escape with `\\%` if you want the literal character.",
             binary.op,
             pattern
         );
@@ -92,8 +104,24 @@ fn extract_string_literal(expr: &Expr) -> Option<String> {
     }
 }
 
-fn contains_like_wildcards(pattern: &str) -> bool {
-    pattern.contains('%') || pattern.contains('_')
+/// Returns `true` when `pattern` contains unescaped `%` or `_`.
+///
+/// A preceding backslash (`\%`, `\_`) signals the user intentionally wants the
+/// literal character, so those occurrences are ignored.
+fn contains_unescaped_like_wildcards(pattern: &str) -> bool {
+    has_unescaped_char(pattern, '%') || has_unescaped_char(pattern, '_')
+}
+
+/// Returns `true` when `pattern` contains an unescaped occurrence of `ch`.
+fn has_unescaped_char(pattern: &str, ch: char) -> bool {
+    let mut prev_backslash = false;
+    for c in pattern.chars() {
+        if c == ch && !prev_backslash {
+            return true;
+        }
+        prev_backslash = c == '\\';
+    }
+    false
 }
 
 fn is_regex_operator(op: Operator) -> bool {
@@ -116,7 +144,7 @@ mod tests {
 
     use super::PatternValidator;
     use crate::runtime::pattern_validator::{
-        contains_like_wildcards, extract_string_literal, validate_expr,
+        contains_unescaped_like_wildcards, extract_string_literal, validate_expr,
     };
 
     #[test]
@@ -145,6 +173,16 @@ mod tests {
     }
 
     #[test]
+    fn similar_to_with_escaped_percent_passes() {
+        assert_rewrite_passes(&similar_to_expr(r"100\%"));
+    }
+
+    #[test]
+    fn similar_to_with_escaped_underscore_passes() {
+        assert_rewrite_passes(&similar_to_expr(r"incident\_io"));
+    }
+
+    #[test]
     fn regex_match_with_percent_returns_error() {
         let error = rewrite_err(regex_expr(Operator::RegexMatch, "(Slack|Weekly)%"));
         assert!(error.contains("Regex operator `~` pattern '(Slack|Weekly)%'"));
@@ -154,6 +192,11 @@ mod tests {
     #[test]
     fn regex_match_without_percent_passes() {
         assert_rewrite_passes(&regex_expr(Operator::RegexMatch, "(Slack|Weekly).*"));
+    }
+
+    #[test]
+    fn regex_match_with_escaped_percent_passes() {
+        assert_rewrite_passes(&regex_expr(Operator::RegexMatch, r"100\%"));
     }
 
     #[test]
@@ -201,10 +244,16 @@ mod tests {
     }
 
     #[test]
-    fn contains_like_wildcards_only_flags_like_syntax() {
-        assert!(contains_like_wildcards("Slack%"));
-        assert!(contains_like_wildcards("Slack_"));
-        assert!(!contains_like_wildcards("Slack.*"));
+    fn contains_unescaped_like_wildcards_only_flags_unescaped() {
+        assert!(contains_unescaped_like_wildcards("Slack%"));
+        assert!(contains_unescaped_like_wildcards("Slack_"));
+        assert!(!contains_unescaped_like_wildcards("Slack.*"));
+        assert!(!contains_unescaped_like_wildcards(r"Slack\%"));
+        assert!(!contains_unescaped_like_wildcards(r"Slack\_"));
+        assert!(!contains_unescaped_like_wildcards(r"incident\_io"));
+        assert!(contains_unescaped_like_wildcards(r"incident_io"));
+        assert!(!contains_unescaped_like_wildcards(r"100\%"));
+        assert!(contains_unescaped_like_wildcards(r"100%"));
     }
 
     #[test]

--- a/crates/coral-engine/tests/engine/pattern_error_tests.rs
+++ b/crates/coral-engine/tests/engine/pattern_error_tests.rs
@@ -81,21 +81,20 @@ async fn similar_to_with_like_wildcard_returns_clear_error() {
 }
 
 #[tokio::test]
-async fn regex_match_with_like_wildcard_returns_clear_error() {
+async fn regex_match_with_percent_is_valid() {
     let temp = TempDir::new().expect("temp dir");
     let source = write_projects_fixture(temp.path());
 
-    let error = CoralQuery::execute_sql(
+    // % is a literal character in regex — no error, just zero matches
+    let execution = CoralQuery::execute_sql(
         &[source],
         &TestRuntime,
         "SELECT id, name FROM linear.projects WHERE name ~ '(Slack|Weekly)%'",
     )
     .await
-    .expect_err("regex wildcard mismatch should fail");
+    .expect("regex with literal % should succeed");
 
-    let detail = invalid_input_detail(error);
-    assert!(detail.contains("Regex operator `~` pattern '(Slack|Weekly)%'"));
-    assert!(detail.contains("Use `.*` instead of `%`"));
+    assert_row_count(&execution, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Limit LIKE-wildcard validation to SIMILAR TO patterns only.
- Allow escaped `%` and `_` in SIMILAR TO patterns as intentional literals.
- Add tests covering escaped SIMILAR TO wildcards and regex literal `%`/`_` patterns.

## Test plan
- [x] Run engine pattern validator unit tests.
- [x] Run engine pattern error integration tests.