### PR TITLE
chore: use basic auth for the manifest using it

### DIFF
--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -117,14 +117,14 @@ AWS secret access key for SigV4 signing.
 Base URL of your Atlassian Cloud site, without the `/wiki` suffix
 (for example `https://acme.atlassian.net`).
 
-`CONFLUENCE_BASIC_AUTH` (required)
+`CONFLUENCE_EMAIL` (required)
 
-Use Base64-encoded `email:api_token` credentials for Confluence
-Cloud Basic auth.
+Email address for your Atlassian account.
+
+`CONFLUENCE_API_TOKEN` (required)
+
 Create an API token at
-[Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens),
-then encode `email:api_token`.
-Example: `printf '%s' 'you@example.com:YOUR_CONFLUENCE_API_TOKEN' | base64`.
+[Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 
 ### `datadog`
 
@@ -222,14 +222,14 @@ See [Intercom authentication docs](https://developers.intercom.com/docs/build-an
 Base URL of your Jira Cloud site (for example
 `https://acme.atlassian.net`).
 
-`JIRA_BASIC_AUTH` (required)
+`JIRA_EMAIL` (required)
 
-Use Base64-encoded `email:api_token` credentials for Jira Cloud
-Basic auth.
+Email address for your Atlassian account.
+
+`JIRA_API_TOKEN` (required)
+
 Create an API token at
-[Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens),
-then encode `email:api_token`.
-Example: `printf '%s' 'you@example.com:YOUR_JIRA_API_TOKEN' | base64`.
+[Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 
 ### `launchdarkly`
 
@@ -266,10 +266,13 @@ default `default`
 Organization slug in OpenObserve. Keep the default `default` for
 single-tenant setups.
 
-`OPENOBSERVE_BASIC_AUTH` (required)
+`OPENOBSERVE_USERNAME` (required)
 
-Base64-encoded `email:password` credentials for HTTP Basic auth.
-Example: `echo -n 'user@example.com:password' | base64`.
+OpenObserve username or email for HTTP Basic auth.
+
+`OPENOBSERVE_PASSWORD` (required)
+
+OpenObserve password for HTTP Basic auth.
 
 ### `pagerduty`
 

--- a/sources/confluence/README.md
+++ b/sources/confluence/README.md
@@ -7,10 +7,11 @@
 
 ## Authentication
 
-Requires `CONFLUENCE_BASIC_AUTH`, which is the Base64 form of `email:api_token` for Confluence Cloud. Create an API token at [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens), then encode:
+Requires `CONFLUENCE_EMAIL` and `CONFLUENCE_API_TOKEN` for Confluence Cloud. Create an API token at [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 
 ```bash
-printf '%s' 'you@example.com:YOUR_CONFLUENCE_API_TOKEN' | base64
+export CONFLUENCE_EMAIL="you@example.com"
+export CONFLUENCE_API_TOKEN="YOUR_CONFLUENCE_API_TOKEN"
 ```
 
 ## Quick start

--- a/sources/confluence/manifest.yaml
+++ b/sources/confluence/manifest.yaml
@@ -11,22 +11,20 @@ inputs:
     hint: |
       Base URL of your Atlassian Cloud site, without the `/wiki` suffix
       (for example `https://acme.atlassian.net`).
-  CONFLUENCE_BASIC_AUTH:
+  CONFLUENCE_EMAIL:
+    kind: variable
+    hint: |
+      Email address for your Atlassian account.
+  CONFLUENCE_API_TOKEN:
     kind: secret
     hint: |
-      Use Base64-encoded `email:api_token` credentials for Confluence
-      Cloud Basic auth.
       Create an API token at
-      [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens),
-      then encode `email:api_token`.
-      Example: `printf '%s' 'you@example.com:YOUR_CONFLUENCE_API_TOKEN' | base64`.
+      [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 base_url: "{{input.CONFLUENCE_BASE_URL}}"
 auth:
-  type: HeaderAuth
-  headers:
-    - name: Authorization
-      from: template
-      template: Basic {{input.CONFLUENCE_BASIC_AUTH}}
+  type: BasicAuth
+  username: "{{input.CONFLUENCE_EMAIL}}"
+  password: "{{input.CONFLUENCE_API_TOKEN}}"
 request_headers:
   - name: Accept
     from: literal

--- a/sources/jira/README.md
+++ b/sources/jira/README.md
@@ -7,10 +7,11 @@
 
 ## Authentication
 
-Requires `JIRA_BASIC_AUTH`, which is the Base64 form of `email:api_token` for Jira Cloud. Create an API token at [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens), then encode:
+Requires `JIRA_EMAIL` and `JIRA_API_TOKEN` for Jira Cloud. Create an API token at [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 
 ```bash
-printf '%s' 'you@example.com:YOUR_JIRA_API_TOKEN' | base64
+export JIRA_EMAIL="you@example.com"
+export JIRA_API_TOKEN="YOUR_JIRA_API_TOKEN"
 ```
 
 ## Quick start

--- a/sources/jira/manifest.yaml
+++ b/sources/jira/manifest.yaml
@@ -11,22 +11,20 @@ inputs:
     hint: |
       Base URL of your Jira Cloud site (for example
       `https://acme.atlassian.net`).
-  JIRA_BASIC_AUTH:
+  JIRA_EMAIL:
+    kind: variable
+    hint: |
+      Email address for your Atlassian account.
+  JIRA_API_TOKEN:
     kind: secret
     hint: |
-      Use Base64-encoded `email:api_token` credentials for Jira Cloud
-      Basic auth.
       Create an API token at
-      [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens),
-      then encode `email:api_token`.
-      Example: `printf '%s' 'you@example.com:YOUR_JIRA_API_TOKEN' | base64`.
+      [Atlassian API token settings](https://id.atlassian.com/manage-profile/security/api-tokens).
 base_url: "{{input.JIRA_BASE_URL}}"
 auth:
-  type: HeaderAuth
-  headers:
-    - name: Authorization
-      from: template
-      template: Basic {{input.JIRA_BASIC_AUTH}}
+  type: BasicAuth
+  username: "{{input.JIRA_EMAIL}}"
+  password: "{{input.JIRA_API_TOKEN}}"
 request_headers:
   - name: Accept
     from: literal

--- a/sources/openobserve/README.md
+++ b/sources/openobserve/README.md
@@ -4,19 +4,21 @@ This source connects Coral to an OpenObserve instance over HTTP.
 
 ## Auth
 
-Set `OPENOBSERVE_BASIC_AUTH` to the base64-encoded `user:password` value that should be sent in the `Authorization: Basic ...` header.
+Set `OPENOBSERVE_USERNAME` and `OPENOBSERVE_PASSWORD`. Coral sends them with HTTP Basic auth.
 
 Example:
 
 ```text
-echo -n 'user@example.com:password' | base64
+export OPENOBSERVE_USERNAME="user@example.com"
+export OPENOBSERVE_PASSWORD="password"
 ```
 
 ## Inputs
 
 - `OPENOBSERVE_URL`: Base URL for the OpenObserve instance, for example `http://localhost:5080`
 - `OPENOBSERVE_ORG`: OpenObserve organization name. Defaults to `default`
-- `OPENOBSERVE_BASIC_AUTH`: Base64-encoded `user:password` for HTTP Basic auth
+- `OPENOBSERVE_USERNAME`: Username or email for HTTP Basic auth
+- `OPENOBSERVE_PASSWORD`: Password for HTTP Basic auth
 
 ## Example Queries
 

--- a/sources/openobserve/manifest.yaml
+++ b/sources/openobserve/manifest.yaml
@@ -17,18 +17,19 @@ inputs:
     hint: |
       Organization slug in OpenObserve. Keep the default `default` for
       single-tenant setups.
-  OPENOBSERVE_BASIC_AUTH:
+  OPENOBSERVE_USERNAME:
+    kind: variable
+    hint: |
+      OpenObserve username or email for HTTP Basic auth.
+  OPENOBSERVE_PASSWORD:
     kind: secret
     hint: |
-      Base64-encoded `email:password` credentials for HTTP Basic auth.
-      Example: `echo -n 'user@example.com:password' | base64`.
+      OpenObserve password for HTTP Basic auth.
 base_url: "{{input.OPENOBSERVE_URL}}"
 auth:
-  type: HeaderAuth
-  headers:
-    - name: Authorization
-      from: template
-      template: "Basic {{input.OPENOBSERVE_BASIC_AUTH}}"
+  type: BasicAuth
+  username: "{{input.OPENOBSERVE_USERNAME}}"
+  password: "{{input.OPENOBSERVE_PASSWORD}}"
 
 test_queries:
   - SELECT * FROM openobserve.streams LIMIT 1


### PR DESCRIPTION
### Summary

Switches to `BasicAuth` DSL manifest which use basic auth