### PR TITLE
fix(engine): preserve file source input metadata

### DIFF
--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -25,7 +25,7 @@ use coral_spec::backends::http::HttpTableSpec;
 pub(crate) struct HttpSourceTableProvider {
     backend: HttpSourceClient,
     source_schema: String,
-    table: HttpTableSpec,
+    table: Arc<HttpTableSpec>,
     schema: SchemaRef,
 }
 
@@ -54,7 +54,7 @@ impl HttpSourceTableProvider {
         Ok(Self {
             backend,
             source_schema,
-            table,
+            table: Arc::new(table),
             schema,
         })
     }
@@ -64,7 +64,7 @@ impl HttpSourceTableProvider {
 struct HttpFetchPlan {
     backend: HttpSourceClient,
     table: Arc<HttpTableSpec>,
-    filters: HashMap<String, String>,
+    filters: Arc<HashMap<String, String>>,
     limit: Option<usize>,
 }
 
@@ -72,7 +72,7 @@ struct HttpFetchPlan {
 impl RowFetcher for HttpFetchPlan {
     async fn fetch(&self) -> Result<Vec<Value>> {
         self.backend
-            .fetch(self.table.as_ref(), &self.filters, self.limit)
+            .fetch(self.table.as_ref(), self.filters.as_ref(), self.limit)
             .await
     }
 }
@@ -135,18 +135,24 @@ impl TableProvider for HttpSourceTableProvider {
             }
         }
 
+        let table = self.table.clone();
+        let filters = Arc::new(filter_values);
         let fetcher = Arc::new(HttpFetchPlan {
             backend: self.backend.clone(),
-            table: Arc::new(self.table.clone()),
-            filters: filter_values.clone(),
+            table: table.clone(),
+            filters: filters.clone(),
             limit,
         });
 
         let schema = self.schema.clone();
-        let table = self.table.clone();
-        let filters_for_convert = filter_values;
+        let filters_for_convert = filters;
         let converter = Arc::new(move |items: &[Value]| {
-            convert_items(table.columns(), schema.clone(), &filters_for_convert, items)
+            convert_items(
+                table.columns(),
+                schema.clone(),
+                filters_for_convert.as_ref(),
+                items,
+            )
         });
 
         let exec = JsonExec::new(

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -297,7 +297,11 @@ impl CompiledBackendSource for JsonlCompiledSource {
         }
 
         let secret_keys = self.source_secrets.keys().cloned().collect();
-        let inputs = build_registered_inputs(&[], &self.source_variables, &secret_keys);
+        let inputs = build_registered_inputs(
+            &self.manifest.declared_inputs,
+            &self.source_variables,
+            &secret_keys,
+        );
 
         Ok(BackendRegistration {
             tables,

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -243,7 +243,11 @@ impl CompiledBackendSource for ParquetCompiledSource {
         }
 
         let secret_keys = self.source_secrets.keys().cloned().collect();
-        let inputs = build_registered_inputs(&[], &self.source_variables, &secret_keys);
+        let inputs = build_registered_inputs(
+            &self.manifest.declared_inputs,
+            &self.source_variables,
+            &secret_keys,
+        );
 
         Ok(BackendRegistration {
             tables,

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -310,6 +310,37 @@ fn build_demo_source(variables: &[(&str, &str)], secrets: &[(&str, &str)]) -> Qu
     )
 }
 
+fn jsonl_manifest_with_inputs(dir: &std::path::Path) -> Value {
+    json!({
+        "name": "jsonl_inputs",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "inputs": {
+            "DATASET": {
+                "kind": "variable",
+                "default": "events",
+                "hint": "Dataset label"
+            },
+            "LOCAL_TOKEN": {
+                "kind": "secret",
+                "hint": "Local file source token"
+            }
+        },
+        "tables": [{
+            "name": "events",
+            "description": "Input metadata regression fixture",
+            "source": {
+                "location": dir_url(dir),
+                "glob": "**/*.jsonl"
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" }
+            ]
+        }]
+    })
+}
+
 #[tokio::test]
 async fn coral_inputs_exposes_variable_values_and_defaults() {
     let sources = vec![build_demo_source(
@@ -354,6 +385,49 @@ async fn coral_inputs_exposes_variable_values_and_defaults() {
                 "default_value": "datadoghq.com",
                 "hint": "Datadog site host",
                 "required": false,
+                "is_set": true,
+            }),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn coral_inputs_exposes_file_source_inputs() {
+    let temp = TempDir::new().expect("temp dir");
+    let data_dir = temp.path().join("jsonl-inputs");
+    write_jsonl_file(&data_dir, "events.jsonl", &[json!({"id": 1})]);
+    let sources = vec![build_source_with_inputs(
+        jsonl_manifest_with_inputs(&data_dir),
+        BTreeMap::from([("DATASET".to_string(), "audit".to_string())]),
+        BTreeMap::from([("LOCAL_TOKEN".to_string(), "secret-value".to_string())]),
+    )];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT key, kind, value, default_value, hint, is_set \
+             FROM coral.inputs WHERE schema_name = 'jsonl_inputs' ORDER BY key",
+        )
+        .await
+        .expect("catalog query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({
+                "key": "DATASET",
+                "kind": "variable",
+                "value": "audit",
+                "default_value": "events",
+                "hint": "Dataset label",
+                "is_set": true,
+            }),
+            json!({
+                "key": "LOCAL_TOKEN",
+                "kind": "secret",
+                "hint": "Local file source token",
                 "is_set": true,
             }),
         ]


### PR DESCRIPTION
## Summary

Preserve declared input metadata for JSONL and Parquet sources in the runtime catalog so `coral.inputs` reflects the same install-time variables and secrets that `coral-spec` and `coral-app` already validate and persist.

This also trims unnecessary HTTP scan setup cloning by sharing table specs and filter values across the fetch and conversion closures.

## Validation

- `cargo test -p coral-engine --test engine coral_inputs_exposes_file_source_inputs`
- `make rust-checks`
