### PR TITLE
feat(engine): observe parquet column stats

### DIFF
--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -216,7 +216,10 @@ impl CompiledBackendSource for FileCompiledSource {
         );
 
         for table in &self.manifest.tables {
-            let table_statistics = if matches!(table.format, FileFormat::Json | FileFormat::Jsonl) {
+            let table_statistics = if matches!(
+                table.format,
+                FileFormat::Json | FileFormat::Jsonl | FileFormat::Parquet
+            ) {
                 Some(FileStatisticsRegistration::new(
                     self.manifest.common.version.clone(),
                 ))

--- a/crates/coral-engine/src/runtime/statistics.rs
+++ b/crates/coral-engine/src/runtime/statistics.rs
@@ -728,8 +728,10 @@ fn record_bool_values(values: &mut HashSet<bool>, array: &dyn Array) -> Distinct
 mod tests {
     use std::sync::Arc;
 
-    use datafusion::arrow::array::{Float64Array, Int64Array, StringArray};
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::array::{
+        DictionaryArray, Float64Array, Int64Array, StringArray, StringViewArray, UInt16Array,
+    };
+    use datafusion::arrow::datatypes::{DataType, Field, Schema, UInt16Type};
 
     use super::{BatchStatisticsPlan, DISTINCT_COUNT_MAX_VALUES, collect_batch_statistics};
     use crate::contracts::{
@@ -855,6 +857,95 @@ mod tests {
             vec![Arc::new(StringArray::from(values))],
         )
         .expect("batch");
+        let signature = TableSchemaSignature {
+            columns: vec![ColumnSchemaSignature {
+                name: "name".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: true,
+                is_virtual: false,
+                is_required_filter: false,
+            }],
+            required_filters: Vec::new(),
+        };
+        let plan = BatchStatisticsPlan::table_global("local", "events", None, signature);
+
+        let observation = collect_batch_statistics(&plan, &[batch]).expect("observation");
+
+        let name = observation
+            .columns
+            .iter()
+            .find(|column| column.column_name == "name")
+            .expect("name stats");
+        assert_eq!(name.null_count.as_ref().expect("null count").value, 0);
+        assert!(name.approx_distinct_count.is_none());
+    }
+
+    #[test]
+    fn utf8_view_distinct_counts_are_collected() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "name",
+            DataType::Utf8View,
+            true,
+        )]));
+        let batch = datafusion::arrow::array::RecordBatch::try_new(
+            schema,
+            vec![Arc::new(StringViewArray::from(vec![
+                Some("alpha"),
+                Some("beta"),
+                None,
+                Some("alpha"),
+            ]))],
+        )
+        .expect("batch");
+        let signature = TableSchemaSignature {
+            columns: vec![ColumnSchemaSignature {
+                name: "name".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: true,
+                is_virtual: false,
+                is_required_filter: false,
+            }],
+            required_filters: Vec::new(),
+        };
+        let plan = BatchStatisticsPlan::table_global("local", "events", None, signature);
+
+        let observation = collect_batch_statistics(&plan, &[batch]).expect("observation");
+
+        let name = observation
+            .columns
+            .iter()
+            .find(|column| column.column_name == "name")
+            .expect("name stats");
+        assert_eq!(name.null_count.as_ref().expect("null count").value, 1);
+        assert_eq!(
+            name.approx_distinct_count
+                .as_ref()
+                .expect("distinct count")
+                .value,
+            2
+        );
+    }
+
+    #[test]
+    fn dictionary_utf8_distinct_counts_are_capped() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "name",
+            DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
+            true,
+        )]));
+        let keys = UInt16Array::from(
+            (0..=DISTINCT_COUNT_MAX_VALUES)
+                .map(|index| u16::try_from(index).expect("test value fits in u16"))
+                .collect::<Vec<_>>(),
+        );
+        let values = Arc::new(StringArray::from(
+            (0..=DISTINCT_COUNT_MAX_VALUES)
+                .map(|index| format!("value-{index}"))
+                .collect::<Vec<_>>(),
+        ));
+        let names = Arc::new(DictionaryArray::<UInt16Type>::try_new(keys, values).expect("dict"));
+        let batch =
+            datafusion::arrow::array::RecordBatch::try_new(schema, vec![names]).expect("batch");
         let signature = TableSchemaSignature {
             columns: vec![ColumnSchemaSignature {
                 name: "name".to_string(),

--- a/crates/coral-engine/tests/engine/parquet_tests.rs
+++ b/crates/coral-engine/tests/engine/parquet_tests.rs
@@ -1,12 +1,13 @@
 use std::path::Path;
 
-use coral_engine::CoralQuery;
+use coral_engine::{CoralQuery, StatisticsObservationScope};
 use serde_json::{Value, json};
 use tempfile::TempDir;
 
 use crate::harness::{
-    assert_table_not_found, build_source, build_source_with_secrets, dir_url, execution_to_rows,
-    test_runtime, users_batch, write_parquet_file,
+    assert_table_not_found, build_source, build_source_with_secrets, dir_url,
+    execute_sql_with_trace_observations, execution_to_rows, test_runtime, users_batch,
+    write_parquet_file,
 };
 
 fn parquet_manifest(name: &str, dir: &Path) -> Value {
@@ -34,15 +35,13 @@ async fn select_all_from_parquet_source() {
     write_parquet_file(temp.path(), "users.parquet", &users_batch());
     let source = build_source(parquet_manifest("parquet_users", temp.path()));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT id, name, email FROM parquet_users.users ORDER BY id",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT id, name, email FROM parquet_users.users ORDER BY id",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
     assert_eq!(
         rows,
@@ -52,6 +51,19 @@ async fn select_all_from_parquet_source() {
             json!({"id": 3, "name": "Linus", "email": "linus@example.com"}),
         ]
     );
+
+    assert_eq!(observations.len(), 1);
+    let observation = observations.first().expect("one observation");
+    assert_eq!(observation.scope, StatisticsObservationScope::TableGlobal);
+    let by_name = observation
+        .columns
+        .iter()
+        .map(|column| (column.column_name.as_str(), column))
+        .collect::<std::collections::HashMap<_, _>>();
+    let id = by_name.get("id").expect("id stats");
+    let name = by_name.get("name").expect("name stats");
+    assert_eq!(id.approx_distinct_count.as_ref().unwrap().value, 3);
+    assert_eq!(name.sample_count, 3);
 }
 
 #[tokio::test]
@@ -60,15 +72,13 @@ async fn select_with_column_projection() {
     write_parquet_file(temp.path(), "users.parquet", &users_batch());
     let source = build_source(parquet_manifest("parquet_projection", temp.path()));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT email FROM parquet_projection.users ORDER BY email",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT email FROM parquet_projection.users ORDER BY email",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
     assert_eq!(
         rows,
@@ -78,6 +88,12 @@ async fn select_with_column_projection() {
             json!({"email": "linus@example.com"}),
         ]
     );
+    assert_eq!(observations.len(), 1);
+    let observation = observations.first().expect("one observation");
+    assert_eq!(observation.scope, StatisticsObservationScope::Unknown);
+    assert_eq!(observation.columns.len(), 1);
+    let column = observation.columns.first().expect("one column");
+    assert_eq!(column.column_name, "email");
 }
 
 #[tokio::test]
@@ -130,17 +146,47 @@ async fn select_count_aggregation() {
     write_parquet_file(temp.path(), "users.parquet", &users_batch());
     let source = build_source(parquet_manifest("parquet_count", temp.path()));
 
-    let rows = execution_to_rows(
-        &CoralQuery::execute_sql(
-            &[source],
-            test_runtime(),
-            "SELECT COUNT(*) AS n FROM parquet_count.users",
-        )
-        .await
-        .expect("query should succeed"),
-    );
+    let (execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT COUNT(*) AS n FROM parquet_count.users",
+    )
+    .await
+    .expect("query should succeed");
+    let rows = execution_to_rows(&execution);
 
     assert_eq!(rows, vec![json!({"n": 3})]);
+    assert!(
+        observations
+            .iter()
+            .all(|observation| observation.scope != StatisticsObservationScope::TableGlobal),
+        "aggregate scans must not persist projected parquet stats as table-global"
+    );
+}
+
+#[tokio::test]
+async fn multi_file_scan_emits_one_table_global_observation() {
+    let temp = TempDir::new().expect("temp dir");
+    write_parquet_file(temp.path(), "users-a.parquet", &users_batch());
+    write_parquet_file(temp.path(), "users-b.parquet", &users_batch());
+    let source = build_source(parquet_manifest("parquet_multi", temp.path()));
+
+    let (_execution, observations) = execute_sql_with_trace_observations(
+        &[source],
+        "SELECT id, name, email FROM parquet_multi.users",
+    )
+    .await
+    .expect("query should succeed");
+
+    assert_eq!(observations.len(), 1);
+    let observation = observations.first().expect("one observation");
+    assert_eq!(observation.scope, StatisticsObservationScope::TableGlobal);
+    let id = observation
+        .columns
+        .iter()
+        .find(|column| column.column_name == "id")
+        .expect("id stats");
+    assert_eq!(id.sample_count, 6);
+    assert_eq!(id.null_count.as_ref().expect("null count").value, 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Ticket

- [SOURCE-470](https://linear.app/withcoral/issue/SOURCE-470/add-column-level-statistics-to-coralcolumns-nullability-rate)

## What This PR Does

Adds Parquet scan observations to the telemetry-backed column-statistics pipeline.

Concretely, this PR:

- Emits telemetry observations for full, unfiltered, unprojected Parquet scans that can safely be treated as table-global.
- Downgrades projected, filtered, limited, and partition-fragment observations so they are not materialized as table-global catalog stats.
- Aggregates/collects incrementally with bounded memory behavior instead of retaining every scanned batch for stats.
- Applies the same distinct-count cap across string representations, including dictionary-backed strings.

## What This PR Does Not Do

- Does not extract exact Parquet footer statistics as the public stats source.
- Does not persist observations itself.
- Does not materialize projected or partition-fragment scans into `coral.columns` as table-global stats.
- Does not change the app cache model from #291.

The important contract is: Parquet participates in the same telemetry observation path as other backends; app materialization decides what is safe to project.

## Stack Position

Depends on #289, #290, and #291. #293 documents the public behavior and validation.

## Validation

Rebased on fresh `origin/main` at `96532449`.

- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=target/source-470-check make rust-checks`
- Compiled CLI local-source smoke with `target/source-470-check/debug/coral`:
  - Parquet: generated deterministic `pyarrow` fixture with `Int64`, `Utf8`, nullable `Utf8`, and `Boolean` columns; queried through compiled CLI; verified `coral.columns` shows materialized stats.
  - JSONL and HTTP stack smokes also passed to verify cross-backend scope/materialization behavior still holds.
