### PR TITLE
feat(api): expose table namespaces

### DIFF
--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -28,4 +28,6 @@ message Table {
   repeated Column columns = 5;
   // Required filter names, if any.
   repeated string required_filters = 6;
+  // The table namespace within the source. Core tables use "core".
+  string namespace = 7;
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -42,6 +42,7 @@ pub(crate) fn table_to_proto(
     Table {
         workspace: Some(workspace_to_proto(workspace_name)),
         schema_name: table.schema_name,
+        namespace: table.namespace,
         name: table.table_name,
         description: table.description,
         columns: table
@@ -170,6 +171,7 @@ mod tests {
 
         assert_eq!(proto.workspace, Some(workspace_to_proto(&workspace_name)));
         assert_eq!(proto.schema_name, "demo");
+        assert_eq!(proto.namespace, DEFAULT_NAMESPACE);
         assert_eq!(proto.name, "users");
         assert_eq!(proto.description, "User records");
         assert_eq!(proto.columns.len(), 1);

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -7,6 +7,7 @@ use coral_api::v1::{
     ValidateSourceRequest, Workspace, query_test_result,
 };
 use coral_client::default_workspace;
+use coral_spec::DEFAULT_NAMESPACE;
 use tempfile::TempDir;
 use tonic::Request;
 
@@ -196,6 +197,7 @@ async fn validate_source_returns_tables() {
     let validated = harness.validate_source("local_messages").await;
     assert_eq!(validated.tables.len(), 1);
     assert_eq!(validated.tables[0].schema_name, "local_messages");
+    assert_eq!(validated.tables[0].namespace, DEFAULT_NAMESPACE);
     assert_eq!(validated.tables[0].name, "messages");
     assert!(validated.tables[0].required_filters.is_empty());
     assert!(validated.query_tests.is_empty());

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -48,6 +48,7 @@ fn mock_table(schema_name: &str, name: &str) -> Table {
     Table {
         workspace: Some(workspace()),
         schema_name: schema_name.to_string(),
+        namespace: "core".to_string(),
         name: name.to_string(),
         description: String::new(),
         columns: Vec::new(),
@@ -59,6 +60,7 @@ fn mock_visible_table() -> Table {
     Table {
         workspace: Some(workspace()),
         schema_name: "local_messages".to_string(),
+        namespace: "core".to_string(),
         name: "messages".to_string(),
         description: "Fixture messages".to_string(),
         columns: vec![

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -86,7 +86,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
     assert!(guide_text.contains("## Available Schemas"));
     assert!(guide_text.contains("- local_messages"));
     assert!(guide_text.contains(
-        "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'messages'"
+        "FROM coral.columns WHERE schema_name = 'local_messages' AND namespace = 'core' AND table_name = 'messages'"
     ));
 
     let tables = client

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -8,7 +8,7 @@ Always inspect queryable tables and table metadata before writing queries:
 
 ```sql
 -- List visible tables, descriptions, and required filters
-SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
+SELECT schema_name, namespace, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, namespace, table_name;
 
 -- Inspect columns for one visible table
 {{COLUMNS_EXAMPLE}}

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,6 +5,8 @@ use coral_api::v1::{Source, Table};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
+const DEFAULT_TABLE_NAMESPACE: &str = "core";
+
 static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables` to inspect queryable tables, and use `sql` against `coral.tables` and `coral.columns` for discovery.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
@@ -52,13 +54,15 @@ pub(crate) fn guide_resource_content(sources: &[Source], tables: &[Table]) -> St
     let columns_example = first_visible_table(tables).map_or_else(
         || {
             "SELECT column_name, data_type, is_required_filter, description \
-FROM coral.columns WHERE schema_name = '<schema>' AND table_name = '<table>' ORDER BY ordinal_position;"
+FROM coral.columns WHERE schema_name = '<schema>' AND namespace = '<namespace>' AND table_name = '<table>' ORDER BY ordinal_position;"
                 .to_string()
         },
-        |(schema_name, table_name)| {
+        |table| {
+            let namespace = normalized_table_namespace(table);
             format!(
                 "SELECT column_name, data_type, is_required_filter, description \
-FROM coral.columns WHERE schema_name = '{schema_name}' AND table_name = '{table_name}' ORDER BY ordinal_position;"
+FROM coral.columns WHERE schema_name = '{}' AND namespace = '{}' AND table_name = '{}' ORDER BY ordinal_position;",
+                table.schema_name, namespace, table.name
             )
         },
     );
@@ -109,7 +113,10 @@ fn queryable_tables(tables: &[Table]) -> Vec<Value> {
         .iter()
         .map(|table| {
             json!({
-                "name": format!("{}.{}", table.schema_name, table.name),
+                "name": table_sql_name(table),
+                "schema_name": table.schema_name,
+                "namespace": normalized_table_namespace(table),
+                "table_name": table.name,
                 "description": table.description,
                 "required_filters": table.required_filters,
             })
@@ -123,20 +130,45 @@ fn queryable_tables(tables: &[Table]) -> Vec<Value> {
     summaries
 }
 
-fn first_visible_table(tables: &[Table]) -> Option<(&str, &str)> {
-    tables
-        .iter()
-        .min_by(|left, right| {
-            (&left.schema_name, &left.name).cmp(&(&right.schema_name, &right.name))
-        })
-        .map(|table| (table.schema_name.as_str(), table.name.as_str()))
+fn first_visible_table(tables: &[Table]) -> Option<&Table> {
+    tables.iter().min_by(|left, right| {
+        (
+            &left.schema_name,
+            normalized_table_namespace(left),
+            &left.name,
+        )
+            .cmp(&(
+                &right.schema_name,
+                normalized_table_namespace(right),
+                &right.name,
+            ))
+    })
+}
+
+fn normalized_table_namespace(table: &Table) -> &str {
+    // Current servers always send a namespace. Proto3 still decodes missing
+    // values from older producers as an empty string, which should behave as core.
+    if table.namespace.is_empty() {
+        DEFAULT_TABLE_NAMESPACE
+    } else {
+        &table.namespace
+    }
+}
+
+fn table_sql_name(table: &Table) -> String {
+    let namespace = normalized_table_namespace(table);
+    if namespace == DEFAULT_TABLE_NAMESPACE {
+        format!("{}.{}", table.schema_name, table.name)
+    } else {
+        format!("{}.{}.{}", table.schema_name, namespace, table.name)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use coral_api::v1::{Source, Table, Workspace};
 
-    use super::guide_resource_content;
+    use super::{DEFAULT_TABLE_NAMESPACE, guide_resource_content, list_tables_value};
 
     fn source(name: &str) -> Source {
         Source {
@@ -152,11 +184,16 @@ mod tests {
     }
 
     fn table(schema_name: &str, name: &str) -> Table {
+        table_with_namespace(schema_name, DEFAULT_TABLE_NAMESPACE, name)
+    }
+
+    fn table_with_namespace(schema_name: &str, namespace: &str, name: &str) -> Table {
         Table {
             workspace: Some(Workspace {
                 name: "default".to_string(),
             }),
             schema_name: schema_name.to_string(),
+            namespace: namespace.to_string(),
             name: name.to_string(),
             description: format!("{name} description"),
             columns: Vec::new(),
@@ -184,5 +221,41 @@ mod tests {
         assert!(content.contains("Visible source schemas:"));
         assert!(content.contains("- slack"));
         assert!(content.contains("Fully qualify tables in SQL, for example `slack.messages`."));
+        assert!(content.contains(
+            "FROM coral.columns WHERE schema_name = 'slack' AND namespace = 'core' AND table_name = 'channels'"
+        ));
+    }
+
+    #[test]
+    fn guide_content_uses_namespace_when_first_table_is_non_core() {
+        let content = guide_resource_content(
+            &[source("github")],
+            &[table_with_namespace(
+                "github",
+                "actions",
+                "repo_action_runs",
+            )],
+        );
+        assert!(content.contains(
+            "FROM coral.columns WHERE schema_name = 'github' AND namespace = 'actions' AND table_name = 'repo_action_runs'"
+        ));
+    }
+
+    #[test]
+    fn list_tables_renders_canonical_sql_names_and_structured_parts() {
+        let value = list_tables_value(&[
+            table("slack", "messages"),
+            table_with_namespace("github", "actions", "repo_action_runs"),
+        ]);
+
+        assert_eq!(
+            value["tables"][0]["name"],
+            "github.actions.repo_action_runs"
+        );
+        assert_eq!(value["tables"][0]["schema_name"], "github");
+        assert_eq!(value["tables"][0]["namespace"], "actions");
+        assert_eq!(value["tables"][0]["table_name"], "repo_action_runs");
+        assert_eq!(value["tables"][1]["name"], "slack.messages");
+        assert_eq!(value["tables"][1]["namespace"], "core");
     }
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -237,7 +237,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert!(updated_guide_text.contains("- local_messages"));
     assert!(!updated_guide_text.contains("## Visible SQL Schemas"));
     assert!(updated_guide_text.contains(
-        "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'messages'"
+        "FROM coral.columns WHERE schema_name = 'local_messages' AND namespace = 'core' AND table_name = 'messages'"
     ));
 
     let tables = client

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -15,12 +15,12 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
-| Tool     | `list_tables`    | List queryable fully qualified tables                   |
+| Tool     | `list_tables`    | List queryable fully qualified table paths              |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
-| Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
+| Resource | `coral://tables` | JSON summaries of queryable table paths and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
+For richer metadata, have the agent query `coral.namespaces`, `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`. `list_tables` and `coral://tables` render core tables as `source.table` and namespaced tables as `source.namespace.table`.
 
 ## Client setup
 
@@ -175,7 +175,7 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources.
+The agent should call `list_tables` or query `coral.tables` and return the queryable table paths from your installed sources.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- adds `namespace` to the API `Table` contract and populates it from engine table metadata
- renders MCP `list_tables` / `coral://tables` names as canonical SQL paths: `source.table` for core and `source.namespace.table` for non-core
- updates MCP guide discovery SQL to include `namespace` when inspecting `coral.tables` / `coral.columns`

## Validation
- `cargo test -p coral-mcp --lib`
- `cargo test -p coral-cli --test mcp --features cli-test-server`
- `cargo test -p coral-app --test grpc validate_source_returns_tables`
- `make rust-checks`