### PR TITLE
feat(http): add TTL-based in-memory response cache for HTTP tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,6 +1345,7 @@ dependencies = [
  "datafusion-tracing",
  "futures",
  "httpdate",
+ "moka",
  "object_store",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1453,6 +1454,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3568,6 +3587,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5314,6 +5353,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,7 @@ dependencies = [
 name = "coral-spec"
 version = "0.4.1"
 dependencies = [
+ "http 1.4.1",
  "jsonschema",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ etcetera = "0.11"
 fs2 = "0.4"
 futures = "0.3"
 glob = "0.3"
+http = "1"
 http-body = "1"
 httpdate = "1.0.3"
 jsonschema = { version = "0.18", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ parquet = { version = "58.1.0", features = ["arrow"] }
 prost = "0.14.1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking", "charset", "form", "http2", "json", "query", "rustls", "system-proxy"] }
 regex = "1"
+moka = { version = "0.12", features = ["future"] }
 rmcp = { version = "1.6.0", features = ["client", "reqwest", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 rusqlite = { version = "0.37", features = ["bundled"] }
 rust-embed = { version = "8", features = ["mime-guess"] }

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -282,7 +282,7 @@ impl ServerBuilder {
             query_runtime_context,
             layout,
             self.config.engine_extensions_providers,
-        );
+        )?;
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
         } else {
@@ -714,7 +714,8 @@ enabled = false
             QueryRuntimeContext::default(),
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
+        )
+        .expect("query manager should build");
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
         let server = start_server(
@@ -1095,7 +1096,8 @@ tables:
             },
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
+        )
+        .expect("query manager should build");
         let running = start_server(
             source_manager,
             query_manager,
@@ -1194,7 +1196,8 @@ tables:
             QueryRuntimeContext::default(),
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
+        )
+        .expect("query manager should build");
         let running = start_server(
             source_manager,
             query_manager,
@@ -1293,7 +1296,8 @@ tables:
             QueryRuntimeContext::default(),
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
-        );
+        )
+        .expect("query manager should build");
         let running = start_server(
             source_manager,
             query_manager,

--- a/crates/coral-app/src/http_cache.rs
+++ b/crates/coral-app/src/http_cache.rs
@@ -53,8 +53,8 @@ struct HttpCacheConfigFile {
 #[serde(default, deny_unknown_fields)]
 struct RawHttpCacheConfig {
     enabled: bool,
-    default_max_bytes_per_source: String,
-    total_max_bytes: Option<String>,
+    default_max_bytes_per_source: RawByteSize,
+    total_max_bytes: Option<RawByteSize>,
     sources: HashMap<String, RawSourceCacheConfig>,
 }
 
@@ -62,7 +62,7 @@ impl Default for RawHttpCacheConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            default_max_bytes_per_source: format!("{DEFAULT_PER_SOURCE_MAX_BYTES}B"),
+            default_max_bytes_per_source: RawByteSize::Integer(DEFAULT_PER_SOURCE_MAX_BYTES),
             total_max_bytes: None,
             sources: HashMap::new(),
         }
@@ -72,24 +72,42 @@ impl Default for RawHttpCacheConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawSourceCacheConfig {
-    max_bytes: String,
+    max_bytes: RawByteSize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum RawByteSize {
+    Integer(u64),
+    String(String),
+}
+
+impl RawByteSize {
+    fn parse(&self) -> Result<u64, String> {
+        match self {
+            Self::Integer(value) => Ok(*value),
+            Self::String(value) => parse_byte_size(value),
+        }
+    }
 }
 
 impl TryFrom<RawHttpCacheConfig> for HttpCacheConfig {
     type Error = AppError;
 
     fn try_from(raw: RawHttpCacheConfig) -> Result<Self, Self::Error> {
-        let default_max_bytes_per_source = parse_byte_size(&raw.default_max_bytes_per_source)
+        let default_max_bytes_per_source = raw
+            .default_max_bytes_per_source
+            .parse()
             .map_err(|err| http_cache_error("default_max_bytes_per_source", &err))?;
         let total_max_bytes = raw
             .total_max_bytes
-            .as_deref()
-            .map(parse_byte_size)
+            .as_ref()
+            .map(RawByteSize::parse)
             .transpose()
             .map_err(|err| http_cache_error("total_max_bytes", &err))?;
         let mut per_source_max_bytes = HashMap::with_capacity(raw.sources.len());
         for (source_name, source_config) in raw.sources {
-            let bytes = parse_byte_size(&source_config.max_bytes).map_err(|err| {
+            let bytes = source_config.max_bytes.parse().map_err(|err| {
                 http_cache_error(&format!("sources.{source_name}.max_bytes"), &err)
             })?;
             per_source_max_bytes.insert(source_name, bytes);
@@ -234,6 +252,27 @@ max_bytes = "16MiB"
         assert_eq!(
             cfg.per_source_max_bytes.get("jsonph"),
             Some(&(16 * 1024 * 1024))
+        );
+    }
+
+    #[test]
+    fn loads_bare_integer_byte_limits() {
+        let cfg = load_with_config(
+            r"
+[http_cache]
+default_max_bytes_per_source = 134217728
+total_max_bytes  = 2147483648
+
+[http_cache.sources.github]
+max_bytes = 524288000
+",
+        )
+        .expect("config loads");
+        assert_eq!(cfg.default_max_bytes_per_source, 128 * 1024 * 1024);
+        assert_eq!(cfg.total_max_bytes, Some(2 * 1024 * 1024 * 1024));
+        assert_eq!(
+            cfg.per_source_max_bytes.get("github"),
+            Some(&(500 * 1024 * 1024))
         );
     }
 

--- a/crates/coral-app/src/http_cache.rs
+++ b/crates/coral-app/src/http_cache.rs
@@ -1,0 +1,267 @@
+//! `[http_cache]` config section: tunables for the HTTP response cache.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::bootstrap::AppError;
+use crate::state::AppStateLayout;
+
+/// Default per-source cache capacity when no override is supplied.
+const DEFAULT_PER_SOURCE_MAX_BYTES: u64 = 256 * 1024 * 1024;
+
+/// `[http_cache]` settings loaded from `config.toml`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct HttpCacheConfig {
+    pub(super) enabled: bool,
+    pub(super) default_max_bytes_per_source: u64,
+    pub(super) total_max_bytes: Option<u64>,
+    pub(super) per_source_max_bytes: HashMap<String, u64>,
+}
+
+impl Default for HttpCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            default_max_bytes_per_source: DEFAULT_PER_SOURCE_MAX_BYTES,
+            total_max_bytes: None,
+            per_source_max_bytes: HashMap::new(),
+        }
+    }
+}
+
+impl HttpCacheConfig {
+    /// Load the `[http_cache]` section from `config.toml`. Returns defaults
+    /// when the file or section is missing.
+    pub(super) fn load(layout: &AppStateLayout) -> Result<Self, AppError> {
+        if !layout.config_file().exists() {
+            return Ok(Self::default());
+        }
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        let file = toml::from_str::<HttpCacheConfigFile>(&raw)?;
+        file.http_cache.try_into()
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+struct HttpCacheConfigFile {
+    #[serde(default)]
+    http_cache: RawHttpCacheConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+struct RawHttpCacheConfig {
+    enabled: bool,
+    default_max_bytes_per_source: String,
+    total_max_bytes: Option<String>,
+    sources: HashMap<String, RawSourceCacheConfig>,
+}
+
+impl Default for RawHttpCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            default_max_bytes_per_source: format!("{DEFAULT_PER_SOURCE_MAX_BYTES}B"),
+            total_max_bytes: None,
+            sources: HashMap::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSourceCacheConfig {
+    max_bytes: String,
+}
+
+impl TryFrom<RawHttpCacheConfig> for HttpCacheConfig {
+    type Error = AppError;
+
+    fn try_from(raw: RawHttpCacheConfig) -> Result<Self, Self::Error> {
+        let default_max_bytes_per_source = parse_byte_size(&raw.default_max_bytes_per_source)
+            .map_err(|err| http_cache_error("default_max_bytes_per_source", &err))?;
+        let total_max_bytes = raw
+            .total_max_bytes
+            .as_deref()
+            .map(parse_byte_size)
+            .transpose()
+            .map_err(|err| http_cache_error("total_max_bytes", &err))?;
+        let mut per_source_max_bytes = HashMap::with_capacity(raw.sources.len());
+        for (source_name, source_config) in raw.sources {
+            let bytes = parse_byte_size(&source_config.max_bytes).map_err(|err| {
+                http_cache_error(&format!("sources.{source_name}.max_bytes"), &err)
+            })?;
+            per_source_max_bytes.insert(source_name, bytes);
+        }
+        Ok(Self {
+            enabled: raw.enabled,
+            default_max_bytes_per_source,
+            total_max_bytes,
+            per_source_max_bytes,
+        })
+    }
+}
+
+fn http_cache_error(field: &str, detail: &str) -> AppError {
+    AppError::InvalidInput(format!("[http_cache].{field}: {detail}"))
+}
+
+/// Parse a human-readable byte size string. Accepts decimal suffixes (KB/MB/GB,
+/// 1000-based) and binary suffixes (KiB/MiB/GiB, 1024-based). Bare integers and
+/// the `B` suffix are interpreted as bytes. Case-insensitive on the suffix.
+fn parse_byte_size(value: &str) -> Result<u64, String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err("must not be empty".to_string());
+    }
+    let split_at = trimmed
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (digits, suffix) = trimmed.split_at(split_at);
+    if digits.is_empty() {
+        return Err(format!("'{value}' missing a numeric value"));
+    }
+    let number: u64 = digits
+        .parse()
+        .map_err(|error| format!("'{value}' is not a valid byte count: {error}"))?;
+    let multiplier: u64 = match suffix.trim().to_ascii_uppercase().as_str() {
+        "" | "B" => 1,
+        "KB" => 1_000,
+        "MB" => 1_000_000,
+        "GB" => 1_000_000_000,
+        "KIB" => 1 << 10,
+        "MIB" => 1 << 20,
+        "GIB" => 1 << 30,
+        other => {
+            return Err(format!(
+                "'{value}' has unknown unit '{other}'; use B, KB, MB, GB, KiB, MiB, or GiB"
+            ));
+        }
+    };
+    number
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("'{value}' overflows u64 bytes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_byte_size_accepts_plain_integers_as_bytes() {
+        assert_eq!(parse_byte_size("1024").unwrap(), 1024);
+        assert_eq!(parse_byte_size("0").unwrap(), 0);
+    }
+
+    #[test]
+    fn parse_byte_size_handles_binary_and_decimal_suffixes() {
+        assert_eq!(parse_byte_size("1KiB").unwrap(), 1024);
+        assert_eq!(parse_byte_size("1MiB").unwrap(), 1024 * 1024);
+        assert_eq!(parse_byte_size("1GiB").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_byte_size("1KB").unwrap(), 1000);
+        assert_eq!(parse_byte_size("1MB").unwrap(), 1_000_000);
+        assert_eq!(parse_byte_size("1GB").unwrap(), 1_000_000_000);
+    }
+
+    #[test]
+    fn parse_byte_size_is_case_insensitive() {
+        assert_eq!(parse_byte_size("256mib").unwrap(), 256 * 1024 * 1024);
+        assert_eq!(parse_byte_size("256 MiB").unwrap(), 256 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_byte_size_rejects_unknown_suffix() {
+        parse_byte_size("10TB").expect_err("unknown suffix should fail");
+        parse_byte_size("ten").expect_err("missing digits should fail");
+        parse_byte_size("").expect_err("empty value should fail");
+    }
+
+    #[test]
+    fn parse_byte_size_rejects_overflow() {
+        parse_byte_size("18446744073709551615GiB").expect_err("overflow should fail");
+    }
+
+    fn load_with_config(toml: &str) -> Result<HttpCacheConfig, AppError> {
+        use std::io::Write;
+        let temp = tempfile::TempDir::new()?;
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))?;
+        layout.ensure()?;
+        let mut file = std::fs::File::create(layout.config_file())?;
+        file.write_all(toml.as_bytes())?;
+        HttpCacheConfig::load(&layout)
+    }
+
+    #[test]
+    fn defaults_when_section_is_missing() {
+        let temp = tempfile::TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let cfg = HttpCacheConfig::load(&layout).expect("default");
+        assert_eq!(cfg, HttpCacheConfig::default());
+        assert!(cfg.enabled);
+        assert_eq!(
+            cfg.default_max_bytes_per_source,
+            DEFAULT_PER_SOURCE_MAX_BYTES
+        );
+        assert_eq!(cfg.total_max_bytes, None);
+        assert!(cfg.per_source_max_bytes.is_empty());
+    }
+
+    #[test]
+    fn loads_per_source_overrides_and_total_ceiling() {
+        let cfg = load_with_config(
+            r#"
+[http_cache]
+default_max_bytes_per_source = "128MiB"
+total_max_bytes  = "2GiB"
+
+[http_cache.sources.github]
+max_bytes = "500MiB"
+
+[http_cache.sources.jsonph]
+max_bytes = "16MiB"
+"#,
+        )
+        .expect("config loads");
+        assert!(cfg.enabled);
+        assert_eq!(cfg.default_max_bytes_per_source, 128 * 1024 * 1024);
+        assert_eq!(cfg.total_max_bytes, Some(2 * 1024 * 1024 * 1024));
+        assert_eq!(
+            cfg.per_source_max_bytes.get("github"),
+            Some(&(500 * 1024 * 1024))
+        );
+        assert_eq!(
+            cfg.per_source_max_bytes.get("jsonph"),
+            Some(&(16 * 1024 * 1024))
+        );
+    }
+
+    #[test]
+    fn enabled_false_disables_cache() {
+        let cfg = load_with_config(
+            r"
+[http_cache]
+enabled = false
+",
+        )
+        .expect("config loads");
+        assert!(!cfg.enabled);
+    }
+
+    #[test]
+    fn invalid_byte_string_surfaces_field_path() {
+        let err = load_with_config(
+            r#"
+[http_cache]
+default_max_bytes_per_source = "many"
+"#,
+        )
+        .expect_err("invalid bytes should fail");
+        let message = format!("{err}");
+        assert!(
+            message.contains("[http_cache].default_max_bytes_per_source"),
+            "expected error to mention field path; got: {message}"
+        );
+    }
+}

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -39,6 +39,7 @@ mod catalog;
 mod credentials;
 pub mod features;
 mod feedback;
+mod http_cache;
 mod identity;
 mod query;
 mod sources;

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -176,6 +176,7 @@ pub(crate) fn engine_extensions_for_providers(
             query_result_observers,
             request_authenticators,
             source_input_resolver,
+            cache_namespace,
             http_cache_registry,
         } = extra;
         merged.source_decorators.extend(source_decorators);
@@ -183,6 +184,9 @@ pub(crate) fn engine_extensions_for_providers(
         merged.request_authenticators.extend(request_authenticators);
         if source_input_resolver.is_some() {
             merged.source_input_resolver = source_input_resolver;
+        }
+        if cache_namespace.is_some() {
+            merged.cache_namespace = cache_namespace;
         }
         if http_cache_registry.is_some() {
             merged.http_cache_registry = http_cache_registry;

--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -176,12 +176,16 @@ pub(crate) fn engine_extensions_for_providers(
             query_result_observers,
             request_authenticators,
             source_input_resolver,
+            http_cache_registry,
         } = extra;
         merged.source_decorators.extend(source_decorators);
         merged.query_result_observers.extend(query_result_observers);
         merged.request_authenticators.extend(request_authenticators);
         if source_input_resolver.is_some() {
             merged.source_input_resolver = source_input_resolver;
+        }
+        if http_cache_registry.is_some() {
+            merged.http_cache_registry = http_cache_registry;
         }
     }
     merged

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -318,8 +318,12 @@ impl QueryManager {
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
-        extensions.cache_namespace = Some(workspace_name.as_str().to_string());
-        extensions.http_cache_registry = self.http_cache_registry.as_ref().map(Arc::clone);
+        extensions
+            .cache_namespace
+            .get_or_insert_with(|| workspace_name.as_str().to_string());
+        if extensions.http_cache_registry.is_none() {
+            extensions.http_cache_registry = self.http_cache_registry.as_ref().map(Arc::clone);
+        }
         QueryRuntimeConfig::new(self.runtime_context.clone(), extensions)
     }
 }
@@ -518,6 +522,20 @@ mod tests {
         manager: QueryManager,
     }
 
+    struct CacheOverrideProvider {
+        registry: Arc<HttpCacheRegistry>,
+    }
+
+    impl EngineExtensionsProvider for CacheOverrideProvider {
+        fn extensions_for(&self, _selected_sources: &[QuerySource]) -> EngineExtensions {
+            EngineExtensions {
+                cache_namespace: Some("provider-namespace".to_string()),
+                http_cache_registry: Some(Arc::clone(&self.registry)),
+                ..EngineExtensions::default()
+            }
+        }
+    }
+
     fn query_manager_with(
         runtime_context: QueryRuntimeContext,
         providers: Vec<Arc<dyn EngineExtensionsProvider>>,
@@ -571,6 +589,32 @@ mod tests {
             runtime.extensions.cache_namespace.as_deref(),
             Some(WorkspaceName::default().as_str())
         );
+    }
+
+    #[test]
+    fn runtime_config_preserves_provider_owned_cache_extensions() {
+        let provider_registry = Arc::new(HttpCacheRegistry::new());
+        let fixture = query_manager_with(
+            QueryRuntimeContext::default(),
+            vec![Arc::new(CacheOverrideProvider {
+                registry: Arc::clone(&provider_registry),
+            })],
+        );
+
+        let runtime = fixture
+            .manager
+            .runtime_config(&WorkspaceName::default(), &[]);
+
+        assert_eq!(
+            runtime.extensions.cache_namespace.as_deref(),
+            Some("provider-namespace")
+        );
+        let runtime_registry = runtime
+            .extensions
+            .http_cache_registry
+            .as_ref()
+            .expect("provider registry should be preserved");
+        assert!(Arc::ptr_eq(runtime_registry, &provider_registry));
     }
 
     #[test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use coral_engine::{
-    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,
-    HttpCacheRegistry, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage,
+    CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, HttpCacheRegistry, QueryExecution,
+    QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage,
     SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
@@ -48,7 +48,7 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    http_cache_registry: Arc<HttpCacheRegistry>,
+    http_cache_registry: Option<Arc<HttpCacheRegistry>>,
 }
 
 impl QueryManager {
@@ -58,15 +58,23 @@ impl QueryManager {
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, AppError> {
+        let cache_config = crate::http_cache::HttpCacheConfig::load(&layout)?;
+        let http_cache_registry = cache_config.enabled.then(|| {
+            Arc::new(HttpCacheRegistry::with_policy(
+                cache_config.default_max_bytes_per_source,
+                cache_config.total_max_bytes,
+                cache_config.per_source_max_bytes,
+            ))
+        });
+        Ok(Self {
             config_store,
             credential_manager,
             runtime_context,
             layout,
             engine_extensions_providers,
-            http_cache_registry: Arc::new(HttpCacheRegistry::new()),
-        }
+            http_cache_registry,
+        })
     }
 
     pub(crate) async fn list_tables(
@@ -310,7 +318,7 @@ impl QueryManager {
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
-        extensions.http_cache_registry = Some(Arc::clone(&self.http_cache_registry));
+        extensions.http_cache_registry = self.http_cache_registry.as_ref().map(Arc::clone);
         QueryRuntimeConfig::new(self.runtime_context.clone(), extensions)
     }
 }
@@ -522,7 +530,8 @@ mod tests {
             runtime_context,
             layout,
             providers,
-        );
+        )
+        .expect("query manager should build");
         QueryManagerFixture {
             _temp: temp,
             manager,
@@ -814,7 +823,8 @@ surfaces:
             QueryRuntimeContext::default(),
             layout,
             Vec::new(),
-        );
+        )
+        .expect("query manager should build");
 
         let error = manager
             .load_query_sources(&workspace_name)

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -318,12 +318,8 @@ impl QueryManager {
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
-        extensions
-            .cache_namespace
-            .get_or_insert_with(|| workspace_name.as_str().to_string());
-        if extensions.http_cache_registry.is_none() {
-            extensions.http_cache_registry = self.http_cache_registry.as_ref().map(Arc::clone);
-        }
+        extensions.cache_namespace = Some(workspace_name.as_str().to_string());
+        extensions.http_cache_registry = self.http_cache_registry.as_ref().map(Arc::clone);
         QueryRuntimeConfig::new(self.runtime_context.clone(), extensions)
     }
 }
@@ -592,7 +588,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_config_preserves_provider_owned_cache_extensions() {
+    fn runtime_config_uses_app_owned_cache_extensions() {
         let provider_registry = Arc::new(HttpCacheRegistry::new());
         let fixture = query_manager_with(
             QueryRuntimeContext::default(),
@@ -607,14 +603,49 @@ mod tests {
 
         assert_eq!(
             runtime.extensions.cache_namespace.as_deref(),
-            Some("provider-namespace")
+            Some(WorkspaceName::default().as_str())
         );
         let runtime_registry = runtime
             .extensions
             .http_cache_registry
             .as_ref()
-            .expect("provider registry should be preserved");
-        assert!(Arc::ptr_eq(runtime_registry, &provider_registry));
+            .expect("app registry should be installed");
+        assert!(!Arc::ptr_eq(runtime_registry, &provider_registry));
+    }
+
+    #[test]
+    fn runtime_config_cache_disabled_overrides_provider_registry() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("layout should be created");
+        std::fs::write(
+            layout.config_file(),
+            r"
+[http_cache]
+enabled = false
+",
+        )
+        .expect("config should be written");
+        let provider_registry = Arc::new(HttpCacheRegistry::new());
+        let manager = QueryManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            QueryRuntimeContext::default(),
+            layout,
+            vec![Arc::new(CacheOverrideProvider {
+                registry: provider_registry,
+            })],
+        )
+        .expect("query manager should build");
+
+        let runtime = manager.runtime_config(&WorkspaceName::default(), &[]);
+
+        assert_eq!(
+            runtime.extensions.cache_namespace.as_deref(),
+            Some(WorkspaceName::default().as_str())
+        );
+        assert!(runtime.extensions.http_cache_registry.is_none());
     }
 
     #[test]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage,
+    HttpCacheRegistry, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, RuntimeSourcePackage,
     SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
@@ -48,6 +48,7 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    http_cache_registry: Arc<HttpCacheRegistry>,
 }
 
 impl QueryManager {
@@ -64,6 +65,7 @@ impl QueryManager {
             runtime_context,
             layout,
             engine_extensions_providers,
+            http_cache_registry: Arc::new(HttpCacheRegistry::new()),
         }
     }
 
@@ -308,6 +310,7 @@ impl QueryManager {
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
+        extensions.http_cache_registry = Some(Arc::clone(&self.http_cache_registry));
         QueryRuntimeConfig::new(self.runtime_context.clone(), extensions)
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -318,6 +318,7 @@ impl QueryManager {
             self.credential_manager.clone(),
             provider_input_resolver,
         )));
+        extensions.cache_namespace = Some(workspace_name.as_str().to_string());
         extensions.http_cache_registry = self.http_cache_registry.as_ref().map(Arc::clone);
         QueryRuntimeConfig::new(self.runtime_context.clone(), extensions)
     }
@@ -566,6 +567,10 @@ mod tests {
             .body_capture_max_bytes
             .expect("body capture config");
         assert_eq!(config, 42);
+        assert_eq!(
+            runtime.extensions.cache_namespace.as_deref(),
+            Some(WorkspaceName::default().as_str())
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -108,6 +108,7 @@ fn http_manifest_for_surface(
                         }
                     },
                     pagination: projection.pagination.clone(),
+                    cache: None,
                 });
             }
             ProjectionKind::TableFunction { function_kind } => {

--- a/crates/coral-app/src/sources/runtime_package.rs
+++ b/crates/coral-app/src/sources/runtime_package.rs
@@ -5,11 +5,14 @@ use std::collections::HashMap;
 use coral_engine::RuntimeSourceComponent;
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::v4::{
-    ProjectionKind, ProjectionVisibility, V4MaterializedSource, V4SourceManifest,
-    openapi_document_metadata, projection_arg_specs, projection_column_specs,
-    projection_filter_specs, request_spec_for_projection,
+    IrExecutionAttachment, IrOperation, Projection, ProjectionKind, ProjectionVisibility,
+    V4MaterializedSource, V4SourceManifest, openapi_document_metadata, projection_arg_specs,
+    projection_column_specs, projection_filter_specs, request_spec_for_projection,
 };
-use coral_spec::{ParsedTemplate, SourceManifestCommon, SourceTableFunctionSpec, TableCommon};
+use coral_spec::{
+    ParsedTemplate, RequestSpec, ResponseSpec, SourceManifestCommon, SourceTableFunctionSpec,
+    TableCommon,
+};
 
 use crate::bootstrap::AppError;
 
@@ -84,53 +87,7 @@ fn http_manifest_for_surface(
                     projection.name, projection.operation_id
                 ))
             })?;
-        let request = request_spec_for_projection(projection, operation)
-            .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
-        let columns = projection_column_specs(projection);
-        match &projection.kind {
-            ProjectionKind::Table => {
-                tables.push(HttpTableSpec {
-                    common: TableCommon {
-                        name: projection.name.clone(),
-                        description: projection.description.clone(),
-                        guide: projection.guide.clone(),
-                        filters: projection_filter_specs(projection),
-                        fetch_limit_default: None,
-                        search_limits: projection.search_limits.clone(),
-                        detail_hints: projection.detail_hints.clone(),
-                        columns,
-                    },
-                    request,
-                    requests: Vec::new(),
-                    response: match &operation.execution {
-                        coral_spec::v4::IrExecutionAttachment::Rest(rest) => {
-                            rest.response.response.clone()
-                        }
-                    },
-                    pagination: projection.pagination.clone(),
-                    cache: None,
-                });
-            }
-            ProjectionKind::TableFunction { function_kind } => {
-                functions.push(SourceTableFunctionSpec {
-                    name: projection.name.clone(),
-                    kind: *function_kind,
-                    description: projection.description.clone(),
-                    fetch_limit_default: None,
-                    search_limits: projection.search_limits.clone(),
-                    detail_hints: projection.detail_hints.clone(),
-                    args: projection_arg_specs(projection),
-                    request,
-                    response: match &operation.execution {
-                        coral_spec::v4::IrExecutionAttachment::Rest(rest) => {
-                            rest.response.response.clone()
-                        }
-                    },
-                    pagination: projection.pagination.clone(),
-                    columns,
-                });
-            }
-        }
+        push_projection_runtime_spec(&mut tables, &mut functions, projection, operation)?;
     }
     Ok(HttpSourceManifest {
         common: SourceManifestCommon {
@@ -148,6 +105,69 @@ fn http_manifest_for_surface(
         functions,
         declared_inputs: manifest.declared_inputs.clone(),
     })
+}
+
+fn push_projection_runtime_spec(
+    tables: &mut Vec<HttpTableSpec>,
+    functions: &mut Vec<SourceTableFunctionSpec>,
+    projection: &Projection,
+    operation: &IrOperation,
+) -> Result<(), AppError> {
+    let request = request_spec_for_projection(projection, operation)
+        .map_err(|error| AppError::FailedPrecondition(error.to_string()))?;
+    let response = response_spec_for_operation(operation);
+    let columns = projection_column_specs(projection);
+    match &projection.kind {
+        ProjectionKind::Table => tables.push(http_table_spec_for_projection(
+            projection, request, response, columns,
+        )),
+        ProjectionKind::TableFunction { function_kind } => {
+            functions.push(SourceTableFunctionSpec {
+                name: projection.name.clone(),
+                kind: *function_kind,
+                description: projection.description.clone(),
+                fetch_limit_default: None,
+                search_limits: projection.search_limits.clone(),
+                detail_hints: projection.detail_hints.clone(),
+                args: projection_arg_specs(projection),
+                request,
+                response,
+                pagination: projection.pagination.clone(),
+                columns,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn http_table_spec_for_projection(
+    projection: &Projection,
+    request: RequestSpec,
+    response: ResponseSpec,
+    columns: Vec<coral_spec::ColumnSpec>,
+) -> HttpTableSpec {
+    HttpTableSpec {
+        common: TableCommon {
+            name: projection.name.clone(),
+            description: projection.description.clone(),
+            guide: projection.guide.clone(),
+            filters: projection_filter_specs(projection),
+            fetch_limit_default: None,
+            search_limits: projection.search_limits.clone(),
+            detail_hints: projection.detail_hints.clone(),
+            columns,
+        },
+        request,
+        requests: Vec::new(),
+        response,
+        pagination: projection.pagination.clone(),
+        cache: None,
+    }
+}
+
+fn response_spec_for_operation(operation: &IrOperation) -> ResponseSpec {
+    let IrExecutionAttachment::Rest(rest) = &operation.execution;
+    rest.response.response.clone()
 }
 
 fn surface_base_url(

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -22,6 +22,7 @@ datafusion-functions-json.workspace = true
 datafusion-tracing.workspace = true
 futures.workspace = true
 httpdate.workspace = true
+moka.workspace = true
 object_store.workspace = true
 opentelemetry.workspace = true
 parquet.workspace = true
@@ -47,6 +48,6 @@ opentelemetry_sdk = { workspace = true, features = ["testing"] }
 parquet.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
 tracing-subscriber.workspace = true
 wiremock.workspace = true

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -133,6 +133,8 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(crate) cache_namespace: String,
+    pub(crate) source_input_fingerprint: u64,
     pub(crate) http_cache_registry: Option<Arc<crate::backends::http::cache::HttpCacheRegistry>>,
 }
 

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -133,6 +133,7 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    pub(crate) http_cache_registry: Option<Arc<crate::backends::http::cache::HttpCacheRegistry>>,
 }
 
 /// Shared resources available while registering one batch of compiled sources.

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -133,9 +133,8 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    pub(crate) cache_namespace: String,
-    pub(crate) source_input_fingerprint: u64,
-    pub(crate) http_cache_registry: Option<Arc<crate::backends::http::cache::HttpCacheRegistry>>,
+    pub(crate) cache_namespace: Option<String>,
+    pub(crate) http_cache_registry: Option<Arc<crate::HttpCacheRegistry>>,
 }
 
 /// Shared resources available while registering one batch of compiled sources.

--- a/crates/coral-engine/src/backends/http/cache.rs
+++ b/crates/coral-engine/src/backends/http/cache.rs
@@ -550,4 +550,32 @@ mod tests {
         assert!(fresh_source.try_admit(1).await);
         assert_eq!(expired_source.weighted_size(), 0);
     }
+
+    #[tokio::test]
+    async fn admission_defers_global_expiry_cleanup_until_capacity_pressure() {
+        let registry = HttpCacheRegistry::with_policy(64, Some(10), HashMap::new());
+        let expired_source = registry
+            .get_or_create("default", "expired_source", "0.1.0")
+            .await;
+        expired_source
+            .put(
+                "expired".to_string(),
+                HttpCacheEntry {
+                    payload: json!({"stale": true}),
+                    next_url: None,
+                    ttl: Duration::from_millis(1),
+                    estimated_bytes: 1,
+                },
+            )
+            .await;
+        assert_eq!(expired_source.weighted_size(), 1);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let fresh_source = registry
+            .get_or_create("default", "fresh_source", "0.1.0")
+            .await;
+
+        assert!(fresh_source.try_admit(1).await);
+        assert_eq!(expired_source.weighted_size(), 1);
+    }
 }

--- a/crates/coral-engine/src/backends/http/cache.rs
+++ b/crates/coral-engine/src/backends/http/cache.rs
@@ -511,13 +511,13 @@ mod tests {
     async fn registry_prunes_empty_obsolete_buckets_on_lookup() {
         let registry = HttpCacheRegistry::with_policy(64, None, HashMap::new());
         let first = registry
-            .get_or_create("default", "first_source", "0.1.0")
+            .get_or_create("default", "versioned_source", "0.1.0")
             .await;
         assert_eq!(registry.bucket_count(), 1);
         drop(first);
 
         let _second = registry
-            .get_or_create("default", "second_source", "0.1.0")
+            .get_or_create("default", "versioned_source", "0.2.0")
             .await;
 
         assert_eq!(registry.bucket_count(), 1);

--- a/crates/coral-engine/src/backends/http/cache.rs
+++ b/crates/coral-engine/src/backends/http/cache.rs
@@ -2,19 +2,20 @@
 //!
 //! Cache entries are keyed by a stable canonical string derived from all
 //! request-determining material: source identity, table, rendered URL, query
-//! params, body hash, hashed vary header values, and the declared TTL. Secret
-//! values are never included in keys, values, or trace events.
+//! params, body hash, hashed vary header values, and the declared TTL. Rendered
+//! request material is hashed before it becomes part of the stored cache key.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, Weak};
+use std::hash::Hasher as _;
 use std::time::Duration;
 
-use moka::Expiry;
-use moka::future::Cache;
 use serde_json::Value;
 
+use crate::backends::shared::cache::{
+    CacheBucket, CacheBucketKey, CacheRegistry, CacheValue, hash_cache_bytes,
+};
+
 const CACHE_FORMAT_VERSION: u8 = 1;
-const DEFAULT_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
 
 /// A single decoded HTTP response page held in the cache.
 #[derive(Clone)]
@@ -29,132 +30,17 @@ pub(crate) struct HttpCacheEntry {
     pub(crate) estimated_bytes: usize,
 }
 
-struct EntryExpiry;
-
-impl Expiry<String, HttpCacheEntry> for EntryExpiry {
-    fn expire_after_create(
-        &self,
-        _key: &String,
-        value: &HttpCacheEntry,
-        _created_at: std::time::Instant,
-    ) -> Option<Duration> {
-        Some(value.ttl)
+impl CacheValue for HttpCacheEntry {
+    fn ttl(&self) -> Duration {
+        self.ttl
     }
 
-    fn expire_after_read(
-        &self,
-        _key: &String,
-        _value: &HttpCacheEntry,
-        _current_time: std::time::Instant,
-        current_duration: Option<Duration>,
-        _last_modified_at: std::time::Instant,
-    ) -> Option<Duration> {
-        current_duration
-    }
-
-    fn expire_after_update(
-        &self,
-        _key: &String,
-        value: &HttpCacheEntry,
-        _current_time: std::time::Instant,
-        _current_duration: Option<Duration>,
-    ) -> Option<Duration> {
-        Some(value.ttl)
+    fn estimated_bytes(&self) -> usize {
+        self.estimated_bytes
     }
 }
 
-/// Shared in-memory HTTP response page cache backed by moka.
-///
-/// `Clone` is cheap — all clones share the same underlying cache.
-#[derive(Clone)]
-pub(crate) struct HttpResponseCache {
-    inner: Arc<Cache<String, HttpCacheEntry>>,
-    registry: Option<Weak<HttpCacheRegistryInner>>,
-}
-
-impl HttpResponseCache {
-    /// Create a new cache with the default 256 MiB capacity limit.
-    #[cfg(test)]
-    pub(crate) fn new() -> Self {
-        Self::build(DEFAULT_CACHE_MAX_BYTES, None)
-    }
-
-    fn build(max_bytes: u64, registry: Option<Weak<HttpCacheRegistryInner>>) -> Self {
-        let inner = Cache::builder()
-            .max_capacity(max_bytes)
-            .weigher(|_key: &String, value: &HttpCacheEntry| {
-                #[expect(
-                    clippy::cast_possible_truncation,
-                    reason = "Saturating at u32::MAX is the correct moka weigher clamp"
-                )]
-                let weight = value.estimated_bytes.min(u32::MAX as usize) as u32;
-                weight
-            })
-            .expire_after(EntryExpiry)
-            .build();
-        Self {
-            inner: Arc::new(inner),
-            registry,
-        }
-    }
-
-    /// Approximate weighted byte size currently stored.
-    pub(crate) fn weighted_size(&self) -> u64 {
-        self.inner.weighted_size()
-    }
-
-    /// Soft admission check against the parent registry's `total_max_bytes`,
-    /// if any. Returns `true` when no registry is attached or no total
-    /// ceiling is configured.
-    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
-        let Some(weak) = &self.registry else {
-            return true;
-        };
-        let Some(inner) = weak.upgrade() else {
-            return true;
-        };
-        HttpCacheRegistry { inner }.try_admit(incoming_bytes)
-    }
-
-    /// Return the cached entry for `key`, or `None` on miss or expiry.
-    #[cfg(test)]
-    pub(crate) async fn get(&self, key: &str) -> Option<HttpCacheEntry> {
-        self.inner.get(key).await
-    }
-
-    /// Insert `entry` under `key`.
-    #[cfg(test)]
-    pub(crate) async fn put(&self, key: String, entry: HttpCacheEntry) {
-        self.inner.insert(key, entry).await;
-    }
-
-    /// Single-flight get-or-fetch. Returns `(entry, is_fresh)` where
-    /// `is_fresh` is true when this caller's `init` ran (cache miss).
-    pub(crate) async fn try_get_or_insert_with<F, E>(
-        &self,
-        key: &str,
-        init: F,
-    ) -> Result<(HttpCacheEntry, bool), Arc<E>>
-    where
-        F: std::future::Future<Output = Result<HttpCacheEntry, E>>,
-        E: Send + Sync + 'static,
-    {
-        let entry = self
-            .inner
-            .entry_by_ref(key)
-            .or_try_insert_with(init)
-            .await?;
-        let is_fresh = entry.is_fresh();
-        Ok((entry.into_value(), is_fresh))
-    }
-}
-
-pub(crate) struct HttpCacheRegistryInner {
-    entries: Mutex<HashMap<(String, String), HttpResponseCache>>,
-    default_max_bytes: u64,
-    total_max_bytes: Option<u64>,
-    per_source_max_bytes: HashMap<String, u64>,
-}
+pub(crate) type HttpResponseCache = CacheBucket<HttpCacheEntry>;
 
 /// Per-source `HttpResponseCache` instances keyed by `(name, version)`.
 ///
@@ -162,16 +48,13 @@ pub(crate) struct HttpCacheRegistryInner {
 /// survive across the per-query runtime rebuild.
 #[derive(Clone)]
 pub struct HttpCacheRegistry {
-    inner: Arc<HttpCacheRegistryInner>,
+    inner: CacheRegistry<HttpCacheEntry>,
 }
 
 impl std::fmt::Debug for HttpCacheRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let len = self.inner.entries.lock().map_or(0, |g| g.len());
-        f.debug_struct("HttpCacheRegistry")
-            .field("entries", &len)
-            .field("default_max_bytes", &self.inner.default_max_bytes)
-            .field("total_max_bytes", &self.inner.total_max_bytes)
+        f.debug_tuple("HttpCacheRegistry")
+            .field(&self.inner)
             .finish()
     }
 }
@@ -181,7 +64,9 @@ impl HttpCacheRegistry {
     /// cross-source ceiling.
     #[must_use]
     pub fn new() -> Self {
-        Self::with_policy(DEFAULT_CACHE_MAX_BYTES, None, HashMap::new())
+        Self {
+            inner: CacheRegistry::new(),
+        }
     }
 
     /// Build a registry with explicit policy.
@@ -198,59 +83,36 @@ impl HttpCacheRegistry {
         per_source_max_bytes: HashMap<String, u64>,
     ) -> Self {
         Self {
-            inner: Arc::new(HttpCacheRegistryInner {
-                entries: Mutex::new(HashMap::new()),
+            inner: CacheRegistry::with_policy(
                 default_max_bytes,
                 total_max_bytes,
                 per_source_max_bytes,
-            }),
+            ),
         }
     }
 
     pub(crate) fn get_or_create(
         &self,
+        namespace: &str,
         source_name: &str,
         source_version: &str,
+        input_fingerprint: u64,
     ) -> HttpResponseCache {
-        let mut guard = self
-            .inner
-            .entries
-            .lock()
-            .expect("HttpCacheRegistry mutex poisoned");
-        let key = (source_name.to_string(), source_version.to_string());
-        if let Some(existing) = guard.get(&key) {
-            return existing.clone();
-        }
-        let max_bytes = self
-            .inner
-            .per_source_max_bytes
-            .get(source_name)
-            .copied()
-            .unwrap_or(self.inner.default_max_bytes);
-        let cache = HttpResponseCache::build(max_bytes, Some(Arc::downgrade(&self.inner)));
-        guard.insert(key, cache.clone());
-        cache
+        self.inner.get_or_create(CacheBucketKey::new(
+            namespace,
+            "http",
+            source_name,
+            source_version,
+            input_fingerprint,
+        ))
     }
 
     /// Soft check: would admitting `incoming_bytes` keep the registry's total
     /// weighted size within `total_max_bytes`? Returns `true` if no ceiling is
     /// configured.
+    #[cfg(test)]
     pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
-        let Some(total) = self.inner.total_max_bytes else {
-            return true;
-        };
-        let current = {
-            let guard = self
-                .inner
-                .entries
-                .lock()
-                .expect("HttpCacheRegistry mutex poisoned");
-            guard
-                .values()
-                .map(HttpResponseCache::weighted_size)
-                .sum::<u64>()
-        };
-        current.saturating_add(incoming_bytes) <= total
+        self.inner.try_admit(incoming_bytes)
     }
 }
 
@@ -286,14 +148,25 @@ pub(crate) fn build_cache_key(
     let mut vary_sorted = vary_headers.to_vec();
     vary_sorted.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
 
+    let url_hash = hash_cache_bytes(url.as_bytes());
+    let query_hash = hash_cache_value(&sorted_qs);
+    let vary_hash = hash_cache_value(&vary_sorted);
+    let body_hash = body_hash.map(|hash| format!("{hash:016x}"));
+
     format!(
-        "v{CACHE_FORMAT_VERSION}\t{source_name}\t{source_version}\t{table_name}\t{method}\t{url}\t{sorted_qs:?}\t{body_hash:?}\t{vary_sorted:?}\t{ttl_secs}"
+        "v{CACHE_FORMAT_VERSION}\t{source_name}\t{source_version}\t{table_name}\t{method}\turl:{url_hash:016x}\tquery:{query_hash:016x}\tbody:{body_hash:?}\tvary:{vary_hash:016x}\tttl:{ttl_secs}"
     )
 }
 
 /// Estimate the in-memory size of a JSON value using its serialized length.
 pub(crate) fn estimate_json_bytes(value: &Value) -> usize {
     serde_json::to_string(value).map_or(0, |s| s.len())
+}
+
+fn hash_cache_value<T: std::hash::Hash>(value: &T) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
 }
 
 #[cfg(test)]
@@ -469,6 +342,27 @@ mod tests {
         assert_ne!(key1, key2);
     }
 
+    #[test]
+    fn cache_key_hashes_rendered_request_material() {
+        let key = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users?token=secret-token",
+            &[("api_key".to_string(), "secret-key".to_string())],
+            Some(42),
+            &[("authorization".to_string(), Some(99))],
+            300,
+        );
+
+        assert!(!key.contains("secret-token"));
+        assert!(!key.contains("secret-key"));
+        assert!(!key.contains("https://api.example.com"));
+        assert!(key.contains("url:"));
+        assert!(key.contains("query:"));
+    }
+
     #[tokio::test]
     async fn updating_entry_resets_ttl() {
         let cache = HttpResponseCache::new();
@@ -521,8 +415,8 @@ mod tests {
         let mut overrides = HashMap::new();
         overrides.insert("large_source".to_string(), 1024);
         let registry = HttpCacheRegistry::with_policy(64, None, overrides);
-        let small = registry.get_or_create("small_source", "0.1.0");
-        let large = registry.get_or_create("large_source", "0.1.0");
+        let small = registry.get_or_create("default", "small_source", "0.1.0", 0);
+        let large = registry.get_or_create("default", "large_source", "0.1.0", 0);
         // Small source uses the default capacity (64); large source has an override (1024).
         // Different moka caches → different identity. We can't read max_capacity off
         // moka directly, but admission against a zero-size ceiling proves the registry
@@ -530,7 +424,7 @@ mod tests {
         assert_eq!(small.weighted_size(), 0);
         assert_eq!(large.weighted_size(), 0);
         let zero_ceiling = HttpCacheRegistry::with_policy(64, Some(0), HashMap::new());
-        let _ = zero_ceiling.get_or_create("s", "0");
+        let _ = zero_ceiling.get_or_create("default", "s", "0", 0);
         assert!(!zero_ceiling.try_admit(1));
     }
 }

--- a/crates/coral-engine/src/backends/http/cache.rs
+++ b/crates/coral-engine/src/backends/http/cache.rs
@@ -6,7 +6,7 @@
 //! values are never included in keys, values, or trace events.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 use moka::Expiry;
@@ -69,13 +69,19 @@ impl Expiry<String, HttpCacheEntry> for EntryExpiry {
 #[derive(Clone)]
 pub(crate) struct HttpResponseCache {
     inner: Arc<Cache<String, HttpCacheEntry>>,
+    registry: Option<Weak<HttpCacheRegistryInner>>,
 }
 
 impl HttpResponseCache {
     /// Create a new cache with the default 256 MiB capacity limit.
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
+        Self::build(DEFAULT_CACHE_MAX_BYTES, None)
+    }
+
+    fn build(max_bytes: u64, registry: Option<Weak<HttpCacheRegistryInner>>) -> Self {
         let inner = Cache::builder()
-            .max_capacity(DEFAULT_CACHE_MAX_BYTES)
+            .max_capacity(max_bytes)
             .weigher(|_key: &String, value: &HttpCacheEntry| {
                 #[expect(
                     clippy::cast_possible_truncation,
@@ -88,7 +94,26 @@ impl HttpResponseCache {
             .build();
         Self {
             inner: Arc::new(inner),
+            registry,
         }
+    }
+
+    /// Approximate weighted byte size currently stored.
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.inner.weighted_size()
+    }
+
+    /// Soft admission check against the parent registry's `total_max_bytes`,
+    /// if any. Returns `true` when no registry is attached or no total
+    /// ceiling is configured.
+    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
+        let Some(weak) = &self.registry else {
+            return true;
+        };
+        let Some(inner) = weak.upgrade() else {
+            return true;
+        };
+        HttpCacheRegistry { inner }.try_admit(incoming_bytes)
     }
 
     /// Return the cached entry for `key`, or `None` on miss or expiry.
@@ -124,29 +149,61 @@ impl HttpResponseCache {
     }
 }
 
+pub(crate) struct HttpCacheRegistryInner {
+    entries: Mutex<HashMap<(String, String), HttpResponseCache>>,
+    default_max_bytes: u64,
+    total_max_bytes: Option<u64>,
+    per_source_max_bytes: HashMap<String, u64>,
+}
+
 /// Per-source `HttpResponseCache` instances keyed by `(name, version)`.
 ///
 /// Held by long-lived callers (e.g. `QueryManager`) so cache entries
 /// survive across the per-query runtime rebuild.
+#[derive(Clone)]
 pub struct HttpCacheRegistry {
-    entries: Mutex<HashMap<(String, String), HttpResponseCache>>,
+    inner: Arc<HttpCacheRegistryInner>,
 }
 
 impl std::fmt::Debug for HttpCacheRegistry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let len = self.entries.lock().map_or(0, |g| g.len());
+        let len = self.inner.entries.lock().map_or(0, |g| g.len());
         f.debug_struct("HttpCacheRegistry")
             .field("entries", &len)
+            .field("default_max_bytes", &self.inner.default_max_bytes)
+            .field("total_max_bytes", &self.inner.total_max_bytes)
             .finish()
     }
 }
 
 impl HttpCacheRegistry {
-    /// Build an empty registry.
+    /// Build a registry with default per-source capacity (256 MiB) and no
+    /// cross-source ceiling.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_policy(DEFAULT_CACHE_MAX_BYTES, None, HashMap::new())
+    }
+
+    /// Build a registry with explicit policy.
+    ///
+    /// `default_max_bytes` is the per-source cache capacity applied when a
+    /// source has no override in `per_source_max_bytes`. `total_max_bytes`,
+    /// when set, is a soft ceiling on the sum of weighted bytes across all
+    /// per-source caches; entries that would push the running total over the
+    /// ceiling are skipped (the response is still returned to the caller).
+    #[must_use]
+    pub fn with_policy(
+        default_max_bytes: u64,
+        total_max_bytes: Option<u64>,
+        per_source_max_bytes: HashMap<String, u64>,
+    ) -> Self {
         Self {
-            entries: Mutex::new(HashMap::new()),
+            inner: Arc::new(HttpCacheRegistryInner {
+                entries: Mutex::new(HashMap::new()),
+                default_max_bytes,
+                total_max_bytes,
+                per_source_max_bytes,
+            }),
         }
     }
 
@@ -156,18 +213,44 @@ impl HttpCacheRegistry {
         source_version: &str,
     ) -> HttpResponseCache {
         let mut guard = self
+            .inner
             .entries
             .lock()
             .expect("HttpCacheRegistry mutex poisoned");
-        if let Some(existing) = guard.get(&(source_name.to_string(), source_version.to_string())) {
+        let key = (source_name.to_string(), source_version.to_string());
+        if let Some(existing) = guard.get(&key) {
             return existing.clone();
         }
-        let cache = HttpResponseCache::new();
-        guard.insert(
-            (source_name.to_string(), source_version.to_string()),
-            cache.clone(),
-        );
+        let max_bytes = self
+            .inner
+            .per_source_max_bytes
+            .get(source_name)
+            .copied()
+            .unwrap_or(self.inner.default_max_bytes);
+        let cache = HttpResponseCache::build(max_bytes, Some(Arc::downgrade(&self.inner)));
+        guard.insert(key, cache.clone());
         cache
+    }
+
+    /// Soft check: would admitting `incoming_bytes` keep the registry's total
+    /// weighted size within `total_max_bytes`? Returns `true` if no ceiling is
+    /// configured.
+    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
+        let Some(total) = self.inner.total_max_bytes else {
+            return true;
+        };
+        let current = {
+            let guard = self
+                .inner
+                .entries
+                .lock()
+                .expect("HttpCacheRegistry mutex poisoned");
+            guard
+                .values()
+                .map(HttpResponseCache::weighted_size)
+                .sum::<u64>()
+        };
+        current.saturating_add(incoming_bytes) <= total
     }
 }
 
@@ -425,5 +508,29 @@ mod tests {
         let estimated = estimate_json_bytes(&value);
         let serialized = serde_json::to_string(&value).unwrap();
         assert_eq!(estimated, serialized.len());
+    }
+
+    #[test]
+    fn registry_with_no_ceiling_admits_anything() {
+        let registry = HttpCacheRegistry::with_policy(1024, None, HashMap::new());
+        assert!(registry.try_admit(1024 * 1024));
+    }
+
+    #[test]
+    fn registry_returns_distinct_caches_for_distinct_sources() {
+        let mut overrides = HashMap::new();
+        overrides.insert("large_source".to_string(), 1024);
+        let registry = HttpCacheRegistry::with_policy(64, None, overrides);
+        let small = registry.get_or_create("small_source", "0.1.0");
+        let large = registry.get_or_create("large_source", "0.1.0");
+        // Small source uses the default capacity (64); large source has an override (1024).
+        // Different moka caches → different identity. We can't read max_capacity off
+        // moka directly, but admission against a zero-size ceiling proves the registry
+        // is exercising both entries.
+        assert_eq!(small.weighted_size(), 0);
+        assert_eq!(large.weighted_size(), 0);
+        let zero_ceiling = HttpCacheRegistry::with_policy(64, Some(0), HashMap::new());
+        let _ = zero_ceiling.get_or_create("s", "0");
+        assert!(!zero_ceiling.try_admit(1));
     }
 }

--- a/crates/coral-engine/src/backends/http/cache.rs
+++ b/crates/coral-engine/src/backends/http/cache.rs
@@ -5,8 +5,8 @@
 //! params, body hash, hashed vary header values, and the declared TTL. Rendered
 //! request material is hashed before it becomes part of the stored cache key.
 
-use std::collections::HashMap;
-use std::hash::Hasher as _;
+use std::collections::{BTreeMap, HashMap};
+use std::hash::{Hash as _, Hasher as _};
 use std::time::Duration;
 
 use serde_json::Value;
@@ -47,7 +47,7 @@ pub(crate) type HttpResponseCache = CacheBucket<HttpCacheEntry>;
 /// Held by long-lived callers (e.g. `QueryManager`) so cache entries
 /// survive across the per-query runtime rebuild.
 #[derive(Clone)]
-pub struct HttpCacheRegistry {
+pub(crate) struct HttpCacheRegistry {
     inner: CacheRegistry<HttpCacheEntry>,
 }
 
@@ -63,7 +63,7 @@ impl HttpCacheRegistry {
     /// Build a registry with default per-source capacity (256 MiB) and no
     /// cross-source ceiling.
     #[must_use]
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             inner: CacheRegistry::new(),
         }
@@ -77,7 +77,7 @@ impl HttpCacheRegistry {
     /// per-source caches; entries that would push the running total over the
     /// ceiling are skipped (the response is still returned to the caller).
     #[must_use]
-    pub fn with_policy(
+    pub(crate) fn with_policy(
         default_max_bytes: u64,
         total_max_bytes: Option<u64>,
         per_source_max_bytes: HashMap<String, u64>,
@@ -91,20 +91,20 @@ impl HttpCacheRegistry {
         }
     }
 
-    pub(crate) fn get_or_create(
+    pub(crate) async fn get_or_create(
         &self,
         namespace: &str,
         source_name: &str,
         source_version: &str,
-        input_fingerprint: u64,
     ) -> HttpResponseCache {
-        self.inner.get_or_create(CacheBucketKey::new(
-            namespace,
-            "http",
-            source_name,
-            source_version,
-            input_fingerprint,
-        ))
+        self.inner
+            .get_or_create(CacheBucketKey::new(
+                namespace,
+                "http",
+                source_name,
+                source_version,
+            ))
+            .await
     }
 
     /// Soft check: would admitting `incoming_bytes` keep the registry's total
@@ -113,6 +113,11 @@ impl HttpCacheRegistry {
     #[cfg(test)]
     pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
         self.inner.try_admit(incoming_bytes)
+    }
+
+    #[cfg(test)]
+    fn bucket_count(&self) -> usize {
+        self.inner.bucket_count()
     }
 }
 
@@ -134,6 +139,7 @@ impl Default for HttpCacheRegistry {
 pub(crate) fn build_cache_key(
     source_name: &str,
     source_version: &str,
+    resolved_input_fingerprint: u64,
     table_name: &str,
     method: &str,
     url: &str,
@@ -142,19 +148,16 @@ pub(crate) fn build_cache_key(
     vary_headers: &[(String, Option<u64>)],
     ttl_secs: u64,
 ) -> String {
-    let mut sorted_qs = query_pairs.to_vec();
-    sorted_qs.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-
     let mut vary_sorted = vary_headers.to_vec();
     vary_sorted.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
 
     let url_hash = hash_cache_bytes(url.as_bytes());
-    let query_hash = hash_cache_value(&sorted_qs);
+    let query_hash = hash_cache_value(query_pairs);
     let vary_hash = hash_cache_value(&vary_sorted);
     let body_hash = body_hash.map(|hash| format!("{hash:016x}"));
 
     format!(
-        "v{CACHE_FORMAT_VERSION}\t{source_name}\t{source_version}\t{table_name}\t{method}\turl:{url_hash:016x}\tquery:{query_hash:016x}\tbody:{body_hash:?}\tvary:{vary_hash:016x}\tttl:{ttl_secs}"
+        "v{CACHE_FORMAT_VERSION}\t{source_name}\t{source_version}\tinputs:{resolved_input_fingerprint:016x}\t{table_name}\t{method}\turl:{url_hash:016x}\tquery:{query_hash:016x}\tbody:{body_hash:?}\tvary:{vary_hash:016x}\tttl:{ttl_secs}"
     )
 }
 
@@ -163,7 +166,16 @@ pub(crate) fn estimate_json_bytes(value: &Value) -> usize {
     serde_json::to_string(value).map_or(0, |s| s.len())
 }
 
-fn hash_cache_value<T: std::hash::Hash>(value: &T) -> u64 {
+pub(crate) fn resolved_inputs_cache_fingerprint(resolved_inputs: &BTreeMap<String, String>) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for (key, value) in resolved_inputs {
+        key.hash(&mut hasher);
+        hash_cache_bytes(value.as_bytes()).hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+fn hash_cache_value<T: std::hash::Hash + ?Sized>(value: &T) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     value.hash(&mut hasher);
     hasher.finish()
@@ -179,6 +191,7 @@ mod tests {
         let key1 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -190,6 +203,7 @@ mod tests {
         let key2 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -206,6 +220,7 @@ mod tests {
         let key1 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -217,6 +232,7 @@ mod tests {
         let key2 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -229,10 +245,11 @@ mod tests {
     }
 
     #[test]
-    fn cache_key_normalises_query_param_order() {
+    fn cache_key_preserves_query_param_order() {
         let key1 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "items",
             "GET",
             "https://api.example.com/items",
@@ -247,6 +264,7 @@ mod tests {
         let key2 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "items",
             "GET",
             "https://api.example.com/items",
@@ -258,7 +276,7 @@ mod tests {
             &[],
             60,
         );
-        assert_eq!(key1, key2);
+        assert_ne!(key1, key2);
     }
 
     #[test]
@@ -266,6 +284,7 @@ mod tests {
         let key1 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -277,6 +296,36 @@ mod tests {
         let key2 = build_cache_key(
             "demo",
             "0.2.0",
+            0,
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[],
+            300,
+        );
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_resolved_inputs() {
+        let key1 = build_cache_key(
+            "demo",
+            "0.1.0",
+            1,
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[],
+            300,
+        );
+        let key2 = build_cache_key(
+            "demo",
+            "0.1.0",
+            2,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -293,6 +342,7 @@ mod tests {
         let key1 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -304,6 +354,7 @@ mod tests {
         let key2 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -320,6 +371,7 @@ mod tests {
         let key1 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -331,6 +383,7 @@ mod tests {
         let key2 = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users",
@@ -347,6 +400,7 @@ mod tests {
         let key = build_cache_key(
             "demo",
             "0.1.0",
+            0,
             "users",
             "GET",
             "https://api.example.com/users?token=secret-token",
@@ -361,6 +415,27 @@ mod tests {
         assert!(!key.contains("https://api.example.com"));
         assert!(key.contains("url:"));
         assert!(key.contains("query:"));
+    }
+
+    #[test]
+    fn resolved_inputs_fingerprint_hashes_values() {
+        let inputs = BTreeMap::from([("TOKEN".to_string(), "secret-token".to_string())]);
+        let fingerprint = resolved_inputs_cache_fingerprint(&inputs);
+        let key = build_cache_key(
+            "demo",
+            "0.1.0",
+            fingerprint,
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[],
+            300,
+        );
+
+        assert_ne!(fingerprint, 0);
+        assert!(!key.contains("secret-token"));
     }
 
     #[tokio::test]
@@ -410,21 +485,41 @@ mod tests {
         assert!(registry.try_admit(1024 * 1024));
     }
 
-    #[test]
-    fn registry_returns_distinct_caches_for_distinct_sources() {
+    #[tokio::test]
+    async fn registry_returns_distinct_caches_for_distinct_sources() {
         let mut overrides = HashMap::new();
         overrides.insert("large_source".to_string(), 1024);
         let registry = HttpCacheRegistry::with_policy(64, None, overrides);
-        let small = registry.get_or_create("default", "small_source", "0.1.0", 0);
-        let large = registry.get_or_create("default", "large_source", "0.1.0", 0);
+        let small = registry
+            .get_or_create("default", "small_source", "0.1.0")
+            .await;
+        let large = registry
+            .get_or_create("default", "large_source", "0.1.0")
+            .await;
         // Small source uses the default capacity (64); large source has an override (1024).
-        // Different moka caches → different identity. We can't read max_capacity off
+        // Different moka caches mean different identity. We can't read max_capacity off
         // moka directly, but admission against a zero-size ceiling proves the registry
         // is exercising both entries.
         assert_eq!(small.weighted_size(), 0);
         assert_eq!(large.weighted_size(), 0);
         let zero_ceiling = HttpCacheRegistry::with_policy(64, Some(0), HashMap::new());
-        let _ = zero_ceiling.get_or_create("default", "s", "0", 0);
+        let _ = zero_ceiling.get_or_create("default", "s", "0").await;
         assert!(!zero_ceiling.try_admit(1));
+    }
+
+    #[tokio::test]
+    async fn registry_prunes_empty_obsolete_buckets_on_lookup() {
+        let registry = HttpCacheRegistry::with_policy(64, None, HashMap::new());
+        let first = registry
+            .get_or_create("default", "first_source", "0.1.0")
+            .await;
+        assert_eq!(registry.bucket_count(), 1);
+        drop(first);
+
+        let _second = registry
+            .get_or_create("default", "second_source", "0.1.0")
+            .await;
+
+        assert_eq!(registry.bucket_count(), 1);
     }
 }

--- a/crates/coral-engine/src/backends/http/cache.rs
+++ b/crates/coral-engine/src/backends/http/cache.rs
@@ -111,8 +111,8 @@ impl HttpCacheRegistry {
     /// weighted size within `total_max_bytes`? Returns `true` if no ceiling is
     /// configured.
     #[cfg(test)]
-    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
-        self.inner.try_admit(incoming_bytes)
+    pub(crate) async fn try_admit(&self, incoming_bytes: u64) -> bool {
+        self.inner.try_admit(incoming_bytes).await
     }
 
     #[cfg(test)]
@@ -479,10 +479,10 @@ mod tests {
         assert_eq!(estimated, serialized.len());
     }
 
-    #[test]
-    fn registry_with_no_ceiling_admits_anything() {
+    #[tokio::test]
+    async fn registry_with_no_ceiling_admits_anything() {
         let registry = HttpCacheRegistry::with_policy(1024, None, HashMap::new());
-        assert!(registry.try_admit(1024 * 1024));
+        assert!(registry.try_admit(1024 * 1024).await);
     }
 
     #[tokio::test]
@@ -504,7 +504,7 @@ mod tests {
         assert_eq!(large.weighted_size(), 0);
         let zero_ceiling = HttpCacheRegistry::with_policy(64, Some(0), HashMap::new());
         let _ = zero_ceiling.get_or_create("default", "s", "0").await;
-        assert!(!zero_ceiling.try_admit(1));
+        assert!(!zero_ceiling.try_admit(1).await);
     }
 
     #[tokio::test]
@@ -521,5 +521,33 @@ mod tests {
             .await;
 
         assert_eq!(registry.bucket_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn admission_ignores_expired_entries_from_other_sources() {
+        let registry = HttpCacheRegistry::with_policy(64, Some(1), HashMap::new());
+        let expired_source = registry
+            .get_or_create("default", "expired_source", "0.1.0")
+            .await;
+        expired_source
+            .put(
+                "expired".to_string(),
+                HttpCacheEntry {
+                    payload: json!({"stale": true}),
+                    next_url: None,
+                    ttl: Duration::from_millis(1),
+                    estimated_bytes: 1,
+                },
+            )
+            .await;
+        assert_eq!(expired_source.weighted_size(), 1);
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let fresh_source = registry
+            .get_or_create("default", "fresh_source", "0.1.0")
+            .await;
+
+        assert!(fresh_source.try_admit(1).await);
+        assert_eq!(expired_source.weighted_size(), 0);
     }
 }

--- a/crates/coral-engine/src/backends/http/cache.rs
+++ b/crates/coral-engine/src/backends/http/cache.rs
@@ -1,0 +1,429 @@
+//! In-memory HTTP response page cache for opt-in TTL-based caching.
+//!
+//! Cache entries are keyed by a stable canonical string derived from all
+//! request-determining material: source identity, table, rendered URL, query
+//! params, body hash, hashed vary header values, and the declared TTL. Secret
+//! values are never included in keys, values, or trace events.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use moka::Expiry;
+use moka::future::Cache;
+use serde_json::Value;
+
+const CACHE_FORMAT_VERSION: u8 = 1;
+const DEFAULT_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+
+/// A single decoded HTTP response page held in the cache.
+#[derive(Clone)]
+pub(crate) struct HttpCacheEntry {
+    /// Decoded response payload.
+    pub(crate) payload: Value,
+    /// Parsed `Link: <...>; rel="next"` URL from the response, if any.
+    pub(crate) next_url: Option<String>,
+    /// Time-to-live used to set expiry when the entry was created.
+    pub(crate) ttl: Duration,
+    /// Estimated in-memory size in bytes (JSON string length approximation).
+    pub(crate) estimated_bytes: usize,
+}
+
+struct EntryExpiry;
+
+impl Expiry<String, HttpCacheEntry> for EntryExpiry {
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &HttpCacheEntry,
+        _created_at: std::time::Instant,
+    ) -> Option<Duration> {
+        Some(value.ttl)
+    }
+
+    fn expire_after_read(
+        &self,
+        _key: &String,
+        _value: &HttpCacheEntry,
+        _current_time: std::time::Instant,
+        current_duration: Option<Duration>,
+        _last_modified_at: std::time::Instant,
+    ) -> Option<Duration> {
+        current_duration
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &String,
+        value: &HttpCacheEntry,
+        _current_time: std::time::Instant,
+        _current_duration: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(value.ttl)
+    }
+}
+
+/// Shared in-memory HTTP response page cache backed by moka.
+///
+/// `Clone` is cheap — all clones share the same underlying cache.
+#[derive(Clone)]
+pub(crate) struct HttpResponseCache {
+    inner: Arc<Cache<String, HttpCacheEntry>>,
+}
+
+impl HttpResponseCache {
+    /// Create a new cache with the default 256 MiB capacity limit.
+    pub(crate) fn new() -> Self {
+        let inner = Cache::builder()
+            .max_capacity(DEFAULT_CACHE_MAX_BYTES)
+            .weigher(|_key: &String, value: &HttpCacheEntry| {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "Saturating at u32::MAX is the correct moka weigher clamp"
+                )]
+                let weight = value.estimated_bytes.min(u32::MAX as usize) as u32;
+                weight
+            })
+            .expire_after(EntryExpiry)
+            .build();
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Return the cached entry for `key`, or `None` on miss or expiry.
+    #[cfg(test)]
+    pub(crate) async fn get(&self, key: &str) -> Option<HttpCacheEntry> {
+        self.inner.get(key).await
+    }
+
+    /// Insert `entry` under `key`.
+    #[cfg(test)]
+    pub(crate) async fn put(&self, key: String, entry: HttpCacheEntry) {
+        self.inner.insert(key, entry).await;
+    }
+
+    /// Single-flight get-or-fetch. Returns `(entry, is_fresh)` where
+    /// `is_fresh` is true when this caller's `init` ran (cache miss).
+    pub(crate) async fn try_get_or_insert_with<F, E>(
+        &self,
+        key: &str,
+        init: F,
+    ) -> Result<(HttpCacheEntry, bool), Arc<E>>
+    where
+        F: std::future::Future<Output = Result<HttpCacheEntry, E>>,
+        E: Send + Sync + 'static,
+    {
+        let entry = self
+            .inner
+            .entry_by_ref(key)
+            .or_try_insert_with(init)
+            .await?;
+        let is_fresh = entry.is_fresh();
+        Ok((entry.into_value(), is_fresh))
+    }
+}
+
+/// Per-source `HttpResponseCache` instances keyed by `(name, version)`.
+///
+/// Held by long-lived callers (e.g. `QueryManager`) so cache entries
+/// survive across the per-query runtime rebuild.
+pub struct HttpCacheRegistry {
+    entries: Mutex<HashMap<(String, String), HttpResponseCache>>,
+}
+
+impl std::fmt::Debug for HttpCacheRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.entries.lock().map_or(0, |g| g.len());
+        f.debug_struct("HttpCacheRegistry")
+            .field("entries", &len)
+            .finish()
+    }
+}
+
+impl HttpCacheRegistry {
+    /// Build an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn get_or_create(
+        &self,
+        source_name: &str,
+        source_version: &str,
+    ) -> HttpResponseCache {
+        let mut guard = self
+            .entries
+            .lock()
+            .expect("HttpCacheRegistry mutex poisoned");
+        if let Some(existing) = guard.get(&(source_name.to_string(), source_version.to_string())) {
+            return existing.clone();
+        }
+        let cache = HttpResponseCache::new();
+        guard.insert(
+            (source_name.to_string(), source_version.to_string()),
+            cache.clone(),
+        );
+        cache
+    }
+}
+
+impl Default for HttpCacheRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Build a stable, canonical cache key string from all request-determining
+/// material.  Auth headers and secret values are never included.
+///
+/// `body_hash` is a pre-computed hash of the serialized request body, allowing
+/// callers to hash the body without exposing its type to this module.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "All parameters are distinct key dimensions; introducing a struct would add noise"
+)]
+pub(crate) fn build_cache_key(
+    source_name: &str,
+    source_version: &str,
+    table_name: &str,
+    method: &str,
+    url: &str,
+    query_pairs: &[(String, String)],
+    body_hash: Option<u64>,
+    vary_headers: &[(String, Option<u64>)],
+    ttl_secs: u64,
+) -> String {
+    let mut sorted_qs = query_pairs.to_vec();
+    sorted_qs.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    let mut vary_sorted = vary_headers.to_vec();
+    vary_sorted.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+
+    format!(
+        "v{CACHE_FORMAT_VERSION}\t{source_name}\t{source_version}\t{table_name}\t{method}\t{url}\t{sorted_qs:?}\t{body_hash:?}\t{vary_sorted:?}\t{ttl_secs}"
+    )
+}
+
+/// Estimate the in-memory size of a JSON value using its serialized length.
+pub(crate) fn estimate_json_bytes(value: &Value) -> usize {
+    serde_json::to_string(value).map_or(0, |s| s.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn cache_key_is_stable_for_identical_inputs() {
+        let key1 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[("page".to_string(), "1".to_string())],
+            None,
+            &[],
+            300,
+        );
+        let key2 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[("page".to_string(), "1".to_string())],
+            None,
+            &[],
+            300,
+        );
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_query_params() {
+        let key1 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[("page".to_string(), "1".to_string())],
+            None,
+            &[],
+            300,
+        );
+        let key2 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[("page".to_string(), "2".to_string())],
+            None,
+            &[],
+            300,
+        );
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_normalises_query_param_order() {
+        let key1 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "items",
+            "GET",
+            "https://api.example.com/items",
+            &[
+                ("b".to_string(), "2".to_string()),
+                ("a".to_string(), "1".to_string()),
+            ],
+            None,
+            &[],
+            60,
+        );
+        let key2 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "items",
+            "GET",
+            "https://api.example.com/items",
+            &[
+                ("a".to_string(), "1".to_string()),
+                ("b".to_string(), "2".to_string()),
+            ],
+            None,
+            &[],
+            60,
+        );
+        assert_eq!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_source_version() {
+        let key1 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[],
+            300,
+        );
+        let key2 = build_cache_key(
+            "demo",
+            "0.2.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[],
+            300,
+        );
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_ttl() {
+        let key1 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[],
+            60,
+        );
+        let key2 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[],
+            300,
+        );
+        assert_ne!(key1, key2);
+    }
+
+    #[test]
+    fn cache_key_differs_for_different_vary_header_values() {
+        let key1 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[("accept".to_string(), Some(1))],
+            300,
+        );
+        let key2 = build_cache_key(
+            "demo",
+            "0.1.0",
+            "users",
+            "GET",
+            "https://api.example.com/users",
+            &[],
+            None,
+            &[("accept".to_string(), Some(2))],
+            300,
+        );
+        assert_ne!(key1, key2);
+    }
+
+    #[tokio::test]
+    async fn updating_entry_resets_ttl() {
+        let cache = HttpResponseCache::new();
+        let key = "ttl-refresh".to_string();
+        cache
+            .put(
+                key.clone(),
+                HttpCacheEntry {
+                    payload: json!({"version": 1}),
+                    next_url: None,
+                    ttl: Duration::from_secs(1),
+                    estimated_bytes: 1,
+                },
+            )
+            .await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        cache
+            .put(
+                key.clone(),
+                HttpCacheEntry {
+                    payload: json!({"version": 2}),
+                    next_url: None,
+                    ttl: Duration::from_secs(1),
+                    estimated_bytes: 1,
+                },
+            )
+            .await;
+        tokio::time::sleep(Duration::from_millis(700)).await;
+
+        let entry = cache.get(&key).await.expect("updated entry should remain");
+        assert_eq!(entry.payload, json!({"version": 2}));
+    }
+
+    #[test]
+    fn estimate_json_bytes_returns_string_length() {
+        let value = json!({"key": "value", "num": 42});
+        let estimated = estimate_json_bytes(&value);
+        let serialized = serde_json::to_string(&value).unwrap();
+        assert_eq!(estimated, serialized.len());
+    }
+}

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -38,7 +38,7 @@ pub(crate) struct HttpSourceClient {
     pub(super) rate_limit: RateLimitSpec,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
     pub(super) body_capture: HttpBodyCapture,
-    pub(super) cache: HttpResponseCache,
+    pub(super) cache: Option<HttpResponseCache>,
 }
 
 pub(crate) struct HttpSourceClientRuntime {
@@ -68,6 +68,20 @@ impl HttpSourceClientRuntime {
 
     #[cfg(test)]
     fn static_inputs(body_capture_max_bytes: Option<usize>, http: reqwest::Client) -> Self {
+        Self {
+            source_input_resolution_context: None,
+            source_input_resolver: None,
+            body_capture_max_bytes,
+            http,
+            cache: Some(HttpResponseCache::new()),
+        }
+    }
+
+    #[cfg(test)]
+    fn static_inputs_without_cache(
+        body_capture_max_bytes: Option<usize>,
+        http: reqwest::Client,
+    ) -> Self {
         Self {
             source_input_resolution_context: None,
             source_input_resolver: None,
@@ -135,6 +149,24 @@ impl HttpSourceClient {
         )
     }
 
+    #[cfg(test)]
+    pub(crate) fn from_manifest_without_cache(
+        manifest: &HttpSourceManifest,
+        source_secrets: &BTreeMap<String, String>,
+        source_variables: &BTreeMap<String, String>,
+        request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
+        body_capture_max_bytes: Option<usize>,
+        http: reqwest::Client,
+    ) -> Result<Self> {
+        Self::build(
+            manifest,
+            source_secrets,
+            source_variables,
+            request_authenticators,
+            HttpSourceClientRuntime::static_inputs_without_cache(body_capture_max_bytes, http),
+        )
+    }
+
     pub(crate) fn from_manifest_with_source_input_resolver(
         manifest: &HttpSourceManifest,
         source_secrets: &BTreeMap<String, String>,
@@ -178,7 +210,7 @@ impl HttpSourceClient {
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
             body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),
-            cache: runtime.cache.unwrap_or_else(HttpResponseCache::new),
+            cache: runtime.cache,
         })
     }
 

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -8,6 +8,7 @@ use datafusion::error::{DataFusionError, Result};
 use serde_json::Value;
 
 use crate::backends::BackendRegistrationContext;
+use crate::backends::http::cache::HttpResponseCache;
 use crate::backends::http::fetch::fetch_rows;
 use crate::backends::http::registration_checks::validate_source_scoped_http_config;
 use crate::backends::http::target::HttpFetchTarget;
@@ -27,6 +28,7 @@ pub(crate) struct HttpSourceClient {
     pub(super) http: reqwest::Client,
     pub(super) request_timeout: Duration,
     pub(super) source_schema: String,
+    pub(super) source_version: String,
     pub(super) base_url: ParsedTemplate,
     pub(super) auth: AuthSpec,
     pub(super) request_headers: Vec<HeaderSpec>,
@@ -36,6 +38,7 @@ pub(crate) struct HttpSourceClient {
     pub(super) rate_limit: RateLimitSpec,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
     pub(super) body_capture: HttpBodyCapture,
+    pub(super) cache: HttpResponseCache,
 }
 
 pub(crate) struct HttpSourceClientRuntime {
@@ -43,6 +46,7 @@ pub(crate) struct HttpSourceClientRuntime {
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     body_capture_max_bytes: Option<usize>,
     http: reqwest::Client,
+    cache: Option<HttpResponseCache>,
 }
 
 impl HttpSourceClientRuntime {
@@ -51,12 +55,14 @@ impl HttpSourceClientRuntime {
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
         body_capture_max_bytes: Option<usize>,
         http: reqwest::Client,
+        cache: Option<HttpResponseCache>,
     ) -> Self {
         Self {
             source_input_resolution_context: Some(source_input_resolution_context),
             source_input_resolver,
             body_capture_max_bytes,
             http,
+            cache,
         }
     }
 
@@ -67,6 +73,7 @@ impl HttpSourceClientRuntime {
             source_input_resolver: None,
             body_capture_max_bytes,
             http,
+            cache: None,
         }
     }
 }
@@ -161,6 +168,7 @@ impl HttpSourceClient {
             http: runtime.http,
             request_timeout,
             source_schema: manifest.common.name.clone(),
+            source_version: manifest.common.version.clone(),
             base_url: manifest.base_url.clone(),
             auth: manifest.auth.clone(),
             request_headers: manifest.request_headers.clone(),
@@ -170,6 +178,7 @@ impl HttpSourceClient {
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
             body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),
+            cache: runtime.cache.unwrap_or_else(HttpResponseCache::new),
         })
     }
 

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -17,7 +17,7 @@ const NOT_FOUND: u16 = HttpStatus::NOT_FOUND.as_u16();
 const TOO_MANY_REQUESTS: u16 = HttpStatus::TOO_MANY_REQUESTS.as_u16();
 
 /// Structured query-time failures for HTTP-backed tables.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub(crate) enum ProviderQueryError {
     #[error(
         "{schema}.{table} table requires a constant equality filter: WHERE {column} = <constant>"

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -1,27 +1,166 @@
 //! Paginated HTTP fetch orchestration.
 
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
 
 use datafusion::error::{DataFusionError, Result};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::Value;
 
 use crate::backends::http::ProviderQueryError;
+use crate::backends::http::cache::{HttpCacheEntry, build_cache_key, estimate_json_bytes};
 use crate::backends::http::client::HttpSourceClient;
 use crate::backends::http::error::{pagination_error, provider_error};
 use crate::backends::http::pagination::{
     PageState, apply_pagination_body_fields, apply_pagination_query_pairs, page_is_exhausted,
     pagination_state_values, resolve_page_size,
 };
-use crate::backends::http::request::{build_query_pairs, build_request_body};
+use crate::backends::http::request::{RequestBody, build_query_pairs, build_request_body};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::transport::{OutgoingHttpRequest, execute_request};
 use crate::backends::http::url::{join_url, normalize_base_url};
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::response_rows::extract_rows;
-use crate::backends::shared::template::{RenderContext, render_template};
-use coral_spec::ValidatedPaginationMode;
+use crate::backends::shared::template::{
+    RenderContext, render_template, resolve_value_source, value_to_string,
+};
+use coral_spec::backends::http::HttpCacheMode;
+use coral_spec::{HeaderSpec, HttpMethod, ValidatedPaginationMode};
 
 const DEFAULT_MAX_PAGES: usize = 10_000;
+
+/// Single-flight outcome carried as `Err` for non-cacheable fetches.
+/// `Clone` is required by moka; `Arc` keeps the inner error intact.
+#[derive(Clone)]
+enum FetchSkipped {
+    NoData,
+    NotCacheable {
+        payload: Value,
+        next_url: Option<String>,
+    },
+    NetworkError(Arc<DataFusionError>),
+}
+
+impl FetchSkipped {
+    fn network_error(err: DataFusionError) -> Self {
+        Self::NetworkError(Arc::new(err))
+    }
+
+    fn no_data() -> Self {
+        Self::NoData
+    }
+
+    fn not_cacheable(payload: Value, next_url: Option<String>) -> Self {
+        Self::NotCacheable { payload, next_url }
+    }
+}
+
+/// Fallback wrapper exposing the inner error via `Error::source()`.
+#[derive(Debug)]
+struct SharedDataFusionError(Arc<DataFusionError>);
+
+impl std::fmt::Display for SharedDataFusionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&*self.0, f)
+    }
+}
+
+impl std::error::Error for SharedDataFusionError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&*self.0)
+    }
+}
+
+/// moka keeps an internal `Arc` clone, so `try_unwrap` never succeeds;
+/// downcast-clone preserves the original variant for the common case.
+fn unwrap_network_error(err: Arc<DataFusionError>) -> DataFusionError {
+    if let DataFusionError::External(boxed) = &*err
+        && let Some(provider_err) = boxed.downcast_ref::<ProviderQueryError>()
+    {
+        return DataFusionError::External(Box::new(provider_err.clone()));
+    }
+    DataFusionError::External(Box::new(SharedDataFusionError(err)))
+}
+
+fn http_method_label(method: HttpMethod) -> &'static str {
+    match method {
+        HttpMethod::GET => "GET",
+        HttpMethod::POST => "POST",
+    }
+}
+
+fn hash_cache_bytes(value: &[u8]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash as _, Hasher as _};
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn hash_request_body(body: &RequestBody) -> u64 {
+    match body {
+        RequestBody::Json(value) => {
+            hash_cache_bytes(serde_json::to_string(value).unwrap_or_default().as_bytes())
+        }
+        RequestBody::Text(text) => hash_cache_bytes(text.as_bytes()),
+    }
+}
+
+fn cache_vary_header_hashes(
+    request_headers: &[HeaderSpec],
+    table_headers: &[HeaderSpec],
+    body: Option<&RequestBody>,
+    render_context: &RenderContext<'_>,
+    vary_headers: &[String],
+) -> Result<Vec<(String, Option<u64>)>> {
+    if vary_headers.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut header_map = HeaderMap::new();
+    for header in request_headers.iter().chain(table_headers.iter()) {
+        if let Some(value) = resolve_value_source(&header.value, render_context)? {
+            let name = HeaderName::try_from(header.name.as_str()).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "invalid request header name '{}': {error}",
+                    header.name
+                ))
+            })?;
+            let value =
+                HeaderValue::try_from(value_to_string(&value).as_str()).map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "invalid request header value for '{}': {error}",
+                        header.name
+                    ))
+                })?;
+            header_map.insert(name, value);
+        }
+    }
+    if matches!(body, Some(RequestBody::Text(_)))
+        && !header_map.contains_key(reqwest::header::CONTENT_TYPE)
+    {
+        header_map.insert(
+            reqwest::header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain"),
+        );
+    }
+
+    vary_headers
+        .iter()
+        .map(|header| {
+            let name = HeaderName::try_from(header.as_str()).map_err(|error| {
+                DataFusionError::Execution(format!(
+                    "invalid cache vary header name '{header}': {error}"
+                ))
+            })?;
+            let value_hash = header_map
+                .get(&name)
+                .map(|value| hash_cache_bytes(value.as_bytes()));
+            Ok((name.as_str().to_string(), value_hash))
+        })
+        .collect()
+}
 
 #[derive(Debug, Clone, Copy)]
 struct FetchLimits {
@@ -145,32 +284,162 @@ pub(super) async fn fetch_rows(
             (query_pairs, body)
         };
 
-        let request = execute_request(
-            &client.http,
-            client.request_timeout,
-            OutgoingHttpRequest {
-                auth: &client.auth,
-                request_headers: &client.request_headers,
-                request_authenticators: &client.request_authenticators,
-                table_headers: &active_request.headers,
-                table_name: target.name(),
-                method: active_request.method,
-                base_url: &base_url,
-                url: &url,
-                query_pairs: &query_pairs,
-                body: body.as_ref(),
-                response_format: target.response().format,
-                source_schema: &client.source_schema,
-                rate_limit: &client.rate_limit,
-                body_capture: client.body_capture,
-                render_context,
-                allow_404_empty: target.response().allow_404_empty,
-                link_header_require_results: pagination.link_header_require_results,
-            },
-        )
-        .await?;
+        let cache_key: Option<(String, usize, Duration)> = target
+            .cache()
+            .filter(|p| p.mode == HttpCacheMode::Ttl)
+            .filter(|policy| {
+                policy
+                    .max_pages
+                    .is_none_or(|max_cache_pages| page_count <= max_cache_pages)
+            })
+            .map(|policy| {
+                let body_hash = body.as_ref().map(hash_request_body);
+                let vary_headers = cache_vary_header_hashes(
+                    &client.request_headers,
+                    &active_request.headers,
+                    body.as_ref(),
+                    &render_context,
+                    &policy.vary_headers,
+                )?;
+                let key = build_cache_key(
+                    &client.source_schema,
+                    &client.source_version,
+                    target.name(),
+                    http_method_label(active_request.method),
+                    &url,
+                    &query_pairs,
+                    body_hash,
+                    &vary_headers,
+                    policy.ttl.as_secs(),
+                );
+                let max_entry = policy.max_entry_bytes.unwrap_or(usize::MAX);
+                Ok::<_, DataFusionError>((key, max_entry, policy.ttl))
+            })
+            .transpose()?;
 
-        let Some((payload, next_url)) = request else {
+        let page = if let Some((ref key, max_entry_bytes, ttl)) = cache_key {
+            let source_schema = client.source_schema.clone();
+            let table_name = target.name().to_string();
+            let ok_path = target.response().ok_path.clone();
+            let result = client
+                .cache
+                .try_get_or_insert_with::<_, FetchSkipped>(key, async {
+                    tracing::trace!(
+                        source = %source_schema,
+                        table = %table_name,
+                        "http cache miss"
+                    );
+                    let result = execute_request(
+                        &client.http,
+                        client.request_timeout,
+                        OutgoingHttpRequest {
+                            auth: &client.auth,
+                            request_headers: &client.request_headers,
+                            request_authenticators: &client.request_authenticators,
+                            table_headers: &active_request.headers,
+                            table_name: target.name(),
+                            method: active_request.method,
+                            base_url: &base_url,
+                            url: &url,
+                            query_pairs: &query_pairs,
+                            body: body.as_ref(),
+                            response_format: target.response().format,
+                            source_schema: &client.source_schema,
+                            rate_limit: &client.rate_limit,
+                            body_capture: client.body_capture,
+                            render_context,
+                            allow_404_empty: target.response().allow_404_empty,
+                            link_header_require_results: pagination.link_header_require_results,
+                        },
+                    )
+                    .await
+                    .map_err(FetchSkipped::network_error)?;
+                    let Some((payload, next_url)) = result else {
+                        return Err(FetchSkipped::no_data());
+                    };
+                    let estimated_bytes = estimate_json_bytes(&payload);
+                    let ok_for_cache = ok_path.is_empty()
+                        || get_path_value(&payload, &ok_path)
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false);
+                    if !ok_for_cache {
+                        tracing::trace!(
+                            source = %source_schema,
+                            table = %table_name,
+                            "http cache entry skipped: ok_path=false"
+                        );
+                        return Err(FetchSkipped::not_cacheable(payload, next_url));
+                    }
+                    if estimated_bytes > max_entry_bytes {
+                        tracing::trace!(
+                            source = %source_schema,
+                            table = %table_name,
+                            estimated_bytes,
+                            "http cache entry skipped: exceeds max_entry_bytes"
+                        );
+                        return Err(FetchSkipped::not_cacheable(payload, next_url));
+                    }
+                    Ok(HttpCacheEntry {
+                        payload,
+                        next_url,
+                        ttl,
+                        estimated_bytes,
+                    })
+                })
+                .await;
+
+            match result {
+                Ok((entry, is_fresh)) => {
+                    if !is_fresh {
+                        tracing::trace!(
+                            source = %client.source_schema,
+                            table = %target.name(),
+                            "http cache hit"
+                        );
+                    }
+                    Some((entry.payload, entry.next_url))
+                }
+                Err(arc) => {
+                    let skipped = Arc::try_unwrap(arc).unwrap_or_else(|a| (*a).clone());
+                    match skipped {
+                        FetchSkipped::NetworkError(err) => {
+                            return Err(unwrap_network_error(err));
+                        }
+                        FetchSkipped::NoData => None,
+                        FetchSkipped::NotCacheable { payload, next_url } => {
+                            Some((payload, next_url))
+                        }
+                    }
+                }
+            }
+        } else {
+            execute_request(
+                &client.http,
+                client.request_timeout,
+                OutgoingHttpRequest {
+                    auth: &client.auth,
+                    request_headers: &client.request_headers,
+                    request_authenticators: &client.request_authenticators,
+                    table_headers: &active_request.headers,
+                    table_name: target.name(),
+                    method: active_request.method,
+                    base_url: &base_url,
+                    url: &url,
+                    query_pairs: &query_pairs,
+                    body: body.as_ref(),
+                    response_format: target.response().format,
+                    source_schema: &client.source_schema,
+                    rate_limit: &client.rate_limit,
+                    body_capture: client.body_capture,
+                    render_context,
+                    allow_404_empty: target.response().allow_404_empty,
+                    link_header_require_results: pagination.link_header_require_results,
+                },
+            )
+            .await?
+        };
+
+        let Some((payload, next_url)) = page else {
             break;
         };
 
@@ -284,5 +553,1101 @@ fn resolve_fetch_limits(target: &HttpFetchTarget, sql_limit: Option<usize>) -> F
         effective_limit: Some(requested_top_k.min(max_candidates)),
         page_size_limit: Some(requested_top_k.min(search_limits.max_top_k)),
         max_search_calls: Some(search_limits.max_calls_per_query),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::backends::http::test_support::{parse_http_manifest, test_http_request_target};
+    use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
+    use coral_spec::parse_source_manifest_value;
+
+    // ── Cache tests ───────────────────────────────────────────────────────────
+
+    fn cached_users_manifest(base_url: &str) -> HttpSourceManifest {
+        parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": base_url,
+            "tables": [{
+                "name": "users",
+                "description": "Users",
+                "request": { "path": "/api/users" },
+                "response": { "rows_path": ["data"] },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [
+                    { "name": "id", "type": "Int64" },
+                    { "name": "name", "type": "Utf8" }
+                ]
+            }]
+        }))
+    }
+
+    fn build_test_client(manifest: &HttpSourceManifest) -> HttpSourceClient {
+        HttpSourceClient::from_manifest(
+            manifest,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &HashMap::new(),
+            None,
+            reqwest::Client::new(),
+        )
+        .expect("test client should build")
+    }
+
+    fn first_table(manifest: &HttpSourceManifest) -> &HttpTableSpec {
+        manifest
+            .tables
+            .first()
+            .expect("manifest should have a table")
+    }
+
+    async fn fetch_table(
+        client: &HttpSourceClient,
+        table: &HttpTableSpec,
+        filters: &HashMap<String, String>,
+        sql_limit: Option<usize>,
+    ) -> datafusion::error::Result<Vec<serde_json::Value>> {
+        let target = test_http_request_target(table);
+        client
+            .fetch(&target, filters, &HashMap::new(), sql_limit)
+            .await
+    }
+
+    #[tokio::test]
+    async fn cache_hit_avoids_second_outbound_request() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [
+                    { "id": 1, "name": "Ada" },
+                    { "id": 2, "name": "Grace" }
+                ]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        let rows1 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("first fetch");
+        let rows2 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second fetch from cache");
+
+        assert_eq!(rows1, rows2);
+        assert_eq!(rows1.len(), 2);
+        // MockServer verifies .expect(1) on drop — panics if != 1 request made
+    }
+
+    #[tokio::test]
+    async fn cache_miss_on_different_filter_values() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "filters": [{ "name": "status" }],
+                "request": {
+                    "path": "/api/items",
+                    "query": [{ "name": "status", "from": "filter", "key": "status" }]
+                },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("status", "open"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 1 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("status", "closed"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 2 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+
+        let rows_open = fetch_table(
+            &client,
+            table,
+            &HashMap::from([("status".into(), "open".into())]),
+            None,
+        )
+        .await
+        .expect("open fetch");
+        let rows_closed = fetch_table(
+            &client,
+            table,
+            &HashMap::from([("status".into(), "closed".into())]),
+            None,
+        )
+        .await
+        .expect("closed fetch");
+
+        assert_ne!(rows_open, rows_closed);
+        // Both mocks have .expect(1) — verified on drop
+    }
+
+    #[tokio::test]
+    async fn cache_miss_on_different_vary_header_values() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "filters": [{ "name": "mode" }],
+                "request": {
+                    "path": "/api/items",
+                    "headers": [{ "name": "X-Mode", "from": "filter", "key": "mode" }]
+                },
+                "cache": {
+                    "mode": "ttl",
+                    "ttl": "1h",
+                    "vary": { "headers": ["X-Mode"] }
+                },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(header("X-Mode", "alpha"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 1 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(header("X-Mode", "beta"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 2 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+
+        let rows_alpha = fetch_table(
+            &client,
+            table,
+            &HashMap::from([("mode".into(), "alpha".into())]),
+            None,
+        )
+        .await
+        .expect("alpha fetch");
+        let rows_beta = fetch_table(
+            &client,
+            table,
+            &HashMap::from([("mode".into(), "beta".into())]),
+            None,
+        )
+        .await
+        .expect("beta fetch");
+
+        assert_ne!(rows_alpha, rows_beta);
+    }
+
+    #[tokio::test]
+    async fn cache_second_identical_query_uses_first_result() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "filters": [{ "name": "status" }],
+                "request": {
+                    "path": "/api/items",
+                    "query": [{ "name": "status", "from": "filter", "key": "status" }]
+                },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("status", "open"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 1 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::from([("status".to_string(), "open".to_string())]);
+
+        let r1 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("first");
+        let r2 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second, from cache");
+        assert_eq!(r1, r2);
+        // .expect(1) verified on drop
+    }
+
+    #[tokio::test]
+    async fn cache_does_not_cache_failed_responses() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+
+        // Use 400 (not retried, unlike 5xx) to get exactly one request per fetch() call.
+        // The second call must still hit the server, proving failed responses are not cached.
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "first call should fail"
+        );
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "second call should also fail"
+        );
+        // .expect(2) verifies 2 separate outbound requests (no caching of errors)
+    }
+
+    #[tokio::test]
+    async fn cache_expires_after_ttl() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "data": [{ "id": 1 }] })),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "users",
+                "description": "Users",
+                "request": { "path": "/api/users" },
+                "response": { "rows_path": ["data"] },
+                "cache": { "mode": "ttl", "ttl": "1s" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        fetch_table(&client, table, &filters, None)
+            .await
+            .expect("first fetch");
+        // Wait for the 1s TTL to expire
+        tokio::time::sleep(Duration::from_millis(1100)).await;
+        fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second fetch after expiry");
+        // .expect(2) verifies 2 outbound requests were made
+    }
+
+    #[tokio::test]
+    async fn cache_disabled_by_default() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "data": [{ "id": 1 }] })),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        // Manifest with no cache field — caching must stay disabled.
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "users",
+                "description": "Users",
+                "request": { "path": "/api/users" },
+                "response": { "rows_path": ["data"] },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        fetch_table(&client, table, &filters, None)
+            .await
+            .expect("first");
+        fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second");
+        // .expect(2) verifies both calls made it to the server (no caching)
+    }
+
+    #[test]
+    fn parse_manifest_accepts_cache_ttl_policy() {
+        use coral_spec::backends::http::HttpCacheMode;
+
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "alpha",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": "https://api.example.com",
+            "tables": [{
+                "name": "items",
+                "description": "items",
+                "request": { "path": "/items" },
+                "cache": {
+                    "mode": "ttl",
+                    "ttl": "5m",
+                    "vary": { "headers": ["Accept"] },
+                    "max_pages": 50,
+                    "max_entry_bytes": 1_048_576
+                },
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }));
+
+        let cache = first_table(&manifest)
+            .cache
+            .as_ref()
+            .expect("cache policy should be set");
+        assert_eq!(cache.mode, HttpCacheMode::Ttl);
+        assert_eq!(cache.ttl.as_secs(), 300);
+        assert_eq!(cache.vary_headers, vec!["Accept"]);
+        assert_eq!(cache.max_pages, Some(50));
+        assert_eq!(cache.max_entry_bytes, Some(1_048_576));
+    }
+
+    #[test]
+    fn parse_manifest_rejects_overflowing_cache_ttl() {
+        let error = parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "alpha",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": "https://api.example.com",
+            "tables": [{
+                "name": "items",
+                "description": "items",
+                "request": { "path": "/items" },
+                "cache": { "mode": "ttl", "ttl": "18446744073709551615h" },
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }))
+        .expect_err("overflowing ttl should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("cache ttl '18446744073709551615h' overflows u64 seconds"),
+            "unexpected ttl overflow error: {error}"
+        );
+    }
+
+    #[test]
+    fn parse_manifest_no_cache_field_gives_none() {
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "alpha",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": "https://api.example.com",
+            "tables": [{
+                "name": "items",
+                "description": "items",
+                "request": { "path": "/items" },
+                "columns": [{ "name": "id", "type": "Utf8" }]
+            }]
+        }));
+
+        assert!(first_table(&manifest).cache.is_none());
+    }
+
+    #[tokio::test]
+    async fn cache_different_post_body_causes_miss() {
+        use wiremock::matchers::{body_json, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "filters": [{ "name": "status" }],
+                "request": {
+                    "method": "POST",
+                    "path": "/api/items",
+                    "body": [{ "path": ["filter"], "from": "filter", "key": "status" }]
+                },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        Mock::given(method("POST"))
+            .and(path("/api/items"))
+            .and(body_json(json!({ "filter": "open" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 1 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/items"))
+            .and(body_json(json!({ "filter": "closed" })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 2 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+
+        let rows_open = fetch_table(
+            &client,
+            table,
+            &HashMap::from([("status".into(), "open".into())]),
+            None,
+        )
+        .await
+        .expect("open fetch");
+        let rows_closed = fetch_table(
+            &client,
+            table,
+            &HashMap::from([("status".into(), "closed".into())]),
+            None,
+        )
+        .await
+        .expect("closed fetch");
+
+        assert_ne!(rows_open, rows_closed);
+        // Both mocks have .expect(1) — verified on drop
+    }
+
+    #[tokio::test]
+    async fn cache_different_pagination_state_causes_miss() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // No page_size query_param so the page number is the only URL-level pagination
+        // state. This ensures the cache key for page 1 is the same regardless of the
+        // SQL limit used by the caller.
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "pagination": {
+                    "mode": "page",
+                    "page_param": "page",
+                    "page_start": 1
+                },
+                "request": { "path": "/api/items" },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        // Page 1 is fetched once from the server (first call), then served from cache
+        // (second call) — same URL so same cache key.
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("page", "1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!([{ "id": 1 }, { "id": 2 }])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        // Page 2 is only fetched by the second call (different cache key: page=2).
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 3 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+
+        // First call: limit=2 → fetches page 1 (2 rows = limit), stops.
+        let rows1 = fetch_table(&client, table, &HashMap::new(), Some(2))
+            .await
+            .expect("first fetch");
+        assert_eq!(rows1.len(), 2);
+
+        // Second call: limit=3 → page 1 served from cache (2 rows), page 2 fresh from server.
+        let rows2 = fetch_table(&client, table, &HashMap::new(), Some(3))
+            .await
+            .expect("second fetch");
+        assert_eq!(rows2.len(), 3);
+        // Page 1 expect(1) and page 2 expect(1) are verified on drop
+    }
+
+    #[tokio::test]
+    async fn cache_pagination_stores_pages_independently() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "pagination": {
+                    "mode": "page",
+                    "page_param": "page",
+                    "page_start": 1,
+                    "page_size": { "default": 2, "max": 100, "query_param": "per_page" }
+                },
+                "request": { "path": "/api/items" },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        // Both pages are fetched once each on the first run, then served from
+        // cache on the second run — total expect(1) per page.
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("page", "1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!([{ "id": 1 }, { "id": 2 }])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 3 }])))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+
+        // First run: fetches both pages from server
+        let rows1 = fetch_table(&client, table, &HashMap::new(), None)
+            .await
+            .expect("first fetch");
+        assert_eq!(rows1.len(), 3);
+
+        // Second run: both pages served from cache — no additional server hits
+        let rows2 = fetch_table(&client, table, &HashMap::new(), None)
+            .await
+            .expect("second fetch");
+        assert_eq!(rows2, rows1);
+        // expect(1) per page verified on mock drop
+    }
+
+    #[tokio::test]
+    async fn cache_max_pages_limits_cached_pages_per_fetch() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "pagination": {
+                    "mode": "page",
+                    "page_param": "page",
+                    "page_start": 1,
+                    "page_size": { "default": 2, "max": 100, "query_param": "per_page" }
+                },
+                "request": { "path": "/api/items" },
+                "cache": { "mode": "ttl", "ttl": "1h", "max_pages": 1 },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("page", "1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!([{ "id": 1 }, { "id": 2 }])),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .and(query_param("page", "2"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{ "id": 3 }])))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+
+        let rows1 = fetch_table(&client, table, &HashMap::new(), None)
+            .await
+            .expect("first fetch");
+        let rows2 = fetch_table(&client, table, &HashMap::new(), None)
+            .await
+            .expect("second fetch");
+
+        assert_eq!(rows2, rows1);
+    }
+
+    #[tokio::test]
+    async fn cache_does_not_cache_5xx_responses() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // 500 triggers 2 retries → 3 requests for first fetch(); served up_to 3 times.
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("server error"))
+            .up_to_n_times(3)
+            .expect(3)
+            .mount(&server)
+            .await;
+        // After the 500 mock is exhausted, the second fetch hits the server and gets 200.
+        // If 5xx responses were incorrectly cached, this mock would never be reached.
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "data": [{ "id": 1, "name": "Ada" }] })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "first call should fail with server error"
+        );
+        let rows = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second call should succeed from server — 5xx response was not cached");
+        assert_eq!(rows.len(), 1);
+        // expect(3) on 500 mock and expect(1) on 200 mock verified on drop
+    }
+
+    #[tokio::test]
+    async fn cache_does_not_cache_429_responses() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // Retry-After: 60 exceeds MAX_SHORT_RETRY_AFTER (15s) → rate limit fails
+        // immediately without retrying, so each fetch() makes exactly one request.
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(429).append_header("Retry-After", "60"))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "first call should fail with rate-limit error"
+        );
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "second call should also fail — 429 responses are not cached"
+        );
+        // expect(2) verifies 2 outbound requests (no caching of rate-limit errors)
+    }
+
+    #[tokio::test]
+    async fn cache_does_not_cache_malformed_json() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("this is not json"))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "first call should fail to decode"
+        );
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "second call should also fail — malformed JSON is not cached"
+        );
+        // expect(2) verifies 2 outbound requests (decode error, no cache write)
+    }
+
+    #[tokio::test]
+    async fn cache_does_not_cache_allow_404_empty() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/items"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "items",
+                "description": "Items",
+                "request": { "path": "/api/items" },
+                "response": { "allow_404_empty": true },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        let rows1 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("first");
+        assert!(rows1.is_empty(), "allow_404_empty should return empty rows");
+
+        let rows2 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second");
+        assert!(rows2.is_empty());
+        // expect(2) verifies both calls hit the server (empty result is not cached)
+    }
+
+    #[tokio::test]
+    async fn cache_skips_oversized_entry_without_failing() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [
+                    { "id": 1, "name": "Ada" },
+                    { "id": 2, "name": "Grace" }
+                ]
+            })))
+            .expect(2) // entry is never cached, so both calls hit server
+            .mount(&server)
+            .await;
+
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "users",
+                "description": "Users",
+                "request": { "path": "/api/users" },
+                "response": { "rows_path": ["data"] },
+                "cache": { "mode": "ttl", "ttl": "1h", "max_entry_bytes": 10 },
+                "columns": [
+                    { "name": "id", "type": "Int64" },
+                    { "name": "name", "type": "Utf8" }
+                ]
+            }]
+        }));
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        let rows1 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("first");
+        assert_eq!(
+            rows1.len(),
+            2,
+            "rows should be returned even when entry is skipped"
+        );
+
+        let rows2 = fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second");
+        assert_eq!(rows2, rows1);
+        // expect(2) verifies both calls hit server (oversized entry was not stored)
+    }
+
+    #[tokio::test]
+    async fn cache_does_not_cache_ok_path_false() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(json!({ "ok": false, "error": "rate limited" })),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let manifest = parse_http_manifest(json!({
+            "dsl_version": 3,
+            "name": "demo",
+            "version": "0.1.0",
+            "backend": "http",
+            "base_url": server.uri(),
+            "tables": [{
+                "name": "users",
+                "description": "Users",
+                "request": { "path": "/api/users" },
+                "response": {
+                    "ok_path": ["ok"],
+                    "error_path": ["error"]
+                },
+                "cache": { "mode": "ttl", "ttl": "1h" },
+                "columns": [{ "name": "id", "type": "Int64" }]
+            }]
+        }));
+
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "first call should fail: ok_path=false"
+        );
+        assert!(
+            fetch_table(&client, table, &filters, None).await.is_err(),
+            "second call should also fail — ok_path=false response was not cached"
+        );
+        // expect(2) verifies both calls hit the server (bad response not cached)
+    }
+
+    #[tokio::test]
+    async fn cache_preserves_original_datafusion_error_variant_when_uncontended() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = build_test_client(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        let err = fetch_table(&client, table, &filters, None)
+            .await
+            .expect_err("400 should fail");
+
+        let mut current: &dyn std::error::Error = &err;
+        let mut found_provider_error = false;
+        loop {
+            if current.downcast_ref::<ProviderQueryError>().is_some() {
+                found_provider_error = true;
+                break;
+            }
+            match current.source() {
+                Some(next) => current = next,
+                None => break,
+            }
+        }
+        assert!(
+            found_provider_error,
+            "structured ProviderQueryError should be reachable via Error::source() chain; got: {err:?}"
+        );
+        assert_eq!(
+            err.to_string(),
+            "External error: demo.users API error: bad request"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_preserves_original_datafusion_error_under_concurrent_single_flight() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad request"))
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = Arc::new(build_test_client(&manifest));
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        let target = test_http_request_target(table);
+        let target = Arc::new(target);
+        let filters_a = filters.clone();
+        let filters_b = filters.clone();
+        let client_a = Arc::clone(&client);
+        let client_b = Arc::clone(&client);
+        let target_a = Arc::clone(&target);
+        let target_b = Arc::clone(&target);
+
+        let (res_a, res_b) = tokio::join!(
+            async move {
+                client_a
+                    .fetch(&target_a, &filters_a, &HashMap::new(), None)
+                    .await
+            },
+            async move {
+                client_b
+                    .fetch(&target_b, &filters_b, &HashMap::new(), None)
+                    .await
+            },
+        );
+
+        for err in [
+            res_a.expect_err("first concurrent call should fail"),
+            res_b.expect_err("second concurrent call should fail"),
+        ] {
+            let mut current: &dyn std::error::Error = &err;
+            let mut found_provider_error = false;
+            loop {
+                if current.downcast_ref::<ProviderQueryError>().is_some() {
+                    found_provider_error = true;
+                    break;
+                }
+                match current.source() {
+                    Some(next) => current = next,
+                    None => break,
+                }
+            }
+            assert!(
+                found_provider_error,
+                "structured ProviderQueryError should still be reachable via Error::source() chain under single-flight contention; got: {err:?}"
+            );
+            assert_eq!(
+                err.to_string(),
+                "External error: demo.users API error: bad request"
+            );
+        }
     }
 }

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -381,7 +381,7 @@ pub(super) async fn fetch_rows(
                         );
                         return Err(FetchSkipped::not_cacheable(payload, next_url));
                     }
-                    if !cache.try_admit(estimated_bytes as u64) {
+                    if !cache.try_admit(estimated_bytes as u64).await {
                         tracing::trace!(
                             source = %source_schema,
                             table = %table_name,

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -9,7 +9,9 @@ use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::Value;
 
 use crate::backends::http::ProviderQueryError;
-use crate::backends::http::cache::{HttpCacheEntry, build_cache_key, estimate_json_bytes};
+use crate::backends::http::cache::{
+    HttpCacheEntry, build_cache_key, estimate_json_bytes, resolved_inputs_cache_fingerprint,
+};
 use crate::backends::http::client::HttpSourceClient;
 use crate::backends::http::error::{pagination_error, provider_error};
 use crate::backends::http::pagination::{
@@ -20,6 +22,7 @@ use crate::backends::http::request::{RequestBody, build_query_pairs, build_reque
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::transport::{OutgoingHttpRequest, execute_request};
 use crate::backends::http::url::{join_url, normalize_base_url};
+use crate::backends::shared::cache::hash_cache_bytes;
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::response_rows::extract_rows;
 use crate::backends::shared::template::{
@@ -88,14 +91,6 @@ fn http_method_label(method: HttpMethod) -> &'static str {
         HttpMethod::GET => "GET",
         HttpMethod::POST => "POST",
     }
-}
-
-fn hash_cache_bytes(value: &[u8]) -> u64 {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash as _, Hasher as _};
-    let mut hasher = DefaultHasher::new();
-    value.hash(&mut hasher);
-    hasher.finish()
 }
 
 fn hash_request_body(body: &RequestBody) -> u64 {
@@ -223,6 +218,7 @@ pub(super) async fn fetch_rows(
         }
 
         let resolved_inputs = client.resolved_inputs_for_request().await?;
+        let resolved_input_fingerprint = resolved_inputs_cache_fingerprint(&resolved_inputs);
         let state_values = pagination_state_values(&state);
         let render_context = RenderContext::new(
             filter_values,
@@ -305,6 +301,7 @@ pub(super) async fn fetch_rows(
                     let key = build_cache_key(
                         &client.source_schema,
                         &client.source_version,
+                        resolved_input_fingerprint,
                         target.name(),
                         http_method_label(active_request.method),
                         &url,

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -284,45 +284,50 @@ pub(super) async fn fetch_rows(
             (query_pairs, body)
         };
 
-        let cache_key: Option<(String, usize, Duration)> = target
-            .cache()
-            .filter(|p| p.mode == HttpCacheMode::Ttl)
-            .filter(|policy| {
-                policy
-                    .max_pages
-                    .is_none_or(|max_cache_pages| page_count <= max_cache_pages)
-            })
-            .map(|policy| {
-                let body_hash = body.as_ref().map(hash_request_body);
-                let vary_headers = cache_vary_header_hashes(
-                    &client.request_headers,
-                    &active_request.headers,
-                    body.as_ref(),
-                    &render_context,
-                    &policy.vary_headers,
-                )?;
-                let key = build_cache_key(
-                    &client.source_schema,
-                    &client.source_version,
-                    target.name(),
-                    http_method_label(active_request.method),
-                    &url,
-                    &query_pairs,
-                    body_hash,
-                    &vary_headers,
-                    policy.ttl.as_secs(),
-                );
-                let max_entry = policy.max_entry_bytes.unwrap_or(usize::MAX);
-                Ok::<_, DataFusionError>((key, max_entry, policy.ttl))
-            })
-            .transpose()?;
+        let cache_key: Option<(String, usize, Duration)> = if client.cache.is_some() {
+            target
+                .cache()
+                .filter(|p| p.mode == HttpCacheMode::Ttl)
+                .filter(|policy| {
+                    policy
+                        .max_pages
+                        .is_none_or(|max_cache_pages| page_count <= max_cache_pages)
+                })
+                .map(|policy| {
+                    let body_hash = body.as_ref().map(hash_request_body);
+                    let vary_headers = cache_vary_header_hashes(
+                        &client.request_headers,
+                        &active_request.headers,
+                        body.as_ref(),
+                        &render_context,
+                        &policy.vary_headers,
+                    )?;
+                    let key = build_cache_key(
+                        &client.source_schema,
+                        &client.source_version,
+                        target.name(),
+                        http_method_label(active_request.method),
+                        &url,
+                        &query_pairs,
+                        body_hash,
+                        &vary_headers,
+                        policy.ttl.as_secs(),
+                    );
+                    let max_entry = policy.max_entry_bytes.unwrap_or(usize::MAX);
+                    Ok::<_, DataFusionError>((key, max_entry, policy.ttl))
+                })
+                .transpose()?
+        } else {
+            None
+        };
 
-        let page = if let Some((ref key, max_entry_bytes, ttl)) = cache_key {
+        let page = if let (Some(cache), Some((ref key, max_entry_bytes, ttl))) =
+            (client.cache.as_ref(), cache_key)
+        {
             let source_schema = client.source_schema.clone();
             let table_name = target.name().to_string();
             let ok_path = target.response().ok_path.clone();
-            let result = client
-                .cache
+            let result = cache
                 .try_get_or_insert_with::<_, FetchSkipped>(key, async {
                     tracing::trace!(
                         source = %source_schema,
@@ -376,6 +381,15 @@ pub(super) async fn fetch_rows(
                             table = %table_name,
                             estimated_bytes,
                             "http cache entry skipped: exceeds max_entry_bytes"
+                        );
+                        return Err(FetchSkipped::not_cacheable(payload, next_url));
+                    }
+                    if !cache.try_admit(estimated_bytes as u64) {
+                        tracing::trace!(
+                            source = %source_schema,
+                            table = %table_name,
+                            estimated_bytes,
+                            "http cache entry skipped: exceeds total_max_bytes"
                         );
                         return Err(FetchSkipped::not_cacheable(payload, next_url));
                     }
@@ -592,6 +606,18 @@ mod tests {
 
     fn build_test_client(manifest: &HttpSourceManifest) -> HttpSourceClient {
         HttpSourceClient::from_manifest(
+            manifest,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &HashMap::new(),
+            None,
+            reqwest::Client::new(),
+        )
+        .expect("test client should build")
+    }
+
+    fn build_test_client_without_cache(manifest: &HttpSourceManifest) -> HttpSourceClient {
+        HttpSourceClient::from_manifest_without_cache(
             manifest,
             &BTreeMap::new(),
             &BTreeMap::new(),
@@ -954,6 +980,36 @@ mod tests {
             .await
             .expect("second");
         // .expect(2) verifies both calls made it to the server (no caching)
+    }
+
+    #[tokio::test]
+    async fn cache_runtime_absence_disables_table_cache_policy() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/users"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({ "data": [{ "id": 1 }] })),
+            )
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let manifest = cached_users_manifest(&server.uri());
+        let client = build_test_client_without_cache(&manifest);
+        let table = first_table(&manifest);
+        let filters = HashMap::new();
+
+        fetch_table(&client, table, &filters, None)
+            .await
+            .expect("first");
+        fetch_table(&client, table, &filters, None)
+            .await
+            .expect("second");
+        // The table declares `cache: { mode: ttl }`, but no runtime cache is
+        // installed, so both calls must reach the server.
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -47,39 +47,25 @@ struct HttpCompiledSource {
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     body_capture_max_bytes: Option<usize>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    cache_namespace: String,
+    source_input_fingerprint: u64,
     http_cache_registry: Option<Arc<cache::HttpCacheRegistry>>,
-}
-
-pub(crate) fn compile_source(
-    manifest: HttpSourceManifest,
-    source_input_resolution: SourceInputResolutionContext,
-    request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
-    body_capture_max_bytes: Option<usize>,
-    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    http_cache_registry: Option<Arc<cache::HttpCacheRegistry>>,
-) -> Box<dyn CompiledBackendSource> {
-    Box::new(HttpCompiledSource {
-        manifest,
-        source_input_resolution,
-        request_authenticators,
-        body_capture_max_bytes,
-        source_input_resolver,
-        http_cache_registry,
-    })
 }
 
 pub(crate) fn compile_manifest(
     manifest: &HttpSourceManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Box<dyn CompiledBackendSource> {
-    compile_source(
-        manifest.clone(),
-        SourceInputResolutionContext::from_query_source(request.source),
-        request.request_authenticators.clone(),
-        request.runtime_context.body_capture_max_bytes,
-        request.source_input_resolver.clone(),
-        request.http_cache_registry.clone(),
-    )
+    Box::new(HttpCompiledSource {
+        manifest: manifest.clone(),
+        source_input_resolution: SourceInputResolutionContext::from_query_source(request.source),
+        request_authenticators: request.request_authenticators.clone(),
+        body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
+        source_input_resolver: request.source_input_resolver.clone(),
+        cache_namespace: request.cache_namespace.clone(),
+        source_input_fingerprint: request.source_input_fingerprint,
+        http_cache_registry: request.http_cache_registry.clone(),
+    })
 }
 
 #[async_trait]
@@ -99,7 +85,12 @@ impl CompiledBackendSource for HttpCompiledSource {
     ) -> Result<BackendRegistration> {
         let http = client::default_http_client(registration, &self.manifest.common.name)?;
         let cache = self.http_cache_registry.as_ref().map(|registry| {
-            registry.get_or_create(&self.manifest.common.name, &self.manifest.common.version)
+            registry.get_or_create(
+                &self.cache_namespace,
+                &self.manifest.common.name,
+                &self.manifest.common.version,
+                self.source_input_fingerprint,
+            )
         });
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -18,6 +18,7 @@ use crate::backends::{
 use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
+pub(crate) mod cache;
 pub(crate) mod client;
 pub(crate) mod error;
 mod fetch;
@@ -46,6 +47,7 @@ struct HttpCompiledSource {
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     body_capture_max_bytes: Option<usize>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    http_cache_registry: Option<Arc<cache::HttpCacheRegistry>>,
 }
 
 pub(crate) fn compile_source(
@@ -54,6 +56,7 @@ pub(crate) fn compile_source(
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     body_capture_max_bytes: Option<usize>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    http_cache_registry: Option<Arc<cache::HttpCacheRegistry>>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
@@ -61,6 +64,7 @@ pub(crate) fn compile_source(
         request_authenticators,
         body_capture_max_bytes,
         source_input_resolver,
+        http_cache_registry,
     })
 }
 
@@ -74,6 +78,7 @@ pub(crate) fn compile_manifest(
         request.request_authenticators.clone(),
         request.runtime_context.body_capture_max_bytes,
         request.source_input_resolver.clone(),
+        request.http_cache_registry.clone(),
     )
 }
 
@@ -93,11 +98,15 @@ impl CompiledBackendSource for HttpCompiledSource {
         registration: &BackendRegistrationContext,
     ) -> Result<BackendRegistration> {
         let http = client::default_http_client(registration, &self.manifest.common.name)?;
+        let cache = self.http_cache_registry.as_ref().map(|registry| {
+            registry.get_or_create(&self.manifest.common.name, &self.manifest.common.version)
+        });
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),
             self.body_capture_max_bytes,
             http,
+            cache,
         );
         let backend = HttpSourceClient::from_manifest_with_source_input_resolver(
             &self.manifest,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -47,9 +47,8 @@ struct HttpCompiledSource {
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     body_capture_max_bytes: Option<usize>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    cache_namespace: String,
-    source_input_fingerprint: u64,
-    http_cache_registry: Option<Arc<cache::HttpCacheRegistry>>,
+    cache_namespace: Option<String>,
+    http_cache_registry: Option<Arc<crate::HttpCacheRegistry>>,
 }
 
 pub(crate) fn compile_manifest(
@@ -63,7 +62,6 @@ pub(crate) fn compile_manifest(
         body_capture_max_bytes: request.runtime_context.body_capture_max_bytes,
         source_input_resolver: request.source_input_resolver.clone(),
         cache_namespace: request.cache_namespace.clone(),
-        source_input_fingerprint: request.source_input_fingerprint,
         http_cache_registry: request.http_cache_registry.clone(),
     })
 }
@@ -84,14 +82,18 @@ impl CompiledBackendSource for HttpCompiledSource {
         registration: &BackendRegistrationContext,
     ) -> Result<BackendRegistration> {
         let http = client::default_http_client(registration, &self.manifest.common.name)?;
-        let cache = self.http_cache_registry.as_ref().map(|registry| {
-            registry.get_or_create(
-                &self.cache_namespace,
-                &self.manifest.common.name,
-                &self.manifest.common.version,
-                self.source_input_fingerprint,
-            )
-        });
+        let cache = match (&self.http_cache_registry, &self.cache_namespace) {
+            (Some(registry), Some(namespace)) => Some(
+                registry
+                    .get_or_create(
+                        namespace,
+                        &self.manifest.common.name,
+                        &self.manifest.common.version,
+                    )
+                    .await,
+            ),
+            _ => None,
+        };
         let runtime = HttpSourceClientRuntime::new(
             self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),

--- a/crates/coral-engine/src/backends/http/target.rs
+++ b/crates/coral-engine/src/backends/http/target.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use coral_spec::backends::http::HttpTableSpec;
+use coral_spec::backends::http::{HttpCachePolicySpec, HttpTableSpec};
 use coral_spec::{
     ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec, SearchLimitsSpec,
     SourceTableFunctionSpec,
@@ -21,6 +21,7 @@ pub(crate) struct HttpFetchTarget {
     resolved_request: RequestSpec,
     response: Arc<ResponseSpec>,
     pagination: Arc<PaginationSpec>,
+    cache: Option<Arc<HttpCachePolicySpec>>,
 }
 
 impl std::fmt::Debug for HttpFetchTarget {
@@ -47,6 +48,7 @@ impl HttpFetchTarget {
             resolved_request,
             response: Arc::new(table.response.clone()),
             pagination: Arc::new(table.pagination.clone()),
+            cache: table.cache.clone().map(Arc::new),
         }
     }
 
@@ -59,6 +61,7 @@ impl HttpFetchTarget {
             resolved_request,
             response: Arc::clone(&self.response),
             pagination: Arc::clone(&self.pagination),
+            cache: self.cache.clone(),
         }
     }
 
@@ -71,6 +74,7 @@ impl HttpFetchTarget {
             resolved_request: function.request.clone(),
             response: Arc::new(function.response.clone()),
             pagination: Arc::new(function.pagination.clone()),
+            cache: None,
         }
     }
 
@@ -104,5 +108,9 @@ impl HttpFetchTarget {
 
     pub(crate) fn pagination(&self) -> &PaginationSpec {
         &self.pagination
+    }
+
+    pub(crate) fn cache(&self) -> Option<&HttpCachePolicySpec> {
+        self.cache.as_deref()
     }
 }

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -67,9 +67,11 @@
 //!   hands a `ListingTableConfig` to `DataFusion`. No transport / fetch /
 //!   response files because `DataFusion` owns those layers.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash as _, Hasher as _};
 use std::sync::Arc;
 
+use crate::backends::shared::cache::hash_cache_bytes;
 use crate::{
     CoreError, QuerySource, RequestAuthenticator, RuntimeSourceComponent, SourceInputResolver,
 };
@@ -96,6 +98,7 @@ pub(crate) fn compile_query_source(
     runtime_context: &crate::QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    cache_namespace: Option<String>,
     http_cache_registry: Option<Arc<crate::backends::http::cache::HttpCacheRegistry>>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
@@ -111,6 +114,8 @@ pub(crate) fn compile_query_source(
         source_variables: source.variables().clone(),
         request_authenticators,
         source_input_resolver,
+        cache_namespace: cache_namespace.unwrap_or_else(|| "default".to_string()),
+        source_input_fingerprint: source_input_fingerprint(source),
         http_cache_registry,
     };
     let compiled_components = source
@@ -122,6 +127,21 @@ pub(crate) fn compile_query_source(
         source.source_name().to_string(),
         compiled_components,
     ))
+}
+
+fn source_input_fingerprint(source: &QuerySource) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    for (key, value) in source.variables() {
+        "variable".hash(&mut hasher);
+        key.hash(&mut hasher);
+        hash_cache_bytes(value.as_bytes()).hash(&mut hasher);
+    }
+    for (key, value) in source.secrets() {
+        "secret".hash(&mut hasher);
+        key.hash(&mut hasher);
+        hash_cache_bytes(value.as_bytes()).hash(&mut hasher);
+    }
+    hasher.finish()
 }
 
 fn compile_component(
@@ -157,6 +177,8 @@ pub(crate) fn compile_source_manifest(
             source_variables,
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
+            cache_namespace: "default".to_string(),
+            source_input_fingerprint: source_input_fingerprint(&source),
             http_cache_registry: None,
         },
     )

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -67,11 +67,9 @@
 //!   hands a `ListingTableConfig` to `DataFusion`. No transport / fetch /
 //!   response files because `DataFusion` owns those layers.
 
-use std::collections::{HashMap, hash_map::DefaultHasher};
-use std::hash::{Hash as _, Hasher as _};
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use crate::backends::shared::cache::hash_cache_bytes;
 use crate::{
     CoreError, QuerySource, RequestAuthenticator, RuntimeSourceComponent, SourceInputResolver,
 };
@@ -99,7 +97,7 @@ pub(crate) fn compile_query_source(
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     cache_namespace: Option<String>,
-    http_cache_registry: Option<Arc<crate::backends::http::cache::HttpCacheRegistry>>,
+    http_cache_registry: Option<Arc<crate::HttpCacheRegistry>>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
@@ -114,8 +112,7 @@ pub(crate) fn compile_query_source(
         source_variables: source.variables().clone(),
         request_authenticators,
         source_input_resolver,
-        cache_namespace: cache_namespace.unwrap_or_else(|| "default".to_string()),
-        source_input_fingerprint: source_input_fingerprint(source),
+        cache_namespace,
         http_cache_registry,
     };
     let compiled_components = source
@@ -127,21 +124,6 @@ pub(crate) fn compile_query_source(
         source.source_name().to_string(),
         compiled_components,
     ))
-}
-
-fn source_input_fingerprint(source: &QuerySource) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    for (key, value) in source.variables() {
-        "variable".hash(&mut hasher);
-        key.hash(&mut hasher);
-        hash_cache_bytes(value.as_bytes()).hash(&mut hasher);
-    }
-    for (key, value) in source.secrets() {
-        "secret".hash(&mut hasher);
-        key.hash(&mut hasher);
-        hash_cache_bytes(value.as_bytes()).hash(&mut hasher);
-    }
-    hasher.finish()
 }
 
 fn compile_component(
@@ -177,8 +159,7 @@ pub(crate) fn compile_source_manifest(
             source_variables,
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
-            cache_namespace: "default".to_string(),
-            source_input_fingerprint: source_input_fingerprint(&source),
+            cache_namespace: Some("default".to_string()),
             http_cache_registry: None,
         },
     )

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -96,6 +96,7 @@ pub(crate) fn compile_query_source(
     runtime_context: &crate::QueryRuntimeContext,
     request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    http_cache_registry: Option<Arc<crate::backends::http::cache::HttpCacheRegistry>>,
 ) -> Result<Box<dyn CompiledBackendSource>, CoreError> {
     if source.components().is_empty() {
         return Err(CoreError::FailedPrecondition(format!(
@@ -110,6 +111,7 @@ pub(crate) fn compile_query_source(
         source_variables: source.variables().clone(),
         request_authenticators,
         source_input_resolver,
+        http_cache_registry,
     };
     let compiled_components = source
         .components()
@@ -155,6 +157,7 @@ pub(crate) fn compile_source_manifest(
             source_variables,
             request_authenticators: &request_authenticators,
             source_input_resolver: None,
+            http_cache_registry: None,
         },
     )
 }

--- a/crates/coral-engine/src/backends/shared/cache.rs
+++ b/crates/coral-engine/src/backends/shared/cache.rs
@@ -1,6 +1,6 @@
 //! Shared in-memory cache primitives for backend-owned response caches.
 
-use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::collections::{HashMap, HashSet, hash_map::DefaultHasher};
 use std::hash::{Hash as _, Hasher as _};
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, Weak};
@@ -107,6 +107,9 @@ where
     V: CacheValue,
 {
     inner: Arc<Cache<String, V>>,
+    // Moka can report an expired key as a miss while its weight remains pending;
+    // this side index lets admission explicitly invalidate those stale entries.
+    known_keys: Arc<Mutex<HashSet<String>>>,
     registry: Option<Weak<CacheRegistryInner<V>>>,
 }
 
@@ -121,6 +124,8 @@ where
     }
 
     fn build(max_bytes: u64, registry: Option<Weak<CacheRegistryInner<V>>>) -> Self {
+        let known_keys = Arc::new(Mutex::new(HashSet::<String>::new()));
+        let listener_keys = Arc::clone(&known_keys);
         let inner = Cache::builder()
             .max_capacity(max_bytes)
             .weigher(|_key: &String, value: &V| {
@@ -132,9 +137,15 @@ where
                 weight
             })
             .expire_after(EntryExpiry::<V>::default())
+            .eviction_listener(move |key, _value, _cause| {
+                if let Ok(mut guard) = listener_keys.lock() {
+                    guard.remove(key.as_str());
+                }
+            })
             .build();
         Self {
             inner: Arc::new(inner),
+            known_keys,
             registry,
         }
     }
@@ -152,21 +163,55 @@ where
         Arc::strong_count(&self.inner) > 1
     }
 
-    async fn run_pending_tasks(&self) {
+    async fn remove_expired_known_entries(&self) {
         self.inner.run_pending_tasks().await;
+
+        let known_keys = self.known_keys();
+        let mut expired_keys = Vec::new();
+        for key in known_keys {
+            if !self.inner.contains_key(&key) {
+                self.inner.invalidate(&key).await;
+                expired_keys.push(key);
+            }
+        }
+        if expired_keys.is_empty() {
+            return;
+        }
+
+        self.inner.run_pending_tasks().await;
+        let mut guard = self.known_keys.lock().expect("cache key mutex poisoned");
+        for key in expired_keys {
+            guard.remove(&key);
+        }
+    }
+
+    fn known_keys(&self) -> Vec<String> {
+        self.known_keys
+            .lock()
+            .expect("cache key mutex poisoned")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    fn remember_key(&self, key: &str) {
+        self.known_keys
+            .lock()
+            .expect("cache key mutex poisoned")
+            .insert(key.to_string());
     }
 
     /// Soft admission check against the parent registry's `total_max_bytes`,
     /// if any. Returns `true` when no registry is attached or no total
     /// ceiling is configured.
-    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
+    pub(crate) async fn try_admit(&self, incoming_bytes: u64) -> bool {
         let Some(weak) = &self.registry else {
             return true;
         };
         let Some(inner) = weak.upgrade() else {
             return true;
         };
-        CacheRegistry { inner }.try_admit(incoming_bytes)
+        CacheRegistry { inner }.try_admit(incoming_bytes).await
     }
 
     /// Return the cached entry for `key`, or `None` on miss or expiry.
@@ -178,7 +223,9 @@ where
     /// Insert `entry` under `key`.
     #[cfg(test)]
     pub(crate) async fn put(&self, key: String, entry: V) {
-        self.inner.insert(key, entry).await;
+        self.inner.insert(key.clone(), entry).await;
+        self.inner.run_pending_tasks().await;
+        self.remember_key(&key);
     }
 
     /// Single-flight get-or-fetch. Returns `(entry, is_fresh)` where
@@ -198,7 +245,9 @@ where
             .or_try_insert_with(init)
             .await?;
         let is_fresh = entry.is_fresh();
-        Ok((entry.into_value(), is_fresh))
+        let value = entry.into_value();
+        self.remember_key(key);
+        Ok((value, is_fresh))
     }
 }
 
@@ -309,7 +358,7 @@ where
                 .collect::<Vec<_>>()
         };
         for bucket in &buckets {
-            bucket.run_pending_tasks().await;
+            bucket.remove_expired_known_entries().await;
         }
         drop(buckets);
 
@@ -327,13 +376,40 @@ where
         });
     }
 
+    async fn run_pending_tasks_for_all_buckets(&self) {
+        let buckets = {
+            let guard = self
+                .inner
+                .entries
+                .lock()
+                .expect("cache registry mutex poisoned");
+            guard.values().cloned().collect::<Vec<_>>()
+        };
+        for bucket in &buckets {
+            bucket.remove_expired_known_entries().await;
+        }
+    }
+
+    fn prune_empty_buckets(&self) {
+        let mut guard = self
+            .inner
+            .entries
+            .lock()
+            .expect("cache registry mutex poisoned");
+        guard.retain(|_key, bucket| {
+            bucket.has_external_refs() || bucket.entry_count() > 0 || bucket.weighted_size() > 0
+        });
+    }
+
     /// Soft check: would admitting `incoming_bytes` keep the registry's total
     /// weighted size within `total_max_bytes`? Returns `true` if no ceiling is
     /// configured.
-    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
+    pub(crate) async fn try_admit(&self, incoming_bytes: u64) -> bool {
         let Some(total) = self.inner.total_max_bytes else {
             return true;
         };
+        self.run_pending_tasks_for_all_buckets().await;
+        self.prune_empty_buckets();
         let current = {
             let guard = self
                 .inner

--- a/crates/coral-engine/src/backends/shared/cache.rs
+++ b/crates/coral-engine/src/backends/shared/cache.rs
@@ -1,0 +1,302 @@
+//! Shared in-memory cache primitives for backend-owned response caches.
+
+use std::collections::{HashMap, hash_map::DefaultHasher};
+use std::hash::{Hash as _, Hasher as _};
+use std::marker::PhantomData;
+use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
+
+use moka::Expiry;
+use moka::future::Cache;
+
+pub(crate) const DEFAULT_CACHE_MAX_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+
+/// Value stored in a backend cache.
+pub(crate) trait CacheValue: Clone + Send + Sync + 'static {
+    /// Entry time-to-live.
+    fn ttl(&self) -> Duration;
+
+    /// Approximate weighted byte size used for cache admission and eviction.
+    fn estimated_bytes(&self) -> usize;
+}
+
+/// Stable bucket identity for one backend/source/cache namespace.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CacheBucketKey {
+    namespace: String,
+    backend: &'static str,
+    source_name: String,
+    source_version: String,
+    input_fingerprint: u64,
+}
+
+impl CacheBucketKey {
+    pub(crate) fn new(
+        namespace: impl Into<String>,
+        backend: &'static str,
+        source_name: impl Into<String>,
+        source_version: impl Into<String>,
+        input_fingerprint: u64,
+    ) -> Self {
+        Self {
+            namespace: namespace.into(),
+            backend,
+            source_name: source_name.into(),
+            source_version: source_version.into(),
+            input_fingerprint,
+        }
+    }
+
+    fn source_name(&self) -> &str {
+        &self.source_name
+    }
+}
+
+struct EntryExpiry<V>(PhantomData<V>);
+
+impl<V> Default for EntryExpiry<V> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<V> Expiry<String, V> for EntryExpiry<V>
+where
+    V: CacheValue,
+{
+    fn expire_after_create(
+        &self,
+        _key: &String,
+        value: &V,
+        _created_at: std::time::Instant,
+    ) -> Option<Duration> {
+        Some(value.ttl())
+    }
+
+    fn expire_after_read(
+        &self,
+        _key: &String,
+        _value: &V,
+        _current_time: std::time::Instant,
+        current_duration: Option<Duration>,
+        _last_modified_at: std::time::Instant,
+    ) -> Option<Duration> {
+        current_duration
+    }
+
+    fn expire_after_update(
+        &self,
+        _key: &String,
+        value: &V,
+        _current_time: std::time::Instant,
+        _current_duration: Option<Duration>,
+    ) -> Option<Duration> {
+        Some(value.ttl())
+    }
+}
+
+/// Shared in-memory cache bucket backed by Moka.
+///
+/// `Clone` is cheap; all clones share the same underlying cache.
+#[derive(Clone)]
+pub(crate) struct CacheBucket<V>
+where
+    V: CacheValue,
+{
+    inner: Arc<Cache<String, V>>,
+    registry: Option<Weak<CacheRegistryInner<V>>>,
+}
+
+impl<V> CacheBucket<V>
+where
+    V: CacheValue,
+{
+    /// Create a new standalone cache with the default 256 MiB capacity limit.
+    #[cfg(test)]
+    pub(crate) fn new() -> Self {
+        Self::build(DEFAULT_CACHE_MAX_BYTES, None)
+    }
+
+    fn build(max_bytes: u64, registry: Option<Weak<CacheRegistryInner<V>>>) -> Self {
+        let inner = Cache::builder()
+            .max_capacity(max_bytes)
+            .weigher(|_key: &String, value: &V| {
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "Saturating at u32::MAX is the correct moka weigher clamp"
+                )]
+                let weight = value.estimated_bytes().min(u32::MAX as usize) as u32;
+                weight
+            })
+            .expire_after(EntryExpiry::<V>::default())
+            .build();
+        Self {
+            inner: Arc::new(inner),
+            registry,
+        }
+    }
+
+    /// Approximate weighted byte size currently stored.
+    pub(crate) fn weighted_size(&self) -> u64 {
+        self.inner.weighted_size()
+    }
+
+    /// Soft admission check against the parent registry's `total_max_bytes`,
+    /// if any. Returns `true` when no registry is attached or no total
+    /// ceiling is configured.
+    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
+        let Some(weak) = &self.registry else {
+            return true;
+        };
+        let Some(inner) = weak.upgrade() else {
+            return true;
+        };
+        CacheRegistry { inner }.try_admit(incoming_bytes)
+    }
+
+    /// Return the cached entry for `key`, or `None` on miss or expiry.
+    #[cfg(test)]
+    pub(crate) async fn get(&self, key: &str) -> Option<V> {
+        self.inner.get(key).await
+    }
+
+    /// Insert `entry` under `key`.
+    #[cfg(test)]
+    pub(crate) async fn put(&self, key: String, entry: V) {
+        self.inner.insert(key, entry).await;
+    }
+
+    /// Single-flight get-or-fetch. Returns `(entry, is_fresh)` where
+    /// `is_fresh` is true when this caller's `init` ran (cache miss).
+    pub(crate) async fn try_get_or_insert_with<F, E>(
+        &self,
+        key: &str,
+        init: F,
+    ) -> Result<(V, bool), Arc<E>>
+    where
+        F: std::future::Future<Output = Result<V, E>>,
+        E: Send + Sync + 'static,
+    {
+        let entry = self
+            .inner
+            .entry_by_ref(key)
+            .or_try_insert_with(init)
+            .await?;
+        let is_fresh = entry.is_fresh();
+        Ok((entry.into_value(), is_fresh))
+    }
+}
+
+struct CacheRegistryInner<V>
+where
+    V: CacheValue,
+{
+    entries: Mutex<HashMap<CacheBucketKey, CacheBucket<V>>>,
+    default_max_bytes: u64,
+    total_max_bytes: Option<u64>,
+    per_source_max_bytes: HashMap<String, u64>,
+}
+
+/// Per-source cache buckets keyed by backend/source identity and namespace.
+#[derive(Clone)]
+pub(crate) struct CacheRegistry<V>
+where
+    V: CacheValue,
+{
+    inner: Arc<CacheRegistryInner<V>>,
+}
+
+impl<V> std::fmt::Debug for CacheRegistry<V>
+where
+    V: CacheValue,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self.inner.entries.lock().map_or(0, |g| g.len());
+        f.debug_struct("CacheRegistry")
+            .field("entries", &len)
+            .field("default_max_bytes", &self.inner.default_max_bytes)
+            .field("total_max_bytes", &self.inner.total_max_bytes)
+            .finish()
+    }
+}
+
+impl<V> CacheRegistry<V>
+where
+    V: CacheValue,
+{
+    /// Build a registry with default per-source capacity (256 MiB) and no
+    /// cross-source ceiling.
+    pub(crate) fn new() -> Self {
+        Self::with_policy(DEFAULT_CACHE_MAX_BYTES, None, HashMap::new())
+    }
+
+    /// Build a registry with explicit policy.
+    pub(crate) fn with_policy(
+        default_max_bytes: u64,
+        total_max_bytes: Option<u64>,
+        per_source_max_bytes: HashMap<String, u64>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(CacheRegistryInner {
+                entries: Mutex::new(HashMap::new()),
+                default_max_bytes,
+                total_max_bytes,
+                per_source_max_bytes,
+            }),
+        }
+    }
+
+    pub(crate) fn get_or_create(&self, key: CacheBucketKey) -> CacheBucket<V> {
+        let mut guard = self
+            .inner
+            .entries
+            .lock()
+            .expect("cache registry mutex poisoned");
+        if let Some(existing) = guard.get(&key) {
+            return existing.clone();
+        }
+        let max_bytes = self
+            .inner
+            .per_source_max_bytes
+            .get(key.source_name())
+            .copied()
+            .unwrap_or(self.inner.default_max_bytes);
+        let cache = CacheBucket::build(max_bytes, Some(Arc::downgrade(&self.inner)));
+        guard.insert(key, cache.clone());
+        cache
+    }
+
+    /// Soft check: would admitting `incoming_bytes` keep the registry's total
+    /// weighted size within `total_max_bytes`? Returns `true` if no ceiling is
+    /// configured.
+    pub(crate) fn try_admit(&self, incoming_bytes: u64) -> bool {
+        let Some(total) = self.inner.total_max_bytes else {
+            return true;
+        };
+        let current = {
+            let guard = self
+                .inner
+                .entries
+                .lock()
+                .expect("cache registry mutex poisoned");
+            guard.values().map(CacheBucket::weighted_size).sum::<u64>()
+        };
+        current.saturating_add(incoming_bytes) <= total
+    }
+}
+
+impl<V> Default for CacheRegistry<V>
+where
+    V: CacheValue,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Hash request/cache identity material without storing raw values in keys.
+pub(crate) fn hash_cache_bytes(value: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    value.hash(&mut hasher);
+    hasher.finish()
+}

--- a/crates/coral-engine/src/backends/shared/cache.rs
+++ b/crates/coral-engine/src/backends/shared/cache.rs
@@ -47,6 +47,12 @@ impl CacheBucketKey {
     fn source_name(&self) -> &str {
         &self.source_name
     }
+
+    fn same_source_family(&self, other: &Self) -> bool {
+        self.namespace == other.namespace
+            && self.backend == other.backend
+            && self.source_name == other.source_name
+    }
 }
 
 struct EntryExpiry<V>(PhantomData<V>);
@@ -256,7 +262,19 @@ where
     }
 
     pub(crate) async fn get_or_create(&self, key: CacheBucketKey) -> CacheBucket<V> {
-        self.prune_empty_buckets(&key).await;
+        {
+            let guard = self
+                .inner
+                .entries
+                .lock()
+                .expect("cache registry mutex poisoned");
+            if let Some(existing) = guard.get(&key) {
+                return existing.clone();
+            }
+        }
+
+        self.prune_empty_source_family_buckets(&key).await;
+
         let mut guard = self
             .inner
             .entries
@@ -265,6 +283,7 @@ where
         if let Some(existing) = guard.get(&key) {
             return existing.clone();
         }
+
         let max_bytes = self
             .inner
             .per_source_max_bytes
@@ -276,14 +295,18 @@ where
         cache
     }
 
-    async fn prune_empty_buckets(&self, keep: &CacheBucketKey) {
+    async fn prune_empty_source_family_buckets(&self, keep: &CacheBucketKey) {
         let buckets = {
             let guard = self
                 .inner
                 .entries
                 .lock()
                 .expect("cache registry mutex poisoned");
-            guard.values().cloned().collect::<Vec<_>>()
+            guard
+                .iter()
+                .filter(|(key, _bucket)| key.same_source_family(keep))
+                .map(|(_key, bucket)| bucket.clone())
+                .collect::<Vec<_>>()
         };
         for bucket in &buckets {
             bucket.run_pending_tasks().await;
@@ -297,6 +320,7 @@ where
             .expect("cache registry mutex poisoned");
         guard.retain(|key, bucket| {
             key == keep
+                || !key.same_source_family(keep)
                 || bucket.has_external_refs()
                 || bucket.entry_count() > 0
                 || bucket.weighted_size() > 0

--- a/crates/coral-engine/src/backends/shared/cache.rs
+++ b/crates/coral-engine/src/backends/shared/cache.rs
@@ -27,7 +27,6 @@ pub(crate) struct CacheBucketKey {
     backend: &'static str,
     source_name: String,
     source_version: String,
-    input_fingerprint: u64,
 }
 
 impl CacheBucketKey {
@@ -36,14 +35,12 @@ impl CacheBucketKey {
         backend: &'static str,
         source_name: impl Into<String>,
         source_version: impl Into<String>,
-        input_fingerprint: u64,
     ) -> Self {
         Self {
             namespace: namespace.into(),
             backend,
             source_name: source_name.into(),
             source_version: source_version.into(),
-            input_fingerprint,
         }
     }
 
@@ -139,6 +136,18 @@ where
     /// Approximate weighted byte size currently stored.
     pub(crate) fn weighted_size(&self) -> u64 {
         self.inner.weighted_size()
+    }
+
+    fn entry_count(&self) -> u64 {
+        self.inner.entry_count()
+    }
+
+    fn has_external_refs(&self) -> bool {
+        Arc::strong_count(&self.inner) > 1
+    }
+
+    async fn run_pending_tasks(&self) {
+        self.inner.run_pending_tasks().await;
     }
 
     /// Soft admission check against the parent registry's `total_max_bytes`,
@@ -246,7 +255,8 @@ where
         }
     }
 
-    pub(crate) fn get_or_create(&self, key: CacheBucketKey) -> CacheBucket<V> {
+    pub(crate) async fn get_or_create(&self, key: CacheBucketKey) -> CacheBucket<V> {
+        self.prune_empty_buckets(&key).await;
         let mut guard = self
             .inner
             .entries
@@ -266,6 +276,33 @@ where
         cache
     }
 
+    async fn prune_empty_buckets(&self, keep: &CacheBucketKey) {
+        let buckets = {
+            let guard = self
+                .inner
+                .entries
+                .lock()
+                .expect("cache registry mutex poisoned");
+            guard.values().cloned().collect::<Vec<_>>()
+        };
+        for bucket in &buckets {
+            bucket.run_pending_tasks().await;
+        }
+        drop(buckets);
+
+        let mut guard = self
+            .inner
+            .entries
+            .lock()
+            .expect("cache registry mutex poisoned");
+        guard.retain(|key, bucket| {
+            key == keep
+                || bucket.has_external_refs()
+                || bucket.entry_count() > 0
+                || bucket.weighted_size() > 0
+        });
+    }
+
     /// Soft check: would admitting `incoming_bytes` keep the registry's total
     /// weighted size within `total_max_bytes`? Returns `true` if no ceiling is
     /// configured.
@@ -282,6 +319,15 @@ where
             guard.values().map(CacheBucket::weighted_size).sum::<u64>()
         };
         current.saturating_add(incoming_bytes) <= total
+    }
+
+    #[cfg(test)]
+    pub(crate) fn bucket_count(&self) -> usize {
+        self.inner
+            .entries
+            .lock()
+            .expect("cache registry mutex poisoned")
+            .len()
     }
 }
 

--- a/crates/coral-engine/src/backends/shared/cache.rs
+++ b/crates/coral-engine/src/backends/shared/cache.rs
@@ -376,7 +376,7 @@ where
         });
     }
 
-    async fn run_pending_tasks_for_all_buckets(&self) {
+    async fn remove_expired_known_entries_from_all_buckets(&self) {
         let buckets = {
             let guard = self
                 .inner
@@ -388,6 +388,15 @@ where
         for bucket in &buckets {
             bucket.remove_expired_known_entries().await;
         }
+    }
+
+    fn current_weighted_size(&self) -> u64 {
+        let guard = self
+            .inner
+            .entries
+            .lock()
+            .expect("cache registry mutex poisoned");
+        guard.values().map(CacheBucket::weighted_size).sum::<u64>()
     }
 
     fn prune_empty_buckets(&self) {
@@ -408,17 +417,13 @@ where
         let Some(total) = self.inner.total_max_bytes else {
             return true;
         };
-        self.run_pending_tasks_for_all_buckets().await;
+        if self.current_weighted_size().saturating_add(incoming_bytes) <= total {
+            return true;
+        }
+
+        self.remove_expired_known_entries_from_all_buckets().await;
         self.prune_empty_buckets();
-        let current = {
-            let guard = self
-                .inner
-                .entries
-                .lock()
-                .expect("cache registry mutex poisoned");
-            guard.values().map(CacheBucket::weighted_size).sum::<u64>()
-        };
-        current.saturating_add(incoming_bytes) <= total
+        self.current_weighted_size().saturating_add(incoming_bytes) <= total
     }
 
     #[cfg(test)]

--- a/crates/coral-engine/src/backends/shared/mod.rs
+++ b/crates/coral-engine/src/backends/shared/mod.rs
@@ -1,5 +1,6 @@
 //! Shared backend helpers used by multiple concrete backends.
 
+pub(crate) mod cache;
 pub(crate) mod filter_expr;
 pub(crate) mod json_exec;
 pub(crate) mod json_path;

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -10,6 +10,7 @@ use datafusion::datasource::TableProvider;
 use reqwest::header::{HeaderName, HeaderValue};
 
 use crate::CoreError;
+use crate::backends::http::cache::HttpCacheRegistry;
 use crate::contracts::QuerySource;
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
@@ -27,6 +28,8 @@ pub struct EngineExtensions {
     pub request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     /// Request-time resolver for app-managed source inputs.
     pub source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    /// Caller-owned HTTP cache registry; `None` means per-runtime caches.
+    pub http_cache_registry: Option<Arc<HttpCacheRegistry>>,
 }
 
 /// Neutral policy decision for one source registration failure.

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -28,7 +28,7 @@ pub struct EngineExtensions {
     pub request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     /// Request-time resolver for app-managed source inputs.
     pub source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-    /// Caller-owned HTTP cache registry; `None` means per-runtime caches.
+    /// Caller-owned HTTP cache registry; `None` disables HTTP response caching.
     pub http_cache_registry: Option<Arc<HttpCacheRegistry>>,
 }
 

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -28,6 +28,9 @@ pub struct EngineExtensions {
     pub request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     /// Request-time resolver for app-managed source inputs.
     pub source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    /// App-owned namespace for backend caches. Apps should scope this to the
+    /// workspace or tenant boundary.
+    pub cache_namespace: Option<String>,
     /// Caller-owned HTTP cache registry; `None` disables HTTP response caching.
     pub http_cache_registry: Option<Arc<HttpCacheRegistry>>,
 }

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -10,12 +10,73 @@ use datafusion::datasource::TableProvider;
 use reqwest::header::{HeaderName, HeaderValue};
 
 use crate::CoreError;
-use crate::backends::http::cache::HttpCacheRegistry;
+use crate::backends::http::cache::HttpCacheRegistry as HttpBackendCacheRegistry;
 use crate::contracts::QuerySource;
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
 /// One source's table providers keyed by manifest table name.
 pub type SourceTables = HashMap<String, Arc<dyn TableProvider>>;
+
+/// Caller-owned registry for opt-in HTTP response cache buckets.
+///
+/// This is part of the engine composition surface; the backend-specific storage
+/// details remain internal to the engine.
+#[derive(Clone)]
+pub struct HttpCacheRegistry {
+    inner: HttpBackendCacheRegistry,
+}
+
+impl HttpCacheRegistry {
+    /// Build a registry with default per-source capacity and no cross-source
+    /// ceiling.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            inner: HttpBackendCacheRegistry::new(),
+        }
+    }
+
+    /// Build a registry with explicit policy.
+    #[must_use]
+    pub fn with_policy(
+        default_max_bytes: u64,
+        total_max_bytes: Option<u64>,
+        per_source_max_bytes: HashMap<String, u64>,
+    ) -> Self {
+        Self {
+            inner: HttpBackendCacheRegistry::with_policy(
+                default_max_bytes,
+                total_max_bytes,
+                per_source_max_bytes,
+            ),
+        }
+    }
+
+    pub(crate) async fn get_or_create(
+        &self,
+        namespace: &str,
+        source_name: &str,
+        source_version: &str,
+    ) -> crate::backends::http::cache::HttpResponseCache {
+        self.inner
+            .get_or_create(namespace, source_name, source_version)
+            .await
+    }
+}
+
+impl std::fmt::Debug for HttpCacheRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("HttpCacheRegistry")
+            .field(&self.inner)
+            .finish()
+    }
+}
+
+impl Default for HttpCacheRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Neutral bundle of optional engine extensions for one runtime build.
 #[derive(Default)]
@@ -29,7 +90,8 @@ pub struct EngineExtensions {
     /// Request-time resolver for app-managed source inputs.
     pub source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     /// App-owned namespace for backend caches. Apps should scope this to the
-    /// workspace or tenant boundary.
+    /// workspace or tenant boundary; backend caching stays disabled when a
+    /// registry is supplied without a namespace.
     pub cache_namespace: Option<String>,
     /// Caller-owned HTTP cache registry; `None` disables HTTP response caching.
     pub http_cache_registry: Option<Arc<HttpCacheRegistry>>,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -60,11 +60,11 @@ mod composition;
 pub mod contracts;
 mod runtime;
 
-pub use backends::http::cache::HttpCacheRegistry;
 pub use composition::{
-    EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
-    RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
-    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
+    EngineExtensions, HttpCacheRegistry, QueryResultObserver, QueryResultObserverError,
+    RequestAuthenticator, RequestAuthenticatorError, SourceDecorator, SourceDecoratorError,
+    SourceFailurePolicy, SourceInputResolutionContext, SourceInputResolver,
+    SourceInputResolverError, SourceTables,
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, DescribeTableInfo, QueryExecution, QueryPlan,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -60,6 +60,7 @@ mod composition;
 pub mod contracts;
 mod runtime;
 
+pub use backends::http::cache::HttpCacheRegistry;
 pub use composition::{
     EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
     RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -90,6 +90,7 @@ async fn build_runtime_inner(
             &runtime_context,
             &extensions.request_authenticators,
             extensions.source_input_resolver.clone(),
+            extensions.http_cache_registry.clone(),
         ) {
             Ok(compiled) => {
                 source_candidates.push(SourceRegistrationCandidate::Compiled(

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -90,6 +90,7 @@ async fn build_runtime_inner(
             &runtime_context,
             &extensions.request_authenticators,
             extensions.source_input_resolver.clone(),
+            extensions.cache_namespace.clone(),
             extensions.http_cache_registry.clone(),
         ) {
             Ok(compiled) => {

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2162,7 +2162,15 @@ async fn legacy_json_body_array_form_still_works() {
 }
 
 fn runtime_with_cache_registry(registry: Arc<HttpCacheRegistry>) -> QueryRuntimeConfig {
+    runtime_with_cache_registry_and_namespace(registry, "default")
+}
+
+fn runtime_with_cache_registry_and_namespace(
+    registry: Arc<HttpCacheRegistry>,
+    namespace: &str,
+) -> QueryRuntimeConfig {
     let extensions = EngineExtensions {
+        cache_namespace: Some(namespace.to_string()),
         http_cache_registry: Some(registry),
         ..EngineExtensions::default()
     };
@@ -2192,6 +2200,23 @@ fn cached_http_manifest(name: &str, base_url: &str) -> Value {
             ]
         }]
     })
+}
+
+fn cached_authenticated_http_manifest(name: &str, base_url: &str) -> Value {
+    let mut manifest = cached_http_manifest(name, base_url);
+    let object = manifest.as_object_mut().expect("manifest should be object");
+    object.insert(
+        "inputs".to_string(),
+        json!({ "API_TOKEN": { "kind": "secret" } }),
+    );
+    object.insert(
+        "auth".to_string(),
+        json!({
+            "type": "HeaderAuth",
+            "headers": [{ "name": "Authorization", "from": "input", "key": "API_TOKEN" }]
+        }),
+    );
+    manifest
 }
 
 #[tokio::test]
@@ -2295,4 +2320,69 @@ async fn cache_registry_isolates_different_source_versions() {
     )
     .await
     .expect("v2 query should succeed");
+}
+
+#[tokio::test]
+async fn cache_registry_isolates_namespaces() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let source = build_source(cached_http_manifest(
+        "http_registry_namespaced",
+        &server.uri(),
+    ));
+    let registry = Arc::new(HttpCacheRegistry::new());
+
+    let _ = CoralQuery::execute_sql(
+        std::slice::from_ref(&source),
+        runtime_with_cache_registry_and_namespace(registry.clone(), "workspace_a"),
+        "SELECT id FROM http_registry_namespaced.users",
+    )
+    .await
+    .expect("workspace_a query should succeed");
+
+    let _ = CoralQuery::execute_sql(
+        &[source],
+        runtime_with_cache_registry_and_namespace(registry, "workspace_b"),
+        "SELECT id FROM http_registry_namespaced.users",
+    )
+    .await
+    .expect("workspace_b query should succeed");
+}
+
+#[tokio::test]
+async fn cache_registry_isolates_different_source_inputs() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let manifest = cached_authenticated_http_manifest("http_registry_inputs", &server.uri());
+    let source_a = build_source_with_secrets(manifest.clone(), [("API_TOKEN", "token-a")]);
+    let source_b = build_source_with_secrets(manifest, [("API_TOKEN", "token-b")]);
+    let registry = Arc::new(HttpCacheRegistry::new());
+
+    let _ = CoralQuery::execute_sql(
+        &[source_a],
+        runtime_with_cache_registry_and_namespace(registry.clone(), "workspace"),
+        "SELECT id FROM http_registry_inputs.users",
+    )
+    .await
+    .expect("token-a query should succeed");
+
+    let _ = CoralQuery::execute_sql(
+        &[source_b],
+        runtime_with_cache_registry_and_namespace(registry, "workspace"),
+        "SELECT id FROM http_registry_inputs.users",
+    )
+    .await
+    .expect("token-b query should succeed");
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -2242,11 +2242,12 @@ async fn cache_coalesces_concurrent_scans_in_same_query() {
         .await;
 
     let source = build_source(cached_http_manifest("http_cache_coalesce", &server.uri()));
+    let registry = Arc::new(HttpCacheRegistry::new());
 
     let _ = execution_to_rows(
         &CoralQuery::execute_sql(
             &[source],
-            test_runtime(),
+            runtime_with_cache_registry(registry),
             "SELECT id FROM http_cache_coalesce.users \
              UNION ALL \
              SELECT id FROM http_cache_coalesce.users",

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -10,7 +10,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use coral_engine::{
     CoralQuery, CoreError, EngineExtensions, HttpCacheRegistry, QueryRuntimeConfig,
-    QueryRuntimeContext, RequestAuthenticator, RequestAuthenticatorError, StatusCode,
+    QueryRuntimeContext, RequestAuthenticator, RequestAuthenticatorError,
+    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -2177,6 +2178,53 @@ fn runtime_with_cache_registry_and_namespace(
     QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
 }
 
+fn runtime_with_cache_registry_namespace_and_resolver(
+    registry: Arc<HttpCacheRegistry>,
+    namespace: &str,
+    resolver: Arc<dyn SourceInputResolver>,
+) -> QueryRuntimeConfig {
+    let extensions = EngineExtensions {
+        cache_namespace: Some(namespace.to_string()),
+        http_cache_registry: Some(registry),
+        source_input_resolver: Some(resolver),
+        ..EngineExtensions::default()
+    };
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+}
+
+fn runtime_with_cache_registry_without_namespace(
+    registry: Arc<HttpCacheRegistry>,
+) -> QueryRuntimeConfig {
+    let extensions = EngineExtensions {
+        http_cache_registry: Some(registry),
+        ..EngineExtensions::default()
+    };
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+}
+
+#[derive(Debug, Default)]
+struct RotatingTokenResolver {
+    calls: AtomicUsize,
+}
+
+#[async_trait::async_trait]
+impl SourceInputResolver for RotatingTokenResolver {
+    async fn resolve_inputs(
+        &self,
+        _source: &SourceInputResolutionContext,
+    ) -> Result<BTreeMap<String, String>, SourceInputResolverError> {
+        let token = if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+            "token-a"
+        } else {
+            "token-b"
+        };
+        Ok(BTreeMap::from([(
+            "API_TOKEN".to_string(),
+            token.to_string(),
+        )]))
+    }
+}
+
 fn cached_http_manifest(name: &str, base_url: &str) -> Value {
     json!({
         "name": name,
@@ -2356,6 +2404,39 @@ async fn cache_registry_isolates_namespaces() {
 }
 
 #[tokio::test]
+async fn cache_registry_without_namespace_disables_cache() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let source = build_source(cached_http_manifest(
+        "http_registry_no_namespace",
+        &server.uri(),
+    ));
+    let registry = Arc::new(HttpCacheRegistry::new());
+
+    let _ = CoralQuery::execute_sql(
+        std::slice::from_ref(&source),
+        runtime_with_cache_registry_without_namespace(registry.clone()),
+        "SELECT id FROM http_registry_no_namespace.users",
+    )
+    .await
+    .expect("first query should succeed");
+
+    let _ = CoralQuery::execute_sql(
+        &[source],
+        runtime_with_cache_registry_without_namespace(registry),
+        "SELECT id FROM http_registry_no_namespace.users",
+    )
+    .await
+    .expect("second query should succeed");
+}
+
+#[tokio::test]
 async fn cache_registry_isolates_different_source_inputs() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
@@ -2382,6 +2463,52 @@ async fn cache_registry_isolates_different_source_inputs() {
         &[source_b],
         runtime_with_cache_registry_and_namespace(registry, "workspace"),
         "SELECT id FROM http_registry_inputs.users",
+    )
+    .await
+    .expect("token-b query should succeed");
+}
+
+#[tokio::test]
+async fn cache_key_includes_request_time_resolved_inputs() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(header("Authorization", "token-a"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(header("Authorization", "token-b"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source_with_secrets(
+        cached_authenticated_http_manifest("http_registry_refreshed_inputs", &server.uri()),
+        [("API_TOKEN", "static-token")],
+    );
+    let registry = Arc::new(HttpCacheRegistry::new());
+    let resolver = Arc::new(RotatingTokenResolver::default());
+
+    let _ = CoralQuery::execute_sql(
+        std::slice::from_ref(&source),
+        runtime_with_cache_registry_namespace_and_resolver(
+            registry.clone(),
+            "workspace",
+            resolver.clone(),
+        ),
+        "SELECT id FROM http_registry_refreshed_inputs.users",
+    )
+    .await
+    .expect("token-a query should succeed");
+
+    let _ = CoralQuery::execute_sql(
+        &[source],
+        runtime_with_cache_registry_namespace_and_resolver(registry, "workspace", resolver),
+        "SELECT id FROM http_registry_refreshed_inputs.users",
     )
     .await
     .expect("token-b query should succeed");

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use coral_engine::{
-    CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext,
-    RequestAuthenticator, RequestAuthenticatorError, StatusCode,
+    CoralQuery, CoreError, EngineExtensions, HttpCacheRegistry, QueryRuntimeConfig,
+    QueryRuntimeContext, RequestAuthenticator, RequestAuthenticatorError, StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -2159,4 +2159,139 @@ async fn legacy_json_body_array_form_still_works() {
     );
 
     assert_eq!(rows, users_rows());
+}
+
+fn runtime_with_cache_registry(registry: Arc<HttpCacheRegistry>) -> QueryRuntimeConfig {
+    let extensions = EngineExtensions {
+        http_cache_registry: Some(registry),
+        ..EngineExtensions::default()
+    };
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+}
+
+fn cached_http_manifest(name: &str, base_url: &str) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "tables": [{
+            "name": "users",
+            "description": "HTTP users with TTL cache",
+            "request": {
+                "method": "GET",
+                "path": "/api/users"
+            },
+            "response": { "rows_path": ["data"] },
+            "cache": { "mode": "ttl", "ttl": "1h" },
+            "columns": [
+                { "name": "id", "type": "Int64" },
+                { "name": "name", "type": "Utf8" },
+                { "name": "email", "type": "Utf8" }
+            ]
+        }]
+    })
+}
+
+#[tokio::test]
+async fn cache_persists_across_execute_sql_calls() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(cached_http_manifest("http_cache_persist", &server.uri()));
+    let registry = Arc::new(HttpCacheRegistry::new());
+
+    let rows1 = execution_to_rows(
+        &CoralQuery::execute_sql(
+            std::slice::from_ref(&source),
+            runtime_with_cache_registry(registry.clone()),
+            "SELECT id, name, email FROM http_cache_persist.users ORDER BY id",
+        )
+        .await
+        .expect("first query should succeed"),
+    );
+
+    let rows2 = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            runtime_with_cache_registry(registry),
+            "SELECT id, name, email FROM http_cache_persist.users ORDER BY id",
+        )
+        .await
+        .expect("second query should succeed (served from cache)"),
+    );
+
+    assert_eq!(rows1, users_rows());
+    assert_eq!(rows2, users_rows());
+}
+
+#[tokio::test]
+async fn cache_coalesces_concurrent_scans_in_same_query() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(cached_http_manifest("http_cache_coalesce", &server.uri()));
+
+    let _ = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT id FROM http_cache_coalesce.users \
+             UNION ALL \
+             SELECT id FROM http_cache_coalesce.users",
+        )
+        .await
+        .expect("union all query should succeed"),
+    );
+}
+
+#[tokio::test]
+async fn cache_registry_isolates_different_source_versions() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let mut manifest_v1 = cached_http_manifest("http_registry_versioned", &server.uri());
+    manifest_v1
+        .as_object_mut()
+        .expect("manifest is an object")
+        .insert("version".to_string(), json!("0.1.0"));
+    let mut manifest_v2 = manifest_v1.clone();
+    manifest_v2
+        .as_object_mut()
+        .expect("manifest is an object")
+        .insert("version".to_string(), json!("0.2.0"));
+
+    let registry = Arc::new(HttpCacheRegistry::new());
+
+    let _ = CoralQuery::execute_sql(
+        &[build_source(manifest_v1)],
+        runtime_with_cache_registry(registry.clone()),
+        "SELECT id FROM http_registry_versioned.users",
+    )
+    .await
+    .expect("v1 query should succeed");
+
+    let _ = CoralQuery::execute_sql(
+        &[build_source(manifest_v2)],
+        runtime_with_cache_registry(registry),
+        "SELECT id FROM http_registry_versioned.users",
+    )
+    .await
+    .expect("v2 query should succeed");
 }

--- a/crates/coral-spec/Cargo.toml
+++ b/crates/coral-spec/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
+http.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -11,6 +11,7 @@
 //! live in this crate.
 
 use std::collections::{BTreeSet, HashSet};
+use std::time::Duration;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -88,6 +89,145 @@ pub struct RateLimitSpec {
     pub reset_header: Option<String>,
 }
 
+/// Cache mode declared in the table manifest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HttpCacheMode {
+    /// Caching is disabled for this table (default).
+    #[default]
+    Disabled,
+    /// Cache entries expire after a fixed TTL.
+    Ttl,
+}
+
+/// Validated table-level HTTP cache policy from the manifest.
+#[derive(Debug, Clone)]
+pub struct HttpCachePolicySpec {
+    /// Whether and how to cache responses for this table.
+    pub mode: HttpCacheMode,
+    /// Time-to-live for cache entries.
+    pub ttl: Duration,
+    /// Request headers whose values affect response identity and must be
+    /// included in the cache key.
+    pub vary_headers: Vec<String>,
+    /// Maximum pages to serve from or write to cache per fetch.
+    pub max_pages: Option<usize>,
+    /// Skip caching entries whose decoded payload exceeds this byte estimate.
+    pub max_entry_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawHttpCachePolicySpec {
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    ttl: Option<String>,
+    #[serde(default)]
+    vary: Option<RawHttpCacheVarySpec>,
+    #[serde(default)]
+    max_pages: Option<usize>,
+    #[serde(default)]
+    max_entry_bytes: Option<usize>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+struct RawHttpCacheVarySpec {
+    #[serde(default)]
+    headers: Vec<String>,
+}
+
+fn parse_ttl_duration(s: &str) -> std::result::Result<Duration, String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err("cache ttl must not be empty".to_string());
+    }
+    let mut total_secs = 0u64;
+    let mut current_number: Option<u64> = None;
+
+    for ch in s.chars() {
+        if ch.is_ascii_digit() {
+            let digit = u64::from(
+                ch.to_digit(10)
+                    .ok_or_else(|| format!("invalid cache ttl '{s}': unexpected '{ch}'"))?,
+            );
+            let base = current_number.unwrap_or(0u64);
+            current_number = Some(
+                base.checked_mul(10)
+                    .and_then(|value| value.checked_add(digit))
+                    .ok_or_else(|| format!("cache ttl '{s}' overflows u64 seconds"))?,
+            );
+        } else {
+            let n = current_number
+                .take()
+                .ok_or_else(|| format!("invalid cache ttl '{s}': unexpected '{ch}'"))?;
+            let multiplier = match ch {
+                'h' => 3600u64,
+                'm' => 60u64,
+                's' => 1u64,
+                other => {
+                    return Err(format!(
+                        "invalid cache ttl '{s}': unknown unit '{other}'; use h, m, or s"
+                    ));
+                }
+            };
+            total_secs = total_secs
+                .checked_add(
+                    n.checked_mul(multiplier)
+                        .ok_or_else(|| format!("cache ttl '{s}' overflows u64 seconds"))?,
+                )
+                .ok_or_else(|| format!("cache ttl '{s}' overflows u64 seconds"))?;
+        }
+    }
+
+    if current_number.is_some() {
+        return Err(format!(
+            "invalid cache ttl '{s}': trailing digits without a unit (h, m, or s)"
+        ));
+    }
+
+    if total_secs == 0 {
+        return Err(format!("cache ttl '{s}' must be positive"));
+    }
+
+    Ok(Duration::from_secs(total_secs))
+}
+
+fn validate_cache_policy(
+    raw: Option<RawHttpCachePolicySpec>,
+) -> crate::Result<Option<HttpCachePolicySpec>> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+
+    let mode = match raw.mode.as_deref().unwrap_or("disabled") {
+        "disabled" => HttpCacheMode::Disabled,
+        "ttl" => HttpCacheMode::Ttl,
+        other => {
+            return Err(crate::ManifestError::validation(format!(
+                "unknown cache mode '{other}'; use 'disabled' or 'ttl'"
+            )));
+        }
+    };
+
+    let ttl = if mode == HttpCacheMode::Ttl {
+        let raw_ttl = raw.ttl.as_deref().ok_or_else(|| {
+            crate::ManifestError::validation("cache mode 'ttl' requires a 'ttl' field".to_string())
+        })?;
+        parse_ttl_duration(raw_ttl).map_err(crate::ManifestError::validation)?
+    } else {
+        Duration::ZERO
+    };
+
+    Ok(Some(HttpCachePolicySpec {
+        mode,
+        ttl,
+        vary_headers: raw.vary.unwrap_or_default().headers,
+        max_pages: raw.max_pages,
+        max_entry_bytes: raw.max_entry_bytes,
+    }))
+}
+
 /// Validated top-level manifest for an HTTP-backed source.
 #[derive(Debug, Clone)]
 pub struct HttpSourceManifest {
@@ -153,6 +293,8 @@ struct RawHttpTableSpec {
     pagination: PaginationSpec,
     #[serde(default)]
     columns: Vec<ColumnSpec>,
+    #[serde(default)]
+    cache: Option<RawHttpCachePolicySpec>,
 }
 
 /// One validated HTTP table declaration.
@@ -163,6 +305,8 @@ pub struct HttpTableSpec {
     pub requests: Vec<RequestRouteSpec>,
     pub response: ResponseSpec,
     pub pagination: PaginationSpec,
+    /// Opt-in cache policy for this table, or `None` if caching is disabled.
+    pub cache: Option<HttpCachePolicySpec>,
 }
 
 impl HttpTableSpec {
@@ -244,6 +388,8 @@ impl RawHttpTableSpec {
             &self.detail_hints,
         )?;
 
+        let cache = validate_cache_policy(self.cache)?;
+
         Ok(HttpTableSpec {
             common: TableCommon::new(
                 self.name,
@@ -259,6 +405,7 @@ impl RawHttpTableSpec {
             requests: self.requests,
             response: self.response,
             pagination: self.pagination,
+            cache,
         })
     }
 }
@@ -392,5 +539,6 @@ pub(crate) fn test_http_table_spec(
         requests: vec![],
         response: ResponseSpec::default(),
         pagination: PaginationSpec::default(),
+        cache: None,
     }
 }

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -234,35 +234,12 @@ fn validate_cache_policy(
 }
 
 fn validate_cache_vary_header_name(header: &str) -> crate::Result<()> {
-    if header.is_empty() || !header.bytes().all(is_http_token_byte) {
-        return Err(crate::ManifestError::validation(format!(
-            "invalid cache vary header name '{header}'"
-        )));
-    }
+    http::header::HeaderName::from_bytes(header.as_bytes()).map_err(|error| {
+        crate::ManifestError::validation(format!(
+            "invalid cache vary header name '{header}': {error}"
+        ))
+    })?;
     Ok(())
-}
-
-fn is_http_token_byte(byte: u8) -> bool {
-    matches!(
-        byte,
-        b'!' | b'#'
-            | b'$'
-            | b'%'
-            | b'&'
-            | b'\''
-            | b'*'
-            | b'+'
-            | b'-'
-            | b'.'
-            | b'^'
-            | b'_'
-            | b'`'
-            | b'|'
-            | b'~'
-            | b'0'..=b'9'
-            | b'A'..=b'Z'
-            | b'a'..=b'z'
-    )
 }
 
 /// Validated top-level manifest for an HTTP-backed source.

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -219,13 +219,50 @@ fn validate_cache_policy(
         Duration::ZERO
     };
 
+    let vary_headers = raw.vary.unwrap_or_default().headers;
+    for header in &vary_headers {
+        validate_cache_vary_header_name(header)?;
+    }
+
     Ok(Some(HttpCachePolicySpec {
         mode,
         ttl,
-        vary_headers: raw.vary.unwrap_or_default().headers,
+        vary_headers,
         max_pages: raw.max_pages,
         max_entry_bytes: raw.max_entry_bytes,
     }))
+}
+
+fn validate_cache_vary_header_name(header: &str) -> crate::Result<()> {
+    if header.is_empty() || !header.bytes().all(is_http_token_byte) {
+        return Err(crate::ManifestError::validation(format!(
+            "invalid cache vary header name '{header}'"
+        )));
+    }
+    Ok(())
+}
+
+fn is_http_token_byte(byte: u8) -> bool {
+    matches!(
+        byte,
+        b'!' | b'#'
+            | b'$'
+            | b'%'
+            | b'&'
+            | b'\''
+            | b'*'
+            | b'+'
+            | b'-'
+            | b'.'
+            | b'^'
+            | b'_'
+            | b'`'
+            | b'|'
+            | b'~'
+            | b'0'..=b'9'
+            | b'A'..=b'Z'
+            | b'a'..=b'z'
+    )
 }
 
 /// Validated top-level manifest for an HTTP-backed source.
@@ -305,7 +342,9 @@ pub struct HttpTableSpec {
     pub requests: Vec<RequestRouteSpec>,
     pub response: ResponseSpec,
     pub pagination: PaginationSpec,
-    /// Opt-in cache policy for this table, or `None` if caching is disabled.
+    /// Opt-in cache policy for this table. `None` means no cache block was
+    /// configured; `Some` callers must check `mode` to determine whether caching
+    /// is enabled.
     pub cache: Option<HttpCachePolicySpec>,
 }
 

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -362,6 +362,39 @@ functions:
     }
 
     #[test]
+    fn parse_source_manifest_rejects_invalid_cache_vary_header_name() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    cache:
+      mode: ttl
+      ttl: 1m
+      vary:
+        headers:
+          - 'Authorization: Bearer'
+",
+        )
+        .expect_err("invalid vary header should fail manifest parsing");
+
+        assert!(
+            error
+                .to_string()
+                .contains("invalid cache vary header name 'Authorization: Bearer'"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn parse_source_manifest_rejects_whitespace_only_test_query() {
         let error = parse_source_manifest_yaml(
             r#"

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -217,6 +217,34 @@ tables:
     }
 
     #[test]
+    fn validate_manifest_schema_requires_ttl_for_ttl_cache_mode() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+    cache:
+      mode: ttl
+",
+        );
+
+        let error = validate_manifest_schema(&manifest)
+            .expect_err("ttl cache mode without ttl should fail schema validation");
+        assert!(
+            error.to_string().contains("\"ttl\" is a required property"),
+            "unexpected schema error: {error}"
+        );
+    }
+
+    #[test]
     fn parse_source_manifest_yaml_accepts_http_table_search_metadata() {
         parse_source_manifest_yaml(
             r"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -398,6 +398,7 @@
         },
         "response": { "$ref": "#/$defs/response" },
         "pagination": { "$ref": "#/$defs/pagination" },
+        "cache": { "$ref": "#/$defs/cache_policy" },
         "columns": {
           "type": "array",
           "items": { "$ref": "#/$defs/column" }
@@ -428,6 +429,35 @@
           "items": { "$ref": "#/$defs/column" }
         }
       }
+    },
+    "cache_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mode": { "type": "string", "enum": ["disabled", "ttl"] },
+        "ttl": { "type": "string", "minLength": 1 },
+        "vary": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "headers": {
+              "type": "array",
+              "items": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "max_pages": { "type": "integer", "minimum": 1 },
+        "max_entry_bytes": { "type": "integer", "minimum": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "mode": { "const": "ttl" } },
+            "required": ["mode"]
+          },
+          "then": { "required": ["ttl"] }
+        }
+      ]
     },
     "source": {
       "type": "object",


### PR DESCRIPTION
## Summary

- Adds opt-in TTL caching for HTTP source tables via source manifests:
  `cache: { mode: ttl, ttl: "5m" }`.
- Caches decoded HTTP response pages in a long-lived moka-backed in-memory cache shared across query runtime rebuilds.
- Builds cache keys from request-determining material: source name/version, table, method, rendered URL, query params, body hash, configured vary headers, and TTL.
- Adds app-level `[http_cache]` config for enabling/disabling the cache and controlling memory ceilings:
  - `enabled`
  - `default_max_bytes_per_source`
  - `total_max_bytes`
  - `[http_cache.sources.<name>].max_bytes`
- Skips cache writes for failed responses, malformed JSON, 429/5xx responses, `allow_404_empty`, `ok_path = false`, oversized entries, and disabled runtime cache.
- Extends `coral-spec` and the source manifest JSON schema with table-level cache policy validation.

## Source spec

```yaml
tables:
  - name: posts
    cache:
      mode: ttl
      ttl: 5m
      vary:
        headers: ["Accept-Language"]
      max_pages: 50
      max_entry_bytes: 1048576
```

## App config

```toml
[http_cache]
enabled = true
default_max_bytes_per_source = "256MiB"
total_max_bytes = "2GiB"

[http_cache.sources.github]
max_bytes = "500MiB"
```

## Future work

- Add optional cache eviction policy selection in `[http_cache]`, for example `tiny_lfu` vs `lru`, if real workloads show the default Moka policy is not enough.
- Extend response caching beyond HTTP-backed tables where the backend has stable request identity and bounded payloads.
- Add a disk-backed cache mode for larger or longer-lived entries, with clear size limits and safe invalidation.
- Add more structured cache-key customization, such as additional safe `vary` dimensions beyond headers, while keeping secret values out of raw keys.
- Expand cache observability beyond trace logs: add hit/miss/skipped-write metrics, current weighted size, per-source/table cache stats, and user-facing inspection commands.
- Add explicit cache management commands, such as inspect, clear all, clear source, and clear table.
- Explore HTTP-aware revalidation with `ETag`, `Last-Modified`, and `Cache-Control` where providers expose useful headers.
- Add credential/input change invalidation so cached entries cannot survive across materially different source configuration.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo build -p coral-cli`
- [x] `../check_http_cache.py --coral-bin target/debug/coral --timeout 45`
- [x] `cargo test -p coral-engine backends::http::cache`
- [x] `cargo test -p coral-engine cache_runtime_absence_disables_table_cache_policy`
- [x] `cargo test -p coral-app http_cache`
- [x] `cargo clippy --workspace --all-features --all-targets`
