### PR TITLE
build(cargo): standardize locked Cargo commands

### DIFF
--- a/.github/workflows/build-timings.yml
+++ b/.github/workflows/build-timings.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build with timings
         run: |
-          cargo build --bin coral --timings 2>&1 | tee build-output.txt
+          cargo build --locked --bin coral --timings 2>&1 | tee build-output.txt
           echo ""
           echo "=== Cache effectiveness ==="
           compiled=$(grep -c "^   Compiling" build-output.txt || true)

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,7 +128,7 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install ryl
-        run: cargo install ryl
+        run: cargo install ryl --locked
 
       - name: Run make lint-sources
         run: make lint-sources

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,13 @@ cargo test --workspace --all-targets --all-features --locked
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 ```
 
+If a Cargo command fails because the lockfile needs to be updated but
+`--locked` was passed, refresh `Cargo.lock` with the narrowest practical
+command, such as `cargo update -p <crate>`, then commit the lockfile with the
+matching `Cargo.toml` change. For broader dependency changes, run one normal
+Cargo build without `--locked` to regenerate the lockfile before rerunning the
+locked checks.
+
 ### Source manifest linting
 
 Source manifests under `sources/*/manifest.yaml` are checked with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,6 @@ If you prefer to run steps individually, the equivalent commands are:
 
 ```bash
 cargo fmt --all -- --check
-cargo check --workspace --all-targets --all-features --locked
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 cargo test --workspace --all-targets --all-features --locked
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,9 +67,11 @@ update the relevant docs in the same pull request.
 If you prefer to run steps individually, the equivalent commands are:
 
 ```bash
-cargo fmt --all
-cargo clippy --workspace --all-targets -- -D warnings
-cargo test --workspace
+cargo fmt --all -- --check
+cargo check --workspace --all-targets --all-features --locked
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+cargo test --workspace --all-targets --all-features --locked
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 ```
 
 ### Source manifest linting
@@ -78,7 +80,7 @@ Source manifests under `sources/*/manifest.yaml` are checked with
 [`ryl`](https://github.com/owenlamont/ryl), a Rust-native yamllint port.
 Config lives in `.yamllint.yaml` at the repo root.
 
-Install `ryl` once with `cargo install ryl`, then:
+Install `ryl` once with `cargo install ryl --locked`, then:
 
 ```bash
 make lint-sources   # check — run this before pushing changes to sources/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 rust-checks:
 	cargo fmt --all -- --check
-	cargo check --workspace --all-targets --all-features --locked
 	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 	cargo test --workspace --all-targets --all-features --locked
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 rust-checks:
 	cargo fmt --all -- --check
 	cargo check --workspace --all-targets --all-features --locked
-	cargo clippy --workspace --all-targets --all-features -- -D warnings
+	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 	cargo test --workspace --all-targets --all-features --locked
-	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 
 # ----------------------------------------------------------------------------
 # Source manifest linting
@@ -29,13 +29,13 @@ fix-sources:
 #   make docs-check      # CI freshness check: non-zero exit if stale
 
 docs-generate:
-	cargo run -p xtask -- generate-docs \
+	cargo run --locked -p xtask -- generate-docs \
 	  --sources-dir sources \
 	  --index docs/reference/bundled-sources.mdx \
 	  --docs-json docs/docs.json
 
 docs-check:
-	cargo run -p xtask -- generate-docs \
+	cargo run --locked -p xtask -- generate-docs \
 	  --sources-dir sources \
 	  --index docs/reference/bundled-sources.mdx \
 	  --docs-json docs/docs.json \

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -28,8 +28,8 @@ Coral ships as a single local CLI. Once installed, the same binary is used for s
     Requires [Rust and Cargo](https://www.rust-lang.org/tools/install) installed.
 
     ```shellscript
-    cargo build -p coral-cli --release
-    ./target/release/coral --help
+    cargo install --path crates/coral-cli --locked
+    coral --help
     ```
   </Tab>
 </Tabs>

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -42,7 +42,7 @@ The user-facing command-line interface.
 | Output formatting | Table and JSON via `coral-client` helpers |
 
 Intentionally thin at the binary boundary — `main.rs` is a small wrapper, `bootstrap.rs` owns CLI bootstrap, and `lib.rs` owns shared command parsing and dispatch for Coral binaries. Query/result helpers stay in `coral-client`.
-For black-box CLI tests, contributors can enable the `CORAL_ENDPOINT` bootstrap override with `cargo test -p coral-cli --features cli-test-server`.
+For black-box CLI tests, contributors can enable the `CORAL_ENDPOINT` bootstrap override with `cargo test --locked -p coral-cli --features cli-test-server`.
 
 ### `coral-client`
 


### PR DESCRIPTION
## Intent

Cargo commands in our local workflow, CI, and docs were not consistently using the checked-in lockfile. That left some commands free to resolve a different semver-compatible dependency graph, which made rebuild behavior look arbitrary and could let local validation drift from committed state.

This change makes locked dependency resolution the default for repo-owned Cargo workflows and source-install instructions.

## Changes

- Add `--locked` to `clippy`, `doc`, and `xtask` docs-generation commands in the Makefile.
- Update contributor docs so the expanded `rust-checks` commands actually match the Makefile.
- Change source install docs to use `cargo install --path crates/coral-cli --locked`.
- Lock Cargo usage in build-timings CI and the `ryl` install path.
- Align the architecture docs' black-box CLI test command with the locked workflow.

## Verification

- `make rust-checks`
- `make docs-check`
- `make lint-sources`
- `cargo install --path crates/coral-cli --locked --root "$tmpdir" --debug`
