### PR TITLE
feat(mcp): add opt-in feedback tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ name = "coral-app"
 version = "0.1.5"
 dependencies = [
  "arrow",
+ "chrono",
  "coral-api",
  "coral-auth-aws",
  "coral-client",
@@ -1008,6 +1009,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -5197,6 +5199,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -14,6 +14,7 @@ fn main() {
             &[
                 "proto/coral/v1/catalog.proto",
                 "proto/coral/v1/resources.proto",
+                "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
                 "proto/coral/v1/query.proto",
             ],

--- a/crates/coral-api/proto/coral/v1/feedback.proto
+++ b/crates/coral-api/proto/coral/v1/feedback.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package coral.v1;
+
+import "coral/v1/resources.proto";
+
+// One agent-submitted feedback report.
+message FeedbackReport {
+  // Server-assigned report identifier.
+  string id = 1;
+  // Owning workspace resource.
+  Workspace workspace = 2;
+  // Server-assigned creation timestamp in RFC3339 format.
+  string created_at = 3;
+  // What the agent was attempting to do.
+  string trying_to_do = 4;
+  // What the agent already tried.
+  string tried = 5;
+  // Where the agent got blocked.
+  string stuck = 6;
+}
+
+// Submits one blocked-agent feedback report.
+message SubmitFeedbackRequest {
+  // Owning workspace resource.
+  Workspace workspace = 1;
+  // What the agent was attempting to do.
+  string trying_to_do = 2;
+  // What the agent already tried.
+  string tried = 3;
+  // Where the agent got blocked.
+  string stuck = 4;
+}
+
+// Returns the persisted feedback report.
+message SubmitFeedbackResponse {
+  // Persisted report.
+  FeedbackReport report = 1;
+}
+
+// Feedback submission APIs.
+service FeedbackService {
+  // Persists one blocked-agent feedback report locally.
+  rpc SubmitFeedback(SubmitFeedbackRequest) returns (SubmitFeedbackResponse);
+}

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 arrow.workspace = true
+chrono.workspace = true
 directories.workspace = true
 fs2.workspace = true
 opentelemetry.workspace = true
@@ -30,6 +31,7 @@ tonic-types.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 
 coral-api.workspace = true
 coral-auth-aws = { path = "../auth/aws" }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+use coral_api::v1::feedback_service_server::FeedbackServiceServer;
 use coral_api::v1::query_service_server::QueryServiceServer;
 use coral_api::v1::source_service_server::SourceServiceServer;
 use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
@@ -17,6 +18,8 @@ use tonic::transport::Server;
 use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
+use crate::feedback::manager::FeedbackManager;
+use crate::feedback::service::FeedbackService;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
@@ -145,6 +148,7 @@ impl ServerBuilder {
         let secret_store = SecretStore::new(layout.clone());
         let source_manager =
             SourceManager::new(config_store.clone(), secret_store.clone(), layout.clone());
+        let feedback_manager = FeedbackManager::new(layout.clone());
         let query_manager = QueryManager::new(
             config_store,
             secret_store,
@@ -152,7 +156,7 @@ impl ServerBuilder {
             layout,
             self.config.engine_extensions_providers,
         );
-        start_server(source_manager, query_manager).await
+        start_server(source_manager, query_manager, feedback_manager).await
     }
 }
 
@@ -221,9 +225,11 @@ impl Drop for RunningServer {
 async fn start_server(
     source_manager: SourceManager,
     query_manager: QueryManager,
+    feedback_manager: FeedbackManager,
 ) -> Result<RunningServer, AppError> {
     let source_service = SourceService::new(source_manager, query_manager.clone());
     let query_service = QueryService::new(query_manager);
+    let feedback_service = FeedbackService::new(feedback_manager);
     let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
     let endpoint_uri = format!("http://{}", listener.local_addr()?);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
@@ -232,6 +238,7 @@ async fn start_server(
         Server::builder()
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE)
             .add_service(SourceServiceServer::new(source_service))
+            .add_service(FeedbackServiceServer::new(feedback_service))
             .add_service(
                 QueryServiceServer::new(query_service)
                     .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
@@ -264,6 +271,7 @@ mod tests {
     use tonic::transport::Endpoint;
 
     use super::{ServerBuilder, start_server};
+    use crate::feedback::manager::FeedbackManager;
     use crate::query::manager::QueryManager;
     use crate::sources::manager::SourceManager;
     use crate::state::{AppStateLayout, ConfigStore, SecretStore};
@@ -311,6 +319,7 @@ mod tests {
             SecretStore::new(layout.clone()),
             layout.clone(),
         );
+        let feedback_manager = FeedbackManager::new(layout.clone());
         let query_manager = QueryManager::new(
             ConfigStore::new(layout.clone()),
             SecretStore::new(layout.clone()),
@@ -320,7 +329,7 @@ mod tests {
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
-        let running = start_server(source_manager, query_manager)
+        let running = start_server(source_manager, query_manager, feedback_manager)
             .await
             .expect("start server");
         let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
@@ -389,6 +398,7 @@ tables:
             SecretStore::new(layout.clone()),
             layout.clone(),
         );
+        let feedback_manager = FeedbackManager::new(layout.clone());
         let query_manager = QueryManager::new(
             ConfigStore::new(layout.clone()),
             SecretStore::new(layout.clone()),
@@ -396,7 +406,7 @@ tables:
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
-        let running = start_server(source_manager, query_manager)
+        let running = start_server(source_manager, query_manager, feedback_manager)
             .await
             .expect("start server");
         let channel = Endpoint::from_shared(running.endpoint_uri().to_string())
@@ -477,6 +487,7 @@ tables:
             SecretStore::new(layout.clone()),
             layout.clone(),
         );
+        let feedback_manager = FeedbackManager::new(layout.clone());
         let query_manager = QueryManager::new(
             ConfigStore::new(layout.clone()),
             SecretStore::new(layout.clone()),
@@ -484,7 +495,7 @@ tables:
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
-        let running = start_server(source_manager, query_manager)
+        let running = start_server(source_manager, query_manager, feedback_manager)
             .await
             .expect("start server");
         let channel = Endpoint::from_shared(running.endpoint_uri().to_string())

--- a/crates/coral-app/src/feedback/manager.rs
+++ b/crates/coral-app/src/feedback/manager.rs
@@ -1,0 +1,148 @@
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::bootstrap::AppError;
+use crate::state::AppStateLayout;
+use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone)]
+pub(crate) struct FeedbackReport {
+    pub(crate) id: String,
+    pub(crate) workspace: WorkspaceName,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) trying_to_do: String,
+    pub(crate) tried: String,
+    pub(crate) stuck: String,
+}
+
+#[derive(Debug, Serialize)]
+struct PersistedFeedbackReport<'a> {
+    id: &'a str,
+    workspace: &'a str,
+    created_at: String,
+    trying_to_do: &'a str,
+    tried: &'a str,
+    stuck: &'a str,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct FeedbackManager {
+    layout: AppStateLayout,
+}
+
+impl FeedbackManager {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    pub(crate) fn submit_feedback(
+        &self,
+        workspace: &WorkspaceName,
+        trying_to_do: &str,
+        tried: &str,
+        stuck: &str,
+    ) -> Result<FeedbackReport, AppError> {
+        let report = FeedbackReport {
+            id: Uuid::new_v4().to_string(),
+            workspace: workspace.clone(),
+            created_at: Utc::now(),
+            trying_to_do: required_text("trying_to_do", trying_to_do)?,
+            tried: required_text("tried", tried)?,
+            stuck: required_text("stuck", stuck)?,
+        };
+        self.append_report(&report)?;
+        Ok(report)
+    }
+
+    fn append_report(&self, report: &FeedbackReport) -> Result<(), AppError> {
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let file = self.layout.feedback_reports_file(&report.workspace);
+        let persisted = PersistedFeedbackReport {
+            id: &report.id,
+            workspace: report.workspace.as_str(),
+            created_at: report.created_at.to_rfc3339(),
+            trying_to_do: &report.trying_to_do,
+            tried: &report.tried,
+            stuck: &report.stuck,
+        };
+        let mut line = serde_json::to_vec(&persisted)?;
+        line.push(b'\n');
+        storage_fs::append_file_private(&file, &line)?;
+        Ok(())
+    }
+}
+
+fn required_text(field: &str, value: &str) -> Result<String, AppError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(AppError::InvalidInput(format!(
+            "missing string argument '{field}'"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use serde_json::Value;
+    use tempfile::TempDir;
+
+    use super::FeedbackManager;
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn submit_feedback_appends_workspace_jsonl_record() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let workspace = WorkspaceName::default();
+        let manager = FeedbackManager::new(layout.clone());
+
+        let report = manager
+            .submit_feedback(&workspace, " trying ", " tried ", " stuck ")
+            .expect("feedback should submit");
+
+        assert_eq!(report.workspace.as_str(), "default");
+        assert_eq!(report.trying_to_do, "trying");
+        let raw = fs::read_to_string(layout.feedback_reports_file(&workspace))
+            .expect("feedback file should exist");
+        let lines = raw.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 1);
+        let value: Value = serde_json::from_str(lines[0]).expect("jsonl record should parse");
+        assert_eq!(value["id"], report.id);
+        assert_eq!(value["workspace"], "default");
+        assert_eq!(value["trying_to_do"], "trying");
+        assert_eq!(value["tried"], "tried");
+        assert_eq!(value["stuck"], "stuck");
+        assert!(
+            value["created_at"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty())
+        );
+    }
+
+    #[test]
+    fn submit_feedback_rejects_blank_fields_before_persisting() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let workspace = WorkspaceName::default();
+        let manager = FeedbackManager::new(layout.clone());
+
+        let error = manager
+            .submit_feedback(&workspace, "trying", " ", "stuck")
+            .expect_err("blank feedback should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing string argument 'tried'")
+        );
+        assert!(!layout.feedback_reports_file(&workspace).exists());
+    }
+}

--- a/crates/coral-app/src/feedback/mod.rs
+++ b/crates/coral-app/src/feedback/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod manager;
+pub(crate) mod service;

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -1,0 +1,54 @@
+use coral_api::v1::feedback_service_server::FeedbackService as FeedbackServiceApi;
+use coral_api::v1::{
+    FeedbackReport as ProtoFeedbackReport, SubmitFeedbackRequest, SubmitFeedbackResponse,
+};
+use tonic::{Request, Response, Status};
+
+use crate::bootstrap::app_status;
+use crate::feedback::manager::{FeedbackManager, FeedbackReport};
+use crate::transport::{workspace_name_from_proto, workspace_to_proto};
+
+#[derive(Clone)]
+pub(crate) struct FeedbackService {
+    feedback: FeedbackManager,
+}
+
+impl FeedbackService {
+    pub(crate) fn new(feedback: FeedbackManager) -> Self {
+        Self { feedback }
+    }
+}
+
+#[tonic::async_trait]
+impl FeedbackServiceApi for FeedbackService {
+    async fn submit_feedback(
+        &self,
+        request: Request<SubmitFeedbackRequest>,
+    ) -> Result<Response<SubmitFeedbackResponse>, Status> {
+        let request = request.into_inner();
+        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+        let report = self
+            .feedback
+            .submit_feedback(
+                &workspace_name,
+                &request.trying_to_do,
+                &request.tried,
+                &request.stuck,
+            )
+            .map_err(app_status)?;
+        Ok(Response::new(SubmitFeedbackResponse {
+            report: Some(feedback_report_to_proto(report)),
+        }))
+    }
+}
+
+fn feedback_report_to_proto(report: FeedbackReport) -> ProtoFeedbackReport {
+    ProtoFeedbackReport {
+        id: report.id,
+        workspace: Some(workspace_to_proto(&report.workspace)),
+        created_at: report.created_at.to_rfc3339(),
+        trying_to_do: report.trying_to_do,
+        tried: report.tried,
+        stuck: report.stuck,
+    }
+}

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -32,6 +32,7 @@
 //!
 /// Bootstrap entrypoints and local server assembly.
 pub mod bootstrap;
+mod feedback;
 mod identity;
 mod query;
 mod sources;

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -62,6 +62,14 @@ impl AppStateLayout {
         self.workspace_dir(workspace_name).join("sources")
     }
 
+    pub(crate) fn feedback_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.workspace_dir(workspace_name).join("feedback")
+    }
+
+    pub(crate) fn feedback_reports_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.feedback_dir(workspace_name).join("reports.jsonl")
+    }
+
     pub(crate) fn source_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -114,6 +122,10 @@ mod tests {
         assert_eq!(
             layout.secret_file(&workspace_name, &source_name),
             std::path::Path::new("/tmp/coral-config/workspaces/default/sources/github/secrets.env")
+        );
+        assert_eq!(
+            layout.feedback_reports_file(&workspace_name),
+            std::path::Path::new("/tmp/coral-config/workspaces/default/feedback/reports.jsonl")
         );
     }
 }

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -1,7 +1,7 @@
 //! Filesystem helpers for private directories, atomic writes, and file locks.
 
 use std::fs::{self, File, OpenOptions};
-use std::io;
+use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 
 use fs2::FileExt;
@@ -24,6 +24,15 @@ pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     replace_atomic(&temp_path, path)?;
     set_file_permissions_private(path)?;
     Ok(())
+}
+
+pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        ensure_dir(parent)?;
+    }
+    let mut file = open_append_file_private(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()
 }
 
 pub(crate) fn replace_atomic(from: &Path, to: &Path) -> io::Result<()> {
@@ -87,6 +96,22 @@ fn open_lock_file(path: &Path) -> io::Result<File> {
         .read(true)
         .write(true)
         .open(path)
+}
+
+#[cfg(unix)]
+fn open_append_file_private(path: &Path) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt;
+
+    OpenOptions::new()
+        .create(true)
+        .append(true)
+        .mode(0o600)
+        .open(path)
+}
+
+#[cfg(not(unix))]
+fn open_append_file_private(path: &Path) -> io::Result<File> {
+    OpenOptions::new().create(true).append(true).open(path)
 }
 
 fn temp_path_for(path: &Path) -> PathBuf {

--- a/crates/coral-app/src/storage/fs.rs
+++ b/crates/coral-app/src/storage/fs.rs
@@ -31,6 +31,7 @@ pub(crate) fn append_file_private(path: &Path, bytes: &[u8]) -> io::Result<()> {
         ensure_dir(parent)?;
     }
     let mut file = open_append_file_private(path)?;
+    set_file_permissions_private(path)?;
     file.write_all(bytes)?;
     file.sync_all()
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -45,7 +45,7 @@ enum Command {
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
-    McpStdio,
+    McpStdio(McpStdioArgs),
     /// Generate shell completion scripts
     Completion(CompletionArgs),
 }
@@ -65,6 +65,14 @@ struct SqlArgs {
     format: OutputFormat,
     /// SQL query to execute
     sql: String,
+}
+
+#[derive(Debug, Args)]
+/// Start the MCP server over stdio
+struct McpStdioArgs {
+    /// Expose the feedback submission tool.
+    #[arg(long)]
+    enable_feedback: bool,
 }
 
 #[derive(Debug, Args)]
@@ -259,8 +267,14 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
         Command::Onboard => {
             onboard::run(&app).await?;
         }
-        Command::McpStdio => {
-            coral_mcp::run_stdio_with_client(app).await?;
+        Command::McpStdio(args) => {
+            coral_mcp::run_stdio_with_client(
+                app,
+                coral_mcp::McpOptions {
+                    feedback_enabled: args.enable_feedback,
+                },
+            )
+            .await?;
         }
         Command::Completion(args) => {
             let mut cmd = Cli::command();

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -177,7 +177,7 @@ where
 {
     matches!(
         Cli::try_parse_from(args).map(|cli| cli.command),
-        Ok(Command::McpStdio)
+        Ok(Command::McpStdio(_))
     )
 }
 
@@ -409,6 +409,15 @@ mod tests {
     #[test]
     fn mcp_stdio_invocation_enables_stderr_logs() {
         assert!(command_enables_stderr_logs(["coral", "mcp-stdio"]));
+    }
+
+    #[test]
+    fn mcp_stdio_with_feedback_invocation_enables_stderr_logs() {
+        assert!(command_enables_stderr_logs([
+            "coral",
+            "mcp-stdio",
+            "--enable-feedback"
+        ]));
     }
 
     #[test]

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -23,9 +23,17 @@ fn json_object(value: &Value) -> Map<String, Value> {
 async fn start_mcp_client(
     server: &MockServer,
 ) -> Result<RunningService<RoleClient, ()>, Box<dyn std::error::Error>> {
+    start_mcp_client_with_args(server, &[]).await
+}
+
+async fn start_mcp_client_with_args(
+    server: &MockServer,
+    args: &[&str],
+) -> Result<RunningService<RoleClient, ()>, Box<dyn std::error::Error>> {
     let transport = TokioChildProcess::new(
         tokio::process::Command::new(env!("CARGO_BIN_EXE_coral")).configure(|cmd| {
             cmd.arg("mcp-stdio")
+                .args(args)
                 .env("CORAL_ENDPOINT", server.endpoint_uri());
         }),
     )?;
@@ -94,6 +102,25 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
         .await?;
     let tables_json: Value = serde_json::from_str(text_content(&tables))?;
     assert_eq!(tables_json["tables"][0]["name"], "local_messages.messages");
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    let client = start_mcp_client_with_args(&server, &["--enable-feedback"]).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["sql", "list_tables", "feedback"]
+    );
 
     client.cancel().await?;
     server.shutdown().await;

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -1,6 +1,7 @@
 //! Client-side bootstrap for local Coral clients.
 
 use coral_api::v1::Workspace;
+use coral_api::v1::feedback_service_client::FeedbackServiceClient;
 use coral_api::v1::query_service_client::QueryServiceClient;
 use coral_api::v1::source_service_client::SourceServiceClient;
 use coral_api::{HTTP2_MAX_HEADER_LIST_SIZE, QUERY_RESPONSE_MAX_MESSAGE_SIZE};
@@ -27,13 +28,22 @@ pub type SourceClient = SourceServiceClient<InterceptedService<Channel, TraceCon
 /// Public SQL query gRPC client.
 pub type QueryClient = QueryServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
 
+/// Public feedback-submission gRPC client.
+///
+/// This stays intentionally thin for now: `coral-client` is a local transport
+/// bootstrap, so it exposes the generated typed client directly rather than
+/// wrapping it in a higher-level SDK surface.
+pub type FeedbackClient =
+    FeedbackServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
+
 /// Public Coral client handle.
 ///
 /// Wraps the generated gRPC clients for a Coral endpoint.
 #[derive(Clone)]
 pub struct AppClient {
-    source_client: SourceClient,
-    query_client: QueryClient,
+    source: SourceClient,
+    query: QueryClient,
+    feedback: FeedbackClient,
 }
 
 impl AppClient {
@@ -52,23 +62,33 @@ impl AppClient {
         let channel = endpoint.connect().await?;
         let source_client =
             SourceServiceClient::with_interceptor(channel.clone(), TraceContextInterceptor);
-        let query_client = QueryServiceClient::with_interceptor(channel, TraceContextInterceptor)
-            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let query_client =
+            QueryServiceClient::with_interceptor(channel.clone(), TraceContextInterceptor)
+                .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let feedback_client =
+            FeedbackServiceClient::with_interceptor(channel, TraceContextInterceptor);
         Ok(Self {
-            source_client,
-            query_client,
+            source: source_client,
+            query: query_client,
+            feedback: feedback_client,
         })
     }
 
     #[must_use]
     /// Returns a cloned source-management client.
     pub fn source_client(&self) -> SourceClient {
-        self.source_client.clone()
+        self.source.clone()
     }
 
     #[must_use]
     /// Returns a cloned query client.
     pub fn query_client(&self) -> QueryClient {
-        self.query_client.clone()
+        self.query.clone()
+    }
+
+    #[must_use]
+    /// Returns a cloned feedback-submission client.
+    pub fn feedback_client(&self) -> FeedbackClient {
+        self.feedback.clone()
     }
 }

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -30,7 +30,9 @@ use arrow::util::pretty::pretty_format_batches;
 use coral_api::v1::ExecuteSqlResponse;
 use serde_json::Value;
 
-pub use client::{AppClient, DEFAULT_WORKSPACE_ID, QueryClient, SourceClient, default_workspace};
+pub use client::{
+    AppClient, DEFAULT_WORKSPACE_ID, FeedbackClient, QueryClient, SourceClient, default_workspace,
+};
 pub use error::{ClientError, QueryResultError};
 pub use status_error::{
     CORAL_ERROR_DOMAIN, CoralQueryError, DecodedStatusError, decode_status_error,

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, `list_tables`
+//! - tools: `sql`, `list_tables`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay
@@ -35,14 +35,21 @@ use rmcp::ServiceExt;
 pub use error::McpError;
 pub(crate) use server::CoralMcpServer;
 
+/// Optional MCP surface features.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct McpOptions {
+    /// Expose the feedback submission tool.
+    pub feedback_enabled: bool,
+}
+
 /// Runs the `MCP` stdio server using an existing Coral client.
 ///
 /// # Errors
 ///
 /// Returns [`McpError`] if the stdio server cannot complete its `MCP`
 /// lifecycle.
-pub async fn run_stdio_with_client(app: AppClient) -> Result<(), McpError> {
-    let server = CoralMcpServer::new(&app)
+pub async fn run_stdio_with_client(app: AppClient, options: McpOptions) -> Result<(), McpError> {
+    let server = CoralMcpServer::new(&app, options)
         .serve((tokio::io::stdin(), tokio::io::stdout()))
         .await?;
     let _ = server.waiting().await?;

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,9 +1,11 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
-use coral_api::v1::{ExecuteSqlRequest, ListSourcesRequest, ListTablesRequest, Source, Table};
+use coral_api::v1::{
+    ExecuteSqlRequest, ListSourcesRequest, ListTablesRequest, Source, SubmitFeedbackRequest, Table,
+};
 use coral_client::{
-    AppClient, QueryClient, SourceClient, batches_to_json_rows, decode_execute_sql_response,
-    default_workspace,
+    AppClient, FeedbackClient, QueryClient, SourceClient, batches_to_json_rows,
+    decode_execute_sql_response, default_workspace,
 };
 use rmcp::{
     ErrorData, ServerHandler,
@@ -17,29 +19,36 @@ use rmcp::{
 use serde_json::Value;
 use tonic::Request;
 
-use crate::surface::{
-    build_tool_result, guide_resource, guide_resource_content, initial_instructions,
-    internal_status, list_tables_tool, list_tables_value, required_string_argument, sql_tool,
-    status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
-    tool_error_result,
+use crate::{
+    McpOptions,
+    surface::{
+        build_tool_result, feedback_tool, guide_resource, guide_resource_content,
+        initial_instructions, internal_status, list_tables_tool, list_tables_value,
+        required_string_argument, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
+    },
 };
 
 #[derive(Clone)]
 pub(crate) struct CoralMcpServer {
-    source_client: SourceClient,
-    query_client: QueryClient,
+    source: SourceClient,
+    query: QueryClient,
+    feedback: FeedbackClient,
+    options: McpOptions,
 }
 
 impl CoralMcpServer {
-    pub(crate) fn new(app: &AppClient) -> Self {
+    pub(crate) fn new(app: &AppClient, options: McpOptions) -> Self {
         Self {
-            source_client: app.source_client(),
-            query_client: app.query_client(),
+            source: app.source_client(),
+            query: app.query_client(),
+            feedback: app.feedback_client(),
+            options,
         }
     }
 
     async fn load_sources(&self) -> Result<Vec<Source>, tonic::Status> {
-        let mut source_client = self.source_client.clone();
+        let mut source_client = self.source.clone();
         Ok(source_client
             .list_sources(Request::new(ListSourcesRequest {
                 workspace: Some(default_workspace()),
@@ -50,7 +59,7 @@ impl CoralMcpServer {
     }
 
     async fn load_tables(&self) -> Result<Vec<Table>, tonic::Status> {
-        let mut query_client = self.query_client.clone();
+        let mut query_client = self.query.clone();
         Ok(query_client
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
@@ -65,7 +74,7 @@ impl CoralMcpServer {
     }
 
     async fn query_rows(&self, sql: &str) -> Result<Vec<Value>, tonic::Status> {
-        let mut query_client = self.query_client.clone();
+        let mut query_client = self.query.clone();
         let response = query_client
             .execute_sql(Request::new(ExecuteSqlRequest {
                 workspace: Some(default_workspace()),
@@ -83,6 +92,32 @@ impl CoralMcpServer {
         self.query_rows(sql)
             .await
             .map(|rows| serde_json::json!({ "rows": rows }))
+    }
+
+    async fn submit_feedback_value(
+        &self,
+        trying_to_do: &str,
+        tried: &str,
+        stuck: &str,
+    ) -> Result<Value, tonic::Status> {
+        let mut feedback_client = self.feedback.clone();
+        let response = feedback_client
+            .submit_feedback(Request::new(SubmitFeedbackRequest {
+                workspace: Some(default_workspace()),
+                trying_to_do: trying_to_do.to_string(),
+                tried: tried.to_string(),
+                stuck: stuck.to_string(),
+            }))
+            .await?
+            .into_inner();
+        let report = response
+            .report
+            .ok_or_else(|| tonic::Status::internal("feedback response missing report"))?;
+        Ok(serde_json::json!({
+            "feedback_id": report.id,
+            "created_at": report.created_at,
+            "message": "Feedback submitted.",
+        }))
     }
 }
 
@@ -107,10 +142,11 @@ impl ServerHandler for CoralMcpServer {
             .load_sources_and_tables()
             .await
             .map_err(|status| status_to_error_data(&status))?;
-        Ok(ListToolsResult::with_all_items(vec![
-            sql_tool(&sources, &tables),
-            list_tables_tool(&tables),
-        ]))
+        let mut tools = vec![sql_tool(&sources, &tables), list_tables_tool(&tables)];
+        if self.options.feedback_enabled {
+            tools.push(feedback_tool());
+        }
+        Ok(ListToolsResult::with_all_items(tools))
     }
 
     async fn call_tool(
@@ -133,6 +169,22 @@ impl ServerHandler for CoralMcpServer {
                     &status,
                 ))),
             },
+            "feedback" if self.options.feedback_enabled => {
+                let trying_to_do =
+                    required_string_argument(request.arguments.as_ref(), "trying_to_do")?;
+                let tried = required_string_argument(request.arguments.as_ref(), "tried")?;
+                let stuck = required_string_argument(request.arguments.as_ref(), "stuck")?;
+                match self
+                    .submit_feedback_value(&trying_to_do, &tried, &stuck)
+                    .await
+                {
+                    Ok(value) => build_tool_result(value),
+                    Err(status) => Ok(tool_error_result(tool_error_from_status(
+                        "Feedback submission",
+                        &status,
+                    ))),
+                }
+            }
             _ => Err(ErrorData::invalid_params(
                 format!("tool '{}' not found", request.name),
                 None,

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -116,7 +116,7 @@ impl CoralMcpServer {
         Ok(serde_json::json!({
             "feedback_id": report.id,
             "created_at": report.created_at,
-            "message": "Feedback submitted.",
+            "message": "Feedback report stored.",
         }))
     }
 }

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -11,4 +11,6 @@ pub(crate) use resources::{
     guide_resource, guide_resource_content, initial_instructions, list_tables_value,
     tables_resource, tables_resource_content,
 };
-pub(crate) use tools::{build_tool_result, list_tables_tool, required_string_argument, sql_tool};
+pub(crate) use tools::{
+    build_tool_result, feedback_tool, list_tables_tool, required_string_argument, sql_tool,
+};

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -54,28 +54,28 @@ pub(crate) fn list_tables_tool(tables: &[Table]) -> Tool {
 pub(crate) fn feedback_tool() -> Tool {
     Tool::new(
         "feedback",
-        "Submit feedback when the agent is blocked or stuck in an unproductive pattern.",
+        "Submit feedback when you are blocked or stuck in an unproductive pattern",
         json_object_schema(&json!({
             "type": "object",
             "required": ["trying_to_do", "tried", "stuck"],
             "properties": {
                 "trying_to_do": {
                     "type": "string",
-                    "description": "What the agent was attempting to do."
+                    "description": "What you were trying to do."
                 },
                 "tried": {
                     "type": "string",
-                    "description": "What the agent already tried."
+                    "description": "What you already tried."
                 },
                 "stuck": {
                     "type": "string",
-                    "description": "Where the agent got blocked."
+                    "description": "Where you got blocked."
                 }
             }
         })),
     )
     .with_annotations(
-        ToolAnnotations::with_title("Submit Feedback")
+        ToolAnnotations::with_title("Store Feedback Report")
             .read_only(false)
             .destructive(false)
             .idempotent(false)

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -51,6 +51,38 @@ pub(crate) fn list_tables_tool(tables: &[Table]) -> Tool {
     )
 }
 
+pub(crate) fn feedback_tool() -> Tool {
+    Tool::new(
+        "feedback",
+        "Submit feedback when the agent is blocked or stuck in an unproductive pattern.",
+        json_object_schema(&json!({
+            "type": "object",
+            "required": ["trying_to_do", "tried", "stuck"],
+            "properties": {
+                "trying_to_do": {
+                    "type": "string",
+                    "description": "What the agent was attempting to do."
+                },
+                "tried": {
+                    "type": "string",
+                    "description": "What the agent already tried."
+                },
+                "stuck": {
+                    "type": "string",
+                    "description": "Where the agent got blocked."
+                }
+            }
+        })),
+    )
+    .with_annotations(
+        ToolAnnotations::with_title("Submit Feedback")
+            .read_only(false)
+            .destructive(false)
+            .idempotent(false)
+            .open_world(false),
+    )
+}
+
 pub(crate) fn required_string_argument(
     arguments: Option<&Map<String, Value>>,
     key: &str,

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -15,7 +15,7 @@ use serde_json::{Map, Value, json};
 use tempfile::TempDir;
 use tonic::Request;
 
-use crate::CoralMcpServer;
+use crate::{CoralMcpServer, McpOptions};
 
 fn write_fixture_manifest(root: &Path) -> PathBuf {
     let source_dir = root.join("fixture-source");
@@ -97,6 +97,10 @@ impl TestSession {
 }
 
 async fn start_session(temp: &TempDir) -> TestSession {
+    start_session_with_options(temp, McpOptions::default()).await
+}
+
+async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> TestSession {
     let server = ServerBuilder::new()
         .with_config_dir(temp.path().join("coral-config"))
         .start()
@@ -109,7 +113,9 @@ async fn start_session(temp: &TempDir) -> TestSession {
 
     let (server_transport, client_transport) = tokio::io::duplex(4096);
     let mcp_server_task = tokio::spawn(async move {
-        let server = CoralMcpServer::new(&app).serve(server_transport).await?;
+        let server = CoralMcpServer::new(&app, options)
+            .serve(server_transport)
+            .await?;
         server.waiting().await?;
         Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     });
@@ -158,7 +164,6 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .expect("sql description")
             .contains("0 configured source")
     );
-
     let initial_resources = client
         .list_all_resources()
         .await
@@ -249,6 +254,129 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         "local_messages.messages"
     );
     assert_eq!(tables.is_error, Some(false));
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_feedback_tool_persists_blocked_agent_report() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session_with_options(
+        &temp,
+        McpOptions {
+            feedback_enabled: true,
+        },
+    )
+    .await;
+    let client = &session.client;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert_eq!(
+        tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>(),
+        vec!["sql", "list_tables", "feedback"]
+    );
+    let feedback_annotations = tools[2].annotations.as_ref().expect("feedback annotations");
+    assert_eq!(feedback_annotations.read_only_hint, Some(false));
+    assert_eq!(feedback_annotations.destructive_hint, Some(false));
+    assert_eq!(feedback_annotations.idempotent_hint, Some(false));
+    assert_eq!(feedback_annotations.open_world_hint, Some(false));
+
+    let feedback = client
+        .call_tool(
+            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
+                "trying_to_do": "Fix failing tests",
+                "tried": "Ran cargo test and inspected the failing assertion",
+                "stuck": "The fixture shape does not match the documented contract"
+            }))),
+        )
+        .await
+        .expect("feedback");
+    assert_eq!(feedback.is_error, Some(false));
+    let structured = feedback.structured_content.expect("structured content");
+    assert!(
+        structured["feedback_id"]
+            .as_str()
+            .is_some_and(|id| !id.is_empty())
+    );
+    assert!(
+        structured["created_at"]
+            .as_str()
+            .is_some_and(|created_at| !created_at.is_empty())
+    );
+    assert_eq!(structured["message"], "Feedback submitted.");
+
+    let raw = fs::read_to_string(
+        temp.path()
+            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
+    )
+    .expect("feedback file should exist");
+    let records = raw.lines().collect::<Vec<_>>();
+    assert_eq!(records.len(), 1);
+    let record: Value = serde_json::from_str(records[0]).expect("feedback JSONL should parse");
+    assert_eq!(record["id"], structured["feedback_id"]);
+    assert_eq!(record["workspace"], "default");
+    assert_eq!(record["trying_to_do"], "Fix failing tests");
+    assert_eq!(
+        record["tried"],
+        "Ran cargo test and inspected the failing assertion"
+    );
+    assert_eq!(
+        record["stuck"],
+        "The fixture shape does not match the documented contract"
+    );
+
+    let blank_feedback = client
+        .call_tool(
+            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
+                "trying_to_do": "Fix failing tests",
+                "tried": " ",
+                "stuck": "The fixture shape does not match the documented contract"
+            }))),
+        )
+        .await
+        .expect_err("blank feedback should fail before persistence");
+    assert!(
+        blank_feedback
+            .to_string()
+            .contains("missing string argument 'tried'")
+    );
+
+    let raw_after_error = fs::read_to_string(
+        temp.path()
+            .join("coral-config/workspaces/default/feedback/reports.jsonl"),
+    )
+    .expect("feedback file should still exist");
+    assert_eq!(raw_after_error.lines().count(), 1);
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_feedback_tool_is_disabled_by_default() {
+    let temp = TempDir::new().expect("temp dir");
+    let session = start_session(&temp).await;
+    let client = &session.client;
+
+    let feedback = client
+        .call_tool(
+            CallToolRequestParams::new("feedback").with_arguments(json_object(&json!({
+                "trying_to_do": "Fix failing tests",
+                "tried": "Ran cargo test",
+                "stuck": "Need more context"
+            }))),
+        )
+        .await
+        .expect_err("feedback should not be exposed by default");
+    assert!(feedback.to_string().contains("tool 'feedback' not found"));
+    assert!(
+        !temp
+            .path()
+            .join("coral-config/workspaces/default/feedback/reports.jsonl")
+            .exists()
+    );
 
     session.shutdown().await;
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -306,7 +306,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .as_str()
             .is_some_and(|created_at| !created_at.is_empty())
     );
-    assert_eq!(structured["message"], "Feedback submitted.");
+    assert_eq!(structured["message"], "Feedback report stored.");
 
     let raw = fs::read_to_string(
         temp.path()

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -16,7 +16,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
 | Tool     | `list_tables`    | List queryable fully qualified tables                   |
-| Tool     | `feedback`       | Submit a blocked-agent feedback report when enabled     |
+| Tool     | `feedback`       | Store a local blocked-agent feedback report when enabled |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -16,15 +16,17 @@ Before setting up a client, make sure you have [connected at least one source](/
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
 | Tool     | `list_tables`    | List queryable fully qualified tables                   |
+| Tool     | `feedback`       | Submit a blocked-agent feedback report when enabled     |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
 For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
+Start Coral as `coral mcp-stdio --enable-feedback` to expose the optional `feedback` tool. Agents can call `feedback` when they get blocked or repeat a pattern that is not working. Coral stores the report locally with what the agent was trying to do, what it tried, and where it got stuck.
 
 ## Client setup
 
-Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`. If a client needs a full path, run `which coral` and use that path in the config instead of `coral`.
+Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`. If a client needs a full path, run `which coral` and use that path in the config instead of `coral`. To include the optional feedback tool, use `coral mcp-stdio --enable-feedback`.
 
 <Tabs>
 <Tab title="npx add-mcp">

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -65,6 +65,7 @@ The local server and core orchestrator.
 | Server bootstrap | In-process gRPC server lifecycle (`bootstrap/`) |
 | Source management | Install, add from file, list, validate, remove (`sources/`) |
 | Workspace state | Config, secrets, and workspace layout (`state/`, `storage/`) |
+| Feedback persistence | Workspace-scoped blocked-agent feedback reports (`feedback/`) |
 | Query orchestration | Loads sources, builds the engine, executes SQL (`query/`) |
 
 This is the largest crate. It ties `coral-spec` and `coral-engine` together and manages all persistent local state.
@@ -101,7 +102,7 @@ The MCP stdio server.
 | --------------- | ------------------------------------------------------------------- |
 | MCP protocol    | Tool and resource handlers via the `rmcp` SDK (`server.rs`)         |
 | Surface shaping | Tool/resource/error helpers split across `surface/{mod,tools,resources,errors}.rs` |
-| Tools           | `sql`, `list_tables`                                                |
+| Tools           | `sql`, `list_tables`, optional `feedback`                           |
 | Resources       | `coral://guide`, `coral://tables`                                   |
 
 Uses `coral-client` to reach `coral-app`, same transport as the CLI.


### PR DESCRIPTION
## Intent

Agents can now report when they are blocked without making feedback collection part of the default MCP surface. The feedback path stays app-owned for persistence while MCP exposes it only when the user explicitly opts in.

## Changes

- Adds a `FeedbackService` transport contract and app-owned JSONL persistence for blocked-agent reports.
- Exposes a `feedback` MCP tool behind `coral mcp-stdio --enable-feedback`.
- Keeps default MCP tools limited to `sql` and `list_tables`.
- Updates client wiring, CLI/MCP tests, and docs for the optional feedback tool.

## Verification

- `cargo test -p coral-app feedback`
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --features cli-test-server mcp_stdio`
