### PR TITLE
docs: fix README architecture link

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ lets the query pick just the columns it needs. Query pushdown and caching
 keep things responsive and cut unnecessary API traffic.
 
 For a deeper understanding of the internals, see the
-[architecture page](https://withcoral.com/docs/contributors/architecture).
+[architecture page](https://withcoral.com/docs/project/architecture).
 
 ## Bundled sources
 


### PR DESCRIPTION
## Why

The docs navigation moved the architecture page from the Contributors section to the Project section, but the README still linked to the old public URL. That stale route can send readers to a missing page.

## What changed

- Update the README architecture link to the current `/docs/project/architecture` route.

## Verification

- Searched the repo for the old `/contributors/architecture` route.
- make docs-check
