### PR TITLE
refactor(app): collapse candidate source input mirror

### DIFF
--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -2,13 +2,11 @@
 
 use std::collections::BTreeSet;
 
-use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_source_manifest_yaml};
+use coral_spec::parse_source_manifest_yaml;
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
-use crate::sources::model::{
-    CandidateSource, CandidateSourceInput, CandidateSourceInputKind, InstalledSource, SourceOrigin,
-};
+use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
@@ -97,41 +95,21 @@ pub(crate) fn describe_manifest(
         name: SourceName::parse(manifest.schema_name())?,
         description: manifest.description().to_string(),
         version: manifest.source_version().to_string(),
-        inputs: manifest
-            .declared_inputs()
-            .iter()
-            .cloned()
-            .map(candidate_input_spec)
-            .collect(),
+        inputs: manifest.declared_inputs().to_vec(),
         installed,
         origin,
     })
-}
-
-fn candidate_input_spec(input: ManifestInputSpec) -> CandidateSourceInput {
-    CandidateSourceInput {
-        key: input.key,
-        kind: candidate_input_kind(input.kind),
-        required: input.required,
-        default_value: input.default_value,
-        hint: input.hint,
-    }
-}
-
-fn candidate_input_kind(kind: ManifestInputKind) -> CandidateSourceInputKind {
-    match kind {
-        ManifestInputKind::Variable => CandidateSourceInputKind::Variable,
-        ManifestInputKind::Secret => CandidateSourceInputKind::Secret,
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeSet;
 
+    use coral_spec::ManifestInputKind;
+
     use super::{describe_manifest, list_bundled_sources};
     use crate::sources::SourceName;
-    use crate::sources::model::{CandidateSourceInputKind, SourceOrigin};
+    use crate::sources::model::SourceOrigin;
 
     #[test]
     fn bundled_sources_load_through_catalog() {
@@ -188,9 +166,9 @@ tables:
         .expect("describe manifest");
         assert_eq!(source.inputs.len(), 2);
         assert_eq!(source.inputs[0].key, "API_BASE");
-        assert_eq!(source.inputs[0].kind, CandidateSourceInputKind::Variable);
+        assert_eq!(source.inputs[0].kind, ManifestInputKind::Variable);
         assert_eq!(source.inputs[1].key, "API_TOKEN");
-        assert_eq!(source.inputs[1].kind, CandidateSourceInputKind::Secret);
+        assert_eq!(source.inputs[1].kind, ManifestInputKind::Secret);
     }
 
     #[test]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -5,15 +5,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use coral_api::v1::{
     CreateBundledSourceRequest, ImportSourceRequest, SourceSecret, SourceVariable,
 };
+use coral_spec::ManifestInputKind;
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
-use crate::sources::model::{
-    CandidateSource, CandidateSourceInputKind, InstalledSource, SourceOrigin,
-};
+use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
@@ -381,13 +380,13 @@ fn validate_bindings(
     let expected_variables = candidate
         .inputs
         .iter()
-        .filter(|input| input.kind == CandidateSourceInputKind::Variable)
+        .filter(|input| input.kind == ManifestInputKind::Variable)
         .map(|input| input.key.clone())
         .collect::<BTreeSet<_>>();
     let expected_secrets = candidate
         .inputs
         .iter()
-        .filter(|input| input.kind == CandidateSourceInputKind::Secret)
+        .filter(|input| input.kind == ManifestInputKind::Secret)
         .map(|input| input.key.clone())
         .collect::<BTreeSet<_>>();
 
@@ -407,7 +406,7 @@ fn validate_bindings(
     }
 
     for input in &candidate.inputs {
-        if input.kind == CandidateSourceInputKind::Variable
+        if input.kind == ManifestInputKind::Variable
             && !variable_values.contains_key(&input.key)
             && !input.default_value.is_empty()
         {
@@ -417,7 +416,7 @@ fn validate_bindings(
 
     for input in &candidate.inputs {
         match input.kind {
-            CandidateSourceInputKind::Variable
+            ManifestInputKind::Variable
                 if input.required && !variable_values.contains_key(&input.key) =>
             {
                 return Err(AppError::InvalidInput(format!(
@@ -425,7 +424,7 @@ fn validate_bindings(
                     input.key
                 )));
             }
-            CandidateSourceInputKind::Secret
+            ManifestInputKind::Secret
                 if input.required && !secret_values.contains_key(&input.key) =>
             {
                 return Err(AppError::InvalidInput(format!(

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeMap;
 
+use coral_spec::ManifestInputSpec;
 use serde::{Deserialize, Serialize};
 
 use crate::sources::SourceName;
@@ -12,24 +13,9 @@ pub(crate) struct CandidateSource {
     pub(crate) name: SourceName,
     pub(crate) description: String,
     pub(crate) version: String,
-    pub(crate) inputs: Vec<CandidateSourceInput>,
+    pub(crate) inputs: Vec<ManifestInputSpec>,
     pub(crate) installed: bool,
     pub(crate) origin: SourceOrigin,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct CandidateSourceInput {
-    pub(crate) key: String,
-    pub(crate) kind: CandidateSourceInputKind,
-    pub(crate) required: bool,
-    pub(crate) default_value: String,
-    pub(crate) hint: Option<String>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CandidateSourceInputKind {
-    Variable,
-    Secret,
 }
 
 /// App-owned model for one source installed in a workspace.

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -8,15 +8,14 @@ use coral_api::v1::{
     SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
     ValidateSourceResponse,
 };
+use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::SourceManager;
-use crate::sources::model::{
-    CandidateSource, CandidateSourceInput, CandidateSourceInputKind, InstalledSource, SourceOrigin,
-};
+use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
     query_status, validate_source_response_to_proto, workspace_name_from_proto, workspace_to_proto,
 };
@@ -215,7 +214,7 @@ fn candidate_source_to_proto(source: CandidateSource) -> SourceInfo {
     }
 }
 
-fn candidate_source_input_to_proto(input: CandidateSourceInput) -> SourceInputSpec {
+fn candidate_source_input_to_proto(input: ManifestInputSpec) -> SourceInputSpec {
     SourceInputSpec {
         key: input.key,
         kind: proto_candidate_input_kind(input.kind) as i32,
@@ -225,9 +224,9 @@ fn candidate_source_input_to_proto(input: CandidateSourceInput) -> SourceInputSp
     }
 }
 
-fn proto_candidate_input_kind(kind: CandidateSourceInputKind) -> SourceInputKind {
+fn proto_candidate_input_kind(kind: ManifestInputKind) -> SourceInputKind {
     match kind {
-        CandidateSourceInputKind::Variable => SourceInputKind::Variable,
-        CandidateSourceInputKind::Secret => SourceInputKind::Secret,
+        ManifestInputKind::Variable => SourceInputKind::Variable,
+        ManifestInputKind::Secret => SourceInputKind::Secret,
     }
 }


### PR DESCRIPTION
## Summary

- Carry `ManifestInputSpec` directly on `CandidateSource`
- Remove the redundant app-private `CandidateSourceInput` and `CandidateSourceInputKind` mirror
- Keep input-to-protobuf conversion localized at the source service boundary

## Intent

Source input semantics are owned by `coral-spec`. The app-layer candidate input mirror had become a field-for-field copy of the spec model, which made future source input changes require another mapping without adding an app-specific invariant. This keeps the app lifecycle model narrower while preserving the transport boundary.

## Validation

- `make rust-checks`
