### PR TITLE
fix(app): record telemetry status attributes

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -9,7 +9,9 @@ use coral_engine::{
     SourceValidationReport, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_source_manifest_yaml};
+use opentelemetry::trace::Status as OtelStatus;
 use tracing::Instrument as _;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
@@ -75,7 +77,7 @@ impl QueryManager {
         sql: &str,
     ) -> Result<QueryExecution, QueryManagerError> {
         let started_at = Instant::now();
-        let query_span = create_query_span(sql);
+        let query_span = create_query_span(workspace_name, sql);
         let result = async {
             let sources = self
                 .load_query_sources(workspace_name)
@@ -100,9 +102,15 @@ impl QueryManager {
             let row_count = u64::try_from(execution.row_count()).unwrap_or(u64::MAX);
             query_span.record("row_count", row_count);
             query_span.record("status", "ok");
-            metrics.rows.record(row_count, &[]);
-        } else {
+            query_span.set_status(OtelStatus::Ok);
+            metrics
+                .rows
+                .record(row_count, std::slice::from_ref(&status));
+        } else if let Err(error) = &result {
+            let error_kind = query_error_kind(error);
             query_span.record("status", "error");
+            query_span.record("error.kind", error_kind);
+            query_span.set_status(OtelStatus::error(error_kind));
         }
 
         result
@@ -203,14 +211,24 @@ impl QueryManager {
     }
 }
 
-fn create_query_span(sql: &str) -> tracing::Span {
+fn create_query_span(workspace_name: &WorkspaceName, sql: &str) -> tracing::Span {
     tracing::info_span!(
         "coral.query",
         otel.name = "coral.query",
+        operation = "execute_sql",
+        workspace = %workspace_name.as_str(),
         sql = %sql,
         row_count = tracing::field::Empty,
         status = tracing::field::Empty,
+        error.kind = tracing::field::Empty,
     )
+}
+
+fn query_error_kind(error: &QueryManagerError) -> &'static str {
+    match error {
+        QueryManagerError::App(_) => "app",
+        QueryManagerError::Core(_) => "core",
+    }
 }
 
 fn validate_required_variables(

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -6,11 +6,12 @@ use arrow::record_batch::RecordBatch;
 use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
 use coral_api::v1::{ExecuteSqlRequest, ExecuteSqlResponse, ListTablesRequest, ListTablesResponse};
 use tonic::{Request, Response, Status};
-use tracing::Instrument as _;
 
 use crate::bootstrap::core_status;
 use crate::query::manager::QueryManager;
-use crate::transport::{grpc_span, query_status, table_to_proto, workspace_name_from_proto};
+use crate::transport::{
+    grpc_span, instrument_grpc, query_status, table_to_proto, workspace_name_from_proto,
+};
 
 #[derive(Clone)]
 pub(crate) struct QueryService {
@@ -33,7 +34,7 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ListTablesResponse>, Status> {
         let span = grpc_span(request.metadata(), "list_tables");
         let queries = self.queries.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let tables = queries
@@ -44,8 +45,7 @@ impl QueryServiceApi for QueryService {
                 .map(|table| table_to_proto(&workspace_name, table))
                 .collect();
             Ok(Response::new(ListTablesResponse { tables }))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -55,7 +55,7 @@ impl QueryServiceApi for QueryService {
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
         let span = grpc_span(request.metadata(), "execute_sql");
         let queries = self.queries.clone();
-        async move {
+        instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let execution = queries
@@ -72,8 +72,7 @@ impl QueryServiceApi for QueryService {
                 row_count: i64::try_from(execution.row_count()).unwrap_or(i64::MAX),
             };
             Ok(Response::new(response))
-        }
-        .instrument(span)
+        })
         .await
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -10,7 +10,6 @@ use coral_api::v1::{
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use tonic::{Request, Response, Status};
-use tracing::Instrument as _;
 
 use crate::bootstrap::app_status;
 use crate::query::manager::QueryManager;
@@ -18,8 +17,8 @@ use crate::sources::SourceName;
 use crate::sources::manager::SourceManager;
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::transport::{
-    grpc_span, query_status, validate_source_response_to_proto, workspace_name_from_proto,
-    workspace_to_proto,
+    grpc_span, instrument_grpc, query_status, validate_source_response_to_proto,
+    workspace_name_from_proto, workspace_to_proto,
 };
 use crate::workspaces::WorkspaceName;
 
@@ -46,7 +45,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<DiscoverSourcesResponse>, Status> {
         let span = grpc_span(request.metadata(), "discover_sources");
         let sources = self.sources.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let sources = sources
@@ -56,8 +55,7 @@ impl SourceServiceApi for SourceService {
                 .map(candidate_source_to_proto)
                 .collect();
             Ok(Response::new(DiscoverSourcesResponse { sources }))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -67,7 +65,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<ListSourcesResponse>, Status> {
         let span = grpc_span(request.metadata(), "list_sources");
         let sources = self.sources.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let sources: Vec<_> = sources
@@ -77,8 +75,7 @@ impl SourceServiceApi for SourceService {
                 .map(|source| installed_source_to_proto(&workspace_name, source))
                 .collect();
             Ok(Response::new(ListSourcesResponse { sources }))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -88,7 +85,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Source>, Status> {
         let span = grpc_span(request.metadata(), "get_source");
         let sources = self.sources.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
@@ -99,8 +96,7 @@ impl SourceServiceApi for SourceService {
                 &workspace_name,
                 source,
             )))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -110,7 +106,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<SourceInfo>, Status> {
         let span = grpc_span(request.metadata(), "get_source_info");
         let sources = self.sources.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
@@ -118,8 +114,7 @@ impl SourceServiceApi for SourceService {
                 .get_source_info(&workspace_name, &source_name)
                 .map_err(app_status)?;
             Ok(Response::new(candidate_source_to_proto(source)))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -129,7 +124,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Source>, Status> {
         let span = grpc_span(request.metadata(), "create_bundled_source");
         let sources = self.sources.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let bundled_name = SourceName::parse(&request.name).map_err(app_status)?;
@@ -140,8 +135,7 @@ impl SourceServiceApi for SourceService {
                 &workspace_name,
                 installed,
             )))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -151,7 +145,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Source>, Status> {
         let span = grpc_span(request.metadata(), "import_source");
         let sources = self.sources.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let installed = sources
@@ -161,8 +155,7 @@ impl SourceServiceApi for SourceService {
                 &workspace_name,
                 installed,
             )))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -172,7 +165,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<()>, Status> {
         let span = grpc_span(request.metadata(), "delete_source");
         let sources = self.sources.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
@@ -180,8 +173,7 @@ impl SourceServiceApi for SourceService {
                 .delete_source(&workspace_name, &source_name)
                 .map_err(app_status)?;
             Ok(Response::new(()))
-        }
-        .instrument(span)
+        })
         .await
     }
 
@@ -191,7 +183,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<ValidateSourceResponse>, Status> {
         let span = grpc_span(request.metadata(), "validate_source");
         let queries = self.queries.clone();
-        async move {
+        instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let source_name = SourceName::parse(&request.name).map_err(app_status)?;
@@ -206,8 +198,7 @@ impl SourceServiceApi for SourceService {
                 &workspace_name,
                 report,
             )))
-        }
-        .instrument(span)
+        })
         .await
     }
 }

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -140,7 +140,10 @@ pub(crate) mod test_support {
 
 #[cfg(test)]
 mod tests {
-    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData, ResourceMetrics};
+    use opentelemetry::Value;
+    use opentelemetry_sdk::metrics::data::{
+        AggregatedMetrics, Histogram, MetricData, ResourceMetrics,
+    };
 
     use super::metrics;
 
@@ -170,6 +173,27 @@ mod tests {
         })
     }
 
+    fn histogram_has_status(metrics: &[ResourceMetrics], name: &str, status: &str) -> bool {
+        find_metric(metrics, name).is_some_and(|metric| match metric.data() {
+            AggregatedMetrics::F64(MetricData::Histogram(histogram)) => {
+                histogram_data_has_status(histogram, status)
+            }
+            AggregatedMetrics::U64(MetricData::Histogram(histogram)) => {
+                histogram_data_has_status(histogram, status)
+            }
+            _ => false,
+        })
+    }
+
+    fn histogram_data_has_status<T>(histogram: &Histogram<T>, status: &str) -> bool {
+        histogram.data_points().any(|point| {
+            point.attributes().any(|attr| {
+                attr.key.as_str() == "status"
+                    && matches!(&attr.value, Value::String(value) if value.as_str() == status)
+            })
+        })
+    }
+
     fn counter_total(metrics: &[ResourceMetrics], name: &str) -> u64 {
         find_metric(metrics, name).map_or(0, |metric| match metric.data() {
             AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
@@ -192,12 +216,13 @@ mod tests {
         metrics.count.add(1, std::slice::from_ref(&err));
         metrics.duration.record(0.5, std::slice::from_ref(&ok));
         metrics.duration.record(0.1, std::slice::from_ref(&err));
-        metrics.rows.record(7, &[]);
+        metrics.rows.record(7, std::slice::from_ref(&ok));
 
         super::test_support::flush_metrics();
         let finished = exporter.get_finished_metrics().expect("finished metrics");
         assert_eq!(counter_total(&finished, "coral.query.count"), 3);
         assert_eq!(histogram_total_count(&finished, "coral.query.duration"), 2);
         assert_eq!(histogram_total_count(&finished, "coral.query.rows"), 1);
+        assert!(histogram_has_status(&finished, "coral.query.rows", "ok"));
     }
 }

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::propagation::Extractor;
-use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
 use opentelemetry_otlp::{
     LogExporter, MetricExporter, SpanExporter, WithExportConfig, WithHttpConfig,
 };
@@ -97,10 +97,22 @@ pub struct RunContext {
 }
 
 /// Runs `fut` under a root CLI span configured from `ctx`.
-pub async fn run_with_context<F: std::future::Future>(ctx: &RunContext, fut: F) -> F::Output {
+///
+/// The returned `Result` is also recorded on the root span as low-cardinality
+/// `status` and OTEL status data.
+///
+/// # Errors
+///
+/// Returns the same error produced by `fut`.
+pub async fn run_with_context<T, E, F>(ctx: &RunContext, fut: F) -> Result<T, E>
+where
+    F: std::future::Future<Output = Result<T, E>>,
+{
     use tracing::Instrument as _;
-    fut.instrument(build_root_span(ctx.trace_parent.as_deref()))
-        .await
+    let span = build_root_span(ctx.trace_parent.as_deref());
+    let result = fut.instrument(span.clone()).await;
+    record_run_status(&span, result.is_ok());
+    result
 }
 
 /// Builds a root CLI span, optionally parented to a W3C `traceparent` string.
@@ -109,7 +121,7 @@ pub async fn run_with_context<F: std::future::Future>(ctx: &RunContext, fut: F) 
 /// `None` for an unparented span. Use `.instrument(span).await` to run the
 /// CLI future under this span.
 pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
-    let span = tracing::info_span!("coral.cli");
+    let span = tracing::info_span!("coral.cli", status = tracing::field::Empty);
     if let Some(tp) = traceparent {
         struct StringMapExtractor<'a>(&'a HashMap<String, String>);
         impl Extractor for StringMapExtractor<'_> {
@@ -127,6 +139,16 @@ pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
         let _ = span.set_parent(parent_cx);
     }
     span
+}
+
+fn record_run_status(span: &tracing::Span, ok: bool) {
+    if ok {
+        span.record("status", "ok");
+        span.set_status(OtelStatus::Ok);
+    } else {
+        span.record("status", "error");
+        span.set_status(OtelStatus::error("error"));
+    }
 }
 
 pub(crate) fn init_tracing(

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -1,11 +1,15 @@
 //! Shared gRPC transport helpers for app-owned services.
 
+use std::future::Future;
+
 use coral_api::v1::{
     Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table,
     ValidateSourceResponse, Workspace, query_test_result,
 };
 use opentelemetry::propagation::Extractor;
-use tonic::Status;
+use opentelemetry::trace::Status as OtelStatus;
+use tonic::{Code, Status};
+use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::{AppError, app_status, core_status};
@@ -44,9 +48,61 @@ pub(crate) fn grpc_span(
     name: &'static str,
 ) -> tracing::Span {
     let parent_cx = extract_trace_context(metadata);
-    let span = tracing::info_span!("grpc", grpc.method = name);
+    let span = tracing::info_span!(
+        "grpc",
+        grpc.method = name,
+        grpc.status_code = tracing::field::Empty,
+        grpc.code = tracing::field::Empty,
+        status = tracing::field::Empty,
+    );
     let _ = span.set_parent(parent_cx);
     span
+}
+
+pub(crate) async fn instrument_grpc<T, F>(span: tracing::Span, future: F) -> Result<T, Status>
+where
+    F: Future<Output = Result<T, Status>>,
+{
+    let result = future.instrument(span.clone()).await;
+    match &result {
+        Ok(_) => record_grpc_status(&span, Code::Ok),
+        Err(status) => record_grpc_status(&span, status.code()),
+    }
+    result
+}
+
+fn record_grpc_status(span: &tracing::Span, code: Code) {
+    span.record("grpc.status_code", code as i64);
+    span.record("grpc.code", grpc_code_label(code));
+    if code == Code::Ok {
+        span.record("status", "ok");
+        span.set_status(OtelStatus::Ok);
+    } else {
+        span.record("status", "error");
+        span.set_status(OtelStatus::error(grpc_code_label(code)));
+    }
+}
+
+fn grpc_code_label(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "ok",
+        Code::Cancelled => "cancelled",
+        Code::Unknown => "unknown",
+        Code::InvalidArgument => "invalid_argument",
+        Code::DeadlineExceeded => "deadline_exceeded",
+        Code::NotFound => "not_found",
+        Code::AlreadyExists => "already_exists",
+        Code::PermissionDenied => "permission_denied",
+        Code::ResourceExhausted => "resource_exhausted",
+        Code::FailedPrecondition => "failed_precondition",
+        Code::Aborted => "aborted",
+        Code::OutOfRange => "out_of_range",
+        Code::Unimplemented => "unimplemented",
+        Code::Internal => "internal",
+        Code::Unavailable => "unavailable",
+        Code::DataLoss => "data_loss",
+        Code::Unauthenticated => "unauthenticated",
+    }
 }
 
 #[allow(
@@ -138,8 +194,8 @@ mod tests {
     use tonic::Code;
 
     use super::{
-        query_status, query_test_result_to_proto, table_to_proto, workspace_name_from_proto,
-        workspace_to_proto,
+        grpc_code_label, query_status, query_test_result_to_proto, table_to_proto,
+        workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
@@ -166,6 +222,17 @@ mod tests {
 
         assert_eq!(status.code(), Code::Unavailable);
         assert_eq!(status.message(), "unavailable: backend down");
+    }
+
+    #[test]
+    fn grpc_code_labels_are_low_cardinality() {
+        assert_eq!(grpc_code_label(Code::Ok), "ok");
+        assert_eq!(grpc_code_label(Code::InvalidArgument), "invalid_argument");
+        assert_eq!(
+            grpc_code_label(Code::FailedPrecondition),
+            "failed_precondition"
+        );
+        assert_eq!(grpc_code_label(Code::Unavailable), "unavailable");
     }
 
     #[test]


### PR DESCRIPTION
## Intent

Make Coral's always-on telemetry explicit enough for UI and debugging consumers to classify query flows without inferring success or failure from missing status fields.

## Changes

- Record OTEL status and low-cardinality status attributes on `coral.cli`, `grpc`, and `coral.query`.
- Record gRPC status code/name on shared gRPC service spans.
- Emit raw SQL on `coral.query` for UI display.
- Record `status=ok` on `coral.query.rows` metrics.

## Verification

- `make rust-checks`
- Fresh ClickHouse trace verification for `coral.cli`, `grpc`, and `coral.query` status fields.
- Fresh ClickHouse trace verification that `coral.query` includes `sql` and omits `source_count`.
