### PR TITLE
feat(engine): emit column-stat observations

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -15,6 +15,8 @@ use datafusion::error::DataFusionError;
 use datafusion::logical_expr::Expr;
 use datafusion::prelude::SessionContext;
 
+use crate::contracts::{ColumnSchemaSignature, TableSchemaSignature};
+
 /// Provider factory for one registered source-scoped table function.
 ///
 /// Implementations bind one call site's positional arguments (manifest order,
@@ -50,6 +52,25 @@ pub(crate) struct RegisteredTable {
     pub(crate) filters: Vec<RegisteredFilter>,
     pub(crate) required_filters: Vec<String>,
     pub(crate) search_limits: Option<SearchLimitsSpec>,
+}
+
+impl RegisteredTable {
+    pub(crate) fn schema_signature(&self) -> TableSchemaSignature {
+        TableSchemaSignature {
+            columns: self
+                .columns
+                .iter()
+                .map(|column| ColumnSchemaSignature {
+                    name: column.name.clone(),
+                    data_type: column.data_type.clone(),
+                    nullable: column.nullable,
+                    is_virtual: column.is_virtual,
+                    is_required_filter: column.is_required_filter,
+                })
+                .collect(),
+            required_filters: self.required_filters.clone(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/coral-engine/src/backends/file/json.rs
+++ b/crates/coral-engine/src/backends/file/json.rs
@@ -53,7 +53,9 @@ use super::listing::{PreparedListingTable, prepare_listing_table};
 use super::metadata::FileMetadataColumns;
 use super::partitions::{
     PartitionColumns, filter_is_supported_partition_filter, filter_references_partition,
+    partition_filter_column_names,
 };
+use super::{FileStatisticsRegistration, FileTableStatistics};
 
 const JSON_ARRAY_CHANNEL_BUFFER_SIZE: usize = 128;
 const JSON_ARRAY_CONVERTER_BUFFER_SIZE: usize = 2 * 1024 * 1024;
@@ -99,6 +101,7 @@ pub(super) struct JsonFileTableProvider {
     json_fields: Arc<HashSet<String>>,
     metadata_columns: FileMetadataColumns,
     partition_columns: PartitionColumns,
+    statistics: Option<FileTableStatistics>,
 }
 
 impl fmt::Debug for JsonFileTableProvider {
@@ -119,6 +122,7 @@ impl JsonFileTableProvider {
         table: FileTableSpec,
         home_dir: Option<&Path>,
         resolved_inputs: &BTreeMap<String, String>,
+        statistics: Option<FileStatisticsRegistration>,
     ) -> Result<Self> {
         let format = table.format;
         let PreparedListingTable {
@@ -135,6 +139,16 @@ impl JsonFileTableProvider {
         let table_schema = metadata_columns.extend_table_schema_if_present(table_schema);
         let schema = Arc::clone(table_schema.table_schema());
         let json_fields = Arc::new(json_field_names(table.columns()));
+        let table_metadata = super::registered_table(&table, &schema);
+        let statistics = statistics.map(|registration| {
+            FileTableStatistics::new(
+                source_schema,
+                table.name(),
+                table_metadata.schema_signature(),
+                schema.fields().len(),
+                registration,
+            )
+        });
 
         Ok(Self {
             source_schema: source_schema.to_string(),
@@ -148,6 +162,7 @@ impl JsonFileTableProvider {
             json_fields,
             metadata_columns,
             partition_columns,
+            statistics,
         })
     }
 }
@@ -240,7 +255,15 @@ impl TableProvider for JsonFileTableProvider {
             .with_projection_indices(projection.cloned())?
             .build();
 
-        Ok(DataSourceExec::from_data_source(config))
+        let exec = DataSourceExec::from_data_source(config);
+        Ok(match &self.statistics {
+            Some(statistics) => {
+                let pushed_filter_columns =
+                    partition_filter_column_names(filters, &self.partition_columns);
+                statistics.observe_scan(exec, projection, pushed_filter_columns, limit)
+            }
+            None => exec,
+        })
     }
 }
 

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -12,7 +12,7 @@ mod provider;
 #[cfg(test)]
 mod tests;
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result;
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{
@@ -29,6 +30,8 @@ use crate::backends::{
     registered_columns_from_specs, required_filter_names,
     validate_lookup_key_filter_backend_support,
 };
+use crate::contracts::{StatisticsObservationScope, TableSchemaSignature};
+use crate::runtime::statistics::{BatchStatisticsPlan, observe_execution_plan};
 use coral_spec::SourceBackend;
 use coral_spec::backends::file::{FileFormat, FileSourceManifest, FileTableSpec};
 
@@ -69,6 +72,114 @@ pub(crate) fn compile_manifest(
     )
 }
 
+#[derive(Debug, Clone)]
+pub(super) struct FileStatisticsRegistration {
+    source_version: String,
+}
+
+impl FileStatisticsRegistration {
+    fn new(source_version: impl Into<String>) -> Self {
+        Self {
+            source_version: source_version.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct FileTableStatistics {
+    source_schema: String,
+    table_name: String,
+    source_version: Option<String>,
+    schema_signature: TableSchemaSignature,
+    field_count: usize,
+}
+
+impl FileTableStatistics {
+    fn new(
+        source_schema: &str,
+        table_name: &str,
+        schema_signature: TableSchemaSignature,
+        field_count: usize,
+        registration: FileStatisticsRegistration,
+    ) -> Self {
+        Self {
+            source_schema: source_schema.to_string(),
+            table_name: table_name.to_string(),
+            source_version: Some(registration.source_version),
+            schema_signature,
+            field_count,
+        }
+    }
+
+    fn observe_scan(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+        projection: Option<&Vec<usize>>,
+        pushed_filter_columns: Vec<String>,
+        limit: Option<usize>,
+    ) -> Arc<dyn ExecutionPlan> {
+        observe_execution_plan(
+            input,
+            self.plan_with_scope(self.scope(projection, pushed_filter_columns, limit)),
+        )
+    }
+
+    fn observe_scan_with_scope(
+        &self,
+        input: Arc<dyn ExecutionPlan>,
+        scope: StatisticsObservationScope,
+    ) -> Arc<dyn ExecutionPlan> {
+        observe_execution_plan(input, self.plan_with_scope(scope))
+    }
+
+    fn scope(
+        &self,
+        projection: Option<&Vec<usize>>,
+        pushed_filter_columns: Vec<String>,
+        limit: Option<usize>,
+    ) -> StatisticsObservationScope {
+        statistics_scope(projection, self.field_count, pushed_filter_columns, limit)
+    }
+
+    fn plan_with_scope(&self, scope: StatisticsObservationScope) -> BatchStatisticsPlan {
+        BatchStatisticsPlan::table_global(
+            self.source_schema.clone(),
+            self.table_name.clone(),
+            self.source_version.clone(),
+            self.schema_signature.clone(),
+        )
+        .with_scope(scope)
+    }
+}
+
+fn statistics_scope(
+    projection: Option<&Vec<usize>>,
+    field_count: usize,
+    pushed_filter_columns: Vec<String>,
+    limit: Option<usize>,
+) -> StatisticsObservationScope {
+    if limit.is_some() {
+        return StatisticsObservationScope::Limited;
+    }
+    if projection_is_partial(projection, field_count) {
+        return StatisticsObservationScope::Unknown;
+    }
+    if pushed_filter_columns.is_empty() {
+        StatisticsObservationScope::TableGlobal
+    } else {
+        StatisticsObservationScope::Filtered {
+            filter_columns: pushed_filter_columns,
+        }
+    }
+}
+
+fn projection_is_partial(projection: Option<&Vec<usize>>, field_count: usize) -> bool {
+    let Some(projection) = projection else {
+        return false;
+    };
+    projection.iter().copied().collect::<BTreeSet<_>>().len() != field_count
+}
+
 #[async_trait]
 impl CompiledBackendSource for FileCompiledSource {
     fn schema_name(&self) -> &str {
@@ -105,6 +216,13 @@ impl CompiledBackendSource for FileCompiledSource {
         );
 
         for table in &self.manifest.tables {
+            let table_statistics = if matches!(table.format, FileFormat::Json | FileFormat::Jsonl) {
+                Some(FileStatisticsRegistration::new(
+                    self.manifest.common.version.clone(),
+                ))
+            } else {
+                None
+            };
             let provider: Arc<dyn TableProvider> = match table.format {
                 FileFormat::Jsonl | FileFormat::Json if json::requires_custom_provider(table)? => {
                     Arc::new(
@@ -114,6 +232,7 @@ impl CompiledBackendSource for FileCompiledSource {
                             table.clone(),
                             self.home_dir.as_deref(),
                             &resolved_inputs,
+                            table_statistics,
                         )
                         .await?,
                     )
@@ -126,6 +245,7 @@ impl CompiledBackendSource for FileCompiledSource {
                             table.clone(),
                             self.home_dir.as_deref(),
                             &resolved_inputs,
+                            table_statistics,
                         )
                         .await?,
                     )

--- a/crates/coral-engine/src/backends/file/partitions.rs
+++ b/crates/coral-engine/src/backends/file/partitions.rs
@@ -1,6 +1,6 @@
 //! Partition extraction and pruning helpers for file-backed sources.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
@@ -248,6 +248,37 @@ pub(super) fn partition_filter_constraints(
         collect_partition_filter_constraints(filter, partitions, &mut constraints);
     }
     constraints
+}
+
+pub(super) fn partition_filter_column_names(
+    filters: &[Expr],
+    partitions: &PartitionColumns,
+) -> Vec<String> {
+    let mut columns = BTreeSet::new();
+    for filter in filters {
+        collect_partition_filter_column_names(filter, partitions, &mut columns);
+    }
+    columns.into_iter().collect()
+}
+
+fn collect_partition_filter_column_names(
+    expr: &Expr,
+    partitions: &PartitionColumns,
+    columns: &mut BTreeSet<String>,
+) {
+    match expr {
+        Expr::BinaryExpr(binary) if binary.op == Operator::And => {
+            collect_partition_filter_column_names(binary.left.as_ref(), partitions, columns);
+            collect_partition_filter_column_names(binary.right.as_ref(), partitions, columns);
+        }
+        _ => {
+            if let Some(constraint) = partition_constraint(expr, partitions)
+                && let Some(partition) = partitions.get(constraint.index)
+            {
+                columns.insert(partition.name.clone());
+            }
+        }
+    }
 }
 
 fn collect_partition_filter_constraints(

--- a/crates/coral-engine/src/backends/file/provider.rs
+++ b/crates/coral-engine/src/backends/file/provider.rs
@@ -21,6 +21,7 @@ use futures::TryStreamExt as _;
 use object_store::ObjectStore;
 
 use crate::backends::schema_from_columns;
+use crate::contracts::StatisticsObservationScope;
 use coral_spec::backends::file::{FileFormat, FileTableSpec};
 
 use super::file_groups::{FileGroupsForScan, file_groups_for_scan};
@@ -29,17 +30,30 @@ use super::metadata::FileMetadataColumns;
 use super::parquet_schema::infer_schema_expand_dicts;
 use super::partitions::{
     PartitionColumns, filter_is_supported_partition_filter, filter_references_partition,
+    partition_filter_column_names,
 };
+use super::{FileStatisticsRegistration, FileTableStatistics};
 
 #[derive(Debug)]
 pub(crate) struct FileTableProvider {
     inner: FileTableProviderInner,
+    statistics: Option<FileTableStatistics>,
+    filter_scope_mode: FilterScopeMode,
 }
 
 #[derive(Debug)]
 enum FileTableProviderInner {
     Listing(ListingTable),
     Metadata(MetadataFileTableProvider),
+}
+
+impl FileTableProviderInner {
+    fn schema(&self) -> SchemaRef {
+        match self {
+            Self::Listing(inner) => inner.schema(),
+            Self::Metadata(inner) => inner.schema.clone(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -62,12 +76,13 @@ impl FileTableProvider {
     /// Returns a `DataFusionError` if the file source configuration is
     /// invalid or the listing table cannot be constructed.
     #[cfg(test)]
-    pub(crate) fn try_new(
+    pub(super) fn try_new(
         ctx: &SessionContext,
         source_schema: &str,
         table: FileTableSpec,
         home_dir: Option<&Path>,
         resolved_inputs: &BTreeMap<String, String>,
+        statistics: Option<FileStatisticsRegistration>,
     ) -> Result<Self> {
         futures::executor::block_on(Self::try_new_async(
             ctx,
@@ -75,15 +90,17 @@ impl FileTableProvider {
             table,
             home_dir,
             resolved_inputs,
+            statistics,
         ))
     }
 
-    pub(crate) async fn try_new_async(
+    pub(super) async fn try_new_async(
         ctx: &SessionContext,
         source_schema: &str,
         table: FileTableSpec,
         home_dir: Option<&Path>,
         resolved_inputs: &BTreeMap<String, String>,
+        statistics: Option<FileStatisticsRegistration>,
     ) -> Result<Self> {
         let inner = Self::build_provider(
             ctx.clone(),
@@ -93,7 +110,25 @@ impl FileTableProvider {
             resolved_inputs,
         )
         .await?;
-        Ok(Self { inner })
+        let schema = inner.schema();
+        let table_metadata = super::registered_table(&table, &schema);
+        let statistics = statistics.map(|registration| {
+            FileTableStatistics::new(
+                source_schema,
+                table.name(),
+                table_metadata.schema_signature(),
+                schema.fields().len(),
+                registration,
+            )
+        });
+        Ok(Self {
+            inner,
+            statistics,
+            filter_scope_mode: FilterScopeMode::from_format(
+                table.format,
+                !table.source.partitions.is_empty(),
+            ),
+        })
     }
 
     async fn build_listing_table(
@@ -317,13 +352,66 @@ impl TableProvider for FileTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        match &self.inner {
+        let exec = match &self.inner {
             FileTableProviderInner::Listing(inner) => {
                 inner.scan(state, projection, filters, limit).await
             }
             FileTableProviderInner::Metadata(inner) => {
                 inner.scan(state, projection, filters, limit).await
             }
+        }?;
+        Ok(match &self.statistics {
+            Some(statistics) => {
+                let scope = self.statistics_scope(statistics, projection, filters, limit);
+                statistics.observe_scan_with_scope(exec, scope)
+            }
+            None => exec,
+        })
+    }
+}
+
+impl FileTableProvider {
+    fn statistics_scope(
+        &self,
+        statistics: &FileTableStatistics,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        limit: Option<usize>,
+    ) -> StatisticsObservationScope {
+        if let FileTableProviderInner::Metadata(inner) = &self.inner {
+            return statistics.scope(
+                projection,
+                partition_filter_column_names(filters, &inner.partition_columns),
+                limit,
+            );
+        }
+
+        match self.filter_scope_mode {
+            FilterScopeMode::UnknownWhenPresent if !filters.is_empty() && limit.is_none() => {
+                StatisticsObservationScope::Unknown
+            }
+            FilterScopeMode::Ignored | FilterScopeMode::UnknownWhenPresent => {
+                statistics.scope(projection, Vec::new(), limit)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum FilterScopeMode {
+    Ignored,
+    UnknownWhenPresent,
+}
+
+impl FilterScopeMode {
+    fn from_format(format: FileFormat, has_partitions: bool) -> Self {
+        if has_partitions {
+            return Self::UnknownWhenPresent;
+        }
+
+        match format {
+            FileFormat::Parquet => Self::UnknownWhenPresent,
+            FileFormat::Csv | FileFormat::Json | FileFormat::Jsonl => Self::Ignored,
         }
     }
 }

--- a/crates/coral-engine/src/backends/file/tests.rs
+++ b/crates/coral-engine/src/backends/file/tests.rs
@@ -795,7 +795,7 @@ fn infer_schema_slow_path_returns_error_for_corrupt_parquet_footer() {
     let ctx = SessionContext::new();
     let location = file_url_from_directory_path(dir.path());
     let table = parquet_table_spec(&location);
-    let result = FileTableProvider::try_new(&ctx, "otel", table, None, &BTreeMap::default());
+    let result = FileTableProvider::try_new(&ctx, "otel", table, None, &BTreeMap::default(), None);
     let error = result.expect_err("corrupt parquet should cause provider construction failure");
     assert!(
         error.to_string().contains("data.parquet"),
@@ -812,7 +812,7 @@ fn infer_schema_slow_path_returns_error_for_too_small_parquet_file() {
     let ctx = SessionContext::new();
     let location = file_url_from_directory_path(dir.path());
     let table = parquet_table_spec(&location);
-    let result = FileTableProvider::try_new(&ctx, "otel", table, None, &BTreeMap::default());
+    let result = FileTableProvider::try_new(&ctx, "otel", table, None, &BTreeMap::default(), None);
     assert!(
         result.is_err(),
         "too-small parquet should cause provider construction failure"

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -155,6 +155,7 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
             arg_values: self.arg_values.clone(),
             projection,
             limit,
+            statistics_plan: None,
         })
     }
 }

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -130,13 +130,16 @@ impl CompiledBackendSource for HttpCompiledSource {
         let mut table_infos = Vec::with_capacity(self.manifest.tables.len());
 
         for table in &self.manifest.tables {
+            let metadata = registered_table(table);
             let provider: Arc<dyn TableProvider> = Arc::new(HttpSourceTableProvider::new(
                 backend.clone(),
                 self.manifest.common.name.clone(),
+                Some(self.manifest.common.version.clone()),
                 table.clone(),
+                metadata.schema_signature(),
             )?);
             tables.insert(table.name().to_string(), provider);
-            table_infos.push(registered_table(table));
+            table_infos.push(metadata);
         }
         let mut table_function_infos = Vec::with_capacity(self.manifest.functions.len());
         for function in &self.manifest.functions {

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -24,15 +24,19 @@ use crate::backends::shared::filter_expr::{
 };
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
 use crate::backends::shared::mapping::{convert_items, filter_items_by_column_values};
+use crate::contracts::{StatisticsObservationScope, TableSchemaSignature};
+use crate::runtime::statistics::BatchStatisticsPlan;
 use coral_spec::backends::http::HttpTableSpec;
 
 /// Table provider that exposes one manifest-defined HTTP table to `DataFusion`.
 pub(crate) struct HttpSourceTableProvider {
     backend: HttpSourceClient,
     source_schema: String,
+    source_version: Option<String>,
     table: Arc<HttpTableSpec>,
     target: HttpFetchTarget,
     schema: SchemaRef,
+    schema_signature: TableSchemaSignature,
 }
 
 impl std::fmt::Debug for HttpSourceTableProvider {
@@ -54,16 +58,20 @@ impl HttpSourceTableProvider {
     pub(crate) fn new(
         backend: HttpSourceClient,
         source_schema: String,
+        source_version: Option<String>,
         table: HttpTableSpec,
+        schema_signature: TableSchemaSignature,
     ) -> Result<Self> {
         let schema = schema_from_columns(table.columns(), &source_schema, table.name())?;
         let target = HttpFetchTarget::from_resolved_table_request(&table, table.request.clone());
         Ok(Self {
             backend,
             source_schema,
+            source_version,
             table: Arc::new(table),
             target,
             schema,
+            schema_signature,
         })
     }
 
@@ -102,6 +110,7 @@ pub(crate) struct HttpJsonExecRequest<'a> {
     pub(crate) arg_values: HashMap<String, String>,
     pub(crate) projection: Option<&'a Vec<usize>>,
     pub(crate) limit: Option<usize>,
+    pub(crate) statistics_plan: Option<BatchStatisticsPlan>,
 }
 
 #[async_trait]
@@ -144,6 +153,7 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         arg_values,
         projection,
         limit,
+        statistics_plan,
     } = request;
     let target = Arc::new(target);
     let mut conversion_filter_values = request_filter_values.clone();
@@ -204,14 +214,25 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         })
     };
 
-    let exec = JsonExec::new(
-        source_schema,
-        target.name(),
-        schema,
-        fetcher,
-        converter,
-        projection.cloned(),
-    )?;
+    let exec = match statistics_plan {
+        Some(statistics_plan) => JsonExec::new_with_statistics(
+            source_schema,
+            target.name(),
+            schema,
+            fetcher,
+            converter,
+            projection.cloned(),
+            statistics_plan,
+        )?,
+        None => JsonExec::new(
+            source_schema,
+            target.name(),
+            schema,
+            fetcher,
+            converter,
+            projection.cloned(),
+        )?,
+    };
 
     Ok(Arc::new(exec))
 }
@@ -302,6 +323,8 @@ impl TableProvider for HttpSourceTableProvider {
                 FilterExtraction::Contradiction => HashMap::new(),
             };
         let target = self.target.with_resolved_request(active_request);
+        let effective_limit = limit.or_else(|| target.fetch_limit_default());
+        let statistics_plan = self.statistics_plan(&filter_values, effective_limit);
 
         http_json_exec(HttpJsonExecRequest {
             backend: self.backend.clone(),
@@ -315,6 +338,32 @@ impl TableProvider for HttpSourceTableProvider {
             arg_values: HashMap::new(),
             projection,
             limit,
+            statistics_plan: Some(statistics_plan),
         })
+    }
+}
+
+impl HttpSourceTableProvider {
+    fn statistics_plan(
+        &self,
+        filters: &HashMap<String, String>,
+        effective_limit: Option<usize>,
+    ) -> BatchStatisticsPlan {
+        let scope = if effective_limit.is_some() {
+            StatisticsObservationScope::Limited
+        } else if filters.is_empty() {
+            StatisticsObservationScope::TableGlobal
+        } else {
+            let mut filter_columns = filters.keys().cloned().collect::<Vec<_>>();
+            filter_columns.sort();
+            StatisticsObservationScope::Filtered { filter_columns }
+        };
+        BatchStatisticsPlan::table_global(
+            self.source_schema.clone(),
+            self.table.name().to_string(),
+            self.source_version.clone(),
+            self.schema_signature.clone(),
+        )
+        .with_scope(scope)
     }
 }

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -19,6 +19,10 @@ use datafusion::physical_plan::{
 use futures::{TryStreamExt, stream};
 use serde_json::Value;
 
+use crate::runtime::statistics::{
+    BatchStatisticsCollector, BatchStatisticsPlan, report_statistics_observation,
+};
+
 /// Fetches raw JSON rows for one logical table scan.
 #[async_trait]
 pub(crate) trait RowFetcher: fmt::Debug + Send + Sync {
@@ -42,6 +46,7 @@ pub(crate) struct JsonExec {
     fetcher: Fetcher,
     converter: Converter,
     projection: Option<Vec<usize>>,
+    statistics_plan: Option<BatchStatisticsPlan>,
 }
 
 impl fmt::Debug for JsonExec {
@@ -68,6 +73,52 @@ impl JsonExec {
         converter: Converter,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
+        Self::new_inner(
+            source_name,
+            table_name,
+            schema,
+            fetcher,
+            converter,
+            projection,
+            None,
+        )
+    }
+
+    /// Build a `JsonExec` plan node that observes scan statistics.
+    ///
+    /// # Errors
+    ///
+    /// Returns a `DataFusionError` if the requested projection does not match
+    /// the supplied schema.
+    pub(crate) fn new_with_statistics(
+        source_name: &str,
+        table_name: &str,
+        schema: SchemaRef,
+        fetcher: Fetcher,
+        converter: Converter,
+        projection: Option<Vec<usize>>,
+        statistics_plan: BatchStatisticsPlan,
+    ) -> Result<Self> {
+        Self::new_inner(
+            source_name,
+            table_name,
+            schema,
+            fetcher,
+            converter,
+            projection,
+            Some(statistics_plan),
+        )
+    }
+
+    fn new_inner(
+        source_name: &str,
+        table_name: &str,
+        schema: SchemaRef,
+        fetcher: Fetcher,
+        converter: Converter,
+        projection: Option<Vec<usize>>,
+        statistics_plan: Option<BatchStatisticsPlan>,
+    ) -> Result<Self> {
         let projected_schema = match &projection {
             Some(indices) => Arc::new(schema.project(indices).map_err(|error| {
                 datafusion::error::DataFusionError::ArrowError(Box::new(error), None)
@@ -89,6 +140,7 @@ impl JsonExec {
             fetcher,
             converter,
             projection,
+            statistics_plan,
         })
     }
 }
@@ -143,6 +195,7 @@ impl ExecutionPlan for JsonExec {
         let converter = self.converter.clone();
         let projected_schema = self.projected_schema.clone();
         let projection = self.projection.clone();
+        let statistics_plan = self.statistics_plan.clone();
         // Emit the fetched rows in `batch_size`-row chunks rather than a single
         // batch spanning the whole result set. Each chunk's `Vec<Value>` is
         // dropped as soon as it is converted, so the heavy serde_json
@@ -158,6 +211,8 @@ impl ExecutionPlan for JsonExec {
                 projection,
                 batch_size,
                 emitted: false,
+                statistics_plan,
+                statistics_collector: None,
             };
             Ok::<_, DataFusionError>(stream::try_unfold(state, next_projected_batch))
         })
@@ -178,6 +233,8 @@ struct ChunkState {
     projection: Option<Vec<usize>>,
     batch_size: usize,
     emitted: bool,
+    statistics_plan: Option<BatchStatisticsPlan>,
+    statistics_collector: Option<BatchStatisticsCollector>,
 }
 
 /// Pulls up to `batch_size` rows, converts them into one projected
@@ -187,11 +244,23 @@ struct ChunkState {
 async fn next_projected_batch(mut state: ChunkState) -> Result<Option<(RecordBatch, ChunkState)>> {
     let chunk: Vec<Value> = state.rows.by_ref().take(state.batch_size).collect();
     if chunk.is_empty() && state.emitted {
+        if let Some(collector) = state.statistics_collector.take()
+            && let Some(observation) = collector.finish()
+        {
+            report_statistics_observation(&observation);
+        }
         return Ok(None);
     }
     state.emitted = true;
 
     let batch = (state.converter)(&chunk)?;
+    if let Some(plan) = state.statistics_plan.take() {
+        state.statistics_collector = Some(BatchStatisticsCollector::new(plan, &batch.schema()));
+    }
+    if let Some(collector) = &mut state.statistics_collector {
+        collector.record_batch(&batch);
+    }
+
     let batch = match &state.projection {
         Some(indices) => batch
             .project(indices)
@@ -268,6 +337,8 @@ mod tests {
             projection: None,
             batch_size: 2,
             emitted: false,
+            statistics_plan: None,
+            statistics_collector: None,
         };
 
         let mut batches = Vec::new();
@@ -309,6 +380,8 @@ mod tests {
             projection: None,
             batch_size: 8,
             emitted: false,
+            statistics_plan: None,
+            statistics_collector: None,
         };
 
         let (batch, state) = futures::executor::block_on(next_projected_batch(state))

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -17,9 +17,7 @@ use crate::backends::common::{
     RegisteredColumn, RegisteredTableFunctionArgument, RegisteredTableFunctionResultColumn,
 };
 use crate::backends::{RegisteredSource, RegisteredTable, RegisteredTableFunction};
-use crate::contracts::{
-    ColumnStatistics, StatisticsProfile, TableSchemaSignature, TableStatistics,
-};
+use crate::contracts::{ColumnStatistics, StatisticsProfile, TableStatistics};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -954,7 +952,7 @@ fn matching_table_statistics<'a>(
                 table_stats.source_version.as_deref(),
             )
         })
-        .filter(|table_stats| table_stats.schema_signature == table_schema_signature(table))
+        .filter(|table_stats| table_stats.schema_signature == table.schema_signature())
 }
 
 fn source_version_matches(
@@ -1074,23 +1072,6 @@ fn columns_batch(schema: Arc<Schema>, rows: &[CatalogColumn]) -> Result<RecordBa
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))
 }
 
-pub(crate) fn table_schema_signature(table: &RegisteredTable) -> TableSchemaSignature {
-    TableSchemaSignature {
-        columns: table.columns.iter().map(column_schema_signature).collect(),
-        required_filters: table.required_filters.clone(),
-    }
-}
-
-fn column_schema_signature(column: &RegisteredColumn) -> crate::contracts::ColumnSchemaSignature {
-    crate::contracts::ColumnSchemaSignature {
-        name: column.name.clone(),
-        data_type: column.data_type.clone(),
-        nullable: column.nullable,
-        is_virtual: column.is_virtual,
-        is_required_filter: column.is_required_filter,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -1101,7 +1082,7 @@ mod tests {
     use datafusion::arrow::array::{Array, Float64Array, Int64Array, StringArray};
     use datafusion::datasource::TableProvider;
 
-    use super::{build_columns_table, collect_table_functions, table_schema_signature};
+    use super::{build_columns_table, collect_table_functions};
     use crate::backends::common::RegisteredColumn;
     use crate::backends::{RegisteredSource, RegisteredTable, RegisteredTableFunction};
     use crate::contracts::{
@@ -1173,7 +1154,7 @@ mod tests {
                 schema_name: source.schema_name.clone(),
                 table_name: table.table_name.clone(),
                 source_version: Some(source.source_version.clone()),
-                schema_signature: table_schema_signature(table),
+                schema_signature: table.schema_signature(),
                 columns,
             },
         );

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod registry;
 pub(crate) mod schema_provider;
 pub(crate) mod scoped_table_functions;
 pub(crate) mod source_functions;
+pub(crate) mod statistics;

--- a/crates/coral-engine/src/runtime/statistics.rs
+++ b/crates/coral-engine/src/runtime/statistics.rs
@@ -1,0 +1,880 @@
+//! Runtime helpers for scan-level column statistics observations.
+
+use std::any::Any;
+use std::collections::HashSet;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use chrono::{SecondsFormat, Utc};
+use datafusion::arrow::array::{
+    Array, BooleanArray, DictionaryArray, Int64Array, LargeStringArray, RecordBatch, StringArray,
+    StringViewArray, TimestampMicrosecondArray,
+};
+use datafusion::arrow::datatypes::{
+    ArrowDictionaryKeyType, DataType, Int8Type, Int16Type, Int32Type, Int64Type, SchemaRef,
+    TimeUnit, UInt8Type, UInt16Type, UInt32Type, UInt64Type,
+};
+use datafusion::error::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, RecordBatchStream,
+    SendableRecordBatchStream,
+};
+use futures::Stream;
+use opentelemetry::KeyValue;
+use opentelemetry::trace::TraceContextExt as _;
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+use crate::contracts::{
+    ColumnSchemaSignature, ColumnStatisticsObservation, StatisticPrecision, StatisticValue,
+    StatisticsObservation, StatisticsObservationScope, TableSchemaSignature,
+};
+
+const DISTINCT_COUNT_MAX_VALUES: usize = 4096;
+pub(crate) const STATISTICS_OBSERVATION_EVENT_NAME: &str = "coral.statistics.observation";
+pub(crate) const STATISTICS_OBSERVATION_EVENT_ATTRIBUTE: &str = "coral.statistics.observation";
+
+/// Immutable scan metadata needed to turn Arrow batches into one observation.
+#[derive(Debug, Clone)]
+pub(crate) struct BatchStatisticsPlan {
+    pub(crate) schema_name: String,
+    pub(crate) table_name: String,
+    pub(crate) source_version: Option<String>,
+    pub(crate) schema_signature: TableSchemaSignature,
+    pub(crate) scope: StatisticsObservationScope,
+    pub(crate) precision: StatisticPrecision,
+}
+
+impl BatchStatisticsPlan {
+    pub(crate) fn table_global(
+        schema_name: impl Into<String>,
+        table_name: impl Into<String>,
+        source_version: Option<String>,
+        schema_signature: TableSchemaSignature,
+    ) -> Self {
+        Self {
+            schema_name: schema_name.into(),
+            table_name: table_name.into(),
+            source_version,
+            schema_signature,
+            scope: StatisticsObservationScope::TableGlobal,
+            precision: StatisticPrecision::ObservedSample,
+        }
+    }
+
+    pub(crate) fn with_scope(mut self, scope: StatisticsObservationScope) -> Self {
+        self.scope = scope;
+        self
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn collect_batch_statistics(
+    plan: &BatchStatisticsPlan,
+    batches: &[RecordBatch],
+) -> Option<StatisticsObservation> {
+    if batches.is_empty() {
+        return None;
+    }
+
+    let schema = batches.first()?.schema();
+    let mut collector = BatchStatisticsCollector::new(plan.clone(), &schema);
+    for batch in batches {
+        collector.record_batch(batch);
+    }
+    collector.finish()
+}
+
+pub(crate) fn report_statistics_observation(observation: &StatisticsObservation) {
+    let payload = match serde_json::to_string(observation) {
+        Ok(payload) => payload,
+        Err(error) => {
+            tracing::warn!(
+                detail = %error,
+                "discarding statistics observation because it could not be serialized"
+            );
+            return;
+        }
+    };
+
+    let context = tracing::Span::current().context();
+    context.span().add_event(
+        STATISTICS_OBSERVATION_EVENT_NAME,
+        vec![KeyValue::new(
+            STATISTICS_OBSERVATION_EVENT_ATTRIBUTE,
+            payload,
+        )],
+    );
+}
+
+/// Wraps an execution plan and emits one statistics observation after all
+/// output partitions finish successfully, or a conservative limited observation
+/// when a parent operator stops consuming after observing only part of the scan.
+pub(crate) fn observe_execution_plan(
+    input: Arc<dyn ExecutionPlan>,
+    plan: BatchStatisticsPlan,
+) -> Arc<dyn ExecutionPlan> {
+    Arc::new(ObservingExec::new(input, plan))
+}
+
+#[derive(Debug)]
+struct ObservingExec {
+    input: Arc<dyn ExecutionPlan>,
+    plan: BatchStatisticsPlan,
+    accumulator: Arc<Mutex<PartitionedStatisticsAccumulator>>,
+}
+
+impl ObservingExec {
+    fn new(input: Arc<dyn ExecutionPlan>, plan: BatchStatisticsPlan) -> Self {
+        let partition_count = input.output_partitioning().partition_count().max(1);
+        Self {
+            input,
+            plan,
+            accumulator: Arc::new(Mutex::new(PartitionedStatisticsAccumulator::new(
+                partition_count,
+            ))),
+        }
+    }
+}
+
+impl DisplayAs for ObservingExec {
+    fn fmt_as(&self, _format: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "ObservingExec: table={}.{}",
+            self.plan.schema_name, self.plan.table_name
+        )
+    }
+}
+
+impl ExecutionPlan for ObservingExec {
+    fn name(&self) -> &'static str {
+        "ObservingExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<datafusion::physical_plan::PlanProperties> {
+        self.input.properties()
+    }
+
+    fn partition_statistics(
+        &self,
+        partition: Option<usize>,
+    ) -> Result<datafusion::common::Statistics> {
+        self.input.partition_statistics(partition)
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "ObservingExec expected one child, got {}",
+                children.len()
+            )));
+        }
+        Ok(Arc::new(Self::new(children.remove(0), self.plan.clone())))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let input = self.input.execute(partition, context)?;
+        Ok(Box::pin(ObservingStream::new(
+            input,
+            self.plan.clone(),
+            self.accumulator.clone(),
+        )))
+    }
+}
+
+struct ObservingStream {
+    input: SendableRecordBatchStream,
+    schema: SchemaRef,
+    plan: BatchStatisticsPlan,
+    accumulator: Arc<Mutex<PartitionedStatisticsAccumulator>>,
+    partition_finished: bool,
+}
+
+impl ObservingStream {
+    fn new(
+        input: SendableRecordBatchStream,
+        plan: BatchStatisticsPlan,
+        accumulator: Arc<Mutex<PartitionedStatisticsAccumulator>>,
+    ) -> Self {
+        let schema = input.schema();
+        Self {
+            input,
+            schema,
+            plan,
+            accumulator,
+            partition_finished: false,
+        }
+    }
+}
+
+impl RecordBatchStream for ObservingStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+impl Stream for ObservingStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.input.as_mut().poll_next(cx) {
+            Poll::Ready(Some(Ok(batch))) => {
+                record_observed_batch(&self.accumulator, &self.plan, &batch);
+                Poll::Ready(Some(Ok(batch)))
+            }
+            Poll::Ready(Some(Err(error))) => {
+                self.partition_finished = true;
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(None) => {
+                self.partition_finished = true;
+                finish_observed_partition(&self.accumulator);
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for ObservingStream {
+    fn drop(&mut self) {
+        if !self.partition_finished {
+            finish_partially_observed_scan(&self.accumulator);
+        }
+    }
+}
+
+fn record_observed_batch(
+    accumulator: &Mutex<PartitionedStatisticsAccumulator>,
+    plan: &BatchStatisticsPlan,
+    batch: &RecordBatch,
+) {
+    match accumulator.lock() {
+        Ok(mut accumulator) => accumulator.record_batch(plan, batch),
+        Err(error) => tracing::warn!(
+            detail = %error,
+            "discarding statistics batch because accumulator lock is poisoned"
+        ),
+    }
+}
+
+fn finish_observed_partition(accumulator: &Mutex<PartitionedStatisticsAccumulator>) {
+    match accumulator.lock() {
+        Ok(mut accumulator) => {
+            if let Some(observation) = accumulator.finish_partition() {
+                report_statistics_observation(&observation);
+            }
+        }
+        Err(error) => tracing::warn!(
+            detail = %error,
+            "discarding statistics observation because accumulator lock is poisoned"
+        ),
+    }
+}
+
+fn finish_partially_observed_scan(accumulator: &Mutex<PartitionedStatisticsAccumulator>) {
+    match accumulator.lock() {
+        Ok(mut accumulator) => {
+            if let Some(observation) = accumulator.finish_partial_scan() {
+                report_statistics_observation(&observation);
+            }
+        }
+        Err(error) => tracing::warn!(
+            detail = %error,
+            "discarding partial statistics observation because accumulator lock is poisoned"
+        ),
+    }
+}
+
+#[derive(Debug)]
+struct PartitionedStatisticsAccumulator {
+    remaining_partitions: usize,
+    collector: Option<BatchStatisticsCollector>,
+    emitted: bool,
+}
+
+impl PartitionedStatisticsAccumulator {
+    fn new(partition_count: usize) -> Self {
+        Self {
+            remaining_partitions: partition_count,
+            collector: None,
+            emitted: false,
+        }
+    }
+
+    fn record_batch(&mut self, plan: &BatchStatisticsPlan, batch: &RecordBatch) {
+        let collector = self.collector.get_or_insert_with(|| {
+            let schema = batch.schema();
+            BatchStatisticsCollector::new(plan.clone(), &schema)
+        });
+        collector.record_batch(batch);
+    }
+
+    fn finish_partition(&mut self) -> Option<StatisticsObservation> {
+        self.remaining_partitions = self.remaining_partitions.saturating_sub(1);
+        if self.remaining_partitions == 0 && !self.emitted {
+            self.emitted = true;
+            return self
+                .collector
+                .take()
+                .and_then(BatchStatisticsCollector::finish);
+        }
+        None
+    }
+
+    fn finish_partial_scan(&mut self) -> Option<StatisticsObservation> {
+        if self.emitted {
+            return None;
+        }
+        if !self
+            .collector
+            .as_ref()
+            .is_some_and(BatchStatisticsCollector::has_rows)
+        {
+            return None;
+        }
+
+        self.emitted = true;
+        let mut collector = self.collector.take()?;
+        collector.plan.scope = StatisticsObservationScope::Limited;
+        collector.finish()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BatchStatisticsCollector {
+    plan: BatchStatisticsPlan,
+    sample_count: u64,
+    columns: Vec<ColumnStatisticsCollector>,
+}
+
+impl BatchStatisticsCollector {
+    pub(crate) fn new(plan: BatchStatisticsPlan, schema: &SchemaRef) -> Self {
+        let columns = schema
+            .fields()
+            .iter()
+            .enumerate()
+            .filter_map(|(index, field)| {
+                let signature = column_signature(&plan, field.name())?;
+                if signature.is_virtual || signature.is_required_filter {
+                    return None;
+                }
+                Some(ColumnStatisticsCollector {
+                    index,
+                    column_name: field.name().clone(),
+                    null_count: 0,
+                    distinct: DistinctCollector::for_signature(signature, field.data_type()),
+                })
+            })
+            .collect();
+
+        Self {
+            plan,
+            sample_count: 0,
+            columns,
+        }
+    }
+
+    pub(crate) fn record_batch(&mut self, batch: &RecordBatch) {
+        self.sample_count = self
+            .sample_count
+            .saturating_add(u64::try_from(batch.num_rows()).unwrap_or(u64::MAX));
+        for column in &mut self.columns {
+            column.record_batch(batch);
+        }
+    }
+
+    pub(crate) fn finish(self) -> Option<StatisticsObservation> {
+        if self.columns.is_empty() {
+            return None;
+        }
+
+        let columns = self
+            .columns
+            .into_iter()
+            .map(|column| column.finish(self.sample_count, self.plan.precision))
+            .collect();
+
+        Some(StatisticsObservation {
+            schema_name: self.plan.schema_name,
+            table_name: self.plan.table_name,
+            source_version: self.plan.source_version,
+            schema_signature: self.plan.schema_signature,
+            scope: self.plan.scope,
+            observed_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+            columns,
+        })
+    }
+
+    fn has_rows(&self) -> bool {
+        self.sample_count > 0
+    }
+}
+
+#[derive(Debug)]
+struct ColumnStatisticsCollector {
+    index: usize,
+    column_name: String,
+    null_count: u64,
+    distinct: DistinctCollector,
+}
+
+impl ColumnStatisticsCollector {
+    fn record_batch(&mut self, batch: &RecordBatch) {
+        let Some(array) = batch.columns().get(self.index) else {
+            return;
+        };
+        self.null_count = self
+            .null_count
+            .saturating_add(u64::try_from(array.null_count()).unwrap_or(u64::MAX));
+        self.distinct.record_array(array.as_ref());
+    }
+
+    fn finish(
+        self,
+        sample_count: u64,
+        precision: StatisticPrecision,
+    ) -> ColumnStatisticsObservation {
+        ColumnStatisticsObservation {
+            column_name: self.column_name,
+            sample_count,
+            null_count: Some(StatisticValue {
+                value: self.null_count,
+                precision,
+            }),
+            approx_distinct_count: self
+                .distinct
+                .finish()
+                .map(|value| StatisticValue { value, precision }),
+        }
+    }
+}
+
+fn column_signature<'a>(
+    plan: &'a BatchStatisticsPlan,
+    column_name: &str,
+) -> Option<&'a ColumnSchemaSignature> {
+    plan.schema_signature
+        .columns
+        .iter()
+        .find(|column| column.name == column_name)
+}
+
+#[derive(Debug)]
+enum DistinctCollector {
+    Utf8(HashSet<String>),
+    Int64(HashSet<i64>),
+    TimestampMicros(HashSet<i64>),
+    Bool(HashSet<bool>),
+    Unsupported,
+    Capped,
+}
+
+impl DistinctCollector {
+    fn for_signature(signature: &ColumnSchemaSignature, arrow_data_type: &DataType) -> Self {
+        if signature.data_type == "Json" {
+            return Self::Unsupported;
+        }
+
+        match arrow_data_type {
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Self::Utf8(HashSet::new()),
+            DataType::Dictionary(_, value_type) if is_string_like(value_type.as_ref()) => {
+                Self::Utf8(HashSet::new())
+            }
+            DataType::Int64 => Self::Int64(HashSet::new()),
+            DataType::Boolean => Self::Bool(HashSet::new()),
+            DataType::Timestamp(TimeUnit::Microsecond, _) => Self::TimestampMicros(HashSet::new()),
+            _ => Self::Unsupported,
+        }
+    }
+
+    fn record_array(&mut self, array: &dyn Array) {
+        let result = match self {
+            Self::Utf8(values) => record_utf8_values(values, array),
+            Self::Int64(values) => record_int64_values::<Int64Array>(values, array),
+            Self::TimestampMicros(values) => {
+                record_int64_values::<TimestampMicrosecondArray>(values, array)
+            }
+            Self::Bool(values) => record_bool_values(values, array),
+            Self::Unsupported | Self::Capped => DistinctRecordResult::Ok,
+        };
+
+        match result {
+            DistinctRecordResult::Ok => {}
+            DistinctRecordResult::Unsupported => *self = Self::Unsupported,
+            DistinctRecordResult::Capped => *self = Self::Capped,
+        }
+    }
+
+    fn finish(self) -> Option<u64> {
+        match self {
+            Self::Utf8(values) => Some(u64::try_from(values.len()).unwrap_or(u64::MAX)),
+            Self::Int64(values) | Self::TimestampMicros(values) => {
+                Some(u64::try_from(values.len()).unwrap_or(u64::MAX))
+            }
+            Self::Bool(values) => Some(u64::try_from(values.len()).unwrap_or(u64::MAX)),
+            Self::Unsupported | Self::Capped => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DistinctRecordResult {
+    Ok,
+    Unsupported,
+    Capped,
+}
+
+fn record_utf8_values(values: &mut HashSet<String>, array: &dyn Array) -> DistinctRecordResult {
+    match array.data_type() {
+        DataType::Utf8 => {
+            let Some(array) = array.as_any().downcast_ref::<StringArray>() else {
+                return DistinctRecordResult::Unsupported;
+            };
+            record_string_array_values(values, array)
+        }
+        DataType::LargeUtf8 => {
+            let Some(array) = array.as_any().downcast_ref::<LargeStringArray>() else {
+                return DistinctRecordResult::Unsupported;
+            };
+            record_large_string_array_values(values, array)
+        }
+        DataType::Utf8View => {
+            let Some(array) = array.as_any().downcast_ref::<StringViewArray>() else {
+                return DistinctRecordResult::Unsupported;
+            };
+            record_string_view_array_values(values, array)
+        }
+        DataType::Dictionary(key_type, value_type) if is_string_like(value_type.as_ref()) => {
+            match key_type.as_ref() {
+                DataType::Int8 => record_dictionary_utf8_values::<Int8Type>(values, array),
+                DataType::Int16 => record_dictionary_utf8_values::<Int16Type>(values, array),
+                DataType::Int32 => record_dictionary_utf8_values::<Int32Type>(values, array),
+                DataType::Int64 => record_dictionary_utf8_values::<Int64Type>(values, array),
+                DataType::UInt8 => record_dictionary_utf8_values::<UInt8Type>(values, array),
+                DataType::UInt16 => record_dictionary_utf8_values::<UInt16Type>(values, array),
+                DataType::UInt32 => record_dictionary_utf8_values::<UInt32Type>(values, array),
+                DataType::UInt64 => record_dictionary_utf8_values::<UInt64Type>(values, array),
+                _ => DistinctRecordResult::Unsupported,
+            }
+        }
+        _ => DistinctRecordResult::Unsupported,
+    }
+}
+
+fn is_string_like(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+    )
+}
+
+fn record_string_array_values(
+    values: &mut HashSet<String>,
+    array: &StringArray,
+) -> DistinctRecordResult {
+    record_string_values(values, array.len(), |row| {
+        array.is_valid(row).then(|| array.value(row))
+    })
+}
+
+fn record_large_string_array_values(
+    values: &mut HashSet<String>,
+    array: &LargeStringArray,
+) -> DistinctRecordResult {
+    record_string_values(values, array.len(), |row| {
+        array.is_valid(row).then(|| array.value(row))
+    })
+}
+
+fn record_string_view_array_values(
+    values: &mut HashSet<String>,
+    array: &StringViewArray,
+) -> DistinctRecordResult {
+    record_string_values(values, array.len(), |row| {
+        array.is_valid(row).then(|| array.value(row))
+    })
+}
+
+fn record_string_values<'a>(
+    values: &mut HashSet<String>,
+    len: usize,
+    mut value_at: impl FnMut(usize) -> Option<&'a str>,
+) -> DistinctRecordResult {
+    for row in 0..len {
+        if let Some(value) = value_at(row) {
+            values.insert(value.to_string());
+            if values.len() > DISTINCT_COUNT_MAX_VALUES {
+                return DistinctRecordResult::Capped;
+            }
+        }
+    }
+    DistinctRecordResult::Ok
+}
+
+fn record_dictionary_utf8_values<K>(
+    values: &mut HashSet<String>,
+    array: &dyn Array,
+) -> DistinctRecordResult
+where
+    K: ArrowDictionaryKeyType,
+{
+    let Some(array) = array.as_any().downcast_ref::<DictionaryArray<K>>() else {
+        return DistinctRecordResult::Unsupported;
+    };
+    let dictionary_values = array.values();
+
+    for row in 0..array.len() {
+        let Some(key) = array.key(row) else {
+            continue;
+        };
+        if let Some(value) = string_value_at(dictionary_values.as_ref(), key) {
+            values.insert(value.to_string());
+            if values.len() > DISTINCT_COUNT_MAX_VALUES {
+                return DistinctRecordResult::Capped;
+            }
+        }
+    }
+    DistinctRecordResult::Ok
+}
+
+fn string_value_at(array: &dyn Array, index: usize) -> Option<&str> {
+    match array.data_type() {
+        DataType::Utf8 => {
+            let array = array.as_any().downcast_ref::<StringArray>()?;
+            (index < array.len() && array.is_valid(index)).then(|| array.value(index))
+        }
+        DataType::LargeUtf8 => {
+            let array = array.as_any().downcast_ref::<LargeStringArray>()?;
+            (index < array.len() && array.is_valid(index)).then(|| array.value(index))
+        }
+        DataType::Utf8View => {
+            let array = array.as_any().downcast_ref::<StringViewArray>()?;
+            (index < array.len() && array.is_valid(index)).then(|| array.value(index))
+        }
+        _ => None,
+    }
+}
+
+fn record_int64_values<T>(values: &mut HashSet<i64>, array: &dyn Array) -> DistinctRecordResult
+where
+    T: Array + 'static,
+    for<'a> &'a T: Int64Values,
+{
+    let Some(array) = array.as_any().downcast_ref::<T>() else {
+        return DistinctRecordResult::Unsupported;
+    };
+    for row in 0..array.len() {
+        if array.is_valid(row) {
+            values.insert(array.int64_value(row));
+            if values.len() > DISTINCT_COUNT_MAX_VALUES {
+                return DistinctRecordResult::Capped;
+            }
+        }
+    }
+    DistinctRecordResult::Ok
+}
+
+trait Int64Values {
+    fn int64_value(self, index: usize) -> i64;
+}
+
+impl Int64Values for &Int64Array {
+    fn int64_value(self, index: usize) -> i64 {
+        self.value(index)
+    }
+}
+
+impl Int64Values for &TimestampMicrosecondArray {
+    fn int64_value(self, index: usize) -> i64 {
+        self.value(index)
+    }
+}
+
+fn record_bool_values(values: &mut HashSet<bool>, array: &dyn Array) -> DistinctRecordResult {
+    let Some(array) = array.as_any().downcast_ref::<BooleanArray>() else {
+        return DistinctRecordResult::Unsupported;
+    };
+    for row in 0..array.len() {
+        if array.is_valid(row) {
+            values.insert(array.value(row));
+            if values.len() > DISTINCT_COUNT_MAX_VALUES {
+                return DistinctRecordResult::Capped;
+            }
+        }
+    }
+    DistinctRecordResult::Ok
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{Float64Array, Int64Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    use super::{BatchStatisticsPlan, DISTINCT_COUNT_MAX_VALUES, collect_batch_statistics};
+    use crate::contracts::{
+        ColumnSchemaSignature, StatisticsObservationScope, TableSchemaSignature,
+    };
+
+    fn signature() -> TableSchemaSignature {
+        TableSchemaSignature {
+            columns: vec![
+                ColumnSchemaSignature {
+                    name: "id".to_string(),
+                    data_type: "Int64".to_string(),
+                    nullable: false,
+                    is_virtual: false,
+                    is_required_filter: false,
+                },
+                ColumnSchemaSignature {
+                    name: "name".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: true,
+                    is_virtual: false,
+                    is_required_filter: false,
+                },
+                ColumnSchemaSignature {
+                    name: "score".to_string(),
+                    data_type: "Float64".to_string(),
+                    nullable: true,
+                    is_virtual: false,
+                    is_required_filter: false,
+                },
+                ColumnSchemaSignature {
+                    name: "payload".to_string(),
+                    data_type: "Json".to_string(),
+                    nullable: true,
+                    is_virtual: false,
+                    is_required_filter: false,
+                },
+                ColumnSchemaSignature {
+                    name: "filter".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: true,
+                    is_virtual: true,
+                    is_required_filter: true,
+                },
+            ],
+            required_filters: vec!["filter".to_string()],
+        }
+    }
+
+    #[test]
+    fn collects_null_and_distinct_counts_for_supported_types() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("score", DataType::Float64, true),
+            Field::new("payload", DataType::Utf8, true),
+            Field::new("filter", DataType::Utf8, true),
+        ]));
+        let batch = datafusion::arrow::array::RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int64Array::from(vec![1, 2, 3, 3])),
+                Arc::new(StringArray::from(vec![
+                    Some("alpha"),
+                    Some("beta"),
+                    None,
+                    Some("alpha"),
+                ])),
+                Arc::new(Float64Array::from(vec![
+                    Some(1.0),
+                    Some(2.0),
+                    None,
+                    Some(2.0),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some(r#"{"kind":"alpha"}"#),
+                    Some(r#"{"kind":"beta"}"#),
+                    None,
+                    Some(r#"{"kind":"alpha"}"#),
+                ])),
+                Arc::new(StringArray::from(vec![
+                    Some("x"),
+                    Some("x"),
+                    Some("x"),
+                    Some("x"),
+                ])),
+            ],
+        )
+        .expect("batch");
+        let plan =
+            BatchStatisticsPlan::table_global("local", "events", Some("0.1.0".into()), signature());
+
+        let observation = collect_batch_statistics(&plan, &[batch]).expect("observation");
+
+        assert_eq!(observation.scope, StatisticsObservationScope::TableGlobal);
+        assert_eq!(observation.columns.len(), 4);
+        let by_name = observation
+            .columns
+            .iter()
+            .map(|column| (column.column_name.as_str(), column))
+            .collect::<std::collections::HashMap<_, _>>();
+        let id = by_name.get("id").expect("id stats");
+        let name = by_name.get("name").expect("name stats");
+        let score = by_name.get("score").expect("score stats");
+        let payload = by_name.get("payload").expect("payload stats");
+        assert_eq!(id.approx_distinct_count.as_ref().unwrap().value, 3);
+        assert_eq!(name.null_count.as_ref().unwrap().value, 1);
+        assert_eq!(name.approx_distinct_count.as_ref().unwrap().value, 2);
+        assert!(score.approx_distinct_count.is_none());
+        assert_eq!(payload.null_count.as_ref().unwrap().value, 1);
+        assert!(payload.approx_distinct_count.is_none());
+        assert!(!by_name.contains_key("filter"));
+    }
+
+    #[test]
+    fn high_cardinality_distinct_counts_are_capped() {
+        let schema = Arc::new(Schema::new(vec![Field::new("name", DataType::Utf8, true)]));
+        let values = (0..=DISTINCT_COUNT_MAX_VALUES)
+            .map(|index| Some(format!("value-{index}")))
+            .collect::<Vec<_>>();
+        let batch = datafusion::arrow::array::RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringArray::from(values))],
+        )
+        .expect("batch");
+        let signature = TableSchemaSignature {
+            columns: vec![ColumnSchemaSignature {
+                name: "name".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: true,
+                is_virtual: false,
+                is_required_filter: false,
+            }],
+            required_filters: Vec::new(),
+        };
+        let plan = BatchStatisticsPlan::table_global("local", "events", None, signature);
+
+        let observation = collect_batch_statistics(&plan, &[batch]).expect("observation");
+
+        let name = observation
+            .columns
+            .iter()
+            .find(|column| column.column_name == "name")
+            .expect("name stats");
+        assert_eq!(name.null_count.as_ref().expect("null count").value, 0);
+        assert!(name.approx_distinct_count.is_none());
+    }
+}

--- a/crates/coral-engine/tests/engine/harness.rs
+++ b/crates/coral-engine/tests/engine/harness.rs
@@ -6,10 +6,18 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-use coral_engine::{CoreError, QueryExecution, QueryRuntimeConfig, QuerySource, StatusCode};
+use coral_engine::{
+    CoralQuery, CoreError, QueryExecution, QueryRuntimeConfig, QuerySource, StatisticsObservation,
+    StatusCode,
+};
 use coral_spec::parse_source_manifest_value;
+use opentelemetry::Value as OtelValue;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SpanData};
 use parquet::arrow::ArrowWriter;
 use serde_json::{Value, json};
+use tracing::Instrument as _;
+use tracing_subscriber::layer::SubscriberExt as _;
 
 pub(crate) fn test_runtime() -> QueryRuntimeConfig {
     QueryRuntimeConfig::default()
@@ -50,6 +58,55 @@ pub(crate) fn execution_to_rows(execution: &QueryExecution) -> Vec<Value> {
 pub(crate) fn assert_row_count(execution: &QueryExecution, expected: usize) {
     assert_eq!(execution.row_count(), expected);
     assert_eq!(execution_to_rows(execution).len(), expected);
+}
+
+pub(crate) async fn execute_sql_with_trace_observations(
+    sources: &[QuerySource],
+    sql: &str,
+) -> Result<(QueryExecution, Vec<StatisticsObservation>), CoreError> {
+    let source_vec = sources.to_vec();
+    let sql = sql.to_string();
+    let exporter = InMemorySpanExporter::default();
+    let provider = SdkTracerProvider::builder()
+        .with_simple_exporter(exporter.clone())
+        .build();
+    let tracer = provider.tracer("coral-engine-test");
+    let subscriber =
+        tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+    let result = {
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let span = tracing::info_span!("coral.query");
+        let result = CoralQuery::execute_sql(&source_vec, test_runtime(), &sql)
+            .instrument(span.clone())
+            .await;
+        drop(span);
+        result
+    };
+
+    provider.force_flush().expect("trace provider should flush");
+    let spans = exporter
+        .get_finished_spans()
+        .expect("finished spans should be readable");
+    let observations = statistics_observations_from_spans(&spans);
+    result.map(|execution| (execution, observations))
+}
+
+fn statistics_observations_from_spans(spans: &[SpanData]) -> Vec<StatisticsObservation> {
+    spans
+        .iter()
+        .flat_map(|span| {
+            span.events
+                .events
+                .iter()
+                .flat_map(|event| event.attributes.iter())
+        })
+        .filter(|attribute| attribute.key.as_str() == "coral.statistics.observation")
+        .filter_map(|attribute| match &attribute.value {
+            OtelValue::String(value) => serde_json::from_str(value.as_str()).ok(),
+            _ => None,
+        })
+        .collect()
 }
 
 #[expect(

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use coral_engine::{
     CoralQuery, CoreError, EngineExtensions, QueryParameterValue, QueryParameters,
     QueryRuntimeConfig, QueryRuntimeContext, RequestAuthenticator, RequestAuthenticatorError,
-    StatusCode,
+    StatisticsObservationScope, StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -23,7 +23,8 @@ use wiremock::matchers::{
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 use crate::harness::{
-    build_source, build_source_with_secrets, execution_to_rows, test_runtime, users_rows,
+    build_source, build_source_with_secrets, execute_sql_with_trace_observations,
+    execution_to_rows, test_runtime, users_rows,
 };
 
 fn base_http_manifest(name: &str, base_url: &str) -> Value {
@@ -345,17 +346,64 @@ async fn select_all_from_http_source() {
 
     let source = build_source(base_http_manifest("http_users", &server.uri()));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT id, name, email FROM http_users.users ORDER BY id",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT id, name, email FROM http_users.users ORDER BY id",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
     assert_eq!(rows, users_rows());
+
+    assert_eq!(observations.len(), 1);
+    assert_eq!(
+        observations[0].scope,
+        StatisticsObservationScope::TableGlobal
+    );
+    let by_name = observations[0]
+        .columns
+        .iter()
+        .map(|column| (column.column_name.as_str(), column))
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(by_name["id"].sample_count, 3);
+    assert_eq!(
+        by_name["name"]
+            .approx_distinct_count
+            .as_ref()
+            .unwrap()
+            .value,
+        3
+    );
+}
+
+#[tokio::test]
+async fn default_capped_http_scan_emits_limited_statistics_observation() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_default_limit", &server.uri());
+    manifest["tables"][0]["fetch_limit_default"] = json!(2);
+    let source = build_source(manifest);
+
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT id, name, email FROM http_default_limit.users ORDER BY id",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
+
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[0]["id"], 1);
+    assert_eq!(rows[1]["id"], 2);
+
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].scope, StatisticsObservationScope::Limited);
 }
 
 #[tokio::test]
@@ -466,17 +514,23 @@ async fn select_with_where_filter_pushdown() {
     ]);
     let source = build_source(manifest);
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT id, name FROM http_filter.users WHERE id = 2",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT id, name FROM http_filter.users WHERE id = 2",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
     assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+
+    assert_eq!(observations.len(), 1);
+    assert_eq!(
+        observations[0].scope,
+        StatisticsObservationScope::Filtered {
+            filter_columns: vec!["id".to_string()]
+        }
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -4,15 +4,16 @@
     reason = "test code: assertion-style indexing is idiomatic in tests"
 )]
 
-use std::{fs, path::Path};
+use std::path::Path;
 
-use coral_engine::{CoralQuery, CoreError, StatusCode};
+use coral_engine::{CoralQuery, CoreError, StatisticsObservationScope, StatusCode};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    assert_row_count, assert_table_not_found, build_source, dir_url, execution_to_rows,
-    test_runtime, users_rows, write_jsonl_file,
+    assert_row_count, assert_table_not_found, build_source, dir_url,
+    execute_sql_with_trace_observations, execution_to_rows, test_runtime, users_rows,
+    write_jsonl_file,
 };
 
 fn jsonl_manifest(name: &str, dir: &Path, glob: &str) -> Value {
@@ -111,9 +112,8 @@ async fn select_all_from_jsonl_source() {
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
     let source = build_source(jsonl_manifest("jsonl_users", temp.path(), "**/*.jsonl"));
 
-    let execution = CoralQuery::execute_sql(
+    let (execution, observations) = execute_sql_with_trace_observations(
         &[source],
-        test_runtime(),
         "SELECT id, name, email FROM jsonl_users.users ORDER BY id",
     )
     .await
@@ -121,6 +121,21 @@ async fn select_all_from_jsonl_source() {
 
     assert_row_count(&execution, 3);
     assert_eq!(execution_to_rows(&execution), users_rows());
+
+    assert_eq!(observations.len(), 1);
+    assert_eq!(
+        observations[0].scope,
+        StatisticsObservationScope::TableGlobal
+    );
+    let observed_columns = observations[0]
+        .columns
+        .iter()
+        .map(|column| column.column_name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(observed_columns, vec!["id", "name", "email"]);
+    for column in &observations[0].columns {
+        assert_eq!(column.sample_count, 3);
+    }
 }
 
 #[tokio::test]
@@ -233,15 +248,13 @@ async fn select_with_column_projection() {
         "**/*.jsonl",
     ));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT name FROM jsonl_projection.users ORDER BY name DESC",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT name FROM jsonl_projection.users ORDER BY name DESC",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
     assert_eq!(
         rows,
@@ -251,6 +264,18 @@ async fn select_with_column_projection() {
             json!({"name": "Ada"})
         ]
     );
+
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].scope, StatisticsObservationScope::Unknown);
+    let observed_columns = observations[0]
+        .columns
+        .iter()
+        .map(|column| column.column_name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(observed_columns, vec!["name"]);
+    for column in &observations[0].columns {
+        assert_eq!(column.sample_count, 3);
+    }
 }
 
 #[tokio::test]
@@ -259,17 +284,26 @@ async fn select_with_where_filter() {
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
     let source = build_source(jsonl_manifest("jsonl_filter", temp.path(), "**/*.jsonl"));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT id, name FROM jsonl_filter.users WHERE id = 2",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT id, name, email FROM jsonl_filter.users WHERE id = 2",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
-    assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+    assert_eq!(
+        rows,
+        vec![json!({"id": 2, "name": "Grace", "email": "grace@example.com"})]
+    );
+    assert_eq!(observations.len(), 1);
+    assert_eq!(
+        observations[0].scope,
+        StatisticsObservationScope::TableGlobal
+    );
+    for column in &observations[0].columns {
+        assert_eq!(column.sample_count, 3);
+    }
 }
 
 #[tokio::test]
@@ -297,28 +331,36 @@ async fn select_with_order_by_and_limit() {
 #[tokio::test]
 async fn select_with_limit_returns_rows() {
     let temp = TempDir::new().expect("temp dir");
-    fs::write(
-        temp.path().join("users.jsonl"),
-        b"{\"id\":1,\"name\":\"Ada\",\"email\":\"ada@example.com\"}\n{\"id\":2,\"name\":\"Grace\",\"email\":\"grace@example.com\"}\n",
-    )
-    .expect("jsonl fixture should be written");
+    write_jsonl_file(temp.path(), "one.jsonl", &users_rows()[..1]);
+    write_jsonl_file(temp.path(), "two.jsonl", &users_rows()[1..]);
     let source = build_source(jsonl_manifest(
         "jsonl_stream_limit",
         temp.path(),
         "**/*.jsonl",
     ));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT id FROM jsonl_stream_limit.users LIMIT 1",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT id, name, email FROM jsonl_stream_limit.users LIMIT 1",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
-    assert_eq!(rows, vec![json!({"id": 1})]);
+    assert_eq!(rows.len(), 1);
+    assert!(
+        rows.iter().all(|row| row.get("id").is_some()),
+        "limited scan should return one projected row"
+    );
+    assert_eq!(observations.len(), 1);
+    assert_eq!(observations[0].scope, StatisticsObservationScope::Limited);
+    assert!(
+        observations[0]
+            .columns
+            .iter()
+            .all(|column| column.sample_count > 0),
+        "limited scan should emit the rows it consumed"
+    );
 }
 
 #[tokio::test]
@@ -327,17 +369,17 @@ async fn select_count_aggregation() {
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
     let source = build_source(jsonl_manifest("jsonl_count", temp.path(), "**/*.jsonl"));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT COUNT(*) AS n FROM jsonl_count.users",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT COUNT(*) AS n FROM jsonl_count.users",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
     assert_eq!(rows, vec![json!({"n": 3})]);
+
+    assert!(observations.is_empty());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Ticket

- [SOURCE-470](https://linear.app/withcoral/issue/SOURCE-470/add-column-level-statistics-to-coralcolumns-nullability-rate)

## What This PR Does

Adds engine-side scan observation reporting through telemetry.

Concretely, this PR:

- Collects bounded column statistics for supported scalar scan output columns.
- Emits structured `column_statistics` observations as telemetry events on query/scan traces.
- Classifies observation scope from confirmed scan work rather than logical query shape where providers do not push filters/projections/limits.
- Emits conservative limited observations when a parent operator stops consuming file partitions before EOF.
- Leaves unsupported, awkward, JSON, nested, and unsafe cases nullable rather than inventing misleading stats.

## What This PR Does Not Do

- Does not persist statistics.
- Does not return statistics through `QueryExecution`.
- Does not update `coral.columns` directly.
- Does not promote non-global observations into table-global catalog stats.

The important contract is: observations are reported once through the telemetry pipeline; app code may later rebuild a cache from local trace history.

## Stack Position

Depends on #289. Feeds #291, which materializes a rebuildable app cache from local trace history.

## Validation

Rebased on fresh `origin/main` at `b4692fd5`.

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=target/source-470-check cargo test --locked -p coral-engine`
- `CARGO_TARGET_DIR=target/source-470-check cargo test --locked -p coral-app statistics`
- `CARGO_TARGET_DIR=target/source-470-check cargo clippy --locked -p coral-engine --all-targets --all-features -- -D warnings`

Fresh-main restack preserved main's chunked JSON execution path and file metadata providers while keeping SOURCE-470 observations on the telemetry pipeline.

