### PR TITLE
feat(engine): register namespaced table paths

### DIFF
--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -108,6 +108,7 @@ mod tests {
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo,
     };
+    use coral_spec::DEFAULT_NAMESPACE;
 
     #[test]
     fn query_status_maps_app_errors() {
@@ -154,6 +155,7 @@ mod tests {
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let table = TableInfo {
             schema_name: "demo".to_string(),
+            namespace: DEFAULT_NAMESPACE.to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),
             columns: vec![ColumnInfo {

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -7,7 +7,8 @@ use crate::{QueryRuntimeContext, RequestAuthenticator};
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec, TableCommon,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec, NamespaceSpec,
+    TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::datasource::TableProvider;
@@ -27,6 +28,7 @@ pub(crate) struct RegisteredColumn {
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredTable {
     pub(crate) table_name: String,
+    pub(crate) namespace: String,
     pub(crate) description: String,
     pub(crate) guide: String,
     pub(crate) columns: Vec<RegisteredColumn>,
@@ -50,6 +52,7 @@ pub(crate) struct RegisteredInput {
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredSource {
     pub(crate) schema_name: String,
+    pub(crate) namespaces: Vec<RegisteredNamespace>,
     pub(crate) tables: Vec<RegisteredTable>,
     pub(crate) inputs: Vec<RegisteredInput>,
 }
@@ -57,6 +60,12 @@ pub(crate) struct RegisteredSource {
 pub(crate) struct BackendRegistration {
     pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
     pub(crate) source: RegisteredSource,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RegisteredNamespace {
+    pub(crate) name: String,
+    pub(crate) description: String,
 }
 
 pub(crate) struct BackendCompileRequest<'a> {
@@ -176,11 +185,24 @@ pub(crate) fn build_registered_table(
 ) -> RegisteredTable {
     RegisteredTable {
         table_name: common.name.clone(),
+        namespace: common.namespace.clone(),
         description: common.description.clone(),
         guide: common.guide.clone(),
         columns,
         required_filters,
     }
+}
+
+pub(crate) fn build_registered_namespaces(
+    namespaces: &[NamespaceSpec],
+) -> Vec<RegisteredNamespace> {
+    namespaces
+        .iter()
+        .map(|namespace| RegisteredNamespace {
+            name: namespace.name.clone(),
+            description: namespace.description.clone(),
+        })
+        .collect()
 }
 
 pub(crate) fn manifest_data_type_to_arrow(data_type: ManifestDataType) -> DataType {

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -12,7 +12,7 @@ use datafusion::prelude::SessionContext;
 use crate::RequestAuthenticator;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
+    RegisteredTable, build_registered_inputs, build_registered_namespaces, build_registered_table,
     registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
@@ -102,6 +102,7 @@ impl CompiledBackendSource for HttpCompiledSource {
             tables,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
+                namespaces: build_registered_namespaces(&self.manifest.common.namespaces),
                 tables: table_infos,
                 inputs,
             },

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -19,7 +19,7 @@ use crate::backends::shared::json_exec::{Converter, Fetcher, JsonExec, RowFetche
 use crate::backends::shared::mapping::convert_items;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
+    RegisteredTable, build_registered_inputs, build_registered_namespaces, build_registered_table,
     registered_columns_from_specs, required_filter_names, schema_from_columns,
 };
 use crate::{CoreError, QueryRuntimeContext};
@@ -303,6 +303,7 @@ impl CompiledBackendSource for JsonlCompiledSource {
             tables,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
+                namespaces: build_registered_namespaces(&self.manifest.common.namespaces),
                 tables: table_infos,
                 inputs,
             },

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -9,9 +9,9 @@ use coral_spec::ValidatedSourceManifest;
 pub(crate) mod common;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, build_registered_inputs, build_registered_namespaces, build_registered_table,
+    partition_columns_to_arrow, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod http;

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -29,9 +29,9 @@ use parquet::file::reader::{ChunkReader, Length};
 
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, build_registered_inputs, build_registered_namespaces, build_registered_table,
+    partition_columns_to_arrow, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
 use coral_spec::backends::file::{FileTableSpec, ParquetSourceManifest};
 
@@ -249,6 +249,7 @@ impl CompiledBackendSource for ParquetCompiledSource {
             tables,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
+                namespaces: build_registered_namespaces(&self.manifest.common.namespaces),
                 tables: table_infos,
                 inputs,
             },

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -9,6 +9,10 @@ use reqwest::header::{HeaderName, HeaderValue};
 use crate::{CoreError, contracts::QuerySource};
 
 /// One source's table providers keyed by manifest table name.
+///
+/// Table names are unique per source in source-spec v1, even when tables live
+/// in different namespaces. The runtime attaches namespace metadata after
+/// decorators run, before inserting providers into `DataFusion`.
 pub type SourceTables = HashMap<String, Arc<dyn TableProvider>>;
 
 /// Neutral bundle of optional engine extensions for one runtime build.

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -16,6 +16,8 @@ pub struct ColumnInfo {
 pub struct TableInfo {
     /// `SQL` schema name.
     pub schema_name: String,
+    /// Table namespace within the source.
+    pub namespace: String,
     /// Table name within the schema.
     pub table_name: String,
     /// User-facing table description.

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use coral_spec::DEFAULT_NAMESPACE;
 use datafusion::common::utils::quote_identifier;
 
 use super::catalog::TableInfo;
@@ -403,11 +404,20 @@ fn table_not_found_hint(
 /// names stay one quoted identifier; case-preserving names are quoted
 /// only when they would otherwise round-trip wrong).
 fn format_schema_table(info: &TableInfo) -> String {
-    format!(
-        "{}.{}",
-        quote_dotted_identifier(&info.schema_name),
-        quote_identifier(&info.table_name)
-    )
+    if info.namespace == DEFAULT_NAMESPACE {
+        format!(
+            "{}.{}",
+            quote_dotted_identifier(&info.schema_name),
+            quote_identifier(&info.table_name)
+        )
+    } else {
+        format!(
+            "{}.{}.{}",
+            quote_dotted_identifier(&info.schema_name),
+            quote_identifier(&info.namespace),
+            quote_identifier(&info.table_name)
+        )
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -527,11 +537,14 @@ fn quote_dotted_identifier(ident: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use coral_spec::DEFAULT_NAMESPACE;
+
     use super::*;
 
     fn table(schema: &str, name: &str) -> TableInfo {
         TableInfo {
             schema_name: schema.to_string(),
+            namespace: DEFAULT_NAMESPACE.to_string(),
             table_name: name.to_string(),
             description: String::new(),
             columns: vec![],

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -24,12 +24,14 @@ pub(crate) const SYSTEM_SCHEMA: &str = "coral";
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
 pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]) -> Result<()> {
+    let namespaces_table = build_namespaces_table(active_sources)?;
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
+    meta_tables.insert("namespaces".to_string(), Arc::new(namespaces_table));
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
     meta_tables.insert("columns".to_string(), Arc::new(columns_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
@@ -53,6 +55,7 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
         .flat_map(|source| {
             source.tables.iter().map(move |table| TableInfo {
                 schema_name: source.schema_name.clone(),
+                namespace: table.namespace.clone(),
                 table_name: table.table_name.clone(),
                 description: table.description.clone(),
                 columns: table
@@ -69,14 +72,93 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
         })
         .collect::<Vec<_>>();
     tables.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
+        (&left.schema_name, &left.namespace, &left.table_name).cmp(&(
+            &right.schema_name,
+            &right.namespace,
+            &right.table_name,
+        ))
     });
     tables
+}
+
+fn build_namespaces_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("namespace", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+        Field::new("table_count", DataType::Int32, false),
+    ]));
+
+    let mut rows = active_sources
+        .iter()
+        .flat_map(|source| {
+            source.namespaces.iter().map(move |namespace| {
+                let table_count = source
+                    .tables
+                    .iter()
+                    .filter(|table| table.namespace == namespace.name)
+                    .count();
+                CatalogNamespace {
+                    schema_name: source.schema_name.clone(),
+                    namespace: namespace.name.clone(),
+                    description: namespace.description.clone(),
+                    table_count,
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.namespace).cmp(&(&right.schema_name, &right.namespace))
+    });
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.schema_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.namespace.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.description.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| table_count_i32(row.table_count))
+                    .collect::<Result<Int32Array>>()?,
+            ),
+        ],
+    )
+    .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
+
+    MemTable::try_new(schema, vec![vec![batch]])
+}
+
+struct CatalogNamespace {
+    schema_name: String,
+    namespace: String,
+    description: String,
+    table_count: usize,
+}
+
+fn table_count_i32(count: usize) -> Result<Option<i32>> {
+    i32::try_from(count).map(Some).map_err(|_| {
+        DataFusionError::Execution(format!("namespace table_count {count} exceeds i32"))
+    })
 }
 
 fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
+        Field::new("namespace", DataType::Utf8, false),
         Field::new("table_name", DataType::Utf8, false),
         Field::new("description", DataType::Utf8, false),
         Field::new("guide", DataType::Utf8, false),
@@ -86,30 +168,56 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
     let mut rows = active_sources
         .iter()
         .flat_map(|source| {
-            source.tables.iter().map(move |table| {
-                (
-                    source.schema_name.as_str(),
-                    table.table_name.as_str(),
-                    table.description.as_str(),
-                    table.guide.as_str(),
-                    table.required_filters.join(","),
-                )
+            source.tables.iter().map(move |table| CatalogTable {
+                schema_name: source.schema_name.clone(),
+                namespace: table.namespace.clone(),
+                table_name: table.table_name.clone(),
+                description: table.description.clone(),
+                guide: table.guide.clone(),
+                required_filters: table.required_filters.join(","),
             })
         })
         .collect::<Vec<_>>();
 
-    rows.sort_by(|left, right| (left.0, left.1).cmp(&(right.0, right.1)));
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.namespace, &left.table_name).cmp(&(
+            &right.schema_name,
+            &right.namespace,
+            &right.table_name,
+        ))
+    });
 
     let batch = RecordBatch::try_new(
         schema.clone(),
         vec![
-            Arc::new(rows.iter().map(|row| Some(row.0)).collect::<StringArray>()),
-            Arc::new(rows.iter().map(|row| Some(row.1)).collect::<StringArray>()),
-            Arc::new(rows.iter().map(|row| Some(row.2)).collect::<StringArray>()),
-            Arc::new(rows.iter().map(|row| Some(row.3)).collect::<StringArray>()),
             Arc::new(
                 rows.iter()
-                    .map(|row| Some(row.4.as_str()))
+                    .map(|row| Some(row.schema_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.namespace.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.table_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.description.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.guide.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.required_filters.as_str()))
                     .collect::<StringArray>(),
             ),
         ],
@@ -117,6 +225,15 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
 
     MemTable::try_new(schema, vec![vec![batch]])
+}
+
+struct CatalogTable {
+    schema_name: String,
+    namespace: String,
+    table_name: String,
+    description: String,
+    guide: String,
+    required_filters: String,
 }
 
 struct CatalogInput {
@@ -224,6 +341,7 @@ fn build_inputs_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
 
 struct CatalogColumn {
     schema_name: String,
+    namespace: String,
     table_name: String,
     column_name: String,
     data_type: String,
@@ -240,6 +358,7 @@ struct CatalogColumn {
 fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
+        Field::new("namespace", DataType::Utf8, false),
         Field::new("table_name", DataType::Utf8, false),
         Field::new("ordinal_position", DataType::Int32, false),
         Field::new("column_name", DataType::Utf8, false),
@@ -259,6 +378,7 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
                     .enumerate()
                     .map(move |(position, column)| CatalogColumn {
                         schema_name: source.schema_name.clone(),
+                        namespace: table.namespace.clone(),
                         table_name: table.table_name.clone(),
                         column_name: column.name.clone(),
                         data_type: column.data_type.clone(),
@@ -272,11 +392,18 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
         .collect::<Vec<_>>();
 
     rows.sort_by(|left, right| {
-        (&left.schema_name, &left.table_name, left.ordinal_position).cmp(&(
-            &right.schema_name,
-            &right.table_name,
-            right.ordinal_position,
-        ))
+        (
+            &left.schema_name,
+            &left.namespace,
+            &left.table_name,
+            left.ordinal_position,
+        )
+            .cmp(&(
+                &right.schema_name,
+                &right.namespace,
+                &right.table_name,
+                right.ordinal_position,
+            ))
     });
 
     let batch = RecordBatch::try_new(
@@ -285,6 +412,11 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
             Arc::new(
                 rows.iter()
                     .map(|row| Some(row.schema_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.namespace.as_str()))
                     .collect::<StringArray>(),
             ),
             Arc::new(

--- a/crates/coral-engine/src/runtime/catalog_provider.rs
+++ b/crates/coral-engine/src/runtime/catalog_provider.rs
@@ -1,0 +1,60 @@
+//! Static catalog provider used for source-as-catalog registration.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::{CatalogProvider, SchemaProvider};
+use datafusion::error::Result;
+
+/// Immutable catalog provider backed by a fixed set of schemas.
+#[derive(Debug)]
+pub(crate) struct StaticCatalogProvider {
+    schemas: HashMap<String, Arc<dyn SchemaProvider>>,
+}
+
+impl StaticCatalogProvider {
+    #[must_use]
+    /// Builds a catalog provider from the supplied schema map.
+    pub(crate) fn new(schemas: HashMap<String, Arc<dyn SchemaProvider>>) -> Self {
+        Self { schemas }
+    }
+}
+
+#[async_trait]
+impl CatalogProvider for StaticCatalogProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema_names(&self) -> Vec<String> {
+        let mut names = self.schemas.keys().cloned().collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    fn schema(&self, name: &str) -> Option<Arc<dyn SchemaProvider>> {
+        self.schemas.get(name).cloned()
+    }
+
+    fn register_schema(
+        &self,
+        _name: &str,
+        _schema: Arc<dyn SchemaProvider>,
+    ) -> Result<Option<Arc<dyn SchemaProvider>>> {
+        Err(datafusion::error::DataFusionError::Execution(
+            "static catalog provider does not support register_schema".to_string(),
+        ))
+    }
+
+    fn deregister_schema(
+        &self,
+        _name: &str,
+        _cascade: bool,
+    ) -> Result<Option<Arc<dyn SchemaProvider>>> {
+        Err(datafusion::error::DataFusionError::Execution(
+            "static catalog provider does not support deregister_schema".to_string(),
+        ))
+    }
+}

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -2,6 +2,7 @@
 //! tables, and schema plumbing.
 
 pub(crate) mod catalog;
+pub(crate) mod catalog_provider;
 pub(crate) mod error;
 pub(crate) mod json;
 pub(crate) mod pattern_validator;

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -1,16 +1,21 @@
 //! Registers compiled backend sources into a shared `DataFusion` session.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use coral_spec::DEFAULT_NAMESPACE;
+use datafusion::catalog::{CatalogProvider, SchemaProvider};
+use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{BackendRegistration, CompiledBackendSource, RegisteredSource};
+use crate::runtime::catalog_provider::StaticCatalogProvider;
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
 
-const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin"];
+const RESERVED_SOURCE_NAMES: &[&str] = &["coral", "coral_admin", "datafusion"];
 
 /// One selected query source together with its compiled backend artifact.
 ///
@@ -43,7 +48,7 @@ impl SourceRegistrationCandidate {
 /// Captures one source manifest that failed to initialize during registration.
 #[derive(Debug, Clone)]
 pub(crate) struct SourceRegistrationFailure {
-    /// Schema name whose registration failed.
+    /// Source/schema name whose registration failed.
     pub schema_name: String,
     /// Human-readable failure detail.
     pub detail: String,
@@ -55,10 +60,10 @@ pub(crate) struct SourceRegistrationResult {
     pub(crate) failures: Vec<SourceRegistrationFailure>,
 }
 
-fn check_reserved_schema(schema: &str) -> DataFusionResult<()> {
-    if RESERVED_SCHEMA_NAMES.contains(&schema) {
+fn check_reserved_source_name(source_name: &str) -> DataFusionResult<()> {
+    if RESERVED_SOURCE_NAMES.contains(&source_name) {
         return Err(DataFusionError::Execution(format!(
-            "source schema '{schema}' is reserved and cannot be used by manifests"
+            "source name '{source_name}' is reserved and cannot be used by manifests"
         )));
     }
     Ok(())
@@ -106,72 +111,56 @@ pub(crate) async fn register_sources(
                         } = registration;
                         let decorated_tables =
                             decorate_source_tables(source_decorators, query_source, tables)?;
-                        match catalog.register_schema(
+                        match register_runtime_tables(
+                            ctx,
+                            catalog.as_ref(),
                             compiled_source.schema_name(),
-                            Arc::new(StaticSchemaProvider::new(decorated_tables)),
+                            &registered_source,
+                            &decorated_tables,
                         ) {
-                            Ok(_) => result.active_sources.push(registered_source),
+                            Ok(()) => result.active_sources.push(registered_source),
                             Err(error) => {
                                 let core_error = datafusion_to_core(&error, &[]);
-                                if handle_source_registration_failure(
+                                if record_source_failure(
+                                    &mut result,
                                     source_decorators,
                                     query_source,
+                                    &schema_name,
+                                    &source_name,
                                     &core_error,
                                 )? {
                                     return Err(core_error);
                                 }
-                                let failure = SourceRegistrationFailure {
-                                    schema_name,
-                                    detail: core_error.to_string(),
-                                };
-                                tracing::warn!(
-                                    source = %source_name,
-                                    schema_name = %failure.schema_name,
-                                    detail = %failure.detail,
-                                    "skipping source"
-                                );
-                                result.failures.push(failure);
                             }
                         }
                     }
                     Err(error) => {
                         let core_error = datafusion_to_core(&error, &[]);
-                        if handle_source_registration_failure(
+                        if record_source_failure(
+                            &mut result,
                             source_decorators,
                             query_source,
+                            &schema_name,
+                            &source_name,
                             &core_error,
                         )? {
                             return Err(core_error);
                         }
-                        let failure = SourceRegistrationFailure {
-                            schema_name,
-                            detail: core_error.to_string(),
-                        };
-                        tracing::warn!(
-                            source = %source_name,
-                            schema_name = %failure.schema_name,
-                            detail = %failure.detail,
-                            "skipping source"
-                        );
-                        result.failures.push(failure);
                     }
                 }
             }
             SourceRegistrationCandidate::CompileFailed { source, error } => {
-                if handle_source_registration_failure(source_decorators, &source, &error)? {
+                let source_name = source.source_name().to_string();
+                if record_source_failure(
+                    &mut result,
+                    source_decorators,
+                    &source,
+                    &source_name,
+                    &source_name,
+                    &error,
+                )? {
                     return Err(error);
                 }
-                let failure = SourceRegistrationFailure {
-                    schema_name: source.source_name().to_string(),
-                    detail: error.to_string(),
-                };
-                tracing::warn!(
-                    source = %source.source_name(),
-                    schema_name = %failure.schema_name,
-                    detail = %failure.detail,
-                    "skipping source"
-                );
-                result.failures.push(failure);
             }
         }
     }
@@ -202,7 +191,7 @@ async fn register_source(
     seen_schemas: &mut std::collections::HashSet<String>,
     source: &dyn CompiledBackendSource,
 ) -> DataFusionResult<BackendRegistration> {
-    check_reserved_schema(source.schema_name())?;
+    check_reserved_source_name(source.schema_name())?;
 
     if !seen_schemas.insert(source.schema_name().to_string()) {
         return Err(DataFusionError::Execution(format!(
@@ -212,6 +201,144 @@ async fn register_source(
     }
 
     source.register(ctx).await
+}
+
+fn register_runtime_tables(
+    ctx: &SessionContext,
+    default_catalog: &dyn CatalogProvider,
+    schema_name: &str,
+    registered_source: &RegisteredSource,
+    tables: &HashMap<String, Arc<dyn TableProvider>>,
+) -> DataFusionResult<()> {
+    ensure_runtime_path_available(ctx, default_catalog, schema_name)?;
+
+    let providers = align_table_providers(schema_name, registered_source, tables)?;
+    let source_schemas = source_catalog_schemas(&providers);
+    let core_aliases = core_alias_tables(&providers);
+
+    register_core_aliases(default_catalog, schema_name, core_aliases)?;
+
+    if ctx
+        .register_catalog(
+            schema_name.to_string(),
+            Arc::new(StaticCatalogProvider::new(source_schemas)),
+        )
+        .is_some()
+    {
+        rollback_core_aliases(default_catalog, schema_name);
+        return Err(DataFusionError::Execution(format!(
+            "duplicate source catalog '{schema_name}'"
+        )));
+    }
+
+    Ok(())
+}
+
+fn ensure_runtime_path_available(
+    ctx: &SessionContext,
+    default_catalog: &dyn CatalogProvider,
+    schema_name: &str,
+) -> DataFusionResult<()> {
+    if ctx.catalog(schema_name).is_some() {
+        return Err(DataFusionError::Execution(format!(
+            "duplicate source catalog '{schema_name}'"
+        )));
+    }
+    if default_catalog.schema(schema_name).is_some() {
+        return Err(DataFusionError::Execution(format!(
+            "duplicate source schema '{schema_name}'"
+        )));
+    }
+    Ok(())
+}
+
+struct RuntimeTableProvider {
+    namespace: String,
+    table_name: String,
+    provider: Arc<dyn TableProvider>,
+}
+
+fn align_table_providers(
+    schema_name: &str,
+    registered_source: &RegisteredSource,
+    tables: &HashMap<String, Arc<dyn TableProvider>>,
+) -> DataFusionResult<Vec<RuntimeTableProvider>> {
+    // Source decorators still receive the flat provider map because v1 source
+    // specs require table names to be unique per source. This is the boundary
+    // where runtime registration restores the logical namespace for DataFusion.
+    registered_source
+        .tables
+        .iter()
+        .map(|table| {
+            let provider = tables.get(&table.table_name).cloned().ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "{schema_name}.{} has metadata but no registered table provider",
+                    table.table_name
+                ))
+            })?;
+            Ok(RuntimeTableProvider {
+                namespace: table.namespace.clone(),
+                table_name: table.table_name.clone(),
+                provider,
+            })
+        })
+        .collect()
+}
+
+fn source_catalog_schemas(
+    providers: &[RuntimeTableProvider],
+) -> HashMap<String, Arc<dyn SchemaProvider>> {
+    let mut by_namespace: HashMap<String, HashMap<String, Arc<dyn TableProvider>>> = HashMap::new();
+    for table in providers {
+        by_namespace
+            .entry(table.namespace.clone())
+            .or_default()
+            .insert(table.table_name.clone(), table.provider.clone());
+    }
+    by_namespace
+        .into_iter()
+        .map(|(namespace, namespace_tables)| {
+            (
+                namespace,
+                Arc::new(StaticSchemaProvider::new(namespace_tables)) as Arc<dyn SchemaProvider>,
+            )
+        })
+        .collect()
+}
+
+fn core_alias_tables(
+    providers: &[RuntimeTableProvider],
+) -> HashMap<String, Arc<dyn TableProvider>> {
+    providers
+        .iter()
+        .filter(|table| table.namespace == DEFAULT_NAMESPACE)
+        .map(|table| (table.table_name.clone(), table.provider.clone()))
+        .collect()
+}
+
+fn register_core_aliases(
+    default_catalog: &dyn CatalogProvider,
+    schema_name: &str,
+    core_aliases: HashMap<String, Arc<dyn TableProvider>>,
+) -> DataFusionResult<()> {
+    if core_aliases.is_empty() {
+        return Ok(());
+    }
+    default_catalog.register_schema(
+        schema_name,
+        Arc::new(StaticSchemaProvider::new(core_aliases)),
+    )?;
+    Ok(())
+}
+
+fn rollback_core_aliases(default_catalog: &dyn CatalogProvider, schema_name: &str) {
+    if let Err(error) = default_catalog.deregister_schema(schema_name, true) {
+        tracing::warn!(
+            schema_name,
+            detail = %error,
+            "failed to roll back core table aliases after source catalog registration failure"
+        );
+    }
 }
 
 fn prepare_source_decorators(
@@ -257,6 +384,31 @@ fn handle_source_registration_failure(
     Ok(false)
 }
 
+fn record_source_failure(
+    result: &mut SourceRegistrationResult,
+    source_decorators: &mut [Box<dyn SourceDecorator>],
+    source: &QuerySource,
+    schema_name: &str,
+    source_name: &str,
+    error: &CoreError,
+) -> std::result::Result<bool, CoreError> {
+    if handle_source_registration_failure(source_decorators, source, error)? {
+        return Ok(true);
+    }
+    let failure = SourceRegistrationFailure {
+        schema_name: schema_name.to_string(),
+        detail: error.to_string(),
+    };
+    tracing::warn!(
+        source = source_name,
+        schema_name = %failure.schema_name,
+        detail = %failure.detail,
+        "skipping source"
+    );
+    result.failures.push(failure);
+    Ok(false)
+}
+
 fn finish_source_decorators(
     source_decorators: &mut [Box<dyn SourceDecorator>],
 ) -> std::result::Result<(), CoreError> {
@@ -283,23 +435,23 @@ fn source_decorator_error(name: &str, error: &crate::SourceDecoratorError) -> Co
 
 #[cfg(test)]
 mod tests {
-    use super::check_reserved_schema;
+    use super::check_reserved_source_name;
 
     #[test]
-    fn reserved_schema_coral_is_rejected() {
-        let result = check_reserved_schema("coral");
+    fn reserved_source_name_coral_is_rejected() {
+        let result = check_reserved_source_name("coral");
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.contains("coral"),
-            "error message should mention the schema name"
+            "error message should mention the source name"
         );
     }
 
     #[test]
-    fn non_reserved_schema_is_accepted() {
-        assert!(check_reserved_schema("github").is_ok());
-        assert!(check_reserved_schema("pagerduty").is_ok());
-        assert!(check_reserved_schema("slack").is_ok());
+    fn non_reserved_source_name_is_accepted() {
+        assert!(check_reserved_source_name("github").is_ok());
+        assert!(check_reserved_source_name("pagerduty").is_ok());
+        assert!(check_reserved_source_name("slack").is_ok());
     }
 }

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -52,6 +52,51 @@ fn teams_manifest(dir: &std::path::Path) -> Value {
     })
 }
 
+fn namespaced_manifest(core_dir: &std::path::Path, actions_dir: &std::path::Path) -> Value {
+    json!({
+        "name": "github",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "namespaces": {
+            "actions": {
+                "description": "GitHub Actions workflow data"
+            },
+            "core": {
+                "description": "Common GitHub tables"
+            }
+        },
+        "tables": [
+            {
+                "name": "issues",
+                "description": "GitHub issues",
+                "source": {
+                    "location": dir_url(core_dir),
+                    "glob": "**/*.jsonl"
+                },
+                "columns": [
+                    { "name": "number", "type": "Int64" },
+                    { "name": "title", "type": "Utf8" }
+                ]
+            },
+            {
+                "name": "repo_action_runs",
+                "namespace": "actions",
+                "description": "GitHub Actions workflow runs",
+                "source": {
+                    "location": dir_url(actions_dir),
+                    "glob": "**/*.jsonl"
+                },
+                "columns": [
+                    { "name": "run_id", "type": "Int64" },
+                    { "name": "issue_number", "type": "Int64" },
+                    { "name": "status", "type": "Utf8" }
+                ]
+            }
+        ]
+    })
+}
+
 fn build_catalog_sources() -> (TempDir, Vec<QuerySource>) {
     let temp = TempDir::new().expect("temp dir");
     let alpha_dir = temp.path().join("alpha");
@@ -223,6 +268,202 @@ async fn join_across_two_sources() {
             json!({"name": "Grace", "team_name": "Infra"}),
             json!({"name": "Linus", "team_name": "Platform"}),
         ]
+    );
+}
+
+#[tokio::test]
+async fn namespaces_support_core_shorthand_explicit_core_and_non_core_queries() {
+    let temp = TempDir::new().expect("temp dir");
+    let core_dir = temp.path().join("github-core");
+    let actions_dir = temp.path().join("github-actions");
+    write_jsonl_file(
+        &core_dir,
+        "issues.jsonl",
+        &[json!({"number": 1, "title": "first issue"})],
+    );
+    write_jsonl_file(
+        &actions_dir,
+        "runs.jsonl",
+        &[json!({"run_id": 101, "issue_number": 1, "status": "completed"})],
+    );
+    let sources = vec![build_source(namespaced_manifest(&core_dir, &actions_dir))];
+
+    let shorthand_rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT number, title FROM github.issues",
+        )
+        .await
+        .expect("core shorthand query should succeed"),
+    );
+    let explicit_core_rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT number, title FROM github.core.issues",
+        )
+        .await
+        .expect("explicit core query should succeed"),
+    );
+    let namespaced_rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT run_id, status FROM github.actions.repo_action_runs",
+        )
+        .await
+        .expect("non-core namespace query should succeed"),
+    );
+
+    assert_eq!(
+        shorthand_rows,
+        vec![json!({"number": 1, "title": "first issue"})]
+    );
+    assert_eq!(explicit_core_rows, shorthand_rows);
+    assert_eq!(
+        namespaced_rows,
+        vec![json!({"run_id": 101, "status": "completed"})]
+    );
+}
+
+#[tokio::test]
+async fn coral_namespaces_lists_namespace_metadata() {
+    let temp = TempDir::new().expect("temp dir");
+    let core_dir = temp.path().join("github-core");
+    let actions_dir = temp.path().join("github-actions");
+    write_jsonl_file(
+        &core_dir,
+        "issues.jsonl",
+        &[json!({"number": 1, "title": "first issue"})],
+    );
+    write_jsonl_file(
+        &actions_dir,
+        "runs.jsonl",
+        &[json!({"run_id": 101, "issue_number": 1, "status": "completed"})],
+    );
+    let sources = vec![build_source(namespaced_manifest(&core_dir, &actions_dir))];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT namespace, description, table_count \
+             FROM coral.namespaces WHERE schema_name = 'github' ORDER BY namespace",
+        )
+        .await
+        .expect("namespace metadata query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({"namespace": "actions", "description": "GitHub Actions workflow data", "table_count": 1}),
+            json!({"namespace": "core", "description": "Common GitHub tables", "table_count": 1}),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn coral_tables_and_columns_include_namespace_without_alias_duplicates() {
+    let temp = TempDir::new().expect("temp dir");
+    let core_dir = temp.path().join("github-core");
+    let actions_dir = temp.path().join("github-actions");
+    write_jsonl_file(
+        &core_dir,
+        "issues.jsonl",
+        &[json!({"number": 1, "title": "first issue"})],
+    );
+    write_jsonl_file(
+        &actions_dir,
+        "runs.jsonl",
+        &[json!({"run_id": 101, "issue_number": 1, "status": "completed"})],
+    );
+    let sources = vec![build_source(namespaced_manifest(&core_dir, &actions_dir))];
+
+    let table_rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT schema_name, namespace, table_name \
+             FROM coral.tables \
+             WHERE schema_name = 'github' \
+             ORDER BY namespace, table_name",
+        )
+        .await
+        .expect("table metadata query should succeed"),
+    );
+    assert_eq!(
+        table_rows,
+        vec![
+            json!({"schema_name": "github", "namespace": "actions", "table_name": "repo_action_runs"}),
+            json!({"schema_name": "github", "namespace": "core", "table_name": "issues"}),
+        ]
+    );
+
+    let column_rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT namespace, table_name, column_name \
+             FROM coral.columns \
+             WHERE schema_name = 'github' AND table_name = 'repo_action_runs' \
+             ORDER BY ordinal_position",
+        )
+        .await
+        .expect("column metadata query should succeed"),
+    );
+    assert_eq!(
+        column_rows,
+        vec![
+            json!({"namespace": "actions", "table_name": "repo_action_runs", "column_name": "run_id"}),
+            json!({"namespace": "actions", "table_name": "repo_action_runs", "column_name": "issue_number"}),
+            json!({"namespace": "actions", "table_name": "repo_action_runs", "column_name": "status"}),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn cross_source_joins_support_namespaced_tables() {
+    let temp = TempDir::new().expect("temp dir");
+    let github_core_dir = temp.path().join("github-core");
+    let github_actions_dir = temp.path().join("github-actions");
+    let beta_dir = temp.path().join("beta");
+    write_jsonl_file(
+        &github_core_dir,
+        "issues.jsonl",
+        &[json!({"number": 1, "title": "first issue"})],
+    );
+    write_jsonl_file(
+        &github_actions_dir,
+        "runs.jsonl",
+        &[json!({"run_id": 101, "issue_number": 1, "status": "completed"})],
+    );
+    write_jsonl_file(
+        &beta_dir,
+        "teams.jsonl",
+        &[json!({"id": 101, "team_name": "CI"})],
+    );
+    let sources = vec![
+        build_source(namespaced_manifest(&github_core_dir, &github_actions_dir)),
+        build_source(teams_manifest(&beta_dir)),
+    ];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            &TestRuntime,
+            "SELECT r.status, t.team_name \
+             FROM github.actions.repo_action_runs r \
+             JOIN beta.teams t ON r.run_id = t.id",
+        )
+        .await
+        .expect("cross-source join should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({"status": "completed", "team_name": "CI"})]
     );
 }
 


### PR DESCRIPTION
### TL;DR

Adds first-class namespace support to the query engine, exposing namespaced tables via three-part identifiers (`source.namespace.table`) while preserving the existing two-part shorthand (`source.table`) for core-namespace tables.

### What changed?

- `RegisteredTable` now carries a `namespace` field, and `RegisteredSource` carries a `namespaces: Vec<RegisteredNamespace>` field. All backends (HTTP, JSONL, Parquet) populate these from the manifest's `namespaces` block via the new `build_registered_namespaces` helper.
- Source registration now builds a per-source `StaticCatalogProvider` (new `catalog_provider.rs` module) whose schemas map to namespaces. Tables in the `core` namespace are additionally aliased into the default DataFusion catalog under the source's schema name, preserving two-part query compatibility.
- A new `coral.namespaces` metadata table is exposed alongside `coral.tables` and `coral.columns`. Both `coral.tables` and `coral.columns` gain a `namespace` column, and their sort orders now include namespace.
- `format_schema_table` in query error hints emits a three-part identifier for non-core namespaces.
- `DEFAULT_NAMESPACE` and `is_core_namespace` are promoted from `pub(crate)` to `pub` in `coral-spec` and re-exported from the crate root.
- The reserved-name check is extended to include `"datafusion"` and renamed from `check_reserved_schema` to `check_reserved_source_name`.
- Duplicated failure-recording logic in `register_sources` is consolidated into a `record_source_failure` helper.
- `TableInfo` gains a `namespace` field, and `collect_tables` propagates it from registered table metadata.

### How to test?

Four new integration tests in `catalog_tests.rs` cover the main scenarios:

- `namespaces_support_core_shorthand_explicit_core_and_non_core_queries` — verifies that `github.issues`, `github.core.issues`, and `github.actions.repo_action_runs` all resolve correctly.
- `coral_namespaces_lists_namespace_metadata` — queries `coral.namespaces` and asserts the returned rows match the manifest's namespace declarations including `table_count`.
- `coral_tables_and_columns_include_namespace_without_alias_duplicates` — confirms `coral.tables` and `coral.columns` expose the `namespace` column and contain no duplicate rows from the core alias.
- `cross_source_joins_support_namespaced_tables` — joins a namespaced table from one source against a table in a second source.

Run the full engine test suite with `cargo test -p coral-engine`.

### Why make this change?

Source manifests already support declaring named namespaces to logically group tables within a single source. Previously the engine ignored namespace metadata at runtime, making all tables addressable only by two-part names and omitting namespace information from catalog metadata. This change wires namespaces through the full registration and catalog pipeline so that queries can target specific namespaces explicitly, tooling can discover namespace structure via `coral.namespaces`, and error messages correctly reflect three-part identifiers for non-core tables.