### PR TITLE
feat(engine): add source-scoped table functions

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -1,13 +1,15 @@
 //! Shared internal backend contracts and registry-visible metadata.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt::Write;
 use std::sync::Arc;
 
 use crate::{QueryRuntimeContext, RequestAuthenticator};
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec, TableCommon,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
+    SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::datasource::TableProvider;
@@ -34,6 +36,19 @@ pub(crate) struct RegisteredTable {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct RegisteredTableFunction {
+    pub(crate) schema_name: String,
+    pub(crate) function_name: String,
+    pub(crate) public_name: String,
+    pub(crate) internal_name: String,
+    pub(crate) kind: String,
+    pub(crate) description: String,
+    pub(crate) arguments_json: String,
+    pub(crate) result_columns_json: String,
+    pub(crate) arg_names: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct RegisteredInput {
     pub(crate) key: String,
     pub(crate) kind: ManifestInputKind,
@@ -51,12 +66,35 @@ pub(crate) struct RegisteredInput {
 pub(crate) struct RegisteredSource {
     pub(crate) schema_name: String,
     pub(crate) tables: Vec<RegisteredTable>,
+    pub(crate) table_functions: Vec<RegisteredTableFunction>,
     pub(crate) inputs: Vec<RegisteredInput>,
 }
 
 pub(crate) struct BackendRegistration {
     pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
+    pub(crate) table_functions: Vec<BackendTableFunctionRegistration>,
     pub(crate) source: RegisteredSource,
+}
+
+pub(crate) struct BackendTableFunctionRegistration {
+    pub(crate) internal_name: String,
+    pub(crate) function: Arc<dyn datafusion::catalog::TableFunctionImpl>,
+}
+
+pub(crate) fn internal_table_function_name(schema: &str, function: &str) -> String {
+    format!(
+        "__coral_udtf_{}_{}",
+        hex_encode(schema),
+        hex_encode(function)
+    )
+}
+
+fn hex_encode(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value.as_bytes() {
+        write!(&mut encoded, "{byte:02x}").expect("write to string");
+    }
+    encoded
 }
 
 pub(crate) struct BackendCompileRequest<'a> {
@@ -180,6 +218,52 @@ pub(crate) fn build_registered_table(
         guide: common.guide.clone(),
         columns,
         required_filters,
+    }
+}
+
+pub(crate) fn build_registered_table_function(
+    schema_name: &str,
+    function: &SourceTableFunctionSpec,
+    internal_name: String,
+) -> RegisteredTableFunction {
+    let public_name = format!("{schema_name}.{}", function.name);
+    let arguments = function
+        .args
+        .iter()
+        .map(|arg| {
+            serde_json::json!({
+                "name": arg.name,
+                "required": arg.required,
+                "values": arg.values,
+            })
+        })
+        .collect::<Vec<_>>();
+    let result_columns = registered_columns_from_specs(&function.columns, &[])
+        .into_iter()
+        .map(|column| {
+            serde_json::json!({
+                "name": column.name,
+                "type": column.data_type,
+                "nullable": column.nullable,
+                "description": column.description,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    RegisteredTableFunction {
+        schema_name: schema_name.to_string(),
+        function_name: function.name.clone(),
+        public_name,
+        internal_name,
+        kind: if function.kind.is_empty() {
+            "table".to_string()
+        } else {
+            function.kind.clone()
+        },
+        description: function.description.clone(),
+        arguments_json: serde_json::to_string(&arguments).expect("arguments json"),
+        result_columns_json: serde_json::to_string(&result_columns).expect("result columns json"),
+        arg_names: function.args.iter().map(|arg| arg.name.clone()).collect(),
     }
 }
 

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -345,6 +345,7 @@ fn validate_source_scoped_http_config(
     check_base_url_inputs(manifest, resolved_inputs)?;
     check_request_header_inputs(manifest, resolved_inputs)?;
     check_table_request_inputs(manifest, resolved_inputs)?;
+    check_function_request_inputs(manifest, resolved_inputs)?;
     check_auth_inputs(manifest, request_authenticators, resolved_inputs)?;
     Ok(())
 }
@@ -393,6 +394,22 @@ fn check_table_request_inputs(
                 resolved_inputs,
             )?;
         }
+    }
+    Ok(())
+}
+
+fn check_function_request_inputs(
+    manifest: &HttpSourceManifest,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<()> {
+    for function in &manifest.functions {
+        validate_request_template_inputs(
+            &manifest.common.name,
+            &function.name,
+            "function request",
+            &function.request,
+            resolved_inputs,
+        )?;
     }
     Ok(())
 }
@@ -1205,6 +1222,21 @@ mod tests {
             }),
             ValueSourceSpec::FilterBool { key, default } => json!({
                 "from": "filter_bool",
+                "key": key,
+                "default": default,
+            }),
+            ValueSourceSpec::Arg { key, default } => json!({
+                "from": "arg",
+                "key": key,
+                "default": default,
+            }),
+            ValueSourceSpec::ArgInt { key, default } => json!({
+                "from": "arg_int",
+                "key": key,
+                "default": default,
+            }),
+            ValueSourceSpec::ArgBool { key, default } => json!({
+                "from": "arg_bool",
                 "key": key,
                 "default": default,
             }),

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -1,0 +1,162 @@
+//! `DataFusion` table functions for manifest-driven HTTP-backed sources.
+
+use std::sync::Arc;
+
+use datafusion::catalog::TableFunctionImpl;
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::Expr;
+use datafusion::scalar::ScalarValue;
+
+use coral_spec::backends::http::HttpTableSpec;
+use coral_spec::{FunctionArgBinding, SourceTableFunctionSpec, TableCommon};
+
+use crate::backends::http::HttpSourceClient;
+use crate::backends::http::provider::{BoundRequestArgs, HttpSourceTableProvider};
+use crate::backends::shared::filter_expr::literal_to_string;
+
+/// Table-valued function that turns manifest-declared function args into an
+/// `HTTP` table provider with pre-bound request filters.
+#[derive(Debug)]
+pub(crate) struct HttpSourceTableFunction {
+    backend: HttpSourceClient,
+    source_schema: String,
+    function: SourceTableFunctionSpec,
+}
+
+impl HttpSourceTableFunction {
+    pub(crate) fn new(
+        backend: HttpSourceClient,
+        source_schema: String,
+        function: SourceTableFunctionSpec,
+    ) -> Self {
+        Self {
+            backend,
+            source_schema,
+            function,
+        }
+    }
+}
+
+impl TableFunctionImpl for HttpSourceTableFunction {
+    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        let table = function_table_spec(&self.function);
+        let prebound = bind_function_args(&self.source_schema, &self.function, args)?;
+        Ok(Arc::new(
+            HttpSourceTableProvider::with_prebound_request_args(
+                self.backend.clone(),
+                self.source_schema.clone(),
+                table,
+                prebound,
+            )?,
+        ))
+    }
+}
+
+fn bind_function_args(
+    source_schema: &str,
+    function: &SourceTableFunctionSpec,
+    args: &[Expr],
+) -> Result<BoundRequestArgs> {
+    if args.len() > function.args.len() {
+        return Err(DataFusionError::Plan(format!(
+            "{}.{} expected at most {} arguments, got {}",
+            source_schema,
+            function.name,
+            function.args.len(),
+            args.len()
+        )));
+    }
+
+    let mut required_missing = Vec::new();
+    let mut bound = BoundRequestArgs::default();
+
+    for fixed in &function.fixed {
+        bind_value(&mut bound, &fixed.bind, &fixed.value);
+    }
+
+    for (index, spec) in function.args.iter().enumerate() {
+        let Some(expr) = args.get(index) else {
+            if spec.required {
+                required_missing.push(spec.name.as_str());
+            }
+            continue;
+        };
+        if is_null_literal(expr) {
+            if spec.required {
+                required_missing.push(spec.name.as_str());
+            }
+            continue;
+        }
+        let Some(value) = literal_to_string(expr) else {
+            return Err(DataFusionError::Plan(format!(
+                "{}.{} argument '{}' must be a literal",
+                source_schema, function.name, spec.name
+            )));
+        };
+        validate_arg_value(
+            source_schema,
+            function.name.as_str(),
+            spec.name.as_str(),
+            &value,
+            &spec.values,
+        )?;
+        bind_value(&mut bound, &spec.bind, &value);
+    }
+
+    if !required_missing.is_empty() {
+        return Err(DataFusionError::Plan(format!(
+            "{}.{} missing required argument(s): {}",
+            source_schema,
+            function.name,
+            required_missing.join(", ")
+        )));
+    }
+
+    Ok(bound)
+}
+
+fn is_null_literal(expr: &Expr) -> bool {
+    matches!(expr, Expr::Literal(ScalarValue::Null, _))
+}
+
+fn validate_arg_value(
+    source_schema: &str,
+    function_name: &str,
+    arg: &str,
+    value: &str,
+    arg_values: &[String],
+) -> Result<()> {
+    if !arg_values.is_empty() && !arg_values.iter().any(|allowed| allowed == value) {
+        return Err(DataFusionError::Plan(format!(
+            "{source_schema}.{function_name} argument '{arg}' has invalid value '{value}'; expected one of: {}",
+            arg_values.join(", ")
+        )));
+    }
+    Ok(())
+}
+
+fn bind_value(bound: &mut BoundRequestArgs, binding: &FunctionArgBinding, value: &str) {
+    match binding {
+        FunctionArgBinding::RequestArg { arg } => {
+            bound.insert_direct(arg.clone(), value.to_string());
+        }
+    }
+}
+
+fn function_table_spec(function: &SourceTableFunctionSpec) -> HttpTableSpec {
+    HttpTableSpec {
+        common: TableCommon::new(
+            function.name.clone(),
+            function.description.clone(),
+            String::new(),
+            vec![],
+            function.fetch_limit_default,
+            function.columns.clone(),
+        ),
+        request: function.request.clone(),
+        requests: vec![],
+        response: function.response.clone(),
+        pagination: function.pagination.clone(),
+    }
+}

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -11,14 +11,16 @@ use datafusion::prelude::SessionContext;
 
 use crate::RequestAuthenticator;
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
+    BackendCompileRequest, BackendRegistration, BackendTableFunctionRegistration,
+    CompiledBackendSource, RegisteredSource, RegisteredTable, build_registered_inputs,
+    build_registered_table, build_registered_table_function, internal_table_function_name,
     registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
 pub(crate) mod client;
 pub(crate) mod error;
+pub(crate) mod function;
 pub(crate) mod provider;
 mod rate_limit;
 
@@ -90,6 +92,26 @@ impl CompiledBackendSource for HttpCompiledSource {
             tables.insert(table.name().to_string(), provider);
             table_infos.push(registered_table(table));
         }
+        let mut table_functions = Vec::with_capacity(self.manifest.functions.len());
+        let mut table_function_infos = Vec::with_capacity(self.manifest.functions.len());
+        for function in &self.manifest.functions {
+            let internal_name =
+                internal_table_function_name(&self.manifest.common.name, &function.name);
+            let function_impl = function::HttpSourceTableFunction::new(
+                backend.clone(),
+                self.manifest.common.name.clone(),
+                function.clone(),
+            );
+            table_functions.push(BackendTableFunctionRegistration {
+                internal_name: internal_name.clone(),
+                function: Arc::new(function_impl),
+            });
+            table_function_infos.push(build_registered_table_function(
+                &self.manifest.common.name,
+                function,
+                internal_name,
+            ));
+        }
 
         let secret_keys = self.source_secrets.keys().cloned().collect();
         let inputs = build_registered_inputs(
@@ -100,9 +122,11 @@ impl CompiledBackendSource for HttpCompiledSource {
 
         Ok(BackendRegistration {
             tables,
+            table_functions,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                table_functions: table_function_infos,
                 inputs,
             },
         })

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -27,6 +27,12 @@ pub(crate) struct HttpSourceTableProvider {
     source_schema: String,
     table: HttpTableSpec,
     schema: SchemaRef,
+    prebound_request_args: BoundRequestArgs,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct BoundRequestArgs {
+    direct: HashMap<String, String>,
 }
 
 impl std::fmt::Debug for HttpSourceTableProvider {
@@ -56,7 +62,34 @@ impl HttpSourceTableProvider {
             source_schema,
             table,
             schema,
+            prebound_request_args: BoundRequestArgs::default(),
         })
+    }
+
+    pub(crate) fn with_prebound_request_args(
+        backend: HttpSourceClient,
+        source_schema: String,
+        table: HttpTableSpec,
+        prebound_request_args: BoundRequestArgs,
+    ) -> Result<Self> {
+        let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
+        Ok(Self {
+            backend,
+            source_schema,
+            table,
+            schema,
+            prebound_request_args,
+        })
+    }
+}
+
+impl BoundRequestArgs {
+    pub(crate) fn insert_direct(&mut self, arg: String, value: String) {
+        self.direct.insert(arg, value);
+    }
+
+    fn to_filter_values(&self) -> HashMap<String, String> {
+        self.direct.clone()
     }
 }
 
@@ -121,7 +154,8 @@ impl TableProvider for HttpSourceTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let filter_values = extract_filter_values(filters, self.table.filters());
+        let mut filter_values = self.prebound_request_args.to_filter_values();
+        filter_values.extend(extract_filter_values(filters, self.table.filters()));
 
         for required in self.table.filters().iter().filter(|f| f.required) {
             if !filter_values.contains_key(&required.name) {
@@ -134,6 +168,12 @@ impl TableProvider for HttpSourceTableProvider {
                 )));
             }
         }
+        validate_filter_values(
+            &self.source_schema,
+            self.table.name(),
+            self.table.filters(),
+            &filter_values,
+        )?;
 
         let fetcher = Arc::new(HttpFetchPlan {
             backend: self.backend.clone(),
@@ -160,6 +200,31 @@ impl TableProvider for HttpSourceTableProvider {
 
         Ok(Arc::new(exec))
     }
+}
+
+fn validate_filter_values(
+    schema: &str,
+    table: &str,
+    filters: &[coral_spec::FilterSpec],
+    values: &HashMap<String, String>,
+) -> Result<()> {
+    for filter in filters {
+        if filter.values.is_empty() {
+            continue;
+        }
+        let Some(value) = values.get(&filter.name) else {
+            continue;
+        };
+        if !filter.values.iter().any(|allowed| allowed == value) {
+            return Err(DataFusionError::Plan(format!(
+                "{schema}.{table} filter '{}' has invalid value '{}'; expected one of: {}",
+                filter.name,
+                value,
+                filter.values.join(", ")
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn classify_filter(

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -301,9 +301,11 @@ impl CompiledBackendSource for JsonlCompiledSource {
 
         Ok(BackendRegistration {
             tables,
+            table_functions: vec![],
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                table_functions: vec![],
                 inputs,
             },
         })

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -8,10 +8,11 @@ use coral_spec::ValidatedSourceManifest;
 
 pub(crate) mod common;
 pub(crate) use common::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    BackendCompileRequest, BackendRegistration, BackendTableFunctionRegistration,
+    CompiledBackendSource, RegisteredSource, RegisteredTable, RegisteredTableFunction,
+    build_registered_inputs, build_registered_table, build_registered_table_function,
+    internal_table_function_name, partition_columns_to_arrow, registered_columns_from_schema,
+    registered_columns_from_specs, required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod http;

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -247,9 +247,11 @@ impl CompiledBackendSource for ParquetCompiledSource {
 
         Ok(BackendRegistration {
             tables,
+            table_functions: vec![],
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                table_functions: vec![],
                 inputs,
             },
         })

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -187,11 +187,13 @@ mod tests {
                 name: "owner".into(),
                 required: true,
                 mode: FilterMode::default(),
+                values: vec![],
             },
             FilterSpec {
                 name: "status".into(),
                 required: true,
                 mode: FilterMode::default(),
+                values: vec![],
             },
         ];
 
@@ -208,6 +210,7 @@ mod tests {
             name: "repo".into(),
             required: false,
             mode: FilterMode::default(),
+            values: vec![],
         }];
 
         let expr = col("repo").in_list(vec![lit("coral")], false);
@@ -222,6 +225,7 @@ mod tests {
             name: "q".into(),
             required: false,
             mode: FilterMode::Search,
+            values: vec![],
         }];
 
         let expr = equality_expr("q", "deploy");
@@ -235,6 +239,7 @@ mod tests {
             name: "q".into(),
             required: false,
             mode: FilterMode::Equality,
+            values: vec![],
         }];
 
         let expr = like_expr("q", "%deploy%");
@@ -248,6 +253,7 @@ mod tests {
             name: "q".into(),
             required: false,
             mode: FilterMode::Search,
+            values: vec![],
         }];
 
         let values = extract_filter_values(&[like_expr("q", "%deploy")], &filters);
@@ -269,6 +275,7 @@ mod tests {
             name: "q".into(),
             required: false,
             mode: FilterMode::Search,
+            values: vec![],
         }];
 
         let expr = like_expr("q", "%deploy%");
@@ -283,6 +290,7 @@ mod tests {
             name: "descending".into(),
             required: false,
             mode: FilterMode::default(),
+            values: vec![],
         }];
 
         let values = extract_filter_values(&[col("descending")], &filters);
@@ -296,6 +304,7 @@ mod tests {
             name: "descending".into(),
             required: false,
             mode: FilterMode::default(),
+            values: vec![],
         }];
 
         let values = extract_filter_values(&[col("descending").not()], &filters);
@@ -309,6 +318,7 @@ mod tests {
             name: "descending".into(),
             required: false,
             mode: FilterMode::default(),
+            values: vec![],
         }];
 
         let cases = [
@@ -328,6 +338,7 @@ mod tests {
             name: "descending".into(),
             required: false,
             mode: FilterMode::default(),
+            values: vec![],
         }];
 
         for expr in [

--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -272,6 +272,7 @@ fn eval_template(
                     result.push_str(&rendered);
                 }
                 TemplateNamespace::Input
+                | TemplateNamespace::Arg
                 | TemplateNamespace::State
                 | TemplateNamespace::Other(_) => return None,
             },

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -14,22 +14,22 @@ pub(crate) static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(H
 /// Resolve one declarative value source into an optional JSON value.
 pub(crate) fn resolve_value_source(
     value: &ValueSourceSpec,
-    filters: &HashMap<String, String>,
+    request_values: &HashMap<String, String>,
     state: &HashMap<String, String>,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<Option<Value>> {
     match value {
         ValueSourceSpec::Template { template } => {
-            let rendered = render_template(template, filters, state, resolved_inputs)?;
+            let rendered = render_template(template, request_values, state, resolved_inputs)?;
             Ok(Some(Value::String(rendered)))
         }
         ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
-        ValueSourceSpec::Filter { key, default } => Ok(filters
+        ValueSourceSpec::Filter { key, default } => Ok(request_values
             .get(key)
             .map(|v| Value::String(v.clone()))
             .or_else(|| default.clone())),
         ValueSourceSpec::FilterInt { key, default } => {
-            let value = if let Some(filter) = filters.get(key) {
+            let value = if let Some(filter) = request_values.get(key) {
                 let parsed = filter.parse::<i64>().map_err(|error| {
                     DataFusionError::Execution(format!(
                         "filter '{key}' value '{filter}' is not a valid i64: {error}"
@@ -42,10 +42,40 @@ pub(crate) fn resolve_value_source(
             Ok(value)
         }
         ValueSourceSpec::FilterBool { key, default } => {
-            let value = if let Some(filter) = filters.get(key) {
+            let value = if let Some(filter) = request_values.get(key) {
                 let parsed = filter.parse::<bool>().map_err(|error| {
                     DataFusionError::Execution(format!(
                         "filter '{key}' value '{filter}' is not a valid bool: {error}"
+                    ))
+                })?;
+                Some(json!(parsed))
+            } else {
+                default.map(|value| json!(value))
+            };
+            Ok(value)
+        }
+        ValueSourceSpec::Arg { key, default } => Ok(request_values
+            .get(key)
+            .map(|v| Value::String(v.clone()))
+            .or_else(|| default.clone())),
+        ValueSourceSpec::ArgInt { key, default } => {
+            let value = if let Some(arg) = request_values.get(key) {
+                let parsed = arg.parse::<i64>().map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "argument '{key}' value '{arg}' is not a valid i64: {error}"
+                    ))
+                })?;
+                Some(json!(parsed))
+            } else {
+                default.map(|value| json!(value))
+            };
+            Ok(value)
+        }
+        ValueSourceSpec::ArgBool { key, default } => {
+            let value = if let Some(arg) = request_values.get(key) {
+                let parsed = arg.parse::<bool>().map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "argument '{key}' value '{arg}' is not a valid bool: {error}"
                     ))
                 })?;
                 Some(json!(parsed))
@@ -74,7 +104,7 @@ pub(crate) fn resolve_value_source(
 /// Render a parsed template into a concrete string.
 pub(crate) fn render_template(
     template: &ParsedTemplate,
-    filters: &HashMap<String, String>,
+    request_values: &HashMap<String, String>,
     state: &HashMap<String, String>,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<String> {
@@ -85,7 +115,7 @@ pub(crate) fn render_template(
             TemplatePart::Token(token) => {
                 out.push_str(&resolve_template_token(
                     token,
-                    filters,
+                    request_values,
                     state,
                     resolved_inputs,
                 )?);
@@ -97,7 +127,7 @@ pub(crate) fn render_template(
 
 fn resolve_template_token(
     token: &TemplateToken,
-    filters: &HashMap<String, String>,
+    request_values: &HashMap<String, String>,
     state: &HashMap<String, String>,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<String> {
@@ -116,13 +146,17 @@ fn resolve_template_token(
             });
     }
 
-    if token.namespace() == &TemplateNamespace::Filter {
-        return filters
+    if let Some(label) = match token.namespace() {
+        TemplateNamespace::Filter => Some("filter"),
+        TemplateNamespace::Arg => Some("argument"),
+        _ => None,
+    } {
+        return request_values
             .get(token.key())
             .cloned()
             .or(default)
             .ok_or_else(|| {
-                DataFusionError::Execution(format!("missing filter '{}'", token.key()))
+                DataFusionError::Execution(format!("missing {label} '{}'", token.key()))
             });
     }
 
@@ -191,6 +225,9 @@ pub(crate) fn validate_value_source_inputs(
         | ValueSourceSpec::Filter { .. }
         | ValueSourceSpec::FilterInt { .. }
         | ValueSourceSpec::FilterBool { .. }
+        | ValueSourceSpec::Arg { .. }
+        | ValueSourceSpec::ArgInt { .. }
+        | ValueSourceSpec::ArgBool { .. }
         | ValueSourceSpec::State { .. }
         | ValueSourceSpec::NowEpochMinusSeconds { .. } => Ok(()),
     }

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -27,12 +27,17 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
+    let table_functions_table = build_table_functions_table(active_sources)?;
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
     meta_tables.insert("columns".to_string(), Arc::new(columns_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
+    meta_tables.insert(
+        "table_functions".to_string(),
+        Arc::new(table_functions_table),
+    );
 
     let catalog = ctx
         .catalog("datafusion")
@@ -43,6 +48,64 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
     )?;
 
     Ok(())
+}
+
+fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("public_name", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+        Field::new("arguments_json", DataType::Utf8, false),
+        Field::new("result_columns_json", DataType::Utf8, false),
+    ]));
+
+    let mut rows = active_sources
+        .iter()
+        .flat_map(|source| source.table_functions.iter())
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
+    });
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.schema_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.public_name.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.kind.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.description.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.arguments_json.as_str()))
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.result_columns_json.as_str()))
+                    .collect::<StringArray>(),
+            ),
+        ],
+    )
+    .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
+
+    MemTable::try_new(schema, vec![vec![batch]])
 }
 
 /// Collect typed query-visible table metadata for the active source set.

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -7,6 +7,8 @@ use crate::backends::http::ProviderQueryError;
 use crate::contracts::{ColumnParts, StructuredQueryError};
 use crate::{CoreError, SourceDecoratorError, TableInfo};
 
+const INTERNAL_TABLE_FUNCTION_PREFIX: &str = "__coral_udtf_";
+
 pub(crate) fn datafusion_to_core(error: &DataFusionError, tables: &[TableInfo]) -> CoreError {
     // Unwrap Context/Shared/Diagnostic wrappers so wrapped schema errors
     // get classified by their root variant instead of all landing in the
@@ -75,7 +77,7 @@ fn schema_error_to_core(schema_error: &SchemaError) -> CoreError {
 /// downstream hint rendering distinguish `.` as a qualifier from `.` as a
 /// character in a quoted identifier.
 fn column_to_parts(column: &Column) -> ColumnParts {
-    let relation: Vec<String> = column
+    let mut relation: Vec<String> = column
         .relation
         .as_ref()
         .map(|reference| match reference {
@@ -90,6 +92,12 @@ fn column_to_parts(column: &Column) -> ColumnParts {
             } => vec![catalog.to_string(), schema.to_string(), table.to_string()],
         })
         .unwrap_or_default();
+    if relation
+        .last()
+        .is_some_and(|table| table.starts_with(INTERNAL_TABLE_FUNCTION_PREFIX))
+    {
+        relation.clear();
+    }
     ColumnParts {
         relation,
         name: column.name.clone(),
@@ -140,6 +148,39 @@ mod tests {
             CoreError::QueryFailure(sqe) => {
                 assert_eq!(sqe.reason(), UNKNOWN_COLUMN_REASON);
                 assert!(sqe.summary().contains("user_login"));
+            }
+            other => panic!("expected CoreError::QueryFailure, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unknown_column_hides_internal_table_function_names() {
+        let schema_err = Box::new(SchemaError::FieldNotFound {
+            field: Box::new(Column::new_unqualified("q")),
+            valid_fields: vec![
+                Column::new(
+                    Some(TableReference::bare(
+                        "__coral_udtf_676974687562_7365617263685f697373756573()",
+                    )),
+                    "title",
+                ),
+                Column::new(
+                    Some(TableReference::bare(
+                        "__coral_udtf_676974687562_7365617263685f697373756573()",
+                    )),
+                    "html_url",
+                ),
+            ],
+        });
+        let error = DataFusionError::SchemaError(schema_err, Box::new(None));
+
+        let core = datafusion_to_core(&error, &[]);
+
+        match core {
+            CoreError::QueryFailure(sqe) => {
+                assert!(sqe.detail().contains("title"));
+                assert!(sqe.detail().contains("html_url"));
+                assert!(!sqe.detail().contains("__coral_udtf_"));
             }
             other => panic!("expected CoreError::QueryFailure, got {other:?}"),
         }

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -8,3 +8,4 @@ pub(crate) mod pattern_validator;
 pub(crate) mod query;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;
+pub(crate) mod source_functions;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -13,6 +13,7 @@ use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
+use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     CoreError, EngineExtensions, QueryExecution, QueryRuntimeProvider, QuerySource, TableInfo,
 };
@@ -71,6 +72,17 @@ pub(crate) async fn build_runtime(
     catalog::register(&ctx, &registration.active_sources)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_tables(&registration.active_sources);
+    let source_functions = SourceFunctionRegistry::new(
+        registration
+            .active_sources
+            .iter()
+            .flat_map(|source| source.table_functions.iter().cloned())
+            .collect(),
+    );
+    if !source_functions.is_empty() {
+        ctx.register_relation_planner(Arc::new(source_functions))
+            .map_err(|err| datafusion_to_core(&err, &tables))?;
+    }
     for failure in &registration.failures {
         tracing::warn!(
             source = %failure.schema_name,

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 
-use crate::backends::{BackendRegistration, CompiledBackendSource, RegisteredSource};
+use crate::backends::{
+    BackendRegistration, BackendTableFunctionRegistration, CompiledBackendSource, RegisteredSource,
+};
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
@@ -102,8 +104,10 @@ pub(crate) async fn register_sources(
                     Ok(registration) => {
                         let BackendRegistration {
                             tables,
+                            table_functions,
                             source: registered_source,
                         } = registration;
+                        register_table_functions(ctx, table_functions);
                         let decorated_tables =
                             decorate_source_tables(source_decorators, query_source, tables)?;
                         match catalog.register_schema(
@@ -120,17 +124,12 @@ pub(crate) async fn register_sources(
                                 )? {
                                     return Err(core_error);
                                 }
-                                let failure = SourceRegistrationFailure {
-                                    schema_name,
-                                    detail: core_error.to_string(),
-                                };
-                                tracing::warn!(
-                                    source = %source_name,
-                                    schema_name = %failure.schema_name,
-                                    detail = %failure.detail,
-                                    "skipping source"
+                                push_source_failure(
+                                    &mut result,
+                                    &source_name,
+                                    &schema_name,
+                                    core_error.to_string(),
                                 );
-                                result.failures.push(failure);
                             }
                         }
                     }
@@ -143,17 +142,12 @@ pub(crate) async fn register_sources(
                         )? {
                             return Err(core_error);
                         }
-                        let failure = SourceRegistrationFailure {
-                            schema_name,
-                            detail: core_error.to_string(),
-                        };
-                        tracing::warn!(
-                            source = %source_name,
-                            schema_name = %failure.schema_name,
-                            detail = %failure.detail,
-                            "skipping source"
+                        push_source_failure(
+                            &mut result,
+                            &source_name,
+                            &schema_name,
+                            core_error.to_string(),
                         );
-                        result.failures.push(failure);
                     }
                 }
             }
@@ -161,17 +155,12 @@ pub(crate) async fn register_sources(
                 if handle_source_registration_failure(source_decorators, &source, &error)? {
                     return Err(error);
                 }
-                let failure = SourceRegistrationFailure {
-                    schema_name: source.source_name().to_string(),
-                    detail: error.to_string(),
-                };
-                tracing::warn!(
-                    source = %source.source_name(),
-                    schema_name = %failure.schema_name,
-                    detail = %failure.detail,
-                    "skipping source"
+                push_source_failure(
+                    &mut result,
+                    source.source_name(),
+                    source.source_name(),
+                    error.to_string(),
                 );
-                result.failures.push(failure);
             }
         }
     }
@@ -212,6 +201,34 @@ async fn register_source(
     }
 
     source.register(ctx).await
+}
+
+fn push_source_failure(
+    result: &mut SourceRegistrationResult,
+    source_name: &str,
+    schema_name: &str,
+    detail: String,
+) {
+    let failure = SourceRegistrationFailure {
+        schema_name: schema_name.to_string(),
+        detail,
+    };
+    tracing::warn!(
+        source = %source_name,
+        schema_name = %failure.schema_name,
+        detail = %failure.detail,
+        "skipping source"
+    );
+    result.failures.push(failure);
+}
+
+fn register_table_functions(
+    ctx: &SessionContext,
+    table_functions: Vec<BackendTableFunctionRegistration>,
+) {
+    for table_function in table_functions {
+        ctx.register_udtf(&table_function.internal_name, table_function.function);
+    }
 }
 
 fn prepare_source_decorators(

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -1,0 +1,191 @@
+//! Source-scoped table function relation planning.
+
+use std::collections::{HashMap, HashSet};
+
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::planner::{
+    PlannedRelation, RelationPlanner, RelationPlannerContext, RelationPlanning,
+};
+use datafusion::logical_expr::sqlparser::ast::{
+    Expr, FunctionArg, FunctionArgExpr, Ident, ObjectName, TableFactor, TableFunctionArgs, Value,
+};
+
+use crate::backends::RegisteredTableFunction;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SourceFunctionRegistry {
+    functions: HashMap<(String, String), RegisteredTableFunction>,
+    schemas: HashSet<String>,
+}
+
+impl SourceFunctionRegistry {
+    pub(crate) fn new(functions: Vec<RegisteredTableFunction>) -> Self {
+        let schemas = functions
+            .iter()
+            .map(|function| function.schema_name.clone())
+            .collect();
+        let functions = functions
+            .into_iter()
+            .map(|function| {
+                (
+                    (function.schema_name.clone(), function.function_name.clone()),
+                    function,
+                )
+            })
+            .collect();
+        Self { functions, schemas }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.functions.is_empty()
+    }
+}
+
+impl RelationPlanner for SourceFunctionRegistry {
+    fn plan_relation(
+        &self,
+        relation: TableFactor,
+        context: &mut dyn RelationPlannerContext,
+    ) -> Result<RelationPlanning> {
+        let TableFactor::Table {
+            name,
+            alias,
+            args: Some(args),
+            with_hints,
+            version,
+            with_ordinality,
+            partitions,
+            json_path,
+            sample,
+            index_hints,
+        } = relation
+        else {
+            return Ok(RelationPlanning::Original(Box::new(relation)));
+        };
+
+        let Some((schema, function_name)) = source_function_name(&name) else {
+            return Ok(RelationPlanning::Original(Box::new(TableFactor::Table {
+                name,
+                alias,
+                args: Some(args),
+                with_hints,
+                version,
+                with_ordinality,
+                partitions,
+                json_path,
+                sample,
+                index_hints,
+            })));
+        };
+        let Some(function) = self.functions.get(&(schema.clone(), function_name.clone())) else {
+            if self.schemas.contains(&schema) {
+                return Err(DataFusionError::Plan(format!(
+                    "unknown source table function {schema}.{function_name}"
+                )));
+            }
+            return Ok(RelationPlanning::Original(Box::new(TableFactor::Table {
+                name,
+                alias,
+                args: Some(args),
+                with_hints,
+                version,
+                with_ordinality,
+                partitions,
+                json_path,
+                sample,
+                index_hints,
+            })));
+        };
+
+        let internal_relation = TableFactor::Table {
+            name: ObjectName::from(vec![Ident::new(function.internal_name.clone())]),
+            alias,
+            args: Some(TableFunctionArgs {
+                args: lower_args(function, &args)?,
+                settings: None,
+            }),
+            with_hints,
+            version,
+            with_ordinality,
+            partitions,
+            json_path,
+            sample,
+            index_hints,
+        };
+        let plan = context.plan(internal_relation)?;
+        Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
+            plan, None,
+        ))))
+    }
+}
+
+fn source_function_name(name: &ObjectName) -> Option<(String, String)> {
+    if name.0.len() != 2 {
+        return None;
+    }
+    let schema = canonical_ident(name.0[0].as_ident()?);
+    let function = canonical_ident(name.0[1].as_ident()?);
+    Some((schema, function))
+}
+
+fn canonical_ident(ident: &Ident) -> String {
+    if ident.quote_style.is_some() {
+        ident.value.clone()
+    } else {
+        ident.value.to_ascii_lowercase()
+    }
+}
+
+fn lower_args(
+    function: &RegisteredTableFunction,
+    args: &TableFunctionArgs,
+) -> Result<Vec<FunctionArg>> {
+    let mut named = HashMap::new();
+    let mut seen = HashSet::new();
+    for arg in &args.args {
+        match arg {
+            FunctionArg::Named { name, arg, .. } => {
+                let key = canonical_ident(name);
+                if !seen.insert(key.clone()) {
+                    return Err(DataFusionError::Plan(format!(
+                        "{} duplicate argument '{}'",
+                        function.public_name, name.value
+                    )));
+                }
+                named.insert(key, arg.clone());
+            }
+            FunctionArg::Unnamed(_) => {
+                return Err(DataFusionError::Plan(format!(
+                    "{} requires named arguments",
+                    function.public_name
+                )));
+            }
+            FunctionArg::ExprNamed { .. } => {
+                return Err(DataFusionError::Plan(format!(
+                    "{} requires identifier argument names",
+                    function.public_name
+                )));
+            }
+        }
+    }
+
+    for key in named.keys() {
+        if !function.arg_names.iter().any(|arg| arg == key) {
+            return Err(DataFusionError::Plan(format!(
+                "{} unknown argument '{}'",
+                function.public_name, key
+            )));
+        }
+    }
+
+    Ok(function
+        .arg_names
+        .iter()
+        .map(|arg| {
+            let expr = named
+                .remove(&arg.to_ascii_lowercase())
+                .unwrap_or_else(|| FunctionArgExpr::Expr(Expr::value(Value::Null)));
+            FunctionArg::Unnamed(expr)
+        })
+        .collect())
+}

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -40,6 +40,49 @@ fn base_http_manifest(name: &str, base_url: &str) -> Value {
     })
 }
 
+fn github_like_search_manifest(base_url: &str) -> Value {
+    json!({
+        "name": "github_like",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "tables": [],
+        "functions": [{
+            "name": "search_issues",
+            "kind": "search",
+            "description": "Search issues",
+            "args": [
+                {
+                    "name": "q",
+                    "required": true,
+                    "bind": { "kind": "request_arg", "arg": "q" }
+                },
+                {
+                    "name": "mode",
+                    "values": ["lexical", "semantic", "hybrid"],
+                    "bind": { "kind": "request_arg", "arg": "search_type" }
+                }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/api/search/issues",
+                "query": [
+                    { "name": "q", "from": "arg", "key": "q" },
+                    { "name": "search_type", "from": "arg", "key": "search_type" }
+                ]
+            },
+            "response": { "rows_path": ["items"] },
+            "columns": [
+                { "name": "title", "type": "Utf8" },
+                { "name": "html_url", "type": "Utf8" },
+                { "name": "score", "type": "Float64" },
+                { "name": "state", "type": "Utf8" }
+            ]
+        }]
+    })
+}
+
 #[derive(Debug)]
 struct TestRequestAuthenticator;
 
@@ -239,6 +282,153 @@ async fn select_with_where_filter_pushdown() {
     );
 
     assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_builds_http_search_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky cleanup",
+                "html_url": "https://github.com/withcoral/coral/issues/1",
+                "score": 9.5,
+                "state": "open"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let source = build_source(github_like_search_manifest(&server.uri()));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            &TestRuntime,
+            "SELECT issue.title, issue.html_url, issue.score \
+             FROM GITHUB_LIKE.SEARCH_ISSUES(Q => 'flaky cleanup repo:withcoral/coral', MODE => 'hybrid') AS issue \
+             WHERE issue.state = 'open' \
+             LIMIT 10",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky cleanup",
+            "html_url": "https://github.com/withcoral/coral/issues/1",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn table_function_discovery_lists_source_functions() {
+    let server = MockServer::start().await;
+    let manifest = json!({
+        "name": "discoverable",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": server.uri(),
+        "tables": [],
+        "functions": [{
+            "name": "search_issues",
+            "kind": "search",
+            "description": "Search issues",
+            "args": [
+                {
+                    "name": "q",
+                    "required": true,
+                    "bind": { "kind": "request_arg", "arg": "q" }
+                },
+                {
+                    "name": "mode",
+                    "values": ["lexical", "semantic", "hybrid"],
+                    "bind": { "kind": "request_arg", "arg": "search_type" }
+                }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/api/search/issues",
+                "query": [
+                    { "name": "q", "from": "arg", "key": "q" },
+                    { "name": "search_type", "from": "arg", "key": "search_type" }
+                ]
+            },
+            "columns": [
+                { "name": "title", "type": "Utf8" },
+                { "name": "score", "type": "Float64" }
+            ]
+        }]
+    });
+
+    let source = build_source(manifest);
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            &TestRuntime,
+            "SELECT schema_name, public_name, kind, arguments_json, result_columns_json \
+             FROM coral.table_functions \
+             WHERE schema_name = 'discoverable'",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "schema_name": "discoverable",
+            "public_name": "discoverable.search_issues",
+            "kind": "search",
+            "arguments_json": "[{\"name\":\"q\",\"required\":true,\"values\":[]},{\"name\":\"mode\",\"required\":false,\"values\":[\"lexical\",\"semantic\",\"hybrid\"]}]",
+            "result_columns_json": "[{\"name\":\"title\",\"type\":\"Utf8\",\"nullable\":true,\"description\":\"\"},{\"name\":\"score\",\"type\":\"Float64\",\"nullable\":true,\"description\":\"\"}]"
+        })]
+    );
+}
+
+#[tokio::test]
+async fn table_function_does_not_expose_request_args_as_columns() {
+    let server = MockServer::start().await;
+    let manifest = json!({
+        "name": "conflict_search",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": server.uri(),
+        "tables": [],
+        "functions": [{
+            "name": "search_issues",
+            "kind": "search",
+            "args": [{
+                "name": "q",
+                "required": true,
+                "bind": { "kind": "request_arg", "arg": "q" }
+            }],
+            "request": {
+                "method": "GET",
+                "path": "/api/search/issues",
+                "query": [{ "name": "q", "from": "arg", "key": "q" }]
+            },
+            "columns": [{ "name": "title", "type": "Utf8" }]
+        }]
+    });
+
+    let source = build_source(manifest);
+    let error = CoralQuery::execute_sql(
+        &[source],
+        &TestRuntime,
+        "SELECT title FROM conflict_search.search_issues(q => 'flaky') WHERE q = 'raw'",
+    )
+    .await
+    .expect_err("request args should not be queryable as result columns");
+
+    assert!(error.to_string().contains('q'), "unexpected error: {error}");
 }
 
 #[tokio::test]

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -10,6 +10,9 @@ Always inspect queryable tables and table metadata before writing queries:
 -- List visible tables, descriptions, and required filters
 SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
 
+-- List source-scoped table functions, such as provider-native search
+SELECT schema_name, public_name, kind, arguments_json, result_columns_json FROM coral.table_functions ORDER BY schema_name, public_name;
+
 -- Inspect columns for one visible table
 {{COLUMNS_EXAMPLE}}
 ```
@@ -48,6 +51,7 @@ FROM source.events;
 ## Query Guidance
 
 - Fully qualify tables in SQL, for example `slack.messages`.
+- Prefer source-scoped table functions for provider-native search when available, for example `github.search_issues(q => 'deploy failure repo:withcoral/coral')`.
 - Check `coral.tables.required_filters` and `coral.columns.is_required_filter` before querying tables that depend on filter-only inputs.
 - Cross-source joins work with standard SQL after source scans complete.
 - `list_tables` and `coral://tables` show queryable fully qualified tables; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -16,10 +16,12 @@ use serde::Deserialize;
 use serde_json::{Map, Value};
 
 use crate::{
-    ColumnSpec, FilterSpec, HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec,
-    PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
-    SourceBackend, SourceManifestCommon, TableCommon, inputs::collect_source_inputs_value,
-    validate::validate_template, validate_http_table, validate_test_queries,
+    ColumnSpec, FilterSpec, FunctionArgBinding, HeaderSpec, ManifestError, ManifestInputKind,
+    ManifestInputSpec, PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec,
+    Result, SourceBackend, SourceManifestCommon, SourceTableFunctionSpec, TableCommon,
+    inputs::collect_source_inputs_value,
+    validate::{validate_columns, validate_template, validate_unique_values},
+    validate_http_table, validate_test_queries,
 };
 
 /// Source-level authentication requirements for HTTP-backed source specs.
@@ -90,6 +92,7 @@ pub struct HttpSourceManifest {
     pub request_headers: Vec<HeaderSpec>,
     pub rate_limit: RateLimitSpec,
     pub tables: Vec<HttpTableSpec>,
+    pub functions: Vec<SourceTableFunctionSpec>,
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
@@ -115,6 +118,8 @@ struct RawHttpSourceManifest {
     #[serde(default)]
     inputs: Option<Value>,
     tables: Vec<RawHttpTableSpec>,
+    #[serde(default)]
+    functions: Vec<SourceTableFunctionSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -261,6 +266,7 @@ impl HttpSourceManifest {
             rate_limit,
             inputs: _inputs,
             tables,
+            functions,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
         let common =
@@ -268,6 +274,11 @@ impl HttpSourceManifest {
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))
+            .collect::<Result<Vec<_>>>()?;
+        validate_http_function_names(&common.name, &functions)?;
+        let functions = functions
+            .into_iter()
+            .map(|function| function.into_validated_http(&common.name))
             .collect::<Result<Vec<_>>>()?;
         if base_url.raw().trim().is_empty() {
             return Err(ManifestError::validation(format!(
@@ -288,9 +299,266 @@ impl HttpSourceManifest {
             request_headers,
             rate_limit,
             tables,
+            functions,
             declared_inputs,
         })
     }
+}
+
+impl SourceTableFunctionSpec {
+    fn into_validated_http(self, source_name: &str) -> Result<Self> {
+        validate_http_function(source_name, &self)?;
+        Ok(self)
+    }
+}
+
+fn validate_http_function_names(
+    source_name: &str,
+    functions: &[SourceTableFunctionSpec],
+) -> Result<()> {
+    let mut function_names = HashSet::new();
+
+    for function in functions {
+        validate_identifier(
+            &function.name,
+            &format!("source '{source_name}' function name"),
+        )?;
+        if !function_names.insert(function.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' function '{}' is declared more than once",
+                function.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_http_function(source_name: &str, function: &SourceTableFunctionSpec) -> Result<()> {
+    validate_identifier(
+        &function.name,
+        &format!("source '{source_name}' function name"),
+    )?;
+
+    let mut arg_names = HashSet::new();
+    let mut request_arg_names = HashSet::new();
+    let mut direct_targets = HashSet::new();
+
+    for fixed in &function.fixed {
+        validate_function_binding(
+            source_name,
+            &function.name,
+            &fixed.bind,
+            &mut request_arg_names,
+            &mut direct_targets,
+        )?;
+    }
+
+    for arg in &function.args {
+        validate_identifier(
+            &arg.name,
+            &format!(
+                "source '{source_name}' function '{}' argument",
+                function.name
+            ),
+        )?;
+        if !arg_names.insert(arg.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' function '{}' argument '{}' is declared more than once",
+                function.name, arg.name
+            )));
+        }
+        validate_unique_values(
+            &arg.values,
+            &format!(
+                "source '{source_name}' function '{}' argument '{}'",
+                function.name, arg.name
+            ),
+        )?;
+        validate_function_binding(
+            source_name,
+            &function.name,
+            &arg.bind,
+            &mut request_arg_names,
+            &mut direct_targets,
+        )?;
+    }
+
+    validate_columns(
+        &function.columns,
+        source_name,
+        &format!("function '{}'", function.name),
+    )?;
+    validate_function_request_bindings(source_name, function, &request_arg_names)?;
+    function
+        .pagination
+        .validate(source_name, &format!("function '{}'", function.name))?;
+
+    Ok(())
+}
+
+fn binding_target(binding: &FunctionArgBinding) -> &str {
+    match binding {
+        FunctionArgBinding::RequestArg { arg } => arg,
+    }
+}
+
+fn validate_function_binding<'a>(
+    source_name: &str,
+    function_name: &str,
+    binding: &'a FunctionArgBinding,
+    request_arg_names: &mut HashSet<&'a str>,
+    direct_targets: &mut HashSet<&'a str>,
+) -> Result<()> {
+    let target = binding_target(binding);
+    request_arg_names.insert(target);
+
+    match binding {
+        FunctionArgBinding::RequestArg { arg } => {
+            if !direct_targets.insert(arg.as_str()) {
+                return Err(ManifestError::validation(format!(
+                    "source '{source_name}' function '{function_name}' has multiple direct bindings for request arg '{arg}'"
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_function_request_bindings(
+    source_name: &str,
+    function: &SourceTableFunctionSpec,
+    request_arg_names: &HashSet<&str>,
+) -> Result<()> {
+    if function.request.path.raw().trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' function '{}' has an empty request.path",
+            function.name
+        )));
+    }
+
+    validate_arg_template(
+        &function.request.path,
+        request_arg_names,
+        &format!("source '{source_name}' function '{}'", function.name),
+    )?;
+
+    for header in &function.request.headers {
+        validate_arg_value_source(
+            &header.value,
+            request_arg_names,
+            &format!(
+                "source '{source_name}' function '{}' request header '{}'",
+                function.name, header.name
+            ),
+        )?;
+    }
+
+    for param in &function.request.query {
+        validate_arg_value_source(
+            &param.value,
+            request_arg_names,
+            &format!(
+                "source '{source_name}' function '{}' query param '{}'",
+                function.name, param.name
+            ),
+        )?;
+    }
+
+    for field in &function.request.body {
+        validate_arg_value_source(
+            &field.value,
+            request_arg_names,
+            &format!(
+                "source '{source_name}' function '{}' request body path '{}'",
+                function.name,
+                field.path.join(".")
+            ),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_arg_value_source(
+    source: &crate::ValueSourceSpec,
+    request_arg_names: &HashSet<&str>,
+    context: &str,
+) -> Result<()> {
+    match source {
+        crate::ValueSourceSpec::Arg { key, .. }
+        | crate::ValueSourceSpec::ArgInt { key, .. }
+        | crate::ValueSourceSpec::ArgBool { key, .. }
+            if !request_arg_names.contains(key.as_str()) =>
+        {
+            return Err(ManifestError::validation(format!(
+                "{context} references unknown request arg '{key}'"
+            )));
+        }
+        crate::ValueSourceSpec::Filter { key, .. }
+        | crate::ValueSourceSpec::FilterInt { key, .. }
+        | crate::ValueSourceSpec::FilterBool { key, .. } => {
+            return Err(ManifestError::validation(format!(
+                "{context} uses table filter '{key}' inside a function request"
+            )));
+        }
+        crate::ValueSourceSpec::Template { template } => {
+            validate_arg_template(template, request_arg_names, context)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_arg_template(
+    template: &ParsedTemplate,
+    request_arg_names: &HashSet<&str>,
+    context: &str,
+) -> Result<()> {
+    for token in template.tokens() {
+        match token.namespace() {
+            crate::TemplateNamespace::Arg => {
+                if !request_arg_names.contains(token.key()) {
+                    return Err(ManifestError::validation(format!(
+                        "{context} references unknown request arg '{}' in template '{}'",
+                        token.key(),
+                        template.raw()
+                    )));
+                }
+            }
+            crate::TemplateNamespace::Input | crate::TemplateNamespace::State => {}
+            crate::TemplateNamespace::Filter
+            | crate::TemplateNamespace::Expr
+            | crate::TemplateNamespace::Other(_) => {
+                return Err(ManifestError::validation(format!(
+                    "{context} uses unsupported function request template token '{}'",
+                    token.raw()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_identifier(value: &str, context: &str) -> Result<()> {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err(ManifestError::validation(format!(
+            "{context} must not be empty"
+        )));
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return Err(ManifestError::validation(format!(
+            "{context} '{value}' must start with a letter or underscore"
+        )));
+    }
+    if chars.any(|ch| !(ch == '_' || ch.is_ascii_alphanumeric())) {
+        return Err(ManifestError::validation(format!(
+            "{context} '{value}' may only contain letters, numbers, and underscores"
+        )));
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -313,5 +581,73 @@ pub(crate) fn test_http_table_spec(
         requests: vec![],
         response: ResponseSpec::default(),
         pagination: PaginationSpec::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        FunctionArgBinding, QueryParamSpec, RequestSpec, SourceTableFunctionSpec,
+        TableFunctionArgSpec, ValueSourceSpec,
+    };
+
+    use super::validate_http_function;
+
+    fn function_with_request_value(value: ValueSourceSpec) -> SourceTableFunctionSpec {
+        SourceTableFunctionSpec {
+            name: "search".to_string(),
+            kind: String::new(),
+            description: String::new(),
+            fetch_limit_default: None,
+            fixed: vec![],
+            args: vec![TableFunctionArgSpec {
+                name: "query".to_string(),
+                required: true,
+                values: vec![],
+                bind: FunctionArgBinding::RequestArg {
+                    arg: "q".to_string(),
+                },
+            }],
+            request: RequestSpec {
+                path: crate::ParsedTemplate::parse("/search").expect("request path"),
+                query: vec![QueryParamSpec {
+                    name: "q".to_string(),
+                    value,
+                }],
+                ..RequestSpec::default()
+            },
+            response: crate::ResponseSpec::default(),
+            pagination: crate::PaginationSpec::default(),
+            columns: vec![],
+        }
+    }
+
+    #[test]
+    fn validate_http_function_rejects_table_filter_value_sources() {
+        let cases = [
+            ValueSourceSpec::Filter {
+                key: "q".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::FilterInt {
+                key: "limit".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::FilterBool {
+                key: "archived".to_string(),
+                default: None,
+            },
+        ];
+
+        for value in cases {
+            let function = function_with_request_value(value);
+            let error = validate_http_function("demo", &function)
+                .expect_err("function requests should reject table filters");
+
+            assert!(
+                error.to_string().contains("uses table filter"),
+                "unexpected error: {error}"
+            );
+        }
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -27,7 +27,7 @@ pub struct SourceManifestCommon {
 }
 
 impl SourceManifestCommon {
-    pub(crate) fn new(
+    pub fn new(
         dsl_version: u32,
         name: String,
         version: String,
@@ -101,7 +101,7 @@ pub struct TableCommon {
 }
 
 impl TableCommon {
-    pub(crate) fn new(
+    pub fn new(
         name: String,
         description: String,
         guide: String,
@@ -141,6 +141,58 @@ pub struct FilterSpec {
     pub required: bool,
     #[serde(default)]
     pub mode: FilterMode,
+    #[serde(default)]
+    pub values: Vec<String>,
+}
+
+/// Declarative table-valued function backed by a manifest table.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SourceTableFunctionSpec {
+    pub name: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub fetch_limit_default: Option<usize>,
+    #[serde(default)]
+    pub fixed: Vec<FixedFunctionBinding>,
+    #[serde(default)]
+    pub args: Vec<TableFunctionArgSpec>,
+    #[serde(default)]
+    pub request: RequestSpec,
+    #[serde(default)]
+    pub response: ResponseSpec,
+    #[serde(default)]
+    pub pagination: PaginationSpec,
+    #[serde(default)]
+    pub columns: Vec<ColumnSpec>,
+}
+
+/// One argument accepted by a source-scoped table-valued function.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TableFunctionArgSpec {
+    pub name: String,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub values: Vec<String>,
+    pub bind: FunctionArgBinding,
+}
+
+/// One constant binding supplied by a source-scoped table-valued function.
+#[derive(Debug, Clone, Deserialize)]
+pub struct FixedFunctionBinding {
+    #[serde(flatten)]
+    pub bind: FunctionArgBinding,
+    pub value: String,
+}
+
+/// How a table function argument contributes to the provider request.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum FunctionArgBinding {
+    RequestArg { arg: String },
 }
 
 /// The base request template for one HTTP table or request route.
@@ -216,6 +268,21 @@ pub enum ValueSourceSpec {
         default: Option<i64>,
     },
     FilterBool {
+        key: String,
+        #[serde(default)]
+        default: Option<bool>,
+    },
+    Arg {
+        key: String,
+        #[serde(default)]
+        default: Option<Value>,
+    },
+    ArgInt {
+        key: String,
+        #[serde(default)]
+        default: Option<i64>,
+    },
+    ArgBool {
         key: String,
         #[serde(default)]
         default: Option<bool>,
@@ -693,6 +760,7 @@ mod tests {
                 name: "id".into(),
                 required: false,
                 mode: FilterMode::default(),
+                values: vec![],
             }],
             RequestSpec {
                 method: HttpMethod::GET,
@@ -728,11 +796,13 @@ mod tests {
                     name: "id".into(),
                     required: false,
                     mode: FilterMode::default(),
+                    values: vec![],
                 },
                 FilterSpec {
                     name: "org".into(),
                     required: false,
                     mode: FilterMode::default(),
+                    values: vec![],
                 },
             ],
             RequestSpec {

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -88,10 +88,12 @@ mod validate;
 pub use backends::http::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 pub(crate) use common::validate_test_queries;
 pub use common::{
-    BodyFieldSpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, HeaderSpec, HttpMethod,
-    ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,
-    RequestRouteSpec, RequestSpec, ResponseSpec, RowStrategy, SourceBackend, SourceManifestCommon,
-    TableCommon, TimestampInput, ValidatedPagination, ValidatedPaginationMode, ValueSourceSpec,
+    BodyFieldSpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, FixedFunctionBinding,
+    FunctionArgBinding, HeaderSpec, HttpMethod, ManifestDataType, PageSizeSpec, PaginationMode,
+    PaginationSpec, QueryParamSpec, RequestRouteSpec, RequestSpec, ResponseSpec, RowStrategy,
+    SourceBackend, SourceManifestCommon, SourceTableFunctionSpec, TableCommon,
+    TableFunctionArgSpec, TimestampInput, ValidatedPagination, ValidatedPaginationMode,
+    ValueSourceSpec,
 };
 pub use error::{ManifestError, Result};
 pub use inputs::{ManifestInputKind, ManifestInputSpec, resolve_inputs};

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -25,8 +25,11 @@
     "rate_limit": { "$ref": "#/$defs/rate_limit" },
     "tables": {
       "type": "array",
-      "minItems": 1,
       "items": { "$ref": "#/$defs/table" }
+    },
+    "functions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/table_function" }
     },
     "onboarding": {
       "type": "object",
@@ -201,7 +204,72 @@
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "required": { "type": "boolean" },
-        "mode": { "type": "string", "enum": ["equality", "search", "contains"] }
+        "mode": { "type": "string", "enum": ["equality", "search", "contains"] },
+        "values": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "table_function": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "request"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "fetch_limit_default": { "type": "integer", "minimum": 1 },
+        "fixed": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/fixed_function_binding" }
+        },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/table_function_arg" }
+        },
+        "request": { "$ref": "#/$defs/request" },
+        "response": { "$ref": "#/$defs/response" },
+        "pagination": { "$ref": "#/$defs/pagination" },
+        "columns": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/column" }
+        }
+      }
+    },
+    "table_function_arg": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "bind"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "required": { "type": "boolean" },
+        "values": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "bind": { "$ref": "#/$defs/function_binding" }
+      }
+    },
+    "fixed_function_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "arg", "value"],
+      "properties": {
+        "kind": { "const": "request_arg" },
+        "arg": { "type": "string", "minLength": 1 },
+        "value": { "type": "string" }
+      }
+    },
+    "function_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "arg"],
+      "properties": {
+        "kind": { "const": "request_arg" },
+        "arg": { "type": "string", "minLength": 1 }
       }
     },
     "request": {
@@ -324,6 +392,29 @@
         {
           "properties": {
             "from": { "const": "filter_bool" },
+            "key": { "type": "string", "minLength": 1 },
+            "default": { "type": "boolean" }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
+            "from": { "const": "arg" },
+            "key": { "type": "string", "minLength": 1 }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
+            "from": { "const": "arg_int" },
+            "key": { "type": "string", "minLength": 1 },
+            "default": { "type": "integer" }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
+            "from": { "const": "arg_bool" },
             "key": { "type": "string", "minLength": 1 },
             "default": { "type": "boolean" }
           },

--- a/crates/coral-spec/src/template.rs
+++ b/crates/coral-spec/src/template.rs
@@ -172,6 +172,8 @@ pub enum TemplateNamespace {
     Input,
     /// A SQL filter token.
     Filter,
+    /// A function-local request argument token.
+    Arg,
     /// A row-expression sub-expression token.
     Expr,
     /// A runtime pagination or request state token.
@@ -185,6 +187,7 @@ impl TemplateNamespace {
         match raw {
             "input" => Self::Input,
             "filter" => Self::Filter,
+            "arg" => Self::Arg,
             "expr" => Self::Expr,
             "state" => Self::State,
             other => Self::Other(other.to_string()),

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -65,6 +65,10 @@ pub(crate) fn validate_filters_and_column_exprs(
                 filter.name
             )));
         }
+        validate_unique_values(
+            &filter.values,
+            &format!("{schema}.{table} filter '{}'", filter.name),
+        )?;
     }
 
     for col in columns {
@@ -78,6 +82,23 @@ pub(crate) fn validate_filters_and_column_exprs(
     }
 
     Ok(known_filters)
+}
+
+pub(crate) fn validate_unique_values(values: &[String], context: &str) -> Result<()> {
+    let mut seen = HashSet::new();
+    for value in values {
+        if value.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "{context} values must not contain empty strings"
+            )));
+        }
+        if !seen.insert(value.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "{context} value '{value}' is declared more than once"
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_columns(columns: &[ColumnSpec], schema: &str, table: &str) -> Result<()> {
@@ -153,6 +174,13 @@ fn validate_value_source(
         }
         ValueSourceSpec::Template { template } => {
             validate_template(template, known_filters, context)?;
+        }
+        ValueSourceSpec::Arg { key, .. }
+        | ValueSourceSpec::ArgInt { key, .. }
+        | ValueSourceSpec::ArgBool { key, .. } => {
+            return Err(ManifestError::validation(format!(
+                "{context} uses function argument '{key}' outside a function request"
+            )));
         }
         _ => {}
     }
@@ -231,7 +259,10 @@ fn validate_expr_template(
                     )));
                 }
             }
-            TemplateNamespace::Input | TemplateNamespace::State | TemplateNamespace::Other(_) => {
+            TemplateNamespace::Input
+            | TemplateNamespace::Arg
+            | TemplateNamespace::State
+            | TemplateNamespace::Other(_) => {
                 return Err(ManifestError::validation(format!(
                     "{context} uses unsupported expr template token '{}'",
                     token.raw()
@@ -260,6 +291,12 @@ pub(crate) fn validate_template(
                 }
             }
             TemplateNamespace::Input | TemplateNamespace::State => {}
+            TemplateNamespace::Arg => {
+                return Err(ManifestError::validation(format!(
+                    "{context} uses function argument token '{}' outside a function request",
+                    token.raw()
+                )));
+            }
             TemplateNamespace::Expr | TemplateNamespace::Other(_) => {
                 return Err(ManifestError::validation(format!(
                     "{context} uses unsupported template token '{}'",
@@ -300,6 +337,7 @@ mod tests {
             name: "id".to_string(),
             required: false,
             mode: FilterMode::Equality,
+            values: vec![],
         }]
     }
 
@@ -378,6 +416,115 @@ mod tests {
             error
                 .to_string()
                 .contains("references unknown filter 'missing'")
+        );
+    }
+
+    #[test]
+    fn validate_http_table_rejects_function_arg_value_sources() {
+        let cases = [
+            ValueSourceSpec::Arg {
+                key: "query".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::ArgInt {
+                key: "limit".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::ArgBool {
+                key: "archived".to_string(),
+                default: None,
+            },
+        ];
+
+        for value in cases {
+            let request = RequestSpec {
+                query: vec![QueryParamSpec {
+                    name: "value".to_string(),
+                    value,
+                }],
+                ..base_request()
+            };
+
+            let error = validate_http_table(
+                "demo",
+                "messages",
+                &test_filters(),
+                &[test_column()],
+                &request,
+                &[],
+                &PaginationSpec::default(),
+            )
+            .expect_err("table requests should reject function arguments");
+
+            assert!(
+                error.to_string().contains("uses function argument"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_http_table_rejects_function_arg_template_tokens() {
+        let request = RequestSpec {
+            path: ParsedTemplate::parse("/search/{{arg.q}}").expect("template"),
+            ..RequestSpec::default()
+        };
+
+        let error = validate_http_table(
+            "demo",
+            "messages",
+            &test_filters(),
+            &[test_column()],
+            &request,
+            &[],
+            &PaginationSpec::default(),
+        )
+        .expect_err("table request templates should reject function arguments");
+
+        assert!(
+            error
+                .to_string()
+                .contains("uses function argument token 'arg.q' outside a function request")
+        );
+    }
+
+    #[test]
+    fn validate_filters_reject_duplicate_values() {
+        let filters = vec![FilterSpec {
+            name: "state".to_string(),
+            required: false,
+            mode: FilterMode::Equality,
+            values: vec!["open".to_string(), "open".to_string()],
+        }];
+
+        let error =
+            validate_filters_and_column_exprs(&filters, &[test_column()], "demo", "messages")
+                .expect_err("duplicate filter values should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("demo.messages filter 'state' value 'open' is declared more than once")
+        );
+    }
+
+    #[test]
+    fn validate_filters_reject_empty_values() {
+        let filters = vec![FilterSpec {
+            name: "state".to_string(),
+            required: false,
+            mode: FilterMode::Equality,
+            values: vec![" ".to_string()],
+        }];
+
+        let error =
+            validate_filters_and_column_exprs(&filters, &[test_column()], "demo", "messages")
+                .expect_err("empty filter values should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("demo.messages filter 'state' values must not contain empty strings")
         );
     }
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -273,6 +273,66 @@ In this minimal example:
 - `inputs` declares the install-time variables and secrets for this source in stable authored order. At install time, `coral source add` reads each key from an environment variable of the same name (or prompts for them when run with `--interactive`). At runtime, installed inputs are surfaced through `coral.inputs`.
 - `{{input.API_TOKEN}}` is resolved from the store implied by the declared input kind
 
+### HTTP table functions
+
+HTTP sources can declare source-scoped table functions for provider-native
+operations that return rows, such as search endpoints. A function owns its
+request, response mapping, pagination, and result columns; it does not need a
+backing table.
+
+```yaml
+functions:
+  - name: search_issues
+    kind: search
+    args:
+      - name: q
+        required: true
+        bind:
+          kind: request_arg
+          arg: q
+      - name: mode
+        values: [lexical, semantic, hybrid]
+        bind:
+          kind: request_arg
+          arg: search_type
+    request:
+      method: GET
+      path: /search/issues
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: search_type
+          from: arg
+          key: search_type
+    response:
+      rows_path: [items]
+    columns:
+      - name: title
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: score
+        type: Float64
+```
+
+The function is queried as:
+
+```sql
+SELECT title, html_url, score
+FROM github.search_issues(
+  q => 'flaky workspace cleanup repo:withcoral/coral',
+  mode => 'hybrid'
+)
+LIMIT 10
+```
+
+Use `kind: request_arg` when a SQL argument maps directly to one provider
+request argument. Function request values can then reference those bound
+arguments with `from: arg`.
+
+Installed source functions are discoverable through `coral.table_functions`.
+
 ### HTTP authentication
 
 The top-level `auth` block declares how Coral authenticates outgoing requests. Pick one of three `type` values:
@@ -414,12 +474,24 @@ Request query params, body fields, and headers support these `from` values:
 | ------------ | ----------- |
 | `literal` | Use the manifest-authored JSON value directly |
 | `template` | Render a string template with `input`, `filter`, or `state` tokens |
-| `filter` | Read a SQL filter as a string |
-| `filter_int` | Read a SQL filter and serialize it as a JSON integer |
-| `filter_bool` | Read a SQL filter and serialize it as a JSON boolean |
+| `filter` | Read a table filter captured from the query `WHERE` clause and serialize it as a string |
+| `filter_int` | Read a table filter captured from the query `WHERE` clause and serialize it as a JSON integer |
+| `filter_bool` | Read a table filter captured from the query `WHERE` clause and serialize it as a JSON boolean |
+| `arg` | Read a source function argument captured from the function call and serialize it as a string |
+| `arg_int` | Read a source function argument captured from the function call and serialize it as a JSON integer |
+| `arg_bool` | Read a source function argument captured from the function call and serialize it as a JSON boolean |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
 | `state` | Read pagination/runtime state |
 | `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |
+
+`filter*` and `arg*` differ by where the value comes from. Table requests use
+`filter`, `filter_int`, and `filter_bool` because their request values come from
+SQL predicates such as `WHERE id = 123`. Source function requests use `arg`,
+`arg_int`, and `arg_bool` because their request values come from named function
+arguments such as `github.search_issues(q => 'flaky')`.
+
+The suffix controls the value type sent to the provider. Use the bare form for a
+string request value, `_int` for a JSON integer, and `_bool` for a JSON boolean.
 
 Boolean filters used with `filter_bool` can be written as normal SQL boolean
 predicates, for example `WHERE include_archived IS FALSE` or

--- a/sources/datadog/manifest.yaml
+++ b/sources/datadog/manifest.yaml
@@ -1,5 +1,5 @@
 name: datadog
-version: 2.0.0
+version: 2.1.0
 dsl_version: 3
 backend: http
 description: >-
@@ -44,6 +44,89 @@ auth:
       key: DD_APPLICATION_KEY
 test_queries:
   - SELECT * FROM datadog.monitors LIMIT 1
+functions:
+  - name: search_monitors
+    kind: search
+    description: Search Datadog monitors.
+    args:
+      - name: query
+        required: true
+        bind:
+          kind: request_arg
+          arg: query
+    request:
+      method: GET
+      path: /api/v1/monitor/search
+      query:
+        - name: query
+          from: arg
+          key: query
+    response:
+      rows_path:
+        - monitors
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 0
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Monitor ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Monitor name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Monitor type
+        expr:
+          kind: path
+          path:
+            - type
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Monitor status
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - overall_state
+            - kind: path
+              path:
+                - status
+      - name: monitor_query
+        type: Utf8
+        nullable: true
+        description: Monitor query
+        expr:
+          kind: path
+          path:
+            - query
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: Comma-separated tags
+        expr:
+          kind: join_array
+          path:
+            - tags
 tables:
   - name: monitors
     description: Datadog monitors with status and alert configuration.

--- a/sources/github/manifest.yaml
+++ b/sources/github/manifest.yaml
@@ -41,6 +41,154 @@ request_headers:
     value: "2022-11-28"
 test_queries:
   - SELECT * FROM github.meta LIMIT 1
+functions:
+  - name: search_code
+    kind: search
+    description: Search GitHub code.
+    args:
+      - name: q
+        required: true
+        bind:
+          kind: request_arg
+          arg: q
+      - name: sort
+        bind:
+          kind: request_arg
+          arg: sort
+      - name: order
+        bind:
+          kind: request_arg
+          arg: order
+    request:
+      method: GET
+      path: /search/code
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: sort
+          from: arg
+          key: sort
+        - name: order
+          from: arg
+          key: order
+    response:
+      rows_path: [items]
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      link_header_require_results: false
+    columns:
+      - name: name
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [name] }
+      - name: path
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [path] }
+      - name: html_url
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [html_url] }
+      - name: language
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [language] }
+      - name: score
+        type: Float64
+        nullable: true
+        expr: { kind: path, path: [score] }
+  - name: search_issues
+    kind: search
+    description: Search GitHub issues and pull requests.
+    args:
+      - name: q
+        required: true
+        bind:
+          kind: request_arg
+          arg: q
+      - name: mode
+        values: [lexical, semantic, hybrid]
+        bind:
+          kind: request_arg
+          arg: search_type
+      - name: advanced
+        bind:
+          kind: request_arg
+          arg: advanced_search
+      - name: sort
+        bind:
+          kind: request_arg
+          arg: sort
+      - name: order
+        bind:
+          kind: request_arg
+          arg: order
+    request:
+      method: GET
+      path: /search/issues
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: sort
+          from: arg
+          key: sort
+        - name: order
+          from: arg
+          key: order
+        - name: advanced_search
+          from: arg
+          key: advanced_search
+        - name: search_type
+          from: arg
+          key: search_type
+    response:
+      rows_path: [items]
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      link_header_require_results: false
+    columns:
+      - name: title
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [title] }
+      - name: html_url
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [html_url] }
+      - name: score
+        type: Float64
+        nullable: true
+        expr: { kind: path, path: [score] }
+      - name: state
+        type: Utf8
+        nullable: true
+        expr: { kind: path, path: [state] }
+      - name: number
+        type: Int64
+        nullable: true
+        expr: { kind: path, path: [number] }
 tables:
   - name: accepted_assignments
     description: List accepted assignments for an assignment
@@ -153419,6 +153567,7 @@ tables:
         required: false
       - name: search_type
         required: false
+        values: [lexical, semantic, hybrid]
     request:
       method: GET
       path: /search/issues


### PR DESCRIPTION
## Spoilers

This is a post-implementation RFC in PR form. I tested it against real GitHub and Datadog sources. It works.

## What changed

This adds source-scoped table functions to Coral SQL:

```sql
SELECT title, html_url, score
FROM github.search_issues(q => 'flaky workspace cleanup repo:withcoral/coral')
LIMIT 10;

SELECT id, name, status
FROM datadog.search_monitors(query => 'webhook')
WHERE status = 'OK'
LIMIT 5;
```

The key UX decision is that function args are provider-native. For GitHub search, agents pass GitHub's own `q` syntax, including qualifiers like `repo:withcoral/coral` or `is:pr`. For now, Coral does not invent a second semantic argument layer and does not secretly append fragments into `q`.

## New source spec shape

HTTP manifests can now declare table functions separately from tables.

A function adds invocation args, but it still has to define the same execution shape as an HTTP table: `request`, `response`, `pagination`, and `columns`. The function call answers "how do we build the request before the table exists?" The rest is still normal table execution.

```yaml
functions:
  - name: search_issues
    kind: search
    args:
      - name: q
        required: true
        bind:
          kind: request_arg
          arg: q
      - name: mode
        values: [lexical, semantic, hybrid]
        bind:
          kind: request_arg
          arg: search_type
    request:
      method: GET
      path: /search/issues
      query:
        - name: q
          from: arg
          key: q
        - name: search_type
          from: arg
          key: search_type
    response:
      rows_path: [items]
      allow_404_empty: false
      row_strategy: direct
    pagination:
      mode: page
      page_size:
        default: 30
        max: 100
        query_param: per_page
      page_param: page
      page_start: 1
      page_step: 1
      offset_start: 0
      link_header_require_results: false
    columns:
      - name: title
        type: Utf8
        expr: { kind: path, path: [title] }
      - name: html_url
        type: Utf8
        expr: { kind: path, path: [html_url] }
      - name: score
        type: Float64
        expr: { kind: path, path: [score] }
```

Important bits:

- `functions` are not backed by hidden search tables.
- `kind: request_arg` is the only function binding kind right now.
- SQL named args are validated against the function spec.
- Args can be supplied in any order; execution emits provider request args from the manifest binding.
- `WHERE` filters result rows. Request inputs belong in the function call.
- Functions are discoverable through `coral.table_functions`.

## Implementation sketch

DataFusion already supports UDTFs, but not source-scoped names like `github.search_issues(...)` directly. The implementation bridges that gap in the planner:

1. Register one DataFusion UDTF per manifest function under an internal collision-safe name.
2. Register one generic relation planner.
3. When SQL contains `FROM github.search_issues(q => '...')`, the planner resolves `github.search_issues` against the source-function registry.
4. The planner parses named args, validates required/unknown/duplicate args, reorders them into manifest order, and emits a call to the internal UDTF.
5. The UDTF builds a normal HTTP table provider from the function spec with request args pre-bound, then reuses the existing HTTP table path for auth, pagination, response mapping, and Arrow batches.

So the user-facing SQL remains source-scoped, while DataFusion sees a normal table-valued function call.

## Validation

Live checks run against installed sources:

```sql
SELECT title, html_url, score, state, number
FROM github.search_issues(q => 'repo:withcoral/coral coral')
LIMIT 5;
```

Returned real GitHub results.

```sql
SELECT title, html_url, state
FROM github.search_issues(mode => 'hybrid', q => 'repo:withcoral/coral is:pr')
WHERE state = 'open'
LIMIT 3;
```

Returned open GitHub PRs, proving named arg order and result filtering work.

```sql
SELECT id, name, type, status
FROM datadog.search_monitors(query => '*')
LIMIT 5;
```

Returned real Datadog monitors.

```sql
SELECT id, name, status
FROM datadog.search_monitors(query => 'webhook')
WHERE status = 'OK'
LIMIT 5;
```

Returned real Datadog monitors after local result filtering.

Failure cases checked:

- invalid enum values fail with public function names
- missing required args fail before provider calls
- request args are not exposed as result columns

Full local check:

```text
make rust-checks
```

passed.
