### PR TITLE
feat(engine): project column stats in catalog

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -106,6 +106,7 @@ pub(crate) struct RegisteredInput {
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredSource {
     pub(crate) schema_name: String,
+    pub(crate) source_version: String,
     pub(crate) tables: Vec<RegisteredTable>,
     pub(crate) table_functions: Vec<RegisteredTableFunction>,
     pub(crate) inputs: Vec<RegisteredInput>,

--- a/crates/coral-engine/src/backends/composite.rs
+++ b/crates/coral-engine/src/backends/composite.rs
@@ -16,15 +16,18 @@ use crate::backends::{
 
 struct CompositeCompiledSource {
     source_name: String,
+    source_version: String,
     components: Vec<Box<dyn CompiledBackendSource>>,
 }
 
 pub(crate) fn compile_source(
     source_name: String,
+    source_version: String,
     components: Vec<Box<dyn CompiledBackendSource>>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(CompositeCompiledSource {
         source_name,
+        source_version,
         components,
     })
 }
@@ -57,9 +60,12 @@ impl CompiledBackendSource for CompositeCompiledSource {
             let registration = component.register(ctx, registration_context).await?;
             for schema in registration.schemas {
                 let schema_name = schema.source.schema_name.clone();
-                let target = schemas
-                    .entry(schema_name.clone())
-                    .or_insert_with(|| CompositeSchemaRegistration::new(schema_name.clone()));
+                let target = schemas.entry(schema_name.clone()).or_insert_with(|| {
+                    CompositeSchemaRegistration::new(
+                        schema_name.clone(),
+                        self.source_version.clone(),
+                    )
+                });
                 for (name, table) in schema.tables {
                     if target.tables.insert(name.clone(), table).is_some() {
                         return Err(DataFusionError::Execution(format!(
@@ -98,6 +104,7 @@ impl CompiledBackendSource for CompositeCompiledSource {
 
 struct CompositeSchemaRegistration {
     schema_name: String,
+    source_version: String,
     tables: HashMap<String, Arc<dyn TableProvider>>,
     function_keys: BTreeSet<String>,
     registered_tables: Vec<RegisteredTable>,
@@ -107,9 +114,10 @@ struct CompositeSchemaRegistration {
 }
 
 impl CompositeSchemaRegistration {
-    fn new(schema_name: String) -> Self {
+    fn new(schema_name: String, source_version: String) -> Self {
         Self {
             schema_name,
+            source_version,
             tables: HashMap::new(),
             function_keys: BTreeSet::new(),
             registered_tables: Vec::new(),
@@ -124,6 +132,7 @@ impl CompositeSchemaRegistration {
             tables: self.tables,
             source: RegisteredSource {
                 schema_name: self.schema_name,
+                source_version: self.source_version,
                 tables: self.registered_tables,
                 table_functions: self.registered_functions,
                 inputs: self.inputs,

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -151,6 +151,7 @@ impl CompiledBackendSource for FileCompiledSource {
                 tables,
                 source: RegisteredSource {
                     schema_name,
+                    source_version: self.manifest.common.version.clone(),
                     tables: table_infos,
                     table_functions: vec![],
                     inputs,

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -5,6 +5,7 @@ use super::partitions::{
 };
 use super::provider::FileTableProvider;
 use crate::backends::compile_source_manifest;
+use crate::contracts::StatisticsProfile;
 use crate::runtime::catalog;
 use crate::runtime::registry::{CompiledQuerySource, register_sources_blocking};
 use crate::{QueryRuntimeContext, QuerySource};
@@ -275,8 +276,12 @@ async fn parquet_provider_exposes_inferred_schema_in_coral_columns() {
 
     let active_sources = register_sources_blocking(&ctx, compile_sources(vec![manifest]))
         .expect("file source should register");
-    catalog::register(&ctx, &active_sources.active_sources)
-        .expect("metadata tables should register");
+    catalog::register(
+        &ctx,
+        &active_sources.active_sources,
+        &StatisticsProfile::empty(),
+    )
+    .expect("metadata tables should register");
 
     let batches = ctx
         .sql(

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -171,6 +171,7 @@ impl CompiledBackendSource for HttpCompiledSource {
                 tables,
                 source: RegisteredSource {
                     schema_name,
+                    source_version: self.manifest.common.version.clone(),
                     tables: table_infos,
                     table_functions: table_function_infos,
                     inputs,

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -249,6 +249,7 @@ impl CompiledBackendSource for McpCompiledSource {
                 tables,
                 source: RegisteredSource {
                     schema_name,
+                    source_version: self.manifest.common.version.clone(),
                     tables: table_infos,
                     table_functions: table_function_infos,
                     inputs,

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -4,6 +4,7 @@ use crate::runtime::registry::{CompiledQuerySource, register_sources_blocking};
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     QuerySource, SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+    StatisticsProfile,
 };
 use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::error::DataFusionError;
@@ -439,7 +440,12 @@ fn register_test_sources(ctx: &SessionContext, sources: Vec<CompiledQuerySource>
 
 fn register_test_sources_with_catalog(ctx: &SessionContext, sources: Vec<CompiledQuerySource>) {
     let registration = register_sources_blocking(ctx, sources).expect("mcp source should register");
-    catalog::register(ctx, &registration.active_sources).expect("catalog should register");
+    catalog::register(
+        ctx,
+        &registration.active_sources,
+        &StatisticsProfile::empty(),
+    )
+    .expect("catalog should register");
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -119,6 +119,7 @@ pub(crate) fn compile_query_source(
         .collect::<Vec<_>>();
     Ok(composite::compile_source(
         source.source_name().to_string(),
+        source.version().unwrap_or_default().to_string(),
         compiled_components,
     ))
 }

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod error;
 mod query;
 mod query_error;
+mod statistics;
 
 pub use catalog::{
     CatalogInfo, ColumnInfo, DescribeTableInfo, TableFunctionArgumentInfo, TableFunctionInfo,
@@ -18,6 +19,11 @@ pub use query::{
     RuntimeSourceComponent, RuntimeSourcePackage, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
+pub use statistics::{
+    ColumnSchemaSignature, ColumnStatistics, ColumnStatisticsObservation, SourceStatistics,
+    StatisticPrecision, StatisticValue, StatisticsObservation, StatisticsObservationScope,
+    StatisticsProfile, TableSchemaSignature, TableStatistics,
+};
 
 #[cfg(test)]
 pub(crate) use query_error::UNKNOWN_COLUMN_REASON;

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -14,7 +14,7 @@ use coral_spec::backends::mcp::McpSourceManifest;
 use coral_spec::{ManifestInputSpec, ValidatedSourceManifest};
 use opentelemetry::Context as OtelContext;
 
-use super::ColumnInfo;
+use super::{ColumnInfo, StatisticsProfile};
 use crate::EngineExtensions;
 
 /// One managed source selected into the current query runtime.
@@ -509,6 +509,8 @@ pub struct QueryRuntimeConfig {
     pub memory: QueryMemoryConfig,
     /// Runtime policy for dependent predicate pushdown.
     pub dependent_join: DependentJoinConfig,
+    /// Column statistics to project through the runtime catalog.
+    pub statistics: StatisticsProfile,
 }
 
 impl QueryRuntimeConfig {
@@ -520,7 +522,15 @@ impl QueryRuntimeConfig {
             extensions,
             memory: QueryMemoryConfig::default(),
             dependent_join: DependentJoinConfig::default(),
+            statistics: StatisticsProfile::empty(),
         }
+    }
+
+    /// Replaces the runtime statistics profile.
+    #[must_use]
+    pub fn with_statistics(mut self, statistics: StatisticsProfile) -> Self {
+        self.statistics = statistics;
+        self
     }
 }
 

--- a/crates/coral-engine/src/contracts/statistics.rs
+++ b/crates/coral-engine/src/contracts/statistics.rs
@@ -1,0 +1,359 @@
+//! Transport-neutral column statistics contracts.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+const STATISTICS_PROFILE_VERSION: u32 = 1;
+
+/// Persistable statistics profile passed from the app layer into one runtime.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatisticsProfile {
+    /// Storage format version.
+    pub version: u32,
+    /// Source statistics keyed by visible SQL schema name.
+    #[serde(default)]
+    pub sources: BTreeMap<String, SourceStatistics>,
+}
+
+impl Default for StatisticsProfile {
+    fn default() -> Self {
+        Self {
+            version: STATISTICS_PROFILE_VERSION,
+            sources: BTreeMap::new(),
+        }
+    }
+}
+
+impl StatisticsProfile {
+    /// Returns an empty profile with the current persisted version.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Removes all source entries except the selected schema names.
+    pub fn retain_sources<'a>(&mut self, schema_names: impl IntoIterator<Item = &'a str>) {
+        let keep = schema_names
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+        self.sources
+            .retain(|schema_name, _| keep.contains(schema_name.as_str()));
+    }
+}
+
+/// Statistics known for one selected source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceStatistics {
+    /// Visible SQL schema name.
+    pub schema_name: String,
+    /// Optional manifest/source version that produced the stats.
+    #[serde(default)]
+    pub source_version: Option<String>,
+    /// Table statistics keyed by visible table name.
+    #[serde(default)]
+    pub tables: BTreeMap<String, TableStatistics>,
+}
+
+/// Statistics known for one source table.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableStatistics {
+    /// Visible SQL schema name.
+    pub schema_name: String,
+    /// Visible table name.
+    pub table_name: String,
+    /// Optional manifest/source version that produced the stats.
+    #[serde(default)]
+    pub source_version: Option<String>,
+    /// Schema signature used to reject stale column statistics.
+    pub schema_signature: TableSchemaSignature,
+    /// Column statistics keyed by column name.
+    #[serde(default)]
+    pub columns: BTreeMap<String, ColumnStatistics>,
+}
+
+/// Stable signature for a table's query-visible shape.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableSchemaSignature {
+    /// Columns in ordinal order.
+    pub columns: Vec<ColumnSchemaSignature>,
+    /// Required filter columns in registered order.
+    pub required_filters: Vec<String>,
+}
+
+/// Stable signature for one column's query-visible metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ColumnSchemaSignature {
+    /// Column name.
+    pub name: String,
+    /// Arrow/DataFusion display type.
+    pub data_type: String,
+    /// Whether the column is nullable.
+    pub nullable: bool,
+    /// Whether the column is virtual.
+    pub is_virtual: bool,
+    /// Whether the column is a required filter.
+    pub is_required_filter: bool,
+}
+
+/// Persistable statistics for one column.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnStatistics {
+    /// Column name.
+    pub column_name: String,
+    /// Number of rows represented by these stats.
+    pub sample_count: u64,
+    /// Null count, when known.
+    #[serde(default)]
+    pub null_count: Option<StatisticValue<u64>>,
+    /// Approximate distinct value count, when known.
+    #[serde(default)]
+    pub approx_distinct_count: Option<StatisticValue<u64>>,
+    /// RFC3339 UTC observation timestamp.
+    #[serde(default)]
+    pub observed_at: Option<String>,
+}
+
+impl ColumnStatistics {
+    /// Projects `null_count / sample_count` for `coral.columns`.
+    #[must_use]
+    pub fn null_fraction(&self) -> Option<f64> {
+        let null_count = self.null_count.as_ref()?.value;
+        if self.sample_count == 0 {
+            return None;
+        }
+        if null_count > self.sample_count {
+            return None;
+        }
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "coral.columns exposes null_fraction as SQL DOUBLE, so lossy u64-to-f64 projection is intentional."
+        )]
+        Some(null_count as f64 / self.sample_count as f64)
+    }
+
+    /// Projects sample count as SQL `BIGINT`.
+    #[must_use]
+    pub fn sample_count_i64(&self) -> Option<i64> {
+        Some(i64::try_from(self.sample_count).unwrap_or(i64::MAX))
+    }
+
+    /// Projects approximate distinct count as SQL `BIGINT`.
+    #[must_use]
+    pub fn approx_distinct_count_i64(&self) -> Option<i64> {
+        self.approx_distinct_count
+            .as_ref()
+            .and_then(|value| i64::try_from(value.value).ok())
+    }
+
+    /// Projects the weakest precision among the displayed statistics.
+    #[must_use]
+    pub fn precision_for_catalog(&self) -> Option<&'static str> {
+        let precision = [
+            self.null_count.as_ref(),
+            self.approx_distinct_count.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .map(|value| value.precision)
+        .reduce(StatisticPrecision::weaker)
+        .or_else(|| (self.sample_count > 0).then_some(StatisticPrecision::Unknown))?;
+        Some(precision.as_str())
+    }
+}
+
+/// A statistic value and its precision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatisticValue<T> {
+    /// Statistic value.
+    pub value: T,
+    /// Precision of the value.
+    pub precision: StatisticPrecision,
+}
+
+/// Precision tags exposed through `stats_precision`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatisticPrecision {
+    /// Exact for the table snapshot observed.
+    Exact,
+    /// Approximate, but intentionally computed as an estimate.
+    Approximate,
+    /// Observed from the rows returned by a scan.
+    ObservedSample,
+    /// Unknown or mixed precision.
+    Unknown,
+}
+
+impl StatisticPrecision {
+    /// Stable catalog string.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Approximate => "approximate",
+            Self::ObservedSample => "observed_sample",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    /// Returns the weaker precision, where exact is strongest and unknown is weakest.
+    #[must_use]
+    pub fn weaker(self, other: Self) -> Self {
+        if self.rank() <= other.rank() {
+            self
+        } else {
+            other
+        }
+    }
+
+    fn rank(self) -> u8 {
+        match self {
+            Self::Unknown => 0,
+            Self::ObservedSample => 1,
+            Self::Approximate => 2,
+            Self::Exact => 3,
+        }
+    }
+}
+
+/// One runtime scan observation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatisticsObservation {
+    /// Visible SQL schema name.
+    pub schema_name: String,
+    /// Visible table name.
+    pub table_name: String,
+    /// Optional manifest/source version that produced the observation.
+    pub source_version: Option<String>,
+    /// Schema signature at observation time.
+    pub schema_signature: TableSchemaSignature,
+    /// Observation scope.
+    pub scope: StatisticsObservationScope,
+    /// RFC3339 UTC observation timestamp.
+    pub observed_at: String,
+    /// Per-column scan observations.
+    pub columns: Vec<ColumnStatisticsObservation>,
+}
+
+/// Scope for one runtime observation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatisticsObservationScope {
+    /// The scan represented the table as a whole.
+    TableGlobal,
+    /// The scan had pushed filters.
+    Filtered {
+        /// Names of pushed filter columns.
+        filter_columns: Vec<String>,
+    },
+    /// The scan had a pushed limit.
+    Limited,
+    /// The backend could not defensibly classify scope.
+    Unknown,
+}
+
+/// Per-column values from one scan observation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnStatisticsObservation {
+    /// Column name.
+    pub column_name: String,
+    /// Number of rows observed.
+    pub sample_count: u64,
+    /// Null count, when known.
+    pub null_count: Option<StatisticValue<u64>>,
+    /// Approximate distinct count, when known.
+    pub approx_distinct_count: Option<StatisticValue<u64>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ColumnStatistics, StatisticPrecision, StatisticValue, StatisticsProfile};
+
+    #[test]
+    fn empty_profile_uses_current_version() {
+        let profile = StatisticsProfile::empty();
+        assert_eq!(profile.version, 1);
+        assert!(profile.sources.is_empty());
+    }
+
+    #[test]
+    fn null_fraction_requires_sample_count_and_null_count() {
+        let without_nulls = ColumnStatistics {
+            column_name: "name".to_string(),
+            sample_count: 10,
+            null_count: None,
+            approx_distinct_count: None,
+            observed_at: None,
+        };
+        assert_eq!(without_nulls.null_fraction(), None);
+
+        let zero_sample = ColumnStatistics {
+            null_count: Some(StatisticValue {
+                value: 0,
+                precision: StatisticPrecision::Exact,
+            }),
+            sample_count: 0,
+            ..without_nulls
+        };
+        assert_eq!(zero_sample.null_fraction(), None);
+
+        let invalid_count = ColumnStatistics {
+            null_count: Some(StatisticValue {
+                value: 2,
+                precision: StatisticPrecision::Exact,
+            }),
+            sample_count: 1,
+            ..zero_sample
+        };
+        assert_eq!(invalid_count.null_fraction(), None);
+    }
+
+    #[test]
+    fn projects_catalog_values() {
+        let stats = ColumnStatistics {
+            column_name: "name".to_string(),
+            sample_count: 10,
+            null_count: Some(StatisticValue {
+                value: 2,
+                precision: StatisticPrecision::Exact,
+            }),
+            approx_distinct_count: Some(StatisticValue {
+                value: 7,
+                precision: StatisticPrecision::ObservedSample,
+            }),
+            observed_at: Some("2026-05-06T00:00:00Z".to_string()),
+        };
+
+        assert_eq!(stats.null_fraction(), Some(0.2));
+        assert_eq!(stats.sample_count_i64(), Some(10));
+        assert_eq!(stats.approx_distinct_count_i64(), Some(7));
+        assert_eq!(stats.precision_for_catalog(), Some("observed_sample"));
+    }
+
+    #[test]
+    fn sample_count_projection_saturates_bigint_overflow() {
+        let stats = ColumnStatistics {
+            column_name: "name".to_string(),
+            sample_count: u64::MAX,
+            null_count: None,
+            approx_distinct_count: None,
+            observed_at: None,
+        };
+
+        assert_eq!(stats.sample_count_i64(), Some(i64::MAX));
+        assert_eq!(stats.precision_for_catalog(), Some("unknown"));
+    }
+
+    #[test]
+    fn weaker_precision_keeps_less_defensible_value() {
+        assert_eq!(
+            StatisticPrecision::Exact.weaker(StatisticPrecision::Approximate),
+            StatisticPrecision::Approximate
+        );
+        assert_eq!(
+            StatisticPrecision::ObservedSample.weaker(StatisticPrecision::Unknown),
+            StatisticPrecision::Unknown
+        );
+    }
+}

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -68,13 +68,16 @@ pub use composition::{
     SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
 };
 pub use contracts::{
-    CatalogInfo, ColumnInfo, CoreError, DependentJoinConfig, DependentJoinSourceConfig,
-    DescribeTableInfo, EffectiveDependentJoinConfig, MemorySize, QueryExecution,
-    QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
-    QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage,
-    QueryTestFailure, QueryTestResult, QueryTestSuccess, RuntimeSourceComponent,
-    RuntimeSourcePackage, SourceValidationReport, StatusCode, StructuredQueryError,
-    TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    CatalogInfo, ColumnInfo, ColumnSchemaSignature, ColumnStatistics, ColumnStatisticsObservation,
+    CoreError, DependentJoinConfig, DependentJoinSourceConfig, DescribeTableInfo,
+    EffectiveDependentJoinConfig, MemorySize, QueryExecution, QueryExecutionProvenance,
+    QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan, QueryRuntimeConfig,
+    QueryRuntimeContext, QuerySource, QueryTableFunctionUsage, QueryTableUsage, QueryTestFailure,
+    QueryTestResult, QueryTestSuccess, RuntimeSourceComponent, RuntimeSourcePackage,
+    SourceStatistics, SourceValidationReport, StatisticPrecision, StatisticValue,
+    StatisticsObservation, StatisticsObservationScope, StatisticsProfile, StatusCode,
+    StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo, TableSchemaSignature, TableStatistics,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use coral_spec::{ManifestInputKind, SearchLimitsSpec};
-use datafusion::arrow::array::{ArrayRef, BooleanArray, Int32Array, RecordBatch, StringArray};
+use datafusion::arrow::array::{
+    ArrayRef, BooleanArray, Float64Array, Int32Array, Int64Array, RecordBatch, StringArray,
+};
 use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::datasource::MemTable;
 use datafusion::error::{DataFusionError, Result};
@@ -12,9 +14,12 @@ use datafusion::prelude::SessionContext;
 use serde::Serialize;
 
 use crate::backends::common::{
-    RegisteredTableFunctionArgument, RegisteredTableFunctionResultColumn,
+    RegisteredColumn, RegisteredTableFunctionArgument, RegisteredTableFunctionResultColumn,
 };
-use crate::backends::{RegisteredSource, RegisteredTableFunction};
+use crate::backends::{RegisteredSource, RegisteredTable, RegisteredTableFunction};
+use crate::contracts::{
+    ColumnStatistics, StatisticsProfile, TableSchemaSignature, TableStatistics,
+};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -30,9 +35,13 @@ pub(crate) const SYSTEM_SCHEMA: &str = "coral";
 ///
 /// Returns a `DataFusionError` if the catalog is missing or the metadata
 /// tables cannot be materialized.
-pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]) -> Result<()> {
+pub(crate) fn register(
+    ctx: &SessionContext,
+    active_sources: &[RegisteredSource],
+    statistics: &StatisticsProfile,
+) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
-    let columns_table = build_columns_table(active_sources)?;
+    let columns_table = build_columns_table(active_sources, statistics)?;
     let filters_table = build_filters_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
     let table_functions_table = build_table_functions_table(active_sources)?;
@@ -818,10 +827,26 @@ struct CatalogColumn {
     filter_mode: Option<String>,
     description: String,
     ordinal_position: usize,
+    null_fraction: Option<f64>,
+    approx_distinct_count: Option<i64>,
+    stats_sample_count: Option<i64>,
+    stats_observed_at: Option<String>,
+    stats_precision: Option<&'static str>,
 }
 
-fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
-    let schema = Arc::new(Schema::new(vec![
+fn build_columns_table(
+    active_sources: &[RegisteredSource],
+    statistics: &StatisticsProfile,
+) -> Result<MemTable> {
+    let schema = columns_schema();
+    let rows = columns_rows(active_sources, statistics);
+    let batch = columns_batch(schema.clone(), &rows)?;
+
+    MemTable::try_new(schema, vec![vec![batch]])
+}
+
+fn columns_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
         Field::new("table_name", DataType::Utf8, false),
         Field::new("ordinal_position", DataType::Int32, false),
@@ -832,17 +857,25 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
         Field::new("is_required_filter", DataType::Boolean, false),
         Field::new("description", DataType::Utf8, false),
         Field::new("filter_mode", DataType::Utf8, true),
-    ]));
-
-    let rows = catalog_column_rows(active_sources);
-    let batch = catalog_columns_batch(schema.clone(), &rows)?;
-
-    MemTable::try_new(schema, vec![vec![batch]])
+        Field::new("null_fraction", DataType::Float64, true),
+        Field::new("approx_distinct_count", DataType::Int64, true),
+        Field::new("stats_sample_count", DataType::Int64, true),
+        Field::new("stats_observed_at", DataType::Utf8, true),
+        Field::new("stats_precision", DataType::Utf8, true),
+    ]))
 }
 
-fn catalog_column_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogColumn> {
+fn columns_rows(
+    active_sources: &[RegisteredSource],
+    statistics: &StatisticsProfile,
+) -> Vec<CatalogColumn> {
     let mut rows = system_catalog_column_rows();
-    rows.extend(source_catalog_column_rows(active_sources));
+    for source in active_sources {
+        for table in &source.tables {
+            rows.extend(columns_for_table(source, table, statistics));
+        }
+    }
+
     rows.sort_by(|left, right| {
         (&left.schema_name, &left.table_name, left.ordinal_position).cmp(&(
             &right.schema_name,
@@ -872,38 +905,96 @@ fn system_catalog_column_rows() -> Vec<CatalogColumn> {
                     filter_mode: None,
                     description: column.description.to_string(),
                     ordinal_position: position,
+                    null_fraction: None,
+                    approx_distinct_count: None,
+                    stats_sample_count: None,
+                    stats_observed_at: None,
+                    stats_precision: None,
                 })
         })
         .collect()
 }
 
-fn source_catalog_column_rows(active_sources: &[RegisteredSource]) -> Vec<CatalogColumn> {
-    active_sources
+fn columns_for_table(
+    source: &RegisteredSource,
+    table: &RegisteredTable,
+    statistics: &StatisticsProfile,
+) -> Vec<CatalogColumn> {
+    let table_statistics = matching_table_statistics(source, table, statistics);
+    table
+        .columns
         .iter()
-        .flat_map(|source| {
-            source.tables.iter().flat_map(move |table| {
-                table
-                    .columns
-                    .iter()
-                    .enumerate()
-                    .map(move |(position, column)| CatalogColumn {
-                        schema_name: source.schema_name.clone(),
-                        table_name: table.table_name.clone(),
-                        column_name: column.name.clone(),
-                        data_type: column.data_type.clone(),
-                        is_nullable: column.nullable,
-                        is_virtual: column.is_virtual,
-                        is_required_filter: column.is_required_filter,
-                        filter_mode: column.filter_mode.clone(),
-                        description: column.description.clone(),
-                        ordinal_position: position,
-                    })
-            })
+        .enumerate()
+        .map(|(position, column)| {
+            let column_statistics =
+                table_statistics.and_then(|stats| stats.columns.get(&column.name));
+            catalog_column(source, table, position, column, column_statistics)
         })
         .collect()
 }
 
-fn catalog_columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<RecordBatch> {
+fn matching_table_statistics<'a>(
+    source: &RegisteredSource,
+    table: &RegisteredTable,
+    statistics: &'a StatisticsProfile,
+) -> Option<&'a TableStatistics> {
+    statistics
+        .sources
+        .get(&source.schema_name)
+        .filter(|source_stats| {
+            source_version_matches(
+                &source.source_version,
+                source_stats.source_version.as_deref(),
+            )
+        })
+        .and_then(|source_stats| source_stats.tables.get(&table.table_name))
+        .filter(|table_stats| {
+            source_version_matches(
+                &source.source_version,
+                table_stats.source_version.as_deref(),
+            )
+        })
+        .filter(|table_stats| table_stats.schema_signature == table_schema_signature(table))
+}
+
+fn source_version_matches(
+    active_source_version: &str,
+    statistics_source_version: Option<&str>,
+) -> bool {
+    match statistics_source_version {
+        Some(statistics_source_version) => statistics_source_version == active_source_version,
+        None => true,
+    }
+}
+
+fn catalog_column(
+    source: &RegisteredSource,
+    table: &RegisteredTable,
+    position: usize,
+    column: &RegisteredColumn,
+    column_statistics: Option<&ColumnStatistics>,
+) -> CatalogColumn {
+    CatalogColumn {
+        schema_name: source.schema_name.clone(),
+        table_name: table.table_name.clone(),
+        column_name: column.name.clone(),
+        data_type: column.data_type.clone(),
+        is_nullable: column.nullable,
+        is_virtual: column.is_virtual,
+        is_required_filter: column.is_required_filter,
+        filter_mode: column.filter_mode.clone(),
+        description: column.description.clone(),
+        ordinal_position: position,
+        null_fraction: column_statistics.and_then(ColumnStatistics::null_fraction),
+        approx_distinct_count: column_statistics
+            .and_then(ColumnStatistics::approx_distinct_count_i64),
+        stats_sample_count: column_statistics.and_then(ColumnStatistics::sample_count_i64),
+        stats_observed_at: column_statistics.and_then(|stats| stats.observed_at.clone()),
+        stats_precision: column_statistics.and_then(ColumnStatistics::precision_for_catalog),
+    }
+}
+
+fn columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<RecordBatch> {
     RecordBatch::try_new(
         schema,
         vec![
@@ -953,24 +1044,354 @@ fn catalog_columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<
                     .collect::<StringArray>(),
             ),
             utf8_column(rows.iter().map(|row| row.filter_mode.as_deref())),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.null_fraction)
+                    .collect::<Float64Array>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.approx_distinct_count)
+                    .collect::<Int64Array>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.stats_sample_count)
+                    .collect::<Int64Array>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.stats_observed_at.as_deref())
+                    .collect::<StringArray>(),
+            ),
+            Arc::new(
+                rows.iter()
+                    .map(|row| row.stats_precision)
+                    .collect::<StringArray>(),
+            ),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))
 }
 
+pub(crate) fn table_schema_signature(table: &RegisteredTable) -> TableSchemaSignature {
+    TableSchemaSignature {
+        columns: table.columns.iter().map(column_schema_signature).collect(),
+        required_filters: table.required_filters.clone(),
+    }
+}
+
+fn column_schema_signature(column: &RegisteredColumn) -> crate::contracts::ColumnSchemaSignature {
+    crate::contracts::ColumnSchemaSignature {
+        name: column.name.clone(),
+        data_type: column.data_type.clone(),
+        nullable: column.nullable,
+        is_virtual: column.is_virtual,
+        is_required_filter: column.is_required_filter,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::sync::Arc;
 
     use crate::backends::common::test_support::StubSourceFunctionFactory;
-    use crate::backends::{RegisteredSource, RegisteredTableFunction};
 
-    use super::collect_table_functions;
+    use datafusion::arrow::array::{Array, Float64Array, Int64Array, StringArray};
+    use datafusion::datasource::TableProvider;
+
+    use super::{build_columns_table, collect_table_functions, table_schema_signature};
+    use crate::backends::common::RegisteredColumn;
+    use crate::backends::{RegisteredSource, RegisteredTable, RegisteredTableFunction};
+    use crate::contracts::{
+        ColumnStatistics, SourceStatistics, StatisticPrecision, StatisticValue, StatisticsProfile,
+        TableStatistics,
+    };
+
+    fn source() -> RegisteredSource {
+        RegisteredSource {
+            schema_name: "local".to_string(),
+            source_version: "0.2.0".to_string(),
+            tables: vec![RegisteredTable {
+                table_name: "events".to_string(),
+                description: "Events".to_string(),
+                guide: String::new(),
+                required_filters: Vec::new(),
+                columns: vec![
+                    RegisteredColumn {
+                        name: "id".to_string(),
+                        data_type: "Int64".to_string(),
+                        nullable: false,
+                        is_virtual: false,
+                        is_required_filter: false,
+                        filter_mode: None,
+                        description: String::new(),
+                    },
+                    RegisteredColumn {
+                        name: "category".to_string(),
+                        data_type: "Utf8".to_string(),
+                        nullable: true,
+                        is_virtual: false,
+                        is_required_filter: false,
+                        filter_mode: None,
+                        description: String::new(),
+                    },
+                ],
+                filters: Vec::new(),
+                search_limits: None,
+            }],
+            table_functions: Vec::new(),
+            inputs: Vec::new(),
+        }
+    }
+
+    fn profile_for(source: &RegisteredSource) -> StatisticsProfile {
+        let table = source.tables.first().expect("source has one table");
+        let mut columns = BTreeMap::new();
+        columns.insert(
+            "category".to_string(),
+            ColumnStatistics {
+                column_name: "category".to_string(),
+                sample_count: 5,
+                null_count: Some(StatisticValue {
+                    value: 2,
+                    precision: StatisticPrecision::ObservedSample,
+                }),
+                approx_distinct_count: Some(StatisticValue {
+                    value: 3,
+                    precision: StatisticPrecision::ObservedSample,
+                }),
+                observed_at: Some("2026-05-06T00:00:00Z".to_string()),
+            },
+        );
+
+        let mut tables = BTreeMap::new();
+        tables.insert(
+            table.table_name.clone(),
+            TableStatistics {
+                schema_name: source.schema_name.clone(),
+                table_name: table.table_name.clone(),
+                source_version: Some(source.source_version.clone()),
+                schema_signature: table_schema_signature(table),
+                columns,
+            },
+        );
+
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            source.schema_name.clone(),
+            SourceStatistics {
+                schema_name: source.schema_name.clone(),
+                source_version: Some(source.source_version.clone()),
+                tables,
+            },
+        );
+
+        StatisticsProfile {
+            version: 1,
+            sources,
+        }
+    }
+
+    #[test]
+    fn columns_table_appends_nullable_statistics_fields() {
+        let source = source();
+        let table = build_columns_table(std::slice::from_ref(&source), &StatisticsProfile::empty())
+            .expect("columns table should build");
+        let schema = table.schema();
+        let names = schema
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            names.get(..10).expect("base column fields"),
+            &[
+                "schema_name",
+                "table_name",
+                "ordinal_position",
+                "column_name",
+                "data_type",
+                "is_nullable",
+                "is_virtual",
+                "is_required_filter",
+                "description",
+                "filter_mode",
+            ]
+        );
+        assert_eq!(
+            names.get(10..).expect("statistics column fields"),
+            &[
+                "null_fraction",
+                "approx_distinct_count",
+                "stats_sample_count",
+                "stats_observed_at",
+                "stats_precision",
+            ]
+        );
+        assert!(
+            schema
+                .field_with_name("null_fraction")
+                .unwrap()
+                .is_nullable()
+        );
+        assert!(
+            schema
+                .field_with_name("approx_distinct_count")
+                .unwrap()
+                .is_nullable()
+        );
+        assert!(
+            schema
+                .field_with_name("stats_sample_count")
+                .unwrap()
+                .is_nullable()
+        );
+        assert!(
+            schema
+                .field_with_name("stats_observed_at")
+                .unwrap()
+                .is_nullable()
+        );
+        assert!(
+            schema
+                .field_with_name("stats_precision")
+                .unwrap()
+                .is_nullable()
+        );
+    }
+
+    #[test]
+    fn empty_profile_projects_null_statistics() {
+        let source = source();
+        let table = build_columns_table(std::slice::from_ref(&source), &StatisticsProfile::empty())
+            .expect("columns table should build");
+        let batch = first_batch(&table);
+
+        for index in [10, 11, 12, 13, 14] {
+            let column = batch.column(index);
+            assert_eq!(column.null_count(), batch.num_rows());
+        }
+    }
+
+    #[test]
+    fn matching_profile_projects_statistics() {
+        let source = source();
+        let profile = profile_for(&source);
+        let table = build_columns_table(std::slice::from_ref(&source), &profile)
+            .expect("columns table should build");
+        let batch = first_batch(&table);
+
+        let null_fraction = batch
+            .column(10)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        let distinct = batch
+            .column(11)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let sample = batch
+            .column(12)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        let id_row = catalog_row_index(&batch, "local", "events", "id");
+        let category_row = catalog_row_index(&batch, "local", "events", "category");
+
+        assert!(null_fraction.is_null(id_row));
+        assert!((null_fraction.value(category_row) - 0.4).abs() < f64::EPSILON);
+        assert_eq!(distinct.value(category_row), 3);
+        assert_eq!(sample.value(category_row), 5);
+    }
+
+    #[test]
+    fn mismatched_schema_signature_projects_null_statistics() {
+        let source = source();
+        let mut profile = profile_for(&source);
+        let source_stats = profile.sources.get_mut("local").unwrap();
+        let table_stats = source_stats.tables.get_mut("events").unwrap();
+        table_stats
+            .schema_signature
+            .required_filters
+            .push("status".to_string());
+
+        let table = build_columns_table(std::slice::from_ref(&source), &profile)
+            .expect("columns table should build");
+        let batch = first_batch(&table);
+
+        for index in [10, 11, 12, 13, 14] {
+            let column = batch.column(index);
+            assert_eq!(column.null_count(), batch.num_rows());
+        }
+    }
+
+    #[test]
+    fn mismatched_source_version_projects_null_statistics() {
+        let source = source();
+        let mut profile = profile_for(&source);
+        let source_stats = profile.sources.get_mut("local").unwrap();
+        source_stats.source_version = Some("0.1.0".to_string());
+        let table_stats = source_stats.tables.get_mut("events").unwrap();
+        table_stats.source_version = Some("0.1.0".to_string());
+
+        let table = build_columns_table(std::slice::from_ref(&source), &profile)
+            .expect("columns table should build");
+        let batch = first_batch(&table);
+
+        for index in [10, 11, 12, 13, 14] {
+            let column = batch.column(index);
+            assert_eq!(column.null_count(), batch.num_rows());
+        }
+    }
+
+    fn first_batch(
+        table: &datafusion::datasource::MemTable,
+    ) -> datafusion::arrow::array::RecordBatch {
+        let partition = table.batches.first().expect("one partition");
+        let batches = futures::executor::block_on(partition.read());
+        batches.first().expect("one batch").clone()
+    }
+
+    fn catalog_row_index(
+        batch: &datafusion::arrow::array::RecordBatch,
+        schema_name: &str,
+        table_name: &str,
+        column_name: &str,
+    ) -> usize {
+        let schemas = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("schema_name column");
+        let tables = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("table_name column");
+        let columns = batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("column_name column");
+
+        (0..batch.num_rows())
+            .find(|row| {
+                schemas.value(*row) == schema_name
+                    && tables.value(*row) == table_name
+                    && columns.value(*row) == column_name
+            })
+            .expect("catalog row should exist")
+    }
 
     #[test]
     fn collect_table_functions_preserves_registered_function_schema() {
         let functions = collect_table_functions(&[RegisteredSource {
             schema_name: "source_schema".to_string(),
+            source_version: "0.2.0".to_string(),
             tables: Vec::new(),
             table_functions: vec![RegisteredTableFunction {
                 schema_name: "function_schema".to_string(),

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -40,7 +40,7 @@ use crate::{
     QueryExecutionProvenance, QueryMemoryConfig, QueryParameterValue, QueryParameters, QueryPlan,
     QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig, QueryRuntimeContext,
     QuerySource, QueryTableFunctionUsage, QueryTableUsage, RequestAuthenticator, SourceDecorator,
-    SourceInputResolver, TableFunctionInfo, TableInfo,
+    SourceInputResolver, StatisticsProfile, TableFunctionInfo, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -65,6 +65,7 @@ struct FallbackRuntimeConfig {
     runtime_context: QueryRuntimeContext,
     dependent_join: DependentJoinConfig,
     memory: QueryMemoryConfig,
+    statistics: StatisticsProfile,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
 }
@@ -99,6 +100,7 @@ async fn build_runtime_inner(
         memory,
         dependent_join,
         mut extensions,
+        statistics,
     } = runtime;
     let request_authenticators = extensions.request_authenticators.clone();
     let source_input_resolver = extensions.source_input_resolver.clone();
@@ -115,6 +117,7 @@ async fn build_runtime_inner(
             runtime_context: runtime_context.clone(),
             dependent_join: dependent_join.clone(),
             memory: memory.clone(),
+            statistics: statistics.clone(),
             request_authenticators: request_authenticators.clone(),
             source_input_resolver: source_input_resolver.clone(),
         })
@@ -128,6 +131,7 @@ async fn build_runtime_inner(
         extensions.source_decorators.as_mut_slice(),
         &dependent_join,
         &memory,
+        &statistics,
     )
     .await?;
 
@@ -151,6 +155,7 @@ async fn build_registered_runtime(
     source_decorators: &mut [Box<dyn SourceDecorator>],
     dependent_join: &DependentJoinConfig,
     memory: &QueryMemoryConfig,
+    statistics: &StatisticsProfile,
 ) -> Result<RegisteredRuntime, CoreError> {
     let ctx = build_session_context(dependent_join, memory)?;
     let registration = register_runtime_sources(
@@ -162,7 +167,7 @@ async fn build_registered_runtime(
         source_decorators,
     )
     .await?;
-    catalog::register(&ctx, &registration.active_sources)
+    catalog::register(&ctx, &registration.active_sources, statistics)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_tables(&registration.active_sources);
     let table_functions = catalog::collect_table_functions(&registration.active_sources);
@@ -784,6 +789,7 @@ impl FallbackRuntimeConfig {
             source_decorators.as_mut_slice(),
             &self.dependent_join.without_rewrites(),
             &self.memory,
+            &self.statistics,
         )
         .await
     }
@@ -949,6 +955,7 @@ mod tests {
             memory: QueryMemoryConfig {
                 limit: Some(MemorySize::from_str("1Ki").unwrap()),
             },
+            statistics: StatisticsProfile::empty(),
             request_authenticators: HashMap::new(),
             source_input_resolver: None,
         };

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -648,6 +648,7 @@ async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinal
             .schema()
             .iter()
             .map(|column| column.name.as_str())
+            .take(10)
             .collect::<Vec<_>>(),
         vec![
             "schema_name",
@@ -660,6 +661,21 @@ async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinal
             "is_required_filter",
             "description",
             "filter_mode",
+        ]
+    );
+    assert_eq!(
+        columns
+            .schema()
+            .iter()
+            .map(|column| column.name.as_str())
+            .skip(10)
+            .collect::<Vec<_>>(),
+        vec![
+            "null_fraction",
+            "approx_distinct_count",
+            "stats_sample_count",
+            "stats_observed_at",
+            "stats_precision",
         ]
     );
 }

--- a/plans/source-470-column-statistics.md
+++ b/plans/source-470-column-statistics.md
@@ -1,0 +1,1332 @@
+# SOURCE-470: Column-Level Statistics Implementation Plan
+
+## Goal
+
+Add column-level statistics to `coral.columns` while keeping `coral.columns` a
+projection over a real statistics model, not the storage model.
+
+The implementation must answer the immediate SOURCE-470 need:
+
+- expose nullable statistics fields in `coral.columns`
+- collect conservative runtime observations for current backend families
+- report observations once through the existing telemetry/trace-history pipeline
+- materialize `profile.json` as a rebuildable workspace cache derived from
+  local trace history
+- reload the materialized profile into later runtime builds
+
+It must not pull in the full old Portable Statistics / Visible Learning system.
+This ticket should leave clean seams for later `coral.statistics`, `ANALYZE`,
+import/export/reset, planner estimates, learning logs, and cost guards.
+
+Confidence: high for the engine/app architecture and Graphite PR split.
+Confidence: moderate for exact Parquet footer-stat extraction until the
+DataFusion/parquet APIs are exercised in code. If exact Parquet footer metadata
+is awkward or unstable, land observed Parquet scan statistics first and keep
+metadata-derived exactness as a follow-up, not a blocker for honest nullable
+stats.
+
+## Non-Goals
+
+Do not implement these in SOURCE-470:
+
+- `ANALYZE`
+- connect-time probing of every table
+- `coral.statistics`
+- `coral.learning_log`
+- CLI/API export, import, reset, or inspect commands for the stats cache
+- planner/cost/budget integration
+- raw sample value persistence
+- filter-scoped statistics in the public catalog
+- hidden API fan-out during runtime registration
+
+## Current Repo Reality
+
+The current migrated repo shape matters more than the old ADP shape.
+
+- `crates/coral-engine/src/runtime/catalog.rs` builds fixed in-memory
+  `coral.tables`, `coral.columns`, and `coral.inputs` tables.
+- `coral.columns` currently has:
+  `schema_name`, `table_name`, `ordinal_position`, `column_name`, `data_type`,
+  `is_nullable`, `is_virtual`, `is_required_filter`, and `description`.
+- `crates/coral-engine/src/contracts/query.rs` owns
+  `QueryRuntimeConfig`, `QueryRuntimeContext`, `QuerySource`, and
+  `QueryExecution`.
+- `crates/coral-engine/src/runtime/query.rs` builds the DataFusion
+  `SessionContext`, registers sources, registers the catalog, executes SQL, and
+  collects final `RecordBatch` results.
+- `crates/coral-engine/src/backends/common.rs` owns registry-visible
+  `RegisteredSource`, `RegisteredTable`, and `RegisteredColumn` metadata.
+- `crates/coral-engine/src/backends/shared/json_exec.rs` is the shared
+  execution node used by JSON-producing backends after rows are fetched and
+  converted into Arrow batches.
+- `crates/coral-engine/src/backends/jsonl/mod.rs` uses `JsonExec` over local
+  JSONL files. It reads matching files on scan, not at registration.
+- `crates/coral-engine/src/backends/http/provider.rs` uses `JsonExec` over
+  HTTP fetches. It knows pushed filters and pushed limits at scan time.
+- `crates/coral-engine/src/backends/parquet/mod.rs` wraps DataFusion
+  `ListingTable` and can wrap its returned scan plan.
+- `crates/coral-app/src/query/manager.rs` is the app orchestration point that
+  loads installed sources, builds `QueryRuntimeConfig`, calls `CoralQuery`, and
+  should refresh the materialized stats cache only after successful execution.
+- `crates/coral-app/src/telemetry/local_store.rs` owns local trace history as
+  rolling JSONL span records with retention and pruning. SOURCE-470 should use
+  this as the durable observation log instead of adding a parallel observation
+  log.
+- `crates/coral-app/src/state/layout.rs` owns workspace paths under
+  `CORAL_CONFIG_DIR`.
+- `crates/coral-app/src/storage/fs.rs` already has private directory creation,
+  file locking, and atomic write helpers.
+- The repo instruction remains: run `make rust-checks` before finishing Rust
+  code changes.
+
+## User-Visible Contract
+
+Append these nullable fields to `coral.columns`:
+
+```sql
+null_fraction DOUBLE NULL,
+approx_distinct_count BIGINT NULL,
+stats_sample_count BIGINT NULL,
+stats_observed_at TEXT NULL,
+stats_precision TEXT NULL
+```
+
+Rules:
+
+- Existing `coral.columns` columns keep their current names, types, order, and
+  meaning.
+- New fields are additive and appear after `description`.
+- All new fields are nullable.
+- Sources and columns without stats show `NULL`, never fabricated values.
+- `approx_distinct_count` is the name. Do not expose `distinct_count`.
+- `stats_precision` uses exactly these stable strings:
+  - `exact`
+  - `approximate`
+  - `observed_sample`
+  - `unknown`
+- `stats_observed_at` is an RFC3339 UTC timestamp string.
+- `stats_sample_count` is the row count used for the displayed per-column
+  statistic. Use SQL `BIGINT` / Arrow `Int64`, saturating only if a `u64`
+  internal value exceeds `i64::MAX`.
+- `null_fraction` is derived as `null_count / sample_count`. It is `NULL` when
+  the internal profile does not know both values or when `sample_count == 0`.
+- `approx_distinct_count` is `NULL` for unsupported types or unsafe scopes.
+- Do not expose or persist `sample_values`.
+
+## Architecture Decisions
+
+1. Keep the real model in `coral-engine` contracts.
+
+   Add transport-neutral statistics types under
+   `crates/coral-engine/src/contracts/statistics.rs` and re-export them through
+   `contracts/mod.rs` and `lib.rs` as needed by `coral-app`.
+
+2. Make `coral.columns` a pure projection.
+
+   `runtime/catalog.rs` receives a `StatisticsProfile` and projects matching
+   profile entries into the new nullable fields while building the existing
+   `MemTable`.
+
+3. Load the materialized stats cache before runtime registration.
+
+   `coral-app` loads a workspace profile, filters it to the selected sources,
+   and passes it through `QueryRuntimeConfig`. `coral-engine` must not read app
+   state or environment variables directly.
+
+4. Report observations from scan nodes through telemetry, not final results.
+
+   Final query results may be aggregated, filtered, joined, or projected in a
+   way that no longer maps cleanly to source-table columns. Observations should
+   be produced at backend scan boundaries where source, table, pushed filters,
+   projection, and limit are known. They should be serialized as structured
+   telemetry events on the active query/scan trace, making local trace history
+   the durable record.
+
+5. Rebuild the cache only after successful query execution.
+
+   `QueryManager::execute_sql` should refresh `profile.json` from local trace
+   history only if `CoralQuery::execute_sql` returns `Ok(QueryExecution)`. If
+   DataFusion starts scanning and later fails, the failed query trace can still
+   exist for diagnostics, but its observations must not update the current
+   catalog cache.
+
+6. Scope controls cache eligibility.
+
+   Only table-global observations may update table-global cached stats.
+   Filtered, required-filter, limited, or unknown-scope observations can be
+   carried in trace history for future use but must not update `coral.columns`
+   in this ticket.
+
+7. Prefer absent stats over misleading stats.
+
+   `NULL` is a correct answer when the system cannot defend a statistic.
+   Misleading precision is worse than no precision.
+
+## Statistics Model
+
+Use this shape as the implementation target. Adjust field names for Rust
+ergonomics, but keep the semantics.
+
+```rust
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StatisticsProfile {
+    pub version: u32,
+    pub sources: BTreeMap<String, SourceStatistics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceStatistics {
+    pub schema_name: String,
+    pub source_version: Option<String>,
+    pub tables: BTreeMap<String, TableStatistics>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TableStatistics {
+    pub schema_name: String,
+    pub table_name: String,
+    pub source_version: Option<String>,
+    pub schema_signature: TableSchemaSignature,
+    pub columns: BTreeMap<String, ColumnStatistics>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TableSchemaSignature {
+    pub columns: Vec<ColumnSchemaSignature>,
+    pub required_filters: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ColumnSchemaSignature {
+    pub name: String,
+    pub data_type: String,
+    pub nullable: bool,
+    pub is_virtual: bool,
+    pub is_required_filter: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnStatistics {
+    pub column_name: String,
+    pub sample_count: u64,
+    pub null_count: Option<StatisticValue<u64>>,
+    pub approx_distinct_count: Option<StatisticValue<u64>>,
+    pub observed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatisticValue<T> {
+    pub value: T,
+    pub precision: StatisticPrecision,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatisticPrecision {
+    Exact,
+    Approximate,
+    ObservedSample,
+    Unknown,
+}
+```
+
+Important details:
+
+- Store counts, not only fractions. `null_fraction` is a projection.
+- Store a table schema signature so stale stats are ignored when source column
+  metadata changes.
+- `source_version` is useful but not sufficient by itself because custom
+  manifests may change without version discipline.
+- Do not add a hash dependency only to identify schemas unless there is a
+  strong reason. A structured signature is simple, reviewable, and avoids
+  pretending to solve data freshness.
+- File contents and API data can change without schema changes. That is not a
+  correctness bug as long as `stats_observed_at` and `stats_precision` are
+  honest.
+
+### Observations
+
+Add a separate runtime observation type. Persisted profiles and telemetry
+observations should not be the same object.
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatisticsObservation {
+    pub schema_name: String,
+    pub table_name: String,
+    pub source_version: Option<String>,
+    pub schema_signature: TableSchemaSignature,
+    pub scope: StatisticsObservationScope,
+    pub observed_at: String,
+    pub columns: Vec<ColumnStatisticsObservation>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StatisticsObservationScope {
+    TableGlobal,
+    Filtered { filter_columns: Vec<String> },
+    Limited,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnStatisticsObservation {
+    pub column_name: String,
+    pub sample_count: u64,
+    pub null_count: Option<StatisticValue<u64>>,
+    pub approx_distinct_count: Option<StatisticValue<u64>>,
+}
+```
+
+Materialization policy:
+
+- `TableGlobal` observations from successful query traces may update cached
+  table stats.
+- `Filtered`, `Limited`, and `Unknown` observations must remain in trace
+  history only for now.
+- The cache is a current table snapshot. For the same source/table, the latest
+  eligible observation replaces the previous cached table entry rather than
+  accumulating raw observations.
+- `null_fraction` projects from the stored `null_count` and `sample_count`.
+- `observed_at` is the observation timestamp from the telemetry event.
+- If schema signatures differ, the catalog projection ignores the stale cached
+  table stats.
+
+## Engine Implementation
+
+### 1. Contracts
+
+Files:
+
+- `crates/coral-engine/Cargo.toml`
+- `crates/coral-engine/src/contracts/statistics.rs`
+- `crates/coral-engine/src/contracts/mod.rs`
+- `crates/coral-engine/src/contracts/query.rs`
+- `crates/coral-engine/src/lib.rs`
+
+Tasks:
+
+- Add `serde.workspace = true` to `crates/coral-engine/Cargo.toml` for the
+  persisted profile contract types.
+- Add statistics profile, observation, signature, precision, and merge helper
+  types.
+- Add `StatisticsProfile::empty()` or `Default`.
+- Add `StatisticPrecision::as_str()` for catalog projection.
+- Add `StatisticPrecision::weaker(self, other)`.
+- Add helpers to compute projected catalog values:
+  - `null_fraction() -> Option<f64>`
+  - `sample_count_i64() -> Option<i64>`
+  - `precision_for_catalog() -> Option<&'static str>`
+- Extend `QueryRuntimeConfig` with:
+
+  ```rust
+  pub statistics: StatisticsProfile,
+  ```
+
+  Keep default config behavior as "empty stats".
+
+- Do not extend `QueryExecution` with observations. Observations are reported
+  through telemetry, and app materialization consumes local trace history.
+
+### 2. Catalog Projection
+
+File:
+
+- `crates/coral-engine/src/runtime/catalog.rs`
+
+Tasks:
+
+- Change `register` signature to accept a stats profile:
+
+  ```rust
+  pub(crate) fn register(
+      ctx: &SessionContext,
+      active_sources: &[RegisteredSource],
+      statistics: &StatisticsProfile,
+  ) -> Result<()>
+  ```
+
+- Change `build_columns_table` to accept the profile.
+- Add new Arrow fields after `description`:
+  - `Field::new("null_fraction", DataType::Float64, true)`
+  - `Field::new("approx_distinct_count", DataType::Int64, true)`
+  - `Field::new("stats_sample_count", DataType::Int64, true)`
+  - `Field::new("stats_observed_at", DataType::Utf8, true)`
+  - `Field::new("stats_precision", DataType::Utf8, true)`
+- Extend `CatalogColumn` with optional projected stats fields.
+- Use `Float64Array`, `Int64Array`, and nullable `StringArray` builders.
+- Match stats by `(schema_name, table_name, column_name)` and require the
+  stored table schema signature to match the current `RegisteredTable`.
+- Add unit tests:
+  - `coral.columns` has the new columns.
+  - empty profile yields all new fields as `NULL`.
+  - matching profile projects expected values.
+  - mismatched schema signature yields `NULL`, not stale stats.
+  - existing columns and ordering before `description` are unchanged.
+
+### 3. Runtime Telemetry Reporting
+
+Files:
+
+- `crates/coral-engine/src/runtime/query.rs`
+- `crates/coral-engine/src/runtime/statistics.rs` or
+  `crates/coral-engine/src/contracts/statistics.rs` if small enough
+- `crates/coral-engine/src/backends/shared/json_exec.rs`
+- `crates/coral-engine/src/backends/file/mod.rs`
+
+Tasks:
+
+- Do not add `StatisticsObservationSink` or `RuntimeStatisticsContext`.
+- Keep backend registration free of app-owned telemetry/storage context. Scan
+  providers build `BatchStatisticsPlan` from their existing source/table
+  metadata and report observations directly.
+- Add one reporting helper that serializes `StatisticsObservation` as JSON and
+  emits a structured telemetry event on the current span:
+
+  ```text
+  event name: coral.statistics.observation
+  attribute: coral.statistics.observation = <serialized observation JSON>
+  ```
+
+- If serialization/reporting fails, warn and keep the query path working.
+- Add a shared Arrow batch collector:
+  - input: schema/table identity, schema signature, scope, projected fields,
+    and one or more `RecordBatch` values
+  - output: `StatisticsObservation`
+  - null counts: use `Array::null_count()` and `RecordBatch::num_rows()`
+  - distinct counts: support manifest scalar types first (`Utf8`, `Int64`,
+    `Boolean`, `Timestamp`). For manifest `Utf8`, handle Arrow `Utf8`,
+    `LargeUtf8`, `Utf8View`, and dictionary-backed string arrays because local
+    Parquet scans can surface string columns as `Utf8View`.
+  - return `NULL` for unsupported nested, JSON, `Float64`, or awkward types.
+  - distinct implementation uses in-memory sets only for the current batch or
+    current scan observation; never persist sets or raw values.
+  - `Float64` distinct remains `NULL` until NaN and signed-zero behavior is
+    specified deliberately.
+
+### 4. JSONL Collection
+
+Files:
+
+- `crates/coral-engine/src/backends/jsonl/mod.rs`
+- `crates/coral-engine/src/backends/shared/json_exec.rs`
+
+Behavior:
+
+- JSONL does not scan during registration.
+- JSONL observes rows only when a query scans a table.
+- Since current JSONL filters are not pushed down to file reading, the scan
+  sees the file-backed table rows. Treat observations as `TableGlobal` only
+  when:
+  - `limit` is absent, and
+  - no required filter columns are projected as real cached stats, and
+  - the observed column is not virtual / filter-only.
+- Virtual or required-filter columns should get no cached stats in this
+  ticket unless their value truly comes from stored data.
+- Precision is `observed_sample` even if the scan happens to read all current
+  files. The data can change and there is no snapshot identity.
+- Add engine tests that run `SELECT` over local JSONL fixtures under a test
+  trace subscriber and assert the telemetry event contains expected null and
+  distinct counts.
+
+### 5. HTTP/API Collection
+
+Files:
+
+- `crates/coral-engine/src/backends/http/provider.rs`
+- `crates/coral-engine/src/backends/shared/json_exec.rs`
+
+Behavior:
+
+- Do not probe HTTP tables during runtime registration.
+- Observe only rows returned by successful query execution.
+- Scope is:
+  - `Filtered` when any pushed filter is present
+  - `Limited` when the scan limit is present
+  - `TableGlobal` only when there are no pushed filters and no pushed limit
+  - `Unknown` if the provider cannot determine scope
+- App materialization only includes `TableGlobal`.
+- Precision is `observed_sample`, not `exact`.
+- Required-filter tables will often show `NULL` stats in `coral.columns`. That
+  is correct.
+- Add engine tests with `wiremock`:
+  - unfiltered query reports a `TableGlobal` observation event
+  - filtered query reports a `Filtered` observation event
+  - limited query reports a `Limited` observation event
+  - only table-global observations are cache-eligible in app tests
+
+### 6. Parquet Collection
+
+Files:
+
+- `crates/coral-engine/src/backends/file/mod.rs`
+- `crates/coral-engine/src/runtime/statistics.rs`
+
+Implementation path:
+
+1. Wrap the `ExecutionPlan` returned by `ListingTable::scan` in an
+   `ObservingExec`.
+2. `ObservingExec` delegates children/properties/schema to the inner plan and
+   wraps the returned stream so each successful batch is forwarded unchanged
+   while being accumulated for stats.
+3. Report one telemetry observation when all output partitions complete
+   successfully.
+4. Scope is:
+   - `Filtered` when pushed filters are present
+   - `Limited` when `limit` is present
+   - `TableGlobal` only when no filters and no limit are present
+5. Precision for scan-observed Parquet stats is `observed_sample`.
+
+Exact metadata path:
+
+- Attempt to collect exact `row_count` and `null_count` from Parquet footer row
+  group metadata when all required metadata is available without forcing a full
+  scan.
+- Mark metadata-derived `null_fraction` as `exact` only when every file and row
+  group needed for the table has row count and null count for the column.
+- Leave `approx_distinct_count` `NULL` unless the metadata genuinely provides a
+  defensible distinct estimate.
+- Do not block SOURCE-470 on exact footer metadata if DataFusion's listing
+  abstractions make this unstable. The honest fallback is observed scan stats
+  with `observed_sample`.
+
+Tests:
+
+- Local Parquet fixture with known nulls yields observed stats after an
+  unfiltered scan.
+- Filtered or limited Parquet scans do not materialize as table-global cached
+  stats.
+- If exact footer stats land, add a test proving all-row-group metadata is
+  required before precision is `exact`.
+
+## App Materialization
+
+Files:
+
+- `crates/coral-app/src/state/layout.rs`
+- `crates/coral-app/src/state/statistics.rs`
+- `crates/coral-app/src/state/mod.rs`
+- `crates/coral-app/src/query/manager.rs`
+- `crates/coral-app/src/telemetry/local_store.rs`
+- `crates/coral-app/src/telemetry/mod.rs`
+- `crates/coral-app/src/bootstrap/server.rs`
+
+### Layout
+
+Add workspace-scoped cache paths:
+
+```rust
+pub(crate) fn statistics_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+    self.workspace_dir(workspace_name).join("statistics")
+}
+
+pub(crate) fn statistics_profile_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
+    self.statistics_dir(workspace_name).join("profile.json")
+}
+```
+
+### Store
+
+Add `StatisticsStore`:
+
+```rust
+#[derive(Debug, Clone)]
+pub(crate) struct StatisticsStore {
+    layout: AppStateLayout,
+}
+```
+
+Responsibilities:
+
+- load missing profile as empty
+- parse JSON profile with versioning
+- save with `storage::fs::write_atomic`
+- use the existing state lock for load/save/update
+- rebuild `profile.json` from telemetry observations read from local trace
+  history
+- include only table-global observations in this ticket
+- filter the rebuilt cache to sources currently selected in the workspace
+- never persist raw values
+
+Storage format:
+
+```text
+$CORAL_CONFIG_DIR/workspaces/<workspace>/statistics/profile.json
+```
+
+This file is a derived cache, not the durable observation log and not a public
+API. Still include a `version` field so cache migrations are possible later.
+
+### Telemetry Reader
+
+Extend the local trace store with a stats-observation reader:
+
+- scan local trace JSONL files under the configured trace-history directory
+- parse each span's `events_json`
+- find `coral.statistics.observation` events
+- deserialize the JSON payload into `StatisticsObservation`
+- preserve chronological file/line order so later eligible observations replace
+  earlier cache entries deterministically
+- tolerate malformed observation payloads by warning and skipping that event;
+  malformed trace JSONL rows should continue to use the existing trace-store
+  error behavior
+
+Expose a narrow `telemetry` module helper for the query manager:
+
+```rust
+pub(crate) async fn load_statistics_observations(
+    store: &InstalledLocalTraceStore,
+) -> Result<Vec<StatisticsObservation>, AppError>
+```
+
+Add a `force_flush_tracing()` helper so successful queries can flush the local
+span exporter before rebuilding the cache.
+
+### Query Manager
+
+Update `QueryManager`:
+
+- add a `statistics_store: StatisticsStore` field
+- add an optional installed local trace store field
+- construct it in `new(...)`
+- in `runtime_config`, load the workspace profile and include it in
+  `QueryRuntimeConfig`
+- after successful `execute_sql`, force-flush tracing, read statistics
+  observations from local trace history, and rebuild the workspace profile cache
+- do not merge on query failure
+- do not refresh stats from `validate_source` / `coral source test` in this
+  ticket; keep cache refresh tied to user query execution
+- if trace history is disabled or unavailable, stats stay `NULL`; do not fall
+  back to a parallel storage path
+- make warnings non-fatal: stats cache load/rebuild/save problems should warn
+  and keep the query result path working unless the failure indicates broader
+  state corruption already treated as fatal elsewhere
+
+Change the manager helper so callers load stats explicitly:
+
+```rust
+fn runtime_config(
+    &self,
+    selected_sources: &[QuerySource],
+    statistics: StatisticsProfile,
+) -> QueryRuntimeConfig
+```
+
+`list_tables` and `execute_sql` should load the workspace profile before
+calling `runtime_config`. `validate_source` can load the profile or pass an
+empty profile, but it must not refresh the stats cache. That keeps environment
+and filesystem access in app orchestration, not in the config helper.
+
+### App Tests
+
+Add tests proving:
+
+- missing profile loads as empty
+- profile save/load round-trips
+- rebuild is atomic and uses the state lock
+- matching `TableGlobal` observations update profile cache
+- filtered/limited/unknown observations are ignored
+- schema signature mismatch drops old stats
+- local trace-store reader extracts stats observation events
+- `QueryManager::execute_sql` refreshes the cache after success when local
+  trace history is installed
+- failed queries do not refresh the stats cache
+- later runtime builds project cached stats through `coral.columns`
+
+## Docs And MCP
+
+Files:
+
+- `crates/coral-mcp/src/guide_template.md`
+- `crates/coral-mcp/src/surface/resources.rs`
+- `docs/guides/use-coral-over-mcp.mdx`
+- `docs/reference/source-spec-reference.mdx` if source-author guidance needs a
+  short note
+
+Guidance:
+
+- Keep MCP prose small. This is not a broad discovery workflow rewrite.
+- Update column-inspection examples to mention the optional stats fields only
+  where useful.
+- Make clear that stats are nullable and may be sample-derived.
+- Do not imply every API table has stats.
+- Do not direct agents to treat `approx_distinct_count` as exact.
+
+Example SQL to use in docs/resources:
+
+```sql
+SELECT
+  column_name,
+  data_type,
+  is_nullable,
+  null_fraction,
+  approx_distinct_count,
+  stats_sample_count,
+  stats_precision,
+  description
+FROM coral.columns
+WHERE schema_name = '<schema>' AND table_name = '<table>'
+ORDER BY ordinal_position;
+```
+
+## Logical PR Split
+
+Use a Graphite stack. Do not put this entire feature in one PR.
+
+### PR 1: `feat(engine): add statistics profile to catalog`
+
+Branch:
+
+```text
+source-470-stats-catalog
+```
+
+Scope:
+
+- statistics contracts
+- `QueryRuntimeConfig.statistics`
+- `coral.columns` projection fields
+- serializable observation contract for trace-event payloads
+- catalog tests with empty and synthetic profiles
+- no backend collection
+- no app materialization
+
+Primary files:
+
+- `crates/coral-engine/Cargo.toml`
+- `crates/coral-engine/src/contracts/statistics.rs`
+- `crates/coral-engine/src/contracts/mod.rs`
+- `crates/coral-engine/src/contracts/query.rs`
+- `crates/coral-engine/src/runtime/catalog.rs`
+- `crates/coral-engine/src/runtime/query.rs`
+- `crates/coral-engine/src/lib.rs`
+
+Validation:
+
+```shell
+cargo fmt --all -- --check
+cargo test -p coral-engine runtime::catalog --locked
+cargo test -p coral-engine contracts::statistics --locked
+```
+
+Acceptance:
+
+- `SELECT * FROM coral.columns` still works with no stats profile.
+- New fields exist and are nullable.
+- Synthetic matching stats project correctly.
+- Synthetic stale stats do not project.
+
+### PR 2: `feat(engine): report column statistics observations`
+
+Branch:
+
+```text
+source-470-stats-observations
+```
+
+Scope:
+
+- shared Arrow batch stats collector
+- telemetry observation reporter
+- `JsonExec` instrumentation
+- JSONL observed stats
+- HTTP observed stats
+- merge-eligibility scope classification in engine-level types
+- no app materialization yet
+
+Primary files:
+
+- `crates/coral-engine/src/contracts/statistics.rs`
+- `crates/coral-engine/src/runtime/statistics.rs`
+- `crates/coral-engine/src/backends/shared/json_exec.rs`
+- `crates/coral-engine/src/backends/file/mod.rs`
+- `crates/coral-engine/src/backends/http/provider.rs`
+
+Validation:
+
+```shell
+cargo fmt --all -- --check
+cargo test -p coral-engine backends::jsonl --locked
+cargo test -p coral-engine backends::http --locked
+cargo test -p coral-engine runtime::statistics --locked
+```
+
+Acceptance:
+
+- JSONL unfiltered scans report table-global telemetry observations.
+- HTTP filtered scans report filtered telemetry observations.
+- HTTP limited scans report limited telemetry observations.
+- Query failures do not update the app cache because app refresh only runs
+  after success.
+- No raw values are persisted or exposed.
+
+### PR 3: `feat(app): materialize workspace column statistics`
+
+Branch:
+
+```text
+source-470-stats-persistence
+```
+
+Scope:
+
+- workspace stats cache path
+- `StatisticsStore`
+- local trace-history statistics observation reader
+- load materialized profile into runtime config
+- rebuild cache from telemetry after successful query execution
+- cached stats visible in later `coral.columns` queries
+- failed queries do not refresh the cache
+
+Primary files:
+
+- `crates/coral-app/src/state/layout.rs`
+- `crates/coral-app/src/state/statistics.rs`
+- `crates/coral-app/src/state/mod.rs`
+- `crates/coral-app/src/telemetry/local_store.rs`
+- `crates/coral-app/src/telemetry/mod.rs`
+- `crates/coral-app/src/bootstrap/server.rs`
+- `crates/coral-app/src/query/manager.rs`
+- app tests under the existing test modules
+
+Validation:
+
+```shell
+cargo fmt --all -- --check
+cargo test -p coral-app state::statistics --locked
+cargo test -p coral-app query::manager --locked
+```
+
+Acceptance:
+
+- profile is written under
+  `$CORAL_CONFIG_DIR/workspaces/default/statistics/profile.json`
+- trace-derived stats survive across separate CLI invocations using the same
+  `CORAL_CONFIG_DIR`
+- filtered/limited observations do not update table-global catalog stats
+- corrupt or mismatched old stats do not poison new catalog rows
+
+### PR 4: `feat(engine): add parquet column statistics observations`
+
+Branch:
+
+```text
+source-470-parquet-stats
+```
+
+Scope:
+
+- Parquet scan telemetry observation via `ObservingExec`
+- observed-sample Parquet scan stats
+- local Parquet tests
+- no exact Parquet footer-stat extraction in SOURCE-470; keep that as a
+  follow-up unless the DataFusion API path becomes trivial and reviewer-safe
+- no docs-only changes unless a small note is needed for reviewers
+
+Primary files:
+
+- `crates/coral-engine/src/backends/file/mod.rs`
+- `crates/coral-engine/src/runtime/statistics.rs`
+- `crates/coral-engine/src/contracts/statistics.rs`
+
+Validation:
+
+```shell
+cargo fmt --all -- --check
+cargo test -p coral-engine backends::parquet --locked
+cargo test -p coral-engine runtime::statistics --locked
+```
+
+Acceptance:
+
+- local Parquet unfiltered scans report observed stats through telemetry.
+- filtered/limited Parquet scans are not merged as table-global stats.
+- Parquet string columns that surface as Arrow `Utf8View` still get bounded
+  distinct-count collection when the manifest type is `Utf8`.
+- the PR description explicitly says Parquet currently lands as
+  `observed_sample`.
+
+### PR 5: `docs(mcp): document nullable column statistics`
+
+Branch:
+
+```text
+source-470-stats-docs-smoke
+```
+
+Scope:
+
+- concise MCP guide/resource updates
+- public docs note
+- compiled-app local-source smoke validation
+- optional smoke script or checked fixture files if that prevents drift
+
+Primary files:
+
+- `crates/coral-mcp/src/guide_template.md`
+- `crates/coral-mcp/src/surface/resources.rs`
+- `docs/guides/use-coral-over-mcp.mdx`
+- `docs/reference/source-spec-reference.mdx`
+- optional `scripts/` or test fixture files for repeatable local-source smoke
+
+Validation:
+
+```shell
+cargo fmt --all -- --check
+cargo test -p coral-mcp --locked
+cargo build -p coral-cli --locked
+make rust-checks
+```
+
+Acceptance:
+
+- docs say stats are nullable and may be observed samples.
+- MCP examples remain concise.
+- compiled app has been run against local JSONL, local HTTP, and local Parquet
+  sources as described below.
+
+## Graphite Workflow
+
+The stack should be created and managed with `gt`, not raw `git push`.
+
+Start from trunk:
+
+```shell
+gt sync
+gt checkout main
+gt log --stack
+```
+
+For each PR, edit the files for that slice, run the slice validation, then
+create the next stacked branch:
+
+```shell
+gt create source-470-stats-catalog \
+  --all \
+  --message "feat(engine): add statistics profile to catalog"
+
+gt create source-470-stats-observations \
+  --all \
+  --message "feat(engine): report column statistics observations"
+
+gt create source-470-stats-persistence \
+  --all \
+  --message "feat(app): materialize workspace column statistics"
+
+gt create source-470-parquet-stats \
+  --all \
+  --message "feat(engine): add parquet column statistics observations"
+
+gt create source-470-stats-docs-smoke \
+  --all \
+  --message "docs(mcp): document nullable column statistics"
+```
+
+Before opening PRs:
+
+```shell
+gt restack
+gt log
+gt submit --stack --dry-run
+```
+
+Open the stack as drafts first:
+
+```shell
+gt submit --stack --draft
+```
+
+When updating a lower PR after review:
+
+```shell
+gt checkout source-470-stats-catalog
+# edit, test
+gt modify --all --message "feat(engine): add statistics profile to catalog"
+gt restack
+gt submit --stack --draft --no-edit
+```
+
+Operational rules:
+
+- Keep every branch reviewable on its own.
+- Keep PR titles in Conventional Commit form.
+- Put the validation commands actually run in each PR description.
+- If a lower branch changes a public Rust contract, immediately restack and
+  re-run affected upstack tests.
+- Do not submit only the top branch. Use `gt submit --stack` from the stack tip.
+
+## Required Validation
+
+Unit and crate tests are required, but they are not enough. The feature must be
+validated by running the compiled app against locally connected sources.
+
+### Rust Checks
+
+Run before final stack submission:
+
+```shell
+cargo fmt --check
+CARGO_TARGET_DIR=target/source-470-check cargo test --locked -p coral-engine -p coral-app -p coral-mcp -p xtask
+CARGO_TARGET_DIR=target/source-470-check cargo clippy --locked -p coral-engine -p coral-app -p coral-mcp -p xtask --all-targets --all-features -- -D warnings
+CARGO_TARGET_DIR=target/source-470-check cargo build --locked -p coral-cli
+```
+
+Also run `make rust-checks` before final merge readiness if full-workspace
+nextest/docs coverage is required by CI or reviewer request. For fast
+iteration, run focused checks per PR as listed above.
+
+### Compiled App Smoke: JSONL
+
+This smoke proves stats are absent before observation, then visible and
+materialized after a real compiled CLI query against a local JSONL source.
+It relies on default-enabled local trace history; disabling trace history is
+expected to leave stats as `NULL`.
+
+```shell
+cargo build -p coral-cli --locked
+
+SMOKE_ROOT="$(mktemp -d)"
+export CORAL_CONFIG_DIR="$SMOKE_ROOT/config"
+mkdir -p "$SMOKE_ROOT/jsonl-data"
+
+cat > "$SMOKE_ROOT/jsonl-data/events.jsonl" <<'EOF'
+{"id":1,"category":"alpha","nullable_text":"one","active":true}
+{"id":2,"category":"beta","nullable_text":null,"active":false}
+{"id":3,"category":"alpha","nullable_text":"three","active":true}
+{"id":4,"category":"gamma","active":false}
+{"id":5,"category":"beta","nullable_text":"five","active":true}
+EOF
+
+cat > "$SMOKE_ROOT/local-stats-jsonl.yaml" <<EOF
+name: local_stats_jsonl
+version: 0.1.0
+dsl_version: 3
+backend: file
+tables:
+  - name: events
+    description: Local stats smoke events
+    format: jsonl
+    source:
+      location: file://$SMOKE_ROOT/jsonl-data/
+      glob: "**/*.jsonl"
+    columns:
+      - name: id
+        type: Int64
+      - name: category
+        type: Utf8
+      - name: nullable_text
+        type: Utf8
+        nullable: true
+      - name: active
+        type: Boolean
+EOF
+
+./target/debug/coral source add --file "$SMOKE_ROOT/local-stats-jsonl.yaml"
+
+./target/debug/coral sql --format json "
+  SELECT column_name, null_fraction, approx_distinct_count, stats_sample_count, stats_precision
+  FROM coral.columns
+  WHERE schema_name = 'local_stats_jsonl' AND table_name = 'events'
+  ORDER BY ordinal_position
+" > "$SMOKE_ROOT/jsonl-before.json"
+
+./target/debug/coral sql --format json "
+  SELECT id, category, nullable_text, active
+  FROM local_stats_jsonl.events
+  ORDER BY id
+" > "$SMOKE_ROOT/jsonl-query.json"
+
+./target/debug/coral sql --format json "
+  SELECT column_name, null_fraction, approx_distinct_count, stats_sample_count, stats_precision
+  FROM coral.columns
+  WHERE schema_name = 'local_stats_jsonl' AND table_name = 'events'
+  ORDER BY ordinal_position
+" > "$SMOKE_ROOT/jsonl-after.json"
+
+python3 - "$SMOKE_ROOT/jsonl-before.json" "$SMOKE_ROOT/jsonl-after.json" <<'PY'
+import json
+import math
+import sys
+
+before = json.load(open(sys.argv[1]))
+after = json.load(open(sys.argv[2]))
+
+assert before, "expected coral.columns rows before observation"
+assert all(row["stats_sample_count"] is None for row in before), before
+
+by_name = {row["column_name"]: row for row in after}
+nullable_text = by_name["nullable_text"]
+category = by_name["category"]
+
+assert nullable_text["stats_sample_count"] == 5, nullable_text
+assert math.isclose(nullable_text["null_fraction"], 0.4), nullable_text
+assert nullable_text["stats_precision"] == "observed_sample", nullable_text
+
+assert category["approx_distinct_count"] == 3, category
+assert category["stats_sample_count"] == 5, category
+PY
+```
+
+Then invoke the compiled CLI again using the same `CORAL_CONFIG_DIR` and assert
+the stats are still present. This proves the materialized cache is reusable
+across runtime rebuilds, not just in-memory observation.
+
+```shell
+./target/debug/coral sql --format json "
+  SELECT column_name, stats_sample_count, stats_precision
+  FROM coral.columns
+  WHERE schema_name = 'local_stats_jsonl' AND table_name = 'events'
+  ORDER BY ordinal_position
+" > "$SMOKE_ROOT/jsonl-reload.json"
+
+python3 - "$SMOKE_ROOT/jsonl-reload.json" <<'PY'
+import json
+import sys
+
+rows = json.load(open(sys.argv[1]))
+assert rows
+assert any(row["stats_sample_count"] == 5 for row in rows), rows
+assert all(
+    row["stats_precision"] in (None, "observed_sample", "approximate", "exact", "unknown")
+    for row in rows
+), rows
+PY
+```
+
+### Compiled App Smoke: HTTP
+
+This smoke proves a locally connected HTTP source does not merge filtered
+observations into table-global stats.
+
+```shell
+mkdir -p "$SMOKE_ROOT/http-data"
+cat > "$SMOKE_ROOT/http-data/messages.json" <<'EOF'
+[
+  {"id": "m1", "status": "open", "body": "first"},
+  {"id": "m2", "status": "closed", "body": null},
+  {"id": "m3", "status": "open", "body": "third"}
+]
+EOF
+
+python3 -m http.server 8765 --directory "$SMOKE_ROOT/http-data" >/tmp/coral-stats-http.log 2>&1 &
+HTTP_PID=$!
+trap 'kill "$HTTP_PID" 2>/dev/null || true' EXIT
+
+cat > "$SMOKE_ROOT/local-stats-http.yaml" <<'EOF'
+name: local_stats_http
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_BASE:
+    kind: variable
+    default: http://127.0.0.1:8765
+base_url: "{{input.API_BASE}}"
+tables:
+  - name: messages
+    description: Local HTTP stats smoke messages
+    filters:
+      - name: status
+        required: false
+    request:
+      method: GET
+      path: /messages.json
+      query:
+        - name: status
+          from: filter
+          key: status
+          default: all
+    response:
+      row_strategy: direct
+    columns:
+      - name: id
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: body
+        type: Utf8
+        nullable: true
+EOF
+
+./target/debug/coral source add --file "$SMOKE_ROOT/local-stats-http.yaml"
+
+./target/debug/coral sql --format json "
+  SELECT id, body
+  FROM local_stats_http.messages
+  WHERE status = 'open'
+  ORDER BY id
+" > "$SMOKE_ROOT/http-filtered-query.json"
+
+./target/debug/coral sql --format json "
+  SELECT column_name, stats_sample_count
+  FROM coral.columns
+  WHERE schema_name = 'local_stats_http' AND table_name = 'messages'
+  ORDER BY ordinal_position
+" > "$SMOKE_ROOT/http-after-filtered.json"
+
+python3 - "$SMOKE_ROOT/http-after-filtered.json" <<'PY'
+import json
+import sys
+
+rows = json.load(open(sys.argv[1]))
+assert rows
+assert all(row["stats_sample_count"] is None for row in rows), rows
+PY
+
+./target/debug/coral sql --format json "
+  SELECT id, status, body
+  FROM local_stats_http.messages
+  ORDER BY id
+" > "$SMOKE_ROOT/http-unfiltered-query.json"
+
+./target/debug/coral sql --format json "
+  SELECT column_name, stats_sample_count, stats_precision
+  FROM coral.columns
+  WHERE schema_name = 'local_stats_http' AND table_name = 'messages'
+  ORDER BY ordinal_position
+" > "$SMOKE_ROOT/http-after-unfiltered.json"
+
+python3 - "$SMOKE_ROOT/http-after-unfiltered.json" <<'PY'
+import json
+import sys
+
+rows = json.load(open(sys.argv[1]))
+assert rows
+assert any(row["stats_sample_count"] == 3 for row in rows), rows
+assert all(
+    row["stats_precision"] in (None, "observed_sample")
+    for row in rows
+), rows
+PY
+```
+
+### Compiled App Smoke: Parquet
+
+Do not skip Parquet. Use a deterministic generated fixture. The local
+development smoke used `pyarrow` to write a small Parquet file with `Int64`,
+`Utf8`, nullable `Utf8`, and `Boolean` columns; this caught the important
+Arrow `Utf8View` string representation path.
+
+Then run the compiled CLI against that generated local file:
+
+```shell
+python3 - "$SMOKE_ROOT/parquet-data/metrics.parquet" <<'PY'
+import pathlib
+import sys
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+path = pathlib.Path(sys.argv[1])
+path.parent.mkdir(parents=True, exist_ok=True)
+table = pa.table({
+    "id": pa.array([1, 2, 3, 4], type=pa.int64()),
+    "category": pa.array(["alpha", "beta", "alpha", "gamma"], type=pa.string()),
+    "nullable_text": pa.array(["one", None, "three", None], type=pa.string()),
+    "active": pa.array([True, False, True, False], type=pa.bool_()),
+})
+pq.write_table(table, path)
+PY
+
+PARQUET_DIR="$SMOKE_ROOT/parquet-data"
+
+cat > "$SMOKE_ROOT/local-stats-parquet.yaml" <<EOF
+name: local_stats_parquet
+version: 0.1.0
+dsl_version: 3
+backend: file
+tables:
+  - name: metrics
+    description: Local stats smoke metrics
+    format: parquet
+    source:
+      location: file://$PARQUET_DIR/
+      glob: "**/*.parquet"
+    columns: []
+EOF
+
+./target/debug/coral source add --file "$SMOKE_ROOT/local-stats-parquet.yaml"
+
+./target/debug/coral sql --format json "
+  SELECT *
+  FROM local_stats_parquet.metrics
+  ORDER BY 1
+" > "$SMOKE_ROOT/parquet-query.json"
+
+./target/debug/coral sql --format json "
+  SELECT column_name, null_fraction, stats_sample_count, stats_precision
+  FROM coral.columns
+  WHERE schema_name = 'local_stats_parquet' AND table_name = 'metrics'
+  ORDER BY ordinal_position
+" > "$SMOKE_ROOT/parquet-after.json"
+
+python3 - "$SMOKE_ROOT/parquet-after.json" <<'PY'
+import json
+import sys
+
+rows = json.load(open(sys.argv[1]))
+assert rows
+assert any(row["stats_sample_count"] is not None for row in rows), rows
+assert all(
+    row["stats_precision"] in (None, "observed_sample", "exact")
+    for row in rows
+), rows
+PY
+```
+
+The local HTTP smoke must run a filtered query first and assert
+`stats_sample_count` remains `NULL`, then run an unfiltered query and assert
+table-global stats appear. The local JSONL smoke must corrupt
+`profile.json`, run another successful source query, and assert the cache is
+rebuilt from trace history.
+
+## Acceptance Criteria
+
+- `SELECT * FROM coral.columns` continues to work for all current sources.
+- Existing `coral.columns` fields keep their behavior.
+- New stats fields exist and are nullable.
+- Empty or missing stats profile yields `NULL` fields.
+- Stale schema stats do not project.
+- JSONL, HTTP, and Parquet have backend-specific tests.
+- Workspace stats are materialized from local trace history and survive runtime
+  rebuilds through `profile.json`.
+- Filtered HTTP/API observations do not update table-global stats.
+- Limited observations do not update table-global stats.
+- Failed queries do not refresh the materialized cache.
+- No raw user values are persisted.
+- MCP/docs describe stats as nullable and sample-derived.
+- `make rust-checks` passes.
+- Compiled `./target/debug/coral` has been run against local JSONL, HTTP, and
+  Parquet sources with the smoke checks above or an equivalent checked script.
+
+## Risks And Guardrails
+
+- Bad stats are worse than absent stats. Prefer `NULL`.
+- Do not add hidden registration-time scans for APIs or large local files.
+- Do not bind cache materialization to the `coral.columns` schema.
+- Do not persist raw sample values or in-memory distinct sets.
+- Do not treat filtered API results as table-global.
+- Do not make the MCP guide noisy; keep docs focused on how to interpret the
+  nullable fields.
+- Do not widen CLI/API transport contracts unless required. This feature is
+  visible through SQL metadata, not a new public RPC.
+- Keep app cache materialization in `coral-app`; keep runtime/stat semantics in
+  `coral-engine`.
+- If exact Parquet footer stats get complicated, land observed Parquet stats
+  with honest `observed_sample` precision and document the exact-stat follow-up
+  in the PR.
+
+## Definition Of Done
+
+The stack is done when:
+
+1. The five PRs are open as a Graphite stack.
+2. Every PR has the focused validation commands in its description.
+3. The stack tip passes `make rust-checks`.
+4. The compiled-app local-source smoke passes and is recorded in the docs/smoke
+   PR description.
+5. `coral.columns` shows the new nullable fields for locally connected sources.
+6. Trace-derived cached stats survive a separate CLI invocation with the same
+   `CORAL_CONFIG_DIR`.
+7. Filtered/limited observations remain out of table-global catalog stats.


### PR DESCRIPTION
## Ticket

- [SOURCE-470](https://linear.app/withcoral/issue/SOURCE-470/add-column-level-statistics-to-coralcolumns-nullability-rate)

## What This PR Does

Adds the engine-side contract that lets `coral.columns` project column statistics when the runtime is given a statistics profile.

Concretely, this PR:

- Defines the engine statistics profile types for source/table/column stats.
- Appends nullable statistics fields to `coral.columns`: `null_fraction`, `approx_distinct_count`, `stats_sample_count`, and `stats_precision`.
- Looks up stats by source, table, column, source version, and schema signature before projecting them.
- Keeps existing catalog behavior unchanged when no statistics profile is provided.
- Saturates oversized internal `sample_count` values to `i64::MAX` when projecting `stats_sample_count` as SQL `BIGINT`.

## What This PR Does Not Do

- Does not collect scan observations.
- Does not expose scan observations on `QueryExecution`.
- Does not persist statistics.
- Does not make `coral.columns` the storage model.
- Does not claim stats are exact or always present.

The important contract is: `coral.columns` is a nullable projection over runtime-provided stats, not the durable stats store. Scan observations are emitted later through telemetry in #290, not attached to final query results here.

## Stack Position

1. #289 engine projection contract for `coral.columns`
2. #290 telemetry scan observations
3. #291 app cache rebuild from local trace history
4. #292 Parquet scan observations
5. #293 docs and validation notes

## Review Follow-up

Addressed the latest #289 review notes:

- Removed the unpopulated `QueryExecution` observation channel from this bottom PR so there is no second, always-empty observation pipeline.
- Changed `ColumnStatistics::sample_count_i64()` to saturate at `i64::MAX` instead of projecting oversized `u64` sample counts as `NULL`.
- Added `sample_count_projection_saturates_bigint_overflow` to lock the overflow behavior.

## Validation

Rebased on fresh `origin/main` at `96532449`.

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=target/source-470-check cargo test --locked -p coral-engine`
- `CARGO_TARGET_DIR=target/source-470-check cargo clippy --locked -p coral-engine --all-targets --all-features -- -D warnings`
- Earlier stack validation also passed with `CARGO_TARGET_DIR=target/source-470-check make rust-checks` and compiled CLI local-source smoke with `target/source-470-check/debug/coral`:
  - JSONL: stats absent before observation, present after query, still present after runtime rebuild, and rebuilt after corrupt `profile.json`.
  - HTTP: filtered observation does not materialize table-global stats; unfiltered observation does.
  - Parquet: generated `pyarrow` fixture materializes column stats through `coral.columns`.
