### PR TITLE
feat(mcp): add describe_table discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1111,6 +1111,7 @@ dependencies = [
  "coral-api",
  "coral-app",
  "coral-client",
+ "jsonschema",
  "regex",
  "rmcp",
  "serde_json",

--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -53,6 +53,8 @@ message ListTablesRequest {
   PaginationRequest pagination = 3;
   // Whether table columns should be omitted from the response.
   bool omit_columns = 4;
+  // Optional exact table name within `schema_name`.
+  string table_name = 5;
 }
 
 // Returns the query-visible tables in one workspace.

--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -53,7 +53,7 @@ message ListTablesRequest {
   PaginationRequest pagination = 3;
   // Whether table columns should be omitted from the response.
   bool omit_columns = 4;
-  // Optional exact table name within `schema_name`.
+  // Optional exact table name. If set without `schema_name`, matches across all schemas.
   string table_name = 5;
 }
 

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -62,12 +62,13 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
         schema_filter: Option<&str>,
+        table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
         let sources = self
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_config(&sources);
-        CoralQuery::list_tables(&sources, runtime, schema_filter)
+        CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
             .await
             .map_err(QueryManagerError::Core)
     }

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -48,8 +48,14 @@ impl QueryServiceApi for QueryService {
             } else {
                 Some(schema_name)
             };
+            let table_name = request.table_name.trim();
+            let table_name = if table_name.is_empty() {
+                None
+            } else {
+                Some(table_name)
+            };
             let tables = queries
-                .list_tables(&workspace_name, schema_name)
+                .list_tables(&workspace_name, schema_name, table_name)
                 .await
                 .map_err(query_status)?;
             let total = tables.len();

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -107,6 +107,7 @@ impl GrpcHarness {
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
                 schema_name: String::new(),
+                table_name: String::new(),
                 pagination: None,
                 omit_columns: false,
             }))

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -230,6 +230,7 @@ async fn list_tables_supports_legacy_full_response_and_paginated_summaries() {
         .list_tables(Request::new(ListTablesRequest {
             workspace: Some(default_workspace()),
             schema_name: String::new(),
+            table_name: String::new(),
             pagination: None,
             omit_columns: false,
         }))
@@ -251,6 +252,7 @@ async fn list_tables_supports_legacy_full_response_and_paginated_summaries() {
         .list_tables(Request::new(ListTablesRequest {
             workspace: Some(default_workspace()),
             schema_name: "local_messages".to_string(),
+            table_name: String::new(),
             pagination: Some(PaginationRequest {
                 limit: 2,
                 offset: 0,
@@ -275,11 +277,14 @@ async fn list_tables_supports_legacy_full_response_and_paginated_summaries() {
     );
     assert!(page.tables.is_empty());
 
+    assert_exact_table_filter(&harness).await;
+
     let unknown_schema = harness
         .query_client()
         .list_tables(Request::new(ListTablesRequest {
             workspace: Some(default_workspace()),
             schema_name: "missing".to_string(),
+            table_name: String::new(),
             pagination: Some(PaginationRequest {
                 limit: 2,
                 offset: 0,
@@ -297,6 +302,33 @@ async fn list_tables_supports_legacy_full_response_and_paginated_summaries() {
     assert!(unknown_schema.tables.is_empty());
     assert!(unknown_schema.table_summaries.is_empty());
     assert!(!unknown_schema_pagination.has_more);
+}
+
+async fn assert_exact_table_filter(harness: &GrpcHarness) {
+    let exact_table = harness
+        .query_client()
+        .list_tables(Request::new(ListTablesRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "local_messages".to_string(),
+            table_name: "messages".to_string(),
+            pagination: Some(PaginationRequest {
+                limit: 1,
+                offset: 0,
+            }),
+            omit_columns: false,
+        }))
+        .await
+        .expect("exact table list tables")
+        .into_inner();
+    let exact_pagination = exact_table
+        .pagination
+        .as_ref()
+        .expect("exact table pagination");
+    assert_eq!(exact_pagination.total_count, 1);
+    assert_eq!(exact_table.tables.len(), 1);
+    assert_eq!(exact_table.tables[0].schema_name, "local_messages");
+    assert_eq!(exact_table.tables[0].name, "messages");
+    assert!(!exact_table.tables[0].columns.is_empty());
 }
 
 #[tokio::test]
@@ -1271,6 +1303,7 @@ async fn rejects_invalid_workspace_and_source_names() {
                 name: r"bad\workspace".to_string(),
             }),
             schema_name: String::new(),
+            table_name: String::new(),
             pagination: None,
             omit_columns: false,
         }))

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -111,10 +111,6 @@ fn table_summary(table: &Table) -> TableSummary {
 }
 
 fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
-    if sql.contains("COUNT(*) AS column_count") && sql.contains("FROM coral.columns") {
-        return mock_column_count_response(3);
-    }
-
     if sql.contains("FROM coral.tables") {
         return mock_coral_tables_response();
     }
@@ -140,20 +136,6 @@ fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
     ExecuteSqlResponse {
         arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
         row_count,
-    }
-}
-
-fn mock_column_count_response(count: i64) -> ExecuteSqlResponse {
-    let schema = Schema::new(vec![Field::new("column_count", DataType::Int64, false)]);
-    let batch = RecordBatch::try_new(
-        Arc::new(schema.clone()),
-        vec![Arc::new(Int64Array::from(vec![count]))],
-    )
-    .expect("build column count batch");
-
-    ExecuteSqlResponse {
-        arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
-        row_count: 1,
     }
 }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -106,6 +106,10 @@ fn table_summary(table: &Table) -> TableSummary {
 }
 
 fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
+    if sql.contains("COUNT(*) AS column_count") && sql.contains("FROM coral.columns") {
+        return mock_column_count_response(3);
+    }
+
     if sql.contains("FROM coral.tables") {
         return mock_coral_tables_response();
     }
@@ -131,6 +135,20 @@ fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
     ExecuteSqlResponse {
         arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
         row_count,
+    }
+}
+
+fn mock_column_count_response(count: i64) -> ExecuteSqlResponse {
+    let schema = Schema::new(vec![Field::new("column_count", DataType::Int64, false)]);
+    let batch = RecordBatch::try_new(
+        Arc::new(schema.clone()),
+        vec![Arc::new(Int64Array::from(vec![count]))],
+    )
+    .expect("build column count batch");
+
+    ExecuteSqlResponse {
+        arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
+        row_count: 1,
     }
 }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -72,6 +72,11 @@ fn mock_visible_table() -> Table {
                 nullable: false,
             },
             Column {
+                name: "sessionId".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: false,
+            },
+            Column {
                 name: "text".to_string(),
                 data_type: "Utf8".to_string(),
                 nullable: false,
@@ -439,6 +444,7 @@ impl QueryService for MockQueryService {
             .filter(|table| {
                 request.schema_name.is_empty() || table.schema_name == request.schema_name
             })
+            .filter(|table| request.table_name.is_empty() || table.name == request.table_name)
             .collect::<Vec<_>>();
         let total = u32::try_from(tables.len()).unwrap_or(u32::MAX);
         let pagination = request.pagination.unwrap_or_default();

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -157,7 +157,7 @@ async fn mcp_stdio_sql_and_list_tables_return_structured_content()
 
     assert_list_tables_tool(&client, &server).await?;
     assert_search_tables_tool(&client, &server).await?;
-    assert_describe_table_tool(&client).await?;
+    assert_describe_table_tool(&client, &server).await?;
     assert_sql_tool(&client).await?;
 
     client.cancel().await?;
@@ -261,7 +261,10 @@ async fn assert_search_tables_tool(
 
 async fn assert_describe_table_tool(
     client: &RunningService<RoleClient, ()>,
+    server: &MockServer,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let list_tables_before = server.list_tables_requests().len();
+    let execute_sql_before = server.execute_sql_requests().len();
     let described = structured_tool_content(
         client,
         CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
@@ -273,6 +276,20 @@ async fn assert_describe_table_tool(
     assert_eq!(described["found"], true);
     assert_eq!(described["name"], "local_messages.messages");
     assert_eq!(described["column_count"], 3);
+
+    let list_tables_requests = server.list_tables_requests();
+    assert_eq!(list_tables_requests.len(), list_tables_before + 1);
+    let describe_request = &list_tables_requests[list_tables_before];
+    assert_eq!(describe_request.schema_name, "local_messages");
+    assert_eq!(describe_request.table_name, "messages");
+    let pagination = describe_request
+        .pagination
+        .as_ref()
+        .expect("describe table pagination");
+    assert_eq!(pagination.limit, 1);
+    assert_eq!(pagination.offset, 0);
+    assert!(!describe_request.omit_columns);
+    assert_eq!(server.execute_sql_requests().len(), execute_sql_before);
     Ok(())
 }
 

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -70,7 +70,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables", "search_tables"]
+        vec!["sql", "list_tables", "search_tables", "describe_table"]
     );
     assert!(
         tools[0]
@@ -135,7 +135,13 @@ async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn s
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables", "search_tables", "feedback"]
+        vec![
+            "sql",
+            "list_tables",
+            "search_tables",
+            "describe_table",
+            "feedback"
+        ]
     );
 
     client.cancel().await?;
@@ -151,6 +157,7 @@ async fn mcp_stdio_sql_and_list_tables_return_structured_content()
 
     assert_list_tables_tool(&client, &server).await?;
     assert_search_tables_tool(&client, &server).await?;
+    assert_describe_table_tool(&client).await?;
     assert_sql_tool(&client).await?;
 
     client.cancel().await?;
@@ -249,6 +256,23 @@ async fn assert_search_tables_tool(
             .iter()
             .any(|field| field == "guide")
     );
+    Ok(())
+}
+
+async fn assert_describe_table_tool(
+    client: &RunningService<RoleClient, ()>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let described = structured_tool_content(
+        client,
+        CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
+            "schema": "local_messages",
+            "table": "messages"
+        }))),
+    )
+    .await?;
+    assert_eq!(described["found"], true);
+    assert_eq!(described["name"], "local_messages.messages");
+    assert_eq!(described["column_count"], 3);
     Ok(())
 }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -41,7 +41,7 @@
 //! # async fn demo(
 //! #     sources: &[QuerySource],
 //! # ) -> Result<(), Box<dyn std::error::Error>> {
-//! let _ = CoralQuery::list_tables(sources, QueryRuntimeConfig::default(), None).await?;
+//! let _ = CoralQuery::list_tables(sources, QueryRuntimeConfig::default(), None, None).await?;
 //! # Ok(())
 //! # }
 //! # Ok(())
@@ -89,10 +89,11 @@ impl CoralQuery {
         sources: &[QuerySource],
         runtime: QueryRuntimeConfig,
         schema_filter: Option<&str>,
+        table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, CoreError> {
         Ok(runtime::query::build_runtime(sources, runtime)
             .await?
-            .list_tables(schema_filter))
+            .list_tables(schema_filter, table_filter))
     }
 
     /// Executes one `SQL` statement over the provided source set.
@@ -143,7 +144,7 @@ impl CoralQuery {
     ) -> Result<SourceValidationReport, CoreError> {
         let query_runtime =
             runtime::query::build_runtime(std::slice::from_ref(source), runtime).await?;
-        let tables = query_runtime.list_tables(Some(source.source_name()));
+        let tables = query_runtime.list_tables(Some(source.source_name()), None);
         if tables.is_empty() {
             if let Some(failure) = query_runtime.registration_failure(source.source_name()) {
                 return Err(CoreError::FailedPrecondition(failure.detail.clone()));

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -110,10 +110,15 @@ pub(crate) async fn build_runtime(
 }
 
 impl QueryRuntimeAdapter {
-    pub(crate) fn list_tables(&self, source_filter: Option<&str>) -> Vec<TableInfo> {
+    pub(crate) fn list_tables(
+        &self,
+        source_filter: Option<&str>,
+        table_filter: Option<&str>,
+    ) -> Vec<TableInfo> {
         self.tables
             .iter()
             .filter(|table| source_filter.is_none_or(|value| table.schema_name == value))
+            .filter(|table| table_filter.is_none_or(|value| table.table_name == value))
             .cloned()
             .collect()
     }

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -159,7 +159,7 @@ async fn coral_columns_default_row_order_matches_ordinal_position() {
 async fn list_tables_matches_catalog() {
     let (_temp, sources) = build_catalog_sources();
 
-    let listed = CoralQuery::list_tables(&sources, test_runtime(), None)
+    let listed = CoralQuery::list_tables(&sources, test_runtime(), None, None)
         .await
         .expect("list_tables should succeed");
     let catalog_rows = execution_to_rows(
@@ -192,7 +192,7 @@ async fn list_tables_matches_catalog() {
 
 #[tokio::test]
 async fn list_tables_empty_when_no_sources() {
-    let tables = CoralQuery::list_tables(&[], test_runtime(), None)
+    let tables = CoralQuery::list_tables(&[], test_runtime(), None, None)
         .await
         .expect("empty source list should succeed");
 

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -22,5 +22,6 @@ coral-client.workspace = true
 
 [dev-dependencies]
 coral-app.workspace = true
+jsonschema.workspace = true
 tempfile.workspace = true
 tonic-types.workspace = true

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -62,4 +62,5 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
 - `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs.
 - `search_tables` searches table names, descriptions, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the table name or required filters.
+- `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
 - `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, paginated `list_tables`, `search_tables`, and optionally `feedback`
+//! - tools: `sql`, paginated `list_tables`, `search_tables`, `describe_table`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -303,12 +303,17 @@ fn describe_missing_table_value(schema: &str, table: &str, summaries: &[TableSum
         .take(10)
         .map(TableSummary::summary_value)
         .collect::<Vec<_>>();
-    let mut search_arguments = serde_json::json!({
-        "pattern": regex::escape(table),
-    });
-    if !same_schema_tables.is_empty() {
-        search_arguments["schema"] = serde_json::json!(schema);
-    }
+    let escaped_table = regex::escape(table);
+    let search_arguments = if same_schema_tables.is_empty() {
+        serde_json::json!({
+            "pattern": escaped_table,
+        })
+    } else {
+        serde_json::json!({
+            "pattern": escaped_table,
+            "schema": schema,
+        })
+    };
     let mut suggested_calls = vec![serde_json::json!({
         "tool": "search_tables",
         "arguments": search_arguments,

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -277,7 +277,6 @@ fn table_summaries_from_proto(tables: &[ProtoTableSummary]) -> Vec<TableSummary>
 }
 
 fn describe_found_table_value(table: &ProtoTable) -> Value {
-    let column_count = u32::try_from(table.columns.len()).unwrap_or(u32::MAX);
     serde_json::json!({
         "found": true,
         "schema_name": table.schema_name,
@@ -286,7 +285,7 @@ fn describe_found_table_value(table: &ProtoTable) -> Value {
         "description": table.description,
         "guide": table.guide,
         "required_filters": table.required_filters,
-        "column_count": column_count,
+        "column_count": table.columns.len(),
         "columns_hint": "Query coral.columns for this schema/table ordered by ordinal_position to inspect columns.",
     })
 }

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -1,8 +1,11 @@
 //! RMCP server implementation for Coral's stdio MCP surface.
 
+use std::collections::BTreeSet;
+
 use coral_api::v1::{
     ExecuteSqlRequest, ListSourcesRequest, ListTablesRequest, ListTablesResponse,
-    PaginationRequest, Source, SubmitFeedbackRequest, TableSummary as ProtoTableSummary,
+    PaginationRequest, Source, SubmitFeedbackRequest, Table as ProtoTable,
+    TableSummary as ProtoTableSummary,
 };
 use coral_client::{
     AppClient, FeedbackClient, QueryClient, SourceClient, batches_to_json_rows,
@@ -17,15 +20,16 @@ use rmcp::{
     },
     service::{RequestContext, RoleServer},
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
 use tonic::Request;
 
 use crate::{
     McpOptions,
     surface::{
-        TableSummary, build_tool_result, compile_metadata_regex, feedback_tool, guide_resource,
-        guide_resource_content, initial_instructions, internal_status, list_tables_arguments,
-        list_tables_tool, list_tables_value, page_items, paged_value, required_string_argument,
+        TableSummary, build_tool_result, compile_metadata_regex, describe_table_arguments,
+        describe_table_tool, feedback_tool, guide_resource, guide_resource_content,
+        initial_instructions, internal_status, list_tables_arguments, list_tables_tool,
+        list_tables_value, page_items, paged_value, required_string_argument,
         search_tables_arguments, search_tables_tool, sql_tool, status_to_error_data,
         tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
     },
@@ -36,6 +40,7 @@ const LIST_TABLES_UNBOUNDED_LIMIT: u32 = 0;
 
 struct LoadTablesParams<'a> {
     schema_name: Option<&'a str>,
+    table_name: Option<&'a str>,
     pagination: PaginationRequest,
     omit_columns: bool,
 }
@@ -78,6 +83,7 @@ impl CoralMcpServer {
             .list_tables(Request::new(ListTablesRequest {
                 workspace: Some(default_workspace()),
                 schema_name: params.schema_name.unwrap_or_default().to_string(),
+                table_name: params.table_name.unwrap_or_default().to_string(),
                 pagination: Some(params.pagination),
                 omit_columns: params.omit_columns,
             }))
@@ -86,9 +92,17 @@ impl CoralMcpServer {
     }
 
     async fn load_all_table_summaries(&self) -> Result<Vec<ProtoTableSummary>, tonic::Status> {
+        self.load_table_summaries(None).await
+    }
+
+    async fn load_table_summaries(
+        &self,
+        schema_name: Option<&str>,
+    ) -> Result<Vec<ProtoTableSummary>, tonic::Status> {
         Ok(self
             .load_tables(LoadTablesParams {
-                schema_name: None,
+                schema_name,
+                table_name: None,
                 pagination: PaginationRequest {
                     limit: LIST_TABLES_UNBOUNDED_LIMIT,
                     offset: 0,
@@ -99,9 +113,31 @@ impl CoralMcpServer {
             .table_summaries)
     }
 
+    async fn load_exact_table(
+        &self,
+        schema_name: &str,
+        table_name: &str,
+    ) -> Result<Option<ProtoTable>, tonic::Status> {
+        Ok(self
+            .load_tables(LoadTablesParams {
+                schema_name: Some(schema_name),
+                table_name: Some(table_name),
+                pagination: PaginationRequest {
+                    limit: LIST_TABLES_COUNT_LIMIT,
+                    offset: 0,
+                },
+                omit_columns: false,
+            })
+            .await?
+            .tables
+            .into_iter()
+            .find(|table| table.schema_name == schema_name && table.name == table_name))
+    }
+
     async fn load_table_count(&self) -> Result<usize, tonic::Status> {
         self.load_tables(LoadTablesParams {
             schema_name: None,
+            table_name: None,
             pagination: PaginationRequest {
                 limit: LIST_TABLES_COUNT_LIMIT,
                 offset: 0,
@@ -172,6 +208,131 @@ impl CoralMcpServer {
             "message": "Feedback report stored.",
         }))
     }
+
+    async fn search_tables_tool_result(
+        &self,
+        request_arguments: Option<&Map<String, Value>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let arguments = search_tables_arguments(request_arguments)?;
+        let regex = compile_metadata_regex(&arguments.pattern, arguments.ignore_case)?;
+        match self.load_table_summaries(arguments.schema.as_deref()).await {
+            Ok(tables) => {
+                let mut matches = Vec::new();
+                for table in &tables {
+                    let summary = TableSummary::from_proto(table);
+                    let matched_fields = summary.matched_fields(&regex);
+                    if !matched_fields.is_empty() {
+                        matches.push(summary.search_result_value(&matched_fields));
+                    }
+                }
+                build_tool_result(paged_value(
+                    "tables",
+                    page_items(matches, arguments.pagination),
+                ))
+            }
+            Err(status) => Ok(tool_error_result(tool_error_from_status(
+                "Table search",
+                &status,
+            ))),
+        }
+    }
+
+    async fn describe_table_tool_result(
+        &self,
+        request_arguments: Option<&Map<String, Value>>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let arguments = describe_table_arguments(request_arguments)?;
+        match self
+            .load_exact_table(&arguments.schema, &arguments.table)
+            .await
+        {
+            Ok(Some(table)) => build_tool_result(describe_found_table_value(&table)),
+            Ok(None) => {
+                let all_tables = match self.load_all_table_summaries().await {
+                    Ok(tables) => tables,
+                    Err(status) => {
+                        return Ok(tool_error_result(tool_error_from_status(
+                            "Table description",
+                            &status,
+                        )));
+                    }
+                };
+                let all_summaries = table_summaries_from_proto(&all_tables);
+                build_tool_result(describe_missing_table_value(
+                    &arguments.schema,
+                    &arguments.table,
+                    &all_summaries,
+                ))
+            }
+            Err(status) => Ok(tool_error_result(tool_error_from_status(
+                "Table description",
+                &status,
+            ))),
+        }
+    }
+}
+
+fn table_summaries_from_proto(tables: &[ProtoTableSummary]) -> Vec<TableSummary> {
+    tables.iter().map(TableSummary::from_proto).collect()
+}
+
+fn describe_found_table_value(table: &ProtoTable) -> Value {
+    let column_count = u32::try_from(table.columns.len()).unwrap_or(u32::MAX);
+    serde_json::json!({
+        "found": true,
+        "schema_name": table.schema_name,
+        "table_name": table.name,
+        "name": format!("{}.{}", table.schema_name, table.name),
+        "description": table.description,
+        "guide": table.guide,
+        "required_filters": table.required_filters,
+        "column_count": column_count,
+        "columns_hint": "Query coral.columns for this schema/table ordered by ordinal_position to inspect columns.",
+    })
+}
+
+fn describe_missing_table_value(schema: &str, table: &str, summaries: &[TableSummary]) -> Value {
+    let available_schemas = summaries
+        .iter()
+        .map(|summary| summary.schema_name.as_str())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    let same_schema_tables = summaries
+        .iter()
+        .filter(|summary| summary.schema_name == schema)
+        .take(10)
+        .map(TableSummary::summary_value)
+        .collect::<Vec<_>>();
+    let mut search_arguments = serde_json::json!({
+        "pattern": regex::escape(table),
+    });
+    if !same_schema_tables.is_empty() {
+        search_arguments["schema"] = serde_json::json!(schema);
+    }
+    let mut suggested_calls = vec![serde_json::json!({
+        "tool": "search_tables",
+        "arguments": search_arguments,
+    })];
+    if !same_schema_tables.is_empty() {
+        suggested_calls.push(serde_json::json!({
+            "tool": "list_tables",
+            "arguments": {
+                "schema": schema,
+                "limit": 10,
+            }
+        }));
+    }
+    serde_json::json!({
+        "found": false,
+        "requested": {
+            "schema": schema,
+            "table": table,
+        },
+        "available_schemas": available_schemas,
+        "same_schema_tables": same_schema_tables,
+        "suggested_calls": suggested_calls,
+    })
 }
 
 impl ServerHandler for CoralMcpServer {
@@ -199,6 +360,7 @@ impl ServerHandler for CoralMcpServer {
             sql_tool(&sources, visible_table_count),
             list_tables_tool(visible_table_count),
             search_tables_tool(visible_table_count),
+            describe_table_tool(),
         ];
         if self.options.feedback_enabled {
             tools.push(feedback_tool());
@@ -224,6 +386,7 @@ impl ServerHandler for CoralMcpServer {
                 match self
                     .load_tables(LoadTablesParams {
                         schema_name: arguments.schema.as_deref(),
+                        table_name: None,
                         pagination: PaginationRequest {
                             limit: arguments.limit,
                             offset: arguments.offset,
@@ -240,38 +403,12 @@ impl ServerHandler for CoralMcpServer {
                 }
             }
             "search_tables" => {
-                let arguments = search_tables_arguments(request.arguments.as_ref())?;
-                let regex = compile_metadata_regex(&arguments.pattern, arguments.ignore_case)?;
-                match self
-                    .load_tables(LoadTablesParams {
-                        schema_name: arguments.schema.as_deref(),
-                        pagination: PaginationRequest {
-                            limit: LIST_TABLES_UNBOUNDED_LIMIT,
-                            offset: 0,
-                        },
-                        omit_columns: true,
-                    })
+                self.search_tables_tool_result(request.arguments.as_ref())
                     .await
-                {
-                    Ok(response) => {
-                        let mut matches = Vec::new();
-                        for table in &response.table_summaries {
-                            let summary = TableSummary::from_proto(table);
-                            let matched_fields = summary.matched_fields(&regex);
-                            if !matched_fields.is_empty() {
-                                matches.push(summary.search_result_value(&matched_fields));
-                            }
-                        }
-                        build_tool_result(paged_value(
-                            "tables",
-                            page_items(matches, arguments.pagination),
-                        ))
-                    }
-                    Err(status) => Ok(tool_error_result(tool_error_from_status(
-                        "Table search",
-                        &status,
-                    ))),
-                }
+            }
+            "describe_table" => {
+                self.describe_table_tool_result(request.arguments.as_ref())
+                    .await
             }
             "feedback" if self.options.feedback_enabled => {
                 let trying_to_do =

--- a/crates/coral-mcp/src/surface/discovery.rs
+++ b/crates/coral-mcp/src/surface/discovery.rs
@@ -95,6 +95,16 @@ impl TableSummary {
             "matched_fields": matched_fields,
         })
     }
+
+    pub(crate) fn summary_value(&self) -> Value {
+        json!({
+            "schema_name": self.schema_name,
+            "table_name": self.table_name,
+            "name": format!("{}.{}", self.schema_name, self.table_name),
+            "description": self.description,
+            "required_filters": self.required_filters,
+        })
+    }
 }
 
 pub(crate) fn parse_pagination(

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use resources::{
     tables_resource, tables_resource_content,
 };
 pub(crate) use tools::{
-    build_tool_result, feedback_tool, list_tables_arguments, list_tables_tool,
-    required_string_argument, search_tables_arguments, search_tables_tool, sql_tool,
+    build_tool_result, describe_table_arguments, describe_table_tool, feedback_tool,
+    list_tables_arguments, list_tables_tool, required_string_argument, search_tables_arguments,
+    search_tables_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{ListTablesResponse, Source, Table, TableSummary};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables` and `search_tables` to inspect queryable tables, and use `sql` against `coral.tables` and `coral.columns` for deeper discovery.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables`, `search_tables`, and `describe_table` to inspect queryable tables, and use `sql` against `coral.tables` and `coral.columns` for deeper discovery.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -276,7 +276,7 @@ fn search_tables_description(visible_table_count: usize) -> String {
 }
 
 fn list_tables_output_schema() -> Arc<Map<String, Value>> {
-    paginated_table_output_schema(json!({
+    paginated_table_output_schema(&json!({
         "type": "object",
         "required": [
             "schema_name",
@@ -304,7 +304,7 @@ fn list_tables_output_schema() -> Arc<Map<String, Value>> {
 }
 
 fn search_tables_output_schema() -> Arc<Map<String, Value>> {
-    paginated_table_output_schema(json!({
+    paginated_table_output_schema(&json!({
         "type": "object",
         "required": [
             "schema_name",
@@ -344,7 +344,7 @@ fn search_tables_output_schema() -> Arc<Map<String, Value>> {
     }))
 }
 
-fn paginated_table_output_schema(table_item_schema: Value) -> Arc<Map<String, Value>> {
+fn paginated_table_output_schema(table_item_schema: &Value) -> Arc<Map<String, Value>> {
     json_object_schema(&json!({
         "type": "object",
         "required": ["tables", "total", "limit", "offset", "has_more"],

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -79,6 +79,7 @@ pub(crate) fn list_tables_tool(visible_table_count: usize) -> Tool {
             }
         })),
     )
+    .with_raw_output_schema(list_tables_output_schema())
     .with_annotations(
         ToolAnnotations::with_title("List Tables")
             .read_only(true)
@@ -125,6 +126,7 @@ pub(crate) fn search_tables_tool(visible_table_count: usize) -> Tool {
             }
         })),
     )
+    .with_raw_output_schema(search_tables_output_schema())
     .with_annotations(
         ToolAnnotations::with_title("Search Tables")
             .read_only(true)
@@ -271,6 +273,106 @@ fn search_tables_description(visible_table_count: usize) -> String {
     format!(
         "Search queryable table metadata with a Rust regex. {visible_table_count} table(s) are currently visible."
     )
+}
+
+fn list_tables_output_schema() -> Arc<Map<String, Value>> {
+    paginated_table_output_schema(json!({
+        "type": "object",
+        "required": [
+            "schema_name",
+            "table_name",
+            "name",
+            "sql_reference",
+            "description",
+            "guide",
+            "required_filters"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "schema_name": { "type": "string" },
+            "table_name": { "type": "string" },
+            "name": { "type": "string" },
+            "sql_reference": { "type": "string" },
+            "description": { "type": "string" },
+            "guide": { "type": "string" },
+            "required_filters": {
+                "type": "array",
+                "items": { "type": "string" }
+            }
+        }
+    }))
+}
+
+fn search_tables_output_schema() -> Arc<Map<String, Value>> {
+    paginated_table_output_schema(json!({
+        "type": "object",
+        "required": [
+            "schema_name",
+            "table_name",
+            "name",
+            "sql_reference",
+            "description",
+            "required_filters",
+            "matched_fields"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "schema_name": { "type": "string" },
+            "table_name": { "type": "string" },
+            "name": { "type": "string" },
+            "sql_reference": { "type": "string" },
+            "description": { "type": "string" },
+            "required_filters": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "matched_fields": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "schema_name",
+                        "table_name",
+                        "name",
+                        "description",
+                        "guide",
+                        "required_filters"
+                    ]
+                }
+            }
+        }
+    }))
+}
+
+fn paginated_table_output_schema(table_item_schema: Value) -> Arc<Map<String, Value>> {
+    json_object_schema(&json!({
+        "type": "object",
+        "required": ["tables", "total", "limit", "offset", "has_more"],
+        "additionalProperties": false,
+        "properties": {
+            "tables": {
+                "type": "array",
+                "items": table_item_schema
+            },
+            "total": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1
+            },
+            "offset": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "has_more": { "type": "boolean" },
+            "next_offset": {
+                "type": "integer",
+                "minimum": 0
+            }
+        }
+    }))
 }
 
 pub(crate) fn optional_string_argument(

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -22,6 +22,11 @@ pub(crate) struct SearchTablesArguments {
     pub(crate) pagination: Pagination,
 }
 
+pub(crate) struct DescribeTableArguments {
+    pub(crate) schema: String,
+    pub(crate) table: String,
+}
+
 pub(crate) fn sql_tool(sources: &[Source], visible_table_count: usize) -> Tool {
     Tool::new(
         "sql",
@@ -129,6 +134,34 @@ pub(crate) fn search_tables_tool(visible_table_count: usize) -> Tool {
     )
 }
 
+pub(crate) fn describe_table_tool() -> Tool {
+    Tool::new(
+        "describe_table",
+        "Describe one queryable table without returning full column definitions.",
+        json_object_schema(&json!({
+            "type": "object",
+            "required": ["schema", "table"],
+            "properties": {
+                "schema": {
+                    "type": "string",
+                    "description": "Exact schema/source name."
+                },
+                "table": {
+                    "type": "string",
+                    "description": "Exact table name within the schema."
+                }
+            }
+        })),
+    )
+    .with_annotations(
+        ToolAnnotations::with_title("Describe Table")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false),
+    )
+}
+
 pub(crate) fn feedback_tool() -> Tool {
     Tool::new(
         "feedback",
@@ -195,6 +228,15 @@ pub(crate) fn search_tables_arguments(
         schema: optional_string_argument(arguments, "schema")?,
         ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
         pagination: parse_pagination_with_limits(arguments, 20, 100)?,
+    })
+}
+
+pub(crate) fn describe_table_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<DescribeTableArguments, ErrorData> {
+    Ok(DescribeTableArguments {
+        schema: required_string_argument(arguments, "schema")?,
+        table: required_string_argument(arguments, "table")?,
     })
 }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -6,9 +6,10 @@ use coral_client::{
     AppClient, SourceClient, default_workspace,
     local::{RunningServer, ServerBuilder},
 };
+use jsonschema::JSONSchema;
 use rmcp::{
     RoleClient, ServiceExt,
-    model::{CallToolRequestParams, ReadResourceRequestParams},
+    model::{CallToolRequestParams, ReadResourceRequestParams, Tool},
     service::RunningService,
 };
 use serde_json::{Map, Value, json};
@@ -163,6 +164,34 @@ fn text_content(result: &rmcp::model::ReadResourceResult) -> &str {
     }
 }
 
+fn tool_by_name<'a>(tools: &'a [Tool], name: &str) -> &'a Tool {
+    tools
+        .iter()
+        .find(|tool| tool.name == name)
+        .expect("tool should be listed")
+}
+
+fn assert_matches_output_schema(tool: &Tool, value: &Value) {
+    let schema = Value::Object(
+        tool.output_schema
+            .as_ref()
+            .unwrap_or_else(|| panic!("tool '{}' should advertise output schema", tool.name))
+            .as_ref()
+            .clone(),
+    );
+    let compiled = JSONSchema::compile(&schema).expect("tool output schema should compile");
+    if let Err(errors) = compiled.validate(value) {
+        let details = errors
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>()
+            .join("; ");
+        panic!(
+            "tool '{}' structured content did not match output schema: {details}",
+            tool.name
+        );
+    }
+}
+
 #[tokio::test]
 #[allow(
     clippy::too_many_lines,
@@ -222,6 +251,8 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     add_demo_source(&mut session.source_client, manifest_yaml).await;
 
     let updated_tools = client.list_all_tools().await.expect("updated tools");
+    let list_tables_tool = tool_by_name(&updated_tools, "list_tables");
+    let search_tables_tool = tool_by_name(&updated_tools, "search_tables");
     assert!(
         updated_tools[0]
             .description
@@ -301,6 +332,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     );
     assert!(structured_tables["tables"][0]["columns"].is_null());
     assert_eq!(tables.is_error, Some(false));
+    assert_matches_output_schema(list_tables_tool, &structured_tables);
 
     let page = client
         .call_tool(
@@ -318,6 +350,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(page["has_more"], true);
     assert_eq!(page["next_offset"], 2);
     assert_eq!(page["tables"].as_array().expect("tables").len(), 2);
+    assert_matches_output_schema(list_tables_tool, &page);
 
     let unknown_schema = client
         .call_tool(
@@ -339,6 +372,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .expect("tables")
             .is_empty()
     );
+    assert_matches_output_schema(list_tables_tool, &unknown_schema);
 
     client
         .call_tool(
@@ -373,6 +407,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .iter()
             .any(|field| field == "table_name")
     );
+    assert_matches_output_schema(search_tables_tool, &search);
 
     let search_page = client
         .call_tool(
@@ -389,6 +424,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(search_page["limit"], 2);
     assert_eq!(search_page["has_more"], true);
     assert_eq!(search_page["next_offset"], 2);
+    assert_matches_output_schema(search_tables_tool, &search_page);
 
     client
         .call_tool(

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -181,7 +181,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables", "search_tables"]
+        vec!["sql", "list_tables", "search_tables", "describe_table"]
     );
     assert!(
         initial_tools[0]
@@ -399,6 +399,85 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .await
         .expect_err("invalid regex should fail");
 
+    let described = client
+        .call_tool(
+            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
+                "schema": "local_messages",
+                "table": "messages"
+            }))),
+        )
+        .await
+        .expect("describe table");
+    let described = described.structured_content.expect("structured content");
+    assert_eq!(described["found"], true);
+    assert_eq!(described["name"], "local_messages.messages");
+    assert_eq!(described["column_count"], 3);
+    assert!(described["columns_hint"].as_str().is_some());
+    assert!(described["columns"].is_null());
+
+    let missing_table = client
+        .call_tool(
+            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
+                "schema": "local_messages",
+                "table": "missing"
+            }))),
+        )
+        .await
+        .expect("describe missing table");
+    assert_eq!(missing_table.is_error, Some(false));
+    let missing_table = missing_table
+        .structured_content
+        .expect("structured content");
+    assert_eq!(missing_table["found"], false);
+    assert_eq!(missing_table["requested"]["schema"], "local_messages");
+    assert_eq!(missing_table["requested"]["table"], "missing");
+    assert_eq!(
+        missing_table["same_schema_tables"][0]["name"],
+        "local_messages.events"
+    );
+    assert_eq!(missing_table["suggested_calls"][0]["tool"], "search_tables");
+    assert_eq!(
+        missing_table["suggested_calls"][0]["arguments"]["pattern"],
+        "missing"
+    );
+    assert_eq!(
+        missing_table["suggested_calls"][0]["arguments"]["schema"],
+        "local_messages"
+    );
+
+    let missing_schema = client
+        .call_tool(
+            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
+                "schema": "local_mesages",
+                "table": "missing["
+            }))),
+        )
+        .await
+        .expect("describe missing schema");
+    assert_eq!(missing_schema.is_error, Some(false));
+    let missing_schema = missing_schema
+        .structured_content
+        .expect("structured content");
+    assert_eq!(missing_schema["found"], false);
+    assert_eq!(
+        missing_schema["suggested_calls"][0]["arguments"]["pattern"],
+        r"missing\["
+    );
+    assert!(
+        missing_schema["suggested_calls"][0]["arguments"]["schema"].is_null(),
+        "search suggestion should not constrain a missing schema"
+    );
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("describe_table").with_arguments(json_object(&json!({
+                "schema": "local_messages",
+                "table": " "
+            }))),
+        )
+        .await
+        .expect_err("blank table should fail");
+
     session.shutdown().await;
 }
 
@@ -420,9 +499,15 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .iter()
             .map(|tool| tool.name.as_ref())
             .collect::<Vec<_>>(),
-        vec!["sql", "list_tables", "search_tables", "feedback"]
+        vec![
+            "sql",
+            "list_tables",
+            "search_tables",
+            "describe_table",
+            "feedback"
+        ]
     );
-    let feedback_annotations = tools[3].annotations.as_ref().expect("feedback annotations");
+    let feedback_annotations = tools[4].annotations.as_ref().expect("feedback annotations");
     assert_eq!(feedback_annotations.read_only_hint, Some(false));
     assert_eq!(feedback_annotations.destructive_hint, Some(false));
     assert_eq!(feedback_annotations.idempotent_hint, Some(false));

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -17,6 +17,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Tool     | `sql`            | Run a SQL query                                         |
 | Tool     | `list_tables`    | List queryable fully qualified tables with pagination   |
 | Tool     | `search_tables`  | Search table metadata with a Rust regex                 |
+| Tool     | `describe_table` | Show compact metadata for one table                     |
 | Tool     | `feedback`       | Store a local blocked-agent feedback report when enabled |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
@@ -24,6 +25,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
 `list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. Use each table's `sql_reference` value in `FROM` and `JOIN` clauses. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 `search_tables` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table names, descriptions, guides, and required filters.
+`describe_table` accepts exact `schema` and `table` arguments and returns guide text, required filters, and a column count without dumping full columns.
 For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
 Start Coral as `coral mcp-stdio --enable-feedback` to expose the optional `feedback` tool. Agents can call `feedback` when they get blocked or repeat a pattern that is not working. Coral stores the report locally with what the agent was trying to do, what it tried, and where it got stuck.
 
@@ -193,7 +195,7 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_tables`, `search_tables`, or query `coral.tables` and return the schemas from your installed sources. Large catalogs should be paged with `limit` and `offset`.
+The agent should call `list_tables`, `search_tables`, `describe_table`, or query `coral.tables` and return the schemas from your installed sources. Large catalogs should be paged with `limit` and `offset`.
 
 ## Troubleshooting
 

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -102,7 +102,7 @@ The MCP stdio server.
 | --------------- | ------------------------------------------------------------------- |
 | MCP protocol    | Tool and resource handlers via the `rmcp` SDK (`server.rs`)         |
 | Surface shaping | Tool/resource/error helpers split across `surface/{mod,tools,resources,errors}.rs` |
-| Tools           | `sql`, `list_tables`, optional `feedback`                           |
+| Tools           | `sql`, `list_tables`, `search_tables`, `describe_table`, optional `feedback` |
 | Resources       | `coral://guide`, `coral://tables`                                   |
 
 Uses `coral-client` to reach `coral-app`, same transport as the CLI.

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -23,7 +23,8 @@ This release is intended for single-user local use:
   server binds to loopback, and the MCP server uses stdio transport.
 
 Coral reduces data exposure by keeping execution local and by exposing a narrow
-MCP surface: `sql`, `list_tables`, `coral://guide`, and `coral://tables`.
+MCP surface: `sql`, `list_tables`, `search_tables`, `describe_table`,
+`coral://guide`, and `coral://tables`.
 Secret values are not returned through `coral.inputs`; secret rows show only
 whether a value is configured.
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -152,6 +152,8 @@ This server exposes:
 | -------- | ---------------- | -------------------------------- |
 | Tool     | `sql`            | Run a SQL query                  |
 | Tool     | `list_tables`    | List available tables by page    |
+| Tool     | `search_tables`  | Search table metadata by regex   |
+| Tool     | `describe_table` | Show compact table metadata      |
 | Resource | `coral://guide`  | Usage guide for agents           |
 | Resource | `coral://tables` | Table summaries for all sources  |
 


### PR DESCRIPTION
Stacked on #281 (merged).

## Summary
- Adds `describe_table` for one exact schema/table lookup without dumping full columns.
- Uses the typed exact-table `ListTables` path for found tables and derives `column_count` from `Table.columns.len()`, so `coral-mcp` does not hand-query `coral.columns` for this metadata.
- Returns compact table metadata, guide text, required filters, and `column_count` for found tables.
- Returns a successful `found: false` recovery payload for unknown tables, including available schemas, same-schema examples, and suggested follow-up calls.

## Review follow-ups
- Updated docs pages that still listed the old MCP tool surface.
- Addressed the catalog ownership feedback by keeping the MCP adapter on the typed catalog API path instead of generic metadata SQL for `column_count`.
- Removed the stale CLI harness `COUNT(*) AS column_count FROM coral.columns` mock and added assertions that `describe_table` sends an exact `ListTablesRequest` with `schema_name`, `table_name`, `omit_columns: false`, `limit: 1`, and does not call `execute_sql`.
- Added MCP `outputSchema` contracts for `list_tables` and `search_tables`, and validate their real `structuredContent` against those schemas in `coral-mcp` tests so `sql_reference` stays part of the advertised contract.
- Clarified the `ListTablesRequest.table_name` proto contract: when set without `schema_name`, it intentionally matches that exact table name across all schemas.
- Removed the unnecessary `u32` saturation from the JSON-only `column_count`; it now serializes `table.columns.len()` directly.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy -p coral-mcp --all-targets --all-features --locked -- -D warnings`
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --test mcp --features cli-test-server`
- `cargo test -p coral-app --test grpc list_tables_supports_legacy_full_response_and_paginated_summaries`
- `cargo build`
- Compiled local app smoke with connected sources: MCP `describe_table {"schema":"github","table":"pulls"}` returned `found: true`, `name: github.pulls`, `column_count: 427`, and `required_filters: ["owner", "repo"]`.
- Compiled local app smoke with connected sources: MCP `tools/list` showed `outputSchema` for `list_tables` and `search_tables`; MCP `list_tables {"limit":2,"offset":0}` returned `total: 369`, `has_more: true`, and `sql_reference` values for `github.accepted_assignments` and `github.access`.

Local smoke emitted the existing `crag` manifest-validation warning, but the GitHub catalog path loaded and the MCP calls succeeded.
