### PR TITLE
feat(sources/sentry): add query filter to sentry.issues

### DIFF
--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -42,43 +42,6 @@ fn base_http_manifest(name: &str, base_url: &str) -> Value {
     })
 }
 
-fn sentry_issues_manifest(name: &str, base_url: &str) -> Value {
-    json!({
-        "name": name,
-        "version": "0.1.0",
-        "dsl_version": 3,
-        "backend": "http",
-        "base_url": base_url,
-        "tables": [{
-            "name": "issues",
-            "description": "Sentry issues",
-            "filters": [
-                { "name": "query" }
-            ],
-            "request": {
-                "method": "GET",
-                "path": "/api/issues",
-                "query": [
-                    { "name": "query", "from": "filter", "key": "query", "default": "" }
-                ]
-            },
-            "response": {
-                "rows_path": ["data"]
-            },
-            "columns": [
-                { "name": "id", "type": "Utf8" },
-                {
-                    "name": "query",
-                    "type": "Utf8",
-                    "nullable": true,
-                    "virtual": true,
-                    "expr": { "kind": "from_filter", "key": "query" }
-                }
-            ]
-        }]
-    })
-}
-
 #[derive(Debug)]
 struct TestRequestAuthenticator;
 
@@ -270,68 +233,6 @@ async fn select_with_where_filter_pushdown() {
     );
 
     assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
-}
-
-#[tokio::test]
-async fn empty_string_filter_default_without_where_clause() {
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/api/issues"))
-        .and(query_param("query", ""))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({ "data": [json!({"id": "ISSUE-1"})] })),
-        )
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let source = build_source(sentry_issues_manifest(
-        "sentry_default_query",
-        &server.uri(),
-    ));
-
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT id FROM sentry_default_query.issues",
-        )
-        .await
-        .expect("query should succeed"),
-    );
-
-    assert_eq!(rows, vec![json!({"id": "ISSUE-1"})]);
-}
-
-#[tokio::test]
-async fn empty_string_filter_default_where_override() {
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/api/issues"))
-        .and(query_param("query", "is:unresolved"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({ "data": [json!({"id": "ISSUE-2"})] })),
-        )
-        .expect(1)
-        .mount(&server)
-        .await;
-
-    let source = build_source(sentry_issues_manifest(
-        "sentry_override_query",
-        &server.uri(),
-    ));
-
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT id FROM sentry_override_query.issues WHERE query = 'is:unresolved'",
-        )
-        .await
-        .expect("query should succeed"),
-    );
-
-    assert_eq!(rows, vec![json!({"id": "ISSUE-2"})]);
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -293,7 +293,7 @@ async fn empty_string_filter_default_without_where_clause() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id FROM sentry_default_query.issues",
         )
         .await
@@ -324,7 +324,7 @@ async fn empty_string_filter_default_where_override() {
     let rows = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            &TestRuntime,
+            test_runtime(),
             "SELECT id FROM sentry_override_query.issues WHERE query = 'is:unresolved'",
         )
         .await

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -42,6 +42,43 @@ fn base_http_manifest(name: &str, base_url: &str) -> Value {
     })
 }
 
+fn sentry_issues_manifest(name: &str, base_url: &str) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "tables": [{
+            "name": "issues",
+            "description": "Sentry issues",
+            "filters": [
+                { "name": "query" }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/api/issues",
+                "query": [
+                    { "name": "query", "from": "filter", "key": "query", "default": "" }
+                ]
+            },
+            "response": {
+                "rows_path": ["data"]
+            },
+            "columns": [
+                { "name": "id", "type": "Utf8" },
+                {
+                    "name": "query",
+                    "type": "Utf8",
+                    "nullable": true,
+                    "virtual": true,
+                    "expr": { "kind": "from_filter", "key": "query" }
+                }
+            ]
+        }]
+    })
+}
+
 #[derive(Debug)]
 struct TestRequestAuthenticator;
 
@@ -233,6 +270,68 @@ async fn select_with_where_filter_pushdown() {
     );
 
     assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+}
+
+#[tokio::test]
+async fn empty_string_filter_default_without_where_clause() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/issues"))
+        .and(query_param("query", ""))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "data": [json!({"id": "ISSUE-1"})] })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(sentry_issues_manifest(
+        "sentry_default_query",
+        &server.uri(),
+    ));
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            &TestRuntime,
+            "SELECT id FROM sentry_default_query.issues",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": "ISSUE-1"})]);
+}
+
+#[tokio::test]
+async fn empty_string_filter_default_where_override() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/issues"))
+        .and(query_param("query", "is:unresolved"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "data": [json!({"id": "ISSUE-2"})] })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(sentry_issues_manifest(
+        "sentry_override_query",
+        &server.uri(),
+    ));
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            &TestRuntime,
+            "SELECT id FROM sentry_override_query.issues WHERE query = 'is:unresolved'",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"id": "ISSUE-2"})]);
 }
 
 #[tokio::test]

--- a/sources/sentry/manifest.yaml
+++ b/sources/sentry/manifest.yaml
@@ -100,6 +100,10 @@ tables:
         - name: project
           from: filter
           key: project
+        - name: query
+          from: filter
+          key: query
+          default: ""
     response: {}
     pagination:
       mode: link_header
@@ -191,8 +195,16 @@ tables:
             - kind: path
               path:
                 - project
+      - name: query
+        type: Utf8
+        nullable: true
+        description: Sentry search query string (e.g. "is:unresolved"). Pass via WHERE to scope results.
+        expr:
+          kind: 'null'
+        virtual: true
     filters:
       - name: project
+      - name: query
   - name: events
     description: Individual events for a specific issue
     guide: |


### PR DESCRIPTION
Exposes Sentry's search query string as a SQL filter on the issues table, so callers can do `WHERE query = 'is:unresolved'`.

Without a `WHERE` clause the param defaults to `query=""` which returns all issues rather than whatever Sentry's server-side default produces.