### PR TITLE
feat(app): cache column stats from traces

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -306,7 +306,8 @@ impl ServerBuilder {
             query_runtime_context,
             layout.clone(),
             self.config.engine_extensions_providers,
-        );
+        )
+        .with_local_trace_store(active_trace_store.clone());
         let search_manager = SearchManager::new(layout, config_store);
         let trace_components =
             active_trace_store.map_or_else(TraceServerComponents::default, |store| {

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -8,7 +8,8 @@ use std::time::Instant;
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, DescribeTableInfo, QueryExecution,
     QueryExecutionProvenance, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    RuntimeSourcePackage, SourceInputResolver, SourceValidationReport, StatusCode, TableInfo,
+    RuntimeSourcePackage, SourceInputResolver, SourceValidationReport, StatisticsProfile,
+    StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -31,8 +32,8 @@ use crate::sources::materialization::{
 };
 use crate::sources::model::InstalledSource;
 use crate::sources::runtime_package::runtime_components_for_v4_source;
-use crate::state::{AppConfig, AppStateLayout, ConfigStore};
-use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
+use crate::state::{AppConfig, AppStateLayout, ConfigStore, StatisticsStore};
+use crate::telemetry::{InstalledLocalTraceStore, WORKSPACE_SPAN_ATTRIBUTE};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug)]
@@ -63,6 +64,8 @@ struct LoadedQuerySource {
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
     credential_manager: CredentialManager,
+    statistics_store: StatisticsStore,
+    local_trace_store: Option<InstalledLocalTraceStore>,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
@@ -79,10 +82,20 @@ impl QueryManager {
         Self {
             config_store,
             credential_manager,
+            statistics_store: StatisticsStore::new(layout.clone()),
+            local_trace_store: None,
             runtime_context,
             layout,
             engine_extensions_providers,
         }
+    }
+
+    pub(crate) fn with_local_trace_store(
+        mut self,
+        local_trace_store: Option<InstalledLocalTraceStore>,
+    ) -> Self {
+        self.local_trace_store = local_trace_store;
+        self
     }
 
     pub(crate) async fn list_tables(
@@ -108,6 +121,7 @@ impl QueryManager {
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
+                        StatisticsProfile::empty(),
                     )
                     .map_err(QueryManagerError::App)?;
                 let sources = query_sources_from_loaded(&loaded_sources);
@@ -143,6 +157,7 @@ impl QueryManager {
                         &loaded_sources,
                         &config,
                         CredentialResolutionMode::StoredOnly,
+                        StatisticsProfile::empty(),
                     )
                     .map_err(QueryManagerError::App)?;
                 let sources = query_sources_from_loaded(&loaded_sources);
@@ -203,7 +218,7 @@ impl QueryManager {
         sql: &str,
         attribution: &QueryAttribution,
     ) -> Result<QueryExecution, QueryManagerError> {
-        run_query_operation(
+        let result = run_query_operation(
             QueryOperation::ExecuteSql,
             workspace_name,
             sql,
@@ -212,18 +227,30 @@ impl QueryManager {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &loaded_sources, &config)
-                    .map_err(QueryManagerError::App)?;
                 let sources = query_sources_from_loaded(&loaded_sources);
-                CoralQuery::execute_sql(&sources, runtime, sql)
+                let statistics = self.load_statistics_profile(workspace_name, &sources);
+                let runtime = self
+                    .runtime_config_with_statistics(
+                        workspace_name,
+                        &loaded_sources,
+                        &config,
+                        statistics,
+                    )
+                    .map_err(QueryManagerError::App)?;
+                let execution = CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
-                    .map_err(QueryManagerError::Core)
+                    .map_err(QueryManagerError::Core)?;
+                Ok(execution)
             },
             |execution| Some(u64::try_from(execution.row_count()).unwrap_or(u64::MAX)),
             |span, execution| record_query_provenance(span, execution.provenance()),
         )
-        .await
+        .await;
+        if result.is_ok() {
+            self.refresh_statistics_profile_from_traces(workspace_name)
+                .await;
+        }
+        result
     }
 
     pub(crate) async fn explain_sql(
@@ -241,10 +268,16 @@ impl QueryManager {
                 let (loaded_sources, config) = self
                     .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
-                let runtime = self
-                    .runtime_config(workspace_name, &loaded_sources, &config)
-                    .map_err(QueryManagerError::App)?;
                 let sources = query_sources_from_loaded(&loaded_sources);
+                let statistics = self.load_statistics_profile(workspace_name, &sources);
+                let runtime = self
+                    .runtime_config_with_statistics(
+                        workspace_name,
+                        &loaded_sources,
+                        &config,
+                        statistics,
+                    )
+                    .map_err(QueryManagerError::App)?;
                 CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
@@ -434,17 +467,54 @@ impl QueryManager {
         ))
     }
 
+    fn load_statistics_profile(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[QuerySource],
+    ) -> StatisticsProfile {
+        match self.statistics_store.load_profile(workspace_name) {
+            Ok(mut profile) => {
+                profile.retain_sources(selected_sources.iter().map(QuerySource::source_name));
+                profile
+            }
+            Err(error) => {
+                tracing::warn!(
+                    workspace = %workspace_name,
+                    detail = %error,
+                    "failed to load workspace statistics profile"
+                );
+                StatisticsProfile::empty()
+            }
+        }
+    }
+
     fn runtime_config(
         &self,
         workspace_name: &WorkspaceName,
         selected_sources: &[LoadedQuerySource],
         config: &AppConfig,
     ) -> Result<QueryRuntimeConfig, AppError> {
+        self.runtime_config_with_statistics(
+            workspace_name,
+            selected_sources,
+            config,
+            StatisticsProfile::empty(),
+        )
+    }
+
+    fn runtime_config_with_statistics(
+        &self,
+        workspace_name: &WorkspaceName,
+        selected_sources: &[LoadedQuerySource],
+        config: &AppConfig,
+        statistics: StatisticsProfile,
+    ) -> Result<QueryRuntimeConfig, AppError> {
         self.runtime_config_with_credential_mode(
             workspace_name,
             selected_sources,
             config,
             CredentialResolutionMode::Refreshing,
+            statistics,
         )
     }
 
@@ -454,6 +524,7 @@ impl QueryManager {
         selected_sources: &[LoadedQuerySource],
         config: &AppConfig,
         credential_resolution_mode: CredentialResolutionMode,
+        statistics: StatisticsProfile,
     ) -> Result<QueryRuntimeConfig, AppError> {
         let query_sources = query_sources_from_loaded(selected_sources);
         let mut extensions =
@@ -489,7 +560,8 @@ impl QueryManager {
         extensions.source_input_resolver = Some(input_resolver);
         let mut runtime_context = self.runtime_context.clone();
         runtime_context.trace_context = Some(tracing::Span::current().context());
-        let mut runtime = QueryRuntimeConfig::new(runtime_context, extensions);
+        let mut runtime =
+            QueryRuntimeConfig::new(runtime_context, extensions).with_statistics(statistics);
         let selected_source_names = selected_sources
             .iter()
             .map(|source| source.query_source.source_name().to_string())
@@ -497,6 +569,65 @@ impl QueryManager {
         runtime.memory = config.memory_config()?;
         runtime.dependent_join = config.dependent_join_config(&selected_source_names)?;
         Ok(runtime)
+    }
+
+    async fn refresh_statistics_profile_from_traces(&self, workspace_name: &WorkspaceName) {
+        let Some(local_trace_store) = &self.local_trace_store else {
+            return;
+        };
+
+        crate::telemetry::force_flush_tracing();
+
+        let observations =
+            match crate::telemetry::load_statistics_observations(local_trace_store, workspace_name)
+                .await
+            {
+                Ok(observations) => observations,
+                Err(error) => {
+                    tracing::warn!(
+                        workspace = %workspace_name,
+                        detail = %error,
+                        "failed to load statistics observations from local trace history"
+                    );
+                    return;
+                }
+            };
+        let config = match self.config_store.load_config() {
+            Ok(config) => config,
+            Err(error) => {
+                tracing::warn!(
+                    workspace = %workspace_name,
+                    detail = %error,
+                    "failed to load config for statistics profile materialization"
+                );
+                return;
+            }
+        };
+        let loaded_sources = match self.load_query_sources_from_config(workspace_name, &config) {
+            Ok(sources) => sources,
+            Err(error) => {
+                tracing::warn!(
+                    workspace = %workspace_name,
+                    detail = %error,
+                    "failed to refresh query sources for statistics profile materialization"
+                );
+                return;
+            }
+        };
+        let sources = query_sources_from_loaded(&loaded_sources);
+        if let Err(error) = self.statistics_store.rebuild_profile_from_observations(
+            workspace_name,
+            &observations,
+            sources
+                .iter()
+                .map(|source| source.source_name().to_string()),
+        ) {
+            tracing::warn!(
+                workspace = %workspace_name,
+                detail = %error,
+                "failed to rebuild statistics profile from local trace history"
+            );
+        }
     }
 }
 
@@ -774,6 +905,7 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use arrow::json::ArrayWriter;
     use coral_engine::{
         EngineExtensions, QueryExecution, QueryExecutionProvenance, QueryTableFunctionUsage,
         QueryTableUsage, SourceInputResolutionContext, SourceInputResolver,
@@ -781,7 +913,7 @@ mod tests {
     };
     use coral_spec::parse_source_manifest_yaml;
     use serde_json::{Value, json};
-    use tempfile::TempDir;
+    use tempfile::{TempDir, tempdir};
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -789,6 +921,8 @@ mod tests {
     use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
     use crate::sources::manager::{ImportSourceCommand, SourceBindings, SourceManager};
     use crate::sources::model::SourceOrigin;
+    use crate::state::StatisticsStore;
+    use crate::storage::fs;
 
     struct QueryManagerFixture {
         _temp: TempDir,
@@ -1635,6 +1769,10 @@ surfaces:
         }
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "integration-style test keeps setup, execution, and assertions together for readability"
+    )]
     #[tokio::test]
     async fn runtime_input_resolver_uses_loaded_credential_snapshot() {
         let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
@@ -1824,5 +1962,198 @@ tables:
                 .as_deref(),
             Some("stored-token")
         );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_without_trace_history_keeps_statistics_empty() {
+        let temp = tempdir().expect("tempdir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("layout should be created");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("local_stats_jsonl").expect("source");
+        let data_dir = temp.path().join("jsonl-data");
+        std::fs::create_dir_all(&data_dir).expect("data dir");
+        std::fs::write(
+            data_dir.join("events.jsonl"),
+            r#"{"id":1,"category":"alpha","nullable_text":"one"}
+{"id":2,"category":"beta","nullable_text":null}
+{"id":3,"category":"alpha","nullable_text":"three"}
+"#,
+        )
+        .expect("jsonl fixture");
+
+        let manifest = format!(
+            r#"name: local_stats_jsonl
+version: 0.1.0
+dsl_version: 3
+backend: file
+tables:
+  - name: events
+    description: Events
+    format: jsonl
+    source:
+      location: file://{}/
+      glob: "**/*.jsonl"
+    columns:
+      - name: id
+        type: Int64
+      - name: category
+        type: Utf8
+      - name: nullable_text
+        type: Utf8
+        nullable: true
+"#,
+            data_dir.display()
+        );
+        let manifest_path = layout.manifest_file(&workspace, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("manifest dir");
+        fs::write_atomic(&manifest_path, manifest.as_bytes()).expect("manifest write");
+
+        let config_store = ConfigStore::new(layout.clone());
+        config_store
+            .upsert_source(
+                &workspace,
+                InstalledSource {
+                    name: source_name,
+                    version: Some("0.1.0".to_string()),
+                    variables: BTreeMap::new(),
+                    secrets: Vec::new(),
+                    credential_storage: None,
+                    origin: SourceOrigin::Imported,
+                },
+            )
+            .expect("install source");
+        let manager = QueryManager::new(
+            config_store,
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            QueryRuntimeContext::default(),
+            layout.clone(),
+            Vec::<Arc<dyn crate::query::extensions::EngineExtensionsProvider>>::new(),
+        );
+
+        manager
+            .execute_sql(
+                &workspace,
+                "SELECT id, category, nullable_text FROM local_stats_jsonl.events ORDER BY id",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("query should succeed");
+
+        let stored = StatisticsStore::new(layout.clone())
+            .load_profile(&workspace)
+            .expect("profile should load");
+        assert!(stored.sources.is_empty());
+
+        let catalog = manager
+            .execute_sql(
+                &workspace,
+                "SELECT column_name, stats_sample_count, approx_distinct_count, stats_precision \
+                 FROM coral.columns \
+                 WHERE schema_name = 'local_stats_jsonl' AND table_name = 'events' \
+                 ORDER BY ordinal_position",
+                &QueryAttribution::default(),
+            )
+            .await
+            .expect("catalog query should succeed");
+        let rows = execution_rows(&catalog);
+        let by_name = rows
+            .iter()
+            .map(|row| (row["column_name"].as_str().expect("column name"), row))
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let category = by_name.get("category").expect("category row");
+        assert!(
+            category
+                .get("stats_sample_count")
+                .is_none_or(Value::is_null)
+        );
+        assert!(
+            category
+                .get("approx_distinct_count")
+                .is_none_or(Value::is_null)
+        );
+        assert!(category.get("stats_precision").is_none_or(Value::is_null));
+    }
+
+    #[tokio::test]
+    async fn failed_query_does_not_create_statistics_profile() {
+        let temp = tempdir().expect("tempdir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("layout should be created");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let manager = QueryManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            QueryRuntimeContext::default(),
+            layout.clone(),
+            Vec::<Arc<dyn crate::query::extensions::EngineExtensionsProvider>>::new(),
+        );
+
+        let result = manager
+            .execute_sql(
+                &workspace,
+                "SELECT * FROM missing.table",
+                &QueryAttribution::default(),
+            )
+            .await;
+
+        let _ = result.unwrap_err();
+        let profile = StatisticsStore::new(layout)
+            .load_profile(&workspace)
+            .expect("profile should load");
+        assert!(profile.sources.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_metadata_does_not_load_persisted_statistics_profile() {
+        let temp = tempdir().expect("tempdir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        layout.ensure().expect("layout should be created");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let profile_path = layout.statistics_profile_file(&workspace);
+        std::fs::create_dir_all(profile_path.parent().expect("profile parent"))
+            .expect("profile dir");
+        std::fs::write(&profile_path, b"{ malformed json").expect("profile write");
+        let manager = QueryManager::new(
+            ConfigStore::new(layout.clone()),
+            CredentialManager::new(CredentialStore::new(layout.clone())),
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::<Arc<dyn crate::query::extensions::EngineExtensionsProvider>>::new(),
+        );
+
+        let tables = manager
+            .list_tables(&workspace, None, None, &QueryAttribution::default())
+            .await
+            .expect("list tables should not read malformed stats profile");
+        let catalog = manager
+            .list_catalog(&workspace, None, &QueryAttribution::default())
+            .await
+            .expect("list catalog should not read malformed stats profile");
+
+        assert!(!tables.is_empty());
+        assert!(tables.iter().all(|table| table.schema_name == "coral"));
+        assert!(!catalog.tables.is_empty());
+        assert!(
+            catalog
+                .tables
+                .iter()
+                .all(|table| table.schema_name == "coral")
+        );
+        assert!(catalog.table_functions.is_empty());
+    }
+
+    fn execution_rows(execution: &QueryExecution) -> Vec<Value> {
+        let mut bytes = Vec::new();
+        {
+            let mut writer = ArrayWriter::new(&mut bytes);
+            for batch in execution.batches() {
+                writer.write(batch).expect("batch should encode");
+            }
+            writer.finish().expect("writer should finish");
+        }
+        serde_json::from_slice(&bytes).expect("json rows")
     }
 }

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -545,7 +545,7 @@ impl SourceManager {
         }
         if let Err(error) = self
             .config_store
-            .remove_source_unlocked(workspace_name, source_name)
+            .remove_source_and_invalidate_statistics_unlocked(workspace_name, source_name)
         {
             let restore_dir_result = source_dir_backup.restore();
             self.restore_source_rollback_state_with_state_lock_held(
@@ -716,7 +716,7 @@ impl SourceManager {
         };
         if let Err(error) = self
             .config_store
-            .upsert_source_unlocked(workspace_name, stored.clone())
+            .upsert_source_and_invalidate_statistics_unlocked(workspace_name, stored.clone())
         {
             let restore_result = restore_materialization_backup(
                 &self.layout,
@@ -1172,6 +1172,12 @@ impl SourceManager {
             {
                 warn!("rollback: failed to remove source credential material: {e}");
             }
+            if let Err(e) = self
+                .config_store
+                .remove_source_unlocked(workspace_name, source_name)
+            {
+                warn!("rollback: failed to remove source config: {e}");
+            }
         }
     }
 
@@ -1563,6 +1569,10 @@ mod tests {
     use std::thread;
     use std::time::Duration;
 
+    use coral_engine::{
+        ColumnSchemaSignature, ColumnStatisticsObservation, StatisticPrecision, StatisticValue,
+        StatisticsObservation, StatisticsObservationScope, TableSchemaSignature,
+    };
     use tempfile::TempDir;
     use tokio::sync::mpsc;
     use tokio::task::JoinHandle;
@@ -1583,7 +1593,7 @@ mod tests {
     use crate::sources::catalog::describe_manifest;
     use crate::sources::materialization::{FINGERPRINT_FILENAME, PROJECTIONS_FILENAME};
     use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
-    use crate::state::{AppStateLayout, ConfigStore};
+    use crate::state::{AppStateLayout, ConfigStore, StatisticsStore};
     use crate::workspaces::WorkspaceName;
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
@@ -2330,6 +2340,51 @@ tables:
         assert!(needs_stored);
     }
 
+    fn messages_statistics_observation() -> StatisticsObservation {
+        StatisticsObservation {
+            schema_name: "secured_messages".to_string(),
+            table_name: "messages".to_string(),
+            source_version: Some("0.1.0".to_string()),
+            schema_signature: TableSchemaSignature {
+                columns: vec![ColumnSchemaSignature {
+                    name: "id".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: false,
+                    is_virtual: false,
+                    is_required_filter: false,
+                }],
+                required_filters: Vec::new(),
+            },
+            scope: StatisticsObservationScope::TableGlobal,
+            observed_at: "2026-05-06T00:00:00Z".to_string(),
+            columns: vec![ColumnStatisticsObservation {
+                column_name: "id".to_string(),
+                sample_count: 3,
+                null_count: Some(StatisticValue {
+                    value: 0,
+                    precision: StatisticPrecision::ObservedSample,
+                }),
+                approx_distinct_count: Some(StatisticValue {
+                    value: 3,
+                    precision: StatisticPrecision::ObservedSample,
+                }),
+            }],
+        }
+    }
+
+    fn seed_messages_statistics(layout: &AppStateLayout) {
+        StatisticsStore::new(layout.clone())
+            .merge_observations(&default_workspace(), &[messages_statistics_observation()])
+            .expect("seed statistics");
+    }
+
+    fn assert_messages_statistics_invalidated(layout: &AppStateLayout) {
+        let profile = StatisticsStore::new(layout.clone())
+            .load_profile(&default_workspace())
+            .expect("load profile");
+        assert!(!profile.sources.contains_key("secured_messages"));
+    }
+
     #[test]
     fn discover_sources_omits_core_v4_preview_sources() {
         let temp = TempDir::new().expect("temp dir");
@@ -2776,6 +2831,38 @@ tables:
     }
 
     #[test]
+    fn import_source_invalidates_existing_statistics() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        seed_messages_statistics(&layout);
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+
+        manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: vec![],
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("import source");
+
+        assert_messages_statistics_invalidated(&layout);
+    }
+
+    #[test]
     fn import_source_without_secret_material_does_not_probe_keychain() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
@@ -2818,6 +2905,42 @@ tables:
     }
 
     #[test]
+    fn delete_source_invalidates_existing_statistics() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: vec![],
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("import source");
+        seed_messages_statistics(&layout);
+
+        manager
+            .delete_source(&default_workspace(), &source_name)
+            .expect("delete source");
+
+        assert_messages_statistics_invalidated(&layout);
+    }
+
+    #[test]
     fn import_missing_secret_does_not_probe_keychain_for_new_source() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
@@ -2847,6 +2970,86 @@ tables:
                 .contains("missing required source secret 'API_TOKEN'"),
             "unexpected error: {error:#}"
         );
+    }
+
+    #[test]
+    fn import_discards_corrupt_statistics_profile() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let profile_path = layout.statistics_profile_file(&default_workspace());
+        std::fs::create_dir_all(profile_path.parent().expect("profile parent"))
+            .expect("profile dir");
+        std::fs::write(&profile_path, "{not-json").expect("write corrupt profile");
+
+        manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: vec![],
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("import source");
+
+        let profile = StatisticsStore::new(layout)
+            .load_profile(&default_workspace())
+            .expect("profile");
+        assert!(profile.sources.is_empty());
+    }
+
+    #[test]
+    fn delete_discards_corrupt_statistics_profile() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::new(layout.clone());
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager =
+            SourceManager::new_for_tests(config_store, credential_manager, layout.clone());
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: vec![],
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("import source");
+        let profile_path = layout.statistics_profile_file(&default_workspace());
+        std::fs::create_dir_all(profile_path.parent().expect("profile parent"))
+            .expect("profile dir");
+        std::fs::write(&profile_path, "{not-json").expect("write corrupt profile");
+
+        manager
+            .delete_source(&default_workspace(), &source_name)
+            .expect("delete source");
+
+        let profile = StatisticsStore::new(layout)
+            .load_profile(&default_workspace())
+            .expect("profile");
+        assert!(profile.sources.is_empty());
     }
 
     #[test]

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -12,6 +12,7 @@ use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
+use crate::state::statistics;
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::{DeletedWorkspace, WorkspaceName, WorkspaceRecord, WorkspaceStore};
 
@@ -609,6 +610,19 @@ impl ConfigStore {
         self.update_catalog_unlocked(|catalog| catalog.upsert_source(workspace_name, source))
     }
 
+    /// Upserts one installed source and invalidates its persisted statistics
+    /// without taking the app state lock.
+    ///
+    /// Callers must already hold the state lock in exclusive mode.
+    pub(crate) fn upsert_source_and_invalidate_statistics_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: InstalledSource,
+    ) -> Result<(), AppError> {
+        statistics::invalidate_source_unlocked(&self.layout, workspace_name, &source.name)?;
+        self.upsert_source_unlocked(workspace_name, source)
+    }
+
     #[cfg(test)]
     pub(crate) fn upsert_source(
         &self,
@@ -633,6 +647,19 @@ impl ConfigStore {
         self.update_catalog_unlocked(|catalog| {
             catalog.remove_source(workspace_name, source_name);
         })
+    }
+
+    /// Removes one installed source and invalidates its persisted statistics
+    /// without taking the app state lock.
+    ///
+    /// Callers must already hold the state lock in exclusive mode.
+    pub(crate) fn remove_source_and_invalidate_statistics_unlocked(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        statistics::invalidate_source_unlocked(&self.layout, workspace_name, source_name)?;
+        self.remove_source_unlocked(workspace_name, source_name)
     }
 
     #[cfg(test)]

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -107,6 +107,14 @@ impl AppStateLayout {
             .join("episodes.jsonl")
     }
 
+    pub(crate) fn statistics_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.workspace_dir(workspace_name).join("statistics")
+    }
+
+    pub(crate) fn statistics_profile_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.statistics_dir(workspace_name).join("profile.json")
+    }
+
     pub(crate) fn source_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -319,6 +327,14 @@ mod tests {
         assert_eq!(
             layout.local_trace_store_dir(),
             config_dir.join("telemetry").join("traces")
+        );
+        assert_eq!(
+            layout.statistics_profile_file(&workspace_name),
+            config_dir
+                .join("workspaces")
+                .join("default")
+                .join("statistics")
+                .join("profile.json")
         );
     }
 

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -2,6 +2,7 @@
 
 mod config;
 mod layout;
+mod statistics;
 
 pub(crate) use config::{AppConfig, ConfigStore};
 pub(crate) use config::{
@@ -9,3 +10,4 @@ pub(crate) use config::{
     set_raw_feature_override,
 };
 pub(crate) use layout::AppStateLayout;
+pub(crate) use statistics::{StatisticsObservationRecord, StatisticsStore};

--- a/crates/coral-app/src/state/statistics.rs
+++ b/crates/coral-app/src/state/statistics.rs
@@ -1,0 +1,576 @@
+//! Workspace-scoped persisted column statistics.
+
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use coral_engine::{
+    ColumnStatistics, SourceStatistics, StatisticsObservation, StatisticsObservationScope,
+    StatisticsProfile, TableStatistics,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::bootstrap::AppError;
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::storage::fs::{self as storage_fs, FileLock};
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone)]
+pub(crate) struct StatisticsStore {
+    layout: AppStateLayout,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct StatisticsObservationRecord {
+    pub(crate) observation: StatisticsObservation,
+    pub(crate) trace_end_unix_nanos: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedStatisticsProfile {
+    version: u32,
+    #[serde(default)]
+    sources: BTreeMap<String, SourceStatistics>,
+    #[serde(default)]
+    source_observation_watermarks: BTreeMap<String, i64>,
+}
+
+impl Default for PersistedStatisticsProfile {
+    fn default() -> Self {
+        let profile = StatisticsProfile::empty();
+        Self {
+            version: profile.version,
+            sources: profile.sources,
+            source_observation_watermarks: BTreeMap::new(),
+        }
+    }
+}
+
+impl PersistedStatisticsProfile {
+    fn empty() -> Self {
+        Self::default()
+    }
+
+    fn into_runtime_profile(self) -> StatisticsProfile {
+        StatisticsProfile {
+            version: self.version,
+            sources: self.sources,
+        }
+    }
+}
+
+impl StatisticsStore {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
+    }
+
+    pub(crate) fn load_profile(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<StatisticsProfile, AppError> {
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        load_profile_unlocked(&self.layout, workspace_name)
+    }
+
+    pub(crate) fn rebuild_profile_from_observations(
+        &self,
+        workspace_name: &WorkspaceName,
+        observations: &[StatisticsObservationRecord],
+        selected_schema_names: impl IntoIterator<Item = String>,
+    ) -> Result<(), AppError> {
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        let selected_schema_names = selected_schema_names.into_iter().collect::<Vec<_>>();
+        let mut persisted = match load_persisted_profile_unlocked(&self.layout, workspace_name) {
+            Ok(profile) => profile,
+            Err(error) => {
+                tracing::warn!(
+                    workspace = %workspace_name,
+                    detail = %error,
+                    "discarding unreadable statistics profile during profile rebuild"
+                );
+                PersistedStatisticsProfile::empty()
+            }
+        };
+        let mut profile = StatisticsProfile::empty();
+        for record in observations {
+            if record_is_after_source_watermark(record, &persisted.source_observation_watermarks) {
+                merge_observation(&mut profile, &record.observation);
+            }
+        }
+        profile.retain_sources(selected_schema_names.iter().map(String::as_str));
+        persisted.sources = profile.sources;
+        save_persisted_profile_unlocked(&self.layout, workspace_name, &persisted)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn merge_observations(
+        &self,
+        workspace_name: &WorkspaceName,
+        observations: &[StatisticsObservation],
+    ) -> Result<(), AppError> {
+        let selected = observations
+            .iter()
+            .map(|observation| observation.schema_name.clone())
+            .collect::<std::collections::BTreeSet<_>>();
+        let records = observations
+            .iter()
+            .cloned()
+            .map(|observation| StatisticsObservationRecord {
+                observation,
+                trace_end_unix_nanos: i64::MAX,
+            })
+            .collect::<Vec<_>>();
+        self.rebuild_profile_from_observations(workspace_name, &records, selected)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn invalidate_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<(), AppError> {
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        invalidate_source_unlocked(&self.layout, workspace_name, source_name)
+    }
+}
+
+pub(super) fn invalidate_source_unlocked(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+) -> Result<(), AppError> {
+    invalidate_source_unlocked_at(layout, workspace_name, source_name, current_unix_nanos())
+}
+
+fn invalidate_source_unlocked_at(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    invalidated_at_unix_nanos: i64,
+) -> Result<(), AppError> {
+    let mut profile = match load_persisted_profile_unlocked(layout, workspace_name) {
+        Ok(profile) => profile,
+        Err(error) => {
+            tracing::warn!(
+                workspace = %workspace_name,
+                source = %source_name,
+                detail = %error,
+                "discarding unreadable statistics profile during source invalidation"
+            );
+            PersistedStatisticsProfile::empty()
+        }
+    };
+    profile.sources.remove(source_name.as_str());
+    profile
+        .source_observation_watermarks
+        .insert(source_name.as_str().to_string(), invalidated_at_unix_nanos);
+    save_persisted_profile_unlocked(layout, workspace_name, &profile)
+}
+
+fn load_profile_unlocked(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+) -> Result<StatisticsProfile, AppError> {
+    load_persisted_profile_unlocked(layout, workspace_name)
+        .map(PersistedStatisticsProfile::into_runtime_profile)
+}
+
+fn load_persisted_profile_unlocked(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+) -> Result<PersistedStatisticsProfile, AppError> {
+    let path = layout.statistics_profile_file(workspace_name);
+    if !path.exists() {
+        return Ok(PersistedStatisticsProfile::empty());
+    }
+
+    let raw = std::fs::read_to_string(&path)?;
+    let profile: PersistedStatisticsProfile = serde_json::from_str(&raw)?;
+    if profile.version != PersistedStatisticsProfile::empty().version {
+        tracing::warn!(
+            workspace = %workspace_name,
+            version = profile.version,
+            "ignoring unsupported statistics profile version"
+        );
+        return Ok(PersistedStatisticsProfile::empty());
+    }
+    Ok(profile)
+}
+
+fn save_persisted_profile_unlocked(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    profile: &PersistedStatisticsProfile,
+) -> Result<(), AppError> {
+    let path = layout.statistics_profile_file(workspace_name);
+    if let Some(parent) = path.parent() {
+        storage_fs::ensure_dir(parent)?;
+    }
+    let raw = serde_json::to_vec_pretty(profile)?;
+    storage_fs::write_atomic(&path, &raw)?;
+    Ok(())
+}
+
+fn record_is_after_source_watermark(
+    record: &StatisticsObservationRecord,
+    source_observation_watermarks: &BTreeMap<String, i64>,
+) -> bool {
+    source_observation_watermarks
+        .get(&record.observation.schema_name)
+        .is_none_or(|watermark| record.trace_end_unix_nanos > *watermark)
+}
+
+fn current_unix_nanos() -> i64 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    i64::try_from(nanos).unwrap_or(i64::MAX)
+}
+
+fn merge_observation(profile: &mut StatisticsProfile, observation: &StatisticsObservation) {
+    if observation.scope != StatisticsObservationScope::TableGlobal {
+        return;
+    }
+
+    let source_stats = profile
+        .sources
+        .entry(observation.schema_name.clone())
+        .or_insert_with(|| SourceStatistics {
+            schema_name: observation.schema_name.clone(),
+            source_version: observation.source_version.clone(),
+            tables: BTreeMap::default(),
+        });
+    if source_stats.source_version != observation.source_version {
+        source_stats.tables.clear();
+    }
+    source_stats
+        .source_version
+        .clone_from(&observation.source_version);
+
+    let mut columns = BTreeMap::new();
+    for column in &observation.columns {
+        columns.insert(
+            column.column_name.clone(),
+            ColumnStatistics {
+                column_name: column.column_name.clone(),
+                sample_count: column.sample_count,
+                null_count: column.null_count.clone(),
+                approx_distinct_count: column.approx_distinct_count.clone(),
+                observed_at: Some(observation.observed_at.clone()),
+            },
+        );
+    }
+
+    source_stats.tables.insert(
+        observation.table_name.clone(),
+        TableStatistics {
+            schema_name: observation.schema_name.clone(),
+            table_name: observation.table_name.clone(),
+            source_version: observation.source_version.clone(),
+            schema_signature: observation.schema_signature.clone(),
+            columns,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use coral_engine::{
+        ColumnSchemaSignature, ColumnStatisticsObservation, StatisticsObservation,
+        StatisticsObservationScope, TableSchemaSignature,
+    };
+    use tempfile::tempdir;
+
+    use super::{
+        StatisticsObservationRecord, StatisticsStore, invalidate_source_unlocked_at,
+        load_persisted_profile_unlocked,
+    };
+    use crate::sources::SourceName;
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+
+    fn workspace() -> WorkspaceName {
+        WorkspaceName::parse("default").expect("workspace")
+    }
+
+    fn store() -> (tempfile::TempDir, StatisticsStore) {
+        let temp = tempdir().expect("tempdir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("config"))).expect("layout");
+        (temp, StatisticsStore::new(layout))
+    }
+
+    fn signature(nullable: bool) -> TableSchemaSignature {
+        TableSchemaSignature {
+            columns: vec![ColumnSchemaSignature {
+                name: "name".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable,
+                is_virtual: false,
+                is_required_filter: false,
+            }],
+            required_filters: Vec::new(),
+        }
+    }
+
+    fn observation(scope: StatisticsObservationScope) -> StatisticsObservation {
+        StatisticsObservation {
+            schema_name: "local".to_string(),
+            table_name: "events".to_string(),
+            source_version: Some("0.1.0".to_string()),
+            schema_signature: signature(true),
+            scope,
+            observed_at: "2026-05-06T00:00:00Z".to_string(),
+            columns: vec![ColumnStatisticsObservation {
+                column_name: "name".to_string(),
+                sample_count: 3,
+                null_count: Some(coral_engine::StatisticValue {
+                    value: 1,
+                    precision: coral_engine::StatisticPrecision::ObservedSample,
+                }),
+                approx_distinct_count: Some(coral_engine::StatisticValue {
+                    value: 2,
+                    precision: coral_engine::StatisticPrecision::ObservedSample,
+                }),
+            }],
+        }
+    }
+
+    fn observation_record(
+        observation: StatisticsObservation,
+        trace_end_unix_nanos: i64,
+    ) -> StatisticsObservationRecord {
+        StatisticsObservationRecord {
+            observation,
+            trace_end_unix_nanos,
+        }
+    }
+
+    fn event_table(profile: &coral_engine::StatisticsProfile) -> &coral_engine::TableStatistics {
+        profile
+            .sources
+            .get("local")
+            .expect("local source")
+            .tables
+            .get("events")
+            .expect("events table")
+    }
+
+    fn name_column(profile: &coral_engine::StatisticsProfile) -> &coral_engine::ColumnStatistics {
+        event_table(profile)
+            .columns
+            .get("name")
+            .expect("name column")
+    }
+
+    #[test]
+    fn missing_profile_loads_as_empty() {
+        let (_temp, store) = store();
+        let profile = store.load_profile(&workspace()).expect("profile");
+
+        assert_eq!(profile.version, 1);
+        assert!(profile.sources.is_empty());
+    }
+
+    #[test]
+    fn profile_save_load_round_trips() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        store
+            .merge_observations(
+                &workspace,
+                &[observation(StatisticsObservationScope::TableGlobal)],
+            )
+            .expect("merge");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+
+        assert_eq!(name_column(&profile).sample_count, 3);
+    }
+
+    #[test]
+    fn non_table_global_observations_are_ignored() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        store
+            .merge_observations(
+                &workspace,
+                &[observation(StatisticsObservationScope::Filtered {
+                    filter_columns: vec!["status".to_string()],
+                })],
+            )
+            .expect("merge");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+
+        assert!(profile.sources.is_empty());
+    }
+
+    #[test]
+    fn matching_table_global_observations_replace_prior_snapshot() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        let observation = observation(StatisticsObservationScope::TableGlobal);
+        store
+            .merge_observations(&workspace, std::slice::from_ref(&observation))
+            .expect("first merge");
+        store
+            .merge_observations(&workspace, &[observation])
+            .expect("second merge");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+        let column = name_column(&profile);
+
+        assert_eq!(column.sample_count, 3);
+        assert_eq!(column.null_count.as_ref().unwrap().value, 1);
+        assert_eq!(column.approx_distinct_count.as_ref().unwrap().value, 2);
+    }
+
+    #[test]
+    fn source_version_change_replaces_source_tables() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        let first = observation(StatisticsObservationScope::TableGlobal);
+        store
+            .merge_observations(&workspace, &[first])
+            .expect("first merge");
+        let mut second = observation(StatisticsObservationScope::TableGlobal);
+        second.source_version = Some("0.2.0".to_string());
+        second.table_name = "new_events".to_string();
+        store
+            .merge_observations(&workspace, &[second])
+            .expect("second merge");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+        let source = profile.sources.get("local").expect("local source");
+
+        assert_eq!(source.source_version.as_deref(), Some("0.2.0"));
+        assert!(!source.tables.contains_key("events"));
+        assert!(source.tables.contains_key("new_events"));
+    }
+
+    #[test]
+    fn schema_signature_mismatch_replaces_old_table_stats() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        let mut first = observation(StatisticsObservationScope::TableGlobal);
+        first.schema_signature = signature(false);
+        store
+            .merge_observations(&workspace, &[first])
+            .expect("first merge");
+        store
+            .merge_observations(
+                &workspace,
+                &[observation(StatisticsObservationScope::TableGlobal)],
+            )
+            .expect("second merge");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+        let table = event_table(&profile);
+        let column = table.columns.get("name").expect("name column");
+
+        assert_eq!(column.sample_count, 3);
+        assert_eq!(table.schema_signature, signature(true));
+    }
+
+    #[test]
+    fn invalidate_source_removes_persisted_source_statistics() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        store
+            .merge_observations(
+                &workspace,
+                &[observation(StatisticsObservationScope::TableGlobal)],
+            )
+            .expect("merge");
+
+        store
+            .invalidate_source(
+                &workspace,
+                &SourceName::parse("local").expect("source name"),
+            )
+            .expect("invalidate source");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+        assert!(!profile.sources.contains_key("local"));
+    }
+
+    #[test]
+    fn invalidate_source_records_observation_watermark() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        let source_name = SourceName::parse("local").expect("source name");
+
+        invalidate_source_unlocked_at(&store.layout, &workspace, &source_name, 100)
+            .expect("invalidate source");
+
+        let profile =
+            load_persisted_profile_unlocked(&store.layout, &workspace).expect("persisted profile");
+        assert_eq!(
+            profile.source_observation_watermarks.get("local").copied(),
+            Some(100)
+        );
+    }
+
+    #[test]
+    fn rebuild_ignores_observations_before_source_watermark() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        let source_name = SourceName::parse("local").expect("source name");
+        invalidate_source_unlocked_at(&store.layout, &workspace, &source_name, 100)
+            .expect("invalidate source");
+
+        store
+            .rebuild_profile_from_observations(
+                &workspace,
+                &[observation_record(
+                    observation(StatisticsObservationScope::TableGlobal),
+                    99,
+                )],
+                ["local".to_string()],
+            )
+            .expect("rebuild");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+        assert!(!profile.sources.contains_key("local"));
+
+        let mut fresh_observation = observation(StatisticsObservationScope::TableGlobal);
+        fresh_observation
+            .columns
+            .first_mut()
+            .expect("sample column")
+            .sample_count = 7;
+        store
+            .rebuild_profile_from_observations(
+                &workspace,
+                &[
+                    observation_record(observation(StatisticsObservationScope::TableGlobal), 99),
+                    observation_record(fresh_observation, 101),
+                ],
+                ["local".to_string()],
+            )
+            .expect("rebuild with fresh observation");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+        assert_eq!(name_column(&profile).sample_count, 7);
+    }
+
+    #[test]
+    fn invalidate_source_discards_unreadable_profile() {
+        let (_temp, store) = store();
+        let workspace = workspace();
+        let path = store.layout.statistics_profile_file(&workspace);
+        std::fs::create_dir_all(path.parent().expect("profile parent")).expect("profile dir");
+        std::fs::write(&path, "{not-json").expect("write corrupt profile");
+
+        store
+            .invalidate_source(
+                &workspace,
+                &SourceName::parse("local").expect("source name"),
+            )
+            .expect("invalidate should tolerate corrupt profile");
+
+        let profile = store.load_profile(&workspace).expect("profile");
+        assert!(profile.sources.is_empty());
+    }
+}

--- a/crates/coral-app/src/telemetry/local_store.rs
+++ b/crates/coral-app/src/telemetry/local_store.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use coral_engine::StatisticsObservation;
 use opentelemetry::trace::{SpanId, SpanKind, Status};
 use opentelemetry::{Array as OtelArray, KeyValue, Value as OtelValue};
 use opentelemetry_sdk::Resource;
@@ -19,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Number as JsonNumber, Value as JsonValue, json};
 use tokio::task;
 
+use crate::state::StatisticsObservationRecord;
 use crate::storage::fs as storage_fs;
 use crate::telemetry::WORKSPACE_SPAN_ATTRIBUTE;
 
@@ -390,6 +392,12 @@ pub(crate) enum TraceStoreError {
         path: PathBuf,
         source: std::io::Error,
     },
+    #[error("failed to decode local trace store file {path} line {line}: {source}")]
+    DecodeLine {
+        path: PathBuf,
+        line: usize,
+        source: serde_json::Error,
+    },
     #[error("failed to rewrite local trace store file {path}: {source}")]
     WriteFile {
         path: PathBuf,
@@ -550,6 +558,18 @@ struct TraceListAggregate {
 }
 
 #[derive(Debug, Deserialize)]
+struct TraceSpanStatisticsRecord {
+    trace_id: String,
+    name: String,
+    #[serde(default)]
+    status: StoredTraceStatus,
+    #[serde(default)]
+    end_time_unix_nanos: i64,
+    attributes_json: String,
+    events_json: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct TraceSpanIdentityRecord {
     trace_id: String,
 }
@@ -603,6 +623,16 @@ impl TraceStore {
     ) -> Result<TraceDetailRecord, TraceStoreError> {
         let traces = self.clone();
         task::spawn_blocking(move || traces.get_trace_sync(&trace_id))
+            .await
+            .map_err(|source| TraceStoreError::Worker { source })?
+    }
+
+    pub(crate) async fn statistics_observations(
+        &self,
+        workspace_name: String,
+    ) -> Result<Vec<StatisticsObservationRecord>, TraceStoreError> {
+        let traces = self.clone();
+        task::spawn_blocking(move || traces.statistics_observations_sync(&workspace_name))
             .await
             .map_err(|source| TraceStoreError::Worker { source })?
     }
@@ -739,6 +769,46 @@ impl TraceStore {
                 .then_with(|| left.span_id.cmp(&right.span_id))
         });
         Ok(entries)
+    }
+
+    fn statistics_observations_sync(
+        &self,
+        workspace_name: &str,
+    ) -> Result<Vec<StatisticsObservationRecord>, TraceStoreError> {
+        self.prune_expired()?;
+        let files = self.jsonl_files_by_modified()?;
+        let mut successful_query_traces = HashSet::new();
+        let mut observations = Vec::new();
+        for file in files {
+            let records = read_statistics_observation_records_file(&file.path)?;
+            for record in records {
+                if successful_query_span(&record, workspace_name) {
+                    successful_query_traces.insert(record.trace_id.clone());
+                }
+                observations.extend(
+                    statistics_observations_from_events(&record.events_json)
+                        .into_iter()
+                        .map(|observation| {
+                            (
+                                record.trace_id.clone(),
+                                record.end_time_unix_nanos,
+                                observation,
+                            )
+                        }),
+                );
+            }
+        }
+        Ok(observations
+            .into_iter()
+            .filter_map(|(trace_id, trace_end_unix_nanos, observation)| {
+                successful_query_traces
+                    .contains(&trace_id)
+                    .then_some(StatisticsObservationRecord {
+                        observation,
+                        trace_end_unix_nanos,
+                    })
+            })
+            .collect())
     }
 
     fn delete_traces_for_workspace_sync(
@@ -1234,6 +1304,54 @@ fn read_query_history_spans_file(
     Ok(spans_by_id.into_values().collect())
 }
 
+fn read_statistics_observation_records_file(
+    path: &Path,
+) -> Result<Vec<TraceSpanStatisticsRecord>, TraceStoreError> {
+    let file = File::open(path).map_err(|source| TraceStoreError::OpenFile {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let mut reader = BufReader::new(file);
+    let mut records = Vec::new();
+    let mut line = String::new();
+    let mut line_number = 0;
+
+    loop {
+        line.clear();
+        let bytes_read =
+            reader
+                .read_line(&mut line)
+                .map_err(|source| TraceStoreError::ReadFile {
+                    path: path.to_path_buf(),
+                    source,
+                })?;
+        if bytes_read == 0 {
+            break;
+        }
+
+        line_number += 1;
+        let complete_line = line.ends_with('\n');
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.trim().is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str::<TraceSpanStatisticsRecord>(trimmed) {
+            Ok(record) => records.push(record),
+            Err(_) if !complete_line => break,
+            Err(source) => {
+                return Err(TraceStoreError::DecodeLine {
+                    path: path.to_path_buf(),
+                    line: line_number,
+                    source,
+                });
+            }
+        }
+    }
+
+    Ok(records)
+}
+
 fn read_workspace_trace_ids(
     files: &[TraceStoreFile],
     workspace_name: &str,
@@ -1410,6 +1528,50 @@ fn restore_trace_file_snapshots(snapshots: Vec<TraceFileSnapshot>) -> Result<(),
         })?;
     }
     Ok(())
+}
+
+fn successful_query_span(record: &TraceSpanStatisticsRecord, workspace_name: &str) -> bool {
+    if record.name != "coral.query" {
+        return false;
+    }
+    let Some(attributes) = parse_attributes(&record.attributes_json) else {
+        return false;
+    };
+    if attr_string(&attributes, "workspace").as_deref() != Some(workspace_name) {
+        return false;
+    }
+    status_from_attributes(Some(&attributes)).unwrap_or(record.status) == StoredTraceStatus::Ok
+}
+
+fn statistics_observations_from_events(events_json: &str) -> Vec<StatisticsObservation> {
+    let Ok(events) = serde_json::from_str::<JsonValue>(events_json) else {
+        return Vec::new();
+    };
+    let Some(events) = events.get("events").and_then(JsonValue::as_array) else {
+        return Vec::new();
+    };
+
+    events
+        .iter()
+        .filter_map(statistics_observation_from_event)
+        .collect()
+}
+
+fn statistics_observation_from_event(event: &JsonValue) -> Option<StatisticsObservation> {
+    let payload = event
+        .get("attributes")?
+        .get("coral.statistics.observation")?
+        .as_str()?;
+    match serde_json::from_str(payload) {
+        Ok(observation) => Some(observation),
+        Err(error) => {
+            tracing::warn!(
+                detail = %error,
+                "skipping malformed statistics observation trace event"
+            );
+            None
+        }
+    }
 }
 
 fn summary_from_spans(trace_id: &str, spans: &[TraceSpanRecord]) -> TraceSummaryRecord {
@@ -2547,6 +2709,82 @@ mod tests {
         assert!(old_name_fresh_path.exists());
         assert_eq!(traces.len(), 1);
         assert_eq!(traces.first().expect("fresh trace").trace_id, "fresh-trace");
+    }
+
+    #[test]
+    fn trace_store_reads_statistics_observation_events_for_workspace() {
+        let temp = TempDir::new().expect("temp dir");
+        let dir = temp.path().join("telemetry").join("traces");
+        fs::create_dir_all(&dir).expect("trace dir");
+        let observation = json!({
+            "schema_name": "local",
+            "table_name": "events",
+            "source_version": "0.1.0",
+            "schema_signature": {
+                "columns": [{
+                    "name": "id",
+                    "data_type": "Int64",
+                    "nullable": false,
+                    "is_virtual": false,
+                    "is_required_filter": false
+                }],
+                "required_filters": []
+            },
+            "scope": "table_global",
+            "observed_at": "2026-05-06T00:00:00Z",
+            "columns": [{
+                "column_name": "id",
+                "sample_count": 3,
+                "null_count": {"value": 0, "precision": "observed_sample"},
+                "approx_distinct_count": {"value": 3, "precision": "observed_sample"}
+            }]
+        });
+        let mut record = trace_record("trace-1", "span-1");
+        record.attributes_json = r#"{"status":"ok","workspace":"default"}"#.to_string();
+        record.events_json = json!({
+            "events": [{
+                "name": "coral.statistics.observation",
+                "time_unix_nanos": 1,
+                "attributes": {
+                    "coral.statistics.observation": observation.to_string()
+                }
+            }]
+        })
+        .to_string();
+        let mut other_workspace_record = trace_record("other-workspace-trace", "other-span");
+        other_workspace_record.attributes_json =
+            r#"{"status":"ok","workspace":"other"}"#.to_string();
+        other_workspace_record.events_json = record.events_json.clone();
+        let mut unscoped_record = trace_record("unscoped-trace", "unscoped-span");
+        unscoped_record.attributes_json = r#"{"status":"ok"}"#.to_string();
+        unscoped_record.events_json = record.events_json.clone();
+        let mut failed_record = trace_record("failed-trace", "failed-span");
+        failed_record.status = StoredTraceStatus::Error;
+        failed_record.attributes_json = r#"{"status":"error","workspace":"default"}"#.to_string();
+        failed_record.events_json = record.events_json.clone();
+        write_record_file_lines(
+            &dir.join(timestamped_jsonl_path(SystemTime::now())),
+            &[
+                record,
+                other_workspace_record,
+                unscoped_record,
+                failed_record,
+            ],
+        );
+
+        let observations = TraceStore::new(dir)
+            .statistics_observations_sync("default")
+            .expect("statistics observations");
+
+        assert_eq!(observations.len(), 1);
+        let observation = &observations.first().expect("observation").observation;
+        assert_eq!(observation.schema_name, "local");
+        assert_eq!(
+            observation.scope,
+            coral_engine::StatisticsObservationScope::TableGlobal
+        );
+        let column = observation.columns.first().expect("column observation");
+        assert_eq!(column.sample_count, 3);
     }
 
     #[test]

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -32,6 +32,7 @@ pub mod metrics;
 pub(crate) mod service;
 
 use crate::bootstrap::AppError;
+use crate::state::StatisticsObservationRecord;
 use crate::workspaces::WorkspaceName;
 pub use config::TelemetryConfig;
 use config::{DEFAULT_LOCAL_TRACE_FILTER, DEFAULT_LOG_FILTER, DEFAULT_TRACE_FILTER};
@@ -614,6 +615,25 @@ pub fn shutdown_tracing() {
     {
         tracing::warn!("OTEL logger provider shutdown error: {error}");
     }
+}
+
+pub(crate) fn force_flush_tracing() {
+    if let Ok(guard) = PROVIDER.lock()
+        && let Some(provider) = guard.as_ref()
+        && let Err(error) = provider.force_flush()
+    {
+        tracing::warn!("OTEL trace provider force_flush error: {error}");
+    }
+}
+
+pub(crate) async fn load_statistics_observations(
+    store: &InstalledLocalTraceStore,
+    workspace_name: &WorkspaceName,
+) -> Result<Vec<StatisticsObservationRecord>, AppError> {
+    local_store::TraceStore::with_retention(store.dir.clone(), store.retention)
+        .statistics_observations(workspace_name.as_str().to_string())
+        .await
+        .map_err(|error| AppError::InvalidInput(error.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/coral-app/src/telemetry/service.rs
+++ b/crates/coral-app/src/telemetry/service.rs
@@ -116,6 +116,7 @@ fn trace_store_status(error: TraceStoreError) -> Status {
         TraceStoreError::ReadDir { .. }
         | TraceStoreError::OpenFile { .. }
         | TraceStoreError::FileMetadata { .. }
+        | TraceStoreError::DecodeLine { .. }
         | TraceStoreError::WriteFile { .. }
         | TraceStoreError::RemoveFile { .. }
         | TraceStoreError::RestoreFile { .. }


### PR DESCRIPTION
## Ticket

- [SOURCE-470](https://linear.app/withcoral/issue/SOURCE-470/add-column-level-statistics-to-coralcolumns-nullability-rate)

## What This PR Does

Adds the app-side cache that rebuilds workspace column statistics from local trace history after successful queries.

Concretely, this PR:

- Reads local trace-history telemetry observations after successful SQL execution.
- Rebuilds `$CORAL_CONFIG_DIR/workspaces/<workspace>/statistics/profile.json` as a materialized cache.
- Passes the retained profile into the engine runtime so `coral.columns` can project cached stats.
- Invalidates source stats on import/delete so stale stats are not projected.
- Keeps metadata listing and source validation independent of persisted stats.
- Preserves current credential-refresh behavior while adding stats profile loading.

## What This PR Does Not Do

- Does not make `profile.json` the durable observation source.
- Does not write observations directly from engine scan code.
- Does not materialize filtered/limited/projected observations as table-global stats.
- Does not require trace history to exist; without it, stats remain `NULL`.

The important contract is: local trace history is the durable local record of observations, and `profile.json` is only a rebuildable app-owned cache.

## Stack Position

Depends on #289 and #290. Enables later backend observation PRs, including #292, to become visible through `coral.columns` after app materialization.

## Validation

Rebased on fresh `origin/main` at `96532449`.

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=target/source-470-check make rust-checks`
- Compiled CLI local-source smoke with `target/source-470-check/debug/coral`:
  - JSONL: stats absent before first source query, present after query, survive runtime rebuild, and recover after corrupt `profile.json`.
  - HTTP: filtered query does not materialize global stats; later unfiltered query does.
  - Parquet: generated local fixture materializes stats through the same trace-history path.
