### PR TITLE
ci(zizmor): surface findings as PR annotations and fail on findings

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -103,8 +103,8 @@ jobs:
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
-          annotations: true
-          advanced-security: false
+          annotations: ${{ github.event_name == 'pull_request' }}
+          advanced-security: ${{ github.event_name != 'pull_request' }}
           min-severity: low
 
   source-lint:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -102,6 +102,10 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          annotations: true
+          advanced-security: false
+          min-severity: low
 
   source-lint:
     name: Lint source manifests


### PR DESCRIPTION
## The Problem

The `gha-security-audit` job was set to upload its findings as [code scanning results](https://github.com/withcoral/coral/security/code-scanning). If a GHA workflow had a security audit issue, the action would upload that to code scanning results, and then show the check as successfully completed.

We want that for commits to main, but for PRs that meant that failures went unnnoticed. On PRs, we want the GHA job to fail instead.

## What changed?
- Configure `zizmorcore/zizmor-action` so PR runs emit inline annotations on the Files tab and Checks panel (`annotations: true`) and fail the `gha-security-audit` job on any low+ finding (`advanced-security: false`), letting branch protection gate merges.
- Preserve the existing main-branch behavior: pushes to main keep `advanced-security: true` so SARIF still uploads to Security → Code scanning.
- `min-severity: low` applies to both event types.

## Test plan
- [x] On [another PR](https://github.com/withcoral/coral/pull/226), confirm any zizmor finding shows up as an inline annotation and the `gha-security-audit` job fails.
- [ ] After merge, confirm the next push to main uploads SARIF to Code Scanning as before.