### PR TITLE
feat(engine): instrument optimizer rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,9 +1989,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-tracing"
-version = "53.0.0"
+version = "53.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387168b2dc738668423132f7d04562fe75f612e970da153da7dd2a686f2798c2"
+checksum = "c8c6042c471ac0d904296cab7c20c11849de2333573879c015aa04462345e7db"
 dependencies = [
  "async-trait",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 datafusion = "53"
 datafusion-functions-json = "0.53"
-datafusion-tracing = "53.0.0"
+datafusion-tracing = "53.0.1"
 dialoguer = "0.12"
 directories = "6"
 fs2 = "0.4"

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
-use datafusion_tracing::InstrumentationOptions;
+use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
@@ -47,6 +47,11 @@ pub(crate) async fn build_runtime(
         .with_default_features()
         .with_physical_optimizer_rule(instrument_rule)
         .build();
+    let session_state = datafusion_tracing::instrument_rules_with_trace_spans!(
+        target: "coral_engine::datafusion",
+        options: RuleInstrumentationOptions::full(),
+        state: session_state
+    );
     let mut ctx = SessionContext::new_with_state(session_state);
     register_json_support(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;
     register_pattern_validator(&mut ctx).map_err(|err| datafusion_to_core(&err, &[]))?;


### PR DESCRIPTION
## Summary
- Bump `datafusion-tracing` to 53.0.1 and wrap the session state with `instrument_rules_with_trace_spans!` so optimizer-rule execution emits trace spans under the `coral_engine::datafusion` target.

Before:

<img width="1649" height="698" alt="image" src="https://github.com/user-attachments/assets/21ceca2e-07d7-443b-8a14-86ccb18ea6a8" />

After:

<img width="1655" height="1019" alt="image" src="https://github.com/user-attachments/assets/9510a9c6-d2a9-4328-bfdf-c0eca5670447" />

<img width="1647" height="1185" alt="image" src="https://github.com/user-attachments/assets/fbdea3d3-41a1-4cc3-bc0d-6c93dd2ae066" />

## Test plan
- [ ] `cargo build` succeeds with the new `datafusion-tracing` 53.0.1 dependency.
- [ ] `cargo fmt` and `cargo clippy` pass.
- [ ] Run `coral sql "SELECT 1"` against a local OTLP collector with `trace_filter` including `coral_engine::datafusion=trace` and confirm optimizer-rule spans appear.