### PR TITLE
perf(app): avoid parsing installed manifests twice

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -8,7 +8,7 @@ use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
     SourceValidationReport, TableInfo,
 };
-use coral_spec::{ManifestInputKind, ManifestInputSpec, parse_source_manifest_yaml};
+use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
 use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
@@ -170,9 +170,7 @@ impl QueryManager {
         source: &InstalledSource,
     ) -> Result<(QuerySource, String), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
-        let manifest_yaml = installed.manifest_yaml;
-        let source_spec = parse_source_manifest_yaml(&manifest_yaml)
-            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        let source_spec = installed.source_spec;
         validate_required_variables(source, source_spec.declared_inputs())?;
         let stored_secrets = self
             .secret_store

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeSet;
 
-use coral_spec::parse_source_manifest_yaml;
+use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
@@ -19,7 +19,7 @@ pub(crate) struct BundledSourceManifest {
 
 #[derive(Debug, Clone)]
 pub(crate) struct InstalledSourceManifest {
-    pub(crate) manifest_yaml: String,
+    pub(crate) source_spec: ValidatedSourceManifest,
     pub(crate) candidate: CandidateSource,
 }
 
@@ -70,7 +70,9 @@ pub(crate) fn resolve_installed_manifest(
             std::fs::read_to_string(layout.manifest_file(workspace_name, &source.name))?
         }
     };
-    let mut candidate = describe_manifest(&manifest_yaml, source.origin, false)?;
+    let source_spec = parse_source_manifest_yaml(&manifest_yaml)
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    let mut candidate = candidate_from_manifest(&source_spec, source.origin, false)?;
     if candidate.name != source.name {
         return Err(AppError::FailedPrecondition(format!(
             "installed source '{}' does not match manifest name '{}'",
@@ -79,7 +81,7 @@ pub(crate) fn resolve_installed_manifest(
     }
     candidate.installed = true;
     Ok(InstalledSourceManifest {
-        manifest_yaml,
+        source_spec,
         candidate,
     })
 }
@@ -91,6 +93,14 @@ pub(crate) fn describe_manifest(
 ) -> Result<CandidateSource, AppError> {
     let manifest = parse_source_manifest_yaml(manifest_yaml)
         .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    candidate_from_manifest(&manifest, origin, installed)
+}
+
+fn candidate_from_manifest(
+    manifest: &ValidatedSourceManifest,
+    origin: SourceOrigin,
+    installed: bool,
+) -> Result<CandidateSource, AppError> {
     Ok(CandidateSource {
         name: SourceName::parse(manifest.schema_name())?,
         description: manifest.description().to_string(),


### PR DESCRIPTION
## Why

Query-time source loading parsed installed source manifests twice: once while resolving and verifying the installed manifest, then again when building the query source. For wide installed catalogs, that duplicate parse inflated the pre-DataFusion portion of `coral.query`.

## What Changed

- Return the parsed `ValidatedSourceManifest` from installed-manifest resolution alongside candidate metadata.
- Build `CandidateSource` metadata from an already parsed manifest to keep source info behavior unchanged.
- Have query loading pass the parsed spec directly into `QuerySource::new` instead of reparsing YAML.

## Validation

- `cargo fmt --check`
- `cargo test -p coral-app sources::catalog --lib`
- `cargo test -p coral-app source_lifecycle_tests::get_source_info_uses_effective_installed_imported_manifest`
- `cargo test -p coral-app source_lifecycle_tests::validate_source_returns_query_test_results_without_unary_error`
- `make rust-checks`

## OTel Performance

Measured with ClickHouse OTel traces for `SELECT COUNT(*) AS table_count FROM coral.tables`. The spans stay in the same shape (`coral.cli -> grpc -> coral.query -> ProjectionExec -> PlaceholderRowExec`), so the relevant movement is in the pre-DataFusion part of `coral.query`, where source loading and manifest parsing happen.

| Run | Trace ID | `coral.query` | Before first DataFusion span | DataFusion spans | Improvement vs original control |
| --- | --- | ---: | ---: | ---: | ---: |
| Before, earlier baseline | `db1b123cff2e28ed4b26a63fd7c7e548` | 3586.005 ms | 3575.263 ms | 2.244 ms | 3.9% faster than control |
| Before, original checkout control | `8bb5729eec8c6a99037e5e1706ea7ba8` | 3733.333 ms | 3725.196 ms | 0.568 ms | baseline |
| After, changed worktree | `2fc5e47165058c5e4d9ad9e9775e6706` | 2383.565 ms | 2370.245 ms | 3.056 ms | 36.2% faster |
| After, changed worktree | `d8b7fed91d754304108dd197739f9726` | 2167.493 ms | 2157.315 ms | 0.268 ms | 41.9% faster |

| Metric | Before average | After average | Delta | Improvement |
| --- | ---: | ---: | ---: | ---: |
| `coral.query` duration | 3659.669 ms | 2275.529 ms | -1384.140 ms | 37.8% faster |
| Pre-DataFusion source-loading phase | 3650.229 ms | 2263.780 ms | -1386.450 ms | 38.0% faster |
