### PR TITLE
fix(catalog): expose column nullability

### DIFF
--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -227,6 +227,7 @@ struct CatalogColumn {
     table_name: String,
     column_name: String,
     data_type: String,
+    is_nullable: bool,
     is_virtual: bool,
     is_required_filter: bool,
     description: String,
@@ -244,6 +245,7 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
         Field::new("ordinal_position", DataType::Int32, false),
         Field::new("column_name", DataType::Utf8, false),
         Field::new("data_type", DataType::Utf8, false),
+        Field::new("is_nullable", DataType::Boolean, false),
         Field::new("is_virtual", DataType::Boolean, false),
         Field::new("is_required_filter", DataType::Boolean, false),
         Field::new("description", DataType::Utf8, false),
@@ -262,6 +264,7 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
                         table_name: table.table_name.clone(),
                         column_name: column.name.clone(),
                         data_type: column.data_type.clone(),
+                        is_nullable: column.nullable,
                         is_virtual: column.is_virtual,
                         is_required_filter: column.is_required_filter,
                         description: column.description.clone(),
@@ -306,6 +309,11 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
                 rows.iter()
                     .map(|row| Some(row.data_type.as_str()))
                     .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.is_nullable))
+                    .collect::<BooleanArray>(),
             ),
             Arc::new(
                 rows.iter()

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -112,7 +112,7 @@ async fn coral_columns_returns_metadata() {
         &CoralQuery::execute_sql(
             &sources,
             test_runtime(),
-            "SELECT column_name, data_type, is_virtual, is_required_filter \
+            "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter \
              FROM coral.columns WHERE schema_name = 'alpha' AND table_name = 'users' \
              ORDER BY ordinal_position",
         )
@@ -123,9 +123,9 @@ async fn coral_columns_returns_metadata() {
     assert_eq!(
         rows,
         vec![
-            json!({"column_name": "id", "data_type": "Int64", "is_virtual": false, "is_required_filter": false}),
-            json!({"column_name": "team_id", "data_type": "Int64", "is_virtual": false, "is_required_filter": false}),
-            json!({"column_name": "name", "data_type": "Utf8", "is_virtual": false, "is_required_filter": false}),
+            json!({"column_name": "id", "data_type": "Int64", "is_nullable": true, "is_virtual": false, "is_required_filter": false}),
+            json!({"column_name": "team_id", "data_type": "Int64", "is_nullable": true, "is_virtual": false, "is_required_filter": false}),
+            json!({"column_name": "name", "data_type": "Utf8", "is_nullable": true, "is_virtual": false, "is_required_filter": false}),
         ]
     );
 }

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -10,7 +10,7 @@ Always inspect queryable tables and table metadata before writing queries:
 -- List visible tables, descriptions, and required filters
 SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
 
--- Inspect columns for one visible table
+-- Inspect columns for one visible table, including nullability and filter-only virtual columns
 {{COLUMNS_EXAMPLE}}
 ```
 

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -51,13 +51,13 @@ pub(crate) fn guide_resource_content(sources: &[Source], tables: &[Table]) -> St
 
     let columns_example = first_visible_table(tables).map_or_else(
         || {
-            "SELECT column_name, data_type, is_required_filter, description \
+            "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter, description \
 FROM coral.columns WHERE schema_name = '<schema>' AND table_name = '<table>' ORDER BY ordinal_position;"
                 .to_string()
         },
         |(schema_name, table_name)| {
             format!(
-                "SELECT column_name, data_type, is_required_filter, description \
+                "SELECT column_name, data_type, is_nullable, is_virtual, is_required_filter, description \
 FROM coral.columns WHERE schema_name = '{schema_name}' AND table_name = '{table_name}' ORDER BY ordinal_position;"
             )
         },

--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -280,6 +280,7 @@ tables:
                 nodes {
                   id
                   name
+                  description
                   slugId
                   state
                   progress
@@ -342,6 +343,14 @@ tables:
           kind: path
           path:
             - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Project description
+        expr:
+          kind: path
+          path:
+            - description
       - name: slug_id
         type: Utf8
         nullable: true


### PR DESCRIPTION
## Summary

- Adds `is_nullable` to `coral.columns` so schema discovery distinguishes nullable and non-nullable columns.
- Updates MCP discovery guidance and large-catalog next steps to include nullability.
- Exposes `linear.projects.description` and marks it nullable in the source manifest.

## Linear feedback mapping

Partially maps to [SOURCE-470](https://linear.app/withcoral/issue/SOURCE-470/add-column-level-statistics-to-coralcolumns-nullability-rate-cardinality). This PR adds static column nullability metadata to `coral.columns`, but does not implement runtime null fractions, cardinality, or sample values.

Partially maps to [SOURCE-501](https://linear.app/withcoral/issue/SOURCE-501/linear-source-lacks-ergonomic-follow-up-metadata) by adding Linear project descriptions to the project metadata surface.

## Verification

- `make rust-checks`
