### PR TITLE
fix(spec): reject duplicate table names

### DIFF
--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -19,7 +19,7 @@ use crate::inputs::collect_source_inputs_value;
 use crate::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ManifestInputKind, ManifestInputSpec,
     Result, SourceBackend, SourceManifestCommon, TableCommon, validate_columns,
-    validate_filters_and_column_exprs, validate_test_queries,
+    validate_filters_and_column_exprs, validate_table_names, validate_test_queries,
 };
 
 /// Validated top-level manifest for a `Parquet`-backed source.
@@ -302,6 +302,7 @@ impl ParquetSourceManifest {
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
+        validate_table_names(&name, tables.iter().map(|table| table.name.as_str()))?;
         let common =
             SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables
@@ -332,6 +333,7 @@ impl JsonlSourceManifest {
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
+        validate_table_names(&name, tables.iter().map(|table| table.name.as_str()))?;
         let common =
             SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -19,7 +19,7 @@ use crate::{
     ColumnSpec, FilterSpec, HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec,
     PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
     SourceBackend, SourceManifestCommon, TableCommon, inputs::collect_source_inputs_value,
-    validate::validate_template, validate_http_table, validate_test_queries,
+    validate::validate_template, validate_http_table, validate_table_names, validate_test_queries,
 };
 
 /// Source-level authentication requirements for HTTP-backed source specs.
@@ -263,6 +263,7 @@ impl HttpSourceManifest {
             tables,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
+        validate_table_names(&name, tables.iter().map(|table| table.name.as_str()))?;
         let common =
             SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
         let tables = tables

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -102,5 +102,5 @@ pub use parser::{
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{
-    validate_columns, validate_filters_and_column_exprs, validate_http_table,
+    validate_columns, validate_filters_and_column_exprs, validate_http_table, validate_table_names,
 };

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -215,6 +215,39 @@ tables:
     }
 
     #[test]
+    fn parse_source_manifest_rejects_duplicate_table_names() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: jsonl
+tables:
+  - name: messages
+    description: Demo messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: kind
+        type: Utf8
+  - name: messages
+    description: Duplicate messages
+    source:
+      location: file:///tmp/demo/
+    columns:
+      - name: id
+        type: Int64
+",
+        )
+        .expect_err("duplicate table names should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'demo' has duplicate table 'messages'"
+        );
+    }
+
+    #[test]
     fn parse_source_manifest_rejects_whitespace_only_test_query() {
         let error = parse_source_manifest_yaml(
             r#"

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -8,6 +8,22 @@ use crate::common::{
 };
 use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
+pub(crate) fn validate_table_names<'a>(
+    schema: &str,
+    table_names: impl IntoIterator<Item = &'a str>,
+) -> Result<()> {
+    let mut seen_tables = HashSet::new();
+    for table_name in table_names {
+        if !seen_tables.insert(table_name) {
+            return Err(ManifestError::validation(format!(
+                "source '{schema}' has duplicate table '{table_name}'"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 pub(crate) fn validate_http_table(
     schema: &str,
     table_name: &str,


### PR DESCRIPTION
## Summary
- Validate source-spec table names once at manifest parse time.
- Apply duplicate-name checks to HTTP, Parquet, and JSONL manifests before backend registration.
- Add a parser regression test for duplicate table names.

## Validation
- make rust-checks
