### PR TITLE
docs: fix telemetry rows metric attributes

### DIFF
--- a/docs/guides/observe-with-opentelemetry.mdx
+++ b/docs/guides/observe-with-opentelemetry.mdx
@@ -76,7 +76,7 @@ Three query instruments are exported on a 5-second periodic reader:
 | ------------------------ | --------- | ----------- | ----------------- | ----------------------------------------- |
 | `coral.query.count`      | Counter   | `{queries}` | `status=ok\|error` | Total queries executed.                   |
 | `coral.query.duration`   | Histogram | `s`         | `status=ok\|error` | Query execution latency in seconds.       |
-| `coral.query.rows`       | Histogram | `{rows}`    | —                 | Rows returned per successful query.       |
+| `coral.query.rows`       | Histogram | `{rows}`    | `status=ok`       | Rows returned per successful query.       |
 
 ## Distributed tracing
 


### PR DESCRIPTION
## Summary

- Correct the OpenTelemetry guide's `coral.query.rows` metric attributes.
- Document that row observations are emitted with `status=ok`, matching the metric implementation and regression test.

## Why

The guide was added after the telemetry status-attribute change and described `coral.query.rows` as having no attributes. That would send operators looking for a metric shape that Coral no longer emits. The fix keeps the public telemetry reference aligned with the code.

## Verification

- `cargo test -p coral-app telemetry::metrics::tests::query_metrics_record_counts_and_rows_with_status`
- `git diff --check`
