### PR TITLE
refactor(api): centralize structured error contract

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -56,3 +56,15 @@ pub const QUERY_RESPONSE_MAX_MESSAGE_SIZE: usize = 64 * 1024 * 1024;
 /// HPACK-encoded request headers on the way in. 128 KiB gives plenty of
 /// headroom in both directions.
 pub const HTTP2_MAX_HEADER_LIST_SIZE: u32 = 128 * 1024;
+
+/// Coral error domain used in `google.rpc.ErrorInfo`.
+pub const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
+
+/// Reserved `ErrorInfo.metadata` key for a one-line error summary.
+pub const CORAL_ERROR_METADATA_SUMMARY: &str = "summary";
+
+/// Reserved `ErrorInfo.metadata` key for a longer error explanation.
+pub const CORAL_ERROR_METADATA_DETAIL: &str = "detail";
+
+/// Reserved `ErrorInfo.metadata` key for actionable recovery guidance.
+pub const CORAL_ERROR_METADATA_HINT: &str = "hint";

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -1,14 +1,14 @@
 //! Defines bootstrap and application-management errors for the local app.
 
+use coral_api::{
+    CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
+    CORAL_ERROR_METADATA_SUMMARY,
+};
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
 use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::state::CredentialsError;
-
-/// Coral error domain for `google.rpc.ErrorInfo`.
-/// Matches `coral_client::CORAL_ERROR_DOMAIN`.
-const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
 
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
@@ -96,15 +96,18 @@ pub(crate) fn core_status(error: CoreError) -> Status {
     match error {
         CoreError::QueryFailure(sqe) => {
             let mut metadata = sqe.metadata().clone();
-            metadata.insert("summary".to_string(), sqe.summary().to_string());
+            metadata.insert(
+                CORAL_ERROR_METADATA_SUMMARY.to_string(),
+                sqe.summary().to_string(),
+            );
             if !sqe.detail().is_empty() {
                 metadata.insert(
-                    "detail".to_string(),
+                    CORAL_ERROR_METADATA_DETAIL.to_string(),
                     truncate_status_detail(sqe.detail().to_string()),
                 );
             }
             if let Some(hint) = sqe.hint() {
-                metadata.insert("hint".to_string(), hint.to_string());
+                metadata.insert(CORAL_ERROR_METADATA_HINT.to_string(), hint.to_string());
             }
 
             let mut details: Vec<ErrorDetail> = vec![ErrorDetail::ErrorInfo(

--- a/crates/coral-client/src/status_error.rs
+++ b/crates/coral-client/src/status_error.rs
@@ -9,10 +9,11 @@
 
 use std::collections::HashMap;
 
+pub use coral_api::CORAL_ERROR_DOMAIN;
+use coral_api::{
+    CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT, CORAL_ERROR_METADATA_SUMMARY,
+};
 use tonic_types::{ErrorDetail, StatusExt as _};
-
-/// Coral error domain used in `google.rpc.ErrorInfo`.
-pub const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
 
 /// Result of decoding a structured query error from a `tonic::Status`.
 pub enum DecodedStatusError {
@@ -82,10 +83,12 @@ pub fn decode_status_error(status: &tonic::Status) -> DecodedStatusError {
         Some(info) => {
             let mut metadata = info.metadata;
             let summary = metadata
-                .remove("summary")
+                .remove(CORAL_ERROR_METADATA_SUMMARY)
                 .unwrap_or_else(|| status.message().to_string());
-            let detail = metadata.remove("detail").unwrap_or_default();
-            let hint = metadata.remove("hint");
+            let detail = metadata
+                .remove(CORAL_ERROR_METADATA_DETAIL)
+                .unwrap_or_default();
+            let hint = metadata.remove(CORAL_ERROR_METADATA_HINT);
             DecodedStatusError::Structured(Box::new(CoralQueryError {
                 reason: info.reason,
                 summary,


### PR DESCRIPTION
## Summary
- Move the Coral structured error domain and reserved ErrorInfo metadata keys into coral-api.
- Have app encoding and client decoding import the same wire-contract constants.
- Preserve coral_client::CORAL_ERROR_DOMAIN as a re-export for existing call sites.

## Validation
- make rust-checks
