### PR TITLE
fix(linear): read comments by issue identifier

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1412,6 +1412,26 @@ mod tests {
                 "key": key,
                 "default": default,
             }),
+            ValueSourceSpec::FilterSplit {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "filter_split",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
+            ValueSourceSpec::FilterSplitInt {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "filter_split_int",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
             ValueSourceSpec::Input { key } => json!({
                 "from": "input",
                 "key": key,
@@ -1579,6 +1599,83 @@ mod tests {
             error
                 .to_string()
                 .contains("filter 'start_time' value 'not-a-number' is not a valid i64")
+        );
+    }
+
+    #[test]
+    fn resolve_value_source_splits_filter_parts() {
+        let filters = HashMap::from([("issue_identifier".to_string(), "SOURCE-496".to_string())]);
+
+        let team = resolve_value_source(
+            &ValueSourceSpec::FilterSplit {
+                key: "issue_identifier".to_string(),
+                separator: "-".to_string(),
+                part: 0,
+            },
+            &filters,
+            &HashMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect("split filter should resolve");
+        let number = resolve_value_source(
+            &ValueSourceSpec::FilterSplitInt {
+                key: "issue_identifier".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+            &filters,
+            &HashMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect("split integer filter should resolve");
+
+        assert_eq!(team, Some(json!("SOURCE")));
+        assert_eq!(number, Some(json!(496)));
+    }
+
+    #[test]
+    fn resolve_value_source_rejects_missing_filter_split_part() {
+        let filters = HashMap::from([("issue_identifier".to_string(), "SOURCE496".to_string())]);
+
+        let error = resolve_value_source(
+            &ValueSourceSpec::FilterSplit {
+                key: "issue_identifier".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+            &filters,
+            &HashMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect_err("missing split part should fail");
+
+        assert!(
+            error.to_string().contains(
+                "filter 'issue_identifier' value 'SOURCE496' does not contain split part 1"
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_value_source_rejects_missing_filter_split_int_part() {
+        let filters = HashMap::from([("issue_identifier".to_string(), "SOURCE496".to_string())]);
+
+        let error = resolve_value_source(
+            &ValueSourceSpec::FilterSplitInt {
+                key: "issue_identifier".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+            &filters,
+            &HashMap::new(),
+            &BTreeMap::new(),
+        )
+        .expect_err("missing split integer part should fail");
+
+        assert!(
+            error.to_string().contains(
+                "filter 'issue_identifier' value 'SOURCE496' does not contain split part 1"
+            )
         );
     }
 

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -54,6 +54,28 @@ pub(crate) fn resolve_value_source(
             };
             Ok(value)
         }
+        ValueSourceSpec::FilterSplit {
+            key,
+            separator,
+            part,
+        } => {
+            split_filter_part(filters, key, separator, *part).map(|value| value.map(Value::String))
+        }
+        ValueSourceSpec::FilterSplitInt {
+            key,
+            separator,
+            part,
+        } => {
+            let Some(raw) = split_filter_part(filters, key, separator, *part)? else {
+                return Ok(None);
+            };
+            let parsed = raw.parse::<i64>().map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "filter '{key}' split part {part} value '{raw}' is not a valid i64: {error}"
+                ))
+            })?;
+            Ok(Some(json!(parsed)))
+        }
         ValueSourceSpec::Input { key } => Ok(resolved_inputs.get(key).cloned().map(Value::String)),
         ValueSourceSpec::State { key } => Ok(state.get(key).map(|v| Value::String(v.clone()))),
         ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
@@ -69,6 +91,25 @@ pub(crate) fn resolve_value_source(
             Ok(Some(json!(value)))
         }
     }
+}
+
+fn split_filter_part(
+    filters: &HashMap<String, String>,
+    key: &str,
+    separator: &str,
+    part: usize,
+) -> Result<Option<String>> {
+    let Some(filter) = filters.get(key) else {
+        return Ok(None);
+    };
+    filter
+        .split(separator)
+        .nth(part)
+        .map_or_else(|| {
+            Err(DataFusionError::Execution(format!(
+                "filter '{key}' value '{filter}' does not contain split part {part} using separator '{separator}'"
+            )))
+        }, |value| Ok(Some(value.to_string())))
 }
 
 /// Render a parsed template into a concrete string.
@@ -191,6 +232,8 @@ pub(crate) fn validate_value_source_inputs(
         | ValueSourceSpec::Filter { .. }
         | ValueSourceSpec::FilterInt { .. }
         | ValueSourceSpec::FilterBool { .. }
+        | ValueSourceSpec::FilterSplit { .. }
+        | ValueSourceSpec::FilterSplitInt { .. }
         | ValueSourceSpec::State { .. }
         | ValueSourceSpec::NowEpochMinusSeconds { .. } => Ok(()),
     }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -313,6 +313,16 @@ pub enum ValueSourceSpec {
         #[serde(default)]
         default: Option<bool>,
     },
+    FilterSplit {
+        key: String,
+        separator: String,
+        part: usize,
+    },
+    FilterSplitInt {
+        key: String,
+        separator: String,
+        part: usize,
+    },
     Input {
         key: String,
     },

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -263,7 +263,9 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "default": {},
-        "seconds": { "type": "integer" }
+        "seconds": { "type": "integer" },
+        "separator": { "type": "string", "minLength": 1 },
+        "part": { "type": "integer", "minimum": 0 }
       },
       "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
     },
@@ -284,7 +286,9 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "default": {},
-        "seconds": { "type": "integer" }
+        "seconds": { "type": "integer" },
+        "separator": { "type": "string", "minLength": 1 },
+        "part": { "type": "integer", "minimum": 0 }
       },
       "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
     },
@@ -308,7 +312,9 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "default": {},
-        "seconds": { "type": "integer" }
+        "seconds": { "type": "integer" },
+        "separator": { "type": "string", "minLength": 1 },
+        "part": { "type": "integer", "minimum": 0 }
       },
       "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
     },
@@ -328,7 +334,9 @@
           "items": { "type": "string", "minLength": 1 }
         },
         "default": {},
-        "seconds": { "type": "integer" }
+        "seconds": { "type": "integer" },
+        "separator": { "type": "string", "minLength": 1 },
+        "part": { "type": "integer", "minimum": 0 }
       },
       "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
     },
@@ -370,6 +378,24 @@
             "default": { "type": "boolean" }
           },
           "required": ["key"]
+        },
+        {
+          "properties": {
+            "from": { "const": "filter_split" },
+            "key": { "type": "string", "minLength": 1 },
+            "separator": { "type": "string", "minLength": 1 },
+            "part": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["key", "separator", "part"]
+        },
+        {
+          "properties": {
+            "from": { "const": "filter_split_int" },
+            "key": { "type": "string", "minLength": 1 },
+            "separator": { "type": "string", "minLength": 1 },
+            "part": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["key", "separator", "part"]
         },
         {
           "properties": {

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -172,6 +172,8 @@ fn validate_value_source(
         ValueSourceSpec::Filter { key, .. }
         | ValueSourceSpec::FilterInt { key, .. }
         | ValueSourceSpec::FilterBool { key, .. }
+        | ValueSourceSpec::FilterSplit { key, .. }
+        | ValueSourceSpec::FilterSplitInt { key, .. }
             if !known_filters.contains(key) =>
         {
             return Err(ManifestError::validation(format!(
@@ -400,6 +402,70 @@ mod tests {
             &PaginationSpec::default(),
         )
         .expect_err("route request should reject unknown filters");
+
+        assert!(
+            error
+                .to_string()
+                .contains("references unknown filter 'missing'")
+        );
+    }
+
+    #[test]
+    fn validate_http_table_rejects_unknown_filter_split_bindings() {
+        let request = RequestSpec {
+            query: vec![QueryParamSpec {
+                name: "team_key".to_string(),
+                value: ValueSourceSpec::FilterSplit {
+                    key: "missing".to_string(),
+                    separator: "-".to_string(),
+                    part: 0,
+                },
+            }],
+            ..base_request()
+        };
+
+        let error = validate_http_table(
+            "demo",
+            "messages",
+            &test_filters(),
+            &[test_column()],
+            &request,
+            &[],
+            &PaginationSpec::default(),
+        )
+        .expect_err("filter_split should reject unknown filters");
+
+        assert!(
+            error
+                .to_string()
+                .contains("references unknown filter 'missing'")
+        );
+    }
+
+    #[test]
+    fn validate_http_table_rejects_unknown_filter_split_int_bindings() {
+        let request = RequestSpec {
+            query: vec![QueryParamSpec {
+                name: "issue_number".to_string(),
+                value: ValueSourceSpec::FilterSplitInt {
+                    key: "missing".to_string(),
+                    separator: "-".to_string(),
+                    part: 1,
+                },
+            }],
+            ..base_request()
+        };
+
+        let error = validate_http_table(
+            "demo",
+            "messages",
+            &test_filters(),
+            &[test_column()],
+            &request,
+            &[],
+            &PaginationSpec::default(),
+        )
+        .expect_err("filter_split_int should reject unknown filters");
 
         assert!(
             error

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -462,6 +462,8 @@ Request query params, body fields, and headers support these `from` values:
 | `filter` | Read a SQL filter as a string |
 | `filter_int` | Read a SQL filter and serialize it as a JSON integer |
 | `filter_bool` | Read a SQL filter and serialize it as a JSON boolean |
+| `filter_split` | Split a SQL filter string and serialize one part as a string |
+| `filter_split_int` | Split a SQL filter string and serialize one part as a JSON integer |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
 | `state` | Read pagination/runtime state |
 | `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |
@@ -469,6 +471,23 @@ Request query params, body fields, and headers support these `from` values:
 Boolean filters used with `filter_bool` can be written as normal SQL boolean
 predicates, for example `WHERE include_archived IS FALSE` or
 `WHERE include_archived = false`.
+
+Use `filter_split` and `filter_split_int` when a provider requires structured
+request fields but users naturally have one compound identifier. For example,
+`SOURCE-496` can become a string team key and integer issue number:
+
+```yaml
+- path: [variables, teamKey]
+  from: filter_split
+  key: issue_identifier
+  separator: "-"
+  part: 0
+- path: [variables, issueNumber]
+  from: filter_split_int
+  key: issue_identifier
+  separator: "-"
+  part: 1
+```
 
 ### HTTP response fields
 

--- a/sources/linear/manifest.yaml
+++ b/sources/linear/manifest.yaml
@@ -1724,6 +1724,172 @@ tables:
     filters:
       - name: issue_id
         required: true
+  - name: issue_comments_by_identifier
+    description: Comments for a specific Linear issue identifier
+    guide: |
+      Requires a human issue identifier such as `SOURCE-496`. Use this table
+      when you have an issue key from Linear UI, Slack, or another tool and
+      need the discussion trail without first looking up the internal issue
+      UUID.
+    request:
+      method: POST
+      path: /graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query IssueCommentsByIdentifier($teamKey: String!, $issueNumber: Float!, $first: Int!, $after: String) {
+              issues(filter: { team: { key: { eq: $teamKey } }, number: { eq: $issueNumber } }, first: 1) {
+                nodes {
+                  id
+                  identifier
+                  comments(first: $first, after: $after) {
+                    nodes {
+                      id
+                      body
+                      createdAt
+                      updatedAt
+                      user {
+                        id
+                        name
+                        displayName
+                        email
+                      }
+                    }
+                    pageInfo {
+                      endCursor
+                    }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - teamKey
+          from: filter_split
+          key: issue_identifier
+          separator: "-"
+          part: 0
+        - path:
+            - variables
+            - issueNumber
+          from: filter_split_int
+          key: issue_identifier
+          separator: "-"
+          part: 1
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - data
+        - issues
+        - nodes
+        - "0"
+        - comments
+        - nodes
+    pagination:
+      mode: cursor_body
+      cursor_body_path:
+        - variables
+        - after
+      response_cursor_path:
+        - data
+        - issues
+        - nodes
+        - "0"
+        - comments
+        - pageInfo
+        - endCursor
+      page_size:
+        default: 100
+        max: 250
+        body_path:
+          - variables
+          - first
+    columns:
+      - name: issue_identifier
+        type: Utf8
+        nullable: false
+        description: Issue identifier filter, for example SOURCE-496
+        expr:
+          kind: from_filter
+          key: issue_identifier
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Comment ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: body
+        type: Utf8
+        nullable: true
+        description: Comment body
+        expr:
+          kind: path
+          path:
+            - body
+      - name: author_id
+        type: Utf8
+        nullable: true
+        description: Comment author user ID
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: author_name
+        type: Utf8
+        nullable: true
+        description: Comment author name
+        expr:
+          kind: path
+          path:
+            - user
+            - name
+      - name: author_display_name
+        type: Utf8
+        nullable: true
+        description: Comment author display name
+        expr:
+          kind: path
+          path:
+            - user
+            - displayName
+      - name: author_email
+        type: Utf8
+        nullable: true
+        description: Comment author email
+        expr:
+          kind: path
+          path:
+            - user
+            - email
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Updated timestamp
+        expr:
+          kind: path
+          path:
+            - updatedAt
+    filters:
+      - name: issue_identifier
+        required: true
   - name: team_issues
     description: Issues for a specific Linear team
     guide: |


### PR DESCRIPTION
## Summary

- Adds `linear.issue_comments_by_identifier` so agents can fetch comments with a human issue key like `SOURCE-496`.
- Supports splitting the issue identifier into Linear team key and number for the GraphQL lookup.
- Returns comment author metadata alongside body and timestamps.

## Linear feedback

Addresses [SOURCE-501](https://linear.app/withcoral/issue/SOURCE-501/linear-source-lacks-ergonomic-follow-up-metadata) by adding the identifier-based comment lookup called out in the issue's suggested direction, avoiding a separate internal UUID lookup before reading discussion context.

## Verification

- `make rust-checks`
