### PR TITLE
feat(mcp): add regex table discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1109,6 +1109,7 @@ dependencies = [
  "coral-api",
  "coral-app",
  "coral-client",
+ "regex",
  "rmcp",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ opentelemetry_sdk = "0.31.0"
 parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
 reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls-native-roots", "system-proxy"] }
+regex = "1"
 rmcp = { version = "1.3.0", features = ["client"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 rust-embed = { version = "8", features = ["mime-guess"] }

--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -28,6 +28,8 @@ message Table {
   repeated Column columns = 5;
   // Required filter names, if any.
   repeated string required_filters = 6;
+  // User-facing query guidance.
+  string guide = 7;
 }
 
 // Table metadata without full column definitions.
@@ -42,4 +44,6 @@ message TableSummary {
   string description = 4;
   // Filter names that must be constrained when querying this table.
   repeated string required_filters = 5;
+  // User-facing query guidance.
+  string guide = 6;
 }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -147,6 +147,7 @@ pub(crate) fn table_summary_to_proto(
         name: table.table_name,
         description: table.description,
         required_filters: table.required_filters,
+        guide: table.guide,
     }
 }
 
@@ -171,6 +172,7 @@ fn table_to_proto_with_columns(
         description: table.description,
         columns,
         required_filters: table.required_filters,
+        guide: table.guide,
     }
 }
 
@@ -284,6 +286,7 @@ mod tests {
             schema_name: "demo".to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),
+            guide: "Filter by org_id.".to_string(),
             columns: vec![ColumnInfo {
                 name: "id".to_string(),
                 data_type: "Int64".to_string(),
@@ -298,6 +301,7 @@ mod tests {
         assert_eq!(proto.schema_name, "demo");
         assert_eq!(proto.name, "users");
         assert_eq!(proto.description, "User records");
+        assert_eq!(proto.guide, "Filter by org_id.");
         assert_eq!(proto.columns.len(), 1);
         assert_eq!(proto.columns[0].name, "id");
         assert_eq!(proto.columns[0].data_type, "Int64");
@@ -312,6 +316,7 @@ mod tests {
             schema_name: "demo".to_string(),
             table_name: "users".to_string(),
             description: "User records".to_string(),
+            guide: "Filter by org_id.".to_string(),
             columns: vec![ColumnInfo {
                 name: "id".to_string(),
                 data_type: "Int64".to_string(),
@@ -326,6 +331,7 @@ mod tests {
         assert_eq!(proto.schema_name, "demo");
         assert_eq!(proto.name, "users");
         assert_eq!(proto.description, "User records");
+        assert_eq!(proto.guide, "Filter by org_id.");
         assert_eq!(proto.required_filters, vec!["org_id"]);
     }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -52,6 +52,7 @@ fn mock_table(schema_name: &str, name: &str) -> Table {
         schema_name: schema_name.to_string(),
         name: name.to_string(),
         description: String::new(),
+        guide: String::new(),
         columns: Vec::new(),
         required_filters: Vec::new(),
     }
@@ -63,6 +64,7 @@ fn mock_visible_table() -> Table {
         schema_name: "local_messages".to_string(),
         name: "messages".to_string(),
         description: "Fixture messages".to_string(),
+        guide: "Query fixture messages.".to_string(),
         columns: vec![
             Column {
                 name: "type".to_string(),
@@ -84,9 +86,11 @@ fn mock_visible_tables() -> Vec<Table> {
     let mut sessions = mock_visible_table();
     sessions.name = "sessions".to_string();
     sessions.description = "Fixture sessions".to_string();
+    sessions.guide = "Query fixture sessions.".to_string();
     let mut events = mock_visible_table();
     events.name = "events".to_string();
     events.description = "Fixture events".to_string();
+    events.guide = "Query fixture events.".to_string();
     vec![events, messages, sessions]
 }
 
@@ -97,10 +101,15 @@ fn table_summary(table: &Table) -> TableSummary {
         name: table.name.clone(),
         description: table.description.clone(),
         required_filters: table.required_filters.clone(),
+        guide: table.guide.clone(),
     }
 }
 
 fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
+    if sql.contains("FROM coral.tables") {
+        return mock_coral_tables_response();
+    }
+
     let (schema, batch, row_count) = if sql.contains("local_messages.messages") {
         let schema = Schema::new(vec![Field::new("text", DataType::Utf8, false)]);
         let batch = RecordBatch::try_new(
@@ -122,6 +131,44 @@ fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
     ExecuteSqlResponse {
         arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
         row_count,
+    }
+}
+
+fn mock_coral_tables_response() -> ExecuteSqlResponse {
+    let schema = Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+        Field::new("guide", DataType::Utf8, false),
+        Field::new("required_filters", DataType::Utf8, false),
+    ]);
+    let batch = RecordBatch::try_new(
+        Arc::new(schema.clone()),
+        vec![
+            Arc::new(StringArray::from(vec![
+                "local_messages",
+                "local_messages",
+                "local_messages",
+            ])),
+            Arc::new(StringArray::from(vec!["events", "messages", "sessions"])),
+            Arc::new(StringArray::from(vec![
+                "Fixture events",
+                "Fixture messages",
+                "Fixture sessions",
+            ])),
+            Arc::new(StringArray::from(vec![
+                "Query fixture events.",
+                "Query fixture messages.",
+                "Query fixture sessions.",
+            ])),
+            Arc::new(StringArray::from(vec!["", "owner,repo", ""])),
+        ],
+    )
+    .expect("build coral.tables batch");
+
+    ExecuteSqlResponse {
+        arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
+        row_count: 3,
     }
 }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -50,6 +50,15 @@ fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
     }
 }
 
+async fn structured_tool_content(
+    client: &RunningService<RoleClient, ()>,
+    request: CallToolRequestParams,
+) -> Result<Value, Box<dyn std::error::Error>> {
+    let result = client.call_tool(request).await?;
+    assert_eq!(result.is_error, Some(false));
+    Ok(result.structured_content.expect("structured content"))
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
@@ -61,7 +70,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables"]
+        vec!["sql", "list_tables", "search_tables"]
     );
     assert!(
         tools[0]
@@ -75,6 +84,13 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .description
             .as_deref()
             .expect("list_tables description")
+            .contains("3 table(s) are currently visible")
+    );
+    assert!(
+        tools[2]
+            .description
+            .as_deref()
+            .expect("search_tables description")
             .contains("3 table(s) are currently visible")
     );
 
@@ -119,7 +135,7 @@ async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn s
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables", "feedback"]
+        vec!["sql", "list_tables", "search_tables", "feedback"]
     );
 
     client.cancel().await?;
@@ -133,11 +149,21 @@ async fn mcp_stdio_sql_and_list_tables_return_structured_content()
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
 
-    let tables = client
-        .call_tool(CallToolRequestParams::new("list_tables"))
-        .await?;
-    assert_eq!(tables.is_error, Some(false));
-    let structured_tables = tables.structured_content.expect("structured content");
+    assert_list_tables_tool(&client, &server).await?;
+    assert_search_tables_tool(&client, &server).await?;
+    assert_sql_tool(&client).await?;
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+async fn assert_list_tables_tool(
+    client: &RunningService<RoleClient, ()>,
+    server: &MockServer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let structured_tables =
+        structured_tool_content(client, CallToolRequestParams::new("list_tables")).await?;
     assert_eq!(structured_tables["total"], 3);
     assert_eq!(structured_tables["limit"], 50);
     assert_eq!(structured_tables["offset"], 0);
@@ -155,35 +181,88 @@ async fn mcp_stdio_sql_and_list_tables_return_structured_content()
     assert_eq!(request_pagination.offset, 0);
     assert!(request.omit_columns);
 
-    let paginated = client
-        .call_tool(
-            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "limit": 2,
-                "offset": 0
-            }))),
-        )
-        .await?;
-    let paginated = paginated.structured_content.expect("structured content");
+    let paginated = structured_tool_content(
+        client,
+        CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+            "schema": "local_messages",
+            "limit": 2,
+            "offset": 0
+        }))),
+    )
+    .await?;
     assert_eq!(paginated["total"], 3);
     assert_eq!(paginated["has_more"], true);
     assert_eq!(paginated["next_offset"], 2);
+    Ok(())
+}
 
-    let sql = client
-        .call_tool(
-            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
-                "sql": "SELECT text FROM local_messages.messages ORDER BY text"
-            }))),
-        )
-        .await?;
-    assert_eq!(sql.is_error, Some(false));
+async fn assert_search_tables_tool(
+    client: &RunningService<RoleClient, ()>,
+    server: &MockServer,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let search = structured_tool_content(
+        client,
+        CallToolRequestParams::new("search_tables").with_arguments(json_object(&json!({
+            "pattern": "fixture.*messages",
+            "schema": "local_messages",
+            "ignore_case": true
+        }))),
+    )
+    .await?;
+    assert_eq!(search["total"], 1);
+    assert_eq!(search["tables"][0]["name"], "local_messages.messages");
     assert_eq!(
-        sql.structured_content.expect("structured content")["rows"][0]["text"],
-        "hello"
+        search["tables"][0]["sql_reference"],
+        "local_messages.messages"
     );
+    assert!(
+        search["tables"][0]["matched_fields"]
+            .as_array()
+            .expect("matched fields")
+            .iter()
+            .any(|field| field == "description")
+    );
+    let search_requests = server.list_tables_requests();
+    let search_request = search_requests.last().expect("search list tables request");
+    assert_eq!(search_request.schema_name, "local_messages");
+    let search_pagination = search_request
+        .pagination
+        .as_ref()
+        .expect("search pagination");
+    assert_eq!(search_pagination.limit, 0);
+    assert_eq!(search_pagination.offset, 0);
+    assert!(search_request.omit_columns);
 
-    client.cancel().await?;
-    server.shutdown().await;
+    let guide_search = structured_tool_content(
+        client,
+        CallToolRequestParams::new("search_tables").with_arguments(json_object(&json!({
+            "pattern": "Query fixture messages",
+            "schema": "local_messages"
+        }))),
+    )
+    .await?;
+    assert_eq!(guide_search["total"], 1);
+    assert!(
+        guide_search["tables"][0]["matched_fields"]
+            .as_array()
+            .expect("matched fields")
+            .iter()
+            .any(|field| field == "guide")
+    );
+    Ok(())
+}
+
+async fn assert_sql_tool(
+    client: &RunningService<RoleClient, ()>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sql = structured_tool_content(
+        client,
+        CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+            "sql": "SELECT text FROM local_messages.messages ORDER BY text"
+        }))),
+    )
+    .await?;
+    assert_eq!(sql["rows"][0]["text"], "hello");
     Ok(())
 }
 

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -20,6 +20,8 @@ pub struct TableInfo {
     pub table_name: String,
     /// User-facing table description.
     pub description: String,
+    /// User-facing query guidance.
+    pub guide: String,
     /// Exposed columns for the table.
     pub columns: Vec<ColumnInfo>,
     /// Required filter names for the table.

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -612,6 +612,7 @@ mod tests {
             schema_name: schema.to_string(),
             table_name: name.to_string(),
             description: String::new(),
+            guide: String::new(),
             columns: vec![],
             required_filters: vec![],
         }

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -99,6 +99,7 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
                 schema_name: source.schema_name.clone(),
                 table_name: table.table_name.clone(),
                 description: table.description.clone(),
+                guide: table.guide.clone(),
                 columns: table
                     .columns
                     .iter()

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+regex.workspace = true
 rmcp.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -61,4 +61,5 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
 - `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs.
+- `search_tables` searches table names, descriptions, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the table name or required filters.
 - `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, paginated `list_tables`, and optionally `feedback`
+//! - tools: `sql`, paginated `list_tables`, `search_tables`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -2,7 +2,7 @@
 
 use coral_api::v1::{
     ExecuteSqlRequest, ListSourcesRequest, ListTablesRequest, ListTablesResponse,
-    PaginationRequest, Source, SubmitFeedbackRequest, TableSummary,
+    PaginationRequest, Source, SubmitFeedbackRequest, TableSummary as ProtoTableSummary,
 };
 use coral_client::{
     AppClient, FeedbackClient, QueryClient, SourceClient, batches_to_json_rows,
@@ -23,9 +23,10 @@ use tonic::Request;
 use crate::{
     McpOptions,
     surface::{
-        build_tool_result, feedback_tool, guide_resource, guide_resource_content,
-        initial_instructions, internal_status, list_tables_arguments, list_tables_tool,
-        list_tables_value, required_string_argument, sql_tool, status_to_error_data,
+        TableSummary, build_tool_result, compile_metadata_regex, feedback_tool, guide_resource,
+        guide_resource_content, initial_instructions, internal_status, list_tables_arguments,
+        list_tables_tool, list_tables_value, page_items, paged_value, required_string_argument,
+        search_tables_arguments, search_tables_tool, sql_tool, status_to_error_data,
         tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
     },
 };
@@ -84,7 +85,7 @@ impl CoralMcpServer {
             .into_inner())
     }
 
-    async fn load_all_table_summaries(&self) -> Result<Vec<TableSummary>, tonic::Status> {
+    async fn load_all_table_summaries(&self) -> Result<Vec<ProtoTableSummary>, tonic::Status> {
         Ok(self
             .load_tables(LoadTablesParams {
                 schema_name: None,
@@ -121,7 +122,7 @@ impl CoralMcpServer {
 
     async fn load_sources_and_table_summaries(
         &self,
-    ) -> Result<(Vec<Source>, Vec<TableSummary>), tonic::Status> {
+    ) -> Result<(Vec<Source>, Vec<ProtoTableSummary>), tonic::Status> {
         tokio::try_join!(self.load_sources(), self.load_all_table_summaries())
     }
 
@@ -197,6 +198,7 @@ impl ServerHandler for CoralMcpServer {
         let mut tools = vec![
             sql_tool(&sources, visible_table_count),
             list_tables_tool(visible_table_count),
+            search_tables_tool(visible_table_count),
         ];
         if self.options.feedback_enabled {
             tools.push(feedback_tool());
@@ -233,6 +235,40 @@ impl ServerHandler for CoralMcpServer {
                     Ok(response) => build_tool_result(list_tables_value(&response)),
                     Err(status) => Ok(tool_error_result(tool_error_from_status(
                         "Table listing",
+                        &status,
+                    ))),
+                }
+            }
+            "search_tables" => {
+                let arguments = search_tables_arguments(request.arguments.as_ref())?;
+                let regex = compile_metadata_regex(&arguments.pattern, arguments.ignore_case)?;
+                match self
+                    .load_tables(LoadTablesParams {
+                        schema_name: arguments.schema.as_deref(),
+                        pagination: PaginationRequest {
+                            limit: LIST_TABLES_UNBOUNDED_LIMIT,
+                            offset: 0,
+                        },
+                        omit_columns: true,
+                    })
+                    .await
+                {
+                    Ok(response) => {
+                        let mut matches = Vec::new();
+                        for table in &response.table_summaries {
+                            let summary = TableSummary::from_proto(table);
+                            let matched_fields = summary.matched_fields(&regex);
+                            if !matched_fields.is_empty() {
+                                matches.push(summary.search_result_value(&matched_fields));
+                            }
+                        }
+                        build_tool_result(paged_value(
+                            "tables",
+                            page_items(matches, arguments.pagination),
+                        ))
+                    }
+                    Err(status) => Ok(tool_error_result(tool_error_from_status(
+                        "Table search",
                         &status,
                     ))),
                 }

--- a/crates/coral-mcp/src/surface/discovery.rs
+++ b/crates/coral-mcp/src/surface/discovery.rs
@@ -1,0 +1,246 @@
+use coral_api::v1::TableSummary as ProtoTableSummary;
+use regex::{Regex, RegexBuilder};
+use rmcp::ErrorData;
+use serde_json::{Map, Value, json};
+
+use super::resources::format_schema_table_equivalent;
+
+const DEFAULT_LIMIT: u32 = 50;
+const MAX_LIMIT: u32 = 200;
+const MAX_METADATA_PATTERN_BYTES: usize = 256;
+const REGEX_SIZE_LIMIT_BYTES: usize = 1 << 20;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct Pagination {
+    pub(crate) limit: u32,
+    pub(crate) offset: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct Page<T> {
+    pub(crate) items: Vec<T>,
+    pub(crate) total: u32,
+    pub(crate) limit: u32,
+    pub(crate) offset: u32,
+    pub(crate) has_more: bool,
+    pub(crate) next_offset: Option<u32>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TableSummary {
+    pub(crate) schema_name: String,
+    pub(crate) table_name: String,
+    pub(crate) description: String,
+    pub(crate) guide: String,
+    pub(crate) required_filters: Vec<String>,
+}
+
+#[allow(
+    dead_code,
+    reason = "Column summaries are shared discovery scaffolding for the follow-up column tool."
+)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ColumnSummary {
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) nullable: bool,
+    pub(crate) is_virtual: bool,
+    pub(crate) is_required_filter: bool,
+    pub(crate) description: String,
+    pub(crate) ordinal_position: u32,
+}
+
+impl TableSummary {
+    pub(crate) fn from_proto(table: &ProtoTableSummary) -> Self {
+        Self {
+            schema_name: table.schema_name.clone(),
+            table_name: table.name.clone(),
+            description: table.description.clone(),
+            guide: table.guide.clone(),
+            required_filters: table.required_filters.clone(),
+        }
+    }
+
+    pub(crate) fn matched_fields(&self, regex: &Regex) -> Vec<&'static str> {
+        let name = format!("{}.{}", self.schema_name, self.table_name);
+        let candidates = [
+            ("schema_name", self.schema_name.as_str()),
+            ("table_name", self.table_name.as_str()),
+            ("name", name.as_str()),
+            ("description", self.description.as_str()),
+            ("guide", self.guide.as_str()),
+        ];
+        let mut matches = candidates
+            .into_iter()
+            .filter_map(|(field, value)| regex.is_match(value).then_some(field))
+            .collect::<Vec<_>>();
+        if self
+            .required_filters
+            .iter()
+            .any(|filter| regex.is_match(filter))
+        {
+            matches.push("required_filters");
+        }
+        matches
+    }
+
+    pub(crate) fn search_result_value(&self, matched_fields: &[&'static str]) -> Value {
+        json!({
+            "schema_name": self.schema_name,
+            "table_name": self.table_name,
+            "name": format!("{}.{}", self.schema_name, self.table_name),
+            "sql_reference": format_schema_table_equivalent(&self.schema_name, &self.table_name),
+            "description": self.description,
+            "required_filters": self.required_filters,
+            "matched_fields": matched_fields,
+        })
+    }
+}
+
+pub(crate) fn parse_pagination(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<Pagination, ErrorData> {
+    parse_pagination_with_limits(arguments, DEFAULT_LIMIT, MAX_LIMIT)
+}
+
+pub(crate) fn parse_pagination_with_limits(
+    arguments: Option<&Map<String, Value>>,
+    default_limit: u32,
+    max_limit: u32,
+) -> Result<Pagination, ErrorData> {
+    Ok(Pagination {
+        limit: optional_u32_argument(arguments, "limit", default_limit, 1, max_limit)?,
+        offset: optional_u32_argument(arguments, "offset", 0, 0, u32::MAX)?,
+    })
+}
+
+pub(crate) fn compile_metadata_regex(pattern: &str, ignore_case: bool) -> Result<Regex, ErrorData> {
+    if pattern.trim().is_empty() {
+        return Err(ErrorData::invalid_params(
+            "argument 'pattern' must not be empty",
+            None,
+        ));
+    }
+    if pattern.len() > MAX_METADATA_PATTERN_BYTES {
+        return Err(ErrorData::invalid_params(
+            format!("argument 'pattern' must be at most {MAX_METADATA_PATTERN_BYTES} bytes"),
+            None,
+        ));
+    }
+    RegexBuilder::new(pattern)
+        .case_insensitive(ignore_case)
+        .size_limit(REGEX_SIZE_LIMIT_BYTES)
+        .build()
+        .map_err(|error| ErrorData::invalid_params(format!("invalid regex pattern: {error}"), None))
+}
+
+pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
+    let total = u32::try_from(items.len()).unwrap_or(u32::MAX);
+    let offset = usize::try_from(pagination.offset).unwrap_or(usize::MAX);
+    let limit = usize::try_from(pagination.limit).unwrap_or(usize::MAX);
+    let items = items
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .collect::<Vec<_>>();
+    let returned_count = u32::try_from(items.len()).unwrap_or(u32::MAX);
+    let advanced_offset = pagination.offset.saturating_add(returned_count);
+    let has_more = advanced_offset < total;
+    Page {
+        items,
+        total,
+        limit: pagination.limit,
+        offset: pagination.offset,
+        has_more,
+        next_offset: has_more.then_some(advanced_offset),
+    }
+}
+
+pub(crate) fn paged_value(key: &str, page: Page<Value>) -> Value {
+    let Page {
+        items,
+        total,
+        limit,
+        offset,
+        has_more,
+        next_offset,
+    } = page;
+    let mut value = json!({
+        key: items,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+        "has_more": has_more,
+    });
+    if let Some(next_offset) = next_offset {
+        value["next_offset"] = json!(next_offset);
+    }
+    value
+}
+
+fn optional_u32_argument(
+    arguments: Option<&Map<String, Value>>,
+    key: &str,
+    default: u32,
+    min: u32,
+    max: u32,
+) -> Result<u32, ErrorData> {
+    let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
+        return Ok(default);
+    };
+    let value = value.as_i64().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be an integer"), None)
+    })?;
+    if value < i64::from(min) || value > i64::from(max) {
+        return Err(ErrorData::invalid_params(
+            format!("argument '{key}' must be between {min} and {max}"),
+            None,
+        ));
+    }
+    u32::try_from(value).map_err(|_| {
+        ErrorData::invalid_params(
+            format!("argument '{key}' must be between {min} and {max}"),
+            None,
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use regex::Regex;
+
+    use super::TableSummary;
+
+    fn table(required_filters: &[&str]) -> TableSummary {
+        TableSummary {
+            schema_name: "github".to_string(),
+            table_name: "Pull.Requests".to_string(),
+            description: "Pull request table".to_string(),
+            guide: "Query pull requests.".to_string(),
+            required_filters: required_filters.iter().map(ToString::to_string).collect(),
+        }
+    }
+
+    #[test]
+    fn search_result_includes_sql_reference() {
+        let value = table(&[]).search_result_value(&["table_name"]);
+
+        assert_eq!(value["name"], "github.Pull.Requests");
+        assert_eq!(value["sql_reference"], "github.\"Pull.Requests\"");
+    }
+
+    #[test]
+    fn required_filters_match_each_filter_independently() {
+        let summary = table(&["owner", "repo"]);
+
+        assert_eq!(
+            summary.matched_fields(&Regex::new("^repo$").expect("regex")),
+            vec!["required_filters"]
+        );
+        assert!(
+            summary
+                .matched_fields(&Regex::new("r.r").expect("regex"))
+                .is_empty()
+        );
+    }
+}

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -1,9 +1,14 @@
 //! Focused helpers for the Coral MCP surface.
 
+mod discovery;
 mod errors;
 mod resources;
 mod tools;
 
+pub(crate) use discovery::{
+    Pagination, TableSummary, compile_metadata_regex, page_items, paged_value, parse_pagination,
+    parse_pagination_with_limits,
+};
 pub(crate) use errors::{
     internal_status, status_to_error_data, tool_error_from_status, tool_error_result,
 };
@@ -13,5 +18,5 @@ pub(crate) use resources::{
 };
 pub(crate) use tools::{
     build_tool_result, feedback_tool, list_tables_arguments, list_tables_tool,
-    required_string_argument, sql_tool,
+    required_string_argument, search_tables_arguments, search_tables_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{ListTablesResponse, Source, Table, TableSummary};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables` to inspect queryable tables, and use `sql` against `coral.tables` and `coral.columns` for discovery.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables` and `search_tables` to inspect queryable tables, and use `sql` against `coral.tables` and `coral.columns` for deeper discovery.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {
@@ -112,6 +112,7 @@ fn queryable_tables(tables: &[TableSummary]) -> Vec<Value> {
                 "name": format!("{}.{}", table.schema_name, table.name),
                 "sql_reference": format_schema_table_equivalent(&table.schema_name, &table.name),
                 "description": table.description,
+                "guide": table.guide,
                 "required_filters": table.required_filters,
             })
         })
@@ -139,6 +140,7 @@ fn table_to_summary(table: &Table) -> TableSummary {
         name: table.name.clone(),
         description: table.description.clone(),
         required_filters: table.required_filters.clone(),
+        guide: table.guide.clone(),
     }
 }
 
@@ -151,7 +153,7 @@ fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
         .map(|table| (table.schema_name.as_str(), table.name.as_str()))
 }
 
-fn format_schema_table_equivalent(schema_name: &str, table_name: &str) -> String {
+pub(crate) fn format_schema_table_equivalent(schema_name: &str, table_name: &str) -> String {
     format!(
         "{}.{}",
         quote_identifier_if_needed(schema_name),
@@ -207,6 +209,7 @@ mod tests {
             name: name.to_string(),
             description: format!("{name} description"),
             required_filters: Vec::new(),
+            guide: format!("Query {name}."),
         }
     }
 
@@ -260,6 +263,7 @@ mod tests {
                 "name": "local_messages.events",
                 "sql_reference": "local_messages.events",
                 "description": "events description",
+                "guide": "Query events.",
                 "required_filters": [],
             })
         );

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -7,10 +7,19 @@ use rmcp::{
 };
 use serde_json::{Map, Value, json};
 
+use super::{Pagination, parse_pagination, parse_pagination_with_limits};
+
 pub(crate) struct ListTablesArguments {
     pub(crate) schema: Option<String>,
     pub(crate) limit: u32,
     pub(crate) offset: u32,
+}
+
+pub(crate) struct SearchTablesArguments {
+    pub(crate) pattern: String,
+    pub(crate) schema: Option<String>,
+    pub(crate) ignore_case: bool,
+    pub(crate) pagination: Pagination,
 }
 
 pub(crate) fn sql_tool(sources: &[Source], visible_table_count: usize) -> Tool {
@@ -74,6 +83,52 @@ pub(crate) fn list_tables_tool(visible_table_count: usize) -> Tool {
     )
 }
 
+pub(crate) fn search_tables_tool(visible_table_count: usize) -> Tool {
+    Tool::new(
+        "search_tables",
+        search_tables_description(visible_table_count),
+        json_object_schema(&json!({
+            "type": "object",
+            "required": ["pattern"],
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Rust regex pattern to match table metadata."
+                },
+                "schema": {
+                    "type": "string",
+                    "description": "Optional exact schema/source name to search."
+                },
+                "ignore_case": {
+                    "type": "boolean",
+                    "description": "Whether regex matching is case-insensitive. Defaults to true."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum tables to return, from 1 to 100. Defaults to 20.",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 20
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of matching tables to skip. Defaults to 0.",
+                    "minimum": 0,
+                    "maximum": u32::MAX,
+                    "default": 0
+                }
+            }
+        })),
+    )
+    .with_annotations(
+        ToolAnnotations::with_title("Search Tables")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false),
+    )
+}
+
 pub(crate) fn feedback_tool() -> Tool {
     Tool::new(
         "feedback",
@@ -124,10 +179,22 @@ pub(crate) fn required_string_argument(
 pub(crate) fn list_tables_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<ListTablesArguments, ErrorData> {
+    let pagination = parse_pagination(arguments)?;
     Ok(ListTablesArguments {
         schema: optional_string_argument(arguments, "schema")?,
-        limit: optional_u32_argument(arguments, "limit", 50, 1, 200)?,
-        offset: optional_u32_argument(arguments, "offset", 0, 0, u32::MAX)?,
+        limit: pagination.limit,
+        offset: pagination.offset,
+    })
+}
+
+pub(crate) fn search_tables_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<SearchTablesArguments, ErrorData> {
+    Ok(SearchTablesArguments {
+        pattern: required_string_argument(arguments, "pattern")?,
+        schema: optional_string_argument(arguments, "schema")?,
+        ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
+        pagination: parse_pagination_with_limits(arguments, 20, 100)?,
     })
 }
 
@@ -158,7 +225,13 @@ fn list_tables_description(visible_table_count: usize) -> String {
     )
 }
 
-fn optional_string_argument(
+fn search_tables_description(visible_table_count: usize) -> String {
+    format!(
+        "Search queryable table metadata with a Rust regex. {visible_table_count} table(s) are currently visible."
+    )
+}
+
+pub(crate) fn optional_string_argument(
     arguments: Option<&Map<String, Value>>,
     key: &str,
 ) -> Result<Option<String>, ErrorData> {
@@ -176,30 +249,16 @@ fn optional_string_argument(
     }
 }
 
-fn optional_u32_argument(
+fn optional_bool_argument(
     arguments: Option<&Map<String, Value>>,
     key: &str,
-    default: u32,
-    min: u32,
-    max: u32,
-) -> Result<u32, ErrorData> {
+    default: bool,
+) -> Result<bool, ErrorData> {
     let Some(value) = arguments.and_then(|arguments| arguments.get(key)) else {
         return Ok(default);
     };
-    let value = value.as_i64().ok_or_else(|| {
-        ErrorData::invalid_params(format!("argument '{key}' must be an integer"), None)
-    })?;
-    if value < i64::from(min) || value > i64::from(max) {
-        return Err(ErrorData::invalid_params(
-            format!("argument '{key}' must be between {min} and {max}"),
-            None,
-        ));
-    }
-    u32::try_from(value).map_err(|_| {
-        ErrorData::invalid_params(
-            format!("argument '{key}' must be between {min} and {max}"),
-            None,
-        )
+    value.as_bool().ok_or_else(|| {
+        ErrorData::invalid_params(format!("argument '{key}' must be a boolean"), None)
     })
 }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -181,7 +181,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables"]
+        vec!["sql", "list_tables", "search_tables"]
     );
     assert!(
         initial_tools[0]
@@ -234,6 +234,13 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .description
             .as_deref()
             .expect("tables description")
+            .contains("3 table(s) are currently visible")
+    );
+    assert!(
+        updated_tools[2]
+            .description
+            .as_deref()
+            .expect("table search description")
             .contains("3 table(s) are currently visible")
     );
 
@@ -342,6 +349,56 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .await
         .expect_err("limit zero should be invalid");
 
+    let search = client
+        .call_tool(
+            CallToolRequestParams::new("search_tables").with_arguments(json_object(&json!({
+                "pattern": "^MESSAGES$",
+                "schema": "local_messages",
+                "ignore_case": true
+            }))),
+        )
+        .await
+        .expect("search tables");
+    let search = search.structured_content.expect("structured content");
+    assert_eq!(search["total"], 1);
+    assert_eq!(search["tables"][0]["name"], "local_messages.messages");
+    assert_eq!(
+        search["tables"][0]["sql_reference"],
+        "local_messages.messages"
+    );
+    assert!(
+        search["tables"][0]["matched_fields"]
+            .as_array()
+            .expect("matched fields")
+            .iter()
+            .any(|field| field == "table_name")
+    );
+
+    let search_page = client
+        .call_tool(
+            CallToolRequestParams::new("search_tables").with_arguments(json_object(&json!({
+                "pattern": "Fixture",
+                "schema": "local_messages",
+                "limit": 2
+            }))),
+        )
+        .await
+        .expect("search table page");
+    let search_page = search_page.structured_content.expect("structured content");
+    assert_eq!(search_page["total"], 3);
+    assert_eq!(search_page["limit"], 2);
+    assert_eq!(search_page["has_more"], true);
+    assert_eq!(search_page["next_offset"], 2);
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("search_tables").with_arguments(json_object(&json!({
+                "pattern": "["
+            }))),
+        )
+        .await
+        .expect_err("invalid regex should fail");
+
     session.shutdown().await;
 }
 
@@ -363,9 +420,9 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables", "feedback"]
+        vec!["sql", "list_tables", "search_tables", "feedback"]
     );
-    let feedback_annotations = tools[2].annotations.as_ref().expect("feedback annotations");
+    let feedback_annotations = tools[3].annotations.as_ref().expect("feedback annotations");
     assert_eq!(feedback_annotations.read_only_hint, Some(false));
     assert_eq!(feedback_annotations.destructive_hint, Some(false));
     assert_eq!(feedback_annotations.idempotent_hint, Some(false));

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -16,12 +16,14 @@ Before setting up a client, make sure you have [connected at least one source](/
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
 | Tool     | `list_tables`    | List queryable fully qualified tables with pagination   |
+| Tool     | `search_tables`  | Search table metadata with a Rust regex                 |
 | Tool     | `feedback`       | Store a local blocked-agent feedback report when enabled |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
 `list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. Use each table's `sql_reference` value in `FROM` and `JOIN` clauses. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+`search_tables` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table names, descriptions, guides, and required filters.
 For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
 Start Coral as `coral mcp-stdio --enable-feedback` to expose the optional `feedback` tool. Agents can call `feedback` when they get blocked or repeat a pattern that is not working. Coral stores the report locally with what the agent was trying to do, what it tried, and where it got stuck.
 
@@ -191,7 +193,7 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_tables` or query `coral.tables` and return the schemas from your installed sources. Large catalogs should be paged with `limit` and `offset`.
+The agent should call `list_tables`, `search_tables`, or query `coral.tables` and return the schemas from your installed sources. Large catalogs should be paged with `limit` and `offset`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Draft stacked on #265.

## Summary
- Adds shared MCP discovery helpers for pagination, regex compilation, SQL string literals, and table-summary shaping.
- Adds `search_tables` over `coral.tables` with optional schema narrowing, regex matching, `matched_fields`, and pagination.
- Updates MCP guide/docs and MCP stdio test coverage.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --test mcp --features cli-test-server`
- `cargo build`
- Compiled local app smoke with connected sources: `github` had 369 visible tables, and MCP `search_tables {"pattern":"^pulls$","schema":"github"}` returned `total: 1`, `limit: 20`, `github.pulls`, `matched_fields: ["table_name"]`.