### PR TITLE
fix(docs): correct How Coral works wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Full [benchmark report](https://withcoral.com/benchmarks).
 
 ## How Coral works
 
-Coral sits between you and your data sources: you (or your agent) write SQL,
+Coral sits between your agents and your data sources: your agents write SQL,
 and Coral translates it into API calls or file reads, then returns a single
 result set.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -75,7 +75,7 @@ Full [benchmark report](https://withcoral.com/benchmarks).
 
 ## How Coral works
 
-Coral sits between you and your data sources: you (or your agent) write SQL, and Coral translates it into API calls or file reads, then returns a single query result.
+Coral sits between your agents and your data sources: your agents write SQL, and Coral translates it into API calls or file reads, then returns a single query result.
 
 You can ask your agents complex questions about your data:
 


### PR DESCRIPTION
### Motivation
- Clarify the "How Coral works" copy to state that agents write SQL and ensure README and site docs match the requested phrasing.

### Description
- Update `README.md` and `docs/index.mdx` to replace the phrase "you (or your agent) write SQL" with "your agents write SQL".

### Testing
- Docs-only change; verified updated occurrences with `rg -n "Coral sits between"`, inspected the edits via `git diff -- README.md docs/index.mdx`, and committed the changes with `git commit`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f90a83ab88832a8e6bdbd9005faa82)