### PR TITLE
feat(engine): add final-result observer hook

### DIFF
--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -49,6 +49,9 @@ pub(crate) fn engine_extensions_for_providers(
         let extra = provider.extensions_for(selected_sources);
         merged.source_decorators.extend(extra.source_decorators);
         merged
+            .query_result_observers
+            .extend(extra.query_result_observers);
+        merged
             .request_authenticators
             .extend(extra.request_authenticators);
     }
@@ -59,7 +62,12 @@ pub(crate) fn engine_extensions_for_providers(
 mod tests {
     use std::collections::BTreeMap;
 
-    use coral_engine::{RequestAuthenticator, RequestAuthenticatorError};
+    use arrow::datatypes::Schema;
+    use arrow::record_batch::RecordBatch;
+    use coral_engine::{
+        QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
+        RequestAuthenticatorError,
+    };
     use reqwest::header::{HeaderName, HeaderValue};
 
     use super::*;
@@ -84,6 +92,25 @@ mod tests {
         }
     }
 
+    struct TestObserver {
+        name: &'static str,
+    }
+
+    impl QueryResultObserver for TestObserver {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+
+        fn observe_result(
+            &self,
+            _sql: &str,
+            _schema: &Schema,
+            _batches: &[RecordBatch],
+        ) -> Result<(), QueryResultObserverError> {
+            Ok(())
+        }
+    }
+
     struct TestEngineExtensionsProvider {
         key: &'static str,
         name: &'static str,
@@ -100,11 +127,26 @@ mod tests {
         }
     }
 
+    struct TestObserverProvider {
+        name: &'static str,
+    }
+
+    impl EngineExtensionsProvider for TestObserverProvider {
+        fn extensions_for(&self, _selected_sources: &[QuerySource]) -> EngineExtensions {
+            let mut extensions = EngineExtensions::default();
+            extensions
+                .query_result_observers
+                .push(Arc::new(TestObserver { name: self.name }));
+            extensions
+        }
+    }
+
     #[test]
     fn noop_provider_installs_no_extensions() {
         let extensions = NoopEngineExtensionsProvider.extensions_for(&[]);
 
         assert!(extensions.source_decorators.is_empty());
+        assert!(extensions.query_result_observers.is_empty());
         assert!(extensions.request_authenticators.is_empty());
     }
 
@@ -145,5 +187,22 @@ mod tests {
 
         assert_eq!(base_authenticator.name(), "base");
         assert_eq!(extra_authenticator.name(), "extra");
+    }
+
+    #[test]
+    fn provider_lists_merge_query_result_observers_in_call_order() {
+        let providers = vec![
+            Arc::new(TestObserverProvider { name: "base" }) as Arc<dyn EngineExtensionsProvider>,
+            Arc::new(TestObserverProvider { name: "extra" }),
+        ];
+
+        let extensions = engine_extensions_for_providers(&providers, &[]);
+        let observer_names = extensions
+            .query_result_observers
+            .iter()
+            .map(|observer| observer.name())
+            .collect::<Vec<_>>();
+
+        assert_eq!(observer_names, ["base", "extra"]);
     }
 }

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -1,8 +1,10 @@
-//! Advanced composition seams for source registration.
+//! Advanced composition seams for engine extension points.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
 use datafusion::datasource::TableProvider;
 use reqwest::header::{HeaderName, HeaderValue};
 
@@ -16,6 +18,8 @@ pub type SourceTables = HashMap<String, Arc<dyn TableProvider>>;
 pub struct EngineExtensions {
     /// Registration-time table decorators for the selected source set.
     pub source_decorators: Vec<Box<dyn SourceDecorator>>,
+    /// Post-query observers invoked after successful SQL result collection.
+    pub query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
     /// Request-time custom authenticators keyed by `auth.authenticator`.
     pub request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
 }
@@ -41,6 +45,31 @@ pub enum SourceDecoratorError {
 }
 
 impl SourceDecoratorError {
+    #[must_use]
+    /// Builds an invalid-input error.
+    pub fn invalid_input(detail: impl Into<String>) -> Self {
+        Self::InvalidInput(detail.into())
+    }
+
+    #[must_use]
+    /// Builds a failed-precondition error.
+    pub fn failed_precondition(detail: impl Into<String>) -> Self {
+        Self::FailedPrecondition(detail.into())
+    }
+}
+
+/// Neutral error type for query-result observer failures.
+#[derive(Debug, thiserror::Error)]
+pub enum QueryResultObserverError {
+    /// The observer was configured with invalid input.
+    #[error("{0}")]
+    InvalidInput(String),
+    /// The observer could not proceed because a precondition was unmet.
+    #[error("{0}")]
+    FailedPrecondition(String),
+}
+
+impl QueryResultObserverError {
     #[must_use]
     /// Builds an invalid-input error.
     pub fn invalid_input(detail: impl Into<String>) -> Self {
@@ -110,6 +139,31 @@ pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
     ) -> Result<(), RequestAuthenticatorError> {
         Ok(())
     }
+}
+
+/// Post-query hook for observing fully materialized successful query results.
+///
+/// Observers run after `DataFusion` successfully collects result batches and
+/// before [`crate::QueryExecution`] is returned. They receive read-only
+/// references to the final SQL text, Arrow schema, and result batches; observer
+/// implementations must not rely on mutating the returned query result.
+pub trait QueryResultObserver: Send + Sync {
+    /// Stable observer name used in diagnostics.
+    fn name(&self) -> &'static str;
+
+    /// Observes one successful query result.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryResultObserverError`] if the observer cannot process the
+    /// final result. Observer failures fail the query after SQL execution has
+    /// succeeded.
+    fn observe_result(
+        &self,
+        sql: &str,
+        schema: &Schema,
+        batches: &[RecordBatch],
+    ) -> Result<(), QueryResultObserverError>;
 }
 
 /// Registration-time hook for wrapping or replacing a source's table providers.

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -143,10 +143,17 @@ pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
 
 /// Post-query hook for observing fully materialized successful query results.
 ///
-/// Observers run after `DataFusion` successfully collects result batches and
-/// before [`crate::QueryExecution`] is returned. They receive read-only
-/// references to the final SQL text, Arrow schema, and result batches; observer
-/// implementations must not rely on mutating the returned query result.
+/// Observers run synchronously on the query execution path after `DataFusion`
+/// successfully collects result batches and before [`crate::QueryExecution`] is
+/// returned. Observer work therefore contributes directly to `execute_sql`
+/// latency, and observer failures fail the query after SQL execution has
+/// succeeded. Implementations should keep in-band work lightweight; expensive
+/// persistence, network calls, or telemetry fanout should be handed off to
+/// background workers when they should not delay the query response.
+///
+/// Observers receive read-only references to the final SQL text, Arrow schema,
+/// and result batches; implementations must not rely on mutating the returned
+/// query result.
 pub trait QueryResultObserver: Send + Sync {
     /// Stable observer name used in diagnostics.
     fn name(&self) -> &'static str;

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -61,8 +61,9 @@ pub mod contracts;
 mod runtime;
 
 pub use composition::{
-    EngineExtensions, RequestAuthenticator, RequestAuthenticatorError, SourceDecorator,
-    SourceDecoratorError, SourceFailurePolicy, SourceTables,
+    EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
+    RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
+    SourceTables,
 };
 pub use contracts::{
     ColumnInfo, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -8,7 +8,7 @@ use datafusion::sql::sqlparser::parser::Parser;
 
 use crate::backends::http::ProviderQueryError;
 use crate::contracts::{ColumnParts, StructuredQueryError, TableRefParts};
-use crate::{CoreError, SourceDecoratorError, TableInfo};
+use crate::{CoreError, QueryResultObserverError, SourceDecoratorError, TableInfo};
 
 pub(crate) fn datafusion_to_core(error: &DataFusionError, tables: &[TableInfo]) -> CoreError {
     datafusion_to_core_with_sql(error, tables, None)
@@ -49,6 +49,15 @@ pub(crate) fn source_decorator_error_to_core(error: &SourceDecoratorError) -> Co
     match error {
         SourceDecoratorError::InvalidInput(detail) => CoreError::InvalidInput(detail.clone()),
         SourceDecoratorError::FailedPrecondition(detail) => {
+            CoreError::FailedPrecondition(detail.clone())
+        }
+    }
+}
+
+pub(crate) fn query_result_observer_error_to_core(error: &QueryResultObserverError) -> CoreError {
+    match error {
+        QueryResultObserverError::InvalidInput(detail) => CoreError::InvalidInput(detail.clone()),
+        QueryResultObserverError::FailedPrecondition(detail) => {
             CoreError::FailedPrecondition(detail.clone())
         }
     }

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -9,18 +9,24 @@ use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
-use crate::runtime::error::{datafusion_to_core, datafusion_to_core_with_sql};
+use crate::runtime::error::{
+    datafusion_to_core, datafusion_to_core_with_sql, query_result_observer_error_to_core,
+};
 use crate::runtime::json::register_json_support;
 use crate::runtime::pattern_validator::register_pattern_validator;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
-use crate::{CoreError, QueryExecution, QueryRuntimeConfig, QuerySource, TableInfo};
+use crate::{
+    CoreError, QueryExecution, QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig,
+    QuerySource, TableInfo,
+};
 
 pub(crate) struct QueryRuntimeAdapter {
     ctx: Arc<SessionContext>,
     tables: Vec<TableInfo>,
     failures: Vec<SourceRegistrationFailure>,
+    query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
 }
 
 pub(crate) async fn build_runtime(
@@ -99,6 +105,7 @@ pub(crate) async fn build_runtime(
         ctx,
         tables,
         failures: registration.failures,
+        query_result_observers: extensions.query_result_observers,
     })
 }
 
@@ -131,7 +138,22 @@ impl QueryRuntimeAdapter {
             .collect()
             .await
             .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        self.observe_query_result(sql, arrow_schema.as_ref(), &batches)?;
         Ok(QueryExecution::new(arrow_schema, batches))
+    }
+
+    fn observe_query_result(
+        &self,
+        sql: &str,
+        schema: &arrow::datatypes::Schema,
+        batches: &[arrow::record_batch::RecordBatch],
+    ) -> Result<(), CoreError> {
+        for observer in &self.query_result_observers {
+            observer
+                .observe_result(sql, schema, batches)
+                .map_err(|error| query_result_observer_error(observer.name(), &error))?;
+        }
+        Ok(())
     }
 }
 
@@ -140,4 +162,17 @@ fn read_only_sql_options() -> SQLOptions {
         .with_allow_ddl(false)
         .with_allow_dml(false)
         .with_allow_statements(false)
+}
+
+fn query_result_observer_error(name: &str, error: &QueryResultObserverError) -> CoreError {
+    let core = query_result_observer_error_to_core(error);
+    match core {
+        CoreError::InvalidInput(detail) => {
+            CoreError::InvalidInput(format!("query result observer '{name}': {detail}"))
+        }
+        CoreError::FailedPrecondition(detail) => {
+            CoreError::FailedPrecondition(format!("query result observer '{name}': {detail}"))
+        }
+        other => other,
+    }
 }

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -19,6 +19,8 @@ mod jsonl_tests;
 mod parquet_tests;
 #[path = "engine/pattern_error_tests.rs"]
 mod pattern_error_tests;
+#[path = "engine/query_result_observer_tests.rs"]
+mod query_result_observer_tests;
 #[path = "engine/structured_error_tests.rs"]
 mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]

--- a/crates/coral-engine/tests/engine/query_result_observer_tests.rs
+++ b/crates/coral-engine/tests/engine/query_result_observer_tests.rs
@@ -1,0 +1,233 @@
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+use coral_engine::{
+    CoralQuery, CoreError, EngineExtensions, QueryResultObserver, QueryResultObserverError,
+    QueryRuntimeConfig, QueryRuntimeContext, StatusCode,
+};
+use serde_json::{Value, json};
+
+use crate::harness::{build_source, dir_url, execution_to_rows, users_rows, write_jsonl_file};
+
+#[derive(Debug, Clone, PartialEq)]
+struct ObservedQuery {
+    sql: String,
+    column_names: Vec<String>,
+    row_count: usize,
+    rows: Vec<Value>,
+}
+
+#[derive(Debug, Default)]
+struct RecordingObserver {
+    calls: Mutex<Vec<ObservedQuery>>,
+}
+
+impl RecordingObserver {
+    fn calls(&self) -> Vec<ObservedQuery> {
+        self.calls
+            .lock()
+            .expect("observer calls lock should not be poisoned")
+            .clone()
+    }
+}
+
+impl QueryResultObserver for RecordingObserver {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+
+    fn observe_result(
+        &self,
+        sql: &str,
+        schema: &Schema,
+        batches: &[RecordBatch],
+    ) -> Result<(), QueryResultObserverError> {
+        self.calls
+            .lock()
+            .expect("observer calls lock should not be poisoned")
+            .push(ObservedQuery {
+                sql: sql.to_string(),
+                column_names: schema
+                    .fields()
+                    .iter()
+                    .map(|field| field.name().clone())
+                    .collect(),
+                row_count: batches.iter().map(RecordBatch::num_rows).sum(),
+                rows: batches_to_rows(batches),
+            });
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct FailingObserver;
+
+impl QueryResultObserver for FailingObserver {
+    fn name(&self) -> &'static str {
+        "failing"
+    }
+
+    fn observe_result(
+        &self,
+        _sql: &str,
+        _schema: &Schema,
+        _batches: &[RecordBatch],
+    ) -> Result<(), QueryResultObserverError> {
+        Err(QueryResultObserverError::failed_precondition(
+            "expected benchmark state is missing",
+        ))
+    }
+}
+
+#[tokio::test]
+async fn observer_called_after_successful_query_and_sees_final_batches() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest("observer_success", temp.path()));
+    let observer = Arc::new(RecordingObserver::default());
+    let runtime = runtime_with_observer(observer.clone());
+    let sql = "SELECT id, name FROM observer_success.users WHERE id >= 2 ORDER BY id";
+
+    let execution = CoralQuery::execute_sql(&[source], runtime, sql)
+        .await
+        .expect("query should succeed");
+
+    assert_eq!(execution.row_count(), 2);
+    let calls = observer.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0],
+        ObservedQuery {
+            sql: sql.to_string(),
+            column_names: vec!["id".to_string(), "name".to_string()],
+            row_count: 2,
+            rows: vec![
+                json!({"id": 2, "name": "Grace"}),
+                json!({"id": 3, "name": "Linus"}),
+            ],
+        }
+    );
+}
+
+#[tokio::test]
+async fn observer_errors_fail_query_with_structured_core_error() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest("observer_error", temp.path()));
+    let runtime = runtime_with_observer(Arc::new(FailingObserver));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        runtime,
+        "SELECT id FROM observer_error.users ORDER BY id",
+    )
+    .await
+    .expect_err("observer failure should fail the query");
+
+    assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
+    match error {
+        CoreError::FailedPrecondition(detail) => {
+            assert_eq!(
+                detail,
+                "query result observer 'failing': expected benchmark state is missing"
+            );
+        }
+        other => panic!("expected CoreError::FailedPrecondition, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn no_observer_keeps_existing_query_behavior_unchanged() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest("observer_none", temp.path()));
+
+    let execution = CoralQuery::execute_sql(
+        &[source],
+        QueryRuntimeConfig::default(),
+        "SELECT id, name FROM observer_none.users WHERE id < 3 ORDER BY id",
+    )
+    .await
+    .expect("query should succeed without observers");
+
+    assert_eq!(execution.row_count(), 2);
+    assert_eq!(
+        execution_to_rows(&execution),
+        vec![
+            json!({"id": 1, "name": "Ada"}),
+            json!({"id": 2, "name": "Grace"}),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn observer_sees_filtered_projected_result_not_raw_source_rows() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest("observer_final", temp.path()));
+    let observer = Arc::new(RecordingObserver::default());
+    let sql = "SELECT name FROM observer_final.users WHERE id = 2";
+
+    let execution =
+        CoralQuery::execute_sql(&[source], runtime_with_observer(observer.clone()), sql)
+            .await
+            .expect("query should succeed");
+
+    assert_eq!(
+        execution_to_rows(&execution),
+        vec![json!({"name": "Grace"})]
+    );
+    let calls = observer.calls();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(
+        calls[0],
+        ObservedQuery {
+            sql: sql.to_string(),
+            column_names: vec!["name".to_string()],
+            row_count: 1,
+            rows: vec![json!({"name": "Grace"})],
+        }
+    );
+}
+
+fn runtime_with_observer(observer: Arc<dyn QueryResultObserver>) -> QueryRuntimeConfig {
+    let mut extensions = EngineExtensions::default();
+    extensions.query_result_observers.push(observer);
+    QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions)
+}
+
+fn jsonl_manifest(name: &str, dir: &Path) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "tables": [{
+            "name": "users",
+            "description": "Users fixture",
+            "source": {
+                "location": dir_url(dir),
+                "glob": "**/*.jsonl",
+            },
+            "columns": [
+                {"name": "id", "type": "Int64"},
+                {"name": "name", "type": "Utf8"},
+                {"name": "email", "type": "Utf8"},
+            ],
+        }],
+    })
+}
+
+fn batches_to_rows(batches: &[RecordBatch]) -> Vec<Value> {
+    let mut bytes = Vec::new();
+    {
+        let mut writer = arrow::json::ArrayWriter::new(&mut bytes);
+        for batch in batches {
+            writer.write(batch).expect("batch should encode to json");
+        }
+        writer.finish().expect("json writer should finish");
+    }
+    serde_json::from_slice(&bytes).expect("json rows should decode")
+}


### PR DESCRIPTION
## Summary

Adds a generic `QueryResultObserver` engine extension that lets external extension crates inspect successful final SQL results after DataFusion collection and before `QueryExecution` is returned.

This wires observer lists through `EngineExtensions` and app extension-provider merging, preserving the existing layering for source decorators and request authenticators. Observer failures are mapped into structured `CoreError` diagnostics, and the new tests cover successful observation, error propagation, no-observer behavior, and filtered/projected final results.

## Intent

This is meant to be a small core hook, not a needle-specific feature.

The immediate use case is cloud/eval needle retrieval tracking: needles are injected inside Coral through an engine extension, and retrieval tracking should be able to observe the same typed final Arrow result regardless of whether the query was run through CLI, gRPC, MCP, tests, or a benchmark harness.

Keeping this in core as a generic observer avoids coupling tracking to one caller's output format, JSON rendering, or client-side decoding path. It also keeps needle-specific matching and logging out of `coral-engine`; those can live in the cloud/evals extension crate on top of this hook.

This does not attempt to provide row provenance. Observers see final materialized results only. They can answer questions like "does the final result contain the expected values?" but not "did this output physically derive from a specific source row through arbitrary SQL operators?"

## Checks

- `make rust-checks`