### PR TITLE
fix(engine): preserve structured table-not-found references

### DIFF
--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -11,7 +11,7 @@ pub use query::{
     QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
     QueryTestResult, QueryTestSuccess, SourceValidationReport,
 };
-pub(crate) use query_error::ColumnParts;
+pub(crate) use query_error::{ColumnParts, TableRefParts};
 
 #[cfg(test)]
 pub(crate) use query_error::UNKNOWN_COLUMN_REASON;

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -39,6 +39,25 @@ pub(crate) struct ColumnParts {
     pub name: String,
 }
 
+/// Structure-preserving table reference used by `table_not_found`.
+///
+/// `DataFusion` formats missing table references as dotted strings, which loses
+/// the distinction between `schema.table` and a quoted identifier containing a
+/// literal dot. Keeping the parsed object-name parts separate lets the table
+/// hint code recover the user's intent without reparsing by raw `.` splits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TableRefParts {
+    /// Object-name parts in order: table, schema.table, or
+    /// catalog.schema.table. Each element is a bare identifier value.
+    pub parts: Vec<String>,
+}
+
+impl TableRefParts {
+    pub(crate) fn new(parts: Vec<String>) -> Self {
+        Self { parts }
+    }
+}
+
 impl ColumnParts {
     /// Renders the reference as SQL, quoting each component individually.
     fn quoted(&self) -> String {
@@ -149,14 +168,13 @@ impl StructuredQueryError {
 
     /// Builds a structured `TABLE_NOT_FOUND` error.
     ///
-    /// `catalog_qualified_ref` is the raw string `DataFusion` surfaces inside
-    /// `"table 'X' not found"` — always a dotted path under the default
-    /// catalog. `known_tables` is consulted to (a) distinguish `DataFusion`'s
+    /// `missing_ref` preserves the SQL object-name components for the missing
+    /// table. `known_tables` is consulted to (a) distinguish `DataFusion`'s
     /// synthetic `public` schema from a real user source also named `public`,
     /// and (b) recover a correct `(schema, table)` split when the source
     /// name itself contains a dot.
-    pub(crate) fn table_not_found(catalog_qualified_ref: &str, known_tables: &[TableInfo]) -> Self {
-        let parsed = parse_table_ref(catalog_qualified_ref, known_tables);
+    pub(crate) fn table_not_found(missing_ref: &TableRefParts, known_tables: &[TableInfo]) -> Self {
+        let parsed = parse_table_ref(missing_ref, known_tables);
 
         let (schema, table) = match &parsed {
             ParsedTableRef::Unqualified { table } => (None, table.clone()),
@@ -421,7 +439,7 @@ enum ParsedTableRef {
     Qualified { schema: String, table: String },
 }
 
-/// Recovers the user's intent from `DataFusion`'s always-3+-part error ref.
+/// Recovers the user's intent from a parsed missing table reference.
 ///
 /// Bare `FROM games` surfaces as `datafusion.public.games` (the default
 /// catalog plus the synthetic `public` schema), which we classify as
@@ -429,8 +447,8 @@ enum ParsedTableRef {
 /// For dotted source names, we try increasingly long schema candidates
 /// against the registered set so `datafusion."foo.bar".missing` is not
 /// silently sliced into `bar` / `missing`.
-fn parse_table_ref(raw: &str, known_tables: &[TableInfo]) -> ParsedTableRef {
-    let parts: Vec<&str> = raw.split('.').collect();
+fn parse_table_ref(reference: &TableRefParts, known_tables: &[TableInfo]) -> ParsedTableRef {
+    let parts = reference.parts.as_slice();
 
     if parts.is_empty() {
         return ParsedTableRef::Unqualified {
@@ -439,13 +457,13 @@ fn parse_table_ref(raw: &str, known_tables: &[TableInfo]) -> ParsedTableRef {
     }
     if parts.len() == 1 {
         return ParsedTableRef::Unqualified {
-            table: parts[0].to_string(),
+            table: parts[0].clone(),
         };
     }
 
     // Strip the default catalog prefix if present.
-    let body: Vec<&str> = if parts[0] == "datafusion" {
-        parts[1..].to_vec()
+    let body = if parts[0] == "datafusion" {
+        &parts[1..]
     } else {
         parts
     };
@@ -455,7 +473,7 @@ fn parse_table_ref(raw: &str, known_tables: &[TableInfo]) -> ParsedTableRef {
             table: String::new(),
         },
         1 => ParsedTableRef::Unqualified {
-            table: body[0].to_string(),
+            table: body[0].clone(),
         },
         _ => {
             // Synthetic `public` schema: `datafusion.public.X` comes from a
@@ -471,7 +489,7 @@ fn parse_table_ref(raw: &str, known_tables: &[TableInfo]) -> ParsedTableRef {
                 && !schema_is_registered("public", known_tables)
             {
                 return ParsedTableRef::Unqualified {
-                    table: body[1..].join("."),
+                    table: join_ref_parts(&body[1..]),
                 };
             }
 
@@ -479,11 +497,11 @@ fn parse_table_ref(raw: &str, known_tables: &[TableInfo]) -> ParsedTableRef {
             // registered schema (case-insensitive). This recovers dotted
             // source names like `"foo.bar"` from their exploded form.
             for schema_len in (1..body.len()).rev() {
-                let candidate_schema = body[..schema_len].join(".");
+                let candidate_schema = join_ref_parts(&body[..schema_len]);
                 if schema_is_registered(&candidate_schema, known_tables) {
                     return ParsedTableRef::Qualified {
                         schema: candidate_schema,
-                        table: body[schema_len..].join("."),
+                        table: join_ref_parts(&body[schema_len..]),
                     };
                 }
             }
@@ -495,11 +513,15 @@ fn parse_table_ref(raw: &str, known_tables: &[TableInfo]) -> ParsedTableRef {
             // install target).
             let last = body.len() - 1;
             ParsedTableRef::Qualified {
-                schema: body[..last].join("."),
-                table: body[last].to_string(),
+                schema: join_ref_parts(&body[..last]),
+                table: body[last].clone(),
             }
         }
     }
+}
+
+fn join_ref_parts(parts: &[String]) -> String {
+    parts.join(".")
 }
 
 fn schema_is_registered(candidate: &str, known_tables: &[TableInfo]) -> bool {
@@ -544,6 +566,10 @@ mod tests {
             relation: relation.iter().map(ToString::to_string).collect(),
             name: name.to_string(),
         }
+    }
+
+    fn tr(parts: &[&str]) -> TableRefParts {
+        TableRefParts::new(parts.iter().map(ToString::to_string).collect())
     }
 
     #[test]
@@ -630,7 +656,10 @@ mod tests {
     #[test]
     fn table_not_found_missing_schema_points_at_coral_tables_catalog() {
         let tables = vec![table("github", "issues")];
-        let err = StructuredQueryError::table_not_found("datafusion.hockey.master", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "hockey", "master"]),
+            &tables,
+        );
 
         assert_eq!(err.reason(), TABLE_NOT_FOUND_REASON);
         assert_eq!(err.status(), StatusCode::NotFound);
@@ -645,7 +674,10 @@ mod tests {
     #[test]
     fn table_not_found_case_insensitive_match_quotes_preserved_name() {
         let tables = vec![table("hockey", "Master")];
-        let err = StructuredQueryError::table_not_found("datafusion.hockey.master", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "hockey", "master"]),
+            &tables,
+        );
 
         let hint = err.hint().expect("hint should be present");
         assert!(
@@ -661,7 +693,8 @@ mod tests {
             table("hockey", "players"),
             table("hockey", "teams"),
         ];
-        let err = StructuredQueryError::table_not_found("datafusion.hockey.game", &tables);
+        let err =
+            StructuredQueryError::table_not_found(&tr(&["datafusion", "hockey", "game"]), &tables);
 
         let hint = err.hint().expect("hint should be present");
         assert!(hint.contains("hockey.games"), "got: {hint}");
@@ -670,7 +703,10 @@ mod tests {
     #[test]
     fn table_not_found_strips_datafusion_catalog_prefix_from_display() {
         let tables = vec![table("hockey", "Master")];
-        let err = StructuredQueryError::table_not_found("datafusion.hockey.master", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "hockey", "master"]),
+            &tables,
+        );
 
         assert!(
             err.summary().contains("`hockey.master`"),
@@ -693,7 +729,8 @@ mod tests {
         // user-registered `public` source, collapse to unqualified and
         // prefer a close cross-schema match over the catalog pointer.
         let tables = vec![table("hockey", "games")];
-        let err = StructuredQueryError::table_not_found("datafusion.public.games", &tables);
+        let err =
+            StructuredQueryError::table_not_found(&tr(&["datafusion", "public", "games"]), &tables);
 
         assert_eq!(err.metadata().get("schema"), None);
         assert_eq!(
@@ -718,7 +755,10 @@ mod tests {
         // parts); the public shortcut must keep everything after `public`
         // as the bare name, not split on the last dot.
         let tables = vec![table("hockey", "player.stats")];
-        let err = StructuredQueryError::table_not_found("datafusion.public.player.stats", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "public", "player.stats"]),
+            &tables,
+        );
 
         assert_eq!(err.metadata().get("schema"), None);
         assert_eq!(
@@ -742,7 +782,10 @@ mod tests {
         // If a user genuinely registered a source named `public`, don't
         // collapse the 2-part body — resolve against the catalog.
         let tables = vec![table("public", "Reports")];
-        let err = StructuredQueryError::table_not_found("datafusion.public.reports", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "public", "reports"]),
+            &tables,
+        );
 
         assert_eq!(
             err.metadata().get("schema").map(String::as_str),
@@ -757,7 +800,10 @@ mod tests {
         // Source name `foo.bar` explodes to `datafusion.foo.bar.items`;
         // parser must recover schema=`foo.bar`, table=`items`.
         let tables = vec![table("foo.bar", "Items")];
-        let err = StructuredQueryError::table_not_found("datafusion.foo.bar.items", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "foo.bar", "items"]),
+            &tables,
+        );
 
         assert_eq!(
             err.metadata().get("schema").map(String::as_str),
@@ -779,7 +825,10 @@ mod tests {
         // Dotted source + wrong table: schema/metadata must still name
         // the real source even when the hint path finds no close match.
         let tables = vec![table("foo.bar", "Items")];
-        let err = StructuredQueryError::table_not_found("datafusion.foo.bar.missing", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "foo.bar", "missing"]),
+            &tables,
+        );
 
         assert_eq!(
             err.metadata().get("schema").map(String::as_str),
@@ -797,7 +846,7 @@ mod tests {
         // emits 3-part paths); catalog entry is distant so cross-schema
         // Levenshtein doesn't fire and the generic pointer surfaces.
         let tables = vec![table("hockey", "zzzzzzzzz")];
-        let err = StructuredQueryError::table_not_found("games", &tables);
+        let err = StructuredQueryError::table_not_found(&tr(&["games"]), &tables);
 
         let hint = err.hint().expect("hint should be present");
         assert!(hint.contains("coral.tables"), "got: {hint}");
@@ -809,7 +858,10 @@ mod tests {
         // the schema-qualified match over the catalog pointer; metadata
         // stays unqualified so it reflects what the user wrote.
         let tables = vec![table("stripe", "accounts"), table("github", "issues")];
-        let err = StructuredQueryError::table_not_found("datafusion.public.account", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "public", "account"]),
+            &tables,
+        );
 
         let hint = err.hint().expect("hint should be present");
         assert!(
@@ -828,7 +880,10 @@ mod tests {
         // Unqualified miss with no close catalog entry: fall back to
         // the generic catalog pointer.
         let tables = vec![table("stripe", "subscriptions")];
-        let err = StructuredQueryError::table_not_found("datafusion.public.account", &tables);
+        let err = StructuredQueryError::table_not_found(
+            &tr(&["datafusion", "public", "account"]),
+            &tables,
+        );
 
         let hint = err.hint().expect("hint should be present");
         assert!(

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -1,13 +1,24 @@
 //! Shared runtime-error normalization for source compilation and registration.
 
-use datafusion::common::{Column, SchemaError, TableReference};
+use datafusion::common::{Column, SchemaError, Span, TableReference};
 use datafusion::error::DataFusionError;
+use datafusion::sql::sqlparser::ast::{ObjectName, ObjectNamePart};
+use datafusion::sql::sqlparser::dialect::GenericDialect;
+use datafusion::sql::sqlparser::parser::Parser;
 
 use crate::backends::http::ProviderQueryError;
-use crate::contracts::{ColumnParts, StructuredQueryError};
+use crate::contracts::{ColumnParts, StructuredQueryError, TableRefParts};
 use crate::{CoreError, SourceDecoratorError, TableInfo};
 
 pub(crate) fn datafusion_to_core(error: &DataFusionError, tables: &[TableInfo]) -> CoreError {
+    datafusion_to_core_with_sql(error, tables, None)
+}
+
+pub(crate) fn datafusion_to_core_with_sql(
+    error: &DataFusionError,
+    tables: &[TableInfo],
+    sql: Option<&str>,
+) -> CoreError {
     // Unwrap Context/Shared/Diagnostic wrappers so wrapped schema errors
     // get classified by their root variant instead of all landing in the
     // `Internal` bucket. Without `find_root()`, `SELECT bogus FROM wide`
@@ -16,7 +27,7 @@ pub(crate) fn datafusion_to_core(error: &DataFusionError, tables: &[TableInfo]) 
     // from the match arms below.
     match error.find_root() {
         DataFusionError::SQL(detail, _) => CoreError::InvalidInput(detail.to_string()),
-        DataFusionError::Plan(detail) => plan_error_to_core(detail, tables),
+        DataFusionError::Plan(detail) => plan_error_to_core(detail, error, tables, sql),
         DataFusionError::SchemaError(schema_error, _) => schema_error_to_core(schema_error),
         DataFusionError::NotImplemented(detail) => CoreError::Unimplemented(detail.clone()),
         DataFusionError::External(inner) => {
@@ -43,10 +54,15 @@ pub(crate) fn source_decorator_error_to_core(error: &SourceDecoratorError) -> Co
     }
 }
 
-fn plan_error_to_core(detail: &str, tables: &[TableInfo]) -> CoreError {
-    if let Some(table_ref) = extract_table_not_found(detail) {
+fn plan_error_to_core(
+    detail: &str,
+    error: &DataFusionError,
+    tables: &[TableInfo],
+    sql: Option<&str>,
+) -> CoreError {
+    if let Some(table_ref) = table_not_found_ref(error, detail, sql) {
         return CoreError::QueryFailure(Box::new(StructuredQueryError::table_not_found(
-            table_ref, tables,
+            &table_ref, tables,
         )));
     }
     CoreError::InvalidInput(detail.to_string())
@@ -96,21 +112,109 @@ fn column_to_parts(column: &Column) -> ColumnParts {
     }
 }
 
-/// Extracts the table reference from a `"table 'xxx' not found"` plan error.
+/// Extracts the missing table reference from a `DataFusion` table-not-found
+/// planning error.
 ///
-/// `DataFusion` raises this literal form from both the SQL-level relation
-/// resolver and the session-state catalog lookup when a referenced table
-/// isn't in the catalog. `DataFusionError::source` for the `Diagnostic`
-/// variant returns the inner error, so `find_root()` unwraps any
-/// diagnostic decoration before we match on the `Plan` string.
-///
-/// The exact prefix/suffix are load-bearing: the integration tests in
-/// `tests/engine/structured_error_tests.rs` exercise this path end-to-end,
-/// so any upstream wording change surfaces as a concrete test failure
-/// rather than silent mis-classification.
+/// `DataFusion` 53 does not expose a structured missing-relation variant; it
+/// currently emits a `Plan` error and, for SQL relation resolution, attaches a
+/// diagnostic span covering the table reference. Prefer reparsing that exact
+/// SQL span so quoted identifiers containing dots remain one component. The
+/// formatted-message parser is retained only for `DataFusion` paths that do not
+/// carry a span, such as direct session catalog lookup.
+fn table_not_found_ref(
+    error: &DataFusionError,
+    detail: &str,
+    sql: Option<&str>,
+) -> Option<TableRefParts> {
+    let spanned_sql_ref = sql
+        .zip(error.diagnostic().and_then(|diagnostic| diagnostic.span))
+        .and_then(|(sql, span)| sql_span(sql, span))
+        .and_then(table_ref_parts_from_sql_object);
+
+    if let Some(table_ref) = spanned_sql_ref
+        && looks_like_table_not_found(detail)
+    {
+        return Some(table_ref);
+    }
+
+    if !is_legacy_table_not_found_plan(detail) {
+        return None;
+    }
+
+    extract_table_not_found(detail)
+        .and_then(table_ref_parts_from_sql_object)
+        .or_else(|| {
+            extract_table_not_found(detail)
+                .map(|raw| TableRefParts::new(raw.split('.').map(ToString::to_string).collect()))
+        })
+}
+
+fn looks_like_table_not_found(detail: &str) -> bool {
+    let lowered = detail.to_lowercase();
+    lowered.contains("table")
+        && lowered.contains("not found")
+        && !lowered.contains("table function")
+}
+
+fn is_legacy_table_not_found_plan(detail: &str) -> bool {
+    extract_table_not_found(detail).is_some()
+}
+
 fn extract_table_not_found(detail: &str) -> Option<&str> {
     let rest = detail.strip_prefix("table '")?;
     rest.strip_suffix("' not found")
+}
+
+fn sql_span(sql: &str, span: Span) -> Option<&str> {
+    if span.start.line != span.end.line || span.start.line == 0 {
+        return None;
+    }
+    let line_index = usize::try_from(span.start.line - 1).ok()?;
+    let start = usize::try_from(span.start.column - 1).ok()?;
+    let end = usize::try_from(span.end.column - 1).ok()?;
+    let line = sql.lines().nth(line_index)?;
+    if start >= end {
+        return None;
+    }
+    byte_range_for_char_range(line, start, end).and_then(|range| line.get(range))
+}
+
+fn byte_range_for_char_range(
+    value: &str,
+    start: usize,
+    end: usize,
+) -> Option<std::ops::Range<usize>> {
+    let start_byte = value
+        .char_indices()
+        .nth(start)
+        .map_or(value.len(), |(index, _)| index);
+    let end_byte = value
+        .char_indices()
+        .nth(end)
+        .map_or(value.len(), |(index, _)| index);
+    (start_byte < end_byte && end_byte <= value.len()).then_some(start_byte..end_byte)
+}
+
+fn table_ref_parts_from_sql_object(raw: &str) -> Option<TableRefParts> {
+    let dialect = GenericDialect {};
+    let mut parser = Parser::new(&dialect).try_with_sql(raw).ok()?;
+    let object_name = parser.parse_object_name(true).ok()?;
+    table_ref_parts_from_object_name(object_name)
+}
+
+fn table_ref_parts_from_object_name(object_name: ObjectName) -> Option<TableRefParts> {
+    let parts = object_name
+        .0
+        .into_iter()
+        .map(|part| match part {
+            ObjectNamePart::Identifier(ident) => Some(match ident.quote_style {
+                Some(_) => ident.value,
+                None => ident.value.to_lowercase(),
+            }),
+            ObjectNamePart::Function(_) => None,
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some(TableRefParts::new(parts))
 }
 
 fn provider_error_to_core(error: &ProviderQueryError) -> CoreError {
@@ -160,7 +264,8 @@ mod tests {
 
     #[test]
     fn plan_error_without_table_prefix_is_invalid_input() {
-        let core = plan_error_to_core("syntax error at position 12", &[]);
+        let error = DataFusionError::Plan("syntax error at position 12".to_string());
+        let core = plan_error_to_core("syntax error at position 12", &error, &[], None);
         match core {
             CoreError::InvalidInput(detail) => assert!(detail.contains("syntax error")),
             other => panic!("expected CoreError::InvalidInput, got {other:?}"),

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -9,7 +9,7 @@ use datafusion_tracing::InstrumentationOptions;
 
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
-use crate::runtime::error::datafusion_to_core;
+use crate::runtime::error::{datafusion_to_core, datafusion_to_core_with_sql};
 use crate::runtime::json::register_json_support;
 use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::registry::{
@@ -120,7 +120,7 @@ impl QueryRuntimeAdapter {
             .ctx
             .sql_with_options(sql, read_only_sql_options())
             .await
-            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+            .map_err(|err| datafusion_to_core_with_sql(&err, &self.tables, Some(sql)))?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let batches = df
             .collect()

--- a/crates/coral-engine/tests/engine/structured_error_tests.rs
+++ b/crates/coral-engine/tests/engine/structured_error_tests.rs
@@ -150,6 +150,34 @@ async fn unqualified_table_suggests_schema_qualified_name() {
 }
 
 #[tokio::test]
+async fn quoted_dotted_missing_table_stays_one_identifier() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(
+        temp.path(),
+        "rows.jsonl",
+        &[json!({"id": 1, "playerID": "ov8"})],
+    );
+    let source = build_source(manifest("hockey", "player.stats", temp.path()));
+
+    let error = CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM \"player.stat\"")
+        .await
+        .expect_err("unknown quoted dotted table should fail");
+
+    let sqe = structured(error);
+    assert_eq!(sqe.reason(), "TABLE_NOT_FOUND");
+    assert_eq!(sqe.metadata().get("schema"), None);
+    assert_eq!(
+        sqe.metadata().get("table").map(String::as_str),
+        Some("player.stat")
+    );
+    let hint = sqe.hint().expect("hint should be present");
+    assert!(
+        hint.contains("hockey.\"player.stats\""),
+        "hint should preserve the dotted table as a quoted identifier, got: {hint}"
+    );
+}
+
+#[tokio::test]
 async fn unknown_column_on_aliased_join_suggests_case_preserved_quoted_name() {
     // Real-world shape: an agent discovers `playerID` in `coral.columns`
     // and writes a self-join `ON g.playerID = m.playerID`. DataFusion


### PR DESCRIPTION
## Summary

This change makes structured `TABLE_NOT_FOUND` errors preserve the table reference the user actually wrote, instead of reparsing DataFusion's formatted error string with raw dot splitting.

DataFusion 53 still reports missing relations as `Plan` errors, but SQL planning attaches a diagnostic span for the relation. The engine now uses that span to recover the original SQL object name and parse it into identifier parts, so quoted identifiers containing dots stay intact.

## Why

The old path treated `datafusion.foo.bar.baz` as a dotted display string and then guessed schema/table boundaries. That loses the difference between `foo."bar.baz"`, `"foo.bar".baz`, and `foo.bar.baz`, which can produce misleading metadata and hints for structured errors.

## Changes

- Pass SQL text into DataFusion error normalization at planning time.
- Add `TableRefParts` so `TABLE_NOT_FOUND` receives parsed object-name parts instead of a lossy string.
- Parse DataFusion diagnostic spans in runtime error normalization using DataFusion's SQL parser re-export.
- Keep the old exact formatted-string parser only as a fallback for spanless DataFusion errors.
- Add an end-to-end regression for a quoted dotted missing table reference.

## Verification

- `cargo test -p coral-engine structured_error_tests`
- `cargo test -p coral-engine contracts::query_error`
- `make rust-checks`
