### PR TITLE
chore: tweak agent instructions on running rust-checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 
 ## Rules
 
-- Run `make rust-checks` before finishing making changes to Rust code.
+- Run `make rust-checks` before submitting PRs that include changes to Rust code.
 - Keep adapters thin. If CLI or MCP behavior gets complex, move it inward.
 - Keep transport contract concerns in `coral-api`, source-spec concerns in
   `coral-spec`, app/state concerns in `coral-app`, and query/runtime


### PR DESCRIPTION
I often find myself blocked between turns in an agent session, waiting minutes for the agent to finish running `make rust-checks`. These checks are frequently expensive, so let's run them only once we're ready to open a PR, rather than every time the agent touches some Rust code.