### PR TITLE
fix(sources): push down repository owner filter

### DIFF
--- a/sources/github/manifest.yaml
+++ b/sources/github/manifest.yaml
@@ -145103,11 +145103,13 @@ tables:
   - name: repositories
     description: List public repositories
     guide: >
-      Use this table to scan public repositories or switch into org-scoped repository lists. Works
-      without WHERE filters. Use LIMIT on the public /repositories feed; add org with one of
-      secret_name, migration_id, runner_group_id, pat_request_id, pat_id, or name to hit the
-      matching org route.
+      Use this table to scan public repositories or switch into user/org-scoped repository lists.
+      Works without WHERE filters. Use LIMIT on the public /repositories feed; filter by
+      owner__login for one user's public repositories; add org with one of secret_name,
+      migration_id, runner_group_id, pat_request_id, pat_id, or name to hit the matching org route.
     filters:
+      - name: owner__login
+        required: false
       - name: secret_name
         required: false
       - name: migration_id
@@ -145126,6 +145128,10 @@ tables:
       method: GET
       path: /repositories
     requests:
+      - when_filters:
+          - owner__login
+        method: GET
+        path: /users/{{filter.owner__login}}/repos
       - when_filters:
           - secret_name
         method: GET


### PR DESCRIPTION
## Summary

- Declare `owner__login` as an optional filter on `github.repositories`
- Route owner-filtered repository queries to GitHub's `/users/{login}/repos` endpoint
- Update the table guide to document owner-scoped repository listing

## Why

`github.repositories` previously used GitHub's global `/repositories` feed for `WHERE owner__login = ...` queries. Coral could not push that predicate down, so bounded queries could still page through the public repository feed before applying the owner filter locally.

With this change, queries such as:

```sql
SELECT * FROM github.repositories WHERE owner__login = 'wycats' LIMIT 1;
```

hit the owner-scoped GitHub endpoint directly while keeping the same nullable repository table schema.

## Validation

- `target/debug/coral source lint sources/github/manifest.yaml`
- Real GitHub smoke test with repo-built Coral:

```bash
target/debug/coral sql "select owner__login, full_name from github.repositories where owner__login = 'wycats' limit 1;" --format json
```

returned:

```json
[{"owner__login":"wycats","full_name":"wycats/2025-heroku-plans"}]
```

- Compared `select *` output for filtered and unfiltered `github.repositories`; both expose the same 128 columns, with route-dependent nullable values.