### PR TITLE
chore(codeowners): adjust project doc ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,10 +14,10 @@
 /xtask/ @withcoral/repo-ops @withcoral/docs
 
 # Project docs.
-/AGENTS.md @withcoral/core-maintainers
+AGENTS.md @withcoral/core-maintainers
 /CONTRIBUTING.md @withcoral/core-maintainers
 /SECURITY.md @withcoral/core-maintainers
-/README.md @withcoral/core-maintainers @withcoral/docs
+/README.md @withcoral/core-maintainers
 
 # Docs.
 /docs/ @withcoral/docs


### PR DESCRIPTION
## Summary

Adjust the project-doc ownership rules after the team-based CODEOWNERS rollout so root project guidance and README ownership match the intended review routing.

## Details

- Let root `AGENTS.md` matching apply consistently by filename.
- Route root `README.md` review through core maintainers only.

## Verification

- `git diff --check HEAD~1 HEAD`
- GitHub CODEOWNERS parser for `james/update-codeowners-project-docs`: no errors
