### PR TITLE
feat(engine): advertise source-scoped table functions

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -7,7 +7,8 @@ use crate::{QueryRuntimeContext, RequestAuthenticator};
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec, TableCommon,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
+    SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::datasource::TableProvider;
@@ -34,6 +35,17 @@ pub(crate) struct RegisteredTable {
 }
 
 #[derive(Debug, Clone)]
+pub(crate) struct RegisteredTableFunction {
+    pub(crate) schema_name: String,
+    pub(crate) function_name: String,
+    pub(crate) public_name: String,
+    pub(crate) kind: String,
+    pub(crate) description: String,
+    pub(crate) arguments_json: String,
+    pub(crate) result_columns_json: String,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct RegisteredInput {
     pub(crate) key: String,
     pub(crate) kind: ManifestInputKind,
@@ -51,6 +63,7 @@ pub(crate) struct RegisteredInput {
 pub(crate) struct RegisteredSource {
     pub(crate) schema_name: String,
     pub(crate) tables: Vec<RegisteredTable>,
+    pub(crate) table_functions: Vec<RegisteredTableFunction>,
     pub(crate) inputs: Vec<RegisteredInput>,
 }
 
@@ -180,6 +193,49 @@ pub(crate) fn build_registered_table(
         guide: common.guide.clone(),
         columns,
         required_filters,
+    }
+}
+
+pub(crate) fn build_registered_table_function(
+    schema_name: &str,
+    function: &SourceTableFunctionSpec,
+) -> RegisteredTableFunction {
+    let public_name = format!("{schema_name}.{}", function.name);
+    let arguments = function
+        .args
+        .iter()
+        .map(|arg| {
+            serde_json::json!({
+                "name": arg.name,
+                "required": arg.required,
+                "values": arg.values,
+            })
+        })
+        .collect::<Vec<_>>();
+    let result_columns = registered_columns_from_specs(&function.columns, &[])
+        .into_iter()
+        .map(|column| {
+            serde_json::json!({
+                "name": column.name,
+                "type": column.data_type,
+                "nullable": column.nullable,
+                "description": column.description,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    RegisteredTableFunction {
+        schema_name: schema_name.to_string(),
+        function_name: function.name.clone(),
+        public_name,
+        kind: if function.kind.is_empty() {
+            "table".to_string()
+        } else {
+            function.kind.clone()
+        },
+        description: function.description.clone(),
+        arguments_json: serde_json::to_string(&arguments).expect("arguments json"),
+        result_columns_json: serde_json::to_string(&result_columns).expect("result columns json"),
     }
 }
 

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -38,8 +38,6 @@ pub(crate) struct RegisteredTable {
 pub(crate) struct RegisteredTableFunction {
     pub(crate) schema_name: String,
     pub(crate) function_name: String,
-    pub(crate) public_name: String,
-    pub(crate) kind: String,
     pub(crate) description: String,
     pub(crate) arguments_json: String,
     pub(crate) result_columns_json: String,
@@ -200,7 +198,6 @@ pub(crate) fn build_registered_table_function(
     schema_name: &str,
     function: &SourceTableFunctionSpec,
 ) -> RegisteredTableFunction {
-    let public_name = format!("{schema_name}.{}", function.name);
     let arguments = function
         .args
         .iter()
@@ -227,12 +224,6 @@ pub(crate) fn build_registered_table_function(
     RegisteredTableFunction {
         schema_name: schema_name.to_string(),
         function_name: function.name.clone(),
-        public_name,
-        kind: if function.kind.is_empty() {
-            "table".to_string()
-        } else {
-            function.kind.clone()
-        },
         description: function.description.clone(),
         arguments_json: serde_json::to_string(&arguments).expect("arguments json"),
         result_columns_json: serde_json::to_string(&result_columns).expect("result columns json"),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -13,7 +13,7 @@ use crate::RequestAuthenticator;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
     RegisteredTable, build_registered_inputs, build_registered_table,
-    registered_columns_from_specs, required_filter_names,
+    build_registered_table_function, registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
@@ -90,6 +90,12 @@ impl CompiledBackendSource for HttpCompiledSource {
             tables.insert(table.name().to_string(), provider);
             table_infos.push(registered_table(table));
         }
+        let table_function_infos = self
+            .manifest
+            .functions
+            .iter()
+            .map(|function| build_registered_table_function(&self.manifest.common.name, function))
+            .collect();
 
         let secret_keys = self.source_secrets.keys().cloned().collect();
         let inputs = build_registered_inputs(
@@ -103,6 +109,7 @@ impl CompiledBackendSource for HttpCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                table_functions: table_function_infos,
                 inputs,
             },
         })

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -308,6 +308,7 @@ impl CompiledBackendSource for JsonlCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                table_functions: vec![],
                 inputs,
             },
         })

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -9,9 +9,9 @@ use coral_spec::ValidatedSourceManifest;
 pub(crate) mod common;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, build_registered_inputs, build_registered_table,
+    build_registered_table_function, partition_columns_to_arrow, registered_columns_from_schema,
+    registered_columns_from_specs, required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod http;

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -254,6 +254,7 @@ impl CompiledBackendSource for ParquetCompiledSource {
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,
+                table_functions: vec![],
                 inputs,
             },
         })

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -53,8 +53,7 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
 fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
     let schema = Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
-        Field::new("public_name", DataType::Utf8, false),
-        Field::new("kind", DataType::Utf8, false),
+        Field::new("function_name", DataType::Utf8, false),
         Field::new("description", DataType::Utf8, false),
         Field::new("arguments_json", DataType::Utf8, false),
         Field::new("result_columns_json", DataType::Utf8, false),
@@ -72,8 +71,7 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
         schema.clone(),
         vec![
             utf8_column(rows.iter().map(|row| Some(row.schema_name.as_str()))),
-            utf8_column(rows.iter().map(|row| Some(row.public_name.as_str()))),
-            utf8_column(rows.iter().map(|row| Some(row.kind.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.function_name.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.arguments_json.as_str()))),
             utf8_column(

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use coral_spec::ManifestInputKind;
-use datafusion::arrow::array::{BooleanArray, Int32Array, RecordBatch, StringArray};
+use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::datasource::MemTable;
 use datafusion::error::{DataFusionError, Result};
@@ -27,12 +27,17 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
+    let table_functions_table = build_table_functions_table(active_sources)?;
 
     let mut meta_tables: HashMap<String, Arc<dyn datafusion::datasource::TableProvider>> =
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
     meta_tables.insert("columns".to_string(), Arc::new(columns_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
+    meta_tables.insert(
+        "table_functions".to_string(),
+        Arc::new(table_functions_table),
+    );
 
     let catalog = ctx
         .catalog("datafusion")
@@ -43,6 +48,47 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
     )?;
 
     Ok(())
+}
+
+fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("public_name", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+        Field::new("arguments_json", DataType::Utf8, false),
+        Field::new("result_columns_json", DataType::Utf8, false),
+    ]));
+
+    let mut rows = active_sources
+        .iter()
+        .flat_map(|source| source.table_functions.iter())
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
+    });
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            utf8_column(rows.iter().map(|row| Some(row.schema_name.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.public_name.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.kind.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.arguments_json.as_str()))),
+            utf8_column(
+                rows.iter()
+                    .map(|row| Some(row.result_columns_json.as_str())),
+            ),
+        ],
+    )
+    .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
+
+    MemTable::try_new(schema, vec![vec![batch]])
+}
+
+fn utf8_column<'a>(values: impl IntoIterator<Item = Option<&'a str>>) -> ArrayRef {
+    Arc::new(values.into_iter().collect::<StringArray>())
 }
 
 /// Collect typed query-visible table metadata for the active source set.

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -316,7 +316,6 @@ fn http_manifest_with_function() -> Value {
         }],
         "functions": [{
             "name": "search_issues",
-            "kind": "search",
             "description": "Search issues",
             "args": [
                 {
@@ -402,7 +401,7 @@ async fn coral_table_functions_lists_source_functions() {
         &CoralQuery::execute_sql(
             &sources,
             test_runtime(),
-            "SELECT schema_name, public_name, kind, description, arguments_json, result_columns_json \
+            "SELECT schema_name, function_name, description, arguments_json, result_columns_json \
              FROM coral.table_functions WHERE schema_name = 'searchy'",
         )
         .await
@@ -412,8 +411,7 @@ async fn coral_table_functions_lists_source_functions() {
     assert_eq!(rows.len(), 1);
     let row = &rows[0];
     assert_eq!(row["schema_name"], "searchy");
-    assert_eq!(row["public_name"], "searchy.search_issues");
-    assert_eq!(row["kind"], "search");
+    assert_eq!(row["function_name"], "search_issues");
     assert_eq!(row["description"], "Search issues");
     assert_eq!(
         serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -296,6 +296,59 @@ fn http_manifest_with_inputs() -> Value {
     })
 }
 
+fn http_manifest_with_function() -> Value {
+    json!({
+        "name": "searchy",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": "https://example.com",
+        "tables": [{
+            "name": "placeholder",
+            "description": "Placeholder table",
+            "request": {
+                "method": "GET",
+                "path": "/placeholder"
+            },
+            "columns": [
+                { "name": "id", "type": "Utf8" }
+            ]
+        }],
+        "functions": [{
+            "name": "search_issues",
+            "kind": "search",
+            "description": "Search issues",
+            "args": [
+                {
+                    "name": "q",
+                    "required": true,
+                    "bind": { "arg": "q" }
+                },
+                {
+                    "name": "mode",
+                    "values": ["lexical", "semantic", "hybrid"],
+                    "bind": { "arg": "search_type" }
+                }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/search/issues",
+                "query": [
+                    { "name": "q", "from": "arg", "key": "q" },
+                    { "name": "search_type", "from": "arg", "key": "search_type" }
+                ]
+            },
+            "response": {
+                "rows_path": ["items"]
+            },
+            "columns": [
+                { "name": "title", "type": "Utf8" },
+                { "name": "score", "type": "Float64" }
+            ]
+        }]
+    })
+}
+
 fn build_demo_source(variables: &[(&str, &str)], secrets: &[(&str, &str)]) -> QuerySource {
     let to_map = |items: &[(&str, &str)]| -> BTreeMap<String, String> {
         items
@@ -339,6 +392,43 @@ fn jsonl_manifest_with_inputs(dir: &std::path::Path) -> Value {
             ]
         }]
     })
+}
+
+#[tokio::test]
+async fn coral_table_functions_lists_source_functions() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT schema_name, public_name, kind, description, arguments_json, result_columns_json \
+             FROM coral.table_functions WHERE schema_name = 'searchy'",
+        )
+        .await
+        .expect("table function catalog query should succeed"),
+    );
+
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["schema_name"], "searchy");
+    assert_eq!(row["public_name"], "searchy.search_issues");
+    assert_eq!(row["kind"], "search");
+    assert_eq!(row["description"], "Search issues");
+    assert_eq!(
+        serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),
+        json!([
+            { "name": "q", "required": true, "values": [] },
+            { "name": "mode", "required": false, "values": ["lexical", "semantic", "hybrid"] }
+        ])
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(row["result_columns_json"].as_str().unwrap()).unwrap(),
+        json!([
+            { "name": "title", "type": "Utf8", "nullable": true, "description": "" },
+            { "name": "score", "type": "Float64", "nullable": true, "description": "" }
+        ])
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

Adds runtime catalog metadata for manifest-declared source-scoped table functions. This does not execute functions yet; it only carries the function shape from validated source manifests into `coral.table_functions`.

## Scope

- Add `RegisteredTableFunction` metadata to registered sources
- Populate HTTP source function metadata from manifest `functions`
- Add `coral.table_functions` with `schema_name`, `function_name`, description, arguments JSON, and result columns JSON
- Keep non-HTTP backends explicit with no table functions
- Add catalog coverage for function discovery

## Not in this PR

- DataFusion UDTF registration
- source-scoped function planning
- executing `github.search_issues(...)`
- GitHub/Datadog manifest rollout

## Validation

- `cargo test -p coral-engine --test engine catalog_tests::coral_table_functions_lists_source_functions -- --nocapture`
- `make rust-checks`
