### PR TITLE
feat(engine): plan source-scoped table functions

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -42,9 +42,11 @@ pub(crate) struct RegisteredTable {
 pub(crate) struct RegisteredTableFunction {
     pub(crate) schema_name: String,
     pub(crate) function_name: String,
+    pub(crate) internal_name: String,
     pub(crate) description: String,
     pub(crate) arguments_json: String,
     pub(crate) result_columns_json: String,
+    pub(crate) arg_names: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -223,6 +225,7 @@ pub(crate) fn build_registered_table(
 pub(crate) fn build_registered_table_function(
     schema_name: &str,
     function: &SourceTableFunctionSpec,
+    internal_name: String,
 ) -> RegisteredTableFunction {
     let arguments = function
         .args
@@ -250,9 +253,11 @@ pub(crate) fn build_registered_table_function(
     RegisteredTableFunction {
         schema_name: schema_name.to_string(),
         function_name: function.name.clone(),
+        internal_name,
         description: function.description.clone(),
         arguments_json: serde_json::to_string(&arguments).expect("arguments json"),
         result_columns_json: serde_json::to_string(&result_columns).expect("result columns json"),
+        arg_names: function.args.iter().map(|arg| arg.name.clone()).collect(),
     }
 }
 

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -155,6 +155,10 @@ fn bind_function_args(
     function: &SourceTableFunctionSpec,
     args: &[Expr],
 ) -> Result<HashMap<String, String>> {
+    // CONTRACT with `SourceFunctionRegistry`: source-scoped SQL calls are
+    // lowered to positional internal UDTF calls in manifest arg order. Omitted
+    // optional args arrive here as NULL, so required-arg validation belongs here
+    // after NULLs have been interpreted as absent.
     let context = FunctionCallContext {
         source_schema,
         function_name: function.name.as_str(),

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -155,10 +155,6 @@ fn bind_function_args(
     function: &SourceTableFunctionSpec,
     args: &[Expr],
 ) -> Result<HashMap<String, String>> {
-    // CONTRACT with `SourceFunctionRegistry`: source-scoped SQL calls are
-    // lowered to positional internal UDTF calls in manifest arg order. Omitted
-    // optional args arrive here as NULL, so required-arg validation belongs here
-    // after NULLs have been interpreted as absent.
     let context = FunctionCallContext {
         source_schema,
         function_name: function.name.as_str(),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -105,7 +105,7 @@ impl CompiledBackendSource for HttpCompiledSource {
                     self.manifest.common.name.clone(),
                     function.clone(),
                 )?);
-            table_functions.insert(internal_name, function_impl);
+            table_functions.insert(internal_name.clone(), function_impl);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
                 function,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -109,6 +109,7 @@ impl CompiledBackendSource for HttpCompiledSource {
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
                 function,
+                internal_name,
             ));
         }
 

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -9,10 +9,10 @@ use coral_spec::ValidatedSourceManifest;
 pub(crate) mod common;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, SourceTableFunctions, build_registered_inputs, build_registered_table,
-    build_registered_table_function, internal_table_function_name, partition_columns_to_arrow,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    RegisteredTable, RegisteredTableFunction, SourceTableFunctions, build_registered_inputs,
+    build_registered_table, build_registered_table_function, internal_table_function_name,
+    partition_columns_to_arrow, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod http;

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -8,3 +8,4 @@ pub(crate) mod pattern_validator;
 pub(crate) mod query;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;
+pub(crate) mod source_functions;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -100,7 +100,8 @@ pub(crate) async fn build_runtime(
             .iter()
             .flat_map(|source| source.table_functions.iter().cloned())
             .collect(),
-    );
+    )
+    .map_err(|err| datafusion_to_core(&err, &tables))?;
     if !source_functions.is_empty() {
         ctx.register_relation_planner(Arc::new(source_functions))
             .map_err(|err| datafusion_to_core(&err, &tables))?;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -98,10 +98,8 @@ pub(crate) async fn build_runtime(
         registration
             .active_sources
             .iter()
-            .flat_map(|source| source.table_functions.iter().cloned())
-            .collect(),
-    )
-    .map_err(|err| datafusion_to_core(&err, &tables))?;
+            .flat_map(|source| source.table_functions.iter()),
+    );
     if !source_functions.is_empty() {
         ctx.register_relation_planner(Arc::new(source_functions))
             .map_err(|err| datafusion_to_core(&err, &tables))?;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -17,6 +17,7 @@ use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
+use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     CoreError, QueryExecution, QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig,
     QuerySource, TableInfo,
@@ -93,6 +94,17 @@ pub(crate) async fn build_runtime(
     catalog::register(&ctx, &registration.active_sources)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_tables(&registration.active_sources);
+    let source_functions = SourceFunctionRegistry::new(
+        registration
+            .active_sources
+            .iter()
+            .flat_map(|source| source.table_functions.iter().cloned())
+            .collect(),
+    );
+    if !source_functions.is_empty() {
+        ctx.register_relation_planner(Arc::new(source_functions))
+            .map_err(|err| datafusion_to_core(&err, &tables))?;
+    }
     for failure in &registration.failures {
         tracing::warn!(
             source = %failure.schema_name,

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -34,34 +34,17 @@ impl SourceFunctionRegistry {
         let mut schemas = HashSet::new();
         let mut registered = HashMap::new();
         for function in functions {
-            let schema_name = manifest_lookup_key(&function.schema_name);
-            let function_name = manifest_lookup_key(&function.function_name);
-            let mut seen_args = HashSet::new();
-            let mut arg_lookup_names = Vec::with_capacity(function.arg_names.len());
-            for arg in &function.arg_names {
-                let lookup_name = manifest_lookup_key(arg);
-                if !seen_args.insert(lookup_name.clone()) {
-                    return Err(DataFusionError::Plan(format!(
-                        "{} has duplicate argument after SQL identifier normalization",
-                        source_function_display_name(&function)
-                    )));
-                }
-                arg_lookup_names.push(lookup_name);
-            }
+            let schema_name = function.schema_name.clone();
+            let function_name = function.function_name.clone();
+            let arg_lookup_names = function.arg_names.clone();
             schemas.insert(schema_name.clone());
-            let replaced = registered.insert(
+            registered.insert(
                 (schema_name, function_name),
                 SourceFunctionEntry {
                     registered: function,
                     arg_lookup_names,
                 },
             );
-            if replaced.is_some() {
-                return Err(DataFusionError::Plan(
-                    "duplicate source table function after SQL identifier normalization"
-                        .to_string(),
-                ));
-            }
         }
         Ok(Self {
             functions: registered,
@@ -75,38 +58,11 @@ impl SourceFunctionRegistry {
 
     fn rewrite_relation(
         &self,
-        relation: TableFactor,
+        mut relation: TableFactor,
         context: &dyn RelationPlannerContext,
     ) -> Result<SourceFunctionRewrite> {
-        let TableFactor::Table {
-            name,
-            alias,
-            args: Some(args),
-            with_hints,
-            version,
-            with_ordinality,
-            partitions,
-            json_path,
-            sample,
-            index_hints,
-        } = relation
-        else {
+        let Some((schema, function_name)) = source_function_name(&relation, context) else {
             return Ok(SourceFunctionRewrite::PassThrough(relation));
-        };
-
-        let Some((schema, function_name)) = source_function_name(&name, context) else {
-            return Ok(SourceFunctionRewrite::PassThrough(TableFactor::Table {
-                name,
-                alias,
-                args: Some(args),
-                with_hints,
-                version,
-                with_ordinality,
-                partitions,
-                json_path,
-                sample,
-                index_hints,
-            }));
         };
         let Some(function) = self.functions.get(&(schema.clone(), function_name.clone())) else {
             if self.schemas.contains(&schema) {
@@ -114,35 +70,26 @@ impl SourceFunctionRegistry {
                     "unknown source table function {schema}.{function_name}"
                 )));
             }
-            return Ok(SourceFunctionRewrite::PassThrough(TableFactor::Table {
-                name,
-                alias,
-                args: Some(args),
-                with_hints,
-                version,
-                with_ordinality,
-                partitions,
-                json_path,
-                sample,
-                index_hints,
-            }));
+            return Ok(SourceFunctionRewrite::PassThrough(relation));
         };
 
-        Ok(SourceFunctionRewrite::Rewritten(TableFactor::Table {
-            name: ObjectName::from(vec![Ident::new(function.registered.internal_name.clone())]),
-            alias,
-            args: Some(TableFunctionArgs {
-                args: named_args_to_positional(function, &args, context)?,
-                settings: None,
-            }),
-            with_hints,
-            version,
-            with_ordinality,
-            partitions,
-            json_path,
-            sample,
-            index_hints,
-        }))
+        let TableFactor::Table { name, args, .. } = &mut relation else {
+            unreachable!("source_function_name only matches table relations");
+        };
+        let lowered_args = named_args_to_positional(
+            function,
+            args.as_ref()
+                .expect("source_function_name only matches table relations with args"),
+            context,
+        )?;
+
+        *name = ObjectName::from(vec![Ident::new(function.registered.internal_name.clone())]);
+        *args = Some(TableFunctionArgs {
+            args: lowered_args,
+            settings: None,
+        });
+
+        Ok(SourceFunctionRewrite::Rewritten(relation))
     }
 }
 
@@ -167,19 +114,23 @@ impl RelationPlanner for SourceFunctionRegistry {
 }
 
 fn source_function_name(
-    name: &ObjectName,
+    relation: &TableFactor,
     context: &dyn RelationPlannerContext,
 ) -> Option<(String, String)> {
+    let TableFactor::Table {
+        name,
+        args: Some(_),
+        ..
+    } = relation
+    else {
+        return None;
+    };
     if name.0.len() != 2 {
         return None;
     }
     let schema = context.normalize_ident(name.0[0].as_ident()?.clone());
     let function = context.normalize_ident(name.0[1].as_ident()?.clone());
     Some((schema, function))
-}
-
-fn manifest_lookup_key(name: &str) -> String {
-    name.to_ascii_lowercase()
 }
 
 fn named_args_to_positional(

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -98,18 +98,27 @@ impl SourceFunctionRegistry {
             return Ok(SourceFunctionRewrite::PassThrough(relation));
         };
 
-        let TableFactor::Table { name, args, .. } = &mut relation else {
+        let TableFactor::Table {
+            name,
+            args: table_args,
+            ..
+        } = &mut relation
+        else {
             unreachable!("source_function_name only matches table relations");
         };
-        let lowered_args = named_args_to_positional(
-            function,
-            args.as_ref()
-                .expect("source_function_name only matches table relations with args"),
-            context,
-        )?;
+        let args = table_args
+            .as_ref()
+            .expect("source_function_name only matches table relations with args");
+        if args.settings.is_some() {
+            return Err(DataFusionError::Plan(format!(
+                "source table function {}.{} does not support SETTINGS",
+                source_function.display_schema, source_function.display_function
+            )));
+        }
+        let lowered_args = named_args_to_positional(function, args, context)?;
 
         *name = ObjectName::from(vec![Ident::new(function.internal_name.clone())]);
-        *args = Some(TableFunctionArgs {
+        *table_args = Some(TableFunctionArgs {
             args: lowered_args,
             settings: None,
         });
@@ -200,6 +209,15 @@ fn named_args_to_positional(
                 if !function.arg_lookup.contains(&key) {
                     return Err(DataFusionError::Plan(format!(
                         "{display_name} unknown argument '{}'",
+                        name.value
+                    )));
+                }
+                if matches!(
+                    arg,
+                    FunctionArgExpr::Wildcard | FunctionArgExpr::QualifiedWildcard(_)
+                ) {
+                    return Err(DataFusionError::Plan(format!(
+                        "{display_name} argument '{}' does not support wildcard values",
                         name.value
                     )));
                 }

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -1,11 +1,10 @@
 //! Source-scoped table function relation planning.
 //!
-//! `DataFusion` registers UDTFs in a flat namespace, while Coral exposes them
-//! as source-scoped SQL relations like `github.find_issues(...)`. Backends
-//! register hidden internal UDTF names, and this relation planner rewrites the
-//! source-scoped relation into the internal function call. Argument names are
-//! lowered into manifest order here; backend-specific validation and execution
-//! stay with the table function implementation.
+//! DataFusion registers UDTFs in one flat namespace. Coral exposes source
+//! functions as scoped SQL relations like `github.find_issues(...)`. Backends
+//! therefore register hidden internal UDTF names, and this planner rewrites the
+//! scoped relation into the hidden function call before handing planning back
+//! to DataFusion.
 
 use std::collections::{HashMap, HashSet};
 
@@ -19,122 +18,73 @@ use datafusion::logical_expr::sqlparser::ast::{
 
 use crate::backends::RegisteredTableFunction;
 
-enum SourceFunctionRewrite {
-    PassThrough(TableFactor),
-    Rewritten(TableFactor),
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct SourceFunctionRegistry {
-    functions: HashMap<(String, String), SourceFunctionEntry>,
-    schemas: HashSet<String>,
+    functions: HashMap<FunctionLookupKey, SourceFunction>,
+    source_schemas: HashSet<String>,
 }
 
-#[derive(Debug, Clone)]
-struct SourceFunctionEntry {
+#[derive(Debug)]
+struct SourceFunction {
     internal_name: String,
     display_name: String,
-    arg_lookup_names: Vec<String>,
-    arg_lookup: HashSet<String>,
+    arg_names: Vec<String>,
+    known_args: HashSet<String>,
 }
 
-struct SourceFunctionName {
-    lookup_schema: String,
-    lookup_function: String,
-    display_schema: String,
-    display_function: String,
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct FunctionLookupKey {
+    schema: String,
+    function: String,
+}
+
+#[derive(Debug)]
+struct SourceFunctionCall {
+    lookup_key: FunctionLookupKey,
+    display_name: String,
 }
 
 impl SourceFunctionRegistry {
-    pub(crate) fn new(functions: Vec<RegisteredTableFunction>) -> Result<Self> {
-        let mut schemas = HashSet::new();
-        let mut registered = HashMap::new();
+    pub(crate) fn new<'a>(
+        functions: impl IntoIterator<Item = &'a RegisteredTableFunction>,
+    ) -> Self {
+        let mut source_schemas = HashSet::new();
+        let mut functions_by_name = HashMap::new();
+
         for function in functions {
-            let schema_name = function.schema_name.clone();
-            let function_name = function.function_name.clone();
-            let arg_lookup_names = function.arg_names.clone();
-            let display_name = source_function_display_name(&function);
-            schemas.insert(schema_name.clone());
-            registered.insert(
-                (schema_name, function_name),
-                SourceFunctionEntry {
-                    internal_name: function.internal_name,
-                    display_name,
-                    arg_lookup: arg_lookup_names.iter().cloned().collect(),
-                    arg_lookup_names,
-                },
-            );
+            let lookup_key = FunctionLookupKey::from_manifest(function);
+            source_schemas.insert(lookup_key.schema.clone());
+            functions_by_name.insert(lookup_key, SourceFunction::from_registered(function));
         }
-        Ok(Self {
-            functions: registered,
-            schemas,
-        })
+
+        Self {
+            functions: functions_by_name,
+            source_schemas,
+        }
     }
 
     pub(crate) fn is_empty(&self) -> bool {
         self.functions.is_empty()
     }
 
-    fn rewrite_relation(
-        &self,
-        mut relation: TableFactor,
-        context: &dyn RelationPlannerContext,
-    ) -> Result<SourceFunctionRewrite> {
-        let Some(source_function) = source_function_name(&relation, context) else {
-            return Ok(SourceFunctionRewrite::PassThrough(relation));
-        };
-        let Some(function) = self.functions.get(&(
-            source_function.lookup_schema.clone(),
-            source_function.lookup_function.clone(),
-        )) else {
-            if self.schemas.contains(&source_function.lookup_schema) {
-                return Err(DataFusionError::Plan(format!(
-                    "unknown source table function {}.{}{}",
-                    source_function.display_schema,
-                    source_function.display_function,
-                    self.available_functions_hint(&source_function.lookup_schema)
-                )));
-            }
-            return Ok(SourceFunctionRewrite::PassThrough(relation));
-        };
+    fn find(&self, call: &SourceFunctionCall) -> Option<&SourceFunction> {
+        self.functions.get(&call.lookup_key)
+    }
 
-        let TableFactor::Table {
-            name,
-            args: table_args,
-            ..
-        } = &mut relation
-        else {
-            unreachable!("source_function_name only matches table relations");
-        };
-        let args = table_args
-            .as_ref()
-            .expect("source_function_name only matches table relations with args");
-        if args.settings.is_some() {
-            return Err(DataFusionError::Plan(format!(
-                "source table function {}.{} does not support SETTINGS",
-                source_function.display_schema, source_function.display_function
-            )));
-        }
-        let lowered_args = named_args_to_positional(function, args, context)?;
-
-        *name = ObjectName::from(vec![Ident::new(function.internal_name.clone())]);
-        *table_args = Some(TableFunctionArgs {
-            args: lowered_args,
-            settings: None,
-        });
-
-        Ok(SourceFunctionRewrite::Rewritten(relation))
+    fn owns_schema(&self, call: &SourceFunctionCall) -> bool {
+        self.source_schemas.contains(&call.lookup_key.schema)
     }
 
     fn available_functions_hint(&self, schema: &str) -> String {
         let mut names: Vec<&str> = self
             .functions
             .iter()
-            .filter_map(|((entry_schema, _), function)| {
-                (entry_schema == schema).then_some(function.display_name.as_str())
+            .filter_map(|(key, function)| {
+                (key.schema == schema).then_some(function.display_name.as_str())
             })
             .collect();
         names.sort_unstable();
+
         if names.is_empty() {
             String::new()
         } else {
@@ -149,109 +99,237 @@ impl RelationPlanner for SourceFunctionRegistry {
         relation: TableFactor,
         context: &mut dyn RelationPlannerContext,
     ) -> Result<RelationPlanning> {
-        match self.rewrite_relation(relation, context)? {
-            SourceFunctionRewrite::PassThrough(relation) => {
-                Ok(RelationPlanning::Original(Box::new(relation)))
+        let Some(call) = SourceFunctionCall::parse(&relation, context) else {
+            return Ok(original_relation(relation));
+        };
+
+        let Some(function) = self.find(&call) else {
+            if self.owns_schema(&call) {
+                return Err(call.unknown_function_error(
+                    self.available_functions_hint(&call.lookup_key.schema),
+                ));
             }
-            SourceFunctionRewrite::Rewritten(relation) => {
-                let plan = context.plan(relation)?;
-                Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
-                    plan, None,
-                ))))
-            }
+            return Ok(original_relation(relation));
+        };
+
+        let rewritten = rewrite_to_internal_udtf(relation, &call, function, context)?;
+        let plan = context.plan(rewritten)?;
+        Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
+            plan, None,
+        ))))
+    }
+}
+
+impl SourceFunction {
+    fn from_registered(function: &RegisteredTableFunction) -> Self {
+        let arg_names = function.arg_names.clone();
+        Self {
+            internal_name: function.internal_name.clone(),
+            display_name: qualified_name(&function.schema_name, &function.function_name),
+            known_args: arg_names.iter().cloned().collect(),
+            arg_names,
+        }
+    }
+
+    fn contains(&self, name: &str) -> bool {
+        self.known_args.contains(name)
+    }
+}
+
+impl FunctionLookupKey {
+    fn from_manifest(function: &RegisteredTableFunction) -> Self {
+        Self {
+            schema: function.schema_name.clone(),
+            function: function.function_name.clone(),
+        }
+    }
+
+    fn from_sql(schema: Ident, function: Ident, context: &dyn RelationPlannerContext) -> Self {
+        Self {
+            schema: context.normalize_ident(schema),
+            function: context.normalize_ident(function),
         }
     }
 }
 
-fn source_function_name(
-    relation: &TableFactor,
-    context: &dyn RelationPlannerContext,
-) -> Option<SourceFunctionName> {
-    let TableFactor::Table {
-        name,
-        args: Some(_),
-        ..
-    } = relation
-    else {
-        return None;
-    };
-    if name.0.len() != 2 {
-        return None;
+impl SourceFunctionCall {
+    fn parse(relation: &TableFactor, context: &dyn RelationPlannerContext) -> Option<Self> {
+        let TableFactor::Table {
+            name,
+            args: Some(_),
+            ..
+        } = relation
+        else {
+            return None;
+        };
+
+        // Coral source functions are exactly `source.function(...)`. Longer
+        // names belong to DataFusion's normal relation/function planner.
+        if name.0.len() != 2 {
+            return None;
+        }
+
+        let schema = name.0[0].as_ident()?.clone();
+        let function = name.0[1].as_ident()?.clone();
+        let display_name = qualified_name(&schema.value, &function.value);
+        let lookup_key = FunctionLookupKey::from_sql(schema, function, context);
+
+        Some(Self {
+            lookup_key,
+            display_name,
+        })
     }
-    let schema = name.0[0].as_ident()?.clone();
-    let function = name.0[1].as_ident()?.clone();
-    Some(SourceFunctionName {
-        lookup_schema: context.normalize_ident(schema.clone()),
-        lookup_function: context.normalize_ident(function.clone()),
-        display_schema: schema.value,
-        display_function: function.value,
-    })
+
+    fn unknown_function_error(&self, hint: String) -> DataFusionError {
+        DataFusionError::Plan(format!(
+            "unknown source table function {}{}",
+            self.display_name, hint
+        ))
+    }
 }
 
-fn named_args_to_positional(
-    function: &SourceFunctionEntry,
+fn qualified_name(schema: &str, function: &str) -> String {
+    format!("{schema}.{function}")
+}
+
+fn original_relation(relation: TableFactor) -> RelationPlanning {
+    RelationPlanning::Original(Box::new(relation))
+}
+
+fn rewrite_to_internal_udtf(
+    mut relation: TableFactor,
+    call: &SourceFunctionCall,
+    function: &SourceFunction,
+    context: &dyn RelationPlannerContext,
+) -> Result<TableFactor> {
+    let TableFactor::Table {
+        name,
+        args: table_args,
+        ..
+    } = &mut relation
+    else {
+        unreachable!("SourceFunctionCall::parse only matches table relations");
+    };
+
+    let call_args = table_args
+        .as_ref()
+        .expect("SourceFunctionCall::parse only matches function calls");
+    reject_settings(call, call_args)?;
+
+    *name = ObjectName::from(vec![Ident::new(function.internal_name.clone())]);
+    *table_args = Some(TableFunctionArgs {
+        args: lower_named_args_to_internal_positions(function, call_args, context)?,
+        settings: None,
+    });
+
+    Ok(relation)
+}
+
+fn reject_settings(call: &SourceFunctionCall, args: &TableFunctionArgs) -> Result<()> {
+    if args.settings.is_some() {
+        return Err(DataFusionError::Plan(format!(
+            "source table function {} does not support SETTINGS",
+            call.display_name
+        )));
+    }
+    Ok(())
+}
+
+fn lower_named_args_to_internal_positions(
+    function: &SourceFunction,
     args: &TableFunctionArgs,
     context: &dyn RelationPlannerContext,
 ) -> Result<Vec<FunctionArg>> {
-    let display_name = &function.display_name;
-    let mut named = HashMap::new();
-    let mut seen = HashSet::new();
-    for arg in &args.args {
-        match arg {
-            FunctionArg::Named { name, arg, .. } => {
-                let key = context.normalize_ident(name.clone());
-                if !seen.insert(key.clone()) {
-                    return Err(DataFusionError::Plan(format!(
-                        "{display_name} duplicate argument '{}'",
-                        name.value
-                    )));
-                }
-                if !function.arg_lookup.contains(&key) {
-                    return Err(DataFusionError::Plan(format!(
-                        "{display_name} unknown argument '{}'",
-                        name.value
-                    )));
-                }
-                if matches!(
-                    arg,
-                    FunctionArgExpr::Wildcard | FunctionArgExpr::QualifiedWildcard(_)
-                ) {
-                    return Err(DataFusionError::Plan(format!(
-                        "{display_name} argument '{}' does not support wildcard values",
-                        name.value
-                    )));
-                }
-                named.insert(key, arg.clone());
-            }
-            FunctionArg::Unnamed(_) => {
-                return Err(DataFusionError::Plan(format!(
-                    "{display_name} requires named arguments"
-                )));
-            }
-            FunctionArg::ExprNamed { .. } => {
-                return Err(DataFusionError::Plan(format!(
-                    "{display_name} requires identifier argument names"
-                )));
-            }
-        }
-    }
+    let mut supplied = collect_named_args(function, args, context)?;
 
-    // CONTRACT with `HttpSourceTableFunction::call`: the internal UDTF is
-    // positional, so this planner emits exactly one slot per manifest argument.
-    // Missing named args are padded with NULL; the backend binder interprets
-    // those NULLs as absent and performs required-argument validation there.
+    // The internal UDTF is positional. Missing optional args are represented as
+    // NULL placeholders; the backend binder treats NULL as absent and performs
+    // required-argument validation after that interpretation.
     Ok(function
-        .arg_lookup_names
+        .arg_names
         .iter()
-        .map(|arg| {
-            let expr = named
-                .remove(arg)
-                .unwrap_or_else(|| FunctionArgExpr::Expr(Expr::value(Value::Null)));
+        .map(|name| {
+            let expr = supplied.remove(name).unwrap_or_else(null_arg);
             FunctionArg::Unnamed(expr)
         })
         .collect())
 }
 
-fn source_function_display_name(function: &RegisteredTableFunction) -> String {
-    format!("{}.{}", function.schema_name, function.function_name)
+fn collect_named_args(
+    function: &SourceFunction,
+    args: &TableFunctionArgs,
+    context: &dyn RelationPlannerContext,
+) -> Result<HashMap<String, FunctionArgExpr>> {
+    let mut supplied = HashMap::new();
+    let mut seen = HashSet::new();
+
+    for arg in &args.args {
+        let FunctionArg::Named { name, arg, .. } = arg else {
+            return Err(non_named_arg_error(function, arg));
+        };
+        insert_named_arg(function, &mut supplied, &mut seen, name, arg, context)?;
+    }
+
+    Ok(supplied)
+}
+
+fn insert_named_arg(
+    function: &SourceFunction,
+    supplied: &mut HashMap<String, FunctionArgExpr>,
+    seen: &mut HashSet<String>,
+    name: &Ident,
+    arg: &FunctionArgExpr,
+    context: &dyn RelationPlannerContext,
+) -> Result<()> {
+    let lookup_name = context.normalize_ident(name.clone());
+    if !seen.insert(lookup_name.clone()) {
+        return Err(DataFusionError::Plan(format!(
+            "{} duplicate argument '{}'",
+            function.display_name, name.value
+        )));
+    }
+    if !function.contains(&lookup_name) {
+        return Err(DataFusionError::Plan(format!(
+            "{} unknown argument '{}'",
+            function.display_name, name.value
+        )));
+    }
+    reject_wildcard_arg(function, name, arg)?;
+    supplied.insert(lookup_name, arg.clone());
+    Ok(())
+}
+
+fn reject_wildcard_arg(
+    function: &SourceFunction,
+    name: &Ident,
+    arg: &FunctionArgExpr,
+) -> Result<()> {
+    if matches!(
+        arg,
+        FunctionArgExpr::Wildcard | FunctionArgExpr::QualifiedWildcard(_)
+    ) {
+        return Err(DataFusionError::Plan(format!(
+            "{} argument '{}' does not support wildcard values",
+            function.display_name, name.value
+        )));
+    }
+    Ok(())
+}
+
+fn non_named_arg_error(function: &SourceFunction, arg: &FunctionArg) -> DataFusionError {
+    match arg {
+        FunctionArg::Unnamed(_) => DataFusionError::Plan(format!(
+            "{} requires named arguments",
+            function.display_name
+        )),
+        FunctionArg::ExprNamed { .. } => DataFusionError::Plan(format!(
+            "{} requires identifier argument names",
+            function.display_name
+        )),
+        FunctionArg::Named { .. } => unreachable!("named arguments are handled by the caller"),
+    }
+}
+
+fn null_arg() -> FunctionArgExpr {
+    FunctionArgExpr::Expr(Expr::value(Value::Null))
 }

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -1,10 +1,10 @@
 //! Source-scoped table function relation planning.
 //!
-//! DataFusion registers UDTFs in one flat namespace. Coral exposes source
+//! `DataFusion` registers UDTFs in one flat namespace. Coral exposes source
 //! functions as scoped SQL relations like `github.find_issues(...)`. Backends
 //! therefore register hidden internal UDTF names, and this planner rewrites the
 //! scoped relation into the hidden function call before handing planning back
-//! to DataFusion.
+//! to `DataFusion`.
 
 use std::collections::{HashMap, HashSet};
 
@@ -105,9 +105,8 @@ impl RelationPlanner for SourceFunctionRegistry {
 
         let Some(function) = self.find(&call) else {
             if self.owns_schema(&call) {
-                return Err(call.unknown_function_error(
-                    self.available_functions_hint(&call.lookup_key.schema),
-                ));
+                let hint = self.available_functions_hint(&call.lookup_key.schema);
+                return Err(call.unknown_function_error(&hint));
             }
             return Ok(original_relation(relation));
         };
@@ -180,7 +179,7 @@ impl SourceFunctionCall {
         })
     }
 
-    fn unknown_function_error(&self, hint: String) -> DataFusionError {
+    fn unknown_function_error(&self, hint: &str) -> DataFusionError {
         DataFusionError::Plan(format!(
             "unknown source table function {}{}",
             self.display_name, hint

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -12,41 +12,72 @@ use datafusion::logical_expr::sqlparser::ast::{
 
 use crate::backends::RegisteredTableFunction;
 
+enum SourceFunctionRewrite {
+    PassThrough(TableFactor),
+    Rewritten(TableFactor),
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct SourceFunctionRegistry {
-    functions: HashMap<(String, String), RegisteredTableFunction>,
+    functions: HashMap<(String, String), SourceFunctionEntry>,
     schemas: HashSet<String>,
 }
 
+#[derive(Debug, Clone)]
+struct SourceFunctionEntry {
+    registered: RegisteredTableFunction,
+    arg_lookup_names: Vec<String>,
+}
+
 impl SourceFunctionRegistry {
-    pub(crate) fn new(functions: Vec<RegisteredTableFunction>) -> Self {
-        let schemas = functions
-            .iter()
-            .map(|function| function.schema_name.clone())
-            .collect();
-        let functions = functions
-            .into_iter()
-            .map(|function| {
-                (
-                    (function.schema_name.clone(), function.function_name.clone()),
-                    function,
-                )
-            })
-            .collect();
-        Self { functions, schemas }
+    pub(crate) fn new(functions: Vec<RegisteredTableFunction>) -> Result<Self> {
+        let mut schemas = HashSet::new();
+        let mut registered = HashMap::new();
+        for function in functions {
+            let schema_name = manifest_lookup_key(&function.schema_name);
+            let function_name = manifest_lookup_key(&function.function_name);
+            let mut seen_args = HashSet::new();
+            let mut arg_lookup_names = Vec::with_capacity(function.arg_names.len());
+            for arg in &function.arg_names {
+                let lookup_name = manifest_lookup_key(arg);
+                if !seen_args.insert(lookup_name.clone()) {
+                    return Err(DataFusionError::Plan(format!(
+                        "{} has duplicate argument after SQL identifier normalization",
+                        source_function_display_name(&function)
+                    )));
+                }
+                arg_lookup_names.push(lookup_name);
+            }
+            schemas.insert(schema_name.clone());
+            let replaced = registered.insert(
+                (schema_name, function_name),
+                SourceFunctionEntry {
+                    registered: function,
+                    arg_lookup_names,
+                },
+            );
+            if replaced.is_some() {
+                return Err(DataFusionError::Plan(
+                    "duplicate source table function after SQL identifier normalization"
+                        .to_string(),
+                ));
+            }
+        }
+        Ok(Self {
+            functions: registered,
+            schemas,
+        })
     }
 
     pub(crate) fn is_empty(&self) -> bool {
         self.functions.is_empty()
     }
-}
 
-impl RelationPlanner for SourceFunctionRegistry {
-    fn plan_relation(
+    fn rewrite_relation(
         &self,
         relation: TableFactor,
-        context: &mut dyn RelationPlannerContext,
-    ) -> Result<RelationPlanning> {
+        context: &dyn RelationPlannerContext,
+    ) -> Result<SourceFunctionRewrite> {
         let TableFactor::Table {
             name,
             alias,
@@ -60,11 +91,11 @@ impl RelationPlanner for SourceFunctionRegistry {
             index_hints,
         } = relation
         else {
-            return Ok(RelationPlanning::Original(Box::new(relation)));
+            return Ok(SourceFunctionRewrite::PassThrough(relation));
         };
 
-        let Some((schema, function_name)) = source_function_name(&name) else {
-            return Ok(RelationPlanning::Original(Box::new(TableFactor::Table {
+        let Some((schema, function_name)) = source_function_name(&name, context) else {
+            return Ok(SourceFunctionRewrite::PassThrough(TableFactor::Table {
                 name,
                 alias,
                 args: Some(args),
@@ -75,7 +106,7 @@ impl RelationPlanner for SourceFunctionRegistry {
                 json_path,
                 sample,
                 index_hints,
-            })));
+            }));
         };
         let Some(function) = self.functions.get(&(schema.clone(), function_name.clone())) else {
             if self.schemas.contains(&schema) {
@@ -83,7 +114,7 @@ impl RelationPlanner for SourceFunctionRegistry {
                     "unknown source table function {schema}.{function_name}"
                 )));
             }
-            return Ok(RelationPlanning::Original(Box::new(TableFactor::Table {
+            return Ok(SourceFunctionRewrite::PassThrough(TableFactor::Table {
                 name,
                 alias,
                 args: Some(args),
@@ -94,14 +125,14 @@ impl RelationPlanner for SourceFunctionRegistry {
                 json_path,
                 sample,
                 index_hints,
-            })));
+            }));
         };
 
-        let internal_relation = TableFactor::Table {
-            name: ObjectName::from(vec![Ident::new(function.internal_name.clone())]),
+        Ok(SourceFunctionRewrite::Rewritten(TableFactor::Table {
+            name: ObjectName::from(vec![Ident::new(function.registered.internal_name.clone())]),
             alias,
             args: Some(TableFunctionArgs {
-                args: lower_args(function, &args)?,
+                args: named_args_to_positional(function, &args, context)?,
                 settings: None,
             }),
             with_hints,
@@ -111,42 +142,58 @@ impl RelationPlanner for SourceFunctionRegistry {
             json_path,
             sample,
             index_hints,
-        };
-        let plan = context.plan(internal_relation)?;
-        Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
-            plan, None,
-        ))))
+        }))
     }
 }
 
-fn source_function_name(name: &ObjectName) -> Option<(String, String)> {
+impl RelationPlanner for SourceFunctionRegistry {
+    fn plan_relation(
+        &self,
+        relation: TableFactor,
+        context: &mut dyn RelationPlannerContext,
+    ) -> Result<RelationPlanning> {
+        match self.rewrite_relation(relation, context)? {
+            SourceFunctionRewrite::PassThrough(relation) => {
+                Ok(RelationPlanning::Original(Box::new(relation)))
+            }
+            SourceFunctionRewrite::Rewritten(relation) => {
+                let plan = context.plan(relation)?;
+                Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
+                    plan, None,
+                ))))
+            }
+        }
+    }
+}
+
+fn source_function_name(
+    name: &ObjectName,
+    context: &dyn RelationPlannerContext,
+) -> Option<(String, String)> {
     if name.0.len() != 2 {
         return None;
     }
-    let schema = canonical_ident(name.0[0].as_ident()?);
-    let function = canonical_ident(name.0[1].as_ident()?);
+    let schema = context.normalize_ident(name.0[0].as_ident()?.clone());
+    let function = context.normalize_ident(name.0[1].as_ident()?.clone());
     Some((schema, function))
 }
 
-fn canonical_ident(ident: &Ident) -> String {
-    if ident.quote_style.is_some() {
-        ident.value.clone()
-    } else {
-        ident.value.to_ascii_lowercase()
-    }
+fn manifest_lookup_key(name: &str) -> String {
+    name.to_ascii_lowercase()
 }
 
-fn lower_args(
-    function: &RegisteredTableFunction,
+fn named_args_to_positional(
+    function: &SourceFunctionEntry,
     args: &TableFunctionArgs,
+    context: &dyn RelationPlannerContext,
 ) -> Result<Vec<FunctionArg>> {
-    let display_name = source_function_display_name(function);
+    let display_name = source_function_display_name(&function.registered);
     let mut named = HashMap::new();
     let mut seen = HashSet::new();
     for arg in &args.args {
         match arg {
             FunctionArg::Named { name, arg, .. } => {
-                let key = canonical_ident(name);
+                let key = context.normalize_ident(name.clone());
                 if !seen.insert(key.clone()) {
                     return Err(DataFusionError::Plan(format!(
                         "{display_name} duplicate argument '{}'",
@@ -169,7 +216,7 @@ fn lower_args(
     }
 
     for key in named.keys() {
-        if !function.arg_names.iter().any(|arg| arg == key) {
+        if !function.arg_lookup_names.iter().any(|arg| arg == key) {
             return Err(DataFusionError::Plan(format!(
                 "{display_name} unknown argument '{key}'"
             )));
@@ -177,11 +224,11 @@ fn lower_args(
     }
 
     Ok(function
-        .arg_names
+        .arg_lookup_names
         .iter()
         .map(|arg| {
             let expr = named
-                .remove(&arg.to_ascii_lowercase())
+                .remove(arg)
                 .unwrap_or_else(|| FunctionArgExpr::Expr(Expr::value(Value::Null)));
             FunctionArg::Unnamed(expr)
         })

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -164,12 +164,12 @@ impl SourceFunctionCall {
 
         // Coral source functions are exactly `source.function(...)`. Longer
         // names belong to DataFusion's normal relation/function planner.
-        if name.0.len() != 2 {
+        let [schema, function] = name.0.as_slice() else {
             return None;
-        }
+        };
 
-        let schema = name.0[0].as_ident()?.clone();
-        let function = name.0[1].as_ident()?.clone();
+        let schema = schema.as_ident()?.clone();
+        let function = function.as_ident()?.clone();
         let display_name = qualified_name(&schema.value, &function.value);
         let lookup_key = FunctionLookupKey::from_sql(schema, function, context);
 

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -1,0 +1,193 @@
+//! Source-scoped table function relation planning.
+
+use std::collections::{HashMap, HashSet};
+
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::planner::{
+    PlannedRelation, RelationPlanner, RelationPlannerContext, RelationPlanning,
+};
+use datafusion::logical_expr::sqlparser::ast::{
+    Expr, FunctionArg, FunctionArgExpr, Ident, ObjectName, TableFactor, TableFunctionArgs, Value,
+};
+
+use crate::backends::RegisteredTableFunction;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SourceFunctionRegistry {
+    functions: HashMap<(String, String), RegisteredTableFunction>,
+    schemas: HashSet<String>,
+}
+
+impl SourceFunctionRegistry {
+    pub(crate) fn new(functions: Vec<RegisteredTableFunction>) -> Self {
+        let schemas = functions
+            .iter()
+            .map(|function| function.schema_name.clone())
+            .collect();
+        let functions = functions
+            .into_iter()
+            .map(|function| {
+                (
+                    (function.schema_name.clone(), function.function_name.clone()),
+                    function,
+                )
+            })
+            .collect();
+        Self { functions, schemas }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.functions.is_empty()
+    }
+}
+
+impl RelationPlanner for SourceFunctionRegistry {
+    fn plan_relation(
+        &self,
+        relation: TableFactor,
+        context: &mut dyn RelationPlannerContext,
+    ) -> Result<RelationPlanning> {
+        let TableFactor::Table {
+            name,
+            alias,
+            args: Some(args),
+            with_hints,
+            version,
+            with_ordinality,
+            partitions,
+            json_path,
+            sample,
+            index_hints,
+        } = relation
+        else {
+            return Ok(RelationPlanning::Original(Box::new(relation)));
+        };
+
+        let Some((schema, function_name)) = source_function_name(&name) else {
+            return Ok(RelationPlanning::Original(Box::new(TableFactor::Table {
+                name,
+                alias,
+                args: Some(args),
+                with_hints,
+                version,
+                with_ordinality,
+                partitions,
+                json_path,
+                sample,
+                index_hints,
+            })));
+        };
+        let Some(function) = self.functions.get(&(schema.clone(), function_name.clone())) else {
+            if self.schemas.contains(&schema) {
+                return Err(DataFusionError::Plan(format!(
+                    "unknown source table function {schema}.{function_name}"
+                )));
+            }
+            return Ok(RelationPlanning::Original(Box::new(TableFactor::Table {
+                name,
+                alias,
+                args: Some(args),
+                with_hints,
+                version,
+                with_ordinality,
+                partitions,
+                json_path,
+                sample,
+                index_hints,
+            })));
+        };
+
+        let internal_relation = TableFactor::Table {
+            name: ObjectName::from(vec![Ident::new(function.internal_name.clone())]),
+            alias,
+            args: Some(TableFunctionArgs {
+                args: lower_args(function, &args)?,
+                settings: None,
+            }),
+            with_hints,
+            version,
+            with_ordinality,
+            partitions,
+            json_path,
+            sample,
+            index_hints,
+        };
+        let plan = context.plan(internal_relation)?;
+        Ok(RelationPlanning::Planned(Box::new(PlannedRelation::new(
+            plan, None,
+        ))))
+    }
+}
+
+fn source_function_name(name: &ObjectName) -> Option<(String, String)> {
+    if name.0.len() != 2 {
+        return None;
+    }
+    let schema = canonical_ident(name.0[0].as_ident()?);
+    let function = canonical_ident(name.0[1].as_ident()?);
+    Some((schema, function))
+}
+
+fn canonical_ident(ident: &Ident) -> String {
+    if ident.quote_style.is_some() {
+        ident.value.clone()
+    } else {
+        ident.value.to_ascii_lowercase()
+    }
+}
+
+fn lower_args(
+    function: &RegisteredTableFunction,
+    args: &TableFunctionArgs,
+) -> Result<Vec<FunctionArg>> {
+    let display_name = source_function_display_name(function);
+    let mut named = HashMap::new();
+    let mut seen = HashSet::new();
+    for arg in &args.args {
+        match arg {
+            FunctionArg::Named { name, arg, .. } => {
+                let key = canonical_ident(name);
+                if !seen.insert(key.clone()) {
+                    return Err(DataFusionError::Plan(format!(
+                        "{display_name} duplicate argument '{}'",
+                        name.value
+                    )));
+                }
+                named.insert(key, arg.clone());
+            }
+            FunctionArg::Unnamed(_) => {
+                return Err(DataFusionError::Plan(format!(
+                    "{display_name} requires named arguments"
+                )));
+            }
+            FunctionArg::ExprNamed { .. } => {
+                return Err(DataFusionError::Plan(format!(
+                    "{display_name} requires identifier argument names"
+                )));
+            }
+        }
+    }
+
+    for key in named.keys() {
+        if !function.arg_names.iter().any(|arg| arg == key) {
+            return Err(DataFusionError::Plan(format!(
+                "{display_name} unknown argument '{key}'"
+            )));
+        }
+    }
+
+    Ok(function
+        .arg_names
+        .iter()
+        .map(|arg| {
+            let expr = named
+                .remove(&arg.to_ascii_lowercase())
+                .unwrap_or_else(|| FunctionArgExpr::Expr(Expr::value(Value::Null)));
+            FunctionArg::Unnamed(expr)
+        })
+        .collect())
+}
+
+fn source_function_display_name(function: &RegisteredTableFunction) -> String {
+    format!("{}.{}", function.schema_name, function.function_name)
+}

--- a/crates/coral-engine/src/runtime/source_functions.rs
+++ b/crates/coral-engine/src/runtime/source_functions.rs
@@ -1,4 +1,11 @@
 //! Source-scoped table function relation planning.
+//!
+//! `DataFusion` registers UDTFs in a flat namespace, while Coral exposes them
+//! as source-scoped SQL relations like `github.find_issues(...)`. Backends
+//! register hidden internal UDTF names, and this relation planner rewrites the
+//! source-scoped relation into the internal function call. Argument names are
+//! lowered into manifest order here; backend-specific validation and execution
+//! stay with the table function implementation.
 
 use std::collections::{HashMap, HashSet};
 
@@ -25,8 +32,17 @@ pub(crate) struct SourceFunctionRegistry {
 
 #[derive(Debug, Clone)]
 struct SourceFunctionEntry {
-    registered: RegisteredTableFunction,
+    internal_name: String,
+    display_name: String,
     arg_lookup_names: Vec<String>,
+    arg_lookup: HashSet<String>,
+}
+
+struct SourceFunctionName {
+    lookup_schema: String,
+    lookup_function: String,
+    display_schema: String,
+    display_function: String,
 }
 
 impl SourceFunctionRegistry {
@@ -37,11 +53,14 @@ impl SourceFunctionRegistry {
             let schema_name = function.schema_name.clone();
             let function_name = function.function_name.clone();
             let arg_lookup_names = function.arg_names.clone();
+            let display_name = source_function_display_name(&function);
             schemas.insert(schema_name.clone());
             registered.insert(
                 (schema_name, function_name),
                 SourceFunctionEntry {
-                    registered: function,
+                    internal_name: function.internal_name,
+                    display_name,
+                    arg_lookup: arg_lookup_names.iter().cloned().collect(),
                     arg_lookup_names,
                 },
             );
@@ -61,13 +80,19 @@ impl SourceFunctionRegistry {
         mut relation: TableFactor,
         context: &dyn RelationPlannerContext,
     ) -> Result<SourceFunctionRewrite> {
-        let Some((schema, function_name)) = source_function_name(&relation, context) else {
+        let Some(source_function) = source_function_name(&relation, context) else {
             return Ok(SourceFunctionRewrite::PassThrough(relation));
         };
-        let Some(function) = self.functions.get(&(schema.clone(), function_name.clone())) else {
-            if self.schemas.contains(&schema) {
+        let Some(function) = self.functions.get(&(
+            source_function.lookup_schema.clone(),
+            source_function.lookup_function.clone(),
+        )) else {
+            if self.schemas.contains(&source_function.lookup_schema) {
                 return Err(DataFusionError::Plan(format!(
-                    "unknown source table function {schema}.{function_name}"
+                    "unknown source table function {}.{}{}",
+                    source_function.display_schema,
+                    source_function.display_function,
+                    self.available_functions_hint(&source_function.lookup_schema)
                 )));
             }
             return Ok(SourceFunctionRewrite::PassThrough(relation));
@@ -83,13 +108,29 @@ impl SourceFunctionRegistry {
             context,
         )?;
 
-        *name = ObjectName::from(vec![Ident::new(function.registered.internal_name.clone())]);
+        *name = ObjectName::from(vec![Ident::new(function.internal_name.clone())]);
         *args = Some(TableFunctionArgs {
             args: lowered_args,
             settings: None,
         });
 
         Ok(SourceFunctionRewrite::Rewritten(relation))
+    }
+
+    fn available_functions_hint(&self, schema: &str) -> String {
+        let mut names: Vec<&str> = self
+            .functions
+            .iter()
+            .filter_map(|((entry_schema, _), function)| {
+                (entry_schema == schema).then_some(function.display_name.as_str())
+            })
+            .collect();
+        names.sort_unstable();
+        if names.is_empty() {
+            String::new()
+        } else {
+            format!("; available functions: {}", names.join(", "))
+        }
     }
 }
 
@@ -116,7 +157,7 @@ impl RelationPlanner for SourceFunctionRegistry {
 fn source_function_name(
     relation: &TableFactor,
     context: &dyn RelationPlannerContext,
-) -> Option<(String, String)> {
+) -> Option<SourceFunctionName> {
     let TableFactor::Table {
         name,
         args: Some(_),
@@ -128,9 +169,14 @@ fn source_function_name(
     if name.0.len() != 2 {
         return None;
     }
-    let schema = context.normalize_ident(name.0[0].as_ident()?.clone());
-    let function = context.normalize_ident(name.0[1].as_ident()?.clone());
-    Some((schema, function))
+    let schema = name.0[0].as_ident()?.clone();
+    let function = name.0[1].as_ident()?.clone();
+    Some(SourceFunctionName {
+        lookup_schema: context.normalize_ident(schema.clone()),
+        lookup_function: context.normalize_ident(function.clone()),
+        display_schema: schema.value,
+        display_function: function.value,
+    })
 }
 
 fn named_args_to_positional(
@@ -138,7 +184,7 @@ fn named_args_to_positional(
     args: &TableFunctionArgs,
     context: &dyn RelationPlannerContext,
 ) -> Result<Vec<FunctionArg>> {
-    let display_name = source_function_display_name(&function.registered);
+    let display_name = &function.display_name;
     let mut named = HashMap::new();
     let mut seen = HashSet::new();
     for arg in &args.args {
@@ -148,6 +194,12 @@ fn named_args_to_positional(
                 if !seen.insert(key.clone()) {
                     return Err(DataFusionError::Plan(format!(
                         "{display_name} duplicate argument '{}'",
+                        name.value
+                    )));
+                }
+                if !function.arg_lookup.contains(&key) {
+                    return Err(DataFusionError::Plan(format!(
+                        "{display_name} unknown argument '{}'",
                         name.value
                     )));
                 }
@@ -166,14 +218,10 @@ fn named_args_to_positional(
         }
     }
 
-    for key in named.keys() {
-        if !function.arg_lookup_names.iter().any(|arg| arg == key) {
-            return Err(DataFusionError::Plan(format!(
-                "{display_name} unknown argument '{key}'"
-            )));
-        }
-    }
-
+    // CONTRACT with `HttpSourceTableFunction::call`: the internal UDTF is
+    // positional, so this planner emits exactly one slot per manifest argument.
+    // Missing named args are padded with NULL; the backend binder interprets
+    // those NULLs as absent and performs required-argument validation there.
     Ok(function
         .arg_lookup_names
         .iter()

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -382,6 +382,124 @@ async fn source_scoped_table_function_preserves_quoted_manifest_identifiers() {
     );
 }
 
+#[tokio::test]
+async fn source_scoped_table_function_omits_optional_named_arg() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param_is_missing("search_type"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("search", &server.uri()));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title, score \
+             FROM search.search_issues(q => 'flaky cleanup repo:withcoral/coral')",
+        )
+        .await
+        .expect("omitted optional named argument should be absent from the request"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_preserves_table_alias() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("search", &server.uri()));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT issue.title, issue.score \
+             FROM search.search_issues(q => 'flaky cleanup repo:withcoral/coral', mode => 'hybrid') AS issue",
+        )
+        .await
+        .expect("source-scoped table function aliases should resolve"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_rejects_duplicate_args() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("search", &server.uri()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM search.search_issues(q => 'flaky', q => 'cleanup')",
+    )
+    .await
+    .expect_err("duplicate function arguments should fail planning");
+
+    assert!(
+        error
+            .to_string()
+            .contains("search.search_issues duplicate argument 'q'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_rejects_unknown_function_in_known_schema() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("search", &server.uri()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM search.find_issues(q => 'flaky')",
+    )
+    .await
+    .expect_err("unknown source-scoped function should fail planning");
+
+    assert!(
+        error.to_string().contains(
+            "unknown source table function search.find_issues; available functions: search.search_issues",
+        ),
+        "unexpected error: {error}"
+    );
+}
+
 async fn assert_search_function_query(sql: &str) {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -332,6 +332,15 @@ async fn source_scoped_table_function_builds_http_search_request() {
     .await;
 }
 
+#[tokio::test]
+async fn source_scoped_table_function_normalizes_unquoted_sql_identifiers() {
+    assert_search_function_query(
+        "SELECT title, score \
+         FROM SEARCH.SEARCH_ISSUES(MODE => 'hybrid', Q => 'flaky cleanup repo:withcoral/coral')",
+    )
+    .await;
+}
+
 async fn assert_search_function_query(sql: &str) {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -323,6 +323,15 @@ async fn internal_table_function_builds_http_search_request() {
     .await;
 }
 
+#[tokio::test]
+async fn source_scoped_table_function_builds_http_search_request() {
+    assert_search_function_query(
+        "SELECT title, score \
+         FROM search.search_issues(mode => 'hybrid', q => 'flaky cleanup repo:withcoral/coral')",
+    )
+    .await;
+}
+
 async fn assert_search_function_query(sql: &str) {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -401,12 +410,11 @@ async fn table_function_treats_typed_null_as_omitted_optional_argument() {
 async fn table_function_rejects_invalid_argument_values() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("bad_mode_search", &server.uri()));
-    let function_name = internal_table_function_name("bad_mode_search", "search_issues");
 
     let error = CoralQuery::execute_sql(
         &[source],
         test_runtime(),
-        &format!("SELECT title FROM {function_name}('flaky', 'banana')"),
+        "SELECT title FROM bad_mode_search.search_issues(q => 'flaky', mode => 'banana')",
     )
     .await
     .expect_err("invalid function argument should fail planning");
@@ -423,12 +431,11 @@ async fn table_function_rejects_invalid_argument_values() {
 async fn table_function_does_not_expose_request_args_as_columns() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("conflict_search", &server.uri()));
-    let function_name = internal_table_function_name("conflict_search", "search_issues");
 
     let error = CoralQuery::execute_sql(
         &[source],
         test_runtime(),
-        &format!("SELECT title FROM {function_name}('flaky') WHERE q = 'raw'"),
+        "SELECT title FROM conflict_search.search_issues(q => 'flaky') WHERE q = 'raw'",
     )
     .await
     .expect_err("request args should not be queryable as result columns");

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -341,6 +341,47 @@ async fn source_scoped_table_function_normalizes_unquoted_sql_identifiers() {
     .await;
 }
 
+#[tokio::test]
+async fn source_scoped_table_function_preserves_quoted_manifest_identifiers() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = search_function_manifest("Search", &server.uri());
+    manifest["functions"][0]["name"] = json!("Search_Issues");
+    manifest["functions"][0]["args"][0]["name"] = json!("Q");
+    let source = build_source(manifest);
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title, score \
+             FROM \"Search\".\"Search_Issues\"(\"Q\" => 'flaky cleanup repo:withcoral/coral', mode => 'hybrid')",
+        )
+        .await
+        .expect("quoted exact manifest identifiers should resolve"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
 async fn assert_search_function_query(sql: &str) {
     let server = MockServer::start().await;
     Mock::given(method("GET"))


### PR DESCRIPTION
## Summary

Adds public source-scoped table-function planning.

After this PR, manifest-declared functions can be called as normal SQL relations:

```sql
SELECT title, score
FROM github.find_issues(q => 'repo:withcoral/coral flaky')
LIMIT 10;
```

The previous PR registers the internal UDTFs. This PR adds the generic planner that recognizes `source.function(...)` and lowers it to those internal functions.

## What Changed

- registers a generic DataFusion `RelationPlanner` when source functions exist
- resolves two-part relation names like `github.find_issues(...)`
- requires named arguments
- normalizes unquoted schema, function, and argument identifiers consistently with DataFusion
- lowers named args into manifest argument order before calling the internal UDTF
- pads omitted optional args with `NULL`, letting the internal UDTF enforce required-arg validation
- returns a loud planning error for unknown functions in a known source schema

## Behavior

The planner only rewrites the table-function relation. It leaves normal DataFusion behavior in charge of projection, aliases, `WHERE`, ordering, and limits.

Function arguments are provider request inputs. `WHERE` predicates filter the returned rows; they are not pushed down as additional provider request args.

SQL `LIMIT` still flows through to execution and bounds HTTP pagination/fetching.

## Not in This PR

- internal UDTF execution substrate; that is the previous PR
- bundled GitHub/Datadog function rollout
- MCP guide updates

## Validation

- `cargo test -p coral-engine --test engine source_scoped_table_function -- --nocapture`
- `make rust-checks`