### PR TITLE
build(cargo): drop redundant check pass

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,6 @@ If you prefer to run steps individually, the equivalent commands are:
 
 ```bash
 cargo fmt --all -- --check
-cargo check --workspace --all-targets --all-features --locked
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 cargo test --workspace --all-targets --all-features --locked
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 rust-checks:
 	cargo fmt --all -- --check
-	cargo check --workspace --all-targets --all-features --locked
 	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 	cargo test --workspace --all-targets --all-features --locked
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked


### PR DESCRIPTION
## Intent

`cargo clippy` already runs the compiler frontend over the workspace before applying lints, so running `cargo check` immediately before it makes `make rust-checks` do a redundant type-check pass.

This follow-up keeps the locked dependency behavior from #301 while shortening the local and CI Rust gate.

## Changes

- Remove the standalone `cargo check --workspace --all-targets --all-features --locked` step from `make rust-checks`.
- Update the expanded contributor command list to match the Makefile.

## Verification

- `make rust-checks`
- `make docs-check`
