### PR TITLE
fix(output): preserve null JSON fields

### DIFF
--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -528,11 +528,10 @@ async fn sql_json_output_renders_multiple_rows() {
     assert_eq!(rows[0].get("id"), Some(&serde_json::json!(1)));
     assert_eq!(rows[0].get("name"), Some(&serde_json::json!("alice")));
     assert_eq!(rows[1].get("id"), Some(&serde_json::json!(2)));
-    // Arrow JSON omits null fields rather than emitting "name":null.
     assert_eq!(
-        rows[1].len(),
-        1,
-        "null name should be omitted from row 2: {:?}",
+        rows[1].get("name"),
+        Some(&serde_json::Value::Null),
+        "null name should be explicit in row 2: {:?}",
         rows[1]
     );
 

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -24,6 +24,7 @@ use std::io::Cursor;
 
 use arrow::datatypes::SchemaRef;
 use arrow::ipc::reader::StreamReader;
+use arrow::json::writer::{JsonArray, WriterBuilder};
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty::pretty_format_batches;
 use coral_api::v1::ExecuteSqlResponse;
@@ -130,7 +131,9 @@ pub fn format_batches_table(batches: &[RecordBatch]) -> Result<String, QueryResu
 pub fn format_batches_json(batches: &[RecordBatch]) -> Result<String, QueryResultError> {
     let mut bytes = Vec::new();
     {
-        let mut writer = arrow::json::ArrayWriter::new(&mut bytes);
+        let mut writer = WriterBuilder::new()
+            .with_explicit_nulls(true)
+            .build::<_, JsonArray>(&mut bytes);
         for batch in batches {
             writer.write(batch)?;
         }
@@ -157,6 +160,7 @@ mod tests {
     use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
     use arrow::record_batch::RecordBatch;
     use coral_api::v1::ExecuteSqlResponse;
+    use serde_json::Value;
 
     use super::{
         CollectedQueryResult, batches_to_json_rows, decode_execute_sql_response,
@@ -227,8 +231,10 @@ mod tests {
         assert!(table.contains("id"));
         let json = format_batches_json(decoded.batches()).expect("json");
         assert!(json.contains("\"name\":\"a\""));
+        assert!(json.contains("\"name\":null"));
         let rows = batches_to_json_rows(decoded.batches()).expect("rows");
         assert_eq!(rows.len(), 2);
+        assert!(rows[1].get("name").is_some_and(Value::is_null));
     }
 
     #[test]

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -17,6 +17,8 @@ coral sql "<SQL>"
 | ---------- | ----------------- | ------- | ------------- |
 | `--format` | `table` \| `json` | `table` | Output format |
 
+JSON output is an array of row objects. Selected nullable columns are included with explicit `null` values when the row value is null.
+
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.

--- a/sources/datadog/manifest.yaml
+++ b/sources/datadog/manifest.yaml
@@ -230,9 +230,9 @@ tables:
   - name: events
     description: Datadog events within a time range.
     guide: >
-      Use this table for event timelines in a bounded window. Keep start and end tight in Unix epoch seconds, then narrow the
-      returned rows by source or priority in SQL; date_happened is Unix epoch seconds and priority only exposes normal or
-      low.
+      Use this table for event timelines in a bounded window. The required start and end filters must be Unix epoch
+      seconds such as 1777593600, not RFC3339 or relative strings; keep the window tight, then narrow the returned rows by
+      source or priority in SQL. date_happened is also Unix epoch seconds and priority only exposes normal or low.
 
     request:
       method: GET
@@ -258,9 +258,9 @@ tables:
         query_param: page_size
     columns:
       - name: id
-        type: Int64
+        type: Utf8
         nullable: true
-        description: Event ID
+        description: Event ID as text to preserve large 64-bit identifiers in JSON output.
         expr:
           kind: path
           path:
@@ -324,14 +324,14 @@ tables:
       - name: start
         type: Utf8
         nullable: true
-        description: Start time virtual filter
+        description: "Required start time virtual filter as Unix epoch seconds, for example 1777593600."
         expr:
           kind: "null"
         virtual: true
       - name: end
         type: Utf8
         nullable: true
-        description: End time virtual filter
+        description: "Required end time virtual filter as Unix epoch seconds, for example 1777597200."
         expr:
           kind: "null"
         virtual: true
@@ -1321,8 +1321,10 @@ tables:
   - name: logs
     description: Datadog logs within a time range.
     guide: >
-      Use this table for log troubleshooting in a bounded window. Keep the required start and end range tight and let query
-      do the main cut, then narrow the returned rows by service, host, or status in SQL; timestamps are ISO 8601.
+      Use this table for log troubleshooting in a bounded window. The required start and end filters are Datadog log search
+      times such as RFC3339 timestamps (2026-05-01T12:00:00Z) or relative strings (now-1h, now-24h); keep the range tight,
+      let query do the main cut, then narrow the returned rows by service, host, or status in SQL. Returned timestamps are
+      ISO 8601.
 
     fetch_limit_default: 1000
     request:
@@ -1464,14 +1466,14 @@ tables:
       - name: start
         type: Utf8
         nullable: true
-        description: Start time virtual filter
+        description: "Required Datadog log search start time, for example 2026-05-01T12:00:00Z or now-1h."
         expr:
           kind: "null"
         virtual: true
       - name: end
         type: Utf8
         nullable: true
-        description: End time virtual filter
+        description: "Required Datadog log search end time, for example 2026-05-01T13:00:00Z or now."
         expr:
           kind: "null"
         virtual: true


### PR DESCRIPTION
## Summary

- Preserves selected nullable columns as explicit `null` values in JSON output.
- Documents JSON null behavior in the CLI reference.
- Clarifies Datadog event/log time filter formats and keeps Datadog event IDs as text.

## Linear feedback mapping

Fixes [SOURCE-497](https://linear.app/withcoral/issue/SOURCE-497/json-rows-omit-selected-null-columns) by emitting explicit JSON nulls for selected nullable columns.

Addresses [SOURCE-499](https://linear.app/withcoral/issue/SOURCE-499/virtual-time-filters-need-format-metadata) for Datadog by documenting accepted time formats directly in table guides and virtual filter descriptions.

Partially addresses [SOURCE-502](https://linear.app/withcoral/issue/SOURCE-502/json-output-exposes-unsafe-int64-identifiers) by exposing Datadog event IDs as text so large provider identifiers are not emitted as unsafe JSON numbers.

## Verification

- `make rust-checks`
