### PR TITLE
feat(engine): add DataFusion query tracing instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,6 +896,7 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1079,6 +1080,7 @@ dependencies = [
  "coral-spec",
  "datafusion",
  "datafusion-functions-json",
+ "datafusion-tracing",
  "futures",
  "glob",
  "httpdate",
@@ -1182,6 +1184,29 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -1963,6 +1988,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-tracing"
+version = "53.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "387168b2dc738668423132f7d04562fe75f612e970da153da7dd2a686f2798c2"
+dependencies = [
+ "async-trait",
+ "comfy-table",
+ "datafusion",
+ "delegate",
+ "futures",
+ "pin-project",
+ "similar",
+ "tracing",
+ "tracing-futures",
+ "unicode-width",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2022,17 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "deranged"
@@ -2060,6 +2114,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -3008,6 +3071,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -5054,6 +5123,18 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 datafusion = "53"
 datafusion-functions-json = "0.53"
+datafusion-tracing = "53.0.0"
 dialoguer = "0.12"
 directories = "6"
 fs2 = "0.4"

--- a/crates/coral-app/src/telemetry/config.rs
+++ b/crates/coral-app/src/telemetry/config.rs
@@ -5,7 +5,8 @@ use serde::Deserialize;
 use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
 
-pub(super) const DEFAULT_TRACE_FILTER: &str = "coral_app=trace,coral_engine=trace";
+pub(super) const DEFAULT_TRACE_FILTER: &str =
+    "coral_app=trace,coral_engine=trace,coral_engine::datafusion=off";
 pub(super) const DEFAULT_LOG_FILTER: &str = "coral_app=info,coral_engine=info";
 const DEFAULT_SERVICE_NAME: &str = "coral";
 

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -355,6 +355,15 @@ mod tests {
     }
 
     #[test]
+    fn default_trace_filter_keeps_http_and_disables_datafusion() {
+        let (targets, error) = build_trace_targets(DEFAULT_TRACE_FILTER);
+
+        assert!(error.is_none());
+        assert!(targets.would_enable("coral_engine::http", &tracing::Level::TRACE));
+        assert!(!targets.would_enable("coral_engine::datafusion", &tracing::Level::TRACE));
+    }
+
+    #[test]
     fn invalid_log_filter_falls_back_to_default() {
         let (filter, error) = build_log_filter(Some("coral_app=["));
         let (expected, default_error) = build_log_filter(Some(DEFAULT_LOG_FILTER));

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -17,6 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 datafusion.workspace = true
 datafusion-functions-json.workspace = true
+datafusion-tracing.workspace = true
 futures.workspace = true
 glob.workspace = true
 httpdate.workspace = true

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -770,6 +770,7 @@ async fn execute_request(
                         status: Some(status.as_u16()),
                         method: Some(method_label.to_string()),
                         url: Some(logged_url.clone()),
+                        filters: filters.clone(),
                         detail: body,
                     },
                 ))));

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -666,6 +666,9 @@ async fn execute_request(
             url.full = %traced_url,
             error = field::Empty,
             exception.message = field::Empty,
+            coral.http.error.timeout = field::Empty,
+            coral.http.error.connect = field::Empty,
+            coral.http.error.request = field::Empty,
         );
 
         let response = http
@@ -674,7 +677,10 @@ async fn execute_request(
             .await
             .map_err(|error| {
                 request_span.record("error", true);
-                request_span.record("exception.message", field::display(&error));
+                request_span.record("exception.message", trace_reqwest_error(&error));
+                request_span.record("coral.http.error.timeout", error.is_timeout());
+                request_span.record("coral.http.error.connect", error.is_connect());
+                request_span.record("coral.http.error.request", error.is_request());
                 request_error(
                     source_schema,
                     table_name,
@@ -859,6 +865,18 @@ fn request_error(
         detail,
         timed_out: error.is_timeout(),
     })
+}
+
+fn trace_reqwest_error(error: &reqwest::Error) -> &'static str {
+    if error.is_timeout() {
+        "source API request timed out"
+    } else if error.is_connect() {
+        "source API connection failed"
+    } else if error.is_request() {
+        "source API request failed before a response was received"
+    } else {
+        "source API request failed"
+    }
 }
 
 fn decode_error(

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -753,7 +753,11 @@ async fn execute_request(
                 .instrument(response_span.clone())
                 .await
                 .unwrap_or_default();
-            response_span.record("exception.message", field::display(&body));
+            response_span.record("http.response.body.size", body.len());
+            response_span.record(
+                "exception.message",
+                field::display(response_error_summary(status, &body)),
+            );
             return Err(DataFusionError::External(Box::new(
                 ProviderQueryError::ApiRequest {
                     source_schema: source_schema.to_string(),
@@ -877,6 +881,14 @@ fn trace_reqwest_error(error: &reqwest::Error) -> &'static str {
     } else {
         "source API request failed"
     }
+}
+
+fn response_error_summary(status: reqwest::StatusCode, body: &str) -> String {
+    format!(
+        "upstream returned HTTP {}; body_bytes={}",
+        status.as_u16(),
+        body.len()
+    )
 }
 
 fn decode_error(

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -568,6 +568,11 @@ async fn execute_request(
     request_timeout: Duration,
     request: RequestSpec<'_>,
 ) -> Result<Option<(Value, Option<String>)>> {
+    enum ResponseOutcome {
+        Done(Result<Option<(Value, Option<String>)>>),
+        Retry(Duration),
+    }
+
     let RequestSpec {
         auth,
         request_headers,
@@ -651,155 +656,167 @@ async fn execute_request(
         let request_id = NEXT_HTTP_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
         let attempt = server_error_retries + throttle_retries + 1;
         let traced_url = sanitize_trace_url(&logged_url);
-        let request_span = tracing::info_span!(
-            target: "coral_engine::http",
-            "http.request",
-            otel.name = "http.request",
-            coral.source = source_schema,
-            coral.table = table_name,
-            coral.http.request_id = request_id,
-            coral.http.attempt = attempt,
-            http.request.method = method_label,
-            http.request.body.present = body.is_some(),
-            http.request.body.size = request_body_size(body).unwrap_or_default(),
-            http.request.query_count = query_pairs.len(),
-            url.full = %traced_url,
-            error = field::Empty,
-            exception.message = field::Empty,
-            coral.http.error.timeout = field::Empty,
-            coral.http.error.connect = field::Empty,
-            coral.http.error.request = field::Empty,
-        );
-
-        let response = http
-            .execute(built)
-            .instrument(request_span.clone())
-            .await
-            .map_err(|error| {
-                request_span.record("error", true);
-                request_span.record("exception.message", trace_reqwest_error(&error));
-                request_span.record("coral.http.error.timeout", error.is_timeout());
-                request_span.record("coral.http.error.connect", error.is_connect());
-                request_span.record("coral.http.error.request", error.is_request());
-                request_error(
-                    source_schema,
-                    table_name,
-                    method_label,
-                    &logged_url,
-                    request_timeout,
-                    &error,
-                )
-            })?;
-        let status = response.status();
-        let response_span = tracing::info_span!(
-            target: "coral_engine::http",
-            "http.response",
-            otel.name = "http.response",
-            coral.source = source_schema,
-            coral.table = table_name,
-            coral.http.request_id = request_id,
-            coral.http.attempt = attempt,
-            http.request.method = method_label,
-            http.response.status_code = status.as_u16(),
-            http.response.body.size = field::Empty,
-            url.full = %traced_url,
-            error = field::Empty,
-            exception.message = field::Empty,
-        );
-        if let Some(length) = response.content_length() {
-            response_span.record("http.response.body.size", length);
-        }
-
-        match check_rate_limit(status, response.headers(), rate_limit, throttle_retries) {
-            RateLimitDecision::Continue => {}
-            RateLimitDecision::Retry(wait) => {
-                response_span.record("error", true);
-                response_span.record("exception.message", "rate limited; retrying");
-                throttle_retries += 1;
-                tokio::time::sleep(wait).await;
-                continue;
-            }
-            RateLimitDecision::Fail(error) => {
-                response_span.record("error", true);
-                response_span.record("exception.message", field::display(&error));
-                return Err(DataFusionError::External(Box::new(
-                    ProviderQueryError::RateLimited {
-                        source_schema: source_schema.to_string(),
-                        table: table_name.to_string(),
-                        method: Some(method_label.to_string()),
-                        url: Some(logged_url),
-                        detail: error.to_string(),
-                    },
-                )));
-            }
-        }
-
-        if status.is_server_error() && server_error_retries < 2 {
-            response_span.record("error", true);
-            response_span.record("exception.message", "server error; retrying");
-            server_error_retries += 1;
-            tokio::time::sleep(Duration::from_secs(2)).await;
-            continue;
-        }
-
-        if status == reqwest::StatusCode::NOT_FOUND && allow_404_empty {
-            return Ok(None);
-        }
-
-        if !status.is_success() {
-            response_span.record("error", true);
-            let body = response
-                .text()
-                .instrument(response_span.clone())
-                .await
-                .unwrap_or_default();
-            response_span.record("http.response.body.size", body.len());
-            response_span.record(
-                "exception.message",
-                field::display(response_error_summary(status, &body)),
+        let response = {
+            let request_span = tracing::info_span!(
+                target: "coral_engine::http",
+                "http.request",
+                otel.name = "http.request",
+                coral.source = source_schema,
+                coral.table = table_name,
+                coral.http.request_id = request_id,
+                coral.http.attempt = attempt,
+                http.request.method = method_label,
+                http.request.body.present = body.is_some(),
+                http.request.body.size = request_body_size(body).unwrap_or_default(),
+                http.request.query_count = query_pairs.len(),
+                url.full = %traced_url,
+                error = field::Empty,
+                exception.message = field::Empty,
+                coral.http.error.timeout = field::Empty,
+                coral.http.error.connect = field::Empty,
+                coral.http.error.request = field::Empty,
             );
-            return Err(DataFusionError::External(Box::new(
-                ProviderQueryError::ApiRequest {
-                    source_schema: source_schema.to_string(),
-                    table: table_name.to_string(),
-                    status: Some(status.as_u16()),
-                    method: Some(method_label.to_string()),
-                    url: Some(logged_url),
-                    filters: filters.clone(),
-                    detail: body,
-                },
-            )));
-        }
-
-        let next_url =
-            extract_next_link_url(response.headers(), base_url, link_header_require_results)
-                .map_err(|error| {
-                    response_span.record("error", true);
-                    response_span.record("exception.message", field::display(&error));
-                    pagination_error(
+            match http.execute(built).instrument(request_span.clone()).await {
+                Ok(response) => response,
+                Err(error) => {
+                    request_span.record("error", true);
+                    request_span.record("exception.message", trace_reqwest_error(&error));
+                    request_span.record("coral.http.error.timeout", error.is_timeout());
+                    request_span.record("coral.http.error.connect", error.is_connect());
+                    request_span.record("coral.http.error.request", error.is_request());
+                    return Err(request_error(
                         source_schema,
                         table_name,
-                        Some(method_label),
-                        Some(&logged_url),
+                        method_label,
+                        &logged_url,
+                        request_timeout,
                         &error,
-                    )
-                })?;
+                    ));
+                }
+            }
+        };
 
-        let payload = decode_response_body(
-            response,
-            response_format,
-            source_schema,
-            table_name,
-            method_label,
-            &logged_url,
-        )
-        .instrument(response_span.clone())
-        .await
-        .inspect_err(|error| {
-            response_span.record("error", true);
-            response_span.record("exception.message", field::display(&error));
-        })?;
-        return Ok(Some((payload, next_url)));
+        let status = response.status();
+        let outcome = 'response: {
+            let response_span = tracing::info_span!(
+                target: "coral_engine::http",
+                "http.response",
+                otel.name = "http.response",
+                coral.source = source_schema,
+                coral.table = table_name,
+                coral.http.request_id = request_id,
+                coral.http.attempt = attempt,
+                http.request.method = method_label,
+                http.response.status_code = status.as_u16(),
+                http.response.body.size = field::Empty,
+                url.full = %traced_url,
+                error = field::Empty,
+                exception.message = field::Empty,
+            );
+            if let Some(length) = response.content_length() {
+                response_span.record("http.response.body.size", length);
+            }
+
+            match check_rate_limit(status, response.headers(), rate_limit, throttle_retries) {
+                RateLimitDecision::Continue => {}
+                RateLimitDecision::Retry(wait) => {
+                    response_span.record("error", true);
+                    response_span.record("exception.message", "rate limited; retrying");
+                    throttle_retries += 1;
+                    break 'response ResponseOutcome::Retry(wait);
+                }
+                RateLimitDecision::Fail(error) => {
+                    response_span.record("error", true);
+                    response_span.record("exception.message", field::display(&error));
+                    break 'response ResponseOutcome::Done(Err(DataFusionError::External(
+                        Box::new(ProviderQueryError::RateLimited {
+                            source_schema: source_schema.to_string(),
+                            table: table_name.to_string(),
+                            method: Some(method_label.to_string()),
+                            url: Some(logged_url.clone()),
+                            detail: error.to_string(),
+                        }),
+                    )));
+                }
+            }
+
+            if status.is_server_error() && server_error_retries < 2 {
+                response_span.record("error", true);
+                response_span.record("exception.message", "server error; retrying");
+                server_error_retries += 1;
+                break 'response ResponseOutcome::Retry(Duration::from_secs(2));
+            }
+
+            if status == reqwest::StatusCode::NOT_FOUND && allow_404_empty {
+                break 'response ResponseOutcome::Done(Ok(None));
+            }
+
+            if !status.is_success() {
+                response_span.record("error", true);
+                let body = response
+                    .text()
+                    .instrument(response_span.clone())
+                    .await
+                    .unwrap_or_default();
+                response_span.record("http.response.body.size", body.len());
+                response_span.record(
+                    "exception.message",
+                    field::display(response_error_summary(status, &body)),
+                );
+                break 'response ResponseOutcome::Done(Err(DataFusionError::External(Box::new(
+                    ProviderQueryError::ApiRequest {
+                        source_schema: source_schema.to_string(),
+                        table: table_name.to_string(),
+                        status: Some(status.as_u16()),
+                        method: Some(method_label.to_string()),
+                        url: Some(logged_url.clone()),
+                        detail: body,
+                    },
+                ))));
+            }
+
+            let next_url =
+                extract_next_link_url(response.headers(), base_url, link_header_require_results)
+                    .map_err(|error| {
+                        response_span.record("error", true);
+                        response_span.record("exception.message", field::display(&error));
+                        pagination_error(
+                            source_schema,
+                            table_name,
+                            Some(method_label),
+                            Some(&logged_url),
+                            &error,
+                        )
+                    });
+            let next_url = match next_url {
+                Ok(next_url) => next_url,
+                Err(error) => break 'response ResponseOutcome::Done(Err(error)),
+            };
+
+            let payload = decode_response_body(
+                response,
+                response_format,
+                source_schema,
+                table_name,
+                method_label,
+                &logged_url,
+            )
+            .instrument(response_span.clone())
+            .await
+            .inspect_err(|error| {
+                response_span.record("error", true);
+                response_span.record("exception.message", field::display(&error));
+            })
+            .map(|payload| Some((payload, next_url)));
+            ResponseOutcome::Done(payload)
+        };
+
+        match outcome {
+            ResponseOutcome::Done(result) => return result,
+            ResponseOutcome::Retry(wait) => {
+                tokio::time::sleep(wait).await;
+            }
+        }
     }
 }
 

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -2,11 +2,14 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use datafusion::error::{DataFusionError, Result};
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Map, Value, json};
+use tracing::Instrument as _;
+use tracing::field;
 
 use crate::RequestAuthenticator;
 use crate::backends::http::ProviderQueryError;
@@ -27,6 +30,7 @@ use coral_spec::{
 const DEFAULT_MAX_PAGES: usize = 10_000;
 const DEFAULT_HTTP_REQUEST_TIMEOUT_SECS: u64 = 30;
 const DEFAULT_HTTP_USER_AGENT: &str = concat!("coral/", env!("CARGO_PKG_VERSION"));
+static NEXT_HTTP_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Executes manifest-driven HTTP requests for one registered source.
 #[derive(Clone)]
@@ -644,31 +648,74 @@ async fn execute_request(
         });
 
         let built = resolve_auth_headers(auth, request, request_authenticators, resolved_inputs)?;
+        let request_id = NEXT_HTTP_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
+        let attempt = server_error_retries + throttle_retries + 1;
+        let traced_url = sanitize_trace_url(&logged_url);
+        let request_span = tracing::info_span!(
+            target: "coral_engine::http",
+            "http.request",
+            otel.name = "http.request",
+            coral.source = source_schema,
+            coral.table = table_name,
+            coral.http.request_id = request_id,
+            coral.http.attempt = attempt,
+            http.request.method = method_label,
+            http.request.body.present = body.is_some(),
+            http.request.body.size = request_body_size(body).unwrap_or_default(),
+            http.request.query_count = query_pairs.len(),
+            url.full = %traced_url,
+            error = field::Empty,
+            exception.message = field::Empty,
+        );
 
-        let response = http.execute(built).await.map_err(|error| {
-            request_error(
-                source_schema,
-                table_name,
-                method_label,
-                &logged_url,
-                request_timeout,
-                &error,
-            )
-        })?;
+        let response = http
+            .execute(built)
+            .instrument(request_span.clone())
+            .await
+            .map_err(|error| {
+                request_span.record("error", true);
+                request_span.record("exception.message", field::display(&error));
+                request_error(
+                    source_schema,
+                    table_name,
+                    method_label,
+                    &logged_url,
+                    request_timeout,
+                    &error,
+                )
+            })?;
+        let status = response.status();
+        let response_span = tracing::info_span!(
+            target: "coral_engine::http",
+            "http.response",
+            otel.name = "http.response",
+            coral.source = source_schema,
+            coral.table = table_name,
+            coral.http.request_id = request_id,
+            coral.http.attempt = attempt,
+            http.request.method = method_label,
+            http.response.status_code = status.as_u16(),
+            http.response.body.size = field::Empty,
+            url.full = %traced_url,
+            error = field::Empty,
+            exception.message = field::Empty,
+        );
+        if let Some(length) = response.content_length() {
+            response_span.record("http.response.body.size", length);
+        }
 
-        match check_rate_limit(
-            response.status(),
-            response.headers(),
-            rate_limit,
-            throttle_retries,
-        ) {
+        match check_rate_limit(status, response.headers(), rate_limit, throttle_retries) {
             RateLimitDecision::Continue => {}
             RateLimitDecision::Retry(wait) => {
+                response_span.record("error", true);
+                response_span.record("exception.message", "rate limited; retrying");
                 throttle_retries += 1;
                 tokio::time::sleep(wait).await;
                 continue;
             }
             RateLimitDecision::Fail(error) => {
+                response_span.record("error", true);
+                response_span.record("exception.message", field::display(&error));
                 return Err(DataFusionError::External(Box::new(
                     ProviderQueryError::RateLimited {
                         source_schema: source_schema.to_string(),
@@ -681,19 +728,26 @@ async fn execute_request(
             }
         }
 
-        if response.status().is_server_error() && server_error_retries < 2 {
+        if status.is_server_error() && server_error_retries < 2 {
+            response_span.record("error", true);
+            response_span.record("exception.message", "server error; retrying");
             server_error_retries += 1;
             tokio::time::sleep(Duration::from_secs(2)).await;
             continue;
         }
 
-        if response.status() == reqwest::StatusCode::NOT_FOUND && allow_404_empty {
+        if status == reqwest::StatusCode::NOT_FOUND && allow_404_empty {
             return Ok(None);
         }
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
+        if !status.is_success() {
+            response_span.record("error", true);
+            let body = response
+                .text()
+                .instrument(response_span.clone())
+                .await
+                .unwrap_or_default();
+            response_span.record("exception.message", field::display(&body));
             return Err(DataFusionError::External(Box::new(
                 ProviderQueryError::ApiRequest {
                     source_schema: source_schema.to_string(),
@@ -710,6 +764,8 @@ async fn execute_request(
         let next_url =
             extract_next_link_url(response.headers(), base_url, link_header_require_results)
                 .map_err(|error| {
+                    response_span.record("error", true);
+                    response_span.record("exception.message", field::display(&error));
                     pagination_error(
                         source_schema,
                         table_name,
@@ -727,7 +783,12 @@ async fn execute_request(
             method_label,
             &logged_url,
         )
-        .await?;
+        .instrument(response_span.clone())
+        .await
+        .inspect_err(|error| {
+            response_span.record("error", true);
+            response_span.record("exception.message", field::display(&error));
+        })?;
         return Ok(Some((payload, next_url)));
     }
 }
@@ -1041,6 +1102,29 @@ fn build_logged_url(url: &str, query_pairs: &[(String, String)]) -> String {
         format!("{url}&{suffix}")
     } else {
         format!("{url}?{suffix}")
+    }
+}
+
+fn sanitize_trace_url(raw: &str) -> String {
+    let Ok(mut url) = reqwest::Url::parse(raw) else {
+        let without_fragment = raw.split_once('#').map_or(raw, |(before, _)| before);
+        return without_fragment
+            .split_once('?')
+            .map_or(without_fragment, |(before, _)| before)
+            .to_string();
+    };
+    url.set_query(None);
+    url.set_fragment(None);
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.to_string()
+}
+
+fn request_body_size(body: Option<&RequestBody>) -> Option<usize> {
+    match body {
+        Some(RequestBody::Json(value)) => serde_json::to_vec(value).ok().map(|body| body.len()),
+        Some(RequestBody::Text(text)) => Some(text.len()),
+        None => None,
     }
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -2,8 +2,10 @@
 
 use std::sync::Arc;
 
+use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
+use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
@@ -32,7 +34,26 @@ pub(crate) async fn build_runtime(
             .build()
             .map_err(|err| datafusion_to_core(&err, &[]))?,
     );
-    let mut ctx = SessionContext::new_with_config_rt(session_config, runtime_env);
+    let exec_options = InstrumentationOptions::builder()
+        .record_metrics(true)
+        .build();
+    let instrument_rule = datafusion_tracing::instrument_with_trace_spans!(
+        target: "coral_engine::datafusion",
+        options: exec_options
+    );
+    let session_state = SessionStateBuilder::new()
+        .with_config(session_config)
+        .with_runtime_env(runtime_env)
+        .with_default_features()
+        .with_physical_optimizer_rule(instrument_rule)
+        .build();
+    let rule_options = RuleInstrumentationOptions::phase_only();
+    let session_state = datafusion_tracing::instrument_rules_with_trace_spans!(
+        target: "coral_engine::datafusion",
+        options: rule_options,
+        state: session_state
+    );
+    let mut ctx = SessionContext::new_with_state(session_state);
     register_json_support(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
     register_pattern_validator(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
     let ctx = Arc::new(ctx);

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
-use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
+use datafusion_tracing::InstrumentationOptions;
 
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
@@ -47,12 +47,6 @@ pub(crate) async fn build_runtime(
         .with_default_features()
         .with_physical_optimizer_rule(instrument_rule)
         .build();
-    let rule_options = RuleInstrumentationOptions::phase_only();
-    let session_state = datafusion_tracing::instrument_rules_with_trace_spans!(
-        target: "coral_engine::datafusion",
-        options: rule_options,
-        state: session_state
-    );
     let mut ctx = SessionContext::new_with_state(session_state);
     register_json_support(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
     register_pattern_validator(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;


### PR DESCRIPTION
## Summary

- Integrates the `datafusion-tracing` crate to instrument DataFusion query execution with OpenTelemetry trace spans.
- Replaces direct `SessionContext` construction with a `SessionStateBuilder` pipeline that attaches physical optimizer and rule instrumentation.
- Emits metrics and trace spans under the `coral_engine::datafusion` target for both execution and optimizer rule phases.

Datafusion tracing is disabled by default, it can be enabled with:

```
[otel]
  trace_filter = "coral_app=trace,coral_engine=trace,coral_engine::datafusion=trace"
```

HTTP tracing can be disabled with:

```
 [otel]
  trace_filter = "coral_app=trace,coral_engine=trace,coral_engine::http=off"
```

Before:

<img width="1849" height="298" alt="image" src="https://github.com/user-attachments/assets/00fbab69-036a-45ec-8386-278a382232ef" />

After 4412de6468e0d6b7f501c090a3ec909dafdee57c :

<img width="1840" height="578" alt="image" src="https://github.com/user-attachments/assets/09c18205-8c1d-4336-b78a-1b79a4b38c67" />

After f62359662fbccec73911d88175f3a0323e2bdf72

<img width="1836" height="1219" alt="image" src="https://github.com/user-attachments/assets/3c19c831-6040-4817-8504-4a6d9d27aeed" />


## Test plan

- [x] Run the existing engine test suite and confirm no regressions.
- [x] Execute a query and verify trace spans appear under `coral_engine::datafusion` in the connected tracing backend.
- [x] Confirm `record_metrics` data is captured alongside spans during query execution.
- [x] Check that optimizer rule instrumentation (`phase_only`) produces spans for each planning phase.