### PR TITLE
refactor(cli): use typed cli errors

### DIFF
--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -141,22 +141,44 @@ enum OutputFormat {
 
 /// Typed CLI error whose stderr rendering and exit code are owned by the binary.
 #[derive(Debug, thiserror::Error)]
-#[error("cli command failed")]
-pub struct CliExitError {
-    rendered_stderr: String,
+pub enum CliError {
+    /// Query execution failed with a structured, user-facing diagnostic.
+    #[error("query failed")]
+    Query {
+        /// Complete stderr diagnostic rendered from the query status.
+        rendered_stderr: String,
+    },
+    /// A source was available as a bundled source but has not been installed.
+    #[error("source '{source_name}' is not installed")]
+    SourceNotInstalled {
+        /// Normalized source name requested by the user.
+        source_name: String,
+    },
+    /// A requested source was not found in installed or bundled sources.
+    #[error("source '{source_name}' was not found")]
+    SourceNotFound {
+        /// Normalized source name requested by the user.
+        source_name: String,
+    },
+    /// Any non-renderable internal command failure.
+    #[error(transparent)]
+    Internal(#[from] anyhow::Error),
 }
 
-impl CliExitError {
+impl CliError {
     #[must_use]
-    /// Builds a CLI error with pre-rendered stderr output.
-    pub fn new(rendered_stderr: String) -> Self {
-        Self { rendered_stderr }
-    }
-
-    #[must_use]
-    /// Returns the stderr block the binary should render before exiting.
-    pub fn rendered_stderr(&self) -> &str {
-        &self.rendered_stderr
+    /// Returns stderr content for user-facing CLI failures.
+    pub fn rendered_stderr(&self) -> Option<String> {
+        match self {
+            Self::Query { rendered_stderr } => Some(rendered_stderr.clone()),
+            Self::SourceNotInstalled { source_name } => Some(format!(
+                "source '{source_name}' is not installed. Run `coral source add {source_name}` to install it, then retry `coral source test {source_name}`.\n"
+            )),
+            Self::SourceNotFound { source_name } => Some(format!(
+                "source '{source_name}' was not found. Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.\n"
+            )),
+            Self::Internal(_) => None,
+        }
     }
 }
 
@@ -187,11 +209,11 @@ where
 ///
 /// Returns an error if argument parsing, command execution, or output
 /// formatting fails.
-pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), anyhow::Error> {
+pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), CliError> {
     coral_app::run_with_context(&ctx, Box::pin(run_parsed(app, Cli::parse()))).await
 }
 
-async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
+async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), CliError> {
     match cli.command {
         Command::Sql(args) => {
             let response = match app
@@ -204,10 +226,12 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
             {
                 Ok(response) => response.into_inner(),
                 Err(status) => {
-                    return Err(CliExitError::new(query_error::render_query_error(&status)).into());
+                    return Err(CliError::Query {
+                        rendered_stderr: query_error::render_query_error(&status),
+                    });
                 }
             };
-            let result = decode_execute_sql_response(&response)?;
+            let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
             print_batches(result.batches(), args.format)?;
         }
         Command::Source(args) => match args.command {
@@ -274,7 +298,8 @@ async fn run_parsed(app: AppClient, cli: Cli) -> Result<(), anyhow::Error> {
                     feedback_enabled: args.enable_feedback,
                 },
             )
-            .await?;
+            .await
+            .map_err(anyhow::Error::from)?;
         }
         Command::Completion(args) => {
             let mut cmd = Cli::command();
@@ -359,7 +384,7 @@ fn pad_cell(value: &str, width: usize, pad: bool) -> String {
     format!("{value}{}", " ".repeat(padding))
 }
 
-async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyhow::Error> {
+async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliError> {
     let SourceAddArgs {
         name,
         file,
@@ -399,7 +424,9 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), anyh
         _ => unreachable!("clap enforces exactly one of name or file"),
     };
     println!("Added source {}", response.name);
-    source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT).await
+    source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
+        .await
+        .map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/crates/coral-cli/src/main.rs
+++ b/crates/coral-cli/src/main.rs
@@ -24,11 +24,11 @@ async fn main() -> Result<(), anyhow::Error> {
     match result {
         Ok(()) => Ok(()),
         Err(error) => {
-            if let Some(cli_error) = error.downcast_ref::<coral_cli::CliExitError>() {
-                eprint!("{}", cli_error.rendered_stderr());
+            if let Some(rendered_stderr) = error.rendered_stderr() {
+                eprint!("{rendered_stderr}");
                 std::process::exit(1);
             }
-            Err(error)
+            Err(error.into())
         }
     }
 }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -114,11 +114,18 @@ pub(crate) async fn validate_source(
     app: &AppClient,
     name: &str,
 ) -> Result<ValidateSourceResponse, anyhow::Error> {
+    Ok(validate_source_request(app, source_name_arg(Some(name))?).await?)
+}
+
+async fn validate_source_request(
+    app: &AppClient,
+    name: String,
+) -> Result<ValidateSourceResponse, tonic::Status> {
     Ok(app
         .source_client()
         .validate_source(Request::new(ValidateSourceRequest {
             workspace: Some(default_workspace()),
-            name: source_name_arg(Some(name))?,
+            name,
         }))
         .await?
         .into_inner())
@@ -377,44 +384,47 @@ pub(crate) async fn test_and_print(
     source_name: &str,
     limit: TableDisplayLimit,
     severity_mode: ValidationSeverityMode,
-) -> Result<(), anyhow::Error> {
+) -> Result<(), crate::CliError> {
     let normalized = source_name_arg(Some(source_name))?;
-    let err = match validate_and_print(app, &normalized, limit, severity_mode).await {
-        Ok(()) => return Ok(()),
-        Err(err) => err,
+    let response = match validate_source_request(app, normalized.clone()).await {
+        Ok(response) => response,
+        Err(status) if status.code() == tonic::Code::NotFound => {
+            return source_test_not_found_error(app, &normalized, status).await;
+        }
+        Err(status) => return Err(anyhow::Error::from(status).into()),
     };
-
-    let is_not_found = err
-        .downcast_ref::<tonic::Status>()
-        .is_some_and(|status| status.code() == tonic::Code::NotFound);
-    if !is_not_found {
-        return Err(err);
+    print_validation_pretty(&response, limit)?;
+    match validation_follow_up(&response, severity_mode) {
+        ValidationFollowUp::None => Ok(()),
+        ValidationFollowUp::Warn(message) => {
+            eprintln!("Warning: {message}");
+            Ok(())
+        }
+        ValidationFollowUp::Fail(message) => Err(anyhow::anyhow!(message).into()),
     }
+}
 
+async fn source_test_not_found_error(
+    app: &AppClient,
+    source_name: &str,
+    original_status: tonic::Status,
+) -> Result<(), crate::CliError> {
     // Discovery failure must not mask the original validation error.
     let Ok(available) = discover_sources(app).await else {
-        return Err(err);
+        return Err(anyhow::Error::from(original_status).into());
     };
     if available
         .iter()
-        .any(|source| source.name == normalized && !source.installed)
+        .any(|source| source.name == source_name && !source.installed)
     {
-        return Err(source_not_installed_error(&normalized));
+        return Err(crate::CliError::SourceNotInstalled {
+            source_name: source_name.to_string(),
+        });
     }
 
-    Err(source_not_found_error(&normalized))
-}
-
-fn source_not_installed_error(source_name: &str) -> anyhow::Error {
-    anyhow::anyhow!(
-        "source '{source_name}' is not installed. Run `coral source add {source_name}` to install it, then retry `coral source test {source_name}`."
-    )
-}
-
-fn source_not_found_error(source_name: &str) -> anyhow::Error {
-    anyhow::anyhow!(
-        "source '{source_name}' was not found. Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install."
-    )
+    Err(crate::CliError::SourceNotFound {
+        source_name: source_name.to_string(),
+    })
 }
 
 pub(crate) fn print_validation_pretty(


### PR DESCRIPTION
## Intent

Stop using `anyhow` as a CLI control-flow protocol for user-facing failures. The CLI entrypoint should receive explicit typed errors and keep stderr rendering plus exit-code mapping in the binary boundary.

## Changes
- Add a small `CliError` enum for query and source-test user-facing failures.
- Make `run` / `run_parsed` return `CliError` and remove the `main` downcast path.
- Preserve typed validation status for `source test` so NotFound handling does not depend on recovering `tonic::Status` from `anyhow`.






