### PR TITLE
docs(github): document pull diff stat scope

### DIFF
--- a/sources/github/manifest.yaml
+++ b/sources/github/manifest.yaml
@@ -90424,7 +90424,8 @@ tables:
     guide: >
       Requires owner and repo. By default this table requests state=all from GitHub so aggregates include open and closed
       pull requests; add state when you need only open, closed, or all. Other useful optional filters are head and base. Add
-      pull_number to jump from the default list call to a specific record lookup.
+      pull_number to jump from the default list call to a specific record lookup. GitHub only populates diff-stat columns
+      such as additions, deletions, and changed_files on that per-PR lookup, so include pull_number before using them.
     filters:
       - name: owner
         required: true
@@ -90679,6 +90680,7 @@ tables:
         type: Int64
         nullable: true
         virtual: false
+        description: Lines added. GitHub only populates this on the per-PR lookup, so filter pull_number before using it.
         expr:
           kind: path
           path:
@@ -92283,6 +92285,7 @@ tables:
         type: Int64
         nullable: true
         virtual: false
+        description: Number of changed files. GitHub only populates this on the per-PR lookup, so filter pull_number before using it.
         expr:
           kind: path
           path:
@@ -92339,6 +92342,7 @@ tables:
         type: Int64
         nullable: true
         virtual: false
+        description: Lines deleted. GitHub only populates this on the per-PR lookup, so filter pull_number before using it.
         expr:
           kind: path
           path:


### PR DESCRIPTION
## Summary

- Documents that GitHub only returns pull request diff-stat fields on the per-PR lookup.
- Adds field-level descriptions for `additions`, `deletions`, and `changed_files` telling agents to filter by `pull_number` first.

## Linear feedback

Further addresses [SOURCE-500](https://linear.app/withcoral/issue/SOURCE-500/github-pr-list-queries-can-silently-mislead-agents) by making the diff-stat caveat explicit instead of allowing list-query nulls to look like real zeroes or missing data.

## Verification

- `make rust-checks`
