### PR TITLE
feat(mcp): paginate list_tables discovery

### DIFF
--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -29,3 +29,17 @@ message Table {
   // Required filter names, if any.
   repeated string required_filters = 6;
 }
+
+// Table metadata without full column definitions.
+message TableSummary {
+  // Workspace that scopes this table.
+  Workspace workspace = 1;
+  // Source schema that owns the table.
+  string schema_name = 2;
+  // Table name within the schema.
+  string name = 3;
+  // Human-readable table description.
+  string description = 4;
+  // Filter names that must be constrained when querying this table.
+  repeated string required_filters = 5;
+}

--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -21,16 +21,48 @@ message ExecuteSqlResponse {
   int64 row_count = 2;
 }
 
+// Page request parameters for list-style APIs.
+message PaginationRequest {
+  // Maximum number of items to return. Zero means unbounded for compatibility.
+  uint32 limit = 1;
+  // Number of matching items to skip before returning results.
+  uint32 offset = 2;
+}
+
+// Page metadata returned by list-style APIs.
+message PaginationResponse {
+  // Matching item count before pagination.
+  uint32 total_count = 1;
+  // Applied result limit. Zero means unbounded.
+  uint32 limit = 2;
+  // Applied result offset.
+  uint32 offset = 3;
+  // Whether another page is available.
+  bool has_more = 4;
+  // Offset to request for the next page when `has_more` is true.
+  uint32 next_offset = 5;
+}
+
 // Lists all query-visible tables in one workspace.
 message ListTablesRequest {
   // Workspace whose current query-visible tables should be listed.
   Workspace workspace = 1;
+  // Optional exact schema/source name.
+  string schema_name = 2;
+  // Optional page request. Missing or zero limit keeps the legacy unbounded behavior.
+  PaginationRequest pagination = 3;
+  // Whether table columns should be omitted from the response.
+  bool omit_columns = 4;
 }
 
 // Returns the query-visible tables in one workspace.
 message ListTablesResponse {
-  // Query-visible tables for the workspace.
+  // Full query-visible tables for legacy callers.
   repeated Table tables = 1;
+  // Page metadata for the table list.
+  PaginationResponse pagination = 2;
+  // Query-visible table summaries for callers that do not need columns.
+  repeated TableSummary table_summaries = 3;
 }
 
 // SQL query execution APIs.

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -61,12 +61,13 @@ impl QueryManager {
     pub(crate) async fn list_tables(
         &self,
         workspace_name: &WorkspaceName,
+        schema_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
         let sources = self
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_config(&sources);
-        CoralQuery::list_tables(&sources, runtime, None)
+        CoralQuery::list_tables(&sources, runtime, schema_filter)
             .await
             .map_err(QueryManagerError::Core)
     }

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -4,13 +4,17 @@ use arrow::datatypes::SchemaRef;
 use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
-use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, ListTablesRequest, ListTablesResponse};
+use coral_api::v1::{
+    ExecuteSqlRequest, ExecuteSqlResponse, ListTablesRequest, ListTablesResponse,
+    PaginationResponse,
+};
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::core_status;
 use crate::query::manager::QueryManager;
 use crate::transport::{
-    grpc_span, instrument_grpc, query_status, table_to_proto, workspace_name_from_proto,
+    grpc_span, instrument_grpc, query_status, table_summary_to_proto, table_to_proto,
+    workspace_name_from_proto,
 };
 
 #[derive(Clone)]
@@ -36,15 +40,54 @@ impl QueryServiceApi for QueryService {
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
+            let pagination = request.pagination.unwrap_or_default();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let schema_name = request.schema_name.trim();
+            let schema_name = if schema_name.is_empty() {
+                None
+            } else {
+                Some(schema_name)
+            };
             let tables = queries
-                .list_tables(&workspace_name)
+                .list_tables(&workspace_name, schema_name)
                 .await
-                .map_err(query_status)?
-                .into_iter()
-                .map(|table| table_to_proto(&workspace_name, table))
-                .collect();
-            Ok(Response::new(ListTablesResponse { tables }))
+                .map_err(query_status)?;
+            let total = tables.len();
+            let offset = pagination.offset as usize;
+            let limit = pagination.limit as usize;
+            let page = paginate_tables(tables, offset, limit);
+            let returned_count = page.len();
+            let has_more = pagination.limit != 0 && offset.saturating_add(returned_count) < total;
+            let (tables, table_summaries) = if request.omit_columns {
+                (
+                    Vec::new(),
+                    page.into_iter()
+                        .map(|table| table_summary_to_proto(&workspace_name, table))
+                        .collect(),
+                )
+            } else {
+                (
+                    page.into_iter()
+                        .map(|table| table_to_proto(&workspace_name, table))
+                        .collect(),
+                    Vec::new(),
+                )
+            };
+            Ok(Response::new(ListTablesResponse {
+                tables,
+                table_summaries,
+                pagination: Some(PaginationResponse {
+                    total_count: count_to_u32(total),
+                    limit: pagination.limit,
+                    offset: pagination.offset,
+                    has_more,
+                    next_offset: if has_more {
+                        count_to_u32(offset.saturating_add(returned_count))
+                    } else {
+                        0
+                    },
+                }),
+            }))
         })
         .await
     }
@@ -75,6 +118,23 @@ impl QueryServiceApi for QueryService {
         })
         .await
     }
+}
+
+fn paginate_tables(
+    tables: Vec<coral_engine::TableInfo>,
+    offset: usize,
+    limit: usize,
+) -> Vec<coral_engine::TableInfo> {
+    let iter = tables.into_iter().skip(offset);
+    if limit == 0 {
+        iter.collect()
+    } else {
+        iter.take(limit).collect()
+    }
+}
+
+fn count_to_u32(count: usize) -> u32 {
+    u32::try_from(count).unwrap_or(u32::MAX)
 }
 
 fn encode_arrow_ipc_stream(

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -3,7 +3,7 @@
 use std::future::Future;
 
 use coral_api::v1::{
-    Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table,
+    Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableSummary,
     ValidateSourceResponse, Workspace, query_test_result,
 };
 use opentelemetry::propagation::Extractor;
@@ -134,20 +134,42 @@ pub(crate) fn table_to_proto(
     workspace_name: &WorkspaceName,
     table: coral_engine::TableInfo,
 ) -> Table {
+    table_to_proto_with_columns(workspace_name, table)
+}
+
+pub(crate) fn table_summary_to_proto(
+    workspace_name: &WorkspaceName,
+    table: coral_engine::TableInfo,
+) -> TableSummary {
+    TableSummary {
+        workspace: Some(workspace_to_proto(workspace_name)),
+        schema_name: table.schema_name,
+        name: table.table_name,
+        description: table.description,
+        required_filters: table.required_filters,
+    }
+}
+
+fn table_to_proto_with_columns(
+    workspace_name: &WorkspaceName,
+    table: coral_engine::TableInfo,
+) -> Table {
+    let columns = table
+        .columns
+        .into_iter()
+        .map(|column| Column {
+            name: column.name,
+            data_type: column.data_type,
+            nullable: column.nullable,
+        })
+        .collect();
+
     Table {
         workspace: Some(workspace_to_proto(workspace_name)),
         schema_name: table.schema_name,
         name: table.table_name,
         description: table.description,
-        columns: table
-            .columns
-            .into_iter()
-            .map(|column| Column {
-                name: column.name,
-                data_type: column.data_type,
-                nullable: column.nullable,
-            })
-            .collect(),
+        columns,
         required_filters: table.required_filters,
     }
 }
@@ -194,8 +216,8 @@ mod tests {
     use tonic::Code;
 
     use super::{
-        grpc_code_label, query_status, query_test_result_to_proto, table_to_proto,
-        workspace_name_from_proto, workspace_to_proto,
+        grpc_code_label, query_status, query_test_result_to_proto, table_summary_to_proto,
+        table_to_proto, workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
@@ -280,6 +302,30 @@ mod tests {
         assert_eq!(proto.columns[0].name, "id");
         assert_eq!(proto.columns[0].data_type, "Int64");
         assert!(!proto.columns[0].nullable);
+        assert_eq!(proto.required_filters, vec!["org_id"]);
+    }
+
+    #[test]
+    fn table_summary_to_proto_preserves_table_metadata_without_columns() {
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let table = TableInfo {
+            schema_name: "demo".to_string(),
+            table_name: "users".to_string(),
+            description: "User records".to_string(),
+            columns: vec![ColumnInfo {
+                name: "id".to_string(),
+                data_type: "Int64".to_string(),
+                nullable: false,
+            }],
+            required_filters: vec!["org_id".to_string()],
+        };
+
+        let proto = table_summary_to_proto(&workspace_name, table);
+
+        assert_eq!(proto.workspace, Some(workspace_to_proto(&workspace_name)));
+        assert_eq!(proto.schema_name, "demo");
+        assert_eq!(proto.name, "users");
+        assert_eq!(proto.description, "User records");
         assert_eq!(proto.required_filters, vec!["org_id"]);
     }
 

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -104,6 +104,9 @@ impl GrpcHarness {
         self.query_client()
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
+                schema_name: String::new(),
+                pagination: None,
+                omit_columns: false,
             }))
             .await
             .expect("list tables")
@@ -196,6 +199,53 @@ impl Drop for FailingHttpFixture {
 
 pub(crate) fn fixture_manifest_yaml(root: &Path) -> String {
     fixture_manifest_with_test_queries_yaml(root, &[])
+}
+
+pub(crate) fn fixture_manifest_with_multiple_tables_yaml(root: &Path) -> String {
+    let data_dir = root.join("fixture-data");
+    fs::create_dir_all(&data_dir).expect("create data dir");
+    fs::write(
+        data_dir.join("messages.jsonl"),
+        r#"{"type":"user","sessionId":"s1","text":"hello"}
+{"type":"assistant","sessionId":"s1","text":"world"}
+"#,
+    )
+    .expect("write jsonl");
+    let table_source = json!({
+        "location": format!("file://{}/", data_dir.display()),
+        "glob": "**/*.jsonl",
+    });
+    let table_columns = json!([
+        {"name": "type", "type": "Utf8"},
+        {"name": "sessionId", "type": "Utf8"},
+        {"name": "text", "type": "Utf8"},
+    ]);
+    manifest_yaml(&json!({
+        "name": "local_messages",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "tables": [
+            {
+                "name": "events",
+                "description": "Fixture events",
+                "source": table_source.clone(),
+                "columns": table_columns.clone(),
+            },
+            {
+                "name": "messages",
+                "description": "Fixture messages",
+                "source": table_source.clone(),
+                "columns": table_columns.clone(),
+            },
+            {
+                "name": "sessions",
+                "description": "Fixture sessions",
+                "source": table_source,
+                "columns": table_columns,
+            },
+        ],
+    }))
 }
 
 pub(crate) fn fixture_manifest_with_test_queries_yaml(

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -3,8 +3,8 @@ use std::fs;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest, ListTablesRequest,
-    QueryTestFailure, QueryTestSuccess, SourceOrigin, SourceSecret, SourceVariable,
-    ValidateSourceRequest, Workspace, query_test_result,
+    PaginationRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin, SourceSecret,
+    SourceVariable, ValidateSourceRequest, Workspace, query_test_result,
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
@@ -12,8 +12,9 @@ use tonic::Request;
 
 use crate::harness::{
     FailingHttpFixture, GrpcHarness, fixture_manifest_with_inputs_yaml,
-    fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
-    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
+    fixture_manifest_with_multiple_tables_yaml, fixture_manifest_with_required_inputs_yaml,
+    fixture_manifest_with_test_queries_yaml, fixture_manifest_yaml, invalid_manifest_yaml,
+    source_dir,
 };
 
 #[tokio::test]
@@ -205,6 +206,91 @@ async fn validate_source_returns_tables() {
         .await;
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["text"], "hello");
+}
+
+#[tokio::test]
+async fn list_tables_supports_legacy_full_response_and_paginated_summaries() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let legacy = harness
+        .query_client()
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+            schema_name: String::new(),
+            pagination: None,
+            omit_columns: false,
+        }))
+        .await
+        .expect("legacy list tables")
+        .into_inner();
+    let legacy_pagination = legacy.pagination.as_ref().expect("legacy pagination");
+    assert_eq!(legacy_pagination.total_count, 3);
+    assert_eq!(legacy_pagination.limit, 0);
+    assert_eq!(legacy_pagination.offset, 0);
+    assert!(!legacy_pagination.has_more);
+    assert_eq!(legacy.tables.len(), 3);
+    assert!(legacy.table_summaries.is_empty());
+    assert_eq!(legacy.tables[0].name, "events");
+    assert!(!legacy.tables[0].columns.is_empty());
+
+    let page = harness
+        .query_client()
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "local_messages".to_string(),
+            pagination: Some(PaginationRequest {
+                limit: 2,
+                offset: 0,
+            }),
+            omit_columns: true,
+        }))
+        .await
+        .expect("paginated list tables")
+        .into_inner();
+    let page_pagination = page.pagination.as_ref().expect("page pagination");
+    assert_eq!(page_pagination.total_count, 3);
+    assert_eq!(page_pagination.limit, 2);
+    assert_eq!(page_pagination.offset, 0);
+    assert!(page_pagination.has_more);
+    assert_eq!(page_pagination.next_offset, 2);
+    assert_eq!(
+        page.table_summaries
+            .iter()
+            .map(|table| table.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["events", "messages"]
+    );
+    assert!(page.tables.is_empty());
+
+    let unknown_schema = harness
+        .query_client()
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "missing".to_string(),
+            pagination: Some(PaginationRequest {
+                limit: 2,
+                offset: 0,
+            }),
+            omit_columns: true,
+        }))
+        .await
+        .expect("unknown schema list tables")
+        .into_inner();
+    let unknown_schema_pagination = unknown_schema
+        .pagination
+        .as_ref()
+        .expect("unknown schema pagination");
+    assert_eq!(unknown_schema_pagination.total_count, 0);
+    assert!(unknown_schema.tables.is_empty());
+    assert!(unknown_schema.table_summaries.is_empty());
+    assert!(!unknown_schema_pagination.has_more);
 }
 
 #[tokio::test]
@@ -1172,6 +1258,9 @@ async fn rejects_invalid_workspace_and_source_names() {
             workspace: Some(Workspace {
                 name: r"bad\workspace".to_string(),
             }),
+            schema_name: String::new(),
+            pagination: None,
+            omit_columns: false,
         }))
         .await
         .expect_err("workspace with backslash should fail");

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -17,8 +17,9 @@ use coral_api::v1::{
     Column, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
     DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, GetSourceInfoRequest,
     GetSourceRequest, ImportSourceRequest, ListSourcesRequest, ListSourcesResponse,
-    ListTablesRequest, ListTablesResponse, Source, SourceInfo, SourceInputKind, SourceInputSpec,
-    SourceOrigin, Table, ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    ListTablesRequest, ListTablesResponse, PaginationResponse, Source, SourceInfo, SourceInputKind,
+    SourceInputSpec, SourceOrigin, Table, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -74,6 +75,27 @@ fn mock_visible_table() -> Table {
             },
         ],
         required_filters: Vec::new(),
+    }
+}
+
+fn mock_visible_tables() -> Vec<Table> {
+    let messages = mock_visible_table();
+    let mut sessions = mock_visible_table();
+    sessions.name = "sessions".to_string();
+    sessions.description = "Fixture sessions".to_string();
+    let mut events = mock_visible_table();
+    events.name = "events".to_string();
+    events.description = "Fixture events".to_string();
+    vec![events, messages, sessions]
+}
+
+fn table_summary(table: &Table) -> TableSummary {
+    TableSummary {
+        workspace: table.workspace.clone(),
+        schema_name: table.schema_name.clone(),
+        name: table.name.clone(),
+        description: table.description.clone(),
+        required_filters: table.required_filters.clone(),
     }
 }
 
@@ -340,13 +362,57 @@ impl QueryService for MockQueryService {
         &self,
         request: Request<ListTablesRequest>,
     ) -> Result<Response<ListTablesResponse>, Status> {
+        let request = request.into_inner();
         self.captured
             .list_tables
             .lock()
             .expect("list_tables capture")
-            .push(request.into_inner());
+            .push(request.clone());
+        let mut tables = mock_visible_tables()
+            .into_iter()
+            .filter(|table| {
+                request.schema_name.is_empty() || table.schema_name == request.schema_name
+            })
+            .collect::<Vec<_>>();
+        let total = u32::try_from(tables.len()).unwrap_or(u32::MAX);
+        let pagination = request.pagination.unwrap_or_default();
+        let offset = usize::try_from(pagination.offset).expect("offset");
+        let limit = usize::try_from(pagination.limit).expect("limit");
+        tables = if limit == 0 {
+            tables.into_iter().skip(offset).collect()
+        } else {
+            tables.into_iter().skip(offset).take(limit).collect()
+        };
+        let table_summaries = if request.omit_columns {
+            tables.iter().map(table_summary).collect()
+        } else {
+            Vec::new()
+        };
+        let returned_count = if request.omit_columns {
+            u32::try_from(table_summaries.len()).unwrap_or(u32::MAX)
+        } else {
+            u32::try_from(tables.len()).unwrap_or(u32::MAX)
+        };
+        if request.omit_columns {
+            tables.clear();
+        }
+        let has_more =
+            pagination.limit != 0 && pagination.offset.saturating_add(returned_count) < total;
+        let next_offset = if has_more {
+            pagination.offset.saturating_add(returned_count)
+        } else {
+            0
+        };
         Ok(Response::new(ListTablesResponse {
-            tables: vec![mock_visible_table()],
+            tables,
+            table_summaries,
+            pagination: Some(PaginationResponse {
+                total_count: total,
+                limit: pagination.limit,
+                offset: pagination.offset,
+                has_more,
+                next_offset,
+            }),
         }))
     }
 
@@ -585,6 +651,14 @@ impl MockServer {
             .list_sources
             .lock()
             .expect("list_sources capture")
+            .clone()
+    }
+
+    pub(crate) fn list_tables_requests(&self) -> Vec<ListTablesRequest> {
+        self.captured
+            .list_tables
+            .lock()
+            .expect("list_tables capture")
             .clone()
     }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -68,14 +68,14 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .description
             .as_deref()
             .expect("sql description")
-            .contains("1 visible SQL schema(s) are currently available")
+            .contains("3 table(s) are currently visible")
     );
     assert!(
         tools[1]
             .description
             .as_deref()
             .expect("list_tables description")
-            .contains("1 table(s) are currently visible")
+            .contains("3 table(s) are currently visible")
     );
 
     let resources = client.list_all_resources().await?;
@@ -94,14 +94,14 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
     assert!(guide_text.contains("## Available Schemas"));
     assert!(guide_text.contains("- local_messages"));
     assert!(guide_text.contains(
-        "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'messages'"
+        "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'events'"
     ));
 
     let tables = client
         .read_resource(ReadResourceRequestParams::new("coral://tables"))
         .await?;
     let tables_json: Value = serde_json::from_str(text_content(&tables))?;
-    assert_eq!(tables_json["tables"][0]["name"], "local_messages.messages");
+    assert_eq!(tables_json["tables"][0]["name"], "local_messages.events");
 
     client.cancel().await?;
     server.shutdown().await;
@@ -137,10 +137,37 @@ async fn mcp_stdio_sql_and_list_tables_return_structured_content()
         .call_tool(CallToolRequestParams::new("list_tables"))
         .await?;
     assert_eq!(tables.is_error, Some(false));
+    let structured_tables = tables.structured_content.expect("structured content");
+    assert_eq!(structured_tables["total"], 3);
+    assert_eq!(structured_tables["limit"], 50);
+    assert_eq!(structured_tables["offset"], 0);
+    assert_eq!(structured_tables["has_more"], false);
     assert_eq!(
-        tables.structured_content.expect("structured content")["tables"][0]["name"],
-        "local_messages.messages"
+        structured_tables["tables"][0]["name"],
+        "local_messages.events"
     );
+    assert!(structured_tables["tables"][0]["columns"].is_null());
+    let requests = server.list_tables_requests();
+    let request = requests.last().expect("list tables request");
+    assert_eq!(request.schema_name, "");
+    let request_pagination = request.pagination.as_ref().expect("request pagination");
+    assert_eq!(request_pagination.limit, 50);
+    assert_eq!(request_pagination.offset, 0);
+    assert!(request.omit_columns);
+
+    let paginated = client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "schema": "local_messages",
+                "limit": 2,
+                "offset": 0
+            }))),
+        )
+        .await?;
+    let paginated = paginated.structured_content.expect("structured content");
+    assert_eq!(paginated["total"], 3);
+    assert_eq!(paginated["has_more"], true);
+    assert_eq!(paginated["next_offset"], 2);
 
     let sql = client
         .call_tool(
@@ -184,7 +211,7 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
     assert_eq!(tables.is_error, Some(false));
     assert_eq!(
         tables.structured_content.expect("structured content")["tables"][0]["name"],
-        "local_messages.messages"
+        "local_messages.events"
     );
 
     client.cancel().await?;

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -59,4 +59,5 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Cross-source joins work with standard SQL after source scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_tables` and `coral://tables` show queryable fully qualified tables; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.
+- `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs.
+- `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, `list_tables`, and optionally `feedback`
+//! - tools: `sql`, paginated `list_tables`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,7 +1,8 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
 use coral_api::v1::{
-    ExecuteSqlRequest, ListSourcesRequest, ListTablesRequest, Source, SubmitFeedbackRequest, Table,
+    ExecuteSqlRequest, ListSourcesRequest, ListTablesRequest, ListTablesResponse,
+    PaginationRequest, Source, SubmitFeedbackRequest, TableSummary,
 };
 use coral_client::{
     AppClient, FeedbackClient, QueryClient, SourceClient, batches_to_json_rows,
@@ -23,11 +24,20 @@ use crate::{
     McpOptions,
     surface::{
         build_tool_result, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, internal_status, list_tables_tool, list_tables_value,
-        required_string_argument, sql_tool, status_to_error_data, tables_resource,
-        tables_resource_content, tool_error_from_status, tool_error_result,
+        initial_instructions, internal_status, list_tables_arguments, list_tables_tool,
+        list_tables_value, required_string_argument, sql_tool, status_to_error_data,
+        tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
     },
 };
+
+const LIST_TABLES_COUNT_LIMIT: u32 = 1;
+const LIST_TABLES_UNBOUNDED_LIMIT: u32 = 0;
+
+struct LoadTablesParams<'a> {
+    schema_name: Option<&'a str>,
+    pagination: PaginationRequest,
+    omit_columns: bool,
+}
 
 #[derive(Clone)]
 pub(crate) struct CoralMcpServer {
@@ -58,19 +68,61 @@ impl CoralMcpServer {
             .sources)
     }
 
-    async fn load_tables(&self) -> Result<Vec<Table>, tonic::Status> {
+    async fn load_tables(
+        &self,
+        params: LoadTablesParams<'_>,
+    ) -> Result<ListTablesResponse, tonic::Status> {
         let mut query_client = self.query.clone();
         Ok(query_client
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
+                schema_name: params.schema_name.unwrap_or_default().to_string(),
+                pagination: Some(params.pagination),
+                omit_columns: params.omit_columns,
             }))
             .await?
-            .into_inner()
-            .tables)
+            .into_inner())
     }
 
-    async fn load_sources_and_tables(&self) -> Result<(Vec<Source>, Vec<Table>), tonic::Status> {
-        tokio::try_join!(self.load_sources(), self.load_tables())
+    async fn load_all_table_summaries(&self) -> Result<Vec<TableSummary>, tonic::Status> {
+        Ok(self
+            .load_tables(LoadTablesParams {
+                schema_name: None,
+                pagination: PaginationRequest {
+                    limit: LIST_TABLES_UNBOUNDED_LIMIT,
+                    offset: 0,
+                },
+                omit_columns: true,
+            })
+            .await?
+            .table_summaries)
+    }
+
+    async fn load_table_count(&self) -> Result<usize, tonic::Status> {
+        self.load_tables(LoadTablesParams {
+            schema_name: None,
+            pagination: PaginationRequest {
+                limit: LIST_TABLES_COUNT_LIMIT,
+                offset: 0,
+            },
+            omit_columns: true,
+        })
+        .await
+        .map(|response| {
+            response
+                .pagination
+                .map_or(0, |pagination| pagination.total_count as usize)
+        })
+    }
+
+    async fn load_sources_and_table_count(&self) -> Result<(Vec<Source>, usize), tonic::Status> {
+        tokio::try_join!(self.load_sources(), self.load_table_count())
+    }
+
+    async fn load_sources_and_table_summaries(
+        &self,
+    ) -> Result<(Vec<Source>, Vec<TableSummary>), tonic::Status> {
+        tokio::try_join!(self.load_sources(), self.load_all_table_summaries())
     }
 
     async fn query_rows(&self, sql: &str) -> Result<Vec<Value>, tonic::Status> {
@@ -138,11 +190,14 @@ impl ServerHandler for CoralMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        let (sources, tables) = self
-            .load_sources_and_tables()
+        let (sources, visible_table_count) = self
+            .load_sources_and_table_count()
             .await
             .map_err(|status| status_to_error_data(&status))?;
-        let mut tools = vec![sql_tool(&sources, &tables), list_tables_tool(&tables)];
+        let mut tools = vec![
+            sql_tool(&sources, visible_table_count),
+            list_tables_tool(visible_table_count),
+        ];
         if self.options.feedback_enabled {
             tools.push(feedback_tool());
         }
@@ -162,13 +217,26 @@ impl ServerHandler for CoralMcpServer {
                     Err(status) => Ok(tool_error_result(tool_error_from_status("Query", &status))),
                 }
             }
-            "list_tables" => match self.load_tables().await {
-                Ok(tables) => build_tool_result(list_tables_value(&tables)),
-                Err(status) => Ok(tool_error_result(tool_error_from_status(
-                    "Table listing",
-                    &status,
-                ))),
-            },
+            "list_tables" => {
+                let arguments = list_tables_arguments(request.arguments.as_ref())?;
+                match self
+                    .load_tables(LoadTablesParams {
+                        schema_name: arguments.schema.as_deref(),
+                        pagination: PaginationRequest {
+                            limit: arguments.limit,
+                            offset: arguments.offset,
+                        },
+                        omit_columns: true,
+                    })
+                    .await
+                {
+                    Ok(response) => build_tool_result(list_tables_value(&response)),
+                    Err(status) => Ok(tool_error_result(tool_error_from_status(
+                        "Table listing",
+                        &status,
+                    ))),
+                }
+            }
             "feedback" if self.options.feedback_enabled => {
                 let trying_to_do =
                     required_string_argument(request.arguments.as_ref(), "trying_to_do")?;
@@ -197,13 +265,13 @@ impl ServerHandler for CoralMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
-        let (sources, tables) = self
-            .load_sources_and_tables()
+        let (sources, visible_table_count) = self
+            .load_sources_and_table_count()
             .await
             .map_err(|status| status_to_error_data(&status))?;
         Ok(ListResourcesResult::with_all_items(vec![
-            guide_resource(&sources, &tables),
-            tables_resource(&tables),
+            guide_resource(&sources, visible_table_count),
+            tables_resource(visible_table_count),
         ]))
     }
 
@@ -215,7 +283,7 @@ impl ServerHandler for CoralMcpServer {
         match request.uri.as_str() {
             "coral://guide" => {
                 let (sources, tables) = self
-                    .load_sources_and_tables()
+                    .load_sources_and_table_summaries()
                     .await
                     .map_err(|status| status_to_error_data(&status))?;
                 Ok(ReadResourceResult::new(vec![
@@ -225,7 +293,7 @@ impl ServerHandler for CoralMcpServer {
             }
             "coral://tables" => {
                 let tables = self
-                    .load_tables()
+                    .load_all_table_summaries()
                     .await
                     .map_err(|status| status_to_error_data(&status))?;
                 let text = tables_resource_content(&tables)

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -12,5 +12,6 @@ pub(crate) use resources::{
     tables_resource, tables_resource_content,
 };
 pub(crate) use tools::{
-    build_tool_result, feedback_tool, list_tables_tool, required_string_argument, sql_tool,
+    build_tool_result, feedback_tool, list_tables_arguments, list_tables_tool,
+    required_string_argument, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
 
-use coral_api::v1::{Source, Table};
+use coral_api::v1::{ListTablesResponse, Source, Table, TableSummary};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
@@ -12,21 +12,21 @@ pub(crate) fn initial_instructions() -> &'static str {
     INITIAL_INSTRUCTIONS
 }
 
-pub(crate) fn guide_resource(sources: &[Source], tables: &[Table]) -> Resource {
+pub(crate) fn guide_resource(sources: &[Source], visible_table_count: usize) -> Resource {
     RawResource::new("coral://guide", "guide")
-        .with_description(guide_resource_description(sources, tables))
+        .with_description(guide_resource_description(sources, visible_table_count))
         .with_mime_type("text/markdown")
         .no_annotation()
 }
 
-pub(crate) fn tables_resource(tables: &[Table]) -> Resource {
+pub(crate) fn tables_resource(visible_table_count: usize) -> Resource {
     RawResource::new("coral://tables", "tables")
-        .with_description(tables_resource_description(tables))
+        .with_description(tables_resource_description(visible_table_count))
         .with_mime_type("application/json")
         .no_annotation()
 }
 
-pub(crate) fn guide_resource_content(sources: &[Source], tables: &[Table]) -> String {
+pub(crate) fn guide_resource_content(sources: &[Source], tables: &[TableSummary]) -> String {
     let mut sources_section = String::from("## Available Schemas\n\n");
     sources_section.push_str(
         "- coral: System metadata schema. Use `coral.tables` and `coral.columns` to discover queryable tables, columns, descriptions, and required filters.\n",
@@ -68,47 +68,47 @@ FROM coral.columns WHERE schema_name = '{schema_name}' AND table_name = '{table_
         .replace("{{COLUMNS_EXAMPLE}}", &columns_example)
 }
 
-pub(crate) fn tables_resource_content(tables: &[Table]) -> Result<String, serde_json::Error> {
+pub(crate) fn tables_resource_content(
+    tables: &[TableSummary],
+) -> Result<String, serde_json::Error> {
     serde_json::to_string_pretty(&json!({ "tables": queryable_tables(tables) }))
 }
 
-pub(crate) fn list_tables_value(tables: &[Table]) -> Value {
-    json!({ "tables": queryable_tables(tables) })
+pub(crate) fn list_tables_value(response: &ListTablesResponse) -> Value {
+    let pagination = response.pagination.unwrap_or_default();
+    let table_summaries = response_table_summaries(response);
+    let mut value = json!({
+        "tables": queryable_tables(&table_summaries),
+        "total": pagination.total_count,
+        "limit": pagination.limit,
+        "offset": pagination.offset,
+        "has_more": pagination.has_more,
+    });
+    if pagination.has_more {
+        value["next_offset"] = json!(pagination.next_offset);
+    }
+    value
 }
 
-pub(super) fn visible_schema_count(tables: &[Table]) -> usize {
-    tables
-        .iter()
-        .map(|table| table.schema_name.as_str())
-        .collect::<BTreeSet<_>>()
-        .len()
-}
-
-pub(super) fn visible_table_count(tables: &[Table]) -> usize {
-    tables.len()
-}
-
-fn guide_resource_description(sources: &[Source], tables: &[Table]) -> String {
+fn guide_resource_description(sources: &[Source], visible_table_count: usize) -> String {
     format!(
-        "Query workflow and schema discovery guidance for {} configured source(s), {} visible schema(s), and {} table(s).",
+        "Query workflow and schema discovery guidance for {} configured source(s) and {} visible table(s).",
         sources.len(),
-        visible_schema_count(tables),
-        visible_table_count(tables)
+        visible_table_count
     )
 }
 
-fn tables_resource_description(tables: &[Table]) -> String {
-    format!(
-        "Queryable fully qualified Coral tables ({} table(s)).",
-        visible_table_count(tables)
-    )
+fn tables_resource_description(visible_table_count: usize) -> String {
+    format!("Queryable fully qualified Coral tables ({visible_table_count} table(s)).")
 }
 
-fn queryable_tables(tables: &[Table]) -> Vec<Value> {
+fn queryable_tables(tables: &[TableSummary]) -> Vec<Value> {
     let mut summaries = tables
         .iter()
         .map(|table| {
             json!({
+                "schema_name": table.schema_name,
+                "table_name": table.name,
                 "name": format!("{}.{}", table.schema_name, table.name),
                 "description": table.description,
                 "required_filters": table.required_filters,
@@ -123,7 +123,25 @@ fn queryable_tables(tables: &[Table]) -> Vec<Value> {
     summaries
 }
 
-fn first_visible_table(tables: &[Table]) -> Option<(&str, &str)> {
+fn response_table_summaries(response: &ListTablesResponse) -> Vec<TableSummary> {
+    if response.table_summaries.is_empty() {
+        response.tables.iter().map(table_to_summary).collect()
+    } else {
+        response.table_summaries.clone()
+    }
+}
+
+fn table_to_summary(table: &Table) -> TableSummary {
+    TableSummary {
+        workspace: table.workspace.clone(),
+        schema_name: table.schema_name.clone(),
+        name: table.name.clone(),
+        description: table.description.clone(),
+        required_filters: table.required_filters.clone(),
+    }
+}
+
+fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
     tables
         .iter()
         .min_by(|left, right| {
@@ -134,7 +152,7 @@ fn first_visible_table(tables: &[Table]) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use coral_api::v1::{Source, Table, Workspace};
+    use coral_api::v1::{Source, TableSummary, Workspace};
 
     use super::guide_resource_content;
 
@@ -151,15 +169,14 @@ mod tests {
         }
     }
 
-    fn table(schema_name: &str, name: &str) -> Table {
-        Table {
+    fn table(schema_name: &str, name: &str) -> TableSummary {
+        TableSummary {
             workspace: Some(Workspace {
                 name: "default".to_string(),
             }),
             schema_name: schema_name.to_string(),
             name: name.to_string(),
             description: format!("{name} description"),
-            columns: Vec::new(),
             required_filters: Vec::new(),
         }
     }

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -1,18 +1,22 @@
 use std::sync::Arc;
 
-use coral_api::v1::{Source, Table};
+use coral_api::v1::Source;
 use rmcp::{
     ErrorData,
     model::{CallToolResult, Content, Tool, ToolAnnotations},
 };
 use serde_json::{Map, Value, json};
 
-use super::resources::{visible_schema_count, visible_table_count};
+pub(crate) struct ListTablesArguments {
+    pub(crate) schema: Option<String>,
+    pub(crate) limit: u32,
+    pub(crate) offset: u32,
+}
 
-pub(crate) fn sql_tool(sources: &[Source], tables: &[Table]) -> Tool {
+pub(crate) fn sql_tool(sources: &[Source], visible_table_count: usize) -> Tool {
     Tool::new(
         "sql",
-        sql_tool_description(sources, tables),
+        sql_tool_description(sources, visible_table_count),
         json_object_schema(&json!({
             "type": "object",
             "required": ["sql"],
@@ -33,13 +37,32 @@ pub(crate) fn sql_tool(sources: &[Source], tables: &[Table]) -> Tool {
     )
 }
 
-pub(crate) fn list_tables_tool(tables: &[Table]) -> Tool {
+pub(crate) fn list_tables_tool(visible_table_count: usize) -> Tool {
     Tool::new(
         "list_tables",
-        list_tables_description(tables),
+        list_tables_description(visible_table_count),
         json_object_schema(&json!({
             "type": "object",
-            "properties": {}
+            "properties": {
+                "schema": {
+                    "type": "string",
+                    "description": "Optional exact schema/source name to list."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum tables to return, from 1 to 200. Defaults to 50.",
+                    "minimum": 1,
+                    "maximum": 200,
+                    "default": 50
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of matching tables to skip. Defaults to 0.",
+                    "minimum": 0,
+                    "maximum": u32::MAX,
+                    "default": 0
+                }
+            }
         })),
     )
     .with_annotations(
@@ -98,6 +121,16 @@ pub(crate) fn required_string_argument(
     Ok(value.to_string())
 }
 
+pub(crate) fn list_tables_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<ListTablesArguments, ErrorData> {
+    Ok(ListTablesArguments {
+        schema: optional_string_argument(arguments, "schema")?,
+        limit: optional_u32_argument(arguments, "limit", 50, 1, 200)?,
+        offset: optional_u32_argument(arguments, "offset", 0, 0, u32::MAX)?,
+    })
+}
+
 pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorData> {
     let pretty = serde_json::to_string_pretty(&value)
         .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
@@ -106,25 +139,68 @@ pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorDat
     Ok(result)
 }
 
-fn sql_tool_description(sources: &[Source], tables: &[Table]) -> String {
-    if tables.is_empty() {
+fn sql_tool_description(sources: &[Source], visible_table_count: usize) -> String {
+    if visible_table_count == 0 {
         format!(
-            "Run a SQL query against local Coral sources. {} configured source(s), but no visible SQL schemas are currently available.",
+            "Run a SQL query against local Coral sources. {} configured source(s), but no visible SQL tables are currently available.",
             sources.len()
         )
     } else {
         format!(
-            "Run a SQL query against local Coral sources. {} visible SQL schema(s) are currently available.",
-            visible_schema_count(tables)
+            "Run a SQL query against local Coral sources. {visible_table_count} table(s) are currently visible."
         )
     }
 }
 
-fn list_tables_description(tables: &[Table]) -> String {
+fn list_tables_description(visible_table_count: usize) -> String {
     format!(
-        "List queryable fully qualified tables. {} table(s) are currently visible.",
-        visible_table_count(tables)
+        "List queryable fully qualified tables. {visible_table_count} table(s) are currently visible."
     )
+}
+
+fn optional_string_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+) -> Result<Option<String>, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(None);
+    };
+    let value = value.as_str().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be a string"), None)
+    })?;
+    let value = value.trim();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value.to_string()))
+    }
+}
+
+fn optional_u32_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+    default: u32,
+    min: u32,
+    max: u32,
+) -> Result<u32, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(default);
+    };
+    let value = value.as_i64().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be an integer"), None)
+    })?;
+    if value < i64::from(min) || value > i64::from(max) {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be between {min} and {max}"),
+            None,
+        ));
+    }
+    u32::try_from(value).map_err(|_| {
+        ErrorData::invalid_params(
+            format!("argument '{key}' must be between {min} and {max}"),
+            None,
+        )
+    })
 }
 
 fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -36,6 +36,18 @@ version: 0.1.0
 dsl_version: 3
 backend: jsonl
 tables:
+  - name: events
+    description: Fixture events
+    source:
+      location: file://{}/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: sessionId
+        type: Utf8
+      - name: text
+        type: Utf8
   - name: messages
     description: Fixture messages
     source:
@@ -48,7 +60,21 @@ tables:
         type: Utf8
       - name: text
         type: Utf8
+  - name: sessions
+    description: Fixture sessions
+    source:
+      location: file://{}/
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: sessionId
+        type: Utf8
+      - name: text
+        type: Utf8
 "#,
+        data_dir.display(),
+        data_dir.display(),
         data_dir.display()
     );
     let manifest_path = source_dir.join("source.yaml");
@@ -201,14 +227,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .description
             .as_deref()
             .expect("sql description")
-            .contains("1 visible SQL schema(s) are currently available")
+            .contains("3 table(s) are currently visible")
     );
     assert!(
         updated_tools[1]
             .description
             .as_deref()
             .expect("tables description")
-            .contains("1 table(s) are currently visible")
+            .contains("3 table(s) are currently visible")
     );
 
     let updated_resources = client
@@ -230,7 +256,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     let tables_text = text_content(&tables_resource);
     let tables_json =
         serde_json::from_str::<serde_json::Value>(tables_text).expect("parse tables resource");
-    assert_eq!(tables_json["tables"][0]["name"], "local_messages.messages");
+    assert_eq!(tables_json["tables"][0]["name"], "local_messages.events");
 
     let updated_guide = client
         .read_resource(ReadResourceRequestParams::new("coral://guide"))
@@ -242,18 +268,71 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert!(updated_guide_text.contains("- local_messages"));
     assert!(!updated_guide_text.contains("## Visible SQL Schemas"));
     assert!(updated_guide_text.contains(
-        "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'messages'"
+        "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'events'"
     ));
 
     let tables = client
         .call_tool(CallToolRequestParams::new("list_tables"))
         .await
         .expect("list tables");
+    let structured_tables = tables.structured_content.expect("structured content");
+    assert_eq!(structured_tables["total"], 3);
+    assert_eq!(structured_tables["limit"], 50);
+    assert_eq!(structured_tables["offset"], 0);
+    assert_eq!(structured_tables["has_more"], false);
     assert_eq!(
-        tables.structured_content.expect("structured content")["tables"][0]["name"],
-        "local_messages.messages"
+        structured_tables["tables"][0]["name"],
+        "local_messages.events"
     );
+    assert!(structured_tables["tables"][0]["columns"].is_null());
     assert_eq!(tables.is_error, Some(false));
+
+    let page = client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "schema": "local_messages",
+                "limit": 2,
+                "offset": 0
+            }))),
+        )
+        .await
+        .expect("list paginated tables");
+    let page = page.structured_content.expect("structured content");
+    assert_eq!(page["total"], 3);
+    assert_eq!(page["limit"], 2);
+    assert_eq!(page["has_more"], true);
+    assert_eq!(page["next_offset"], 2);
+    assert_eq!(page["tables"].as_array().expect("tables").len(), 2);
+
+    let unknown_schema = client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "schema": "missing",
+                "limit": 2,
+                "offset": 0
+            }))),
+        )
+        .await
+        .expect("list unknown schema");
+    let unknown_schema = unknown_schema
+        .structured_content
+        .expect("structured content");
+    assert_eq!(unknown_schema["total"], 0);
+    assert!(
+        unknown_schema["tables"]
+            .as_array()
+            .expect("tables")
+            .is_empty()
+    );
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+                "limit": 0
+            }))),
+        )
+        .await
+        .expect_err("limit zero should be invalid");
 
     session.shutdown().await;
 }
@@ -434,7 +513,7 @@ async fn mcp_tool_error_does_not_end_session() {
         tables_after_error
             .structured_content
             .expect("structured content")["tables"][0]["name"],
-        "local_messages.messages"
+        "local_messages.events"
     );
     assert_eq!(tables_after_error.is_error, Some(false));
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -15,13 +15,13 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
-| Tool     | `list_tables`    | List queryable fully qualified tables                   |
+| Tool     | `list_tables`    | List queryable fully qualified tables with pagination   |
 | Tool     | `feedback`       | Store a local blocked-agent feedback report when enabled |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
+`list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
 Start Coral as `coral mcp-stdio --enable-feedback` to expose the optional `feedback` tool. Agents can call `feedback` when they get blocked or repeat a pattern that is not working. Coral stores the report locally with what the agent was trying to do, what it tried, and where it got stuck.
 
 ## Client setup
@@ -190,7 +190,7 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources.
+The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources. Large catalogs should be paged with `limit` and `offset`.
 
 ## Troubleshooting
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -129,9 +129,9 @@ This server exposes:
 | Type     | Name             | Description                      |
 | -------- | ---------------- | -------------------------------- |
 | Tool     | `sql`            | Run a SQL query                  |
-| Tool     | `list_tables`    | List all available tables        |
+| Tool     | `list_tables`    | List available tables by page    |
 | Resource | `coral://guide`  | Usage guide for agents           |
-| Resource | `coral://tables` | Schema for all installed sources |
+| Resource | `coral://tables` | Table summaries for all sources  |
 
 ## `coral completion <SHELL>`
 


### PR DESCRIPTION
## Summary

Implements PR 1 from the progressive MCP discovery plan: bounded API-backed MCP `list_tables`.

- Adds shared `PaginationRequest` and `PaginationResponse` protobuf messages using unsigned pagination fields, and uses them from `ListTablesRequest` / `ListTablesResponse`.
- Preserves legacy gRPC behavior when callers omit pagination: unbounded table list with columns.
- Routes MCP `list_tables` through bounded query API calls with default `limit: 50`, max `200`, and summary rows only.
- Keeps `coral://tables` as the explicit all-table summary resource while avoiding column serialization.
- Updates MCP docs and tests for page envelopes and validation errors.

## Before / After Output

Both versions were run against the same connected GitHub catalog:

```json
[{"schema_name":"github","table_count":369}]
[{"column_count":424}]
```

### `tools/list`

Before:

```json
{
  "name": "list_tables",
  "inputSchema": {
    "type": "object",
    "properties": {}
  }
}
```

After:

```json
{
  "name": "list_tables",
  "inputSchema": {
    "type": "object",
    "properties": {
      "schema": {"type": "string"},
      "limit": {"type": "integer"},
      "offset": {"type": "integer"}
    }
  }
}
```

### `list_tables {}`

Before returned all 369 tables and no pagination metadata:

```json
{
  "tables": [
    {
      "name": "github.accepted_assignments",
      "description": "List accepted assignments for an assignment",
      "required_filters": ["assignment_id"]
    },
    {
      "name": "github.access",
      "description": "Get the level of access for workflows outside of the repository",
      "required_filters": ["owner", "repo"]
    }
  ]
}
```

Actual payload: `369` tables, about `65,926` text chars.

After returns the first page only:

```json
{
  "tables": [
    {
      "schema_name": "github",
      "table_name": "accepted_assignments",
      "name": "github.accepted_assignments",
      "description": "List accepted assignments for an assignment",
      "required_filters": ["assignment_id"]
    }
  ],
  "total": 369,
  "limit": 50,
  "offset": 0,
  "has_more": true,
  "next_offset": 50
}
```

Actual payload: `50` tables, about `12,046` text chars.

### `list_tables {"schema":"github","limit":50,"offset":50}`

Before ignored args and returned the full first dump again:

```json
{
  "tables_returned": 369,
  "first": "github.accepted_assignments"
}
```

After returns page 2:

```json
{
  "tables_returned": 50,
  "total": 369,
  "limit": 50,
  "offset": 50,
  "has_more": true,
  "next_offset": 100,
  "first": "github.content_exclusion"
}
```

### Invalid Limit

Before `{"limit":0}` was ignored and returned all `369` tables.

After:

```json
{
  "error": "argument 'limit' must be between 1 and 200"
}
```

## Validation

- `cargo test -p coral-api`
- `cargo test -p coral-app --test grpc -- list_tables`
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --test mcp --features cli-test-server`
- `cargo test -p coral-engine --test engine catalog_tests`
- `cargo build`
- `make rust-checks`

Compiled-app validation against local connected sources:

- `target/debug/coral source list` showed `crag` imported and `github` bundled.
- `target/debug/coral sql --format json "SELECT schema_name, COUNT(*) AS table_count FROM coral.tables GROUP BY schema_name ORDER BY schema_name"` returned `github = 369` tables.
- `target/debug/coral sql --format json "SELECT COUNT(*) AS column_count FROM coral.columns WHERE schema_name = 'github' AND table_name = 'pulls'"` returned `424` columns.
- `target/debug/coral sql --format json "SELECT id, number, state, title FROM github.pulls WHERE owner = 'withcoral' AND repo = 'coral' LIMIT 1"` returned a live GitHub pull row.
- Drove `target/debug/coral mcp-stdio` directly over JSON-RPC: `tools/list` returned `sql` and `list_tables`; `list_tables {}` returned 50 of 369 with `next_offset: 50`; `list_tables {"schema":"github","limit":50,"offset":50}` returned page 2; unknown schema returned an empty page; `limit: 0` returned an MCP invalid-params error.