### PR TITLE
feat(sources/sentry): add short_id column

### DIFF
--- a/sources/sentry/manifest.yaml
+++ b/sources/sentry/manifest.yaml
@@ -113,6 +113,14 @@ tables:
           kind: path
           path:
             - id
+      - name: short_id
+        type: Utf8
+        nullable: true
+        description: Human-readable issue identifier (e.g. "PROJECT-123")
+        expr:
+          kind: path
+          path:
+            - shortId
       - name: title
         type: Utf8
         nullable: false


### PR DESCRIPTION
Exposes Sentry's human-readable issue identifier (e.g. `PROJECT-123`)
that was already present in the API response but not mapped in the manifest.

```sql
SELECT id, short_id, title FROM sentry.issues LIMIT 10;
```