### PR TITLE
refactor(engine): introduce HTTP fetch target

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1,6 +1,6 @@
 //! HTTP client used by HTTP-backed source tables.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -15,12 +15,13 @@ use crate::RequestAuthenticator;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::auth::{resolve_auth_headers, validate_auth_inputs};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
+use crate::backends::http::target::HttpRequestTarget;
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::template::{
     render_template, resolve_value_source, validate_input_dependencies,
     validate_value_source_inputs, value_to_string,
 };
-use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
+use coral_spec::backends::http::{HttpSourceManifest, RateLimitSpec};
 use coral_spec::{
     AuthSpec, BodySpec, HeaderSpec, HttpMethod, PageSizeSpec, ParsedTemplate, RequestRouteSpec,
     RequestSpec as ManifestRequestSpec, ResponseBodyFormat, RowStrategy, ValidatedPagination,
@@ -149,19 +150,19 @@ impl HttpSourceClient {
     /// fetched rows cannot be extracted for the table strategy.
     pub(crate) async fn fetch(
         &self,
-        table: &HttpTableSpec,
-        filters: &HashMap<String, String>,
+        target: &HttpRequestTarget,
+        request_values: &HashMap<String, String>,
         sql_limit: Option<usize>,
     ) -> Result<Vec<Value>> {
         let mut all_rows = Vec::new();
-        let effective_limit = sql_limit.or(table.fetch_limit_default());
-        let pagination = table
+        let effective_limit = sql_limit.or(target.fetch_limit_default());
+        let pagination = target
             .pagination
-            .validated(&self.source_schema, table.name())
+            .validated(&self.source_schema, target.name())
             .map_err(|error| {
                 provider_error(ProviderQueryError::Pagination {
                     source_schema: self.source_schema.clone(),
-                    table: table.name().to_string(),
+                    table: target.name().to_string(),
                     method: None,
                     url: None,
                     detail: error.to_string(),
@@ -169,27 +170,26 @@ impl HttpSourceClient {
             })?;
         let page_size = resolve_page_size(pagination.page_size.as_ref(), sql_limit);
 
-        let filter_keys: HashSet<String> = filters.keys().cloned().collect();
-        let active_request = table.resolve_request(&filter_keys);
+        let active_request = &target.request;
 
         let mut state = PageState {
-            page: table.pagination.page_start,
+            page: target.pagination.page_start,
             offset: match &pagination.mode {
                 ValidatedPaginationMode::Offset(offset) => offset.start,
-                _ => table.pagination.offset_start,
+                _ => target.pagination.offset_start,
             },
             ..PageState::default()
         };
 
         let mut page_count = 0usize;
-        let max_pages = table.pagination.max_pages.unwrap_or(DEFAULT_MAX_PAGES);
+        let max_pages = target.pagination.max_pages.unwrap_or(DEFAULT_MAX_PAGES);
 
         loop {
             page_count += 1;
             if page_count > max_pages {
                 return Err(provider_error(ProviderQueryError::Pagination {
                     source_schema: self.source_schema.clone(),
-                    table: table.name().to_string(),
+                    table: target.name().to_string(),
                     method: None,
                     url: None,
                     detail: format!("exceeded pagination max_pages={max_pages}"),
@@ -198,7 +198,7 @@ impl HttpSourceClient {
 
             let base_url = render_template(
                 &self.base_url,
-                filters,
+                request_values,
                 &pagination_state_values(&state),
                 self.resolved_inputs.as_ref(),
             )?;
@@ -217,7 +217,7 @@ impl HttpSourceClient {
             } else {
                 let rendered_path = render_template(
                     &active_request.path,
-                    filters,
+                    request_values,
                     &pagination_state_values(&state),
                     self.resolved_inputs.as_ref(),
                 )?;
@@ -229,37 +229,37 @@ impl HttpSourceClient {
             } else {
                 let mut query_pairs = build_query_pairs(
                     active_request,
-                    filters,
+                    request_values,
                     &state,
                     self.resolved_inputs.as_ref(),
                 )?;
                 apply_pagination_query_pairs(
                     &mut query_pairs,
-                    table,
+                    target,
                     &pagination,
                     &state,
                     page_size,
                 )
                 .map_err(|error| {
-                    pagination_error(&self.source_schema, table.name(), None, Some(&url), &error)
+                    pagination_error(&self.source_schema, target.name(), None, Some(&url), &error)
                 })?;
 
                 let mut body = build_request_body(
                     active_request,
-                    filters,
+                    request_values,
                     &state,
                     self.resolved_inputs.as_ref(),
                 )?;
                 apply_pagination_body_fields(
                     &mut body,
                     &active_request.body,
-                    table,
+                    target,
                     &pagination,
                     &state,
                     page_size,
                 )
                 .map_err(|error| {
-                    pagination_error(&self.source_schema, table.name(), None, Some(&url), &error)
+                    pagination_error(&self.source_schema, target.name(), None, Some(&url), &error)
                 })?;
                 (query_pairs, body)
             };
@@ -273,19 +273,19 @@ impl HttpSourceClient {
                     request_headers: &self.request_headers,
                     request_authenticators: &self.request_authenticators,
                     table_headers: &active_request.headers,
-                    table_name: table.name(),
+                    table_name: target.name(),
                     method: active_request.method,
                     base_url: &base_url,
                     url: &url,
                     query_pairs: &query_pairs,
                     body: body.as_ref(),
-                    response_format: table.response.format,
+                    response_format: target.response.format,
                     source_schema: &self.source_schema,
                     rate_limit: &self.rate_limit,
-                    filters,
+                    filters: request_values,
                     state: &pagination_values,
                     resolved_inputs: self.resolved_inputs.as_ref(),
-                    allow_404_empty: table.response.allow_404_empty,
+                    allow_404_empty: target.response.allow_404_empty,
                     link_header_require_results: pagination.link_header_require_results,
                 },
             )
@@ -295,15 +295,15 @@ impl HttpSourceClient {
                 break;
             };
 
-            if !table.response.ok_path.is_empty() {
-                let ok = get_path_value(&payload, &table.response.ok_path)
+            if !target.response.ok_path.is_empty() {
+                let ok = get_path_value(&payload, &target.response.ok_path)
                     .and_then(Value::as_bool)
                     .unwrap_or(false);
                 if !ok {
-                    let err = if table.response.error_path.is_empty() {
+                    let err = if target.response.error_path.is_empty() {
                         "unknown source API error".to_string()
                     } else {
-                        get_path_value(&payload, &table.response.error_path)
+                        get_path_value(&payload, &target.response.error_path)
                             .and_then(Value::as_str)
                             .unwrap_or("unknown source API error")
                             .to_string()
@@ -311,7 +311,7 @@ impl HttpSourceClient {
                     return Err(DataFusionError::External(Box::new(
                         ProviderQueryError::ApiRequest {
                             source_schema: self.source_schema.clone(),
-                            table: table.name().to_string(),
+                            table: target.name().to_string(),
                             status: None,
                             method: None,
                             url: None,
@@ -322,7 +322,7 @@ impl HttpSourceClient {
                 }
             }
 
-            let mut rows = extract_rows(table, &payload)?;
+            let mut rows = extract_rows(target, &payload)?;
             let rows_on_page = rows.len();
             all_rows.append(&mut rows);
 
@@ -337,7 +337,7 @@ impl HttpSourceClient {
                 ValidatedPaginationMode::None => break,
                 ValidatedPaginationMode::CursorQuery | ValidatedPaginationMode::CursorBody => {
                     let next_cursor =
-                        get_path_value(&payload, &table.pagination.response_cursor_path)
+                        get_path_value(&payload, &target.pagination.response_cursor_path)
                             .and_then(Value::as_str)
                             .map(str::trim)
                             .filter(|s| !s.is_empty())
@@ -351,18 +351,18 @@ impl HttpSourceClient {
                     if page_is_exhausted(rows_on_page, page_size) {
                         break;
                     }
-                    state.page = state.page.saturating_add(table.pagination.page_step);
+                    state.page = state.page.saturating_add(target.pagination.page_step);
                 }
                 ValidatedPaginationMode::Offset(offset) => {
                     if page_is_exhausted(rows_on_page, page_size) {
                         break;
                     }
                     let step = offset
-                        .resolve_step(page_size, &self.source_schema, table.name())
+                        .resolve_step(page_size, &self.source_schema, target.name())
                         .map_err(|error| {
                             provider_error(ProviderQueryError::Pagination {
                                 source_schema: self.source_schema.clone(),
-                                table: table.name().to_string(),
+                                table: target.name().to_string(),
                                 method: None,
                                 url: None,
                                 detail: error.to_string(),
@@ -991,7 +991,7 @@ fn build_query_pairs(
 
 fn apply_pagination_query_pairs(
     params: &mut Vec<(String, String)>,
-    table: &HttpTableSpec,
+    target: &HttpRequestTarget,
     pagination: &ValidatedPagination,
     state: &PageState,
     page_size: Option<usize>,
@@ -1009,7 +1009,7 @@ fn apply_pagination_query_pairs(
         | ValidatedPaginationMode::LinkHeader => {}
         ValidatedPaginationMode::CursorQuery => {
             if let Some(cursor) = &state.cursor {
-                let name = table.pagination.cursor_param.clone().ok_or_else(|| {
+                let name = target.pagination.cursor_param.clone().ok_or_else(|| {
                     DataFusionError::Execution(
                         "cursor_query pagination requires cursor_param".to_string(),
                     )
@@ -1018,7 +1018,7 @@ fn apply_pagination_query_pairs(
             }
         }
         ValidatedPaginationMode::Page => {
-            let name = table.pagination.page_param.clone().ok_or_else(|| {
+            let name = target.pagination.page_param.clone().ok_or_else(|| {
                 DataFusionError::Execution("page pagination requires page_param".to_string())
             })?;
             params.push((name, state.page.to_string()));
@@ -1067,7 +1067,7 @@ fn build_request_body(
 fn apply_pagination_body_fields(
     body: &mut Option<RequestBody>,
     body_spec: &BodySpec,
-    table: &HttpTableSpec,
+    target: &HttpRequestTarget,
     pagination: &ValidatedPagination,
     state: &PageState,
     page_size: Option<usize>,
@@ -1076,7 +1076,7 @@ fn apply_pagination_body_fields(
         .zip(pagination.page_size.as_ref())
         .is_some_and(|(_, spec)| !spec.body_path.is_empty());
     let needs_cursor_body = matches!(pagination.mode, ValidatedPaginationMode::CursorBody)
-        && !table.pagination.cursor_body_path.is_empty()
+        && !target.pagination.cursor_body_path.is_empty()
         && state.cursor.is_some();
 
     if !needs_page_size_body && !needs_cursor_body {
@@ -1106,12 +1106,12 @@ fn apply_pagination_body_fields(
     if matches!(pagination.mode, ValidatedPaginationMode::CursorBody)
         && let Some(cursor) = &state.cursor
     {
-        if table.pagination.cursor_body_path.is_empty() {
+        if target.pagination.cursor_body_path.is_empty() {
             return Err(DataFusionError::Execution(
                 "cursor_body pagination requires cursor_body_path".to_string(),
             ));
         }
-        set_path_value(root, &table.pagination.cursor_body_path, json!(cursor))?;
+        set_path_value(root, &target.pagination.cursor_body_path, json!(cursor))?;
     }
 
     Ok(())
@@ -1253,13 +1253,13 @@ fn set_path_value_at(cursor: &mut Value, path: &[String], value: Value) -> Resul
     clippy::unnecessary_wraps,
     reason = "Keeping a Result return type preserves a uniform extraction interface for callers"
 )]
-fn extract_rows(table: &HttpTableSpec, payload: &Value) -> Result<Vec<Value>> {
-    match table.response.row_strategy {
+fn extract_rows(target: &HttpRequestTarget, payload: &Value) -> Result<Vec<Value>> {
+    match target.response.row_strategy {
         RowStrategy::Direct => {
-            let root = if table.response.rows_path.is_empty() {
+            let root = if target.response.rows_path.is_empty() {
                 payload
             } else {
-                get_path_value(payload, &table.response.rows_path).unwrap_or(&Value::Null)
+                get_path_value(payload, &target.response.rows_path).unwrap_or(&Value::Null)
             };
             match root {
                 Value::Array(items) => Ok(items.clone()),
@@ -1313,10 +1313,10 @@ fn extract_rows(table: &HttpTableSpec, payload: &Value) -> Result<Vec<Value>> {
             Ok(rows)
         }
         RowStrategy::DictEntries => {
-            let root = if table.response.rows_path.is_empty() {
+            let root = if target.response.rows_path.is_empty() {
                 payload
             } else {
-                get_path_value(payload, &table.response.rows_path).unwrap_or(&Value::Null)
+                get_path_value(payload, &target.response.rows_path).unwrap_or(&Value::Null)
             };
             match root {
                 Value::Object(map) => {
@@ -1402,6 +1402,7 @@ mod tests {
         join_url, normalize_base_url, page_is_exhausted, resolve_value_source, set_path_value,
     };
     use crate::backends::http::ProviderQueryError;
+    use crate::backends::http::target::HttpRequestTarget;
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
     use coral_spec::{
@@ -1450,6 +1451,10 @@ mod tests {
         .into_iter()
         .next()
         .expect("table should exist")
+    }
+
+    fn test_http_request_target(table: &HttpTableSpec) -> HttpRequestTarget {
+        HttpRequestTarget::from_table(table, table.request.clone())
     }
 
     #[test]
@@ -2139,7 +2144,8 @@ mod tests {
             ..PageState::default()
         };
 
-        apply_pagination_query_pairs(&mut params, &table, &pagination, &state, Some(25)).unwrap();
+        let target = test_http_request_target(&table);
+        apply_pagination_query_pairs(&mut params, &target, &pagination, &state, Some(25)).unwrap();
 
         assert_eq!(
             params,
@@ -2184,11 +2190,12 @@ mod tests {
         .validated("demo", "items")
         .unwrap();
         let mut body = None;
+        let target = test_http_request_target(&table);
 
         let error = apply_pagination_body_fields(
             &mut body,
             &body_spec,
-            &table,
+            &target,
             &pagination,
             &PageState::default(),
             Some(25),
@@ -2242,7 +2249,7 @@ mod tests {
             }
         });
 
-        let rows = extract_rows(&table, &payload).unwrap();
+        let rows = extract_rows(&test_http_request_target(&table), &payload).unwrap();
         assert_eq!(rows.len(), 2);
         for row in &rows {
             assert!(row.get("_key").is_some());
@@ -2269,7 +2276,7 @@ mod tests {
             }
         });
 
-        let rows = extract_rows(&table, &payload).unwrap();
+        let rows = extract_rows(&test_http_request_target(&table), &payload).unwrap();
         assert_eq!(rows.len(), 2);
         for row in &rows {
             assert!(row.get("_key").is_some());
@@ -2283,7 +2290,7 @@ mod tests {
             make_table_with_row_strategy(RowStrategy::DictEntries, vec!["result".to_string()]);
         let payload = json!({ "result": null });
 
-        let rows = extract_rows(&table, &payload).unwrap();
+        let rows = extract_rows(&test_http_request_target(&table), &payload).unwrap();
         assert!(rows.is_empty());
     }
 
@@ -2293,7 +2300,7 @@ mod tests {
             make_table_with_row_strategy(RowStrategy::DictEntries, vec!["missing".to_string()]);
         let payload = json!({ "result": { "a": 1 } });
 
-        let rows = extract_rows(&table, &payload).unwrap();
+        let rows = extract_rows(&test_http_request_target(&table), &payload).unwrap();
         assert!(rows.is_empty());
     }
 
@@ -2303,7 +2310,7 @@ mod tests {
             make_table_with_row_strategy(RowStrategy::DictEntries, vec!["result".to_string()]);
         let payload = json!({ "result": [1, 2, 3] });
 
-        let rows = extract_rows(&table, &payload).unwrap();
+        let rows = extract_rows(&test_http_request_target(&table), &payload).unwrap();
         assert!(rows.is_empty());
     }
 
@@ -2313,7 +2320,7 @@ mod tests {
             make_table_with_row_strategy(RowStrategy::DictEntries, vec!["result".to_string()]);
         let payload = json!({ "result": {} });
 
-        let rows = extract_rows(&table, &payload).unwrap();
+        let rows = extract_rows(&test_http_request_target(&table), &payload).unwrap();
         assert!(rows.is_empty());
     }
 
@@ -2335,7 +2342,7 @@ mod tests {
             }]
         });
 
-        let rows = extract_rows(&table, &payload).unwrap();
+        let rows = extract_rows(&test_http_request_target(&table), &payload).unwrap();
 
         assert_eq!(
             rows,

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -15,7 +15,7 @@ use crate::RequestAuthenticator;
 use crate::backends::http::ProviderQueryError;
 use crate::backends::http::auth::{resolve_auth_headers, validate_auth_inputs};
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
-use crate::backends::http::target::HttpRequestTarget;
+use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::template::{
     render_template, resolve_value_source, validate_input_dependencies,
@@ -74,7 +74,7 @@ enum RequestBody {
     Text(String),
 }
 
-struct RequestSpec<'a> {
+struct OutgoingHttpRequest<'a> {
     auth: &'a AuthSpec,
     request_headers: &'a [HeaderSpec],
     request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
@@ -88,7 +88,7 @@ struct RequestSpec<'a> {
     response_format: ResponseBodyFormat,
     source_schema: &'a str,
     rate_limit: &'a RateLimitSpec,
-    filters: &'a HashMap<String, String>,
+    request_values: &'a HashMap<String, String>,
     state: &'a HashMap<String, String>,
     resolved_inputs: &'a BTreeMap<String, String>,
     allow_404_empty: bool,
@@ -150,14 +150,14 @@ impl HttpSourceClient {
     /// fetched rows cannot be extracted for the table strategy.
     pub(crate) async fn fetch(
         &self,
-        target: &HttpRequestTarget,
+        target: &HttpFetchTarget,
         request_values: &HashMap<String, String>,
         sql_limit: Option<usize>,
     ) -> Result<Vec<Value>> {
         let mut all_rows = Vec::new();
         let effective_limit = sql_limit.or(target.fetch_limit_default());
         let pagination = target
-            .pagination
+            .pagination()
             .validated(&self.source_schema, target.name())
             .map_err(|error| {
                 provider_error(ProviderQueryError::Pagination {
@@ -170,19 +170,19 @@ impl HttpSourceClient {
             })?;
         let page_size = resolve_page_size(pagination.page_size.as_ref(), sql_limit);
 
-        let active_request = &target.request;
+        let active_request = target.resolved_request();
 
         let mut state = PageState {
-            page: target.pagination.page_start,
+            page: target.pagination().page_start,
             offset: match &pagination.mode {
                 ValidatedPaginationMode::Offset(offset) => offset.start,
-                _ => target.pagination.offset_start,
+                _ => target.pagination().offset_start,
             },
             ..PageState::default()
         };
 
         let mut page_count = 0usize;
-        let max_pages = target.pagination.max_pages.unwrap_or(DEFAULT_MAX_PAGES);
+        let max_pages = target.pagination().max_pages.unwrap_or(DEFAULT_MAX_PAGES);
 
         loop {
             page_count += 1;
@@ -268,7 +268,7 @@ impl HttpSourceClient {
             let request = execute_request(
                 &self.http,
                 self.request_timeout,
-                RequestSpec {
+                OutgoingHttpRequest {
                     auth: &self.auth,
                     request_headers: &self.request_headers,
                     request_authenticators: &self.request_authenticators,
@@ -279,13 +279,13 @@ impl HttpSourceClient {
                     url: &url,
                     query_pairs: &query_pairs,
                     body: body.as_ref(),
-                    response_format: target.response.format,
+                    response_format: target.response().format,
                     source_schema: &self.source_schema,
                     rate_limit: &self.rate_limit,
-                    filters: request_values,
+                    request_values,
                     state: &pagination_values,
                     resolved_inputs: self.resolved_inputs.as_ref(),
-                    allow_404_empty: target.response.allow_404_empty,
+                    allow_404_empty: target.response().allow_404_empty,
                     link_header_require_results: pagination.link_header_require_results,
                 },
             )
@@ -295,15 +295,15 @@ impl HttpSourceClient {
                 break;
             };
 
-            if !target.response.ok_path.is_empty() {
-                let ok = get_path_value(&payload, &target.response.ok_path)
+            if !target.response().ok_path.is_empty() {
+                let ok = get_path_value(&payload, &target.response().ok_path)
                     .and_then(Value::as_bool)
                     .unwrap_or(false);
                 if !ok {
-                    let err = if target.response.error_path.is_empty() {
+                    let err = if target.response().error_path.is_empty() {
                         "unknown source API error".to_string()
                     } else {
-                        get_path_value(&payload, &target.response.error_path)
+                        get_path_value(&payload, &target.response().error_path)
                             .and_then(Value::as_str)
                             .unwrap_or("unknown source API error")
                             .to_string()
@@ -315,7 +315,7 @@ impl HttpSourceClient {
                             status: None,
                             method: None,
                             url: None,
-                            filters: filters.clone(),
+                            filters: request_values.clone(),
                             detail: err,
                         },
                     )));
@@ -337,7 +337,7 @@ impl HttpSourceClient {
                 ValidatedPaginationMode::None => break,
                 ValidatedPaginationMode::CursorQuery | ValidatedPaginationMode::CursorBody => {
                     let next_cursor =
-                        get_path_value(&payload, &target.pagination.response_cursor_path)
+                        get_path_value(&payload, &target.pagination().response_cursor_path)
                             .and_then(Value::as_str)
                             .map(str::trim)
                             .filter(|s| !s.is_empty())
@@ -351,7 +351,7 @@ impl HttpSourceClient {
                     if page_is_exhausted(rows_on_page, page_size) {
                         break;
                     }
-                    state.page = state.page.saturating_add(target.pagination.page_step);
+                    state.page = state.page.saturating_add(target.pagination().page_step);
                 }
                 ValidatedPaginationMode::Offset(offset) => {
                     if page_is_exhausted(rows_on_page, page_size) {
@@ -566,14 +566,14 @@ fn validate_header_inputs(
 async fn execute_request(
     http: &reqwest::Client,
     request_timeout: Duration,
-    request: RequestSpec<'_>,
+    request: OutgoingHttpRequest<'_>,
 ) -> Result<Option<(Value, Option<String>)>> {
     enum ResponseOutcome {
         Done(Result<Option<(Value, Option<String>)>>),
         Retry(Duration),
     }
 
-    let RequestSpec {
+    let OutgoingHttpRequest {
         auth,
         request_headers,
         request_authenticators,
@@ -587,7 +587,7 @@ async fn execute_request(
         response_format,
         source_schema,
         rate_limit,
-        filters,
+        request_values,
         state,
         resolved_inputs,
         allow_404_empty,
@@ -602,7 +602,7 @@ async fn execute_request(
         let mut header_map = HeaderMap::new();
         for header in request_headers.iter().chain(table_headers.iter()) {
             if let Some(value) =
-                resolve_value_source(&header.value, filters, state, resolved_inputs)?
+                resolve_value_source(&header.value, request_values, state, resolved_inputs)?
             {
                 let name = HeaderName::try_from(header.name.as_str()).map_err(|error| {
                     DataFusionError::Execution(format!(
@@ -770,7 +770,7 @@ async fn execute_request(
                         status: Some(status.as_u16()),
                         method: Some(method_label.to_string()),
                         url: Some(logged_url.clone()),
-                        filters: filters.clone(),
+                        filters: request_values.clone(),
                         detail: body,
                     },
                 ))));
@@ -972,7 +972,7 @@ fn build_http_request(
 
 fn build_query_pairs(
     request: &coral_spec::RequestSpec,
-    filters: &HashMap<String, String>,
+    request_values: &HashMap<String, String>,
     state: &PageState,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<Vec<(String, String)>> {
@@ -980,7 +980,8 @@ fn build_query_pairs(
     let mut params = Vec::new();
 
     for param in &request.query {
-        let value = resolve_value_source(&param.value, filters, &state_values, resolved_inputs)?;
+        let value =
+            resolve_value_source(&param.value, request_values, &state_values, resolved_inputs)?;
         if let Some(value) = value {
             params.push((param.name.clone(), value_to_string(&value)));
         }
@@ -991,7 +992,7 @@ fn build_query_pairs(
 
 fn apply_pagination_query_pairs(
     params: &mut Vec<(String, String)>,
-    target: &HttpRequestTarget,
+    target: &HttpFetchTarget,
     pagination: &ValidatedPagination,
     state: &PageState,
     page_size: Option<usize>,
@@ -1009,7 +1010,7 @@ fn apply_pagination_query_pairs(
         | ValidatedPaginationMode::LinkHeader => {}
         ValidatedPaginationMode::CursorQuery => {
             if let Some(cursor) = &state.cursor {
-                let name = target.pagination.cursor_param.clone().ok_or_else(|| {
+                let name = target.pagination().cursor_param.clone().ok_or_else(|| {
                     DataFusionError::Execution(
                         "cursor_query pagination requires cursor_param".to_string(),
                     )
@@ -1018,7 +1019,7 @@ fn apply_pagination_query_pairs(
             }
         }
         ValidatedPaginationMode::Page => {
-            let name = target.pagination.page_param.clone().ok_or_else(|| {
+            let name = target.pagination().page_param.clone().ok_or_else(|| {
                 DataFusionError::Execution("page pagination requires page_param".to_string())
             })?;
             params.push((name, state.page.to_string()));
@@ -1033,7 +1034,7 @@ fn apply_pagination_query_pairs(
 
 fn build_request_body(
     request: &coral_spec::RequestSpec,
-    filters: &HashMap<String, String>,
+    request_values: &HashMap<String, String>,
     state: &PageState,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<Option<RequestBody>> {
@@ -1045,9 +1046,12 @@ fn build_request_body(
             }
             let mut root = Value::Object(Map::new());
             for field in fields {
-                if let Some(value) =
-                    resolve_value_source(&field.value, filters, &state_values, resolved_inputs)?
-                {
+                if let Some(value) = resolve_value_source(
+                    &field.value,
+                    request_values,
+                    &state_values,
+                    resolved_inputs,
+                )? {
                     set_path_value(&mut root, &field.path, value)?;
                 }
             }
@@ -1055,7 +1059,7 @@ fn build_request_body(
         }
         BodySpec::Text { content } => {
             let Some(value) =
-                resolve_value_source(content, filters, &state_values, resolved_inputs)?
+                resolve_value_source(content, request_values, &state_values, resolved_inputs)?
             else {
                 return Ok(None);
             };
@@ -1067,7 +1071,7 @@ fn build_request_body(
 fn apply_pagination_body_fields(
     body: &mut Option<RequestBody>,
     body_spec: &BodySpec,
-    target: &HttpRequestTarget,
+    target: &HttpFetchTarget,
     pagination: &ValidatedPagination,
     state: &PageState,
     page_size: Option<usize>,
@@ -1076,7 +1080,7 @@ fn apply_pagination_body_fields(
         .zip(pagination.page_size.as_ref())
         .is_some_and(|(_, spec)| !spec.body_path.is_empty());
     let needs_cursor_body = matches!(pagination.mode, ValidatedPaginationMode::CursorBody)
-        && !target.pagination.cursor_body_path.is_empty()
+        && !target.pagination().cursor_body_path.is_empty()
         && state.cursor.is_some();
 
     if !needs_page_size_body && !needs_cursor_body {
@@ -1106,12 +1110,12 @@ fn apply_pagination_body_fields(
     if matches!(pagination.mode, ValidatedPaginationMode::CursorBody)
         && let Some(cursor) = &state.cursor
     {
-        if target.pagination.cursor_body_path.is_empty() {
+        if target.pagination().cursor_body_path.is_empty() {
             return Err(DataFusionError::Execution(
                 "cursor_body pagination requires cursor_body_path".to_string(),
             ));
         }
-        set_path_value(root, &target.pagination.cursor_body_path, json!(cursor))?;
+        set_path_value(root, &target.pagination().cursor_body_path, json!(cursor))?;
     }
 
     Ok(())
@@ -1253,13 +1257,13 @@ fn set_path_value_at(cursor: &mut Value, path: &[String], value: Value) -> Resul
     clippy::unnecessary_wraps,
     reason = "Keeping a Result return type preserves a uniform extraction interface for callers"
 )]
-fn extract_rows(target: &HttpRequestTarget, payload: &Value) -> Result<Vec<Value>> {
-    match target.response.row_strategy {
+fn extract_rows(target: &HttpFetchTarget, payload: &Value) -> Result<Vec<Value>> {
+    match target.response().row_strategy {
         RowStrategy::Direct => {
-            let root = if target.response.rows_path.is_empty() {
+            let root = if target.response().rows_path.is_empty() {
                 payload
             } else {
-                get_path_value(payload, &target.response.rows_path).unwrap_or(&Value::Null)
+                get_path_value(payload, &target.response().rows_path).unwrap_or(&Value::Null)
             };
             match root {
                 Value::Array(items) => Ok(items.clone()),
@@ -1313,10 +1317,10 @@ fn extract_rows(target: &HttpRequestTarget, payload: &Value) -> Result<Vec<Value
             Ok(rows)
         }
         RowStrategy::DictEntries => {
-            let root = if target.response.rows_path.is_empty() {
+            let root = if target.response().rows_path.is_empty() {
                 payload
             } else {
-                get_path_value(payload, &target.response.rows_path).unwrap_or(&Value::Null)
+                get_path_value(payload, &target.response().rows_path).unwrap_or(&Value::Null)
             };
             match root {
                 Value::Object(map) => {
@@ -1397,12 +1401,13 @@ mod tests {
     use tokio::task::JoinHandle;
 
     use super::{
-        HttpSourceClient, PageState, RequestSpec as HttpRequestSpec, apply_pagination_body_fields,
-        apply_pagination_query_pairs, execute_request, extract_next_link_url, extract_rows,
-        join_url, normalize_base_url, page_is_exhausted, resolve_value_source, set_path_value,
+        HttpSourceClient, OutgoingHttpRequest as TestOutgoingHttpRequest, PageState,
+        apply_pagination_body_fields, apply_pagination_query_pairs, execute_request,
+        extract_next_link_url, extract_rows, join_url, normalize_base_url, page_is_exhausted,
+        resolve_value_source, set_path_value,
     };
     use crate::backends::http::ProviderQueryError;
-    use crate::backends::http::target::HttpRequestTarget;
+    use crate::backends::http::target::HttpFetchTarget;
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
     use coral_spec::{
@@ -1453,8 +1458,8 @@ mod tests {
         .expect("table should exist")
     }
 
-    fn test_http_request_target(table: &HttpTableSpec) -> HttpRequestTarget {
-        HttpRequestTarget::from_table(table, table.request.clone())
+    fn test_http_request_target(table: &HttpTableSpec) -> HttpFetchTarget {
+        HttpFetchTarget::from_resolved_table_request(table, table.request.clone())
     }
 
     #[test]
@@ -2393,14 +2398,14 @@ mod tests {
             .expect("build test client");
         let url = format!("{base_url}/items");
         let query_pairs = vec![("api_key".to_string(), "secret-token".to_string())];
-        let filters = HashMap::new();
+        let request_values = HashMap::new();
         let state = HashMap::new();
         let resolved_inputs = BTreeMap::new();
 
         let error = execute_request(
             &http,
             request_timeout,
-            HttpRequestSpec {
+            TestOutgoingHttpRequest {
                 auth: &AuthSpec::default(),
                 request_headers: &[],
                 request_authenticators: &HashMap::new(),
@@ -2414,7 +2419,7 @@ mod tests {
                 response_format: ResponseBodyFormat::default(),
                 source_schema: "demo",
                 rate_limit: &RateLimitSpec::default(),
-                filters: &filters,
+                request_values: &request_values,
                 state: &state,
                 resolved_inputs: &resolved_inputs,
                 allow_404_empty: false,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -21,6 +21,7 @@ pub(crate) mod client;
 pub(crate) mod error;
 pub(crate) mod provider;
 mod rate_limit;
+pub(crate) mod target;
 
 pub(crate) use client::HttpSourceClient;
 pub(crate) use error::ProviderQueryError;

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -14,7 +14,7 @@ use serde_json::Value;
 
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::ProviderQueryError;
-use crate::backends::http::target::HttpRequestTarget;
+use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{extract_filter_values, literal_to_string};
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
@@ -27,6 +27,7 @@ pub(crate) struct HttpSourceTableProvider {
     backend: HttpSourceClient,
     source_schema: String,
     table: Arc<HttpTableSpec>,
+    target: HttpFetchTarget,
     schema: SchemaRef,
 }
 
@@ -52,20 +53,22 @@ impl HttpSourceTableProvider {
         table: HttpTableSpec,
     ) -> Result<Self> {
         let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
+        let target = HttpFetchTarget::from_resolved_table_request(&table, table.request.clone());
         Ok(Self {
             backend,
             source_schema,
             table: Arc::new(table),
+            target,
             schema,
         })
     }
 }
 
 #[derive(Debug)]
-pub(crate) struct HttpFetchPlan {
+struct HttpFetchPlan {
     backend: HttpSourceClient,
-    target: Arc<HttpRequestTarget>,
-    request_values: HashMap<String, String>,
+    target: Arc<HttpFetchTarget>,
+    request_values: Arc<HashMap<String, String>>,
     limit: Option<usize>,
 }
 
@@ -78,17 +81,17 @@ impl RowFetcher for HttpFetchPlan {
     }
 }
 
-pub(crate) fn http_json_exec(
+fn http_json_exec(
     backend: HttpSourceClient,
     source_schema: &str,
-    target: HttpRequestTarget,
+    target: HttpFetchTarget,
     schema: SchemaRef,
     request_values: HashMap<String, String>,
     projection: Option<&Vec<usize>>,
     limit: Option<usize>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let target = Arc::new(target);
-    let output_schema = schema.clone();
+    let request_values = Arc::new(request_values);
     let fetcher = Arc::new(HttpFetchPlan {
         backend,
         target: target.clone(),
@@ -96,21 +99,19 @@ pub(crate) fn http_json_exec(
         limit,
     });
 
-    let converter_target = target.clone();
-    let filters_for_convert = request_values;
-    let converter = Arc::new(move |items: &[Value]| {
-        convert_items(
-            converter_target.columns(),
-            schema.clone(),
-            &filters_for_convert,
-            items,
-        )
-    });
+    let converter = {
+        let target = target.clone();
+        let schema = schema.clone();
+        let request_values = request_values.clone();
+        Arc::new(move |items: &[Value]| {
+            convert_items(target.columns(), schema.clone(), &request_values, items)
+        })
+    };
 
     let exec = JsonExec::new(
         source_schema,
         target.name(),
-        output_schema,
+        schema,
         fetcher,
         converter,
         projection.cloned(),
@@ -179,11 +180,12 @@ impl TableProvider for HttpSourceTableProvider {
 
         let request_value_keys: HashSet<String> = request_values.keys().cloned().collect();
         let active_request = self.table.resolve_request(&request_value_keys).clone();
+        let target = self.target.with_resolved_request(active_request);
 
         http_json_exec(
             self.backend.clone(),
             &self.source_schema,
-            HttpRequestTarget::from_table(&self.table, active_request),
+            target,
             self.schema.clone(),
             request_values,
             projection,

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::ProviderQueryError;
+use crate::backends::http::target::HttpRequestTarget;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{extract_filter_values, literal_to_string};
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
@@ -61,10 +62,10 @@ impl HttpSourceTableProvider {
 }
 
 #[derive(Debug)]
-struct HttpFetchPlan {
+pub(crate) struct HttpFetchPlan {
     backend: HttpSourceClient,
-    table: Arc<HttpTableSpec>,
-    filters: Arc<HashMap<String, String>>,
+    target: Arc<HttpRequestTarget>,
+    request_values: HashMap<String, String>,
     limit: Option<usize>,
 }
 
@@ -72,9 +73,50 @@ struct HttpFetchPlan {
 impl RowFetcher for HttpFetchPlan {
     async fn fetch(&self) -> Result<Vec<Value>> {
         self.backend
-            .fetch(self.table.as_ref(), self.filters.as_ref(), self.limit)
+            .fetch(self.target.as_ref(), &self.request_values, self.limit)
             .await
     }
+}
+
+pub(crate) fn http_json_exec(
+    backend: HttpSourceClient,
+    source_schema: &str,
+    target: HttpRequestTarget,
+    schema: SchemaRef,
+    request_values: HashMap<String, String>,
+    projection: Option<&Vec<usize>>,
+    limit: Option<usize>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let target = Arc::new(target);
+    let output_schema = schema.clone();
+    let fetcher = Arc::new(HttpFetchPlan {
+        backend,
+        target: target.clone(),
+        request_values: request_values.clone(),
+        limit,
+    });
+
+    let converter_target = target.clone();
+    let filters_for_convert = request_values;
+    let converter = Arc::new(move |items: &[Value]| {
+        convert_items(
+            converter_target.columns(),
+            schema.clone(),
+            &filters_for_convert,
+            items,
+        )
+    });
+
+    let exec = JsonExec::new(
+        source_schema,
+        target.name(),
+        output_schema,
+        fetcher,
+        converter,
+        projection.cloned(),
+    )?;
+
+    Ok(Arc::new(exec))
 }
 
 #[async_trait]
@@ -121,10 +163,10 @@ impl TableProvider for HttpSourceTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let filter_values = extract_filter_values(filters, self.table.filters());
+        let request_values = extract_filter_values(filters, self.table.filters());
 
         for required in self.table.filters().iter().filter(|f| f.required) {
-            if !filter_values.contains_key(&required.name) {
+            if !request_values.contains_key(&required.name) {
                 return Err(DataFusionError::External(Box::new(
                     ProviderQueryError::MissingRequiredFilter {
                         schema: self.source_schema.clone(),
@@ -135,36 +177,18 @@ impl TableProvider for HttpSourceTableProvider {
             }
         }
 
-        let table = self.table.clone();
-        let filters = Arc::new(filter_values);
-        let fetcher = Arc::new(HttpFetchPlan {
-            backend: self.backend.clone(),
-            table: table.clone(),
-            filters: filters.clone(),
-            limit,
-        });
+        let request_value_keys: HashSet<String> = request_values.keys().cloned().collect();
+        let active_request = self.table.resolve_request(&request_value_keys).clone();
 
-        let schema = self.schema.clone();
-        let filters_for_convert = filters;
-        let converter = Arc::new(move |items: &[Value]| {
-            convert_items(
-                table.columns(),
-                schema.clone(),
-                filters_for_convert.as_ref(),
-                items,
-            )
-        });
-
-        let exec = JsonExec::new(
+        http_json_exec(
+            self.backend.clone(),
             &self.source_schema,
-            self.table.name(),
+            HttpRequestTarget::from_table(&self.table, active_request),
             self.schema.clone(),
-            fetcher,
-            converter,
-            projection.cloned(),
-        )?;
-
-        Ok(Arc::new(exec))
+            request_values,
+            projection,
+            limit,
+        )
     }
 }
 

--- a/crates/coral-engine/src/backends/http/target.rs
+++ b/crates/coral-engine/src/backends/http/target.rs
@@ -1,0 +1,43 @@
+//! Engine-local request shape shared by HTTP tables and table functions.
+
+use coral_spec::backends::http::HttpTableSpec;
+use coral_spec::{ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec};
+
+/// The HTTP request/response description needed to fetch rows.
+///
+/// Tables and table functions are distinct manifest concepts, but once their
+/// SQL-facing inputs have been resolved they share the same HTTP execution path.
+#[derive(Debug, Clone)]
+pub(crate) struct HttpRequestTarget {
+    name: String,
+    columns: Vec<ColumnSpec>,
+    fetch_limit_default: Option<usize>,
+    pub(crate) request: RequestSpec,
+    pub(crate) response: ResponseSpec,
+    pub(crate) pagination: PaginationSpec,
+}
+
+impl HttpRequestTarget {
+    pub(crate) fn from_table(table: &HttpTableSpec, request: RequestSpec) -> Self {
+        Self {
+            name: table.name().to_string(),
+            columns: table.columns().to_vec(),
+            fetch_limit_default: table.fetch_limit_default(),
+            request,
+            response: table.response.clone(),
+            pagination: table.pagination.clone(),
+        }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn columns(&self) -> &[ColumnSpec] {
+        &self.columns
+    }
+
+    pub(crate) fn fetch_limit_default(&self) -> Option<usize> {
+        self.fetch_limit_default
+    }
+}

--- a/crates/coral-engine/src/backends/http/target.rs
+++ b/crates/coral-engine/src/backends/http/target.rs
@@ -1,4 +1,6 @@
-//! Engine-local request shape shared by HTTP tables and table functions.
+//! Engine-local fetch shape shared by HTTP tables and table functions.
+
+use std::sync::Arc;
 
 use coral_spec::backends::http::HttpTableSpec;
 use coral_spec::{ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec};
@@ -7,25 +9,49 @@ use coral_spec::{ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec};
 ///
 /// Tables and table functions are distinct manifest concepts, but once their
 /// SQL-facing inputs have been resolved they share the same HTTP execution path.
-#[derive(Debug, Clone)]
-pub(crate) struct HttpRequestTarget {
-    name: String,
-    columns: Vec<ColumnSpec>,
+#[derive(Clone)]
+pub(crate) struct HttpFetchTarget {
+    name: Arc<str>,
+    columns: Arc<[ColumnSpec]>,
     fetch_limit_default: Option<usize>,
-    pub(crate) request: RequestSpec,
-    pub(crate) response: ResponseSpec,
-    pub(crate) pagination: PaginationSpec,
+    resolved_request: RequestSpec,
+    response: Arc<ResponseSpec>,
+    pagination: Arc<PaginationSpec>,
 }
 
-impl HttpRequestTarget {
-    pub(crate) fn from_table(table: &HttpTableSpec, request: RequestSpec) -> Self {
+impl std::fmt::Debug for HttpFetchTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpFetchTarget")
+            .field("name", &self.name)
+            .field("columns", &self.columns)
+            .field("fetch_limit_default", &self.fetch_limit_default)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HttpFetchTarget {
+    pub(crate) fn from_resolved_table_request(
+        table: &HttpTableSpec,
+        resolved_request: RequestSpec,
+    ) -> Self {
         Self {
-            name: table.name().to_string(),
-            columns: table.columns().to_vec(),
+            name: Arc::from(table.name()),
+            columns: Arc::from(table.columns().to_vec()),
             fetch_limit_default: table.fetch_limit_default(),
-            request,
-            response: table.response.clone(),
-            pagination: table.pagination.clone(),
+            resolved_request,
+            response: Arc::new(table.response.clone()),
+            pagination: Arc::new(table.pagination.clone()),
+        }
+    }
+
+    pub(crate) fn with_resolved_request(&self, resolved_request: RequestSpec) -> Self {
+        Self {
+            name: Arc::clone(&self.name),
+            columns: Arc::clone(&self.columns),
+            fetch_limit_default: self.fetch_limit_default,
+            resolved_request,
+            response: Arc::clone(&self.response),
+            pagination: Arc::clone(&self.pagination),
         }
     }
 
@@ -39,5 +65,17 @@ impl HttpRequestTarget {
 
     pub(crate) fn fetch_limit_default(&self) -> Option<usize> {
         self.fetch_limit_default
+    }
+
+    pub(crate) fn resolved_request(&self) -> &RequestSpec {
+        &self.resolved_request
+    }
+
+    pub(crate) fn response(&self) -> &ResponseSpec {
+        &self.response
+    }
+
+    pub(crate) fn pagination(&self) -> &PaginationSpec {
+        &self.pagination
     }
 }


### PR DESCRIPTION
## Summary

Extracts `HttpFetchTarget`, the engine-local HTTP row source used by `HttpSourceClient`.

This is not a new source-spec model. It is an execution-ready view built after a SQL-facing surface has already resolved its inputs.

## Why

The following PRs add HTTP-backed table functions. Tables and functions bind SQL inputs differently:

- tables bind `WHERE` filters and choose request routes
- functions bind call arguments

After binding, both need the same HTTP execution path: render a request, paginate, decode the response, and map rows into Arrow batches.

## What Changed

- `HttpSourceClient::fetch` now takes `HttpFetchTarget` instead of `HttpTableSpec`
- `HttpSourceTableProvider` still owns table-specific filter extraction and route selection
- `HttpFetchTarget::from_resolved_table_request(...)` makes the handoff explicit
- stable target metadata is shared behind `Arc`s; each scan only swaps in the resolved request
- generic HTTP execution uses `request_values` instead of table-specific `filters`
- `HttpFetchPlan` and `http_json_exec` remain private on this branch

## Not in This PR

- table-function execution
- source-scoped SQL syntax
- bundled GitHub/Datadog function rollout

## Validation

- `make rust-checks`