### PR TITLE
feat(app): add SQL explain API

### DIFF
--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -21,6 +21,31 @@ message ExecuteSqlResponse {
   int64 row_count = 2;
 }
 
+// Produces query-engine plan renderings for one SQL statement without executing
+// it.
+message PlanSqlRequest {
+  // Workspace that scopes the queryable source set.
+  Workspace workspace = 1;
+  // One read-only SQL statement.
+  string sql = 2;
+}
+
+// Query-engine plan renderings for one SQL statement.
+message QueryPlan {
+  // Parsed logical plan before logical optimization.
+  string unoptimized_logical_plan = 1;
+  // Logical plan after logical optimization.
+  string optimized_logical_plan = 2;
+  // Physical execution plan after physical optimization.
+  string physical_plan = 3;
+}
+
+// Query planning response.
+message PlanSqlResponse {
+  // Generated query plan.
+  QueryPlan plan = 1;
+}
+
 // Page request parameters for list-style APIs.
 message PaginationRequest {
   // Maximum number of items to return. Zero means unbounded for compatibility.
@@ -73,4 +98,6 @@ service QueryService {
   rpc ListTables(ListTablesRequest) returns (ListTablesResponse);
   // Executes one read-only SQL statement and returns the full result set.
   rpc ExecuteSql(ExecuteSqlRequest) returns (ExecuteSqlResponse);
+  // Plans one read-only SQL statement without executing it.
+  rpc PlanSql(PlanSqlRequest) returns (PlanSqlResponse);
 }

--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -21,9 +21,9 @@ message ExecuteSqlResponse {
   int64 row_count = 2;
 }
 
-// Produces query-engine plan renderings for one SQL statement without executing
-// it.
-message PlanSqlRequest {
+// Explains one SQL statement by producing query-engine plan renderings without
+// executing it.
+message ExplainSqlRequest {
   // Workspace that scopes the queryable source set.
   Workspace workspace = 1;
   // One read-only SQL statement.
@@ -40,8 +40,8 @@ message QueryPlan {
   string physical_plan = 3;
 }
 
-// Query planning response.
-message PlanSqlResponse {
+// SQL explanation response.
+message ExplainSqlResponse {
   // Generated query plan.
   QueryPlan plan = 1;
 }
@@ -98,6 +98,6 @@ service QueryService {
   rpc ListTables(ListTablesRequest) returns (ListTablesResponse);
   // Executes one read-only SQL statement and returns the full result set.
   rpc ExecuteSql(ExecuteSqlRequest) returns (ExecuteSqlResponse);
-  // Plans one read-only SQL statement without executing it.
-  rpc PlanSql(PlanSqlRequest) returns (PlanSqlResponse);
+  // Explains one read-only SQL statement without executing it.
+  rpc ExplainSql(ExplainSqlRequest) returns (ExplainSqlResponse);
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -97,13 +97,13 @@ impl QueryManager {
         .await
     }
 
-    pub(crate) async fn plan_sql(
+    pub(crate) async fn explain_sql(
         &self,
         workspace_name: &WorkspaceName,
         sql: &str,
     ) -> Result<QueryPlan, QueryManagerError> {
         run_query_operation(
-            QueryOperation::PlanSql,
+            QueryOperation::ExplainSql,
             workspace_name,
             sql,
             async {
@@ -111,7 +111,7 @@ impl QueryManager {
                     .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self.runtime_config(&sources);
-                CoralQuery::plan_sql(&sources, runtime, sql)
+                CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
             },
@@ -221,14 +221,14 @@ impl QueryManager {
 #[derive(Clone, Copy)]
 enum QueryOperation {
     ExecuteSql,
-    PlanSql,
+    ExplainSql,
 }
 
 impl QueryOperation {
     const fn as_str(self) -> &'static str {
         match self {
             Self::ExecuteSql => "execute_sql",
-            Self::PlanSql => "plan_sql",
+            Self::ExplainSql => "explain_sql",
         }
     }
 }

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -5,8 +5,8 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use coral_engine::{
-    CoralQuery, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    SourceValidationReport, StatusCode, TableInfo,
+    CoralQuery, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -120,6 +120,20 @@ impl QueryManager {
         }
 
         result
+    }
+
+    pub(crate) async fn plan_sql(
+        &self,
+        workspace_name: &WorkspaceName,
+        sql: &str,
+    ) -> Result<QueryPlan, QueryManagerError> {
+        let sources = self
+            .load_query_sources(workspace_name)
+            .map_err(QueryManagerError::App)?;
+        let runtime = self.runtime_config(&sources);
+        CoralQuery::plan_sql(&sources, runtime, sql)
+            .await
+            .map_err(QueryManagerError::Core)
     }
 
     pub(crate) async fn validate_source(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -80,7 +80,7 @@ impl QueryManager {
         sql: &str,
     ) -> Result<QueryExecution, QueryManagerError> {
         run_query_operation(
-            "execute_sql",
+            QueryOperation::ExecuteSql,
             workspace_name,
             sql,
             async {
@@ -103,7 +103,7 @@ impl QueryManager {
         sql: &str,
     ) -> Result<QueryPlan, QueryManagerError> {
         run_query_operation(
-            "plan_sql",
+            QueryOperation::PlanSql,
             workspace_name,
             sql,
             async {
@@ -218,8 +218,23 @@ impl QueryManager {
     }
 }
 
+#[derive(Clone, Copy)]
+enum QueryOperation {
+    ExecuteSql,
+    PlanSql,
+}
+
+impl QueryOperation {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExecuteSql => "execute_sql",
+            Self::PlanSql => "plan_sql",
+        }
+    }
+}
+
 async fn run_query_operation<T, Fut, RowCount>(
-    operation: &'static str,
+    operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
     query: Fut,
@@ -235,7 +250,7 @@ where
 
     let metrics = crate::telemetry::metrics::metrics();
     let status = crate::telemetry::metrics::status_attr(result.is_ok());
-    let attributes = [status, KeyValue::new("operation", operation)];
+    let attributes = [status, KeyValue::new("operation", operation.as_str())];
     metrics.count.add(1, &attributes);
     metrics
         .duration
@@ -263,10 +278,11 @@ where
 }
 
 fn create_query_span(
-    operation: &'static str,
+    operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
 ) -> tracing::Span {
+    let operation = operation.as_str();
     tracing::info_span!(
         "coral.query",
         otel.name = "coral.query",

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,6 +1,7 @@
 //! Query-time loading, validation, and execution over installed sources.
 
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -9,7 +10,7 @@ use coral_engine::{
     QuerySource, SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
-use opentelemetry::trace::Status as OtelStatus;
+use opentelemetry::{KeyValue, trace::Status as OtelStatus};
 use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
@@ -78,48 +79,22 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         sql: &str,
     ) -> Result<QueryExecution, QueryManagerError> {
-        let started_at = Instant::now();
-        let query_span = create_query_span(workspace_name, sql);
-        let result = async {
-            let sources = self
-                .load_query_sources(workspace_name)
-                .map_err(QueryManagerError::App)?;
-            let runtime = self.runtime_config(&sources);
-            CoralQuery::execute_sql(&sources, runtime, sql)
-                .await
-                .map_err(QueryManagerError::Core)
-        }
-        .instrument(query_span.clone())
-        .await;
-
-        let metrics = crate::telemetry::metrics::metrics();
-        let status = crate::telemetry::metrics::status_attr(result.is_ok());
-        metrics.count.add(1, std::slice::from_ref(&status));
-        metrics.duration.record(
-            started_at.elapsed().as_secs_f64(),
-            std::slice::from_ref(&status),
-        );
-
-        if let Ok(execution) = &result {
-            let row_count = u64::try_from(execution.row_count()).unwrap_or(u64::MAX);
-            query_span.record("row_count", row_count);
-            query_span.record("status", "ok");
-            query_span.set_status(OtelStatus::Ok);
-            metrics
-                .rows
-                .record(row_count, std::slice::from_ref(&status));
-        } else if let Err(error) = &result {
-            let error_kind = query_error_kind(error);
-            let error_type = query_error_type(error);
-            let error_message = query_error_message(error);
-            query_span.record("status", "error");
-            query_span.record("error.kind", error_kind);
-            query_span.record("error.type", error_type.as_str());
-            query_span.record("exception.message", error_message.as_str());
-            query_span.set_status(OtelStatus::error(error_message));
-        }
-
-        result
+        run_query_operation(
+            "execute_sql",
+            workspace_name,
+            sql,
+            async {
+                let sources = self
+                    .load_query_sources(workspace_name)
+                    .map_err(QueryManagerError::App)?;
+                let runtime = self.runtime_config(&sources);
+                CoralQuery::execute_sql(&sources, runtime, sql)
+                    .await
+                    .map_err(QueryManagerError::Core)
+            },
+            |execution| Some(u64::try_from(execution.row_count()).unwrap_or(u64::MAX)),
+        )
+        .await
     }
 
     pub(crate) async fn plan_sql(
@@ -127,13 +102,22 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         sql: &str,
     ) -> Result<QueryPlan, QueryManagerError> {
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_config(&sources);
-        CoralQuery::plan_sql(&sources, runtime, sql)
-            .await
-            .map_err(QueryManagerError::Core)
+        run_query_operation(
+            "plan_sql",
+            workspace_name,
+            sql,
+            async {
+                let sources = self
+                    .load_query_sources(workspace_name)
+                    .map_err(QueryManagerError::App)?;
+                let runtime = self.runtime_config(&sources);
+                CoralQuery::plan_sql(&sources, runtime, sql)
+                    .await
+                    .map_err(QueryManagerError::Core)
+            },
+            |_| None,
+        )
+        .await
     }
 
     pub(crate) async fn validate_source(
@@ -234,11 +218,59 @@ impl QueryManager {
     }
 }
 
-fn create_query_span(workspace_name: &WorkspaceName, sql: &str) -> tracing::Span {
+async fn run_query_operation<T, Fut, RowCount>(
+    operation: &'static str,
+    workspace_name: &WorkspaceName,
+    sql: &str,
+    query: Fut,
+    row_count: RowCount,
+) -> Result<T, QueryManagerError>
+where
+    Fut: Future<Output = Result<T, QueryManagerError>>,
+    RowCount: FnOnce(&T) -> Option<u64>,
+{
+    let started_at = Instant::now();
+    let query_span = create_query_span(operation, workspace_name, sql);
+    let result = query.instrument(query_span.clone()).await;
+
+    let metrics = crate::telemetry::metrics::metrics();
+    let status = crate::telemetry::metrics::status_attr(result.is_ok());
+    let attributes = [status, KeyValue::new("operation", operation)];
+    metrics.count.add(1, &attributes);
+    metrics
+        .duration
+        .record(started_at.elapsed().as_secs_f64(), &attributes);
+
+    if let Ok(value) = &result {
+        query_span.record("status", "ok");
+        query_span.set_status(OtelStatus::Ok);
+        if let Some(row_count) = row_count(value) {
+            query_span.record("row_count", row_count);
+            metrics.rows.record(row_count, &attributes);
+        }
+    } else if let Err(error) = &result {
+        let error_kind = query_error_kind(error);
+        let error_type = query_error_type(error);
+        let error_message = query_error_message(error);
+        query_span.record("status", "error");
+        query_span.record("error.kind", error_kind);
+        query_span.record("error.type", error_type.as_str());
+        query_span.record("exception.message", error_message.as_str());
+        query_span.set_status(OtelStatus::error(error_message));
+    }
+
+    result
+}
+
+fn create_query_span(
+    operation: &'static str,
+    workspace_name: &WorkspaceName,
+    sql: &str,
+) -> tracing::Span {
     tracing::info_span!(
         "coral.query",
         otel.name = "coral.query",
-        operation = "execute_sql",
+        operation = operation,
         workspace = %workspace_name.as_str(),
         sql = %sql,
         row_count = tracing::field::Empty,

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -5,8 +5,8 @@ use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
 use coral_api::v1::{
-    ExecuteSqlRequest, ExecuteSqlResponse, ListTablesRequest, ListTablesResponse,
-    PaginationResponse, PlanSqlRequest, PlanSqlResponse, QueryPlan as QueryPlanProto,
+    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
+    ListTablesRequest, ListTablesResponse, PaginationResponse, QueryPlan as QueryPlanProto,
 };
 use tonic::{Request, Response, Status};
 
@@ -125,20 +125,20 @@ impl QueryServiceApi for QueryService {
         .await
     }
 
-    async fn plan_sql(
+    async fn explain_sql(
         &self,
-        request: Request<PlanSqlRequest>,
-    ) -> Result<Response<PlanSqlResponse>, Status> {
+        request: Request<ExplainSqlRequest>,
+    ) -> Result<Response<ExplainSqlResponse>, Status> {
         let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
             let plan = queries
-                .plan_sql(&workspace_name, &inner.sql)
+                .explain_sql(&workspace_name, &inner.sql)
                 .await
                 .map_err(query_status)?;
-            Ok(Response::new(PlanSqlResponse {
+            Ok(Response::new(ExplainSqlResponse {
                 plan: Some(query_plan_to_proto(&plan)),
             }))
         })

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -6,7 +6,7 @@ use arrow::record_batch::RecordBatch;
 use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
 use coral_api::v1::{
     ExecuteSqlRequest, ExecuteSqlResponse, ListTablesRequest, ListTablesResponse,
-    PaginationResponse,
+    PaginationResponse, PlanSqlRequest, PlanSqlResponse, QueryPlan as QueryPlanProto,
 };
 use tonic::{Request, Response, Status};
 
@@ -124,6 +124,26 @@ impl QueryServiceApi for QueryService {
         })
         .await
     }
+
+    async fn plan_sql(
+        &self,
+        request: Request<PlanSqlRequest>,
+    ) -> Result<Response<PlanSqlResponse>, Status> {
+        let span = grpc_span(&request);
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let inner = request.into_inner();
+            let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
+            let plan = queries
+                .plan_sql(&workspace_name, &inner.sql)
+                .await
+                .map_err(query_status)?;
+            Ok(Response::new(PlanSqlResponse {
+                plan: Some(query_plan_to_proto(&plan)),
+            }))
+        })
+        .await
+    }
 }
 
 fn paginate_tables(
@@ -141,6 +161,14 @@ fn paginate_tables(
 
 fn count_to_u32(count: usize) -> u32 {
     u32::try_from(count).unwrap_or(u32::MAX)
+}
+
+fn query_plan_to_proto(plan: &coral_engine::QueryPlan) -> QueryPlanProto {
+    QueryPlanProto {
+        unoptimized_logical_plan: plan.unoptimized_logical_plan().to_string(),
+        optimized_logical_plan: plan.optimized_logical_plan().to_string(),
+        physical_plan: plan.physical_plan().to_string(),
+    }
 }
 
 fn encode_arrow_ipc_stream(

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -8,8 +8,8 @@ use std::fs;
 
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
-    GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest, ListTablesRequest,
-    PaginationRequest, PlanSqlRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin,
+    ExplainSqlRequest, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
+    ListTablesRequest, PaginationRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin,
     SourceSecret, SourceVariable, ValidateSourceRequest, Workspace, query_test_result,
 };
 use coral_client::default_workspace;
@@ -338,7 +338,7 @@ async fn assert_exact_table_filter(harness: &GrpcHarness) {
 }
 
 #[tokio::test]
-async fn plan_sql_returns_logical_and_physical_plans() {
+async fn explain_sql_returns_logical_and_physical_plans() {
     let harness = GrpcHarness::new().await;
     harness
         .import_source(
@@ -350,12 +350,12 @@ async fn plan_sql_returns_logical_and_physical_plans() {
 
     let response = harness
         .query_client()
-        .plan_sql(Request::new(PlanSqlRequest {
+        .explain_sql(Request::new(ExplainSqlRequest {
             workspace: Some(default_workspace()),
             sql: "SELECT text FROM local_messages.messages ORDER BY text".to_string(),
         }))
         .await
-        .expect("plan sql")
+        .expect("explain sql")
         .into_inner();
     let plan = response.plan.expect("query plan");
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -9,8 +9,8 @@ use std::fs;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest, ListTablesRequest,
-    PaginationRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin, SourceSecret,
-    SourceVariable, ValidateSourceRequest, Workspace, query_test_result,
+    PaginationRequest, PlanSqlRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin,
+    SourceSecret, SourceVariable, ValidateSourceRequest, Workspace, query_test_result,
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
@@ -335,6 +335,39 @@ async fn assert_exact_table_filter(harness: &GrpcHarness) {
     assert_eq!(exact_table.tables[0].schema_name, "local_messages");
     assert_eq!(exact_table.tables[0].name, "messages");
     assert!(!exact_table.tables[0].columns.is_empty());
+}
+
+#[tokio::test]
+async fn plan_sql_returns_logical_and_physical_plans() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let response = harness
+        .query_client()
+        .plan_sql(Request::new(PlanSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SELECT text FROM local_messages.messages ORDER BY text".to_string(),
+        }))
+        .await
+        .expect("plan sql")
+        .into_inner();
+    let plan = response.plan.expect("query plan");
+
+    assert!(
+        plan.unoptimized_logical_plan
+            .contains("local_messages.messages")
+    );
+    assert!(
+        plan.optimized_logical_plan
+            .contains("local_messages.messages")
+    );
+    assert!(plan.physical_plan.contains("Exec"));
 }
 
 #[tokio::test]

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -18,9 +18,9 @@ use coral_api::v1::{
     DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest,
     ExecuteSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
     GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-    ListSourcesResponse, ListTablesRequest, ListTablesResponse, PaginationResponse, Source,
-    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, Table, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    ListSourcesResponse, ListTablesRequest, ListTablesResponse, PaginationResponse, PlanSqlRequest,
+    PlanSqlResponse, QueryPlan, Source, SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin,
+    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -507,6 +507,19 @@ impl QueryService for MockQueryService {
         };
 
         Ok(Response::new(response))
+    }
+
+    async fn plan_sql(
+        &self,
+        _request: Request<PlanSqlRequest>,
+    ) -> Result<Response<PlanSqlResponse>, Status> {
+        Ok(Response::new(PlanSqlResponse {
+            plan: Some(QueryPlan {
+                unoptimized_logical_plan: "LogicalPlan".to_string(),
+                optimized_logical_plan: "OptimizedLogicalPlan".to_string(),
+                physical_plan: "PhysicalPlan".to_string(),
+            }),
+        }))
     }
 }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -16,11 +16,12 @@ use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
     Column, CreateBundledSourceRequest, CreateBundledSourceResponse, DeleteSourceRequest,
     DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest,
-    ExecuteSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-    ListSourcesResponse, ListTablesRequest, ListTablesResponse, PaginationResponse, PlanSqlRequest,
-    PlanSqlResponse, QueryPlan, Source, SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin,
-    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest,
+    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, ListTablesRequest,
+    ListTablesResponse, PaginationResponse, QueryPlan, Source, SourceInfo, SourceInputKind,
+    SourceInputSpec, SourceOrigin, Table, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -509,11 +510,11 @@ impl QueryService for MockQueryService {
         Ok(Response::new(response))
     }
 
-    async fn plan_sql(
+    async fn explain_sql(
         &self,
-        _request: Request<PlanSqlRequest>,
-    ) -> Result<Response<PlanSqlResponse>, Status> {
-        Ok(Response::new(PlanSqlResponse {
+        _request: Request<ExplainSqlRequest>,
+    ) -> Result<Response<ExplainSqlResponse>, Status> {
+        Ok(Response::new(ExplainSqlResponse {
             plan: Some(QueryPlan {
                 unoptimized_logical_plan: "LogicalPlan".to_string(),
                 optimized_logical_plan: "OptimizedLogicalPlan".to_string(),

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -8,8 +8,8 @@ mod query_error;
 pub use catalog::{ColumnInfo, TableInfo};
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
-    QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
-    QueryTestResult, QueryTestSuccess, SourceValidationReport,
+    QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
+    QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -202,6 +202,48 @@ impl QueryRuntimeConfig {
     }
 }
 
+/// Query-engine plan renderings for one `SQL` statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryPlan {
+    unoptimized_logical: String,
+    optimized_logical: String,
+    physical: String,
+}
+
+impl QueryPlan {
+    #[must_use]
+    /// Builds one query-plan snapshot from engine plan renderings.
+    pub fn new(
+        unoptimized_logical_plan: String,
+        optimized_logical_plan: String,
+        physical_plan: String,
+    ) -> Self {
+        Self {
+            unoptimized_logical: unoptimized_logical_plan,
+            optimized_logical: optimized_logical_plan,
+            physical: physical_plan,
+        }
+    }
+
+    #[must_use]
+    /// Returns the parsed logical plan before logical optimizer rules run.
+    pub fn unoptimized_logical_plan(&self) -> &str {
+        &self.unoptimized_logical
+    }
+
+    #[must_use]
+    /// Returns the logical plan after logical optimizer rules run.
+    pub fn optimized_logical_plan(&self) -> &str {
+        &self.optimized_logical
+    }
+
+    #[must_use]
+    /// Returns the physical execution plan after physical optimizer rules run.
+    pub fn physical_plan(&self) -> &str {
+        &self.physical
+    }
+}
+
 /// The fully materialized result of executing one `SQL` statement.
 #[derive(Debug, Clone)]
 pub struct QueryExecution {

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -117,16 +117,16 @@ impl CoralQuery {
             .await
     }
 
-    /// Produces logical and physical plan renderings for one `SQL` statement.
+    /// Explains one `SQL` statement with logical and physical plan renderings.
     ///
-    /// This plans against the provided source set and current runtime state. It
-    /// does not execute the SQL statement.
+    /// The explanation is built against the provided source set and current
+    /// runtime state. It does not execute the SQL statement.
     ///
     /// # Errors
     ///
     /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
-    /// or if the query engine cannot plan the statement.
-    pub async fn plan_sql(
+    /// or if the query engine cannot explain the statement.
+    pub async fn explain_sql(
         sources: &[QuerySource],
         runtime: QueryRuntimeConfig,
         sql: &str,
@@ -137,7 +137,7 @@ impl CoralQuery {
 
         runtime::query::build_runtime(sources, runtime)
             .await?
-            .plan_sql(sql)
+            .explain_sql(sql)
             .await
     }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -66,9 +66,9 @@ pub use composition::{
     SourceTables,
 };
 pub use contracts::{
-    ColumnInfo, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport, StatusCode,
-    StructuredQueryError, TableInfo,
+    ColumnInfo, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport,
+    StatusCode, StructuredQueryError, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -114,6 +114,30 @@ impl CoralQuery {
         runtime::query::build_runtime(sources, runtime)
             .await?
             .execute_sql(sql)
+            .await
+    }
+
+    /// Produces logical and physical plan renderings for one `SQL` statement.
+    ///
+    /// This plans against the provided source set and current runtime state. It
+    /// does not execute the SQL statement.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if the SQL is empty, if source compilation fails,
+    /// or if the query engine cannot plan the statement.
+    pub async fn plan_sql(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        sql: &str,
+    ) -> Result<QueryPlan, CoreError> {
+        if sql.trim().is_empty() {
+            return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
+        }
+
+        runtime::query::build_runtime(sources, runtime)
+            .await?
+            .plan_sql(sql)
             .await
     }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -191,7 +191,10 @@ impl QueryRuntimeAdapter {
             .create_physical_plan(&optimized_logical_plan, &session_state)
             .await
             .map_err(|err| datafusion_to_core(&err, &self.tables))?;
-        let physical_plan = displayable(physical_plan.as_ref()).indent(true).to_string();
+        let physical_plan = displayable(physical_plan.as_ref())
+            .set_show_schema(true)
+            .indent(true)
+            .to_string();
 
         Ok(QueryPlan::new(
             unoptimized_logical_plan,

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -170,7 +170,7 @@ impl QueryRuntimeAdapter {
         Ok(())
     }
 
-    pub(crate) async fn plan_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
+    pub(crate) async fn explain_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
         let df = self.sql_dataframe(sql).await?;
         let unoptimized_logical_plan = df.logical_plan().display_indent_schema().to_string();
         let (session_state, logical_plan) = df.into_parts();

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::physical_plan::displayable;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 
@@ -19,8 +20,8 @@ use crate::runtime::registry::{
 };
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
-    CoreError, QueryExecution, QueryResultObserver, QueryResultObserverError, QueryRuntimeConfig,
-    QuerySource, TableInfo,
+    CoreError, QueryExecution, QueryPlan, QueryResultObserver, QueryResultObserverError,
+    QueryRuntimeConfig, QuerySource, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
@@ -170,6 +171,33 @@ impl QueryRuntimeAdapter {
                 .map_err(|error| query_result_observer_error(observer.name(), &error))?;
         }
         Ok(())
+    }
+
+    pub(crate) async fn plan_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
+        let df = self
+            .ctx
+            .sql_with_options(sql, read_only_sql_options())
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        let unoptimized_logical_plan = df.logical_plan().display_indent_schema().to_string();
+        let (session_state, logical_plan) = df.into_parts();
+        let optimized_logical_plan = session_state
+            .optimize(&logical_plan)
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        let optimized_logical_plan_display =
+            optimized_logical_plan.display_indent_schema().to_string();
+        let physical_plan = session_state
+            .query_planner()
+            .create_physical_plan(&optimized_logical_plan, &session_state)
+            .await
+            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        let physical_plan = displayable(physical_plan.as_ref()).indent(true).to_string();
+
+        Ok(QueryPlan::new(
+            unoptimized_logical_plan,
+            optimized_logical_plan_display,
+            physical_plan,
+        ))
     }
 }
 

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use datafusion::dataframe::DataFrame;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::physical_plan::displayable;
@@ -145,11 +146,7 @@ impl QueryRuntimeAdapter {
     }
 
     pub(crate) async fn execute_sql(&self, sql: &str) -> Result<QueryExecution, CoreError> {
-        let df = self
-            .ctx
-            .sql_with_options(sql, read_only_sql_options())
-            .await
-            .map_err(|err| datafusion_to_core_with_sql(&err, &self.tables, Some(sql)))?;
+        let df = self.sql_dataframe(sql).await?;
         let arrow_schema = Arc::new(df.schema().as_arrow().clone());
         let batches = df
             .collect()
@@ -174,11 +171,7 @@ impl QueryRuntimeAdapter {
     }
 
     pub(crate) async fn plan_sql(&self, sql: &str) -> Result<QueryPlan, CoreError> {
-        let df = self
-            .ctx
-            .sql_with_options(sql, read_only_sql_options())
-            .await
-            .map_err(|err| datafusion_to_core(&err, &self.tables))?;
+        let df = self.sql_dataframe(sql).await?;
         let unoptimized_logical_plan = df.logical_plan().display_indent_schema().to_string();
         let (session_state, logical_plan) = df.into_parts();
         let optimized_logical_plan = session_state
@@ -201,6 +194,13 @@ impl QueryRuntimeAdapter {
             optimized_logical_plan_display,
             physical_plan,
         ))
+    }
+
+    async fn sql_dataframe(&self, sql: &str) -> Result<DataFrame, CoreError> {
+        self.ctx
+            .sql_with_options(sql, read_only_sql_options())
+            .await
+            .map_err(|err| datafusion_to_core_with_sql(&err, &self.tables, Some(sql)))
     }
 }
 

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -115,6 +115,25 @@ async fn quoted_fully_qualified_table_reference_reports_sql_reference_hint() {
 }
 
 #[tokio::test]
+async fn plan_sql_returns_logical_and_physical_plans() {
+    let temp = TempDir::new().expect("temp dir");
+    write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
+    let source = build_source(jsonl_manifest("jsonl_plan", temp.path(), "**/*.jsonl"));
+
+    let plan = CoralQuery::plan_sql(
+        &[source],
+        test_runtime(),
+        "SELECT id, name FROM jsonl_plan.users WHERE id > 1 ORDER BY name",
+    )
+    .await
+    .expect("query should plan");
+
+    assert!(plan.unoptimized_logical_plan().contains("jsonl_plan.users"));
+    assert!(plan.optimized_logical_plan().contains("jsonl_plan.users"));
+    assert!(plan.physical_plan().contains("Exec"));
+}
+
+#[tokio::test]
 async fn select_with_column_projection() {
     let temp = TempDir::new().expect("temp dir");
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -58,35 +58,29 @@ async fn select_all_from_jsonl_source() {
 #[tokio::test]
 async fn quoted_fully_qualified_table_reference_reports_sql_reference_hint() {
     let temp = TempDir::new().expect("temp dir");
-    write_jsonl_file(
-        temp.path(),
-        "pulls.jsonl",
-        &[json!({"id": 1, "title": "Fix table hint"})],
-    );
-    let source = build_source(json!({
-        "name": "github",
-        "version": "0.1.0",
-        "dsl_version": 3,
-        "backend": "jsonl",
-        "tables": [{
-            "name": "pulls",
-            "description": "Pull requests fixture",
-            "source": {
-                "location": dir_url(temp.path()),
-                "glob": "**/*.jsonl"
-            },
-            "columns": [
-                { "name": "id", "type": "Int64" },
-                { "name": "title", "type": "Utf8" }
-            ]
-        }]
-    }));
+    let source = github_pulls_source(temp.path());
 
     let error =
         CoralQuery::execute_sql(&[source], test_runtime(), "SELECT * FROM \"github.pulls\"")
             .await
             .expect_err("whole-reference quoted table should fail");
 
+    assert_quoted_fully_qualified_table_reference_hint(error);
+}
+
+#[tokio::test]
+async fn plan_sql_quoted_fully_qualified_table_reference_reports_sql_reference_hint() {
+    let temp = TempDir::new().expect("temp dir");
+    let source = github_pulls_source(temp.path());
+
+    let error = CoralQuery::plan_sql(&[source], test_runtime(), "SELECT * FROM \"github.pulls\"")
+        .await
+        .expect_err("whole-reference quoted table should fail during planning");
+
+    assert_quoted_fully_qualified_table_reference_hint(error);
+}
+
+fn assert_quoted_fully_qualified_table_reference_hint(error: CoreError) {
     assert_eq!(error.status_code(), StatusCode::NotFound);
     match error {
         CoreError::QueryFailure(sqe) => {
@@ -131,6 +125,32 @@ async fn plan_sql_returns_logical_and_physical_plans() {
     assert!(plan.unoptimized_logical_plan().contains("jsonl_plan.users"));
     assert!(plan.optimized_logical_plan().contains("jsonl_plan.users"));
     assert!(plan.physical_plan().contains("Exec"));
+}
+
+fn github_pulls_source(dir: &Path) -> coral_engine::QuerySource {
+    write_jsonl_file(
+        dir,
+        "pulls.jsonl",
+        &[json!({"id": 1, "title": "Fix table hint"})],
+    );
+    build_source(json!({
+        "name": "github",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "jsonl",
+        "tables": [{
+            "name": "pulls",
+            "description": "Pull requests fixture",
+            "source": {
+                "location": dir_url(dir),
+                "glob": "**/*.jsonl"
+            },
+            "columns": [
+                { "name": "id", "type": "Int64" },
+                { "name": "title", "type": "Utf8" }
+            ]
+        }]
+    }))
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -69,13 +69,14 @@ async fn quoted_fully_qualified_table_reference_reports_sql_reference_hint() {
 }
 
 #[tokio::test]
-async fn plan_sql_quoted_fully_qualified_table_reference_reports_sql_reference_hint() {
+async fn explain_sql_quoted_fully_qualified_table_reference_reports_sql_reference_hint() {
     let temp = TempDir::new().expect("temp dir");
     let source = github_pulls_source(temp.path());
 
-    let error = CoralQuery::plan_sql(&[source], test_runtime(), "SELECT * FROM \"github.pulls\"")
-        .await
-        .expect_err("whole-reference quoted table should fail during planning");
+    let error =
+        CoralQuery::explain_sql(&[source], test_runtime(), "SELECT * FROM \"github.pulls\"")
+            .await
+            .expect_err("whole-reference quoted table should fail during explanation");
 
     assert_quoted_fully_qualified_table_reference_hint(error);
 }
@@ -109,18 +110,18 @@ fn assert_quoted_fully_qualified_table_reference_hint(error: CoreError) {
 }
 
 #[tokio::test]
-async fn plan_sql_returns_logical_and_physical_plans() {
+async fn explain_sql_returns_logical_and_physical_plans() {
     let temp = TempDir::new().expect("temp dir");
     write_jsonl_file(temp.path(), "users.jsonl", &users_rows());
     let source = build_source(jsonl_manifest("jsonl_plan", temp.path(), "**/*.jsonl"));
 
-    let plan = CoralQuery::plan_sql(
+    let plan = CoralQuery::explain_sql(
         &[source],
         test_runtime(),
         "SELECT id, name FROM jsonl_plan.users WHERE id > 1 ORDER BY name",
     )
     .await
-    .expect("query should plan");
+    .expect("query should explain");
 
     assert!(plan.unoptimized_logical_plan().contains("jsonl_plan.users"));
     assert!(plan.optimized_logical_plan().contains("jsonl_plan.users"));


### PR DESCRIPTION
## Summary

- add `QueryService.PlanSql(workspace, sql)` with transport-level plan messages
- move `CoralQuery::plan_sql` and the engine `QueryPlan` contract into this stacked PR
- add engine and gRPC coverage for logical and physical plan rendering

## Validation

- `RUSTC_WRAPPER= make rust-checks`

Note: `RUSTC_WRAPPER=` bypasses a local `sccache` dep-info write failure in this workspace.