### PR TITLE
feat(spec): add source-scoped table function specs

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1564,6 +1564,21 @@ mod tests {
                 "separator": separator,
                 "part": part,
             }),
+            ValueSourceSpec::Arg { key, default } => json!({
+                "from": "arg",
+                "key": key,
+                "default": default,
+            }),
+            ValueSourceSpec::ArgInt { key, default } => json!({
+                "from": "arg_int",
+                "key": key,
+                "default": default,
+            }),
+            ValueSourceSpec::ArgBool { key, default } => json!({
+                "from": "arg_bool",
+                "key": key,
+                "default": default,
+            }),
             ValueSourceSpec::Input { key } => json!({
                 "from": "input",
                 "key": key,

--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -302,6 +302,7 @@ fn eval_template(
                     result.push_str(&rendered);
                 }
                 TemplateNamespace::Input
+                | TemplateNamespace::Arg
                 | TemplateNamespace::State
                 | TemplateNamespace::Other(_) => return None,
             },

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -76,6 +76,11 @@ pub(crate) fn resolve_value_source(
             })?;
             Ok(Some(json!(parsed)))
         }
+        ValueSourceSpec::Arg { key, .. }
+        | ValueSourceSpec::ArgInt { key, .. }
+        | ValueSourceSpec::ArgBool { key, .. } => Err(DataFusionError::Execution(format!(
+            "function argument '{key}' cannot be resolved outside a function request"
+        ))),
         ValueSourceSpec::Input { key } => Ok(resolved_inputs.get(key).cloned().map(Value::String)),
         ValueSourceSpec::State { key } => Ok(state.get(key).map(|v| Value::String(v.clone()))),
         ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
@@ -234,6 +239,9 @@ pub(crate) fn validate_value_source_inputs(
         | ValueSourceSpec::FilterBool { .. }
         | ValueSourceSpec::FilterSplit { .. }
         | ValueSourceSpec::FilterSplitInt { .. }
+        | ValueSourceSpec::Arg { .. }
+        | ValueSourceSpec::ArgInt { .. }
+        | ValueSourceSpec::ArgBool { .. }
         | ValueSourceSpec::State { .. }
         | ValueSourceSpec::NowEpochMinusSeconds { .. } => Ok(()),
     }

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -275,7 +275,11 @@ impl HttpSourceManifest {
             .into_iter()
             .map(|table| table.into_validated(&common.name))
             .collect::<Result<Vec<_>>>()?;
-        validate_http_function_names(&common.name, &functions)?;
+        validate_http_function_names(
+            &common.name,
+            tables.iter().map(HttpTableSpec::name),
+            &functions,
+        )?;
         let functions = functions
             .into_iter()
             .map(|function| {

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -18,8 +18,9 @@ use serde_json::{Map, Value};
 use crate::{
     ColumnSpec, FilterSpec, HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec,
     PaginationSpec, ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result,
-    SourceBackend, SourceManifestCommon, TableCommon, inputs::collect_source_inputs_value,
-    validate::validate_template, validate_http_table, validate_table_names, validate_test_queries,
+    SourceBackend, SourceManifestCommon, SourceTableFunctionSpec, TableCommon,
+    inputs::collect_source_inputs_value, validate::validate_template, validate_http_function,
+    validate_http_function_names, validate_http_table, validate_table_names, validate_test_queries,
 };
 
 /// Source-level authentication requirements for HTTP-backed source specs.
@@ -90,6 +91,7 @@ pub struct HttpSourceManifest {
     pub request_headers: Vec<HeaderSpec>,
     pub rate_limit: RateLimitSpec,
     pub tables: Vec<HttpTableSpec>,
+    pub functions: Vec<SourceTableFunctionSpec>,
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
@@ -115,6 +117,8 @@ struct RawHttpSourceManifest {
     #[serde(default)]
     inputs: Option<Value>,
     tables: Vec<RawHttpTableSpec>,
+    #[serde(default)]
+    functions: Vec<SourceTableFunctionSpec>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -261,6 +265,7 @@ impl HttpSourceManifest {
             rate_limit,
             inputs: _inputs,
             tables,
+            functions,
         } = raw;
         validate_test_queries(&name, &test_queries)?;
         validate_table_names(&name, tables.iter().map(|table| table.name.as_str()))?;
@@ -269,6 +274,14 @@ impl HttpSourceManifest {
         let tables = tables
             .into_iter()
             .map(|table| table.into_validated(&common.name))
+            .collect::<Result<Vec<_>>>()?;
+        validate_http_function_names(&common.name, &functions)?;
+        let functions = functions
+            .into_iter()
+            .map(|function| {
+                validate_http_function(&common.name, &function)?;
+                Ok(function)
+            })
             .collect::<Result<Vec<_>>>()?;
         if base_url.raw().trim().is_empty() {
             return Err(ManifestError::validation(format!(
@@ -289,6 +302,7 @@ impl HttpSourceManifest {
             request_headers,
             rate_limit,
             tables,
+            functions,
             declared_inputs,
         })
     }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -150,8 +150,6 @@ pub struct FilterSpec {
 pub struct SourceTableFunctionSpec {
     pub name: String,
     #[serde(default)]
-    pub kind: String,
-    #[serde(default)]
     pub description: String,
     #[serde(default)]
     pub fetch_limit_default: Option<usize>,

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -145,6 +145,45 @@ pub struct FilterSpec {
     pub mode: FilterMode,
 }
 
+/// Declarative source-scoped table-valued function.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SourceTableFunctionSpec {
+    pub name: String,
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub fetch_limit_default: Option<usize>,
+    #[serde(default)]
+    pub args: Vec<TableFunctionArgSpec>,
+    #[serde(default)]
+    pub request: RequestSpec,
+    #[serde(default)]
+    pub response: ResponseSpec,
+    #[serde(default)]
+    pub pagination: PaginationSpec,
+    #[serde(default)]
+    pub columns: Vec<ColumnSpec>,
+}
+
+/// One argument accepted by a source-scoped table-valued function.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TableFunctionArgSpec {
+    pub name: String,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(default)]
+    pub values: Vec<String>,
+    pub bind: FunctionArgBinding,
+}
+
+/// How a table function argument contributes to the provider request.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct FunctionArgBinding {
+    pub arg: String,
+}
+
 /// The base request template for one HTTP table or request route.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct RequestSpec {
@@ -322,6 +361,21 @@ pub enum ValueSourceSpec {
         key: String,
         separator: String,
         part: usize,
+    },
+    Arg {
+        key: String,
+        #[serde(default)]
+        default: Option<Value>,
+    },
+    ArgInt {
+        key: String,
+        #[serde(default)]
+        default: Option<i64>,
+    },
+    ArgBool {
+        key: String,
+        #[serde(default)]
+        default: Option<bool>,
     },
     Input {
         key: String,

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -88,11 +88,12 @@ mod validate;
 pub use backends::http::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 pub(crate) use common::validate_test_queries;
 pub use common::{
-    BodyFieldSpec, BodySpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, HeaderSpec, HttpMethod,
-    ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec, QueryParamSpec,
-    RequestRouteSpec, RequestSpec, ResponseBodyFormat, ResponseSpec, RowStrategy, SourceBackend,
-    SourceManifestCommon, TableCommon, TimestampInput, ValidatedPagination,
-    ValidatedPaginationMode, ValueSourceSpec,
+    BodyFieldSpec, BodySpec, ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding,
+    HeaderSpec, HttpMethod, ManifestDataType, PageSizeSpec, PaginationMode, PaginationSpec,
+    QueryParamSpec, RequestRouteSpec, RequestSpec, ResponseBodyFormat, ResponseSpec, RowStrategy,
+    SourceBackend, SourceManifestCommon, SourceTableFunctionSpec, TableCommon,
+    TableFunctionArgSpec, TimestampInput, ValidatedPagination, ValidatedPaginationMode,
+    ValueSourceSpec,
 };
 pub use error::{ManifestError, Result};
 pub use inputs::{ManifestInputKind, ManifestInputSpec, resolve_inputs};
@@ -102,5 +103,6 @@ pub use parser::{
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{
-    validate_columns, validate_filters_and_column_exprs, validate_http_table, validate_table_names,
+    validate_columns, validate_filters_and_column_exprs, validate_http_function,
+    validate_http_function_names, validate_http_table, validate_table_names,
 };

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -211,7 +211,6 @@
       "required": ["name", "request"],
       "properties": {
         "name": { "type": "string", "minLength": 1 },
-        "kind": { "type": "string", "minLength": 1 },
         "description": { "type": "string" },
         "fetch_limit_default": { "type": "integer", "minimum": 1 },
         "args": {

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -28,6 +28,10 @@
       "minItems": 1,
       "items": { "$ref": "#/$defs/table" }
     },
+    "functions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/table_function" }
+    },
     "onboarding": {
       "type": "object",
       "additionalProperties": false,
@@ -199,6 +203,51 @@
         "name": { "type": "string", "minLength": 1 },
         "required": { "type": "boolean" },
         "mode": { "type": "string", "enum": ["equality", "search", "contains"] }
+      }
+    },
+    "table_function": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "request"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "fetch_limit_default": { "type": "integer", "minimum": 1 },
+        "args": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/table_function_arg" }
+        },
+        "request": { "$ref": "#/$defs/request" },
+        "response": { "$ref": "#/$defs/response" },
+        "pagination": { "$ref": "#/$defs/pagination" },
+        "columns": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/column" }
+        }
+      }
+    },
+    "table_function_arg": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "bind"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "required": { "type": "boolean" },
+        "values": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "bind": { "$ref": "#/$defs/function_binding" }
+      }
+    },
+    "function_binding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["arg"],
+      "properties": {
+        "arg": { "type": "string", "minLength": 1 }
       }
     },
     "request": {
@@ -396,6 +445,29 @@
             "part": { "type": "integer", "minimum": 0 }
           },
           "required": ["key", "separator", "part"]
+        },
+        {
+          "properties": {
+            "from": { "const": "arg" },
+            "key": { "type": "string", "minLength": 1 }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
+            "from": { "const": "arg_int" },
+            "key": { "type": "string", "minLength": 1 },
+            "default": { "type": "integer" }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
+            "from": { "const": "arg_bool" },
+            "key": { "type": "string", "minLength": 1 },
+            "default": { "type": "boolean" }
+          },
+          "required": ["key"]
         },
         {
           "properties": {

--- a/crates/coral-spec/src/template.rs
+++ b/crates/coral-spec/src/template.rs
@@ -172,6 +172,8 @@ pub enum TemplateNamespace {
     Input,
     /// A SQL filter token.
     Filter,
+    /// A source-scoped table function request argument token.
+    Arg,
     /// A row-expression sub-expression token.
     Expr,
     /// A runtime pagination or request state token.
@@ -185,6 +187,7 @@ impl TemplateNamespace {
         match raw {
             "input" => Self::Input,
             "filter" => Self::Filter,
+            "arg" => Self::Arg,
             "expr" => Self::Expr,
             "state" => Self::State,
             other => Self::Other(other.to_string()),

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -3,8 +3,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::common::{
-    BodySpec, ColumnSpec, ExprSpec, FilterSpec, PaginationSpec, RequestRouteSpec, RequestSpec,
-    ValueSourceSpec,
+    BodySpec, ColumnSpec, ExprSpec, FilterSpec, FunctionArgBinding, PaginationSpec,
+    RequestRouteSpec, RequestSpec, SourceTableFunctionSpec, ValueSourceSpec,
 };
 use crate::{ManifestError, ParsedTemplate, Result, TemplateNamespace};
 
@@ -67,6 +67,82 @@ pub(crate) fn validate_http_table(
     pagination.validate(schema, table_name)
 }
 
+pub(crate) fn validate_http_function_names(
+    source_name: &str,
+    functions: &[SourceTableFunctionSpec],
+) -> Result<()> {
+    let mut function_names = HashSet::new();
+
+    for function in functions {
+        validate_identifier(
+            &function.name,
+            &format!("source '{source_name}' function name"),
+        )?;
+        if !function_names.insert(function.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' function '{}' is declared more than once",
+                function.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn validate_http_function(
+    source_name: &str,
+    function: &SourceTableFunctionSpec,
+) -> Result<()> {
+    validate_identifier(
+        &function.name,
+        &format!("source '{source_name}' function name"),
+    )?;
+
+    let mut arg_names = HashSet::new();
+    let mut request_arg_names = HashSet::new();
+
+    for arg in &function.args {
+        validate_identifier(
+            &arg.name,
+            &format!(
+                "source '{source_name}' function '{}' argument",
+                function.name
+            ),
+        )?;
+        if !arg_names.insert(arg.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' function '{}' argument '{}' is declared more than once",
+                function.name, arg.name
+            )));
+        }
+        validate_unique_values(
+            &arg.values,
+            &format!(
+                "source '{source_name}' function '{}' argument '{}'",
+                function.name, arg.name
+            ),
+        )?;
+        validate_function_binding(
+            source_name,
+            &function.name,
+            &arg.bind,
+            &mut request_arg_names,
+        )?;
+    }
+
+    validate_columns(
+        &function.columns,
+        source_name,
+        &format!("function '{}'", function.name),
+    )?;
+    validate_function_request_bindings(source_name, function, &request_arg_names)?;
+    function
+        .pagination
+        .validate(source_name, &format!("function '{}'", function.name))?;
+
+    Ok(())
+}
+
 pub(crate) fn validate_filters_and_column_exprs(
     filters: &[FilterSpec],
     columns: &[ColumnSpec],
@@ -94,6 +170,23 @@ pub(crate) fn validate_filters_and_column_exprs(
     }
 
     Ok(known_filters)
+}
+
+pub(crate) fn validate_unique_values(values: &[String], context: &str) -> Result<()> {
+    let mut seen = HashSet::new();
+    for value in values {
+        if value.trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "{context} values must not contain empty strings"
+            )));
+        }
+        if !seen.insert(value.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "{context} value '{value}' is declared more than once"
+            )));
+        }
+    }
+    Ok(())
 }
 
 pub(crate) fn validate_columns(columns: &[ColumnSpec], schema: &str, table: &str) -> Result<()> {
@@ -183,7 +276,179 @@ fn validate_value_source(
         ValueSourceSpec::Template { template } => {
             validate_template(template, known_filters, context)?;
         }
+        ValueSourceSpec::Arg { key, .. }
+        | ValueSourceSpec::ArgInt { key, .. }
+        | ValueSourceSpec::ArgBool { key, .. } => {
+            return Err(ManifestError::validation(format!(
+                "{context} uses function argument '{key}' outside a function request"
+            )));
+        }
         _ => {}
+    }
+    Ok(())
+}
+
+fn validate_function_binding<'a>(
+    source_name: &str,
+    function_name: &str,
+    binding: &'a FunctionArgBinding,
+    request_arg_names: &mut HashSet<&'a str>,
+) -> Result<()> {
+    if !request_arg_names.insert(binding.arg.as_str()) {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' function '{function_name}' has multiple bindings for request arg '{}'",
+            binding.arg
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_function_request_bindings(
+    source_name: &str,
+    function: &SourceTableFunctionSpec,
+    request_arg_names: &HashSet<&str>,
+) -> Result<()> {
+    if function.request.path.raw().trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' function '{}' has an empty request.path",
+            function.name
+        )));
+    }
+
+    validate_arg_template(
+        &function.request.path,
+        request_arg_names,
+        &format!("source '{source_name}' function '{}'", function.name),
+    )?;
+
+    for header in &function.request.headers {
+        validate_arg_value_source(
+            &header.value,
+            request_arg_names,
+            &format!(
+                "source '{source_name}' function '{}' request header '{}'",
+                function.name, header.name
+            ),
+        )?;
+    }
+
+    for param in &function.request.query {
+        validate_arg_value_source(
+            &param.value,
+            request_arg_names,
+            &format!(
+                "source '{source_name}' function '{}' query param '{}'",
+                function.name, param.name
+            ),
+        )?;
+    }
+
+    match &function.request.body {
+        BodySpec::Json { fields } => {
+            for field in fields {
+                validate_arg_value_source(
+                    &field.value,
+                    request_arg_names,
+                    &format!(
+                        "source '{source_name}' function '{}' request body path '{}'",
+                        function.name,
+                        field.path.join(".")
+                    ),
+                )?;
+            }
+        }
+        BodySpec::Text { content } => {
+            validate_arg_value_source(
+                content,
+                request_arg_names,
+                &format!(
+                    "source '{source_name}' function '{}' request body text",
+                    function.name
+                ),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_arg_value_source(
+    source: &ValueSourceSpec,
+    request_arg_names: &HashSet<&str>,
+    context: &str,
+) -> Result<()> {
+    match source {
+        ValueSourceSpec::Arg { key, .. }
+        | ValueSourceSpec::ArgInt { key, .. }
+        | ValueSourceSpec::ArgBool { key, .. }
+            if !request_arg_names.contains(key.as_str()) =>
+        {
+            return Err(ManifestError::validation(format!(
+                "{context} references unknown request arg '{key}'"
+            )));
+        }
+        ValueSourceSpec::Filter { key, .. }
+        | ValueSourceSpec::FilterInt { key, .. }
+        | ValueSourceSpec::FilterBool { key, .. }
+        | ValueSourceSpec::FilterSplit { key, .. }
+        | ValueSourceSpec::FilterSplitInt { key, .. } => {
+            return Err(ManifestError::validation(format!(
+                "{context} uses table filter '{key}' inside a function request"
+            )));
+        }
+        ValueSourceSpec::Template { template } => {
+            validate_arg_template(template, request_arg_names, context)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn validate_arg_template(
+    template: &ParsedTemplate,
+    request_arg_names: &HashSet<&str>,
+    context: &str,
+) -> Result<()> {
+    for token in template.tokens() {
+        match token.namespace() {
+            TemplateNamespace::Arg => {
+                if !request_arg_names.contains(token.key()) {
+                    return Err(ManifestError::validation(format!(
+                        "{context} references unknown request arg '{}' in template '{}'",
+                        token.key(),
+                        template.raw()
+                    )));
+                }
+            }
+            TemplateNamespace::Input | TemplateNamespace::State => {}
+            TemplateNamespace::Filter | TemplateNamespace::Expr | TemplateNamespace::Other(_) => {
+                return Err(ManifestError::validation(format!(
+                    "{context} uses unsupported function request template token '{}'",
+                    token.raw()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_identifier(value: &str, context: &str) -> Result<()> {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err(ManifestError::validation(format!(
+            "{context} must not be empty"
+        )));
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return Err(ManifestError::validation(format!(
+            "{context} '{value}' must start with a letter or underscore"
+        )));
+    }
+    if chars.any(|ch| !(ch == '_' || ch.is_ascii_alphanumeric())) {
+        return Err(ManifestError::validation(format!(
+            "{context} '{value}' may only contain letters, numbers, and underscores"
+        )));
     }
     Ok(())
 }
@@ -260,7 +525,10 @@ fn validate_expr_template(
                     )));
                 }
             }
-            TemplateNamespace::Input | TemplateNamespace::State | TemplateNamespace::Other(_) => {
+            TemplateNamespace::Input
+            | TemplateNamespace::Arg
+            | TemplateNamespace::State
+            | TemplateNamespace::Other(_) => {
                 return Err(ManifestError::validation(format!(
                     "{context} uses unsupported expr template token '{}'",
                     token.raw()
@@ -289,6 +557,12 @@ pub(crate) fn validate_template(
                 }
             }
             TemplateNamespace::Input | TemplateNamespace::State => {}
+            TemplateNamespace::Arg => {
+                return Err(ManifestError::validation(format!(
+                    "{context} uses function argument token '{}' outside a function request",
+                    token.raw()
+                )));
+            }
             TemplateNamespace::Expr | TemplateNamespace::Other(_) => {
                 return Err(ManifestError::validation(format!(
                     "{context} uses unsupported template token '{}'",
@@ -306,12 +580,13 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::common::{
-        ColumnSpec, ExprSpec, FilterMode, FilterSpec, PaginationSpec, QueryParamSpec,
-        RequestRouteSpec, RequestSpec, ValueSourceSpec,
+        ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, PaginationSpec,
+        QueryParamSpec, RequestRouteSpec, RequestSpec, SourceTableFunctionSpec,
+        TableFunctionArgSpec, ValueSourceSpec,
     };
     use crate::template::ParsedTemplate;
 
-    use super::{validate_filters_and_column_exprs, validate_http_table};
+    use super::{validate_filters_and_column_exprs, validate_http_function, validate_http_table};
 
     fn test_column() -> ColumnSpec {
         ColumnSpec {
@@ -342,6 +617,34 @@ mod tests {
         RequestSpec {
             path: ParsedTemplate::parse("/messages").expect("request path"),
             ..RequestSpec::default()
+        }
+    }
+
+    fn function_with_request_value(value: ValueSourceSpec) -> SourceTableFunctionSpec {
+        SourceTableFunctionSpec {
+            name: "search".to_string(),
+            kind: String::new(),
+            description: String::new(),
+            fetch_limit_default: None,
+            args: vec![TableFunctionArgSpec {
+                name: "query".to_string(),
+                required: true,
+                values: vec![],
+                bind: FunctionArgBinding {
+                    arg: "q".to_string(),
+                },
+            }],
+            request: RequestSpec {
+                path: ParsedTemplate::parse("/search").expect("request path"),
+                query: vec![QueryParamSpec {
+                    name: "q".to_string(),
+                    value,
+                }],
+                ..RequestSpec::default()
+            },
+            response: crate::ResponseSpec::default(),
+            pagination: PaginationSpec::default(),
+            columns: vec![],
         }
     }
 
@@ -472,6 +775,114 @@ mod tests {
                 .to_string()
                 .contains("references unknown filter 'missing'")
         );
+    }
+
+    #[test]
+    fn validate_http_table_rejects_function_arg_value_sources() {
+        let cases = [
+            ValueSourceSpec::Arg {
+                key: "query".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::ArgInt {
+                key: "limit".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::ArgBool {
+                key: "archived".to_string(),
+                default: None,
+            },
+        ];
+
+        for value in cases {
+            let request = RequestSpec {
+                query: vec![QueryParamSpec {
+                    name: "value".to_string(),
+                    value,
+                }],
+                ..base_request()
+            };
+
+            let error = validate_http_table(
+                "demo",
+                "messages",
+                &test_filters(),
+                &[test_column()],
+                &request,
+                &[],
+                &PaginationSpec::default(),
+            )
+            .expect_err("table requests should reject function arguments");
+
+            assert!(
+                error.to_string().contains("uses function argument"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_http_table_rejects_function_arg_template_tokens() {
+        let request = RequestSpec {
+            path: ParsedTemplate::parse("/search/{{arg.q}}").expect("template"),
+            ..RequestSpec::default()
+        };
+
+        let error = validate_http_table(
+            "demo",
+            "messages",
+            &test_filters(),
+            &[test_column()],
+            &request,
+            &[],
+            &PaginationSpec::default(),
+        )
+        .expect_err("table request templates should reject function arguments");
+
+        assert!(
+            error
+                .to_string()
+                .contains("uses function argument token 'arg.q' outside a function request")
+        );
+    }
+
+    #[test]
+    fn validate_http_function_rejects_table_filter_value_sources() {
+        let cases = [
+            ValueSourceSpec::Filter {
+                key: "q".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::FilterInt {
+                key: "limit".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::FilterBool {
+                key: "archived".to_string(),
+                default: None,
+            },
+            ValueSourceSpec::FilterSplit {
+                key: "repo".to_string(),
+                separator: "/".to_string(),
+                part: 0,
+            },
+            ValueSourceSpec::FilterSplitInt {
+                key: "issue_key".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+        ];
+
+        for value in cases {
+            let function = function_with_request_value(value);
+            let error = validate_http_function("demo", &function)
+                .expect_err("function requests should reject table filters");
+
+            assert!(
+                error.to_string().contains("uses table filter"),
+                "unexpected error: {error}"
+            );
+        }
     }
 
     #[test]

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -69,9 +69,13 @@ pub(crate) fn validate_http_table(
 
 pub(crate) fn validate_http_function_names(
     source_name: &str,
-    _table_names: impl IntoIterator<Item = impl AsRef<str>>,
+    table_names: impl IntoIterator<Item = impl AsRef<str>>,
     functions: &[SourceTableFunctionSpec],
 ) -> Result<()> {
+    let table_names = table_names
+        .into_iter()
+        .map(|name| name.as_ref().to_string())
+        .collect::<HashSet<_>>();
     let mut function_names = HashSet::new();
 
     for function in functions {
@@ -79,6 +83,12 @@ pub(crate) fn validate_http_function_names(
             &function.name,
             &format!("source '{source_name}' function name"),
         )?;
+        if table_names.contains(&function.name) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' declares both a table and function named '{}'",
+                function.name
+            )));
+        }
         if !function_names.insert(function.name.as_str()) {
             return Err(ManifestError::validation(format!(
                 "source '{source_name}' function '{}' is declared more than once",
@@ -890,7 +900,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_http_function_names_allows_table_name_collisions() {
+    fn validate_http_function_names_rejects_table_name_collisions() {
         let function = SourceTableFunctionSpec {
             name: "messages".to_string(),
             description: String::new(),
@@ -902,8 +912,14 @@ mod tests {
             columns: vec![],
         };
 
-        validate_http_function_names("demo", ["messages"], &[function])
-            .expect("function calls are disambiguated from table scans by SQL args");
+        let error = validate_http_function_names("demo", ["messages"], &[function])
+            .expect_err("function should not share a table name");
+
+        assert!(
+            error
+                .to_string()
+                .contains("declares both a table and function named 'messages'")
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -69,8 +69,13 @@ pub(crate) fn validate_http_table(
 
 pub(crate) fn validate_http_function_names(
     source_name: &str,
+    table_names: impl IntoIterator<Item = impl AsRef<str>>,
     functions: &[SourceTableFunctionSpec],
 ) -> Result<()> {
+    let table_names = table_names
+        .into_iter()
+        .map(|name| name.as_ref().to_string())
+        .collect::<HashSet<_>>();
     let mut function_names = HashSet::new();
 
     for function in functions {
@@ -78,6 +83,12 @@ pub(crate) fn validate_http_function_names(
             &function.name,
             &format!("source '{source_name}' function name"),
         )?;
+        if table_names.contains(&function.name) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' declares both a table and function named '{}'",
+                function.name
+            )));
+        }
         if !function_names.insert(function.name.as_str()) {
             return Err(ManifestError::validation(format!(
                 "source '{source_name}' function '{}' is declared more than once",
@@ -130,7 +141,8 @@ pub(crate) fn validate_http_function(
         )?;
     }
 
-    validate_columns(
+    validate_filters_and_column_exprs(
+        &[],
         &function.columns,
         source_name,
         &format!("function '{}'", function.name),
@@ -586,7 +598,10 @@ mod tests {
     };
     use crate::template::ParsedTemplate;
 
-    use super::{validate_filters_and_column_exprs, validate_http_function, validate_http_table};
+    use super::{
+        validate_filters_and_column_exprs, validate_http_function, validate_http_function_names,
+        validate_http_table,
+    };
 
     fn test_column() -> ColumnSpec {
         ColumnSpec {
@@ -883,6 +898,46 @@ mod tests {
                 "unexpected error: {error}"
             );
         }
+    }
+
+    #[test]
+    fn validate_http_function_names_rejects_table_name_collisions() {
+        let function = SourceTableFunctionSpec {
+            name: "messages".to_string(),
+            kind: String::new(),
+            description: String::new(),
+            fetch_limit_default: None,
+            args: vec![],
+            request: base_request(),
+            response: crate::ResponseSpec::default(),
+            pagination: PaginationSpec::default(),
+            columns: vec![],
+        };
+
+        let error = validate_http_function_names("demo", ["messages"], &[function])
+            .expect_err("function should not share a table name");
+
+        assert!(
+            error
+                .to_string()
+                .contains("declares both a table and function named 'messages'")
+        );
+    }
+
+    #[test]
+    fn validate_http_function_rejects_filter_column_exprs() {
+        let mut function = function_with_request_value(ValueSourceSpec::Arg {
+            key: "q".to_string(),
+            default: None,
+        });
+        function.columns = vec![column_with_expr(ExprSpec::FromFilter {
+            key: "q".to_string(),
+        })];
+
+        let error = validate_http_function("demo", &function)
+            .expect_err("function columns should not reference table filters");
+
+        assert!(error.to_string().contains("references unknown filter 'q'"));
     }
 
     #[test]

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -69,13 +69,9 @@ pub(crate) fn validate_http_table(
 
 pub(crate) fn validate_http_function_names(
     source_name: &str,
-    table_names: impl IntoIterator<Item = impl AsRef<str>>,
+    _table_names: impl IntoIterator<Item = impl AsRef<str>>,
     functions: &[SourceTableFunctionSpec],
 ) -> Result<()> {
-    let table_names = table_names
-        .into_iter()
-        .map(|name| name.as_ref().to_string())
-        .collect::<HashSet<_>>();
     let mut function_names = HashSet::new();
 
     for function in functions {
@@ -83,12 +79,6 @@ pub(crate) fn validate_http_function_names(
             &function.name,
             &format!("source '{source_name}' function name"),
         )?;
-        if table_names.contains(&function.name) {
-            return Err(ManifestError::validation(format!(
-                "source '{source_name}' declares both a table and function named '{}'",
-                function.name
-            )));
-        }
         if !function_names.insert(function.name.as_str()) {
             return Err(ManifestError::validation(format!(
                 "source '{source_name}' function '{}' is declared more than once",
@@ -900,7 +890,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_http_function_names_rejects_table_name_collisions() {
+    fn validate_http_function_names_allows_table_name_collisions() {
         let function = SourceTableFunctionSpec {
             name: "messages".to_string(),
             description: String::new(),
@@ -912,14 +902,8 @@ mod tests {
             columns: vec![],
         };
 
-        let error = validate_http_function_names("demo", ["messages"], &[function])
-            .expect_err("function should not share a table name");
-
-        assert!(
-            error
-                .to_string()
-                .contains("declares both a table and function named 'messages'")
-        );
+        validate_http_function_names("demo", ["messages"], &[function])
+            .expect("function calls are disambiguated from table scans by SQL args");
     }
 
     #[test]

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -638,7 +638,6 @@ mod tests {
     fn function_with_request_value(value: ValueSourceSpec) -> SourceTableFunctionSpec {
         SourceTableFunctionSpec {
             name: "search".to_string(),
-            kind: String::new(),
             description: String::new(),
             fetch_limit_default: None,
             args: vec![TableFunctionArgSpec {
@@ -904,7 +903,6 @@ mod tests {
     fn validate_http_function_names_rejects_table_name_collisions() {
         let function = SourceTableFunctionSpec {
             name: "messages".to_string(),
-            kind: String::new(),
             description: String::new(),
             fetch_limit_default: None,
             args: vec![],

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -534,7 +534,7 @@ Request query params, body fields, and headers support these `from` values:
 the value comes from. Table requests use filter value sources because their
 request values come from SQL predicates such as `WHERE id = 123`. Source
 function requests use arg value sources because their request values come from
-named function arguments such as `github.search_issues(query => 'flaky')`.
+named function arguments such as `github.search_issues(q => 'flaky')`.
 
 The suffix controls the value type sent to the provider. Use the bare form for a
 string request value, `_int` for a JSON integer, and `_bool` for a JSON boolean.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -329,7 +329,6 @@ need a backing table.
 ```yaml
 functions:
   - name: search_issues
-    kind: search
     args:
       - name: q
         required: true

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -318,6 +318,65 @@ In this minimal example:
 - `inputs` declares the install-time variables and secrets for this source in stable authored order. At install time, `coral source add` reads each key from an environment variable of the same name (or prompts for them when run with `--interactive`). At runtime, installed inputs are surfaced through `coral.inputs`.
 - `{{input.API_TOKEN}}` is resolved from the store implied by the declared input kind
 
+### HTTP table functions
+
+HTTP sources can declare source-scoped table functions for provider-native
+operations that return rows, such as search endpoints. A function adds
+invocation arguments, but it still owns the same execution shape as an HTTP
+table: request, response mapping, pagination, and result columns. It does not
+need a backing table.
+
+```yaml
+functions:
+  - name: search_issues
+    kind: search
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: mode
+        values: [lexical, semantic, hybrid]
+        bind:
+          arg: search_type
+    request:
+      method: GET
+      path: /search/issues
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: search_type
+          from: arg
+          key: search_type
+    response:
+      rows_path: [items]
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      link_header_require_results: false
+    columns:
+      - name: title
+        type: Utf8
+      - name: html_url
+        type: Utf8
+      - name: score
+        type: Float64
+```
+
+Use `bind.arg` when a SQL argument should populate a differently named request
+argument. Function request values can then reference those bound arguments with
+`from: arg`.
+
 ### HTTP authentication
 
 The top-level `auth` block declares how Coral authenticates outgoing requests. Pick one of three `type` values:
@@ -459,14 +518,26 @@ Request query params, body fields, and headers support these `from` values:
 | ------------ | ----------- |
 | `literal` | Use the manifest-authored JSON value directly |
 | `template` | Render a string template with `input`, `filter`, or `state` tokens |
-| `filter` | Read a SQL filter as a string |
-| `filter_int` | Read a SQL filter and serialize it as a JSON integer |
-| `filter_bool` | Read a SQL filter and serialize it as a JSON boolean |
-| `filter_split` | Split a SQL filter string and serialize one part as a string |
-| `filter_split_int` | Split a SQL filter string and serialize one part as a JSON integer |
+| `filter` | Read a table filter captured from the query `WHERE` clause and serialize it as a string |
+| `filter_int` | Read a table filter captured from the query `WHERE` clause and serialize it as a JSON integer |
+| `filter_bool` | Read a table filter captured from the query `WHERE` clause and serialize it as a JSON boolean |
+| `filter_split` | Split a table filter string and serialize one part as a string |
+| `filter_split_int` | Split a table filter string and serialize one part as a JSON integer |
+| `arg` | Read a source function argument captured from the function call and serialize it as a string |
+| `arg_int` | Read a source function argument captured from the function call and serialize it as a JSON integer |
+| `arg_bool` | Read a source function argument captured from the function call and serialize it as a JSON boolean |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
 | `state` | Read pagination/runtime state |
 | `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |
+
+`filter*`, `filter_split`, and `filter_split_int` differ from `arg*` by where
+the value comes from. Table requests use filter value sources because their
+request values come from SQL predicates such as `WHERE id = 123`. Source
+function requests use arg value sources because their request values come from
+named function arguments such as `github.search_issues(query => 'flaky')`.
+
+The suffix controls the value type sent to the provider. Use the bare form for a
+string request value, `_int` for a JSON integer, and `_bool` for a JSON boolean.
 
 Boolean filters used with `filter_bool` can be written as normal SQL boolean
 predicates, for example `WHERE include_archived IS FALSE` or


### PR DESCRIPTION
## What changed

Adds the source-spec shape for source-scoped table functions. This lets HTTP source manifests declare provider-native operations that return rows, without pretending the operation is a backing table.

A function adds invocation arguments, but still defines the same HTTP execution shape as a table: `request`, `response`, `pagination`, and `columns`.

```yaml
functions:
  - name: search_issues
    args:
      - name: q
        required: true
        bind:
          arg: q
      - name: mode
        values: [lexical, semantic, hybrid]
        bind:
          arg: search_type
    request:
      method: GET
      path: /search/issues
      query:
        - name: q
          from: arg
          key: q
        - name: search_type
          from: arg
          key: search_type
    response:
      rows_path: [items]
    pagination:
      mode: page
      page_size:
        default: 30
        max: 100
        query_param: per_page
    columns:
      - name: title
        type: Utf8
```

## Scope

- Add manifest models for source-scoped table functions
- Add function args with explicit `bind.arg` request-arg mapping
- Add `from: arg`, `from: arg_int`, and `from: arg_bool` request value sources
- Validate function names, duplicate args, enum values, duplicate request-arg bindings, request templates, pagination, and result columns
- Reject table-only filter value sources inside function requests
- Reject function-only arg value sources inside table requests
- Update the source manifest JSON schema
- Document the source-spec shape

## Not in this PR

- Runtime catalog discovery through `coral.table_functions`
- DataFusion UDTF registration
- Executing `source.function(arg => value)` SQL
- GitHub/Datadog manifest rollout
- Semantic GitHub sugar such as `repo => ...`
- Fixed/hidden function request bindings

## Validation

- `cargo test -p coral-spec`
- `make rust-checks`
