### PR TITLE
feat(spec): decode base64 content columns

### DIFF
--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -3,6 +3,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use chrono::DateTime;
 use datafusion::arrow::array::{
     Array, BooleanArray, Float64Array, Int64Array, RecordBatch, StringArray,
@@ -183,6 +185,7 @@ fn eval_expr(expr: &ExprSpec, row: &Value, filters: &HashMap<String, String>) ->
         ExprSpec::FormatTimestamp { expr, input } => {
             eval_format_timestamp(expr, input, row, filters)
         }
+        ExprSpec::Base64Decode { expr } => eval_base64_decode(expr, row, filters),
         ExprSpec::Replace { expr, from, to } => {
             let raw = to_utf8(eval_expr(expr, row, filters))?;
             Some(Value::String(raw.replace(from, to)))
@@ -244,6 +247,21 @@ fn parse_epoch_micros(s: &str, input: &TimestampInput) -> Option<i64> {
         TimestampInput::Iso8601 => return None,
     };
     Some(whole * multiplier + frac)
+}
+
+fn eval_base64_decode(
+    expr: &ExprSpec,
+    row: &Value,
+    filters: &HashMap<String, String>,
+) -> Option<Value> {
+    let raw = to_utf8(eval_expr(expr, row, filters))?;
+    let compact = raw
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect::<String>();
+    let decoded = BASE64_STANDARD.decode(compact).ok()?;
+    let text = String::from_utf8(decoded).ok()?;
+    Some(Value::String(text))
 }
 
 fn eval_template(
@@ -459,6 +477,10 @@ mod tests {
                 "expr": expr_json(expr),
                 "from": from,
                 "to": to,
+            }),
+            ExprSpec::Base64Decode { expr } => json!({
+                "kind": "base64_decode",
+                "expr": expr_json(expr),
             }),
             ExprSpec::JoinTagValues {
                 path,
@@ -737,6 +759,32 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(col.value(0), "hello-world");
+    }
+
+    #[test]
+    fn base64_decode_expr_decodes_wrapped_utf8_text() {
+        let table = table_with_expr(
+            "content_text",
+            "Utf8",
+            &ExprSpec::Base64Decode {
+                expr: Box::new(ExprSpec::Path {
+                    path: vec!["content".into()],
+                }),
+            },
+        );
+        let schema = schema_from_columns(table.columns(), "test", table.name()).unwrap();
+        let items = vec![
+            serde_json::json!({"content": "aGVs\nbG8="}),
+            serde_json::json!({"content": "not base64"}),
+        ];
+        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let col = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(col.value(0), "hello");
+        assert!(col.is_null(1));
     }
 
     #[test]

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -720,6 +720,9 @@ pub enum ExprSpec {
         #[serde(default)]
         input: TimestampInput,
     },
+    Base64Decode {
+        expr: Box<ExprSpec>,
+    },
     Replace {
         expr: Box<ExprSpec>,
         from: String,

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -676,6 +676,15 @@
         {
           "type": "object",
           "additionalProperties": false,
+          "required": ["kind", "expr"],
+          "properties": {
+            "kind": { "const": "base64_decode" },
+            "expr": { "$ref": "#/$defs/expr" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
           "required": ["kind", "template", "values"],
           "properties": {
             "kind": { "const": "template" },

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -118,6 +118,7 @@ The `expr` field on a column defines how to extract or compute its value from ea
 | `path`               | Extract a value by JSON path segments                              |
 | `join_array_path`    | Join one nested scalar field from each object in an array          |
 | `format_timestamp`   | Convert an epoch timestamp to a `Timestamp` column                 |
+| `base64_decode`      | Decode a base64 string expression into UTF-8 text                  |
 | `replace`            | Replace all occurrences of one substring in the rendered value     |
 | `template`           | Build a string from a template with placeholder substitutions      |
 
@@ -169,6 +170,25 @@ Coral stores `Timestamp` columns as epoch microseconds internally, so the render
 | ------- | ------ | --------- | --------------------------------------------------- |
 | `input` | string | `seconds` | Unit/format of the raw value: `seconds`, `milliseconds`, or `iso8601` |
 | `expr`  | expr   | —         | Inner expression that produces the timestamp value |
+
+### `base64_decode`
+
+Decodes an inner expression as base64 and returns UTF-8 text. Whitespace in the encoded value is ignored, which is useful for APIs that wrap base64 file contents across lines. Invalid base64 or non-UTF-8 bytes produce `NULL`.
+
+```yaml
+- name: content_text
+  type: Utf8
+  expr:
+    kind: base64_decode
+    expr:
+      kind: path
+      path:
+        - content
+```
+
+| Field  | Type | Default | Description                            |
+| ------ | ---- | ------- | -------------------------------------- |
+| `expr` | expr | —       | Inner expression that produces base64 |
 
 ### `replace`
 

--- a/sources/github/manifest.yaml
+++ b/sources/github/manifest.yaml
@@ -30436,8 +30436,9 @@ tables:
   - name: contents
     description: Get repository content
     guide: >
-      Requires owner, repo, and path. Most useful optional filters: ref. Keep queries repository-scoped;
-      fan out across repos client-side when you need broader coverage.
+      Requires owner, repo, and path. Select `content_text` for decoded UTF-8 file contents when GitHub returns base64
+      content; keep `content` only when you need the raw API payload. Most useful optional filters: ref. Keep queries
+      repository-scoped; fan out across repos client-side when you need broader coverage.
     filters:
       - name: owner
         required: true
@@ -30503,10 +30504,22 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
+        description: Raw content returned by GitHub, usually base64 for files.
         expr:
           kind: path
           path:
             - content
+      - name: content_text
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Decoded UTF-8 file content when the GitHub content payload is base64 text.
+        expr:
+          kind: base64_decode
+          expr:
+            kind: path
+            path:
+              - content
       - name: download_url
         type: Utf8
         nullable: true


### PR DESCRIPTION
## Summary

- Adds a source-spec `base64_decode` expression.
- Adds `github.contents.content_text` for decoded UTF-8 file contents while preserving the raw `content` column.
- Documents the new expression in the source-spec reference.

## Linear feedback

Fixes [SOURCE-483](https://linear.app/withcoral/issue/SOURCE-483/expose-file-content-column-on-github-fileblob-tables) for GitHub repository contents by exposing decoded file text as `content_text`.

## Verification

- `make rust-checks`
