### PR TITLE
fix: keep config file data when sources are modified

### DIFF
--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -164,7 +164,12 @@ impl ConfigStore {
     }
 
     fn save_unlocked(&self, config: &AppConfig) -> Result<(), AppError> {
-        let raw = render_config(&PersistedAppConfig::from(config));
+        let existing_raw = if self.layout.config_file().exists() {
+            Some(std::fs::read_to_string(self.layout.config_file())?)
+        } else {
+            None
+        };
+        let raw = render_config(&PersistedAppConfig::from(config), existing_raw.as_deref());
         if let Some(parent) = self.layout.config_file().parent() {
             storage_fs::ensure_dir(parent)?;
         }
@@ -233,9 +238,15 @@ impl ConfigStore {
     }
 }
 
-fn render_config(config: &PersistedAppConfig) -> String {
-    let mut doc = DocumentMut::new();
+fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> String {
+    let mut doc = existing_raw
+        .and_then(|raw| raw.parse::<DocumentMut>().ok())
+        .unwrap_or_default();
+
     doc["version"] = value(i64::from(config.version));
+
+    // Remove and fully rebuild the workspaces section so removed sources don't linger.
+    doc.remove("workspaces");
 
     for (workspace_name, workspace) in &config.workspaces {
         for (source_name, source) in &workspace.sources {
@@ -368,7 +379,7 @@ mod tests {
             catalog,
         };
 
-        let raw = render_config(&PersistedAppConfig::from(&config));
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
         assert!(raw.contains("[workspaces.default.sources.github]"));
         assert!(raw.contains("variables = { GITHUB_API_BASE = \"https://api.github.com\" }"));
         assert!(raw.contains("secrets = [\"GITHUB_TOKEN\"]"));
@@ -391,7 +402,7 @@ mod tests {
             catalog,
         };
 
-        let raw = render_config(&PersistedAppConfig::from(&config));
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
         assert!(!raw.contains("version = \"\""));
         assert!(!raw.contains("version = \""));
     }
@@ -475,6 +486,50 @@ origin = "bundled"
                 )
                 .is_some()
         );
+    }
+
+    #[test]
+    fn preserves_unrelated_sections_when_rendering_with_existing_config() {
+        let existing = r#"
+version = 1
+
+[otel]
+endpoint = "http://localhost:4318"
+headers = "from=config"
+
+[workspaces.default.sources.github]
+version = "1.0.0"
+variables = {}
+secrets = []
+origin = "bundled"
+"#;
+
+        let workspace_name = default_workspace();
+        let mut catalog = SourceCatalog::default();
+        catalog.upsert_source(&workspace_name, installed_source("slack"));
+        let config = AppConfig {
+            version: 1,
+            catalog,
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), Some(existing));
+
+        // OTel section must survive the round-trip.
+        assert!(raw.contains("[otel]"), "otel section should be preserved");
+        assert!(
+            raw.contains("endpoint = \"http://localhost:4318\""),
+            "otel endpoint should be preserved"
+        );
+        assert!(
+            raw.contains("headers = \"from=config\""),
+            "otel headers should be preserved"
+        );
+
+        // The newly added source must be present.
+        assert!(raw.contains("[workspaces.default.sources.slack]"));
+
+        // The old source that was not in the updated catalog must be gone.
+        assert!(!raw.contains("[workspaces.default.sources.github]"));
     }
 
     #[test]

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -1187,3 +1187,64 @@ async fn rejects_invalid_workspace_and_source_names() {
         .expect_err("source name with backslash should fail");
     assert_eq!(invalid_source_name.code(), tonic::Code::InvalidArgument);
 }
+
+#[tokio::test]
+async fn adding_source_preserves_otel_config_and_existing_sources() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+
+    // Pre-populate the config with an [otel] section and an existing source.
+    fs::write(
+        config_dir.join("config.toml"),
+        r#"version = 1
+
+[otel]
+endpoint = "http://localhost:4318"
+headers = "from=config"
+
+[workspaces.default.sources.demo]
+version = "0.1.0"
+variables = {}
+secrets = []
+origin = "imported"
+"#,
+    )
+    .expect("write initial config");
+
+    let harness = GrpcHarness::start_with_config_dir(config_dir.clone()).await;
+    let manifest_yaml = fixture_manifest_yaml(temp.path());
+
+    harness
+        .import_source(manifest_yaml, Vec::new(), Vec::new())
+        .await;
+
+    let config_raw =
+        fs::read_to_string(config_dir.join("config.toml")).expect("read config after import");
+
+    // The [otel] section and its values must survive the round-trip.
+    assert!(
+        config_raw.contains("[otel]"),
+        "otel section should be preserved"
+    );
+    assert!(
+        config_raw.contains("endpoint = \"http://localhost:4318\""),
+        "otel endpoint should be preserved"
+    );
+    assert!(
+        config_raw.contains("headers = \"from=config\""),
+        "otel headers should be preserved"
+    );
+
+    // The pre-existing source must still be present.
+    assert!(
+        config_raw.contains("[workspaces.default.sources.demo]"),
+        "pre-existing source should be preserved"
+    );
+
+    // The newly imported source must now also be present.
+    assert!(
+        config_raw.contains("[workspaces.default.sources.local_messages]"),
+        "newly added source should be in config"
+    );
+}


### PR DESCRIPTION
## Summary

- When saving the config, read the existing file first and parse it as a TOML document so that unrelated sections (e.g. `[otel]`) survive the round-trip.
- Rebuild only the `workspaces` section from the in-memory state, ensuring removed sources are dropped without clobbering other top-level config keys.
- Add unit and integration tests covering preservation of unrelated sections and pre-existing sources after an import.

## Test plan

- [x] Run `cargo test -p coral-app` and confirm `preserves_unrelated_sections_when_rendering_with_existing_config` passes.
- [x] Run the integration test `adding_source_preserves_otel_config_and_existing_sources` and confirm the `[otel]` section and pre-existing sources survive a source import.
- [x] Manually create a `config.toml` with an `[otel]` block, add a source via the gRPC API, and verify the file still contains the `[otel]` section afterward.
- [x] Remove a source and confirm its entry is no longer in the written config while other sections remain intact.