### PR TITLE
fix(linear): expose richer issue and project metadata

### DIFF
--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -107,15 +107,12 @@ fn eval_expr(expr: &ExprSpec, row: &Value, filters: &HashMap<String, String>) ->
         ExprSpec::FromFilter { key } => filters.get(key).map(|v| Value::String(v.clone())),
         ExprSpec::Literal { value } => Some(value.clone()),
         ExprSpec::Null => None,
-        ExprSpec::JoinArray { path, separator } => {
-            let values = get_path_value(row, path)?.as_array()?;
-            let joined = values
-                .iter()
-                .filter_map(value_to_string_for_join)
-                .collect::<Vec<_>>()
-                .join(separator);
-            Some(Value::String(joined))
-        }
+        ExprSpec::JoinArray { path, separator } => eval_join_array(row, path, separator),
+        ExprSpec::JoinArrayPath {
+            path,
+            item_path,
+            separator,
+        } => eval_join_array_path(row, path, item_path, separator),
         ExprSpec::TagValue {
             path,
             key,
@@ -296,6 +293,32 @@ fn eval_template(
     Some(Value::String(result))
 }
 
+fn eval_join_array(row: &Value, path: &[String], separator: &str) -> Option<Value> {
+    let values = get_path_value(row, path)?.as_array()?;
+    let joined = values
+        .iter()
+        .filter_map(value_to_string_for_join)
+        .collect::<Vec<_>>()
+        .join(separator);
+    Some(Value::String(joined))
+}
+
+fn eval_join_array_path(
+    row: &Value,
+    path: &[String],
+    item_path: &[String],
+    separator: &str,
+) -> Option<Value> {
+    let values = get_path_value(row, path)?.as_array()?;
+    let joined = values
+        .iter()
+        .filter_map(|item| get_path_value(item, item_path))
+        .filter_map(value_to_string_for_join)
+        .collect::<Vec<_>>()
+        .join(separator);
+    Some(Value::String(joined))
+}
+
 fn value_to_string_for_join(value: &Value) -> Option<String> {
     match value {
         Value::Null => None,
@@ -460,6 +483,16 @@ mod tests {
                     TimestampInput::Iso8601 => "iso8601",
                 },
             }),
+            ExprSpec::JoinArrayPath {
+                path,
+                item_path,
+                separator,
+            } => json!({
+                "kind": "join_array_path",
+                "path": path,
+                "item_path": item_path,
+                "separator": separator,
+            }),
             other => panic!("unsupported test expr: {other:?}"),
         }
     }
@@ -612,6 +645,43 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(col.value(0), "only one");
+    }
+
+    #[test]
+    fn join_array_path_concatenates_nested_scalar_values() {
+        let table = table_with_expr(
+            "label_names",
+            "Utf8",
+            &ExprSpec::JoinArrayPath {
+                path: vec!["labels".into(), "nodes".into()],
+                item_path: vec!["name".into()],
+                separator: ",".into(),
+            },
+        );
+        let schema = schema_from_columns(table.columns(), "test", table.name()).unwrap();
+        let items = vec![
+            serde_json::json!({
+                "labels": {
+                    "nodes": [
+                        {"name": "bug"},
+                        {"name": "customer"},
+                        {"color": "#fff"}
+                    ]
+                }
+            }),
+            serde_json::json!({"labels": {"nodes": []}}),
+            serde_json::json!({"labels": {"nodes": [{"name": null}]}}),
+        ];
+        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(col.value(0), "bug,customer");
+        assert_eq!(col.value(1), "");
+        assert_eq!(col.value(2), "");
     }
 
     #[test]

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -677,6 +677,12 @@ pub enum ExprSpec {
         #[serde(default = "default_separator")]
         separator: String,
     },
+    JoinArrayPath {
+        path: Vec<String>,
+        item_path: Vec<String>,
+        #[serde(default = "default_separator")]
+        separator: String,
+    },
     TagValue {
         path: Vec<String>,
         key: String,

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -556,6 +556,23 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": ["kind", "path", "item_path"],
+          "properties": {
+            "kind": { "const": "join_array_path" },
+            "path": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "item_path": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            },
+            "separator": { "type": "string" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
           "required": ["kind", "path", "key"],
           "properties": {
             "kind": { "const": "tag_value" },

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -116,9 +116,34 @@ The `expr` field on a column defines how to extract or compute its value from ea
 | Kind                 | Description                                                        |
 | -------------------- | ------------------------------------------------------------------ |
 | `path`               | Extract a value by JSON path segments                              |
+| `join_array_path`    | Join one nested scalar field from each object in an array          |
 | `format_timestamp`   | Convert an epoch timestamp to a `Timestamp` column                 |
 | `replace`            | Replace all occurrences of one substring in the rendered value     |
 | `template`           | Build a string from a template with placeholder substitutions      |
+
+### `join_array_path`
+
+Extracts one nested value from each object in an array and joins the values into one string.
+Use this when an API returns object arrays such as labels, tags, or owners and the table should expose a compact human-readable column.
+
+```yaml
+- name: label_names
+  type: Utf8
+  expr:
+    kind: join_array_path
+    path:
+      - labels
+      - nodes
+    item_path:
+      - name
+    separator: ","
+```
+
+| Field       | Type   | Default | Description                                     |
+| ----------- | ------ | ------- | ----------------------------------------------- |
+| `path`      | array  | —       | JSON path to the array                          |
+| `item_path` | array  | —       | JSON path to extract from each array item       |
+| `separator` | string | `,`     | Separator used between non-null extracted items |
 
 ### `format_timestamp`
 

--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -374,6 +374,22 @@ tables:
           kind: path
           path:
             - targetDate
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Updated timestamp
+        expr:
+          kind: path
+          path:
+            - updatedAt
       - name: team_id
         type: Utf8
         nullable: true
@@ -818,6 +834,12 @@ tables:
                     body
                     createdAt
                     updatedAt
+                    user {
+                      id
+                      name
+                      displayName
+                      email
+                    }
                   }
                   pageInfo {
                     endCursor
@@ -1045,10 +1067,17 @@ tables:
                   }
                   project {
                     id
+                    name
+                    slugId
                   }
                   projectMilestone {
                     id
                     name
+                  }
+                  labels {
+                    nodes {
+                      name
+                    }
                   }
                 }
                 pageInfo {
@@ -1269,6 +1298,43 @@ tables:
           kind: path
           path:
             - completedAt
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Issue URL
+        expr:
+          kind: path
+          path:
+            - url
+      - name: project_name
+        type: Utf8
+        nullable: true
+        description: Project name
+        expr:
+          kind: path
+          path:
+            - project
+            - name
+      - name: project_slug_id
+        type: Utf8
+        nullable: true
+        description: Project short slug identifier
+        expr:
+          kind: path
+          path:
+            - project
+            - slugId
+      - name: label_names
+        type: Utf8
+        nullable: true
+        description: Comma-separated issue label names
+        expr:
+          kind: join_array_path
+          path:
+            - labels
+            - nodes
+          item_path:
+            - name
   - name: issue_comments
     description: Comments for a specific Linear issue
     guide: |
@@ -1292,6 +1358,12 @@ tables:
                     body
                     createdAt
                     updatedAt
+                    user {
+                      id
+                      name
+                      displayName
+                      email
+                    }
                   }
                   pageInfo {
                     endCursor
@@ -1356,6 +1428,42 @@ tables:
           kind: path
           path:
             - body
+      - name: author_id
+        type: Utf8
+        nullable: true
+        description: Comment author user ID
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: author_name
+        type: Utf8
+        nullable: true
+        description: Comment author name
+        expr:
+          kind: path
+          path:
+            - user
+            - name
+      - name: author_display_name
+        type: Utf8
+        nullable: true
+        description: Comment author display name
+        expr:
+          kind: path
+          path:
+            - user
+            - displayName
+      - name: author_email
+        type: Utf8
+        nullable: true
+        description: Comment author email
+        expr:
+          kind: path
+          path:
+            - user
+            - email
       - name: created_at
         type: Utf8
         nullable: true


### PR DESCRIPTION
## Summary

- Adds Linear issue URL, project name/slug, and label-name projections.
- Adds Linear project created/updated timestamps.
- Adds author fields on issue comments.

## Linear feedback

Partially addresses [SOURCE-493](https://linear.app/withcoral/issue/SOURCE-493/dogfood-linearissues-missing-url-project-id-priority-label-columns) by exposing `linear.issues.url` and richer project metadata. The priority-label portion is completed by PR #251 in this stack.

Partially addresses [SOURCE-501](https://linear.app/withcoral/issue/SOURCE-501/linear-source-lacks-ergonomic-follow-up-metadata) by adding workflow-critical Linear metadata needed for follow-up and project triage.

## Verification

- `make rust-checks`
