### PR TITLE
feat(engine): execute internal source UDTFs

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write;
 use std::sync::Arc;
 
-use crate::{QueryRuntimeContext, RequestAuthenticator, SourceTableFunctions};
+use crate::{QueryRuntimeContext, RequestAuthenticator};
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
@@ -12,9 +12,12 @@ use coral_spec::{
     SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use datafusion::catalog::TableFunctionImpl;
 use datafusion::datasource::TableProvider;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
+
+pub(crate) type SourceTableFunctions = HashMap<String, Arc<dyn TableFunctionImpl>>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RegisteredColumn {

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write;
 use std::sync::Arc;
 
-use crate::{QueryRuntimeContext, RequestAuthenticator};
+use crate::{QueryRuntimeContext, RequestAuthenticator, SourceTableFunctions};
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
@@ -68,13 +68,8 @@ pub(crate) struct RegisteredSource {
 
 pub(crate) struct BackendRegistration {
     pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
-    pub(crate) table_functions: Vec<BackendTableFunctionRegistration>,
+    pub(crate) table_functions: SourceTableFunctions,
     pub(crate) source: RegisteredSource,
-}
-
-pub(crate) struct BackendTableFunctionRegistration {
-    pub(crate) internal_name: String,
-    pub(crate) function: Arc<dyn datafusion::catalog::TableFunctionImpl>,
 }
 
 /// Build a collision-free `DataFusion` UDTF name for a source-scoped function.

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -77,6 +77,11 @@ pub(crate) struct BackendTableFunctionRegistration {
     pub(crate) function: Arc<dyn datafusion::catalog::TableFunctionImpl>,
 }
 
+/// Build a collision-free `DataFusion` UDTF name for a source-scoped function.
+///
+/// `DataFusion`'s UDTF registry is flat, so both source schema and public
+/// function name are hex-encoded to preserve arbitrary valid identifiers
+/// without delimiter collisions.
 pub(crate) fn internal_table_function_name(schema: &str, function: &str) -> String {
     format!(
         "__coral_udtf_{}_{}",
@@ -88,7 +93,7 @@ pub(crate) fn internal_table_function_name(schema: &str, function: &str) -> Stri
 fn hex_encode(value: &str) -> String {
     let mut encoded = String::with_capacity(value.len() * 2);
     for byte in value.as_bytes() {
-        write!(&mut encoded, "{byte:02x}").expect("write to string");
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String never fails");
     }
     encoded
 }

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -1,6 +1,7 @@
 //! Shared internal backend contracts and registry-visible metadata.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fmt::Write;
 use std::sync::Arc;
 
 use crate::{QueryRuntimeContext, RequestAuthenticator};
@@ -67,7 +68,29 @@ pub(crate) struct RegisteredSource {
 
 pub(crate) struct BackendRegistration {
     pub(crate) tables: HashMap<String, Arc<dyn TableProvider>>,
+    pub(crate) table_functions: Vec<BackendTableFunctionRegistration>,
     pub(crate) source: RegisteredSource,
+}
+
+pub(crate) struct BackendTableFunctionRegistration {
+    pub(crate) internal_name: String,
+    pub(crate) function: Arc<dyn datafusion::catalog::TableFunctionImpl>,
+}
+
+pub(crate) fn internal_table_function_name(schema: &str, function: &str) -> String {
+    format!(
+        "__coral_udtf_{}_{}",
+        hex_encode(schema),
+        hex_encode(function)
+    )
+}
+
+fn hex_encode(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value.as_bytes() {
+        write!(&mut encoded, "{byte:02x}").expect("write to string");
+    }
+    encoded
 }
 
 pub(crate) struct BackendCompileRequest<'a> {

--- a/crates/coral-engine/src/backends/http/auth.rs
+++ b/crates/coral-engine/src/backends/http/auth.rs
@@ -12,7 +12,7 @@ use coral_spec::{AuthSpec, BasicAuthSpec, HeaderAuthSpec};
 
 use crate::RequestAuthenticator;
 use crate::backends::shared::template::{
-    EMPTY_MAP, render_template, resolve_value_source, value_to_string,
+    RenderContext, render_template, resolve_value_source, value_to_string,
 };
 
 /// Built-in auth variants resolve their headers from resolved inputs only;
@@ -31,8 +31,9 @@ impl BuiltinAuth for BasicAuthSpec {
         &self,
         resolved_inputs: &BTreeMap<String, String>,
     ) -> Result<Vec<(HeaderName, HeaderValue)>> {
-        let username = render_template(&self.username, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
-        let password = render_template(&self.password, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
+        let context = RenderContext::source_scoped(resolved_inputs);
+        let username = render_template(&self.username, &context)?;
+        let password = render_template(&self.password, &context)?;
         let encoded = BASE64_STANDARD.encode(format!("{username}:{password}"));
         let value =
             HeaderValue::try_from(format!("Basic {encoded}").as_str()).map_err(|error| {
@@ -42,8 +43,9 @@ impl BuiltinAuth for BasicAuthSpec {
     }
 
     fn validate(&self, resolved_inputs: &BTreeMap<String, String>) -> Result<()> {
-        render_template(&self.username, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
-        render_template(&self.password, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?;
+        let context = RenderContext::source_scoped(resolved_inputs);
+        render_template(&self.username, &context)?;
+        render_template(&self.password, &context)?;
         Ok(())
     }
 }
@@ -54,15 +56,14 @@ impl BuiltinAuth for HeaderAuthSpec {
         resolved_inputs: &BTreeMap<String, String>,
     ) -> Result<Vec<(HeaderName, HeaderValue)>> {
         let mut out = Vec::with_capacity(self.headers.len());
+        let context = RenderContext::source_scoped(resolved_inputs);
         for header in &self.headers {
-            let resolved =
-                resolve_value_source(&header.value, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)?
-                    .ok_or_else(|| {
-                        DataFusionError::Execution(format!(
-                            "missing value for auth header '{}'",
-                            header.name
-                        ))
-                    })?;
+            let resolved = resolve_value_source(&header.value, &context)?.ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "missing value for auth header '{}'",
+                    header.name
+                ))
+            })?;
             let name = HeaderName::try_from(header.name.as_str()).map_err(|error| {
                 DataFusionError::Execution(format!(
                     "invalid auth header name '{}': {error}",

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -20,7 +20,7 @@ use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::shared::json_path::get_path_value;
 use crate::backends::shared::template::{
-    render_template, resolve_value_source, validate_input_dependencies,
+    RenderContext, render_template, resolve_value_source, validate_input_dependencies,
     validate_value_source_inputs, value_to_string,
 };
 use coral_spec::backends::http::{HttpSourceManifest, RateLimitSpec};
@@ -90,11 +90,14 @@ struct OutgoingHttpRequest<'a> {
     response_format: ResponseBodyFormat,
     source_schema: &'a str,
     rate_limit: &'a RateLimitSpec,
-    request_values: &'a HashMap<String, String>,
-    state: &'a HashMap<String, String>,
-    resolved_inputs: &'a BTreeMap<String, String>,
+    render_context: RenderContext<'a>,
     allow_404_empty: bool,
     link_header_require_results: bool,
+}
+
+struct HttpRequestSite<'a> {
+    label: String,
+    request: &'a ManifestRequestSpec,
 }
 
 impl HttpSourceClient {
@@ -153,7 +156,8 @@ impl HttpSourceClient {
     pub(crate) async fn fetch(
         &self,
         target: &HttpFetchTarget,
-        request_values: &HashMap<String, String>,
+        filter_values: &HashMap<String, String>,
+        arg_values: &HashMap<String, String>,
         sql_limit: Option<usize>,
     ) -> Result<Vec<Value>> {
         let mut all_rows = Vec::new();
@@ -198,12 +202,14 @@ impl HttpSourceClient {
                 }));
             }
 
-            let base_url = render_template(
-                &self.base_url,
-                request_values,
-                &pagination_state_values(&state),
+            let state_values = pagination_state_values(&state);
+            let render_context = RenderContext::new(
+                filter_values,
+                arg_values,
+                &state_values,
                 self.resolved_inputs.as_ref(),
-            )?;
+            );
+            let base_url = render_template(&self.base_url, &render_context)?;
             let base_url = normalize_base_url(&base_url);
             let following_link_header = matches!(
                 pagination.mode,
@@ -217,24 +223,14 @@ impl HttpSourceClient {
             {
                 next
             } else {
-                let rendered_path = render_template(
-                    &active_request.path,
-                    request_values,
-                    &pagination_state_values(&state),
-                    self.resolved_inputs.as_ref(),
-                )?;
+                let rendered_path = render_template(&active_request.path, &render_context)?;
                 join_url(&base_url, &rendered_path)?
             };
 
             let (query_pairs, body) = if following_link_header {
                 (Vec::new(), None)
             } else {
-                let mut query_pairs = build_query_pairs(
-                    active_request,
-                    request_values,
-                    &state,
-                    self.resolved_inputs.as_ref(),
-                )?;
+                let mut query_pairs = build_query_pairs(active_request, &render_context)?;
                 apply_pagination_query_pairs(
                     &mut query_pairs,
                     target,
@@ -246,12 +242,7 @@ impl HttpSourceClient {
                     pagination_error(&self.source_schema, target.name(), None, Some(&url), &error)
                 })?;
 
-                let mut body = build_request_body(
-                    active_request,
-                    request_values,
-                    &state,
-                    self.resolved_inputs.as_ref(),
-                )?;
+                let mut body = build_request_body(active_request, &render_context)?;
                 apply_pagination_body_fields(
                     &mut body,
                     &active_request.body,
@@ -266,7 +257,6 @@ impl HttpSourceClient {
                 (query_pairs, body)
             };
 
-            let pagination_values = pagination_state_values(&state);
             let request = execute_request(
                 &self.http,
                 self.request_timeout,
@@ -284,9 +274,7 @@ impl HttpSourceClient {
                     response_format: target.response().format,
                     source_schema: &self.source_schema,
                     rate_limit: &self.rate_limit,
-                    request_values,
-                    state: &pagination_values,
-                    resolved_inputs: self.resolved_inputs.as_ref(),
+                    render_context,
                     allow_404_empty: target.response().allow_404_empty,
                     link_header_require_results: pagination.link_header_require_results,
                 },
@@ -317,7 +305,7 @@ impl HttpSourceClient {
                             status: None,
                             method: None,
                             url: None,
-                            filters: request_values.clone(),
+                            filters: filter_values.clone(),
                             detail: err,
                         },
                     )));
@@ -392,7 +380,7 @@ fn validate_source_scoped_http_config(
 ) -> Result<()> {
     check_base_url_inputs(manifest, resolved_inputs)?;
     check_request_header_inputs(manifest, resolved_inputs)?;
-    check_table_request_inputs(manifest, resolved_inputs)?;
+    check_request_site_inputs(manifest, resolved_inputs)?;
     check_auth_inputs(manifest, request_authenticators, resolved_inputs)?;
     Ok(())
 }
@@ -421,28 +409,51 @@ fn check_request_header_inputs(
     Ok(())
 }
 
-fn check_table_request_inputs(
+fn check_request_site_inputs(
     manifest: &HttpSourceManifest,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<()> {
-    for table in &manifest.tables {
+    for site in http_request_sites(manifest) {
         validate_request_template_inputs(
             &manifest.common.name,
-            table.name(),
-            "request",
-            &table.request,
+            &site.label,
+            site.request,
             resolved_inputs,
         )?;
-        for route in &table.requests {
-            validate_request_route_inputs(
-                &manifest.common.name,
-                table.name(),
-                route,
-                resolved_inputs,
-            )?;
-        }
     }
     Ok(())
+}
+
+fn http_request_sites(manifest: &HttpSourceManifest) -> Vec<HttpRequestSite<'_>> {
+    let table_sites = manifest.tables.iter().flat_map(|table| {
+        let default = std::iter::once(HttpRequestSite {
+            label: format!("table '{}' request", table.name()),
+            request: &table.request,
+        });
+        let routes = table.requests.iter().map(move |route| HttpRequestSite {
+            label: table_request_route_label(table.name(), route),
+            request: &route.request,
+        });
+        default.chain(routes)
+    });
+
+    let function_sites = manifest.functions.iter().map(|function| HttpRequestSite {
+        label: format!("function '{}' request", function.name),
+        request: &function.request,
+    });
+
+    table_sites.chain(function_sites).collect()
+}
+
+fn table_request_route_label(table_name: &str, route: &RequestRouteSpec) -> String {
+    if route.when_filters.is_empty() {
+        format!("table '{table_name}' request route")
+    } else {
+        format!(
+            "table '{table_name}' request route for filters [{}]",
+            route.when_filters.join(", ")
+        )
+    }
 }
 
 /// Auth is source-scoped: all template dependencies must resolve from inputs
@@ -462,46 +473,18 @@ fn registration_error(source: &str, field: &str, error: &DataFusionError) -> Dat
     ))
 }
 
-fn validate_request_route_inputs(
-    source_name: &str,
-    table_name: &str,
-    route: &RequestRouteSpec,
-    resolved_inputs: &BTreeMap<String, String>,
-) -> Result<()> {
-    let route_label = if route.when_filters.is_empty() {
-        "request route".to_string()
-    } else {
-        format!(
-            "request route for filters [{}]",
-            route.when_filters.join(", ")
-        )
-    };
-    validate_request_template_inputs(
-        source_name,
-        table_name,
-        &route_label,
-        &route.request,
-        resolved_inputs,
-    )
-}
-
 fn validate_request_template_inputs(
     source_name: &str,
-    table_name: &str,
     request_label: &str,
     request: &ManifestRequestSpec,
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<()> {
     validate_input_dependencies(&request.path, resolved_inputs).map_err(|error| {
-        registration_error(
-            source_name,
-            &format!("table '{table_name}' {request_label} path"),
-            &error,
-        )
+        registration_error(source_name, &format!("{request_label} path"), &error)
     })?;
     validate_header_inputs(
         source_name,
-        &format!("table '{table_name}' {request_label} header"),
+        &format!("{request_label} header"),
         &request.headers,
         resolved_inputs,
     )?;
@@ -509,10 +492,7 @@ fn validate_request_template_inputs(
         validate_value_source_inputs(&param.value, resolved_inputs).map_err(|error| {
             registration_error(
                 source_name,
-                &format!(
-                    "table '{table_name}' {request_label} query param '{}'",
-                    param.name
-                ),
+                &format!("{request_label} query param '{}'", param.name),
                 &error,
             )
         })?;
@@ -528,7 +508,7 @@ fn validate_request_template_inputs(
                 validate_value_source_inputs(&field.value, resolved_inputs).map_err(|error| {
                     registration_error(
                         source_name,
-                        &format!("table '{table_name}' {request_label} body field '{field_path}'"),
+                        &format!("{request_label} body field '{field_path}'"),
                         &error,
                     )
                 })?;
@@ -536,11 +516,7 @@ fn validate_request_template_inputs(
         }
         BodySpec::Text { content } => {
             validate_value_source_inputs(content, resolved_inputs).map_err(|error| {
-                registration_error(
-                    source_name,
-                    &format!("table '{table_name}' {request_label} body text"),
-                    &error,
-                )
+                registration_error(source_name, &format!("{request_label} body text"), &error)
             })?;
         }
     }
@@ -589,9 +565,7 @@ async fn execute_request(
         response_format,
         source_schema,
         rate_limit,
-        request_values,
-        state,
-        resolved_inputs,
+        render_context,
         allow_404_empty,
         link_header_require_results,
     } = request;
@@ -603,9 +577,7 @@ async fn execute_request(
 
         let mut header_map = HeaderMap::new();
         for header in request_headers.iter().chain(table_headers.iter()) {
-            if let Some(value) =
-                resolve_value_source(&header.value, request_values, state, resolved_inputs)?
-            {
+            if let Some(value) = resolve_value_source(&header.value, &render_context)? {
                 let name = HeaderName::try_from(header.name.as_str()).map_err(|error| {
                     DataFusionError::Execution(format!(
                         "invalid request header name '{}': {error}",
@@ -694,14 +666,18 @@ async fn execute_request(
             None => {}
         }
 
-        let built =
-            match resolve_auth_headers(auth, request, request_authenticators, resolved_inputs) {
-                Ok(request) => request,
-                Err(error) => {
-                    record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
-                    return Err(error);
-                }
-            };
+        let built = match resolve_auth_headers(
+            auth,
+            request,
+            request_authenticators,
+            render_context.resolved_inputs,
+        ) {
+            Ok(request) => request,
+            Err(error) => {
+                record_http_processing_error(&request_span, "REQUEST_SETUP", &error);
+                return Err(error);
+            }
+        };
         let response = match http.execute(built).instrument(request_span.clone()).await {
             Ok(response) => response,
             Err(error) => {
@@ -782,7 +758,7 @@ async fn execute_request(
                         status: Some(status.as_u16()),
                         method: Some(method_label.to_string()),
                         url: Some(logged_url.clone()),
-                        filters: request_values.clone(),
+                        filters: render_context.filters.clone(),
                         detail: body,
                     },
                 ))));
@@ -1019,16 +995,12 @@ fn build_http_request(
 
 fn build_query_pairs(
     request: &coral_spec::RequestSpec,
-    request_values: &HashMap<String, String>,
-    state: &PageState,
-    resolved_inputs: &BTreeMap<String, String>,
+    render_context: &RenderContext<'_>,
 ) -> Result<Vec<(String, String)>> {
-    let state_values = pagination_state_values(state);
     let mut params = Vec::new();
 
     for param in &request.query {
-        let value =
-            resolve_value_source(&param.value, request_values, &state_values, resolved_inputs)?;
+        let value = resolve_value_source(&param.value, render_context)?;
         if let Some(value) = value {
             params.push((param.name.clone(), value_to_string(&value)));
         }
@@ -1081,11 +1053,8 @@ fn apply_pagination_query_pairs(
 
 fn build_request_body(
     request: &coral_spec::RequestSpec,
-    request_values: &HashMap<String, String>,
-    state: &PageState,
-    resolved_inputs: &BTreeMap<String, String>,
+    render_context: &RenderContext<'_>,
 ) -> Result<Option<RequestBody>> {
-    let state_values = pagination_state_values(state);
     match &request.body {
         BodySpec::Json { fields } => {
             if fields.is_empty() {
@@ -1093,21 +1062,14 @@ fn build_request_body(
             }
             let mut root = Value::Object(Map::new());
             for field in fields {
-                if let Some(value) = resolve_value_source(
-                    &field.value,
-                    request_values,
-                    &state_values,
-                    resolved_inputs,
-                )? {
+                if let Some(value) = resolve_value_source(&field.value, render_context)? {
                     set_path_value(&mut root, &field.path, value)?;
                 }
             }
             Ok(Some(RequestBody::Json(root)))
         }
         BodySpec::Text { content } => {
-            let Some(value) =
-                resolve_value_source(content, request_values, &state_values, resolved_inputs)?
-            else {
+            let Some(value) = resolve_value_source(content, render_context)? else {
                 return Ok(None);
             };
             Ok(Some(RequestBody::Text(value_to_string(&value))))
@@ -1515,6 +1477,7 @@ mod tests {
     };
     use crate::backends::http::ProviderQueryError;
     use crate::backends::http::target::HttpFetchTarget;
+    use crate::backends::shared::template::{EMPTY_MAP, RenderContext};
     use coral_spec::PaginationMode;
     use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec, RateLimitSpec};
     use coral_spec::{
@@ -1567,6 +1530,14 @@ mod tests {
 
     fn test_http_request_target(table: &HttpTableSpec) -> HttpFetchTarget {
         HttpFetchTarget::from_resolved_table_request(table, table.request.clone())
+    }
+
+    fn test_render_context<'a>(
+        filters: &'a HashMap<String, String>,
+        args: &'a HashMap<String, String>,
+        resolved_inputs: &'a BTreeMap<String, String>,
+    ) -> RenderContext<'a> {
+        RenderContext::new(filters, args, &EMPTY_MAP, resolved_inputs)
     }
 
     #[test]
@@ -1834,9 +1805,7 @@ mod tests {
             &ValueSourceSpec::Input {
                 key: "API_KEY".to_string(),
             },
-            &HashMap::new(),
-            &HashMap::new(),
-            &resolved_inputs,
+            &test_render_context(&HashMap::new(), &HashMap::new(), &resolved_inputs),
         )
         .expect("input lookup should succeed");
 
@@ -1851,9 +1820,7 @@ mod tests {
             &ValueSourceSpec::Input {
                 key: "API_KEY".to_string(),
             },
-            &HashMap::new(),
-            &HashMap::new(),
-            &resolved_inputs,
+            &test_render_context(&HashMap::new(), &HashMap::new(), &resolved_inputs),
         )
         .expect("input lookup should succeed");
 
@@ -1869,9 +1836,7 @@ mod tests {
                 key: "start_time".to_string(),
                 default: None,
             },
-            &filters,
-            &HashMap::new(),
-            &BTreeMap::new(),
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
         .expect("integer filter should resolve");
 
@@ -1887,9 +1852,7 @@ mod tests {
                 key: "start_time".to_string(),
                 default: None,
             },
-            &filters,
-            &HashMap::new(),
-            &BTreeMap::new(),
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
         .expect_err("invalid integer filter should fail");
 
@@ -1910,9 +1873,7 @@ mod tests {
                 separator: "-".to_string(),
                 part: 0,
             },
-            &filters,
-            &HashMap::new(),
-            &BTreeMap::new(),
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
         .expect("split filter should resolve");
         let number = resolve_value_source(
@@ -1921,9 +1882,7 @@ mod tests {
                 separator: "-".to_string(),
                 part: 1,
             },
-            &filters,
-            &HashMap::new(),
-            &BTreeMap::new(),
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
         .expect("split integer filter should resolve");
 
@@ -1941,9 +1900,7 @@ mod tests {
                 separator: "-".to_string(),
                 part: 1,
             },
-            &filters,
-            &HashMap::new(),
-            &BTreeMap::new(),
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
         .expect_err("missing split part should fail");
 
@@ -1964,9 +1921,7 @@ mod tests {
                 separator: "-".to_string(),
                 part: 1,
             },
-            &filters,
-            &HashMap::new(),
-            &BTreeMap::new(),
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
         .expect_err("missing split integer part should fail");
 
@@ -1986,9 +1941,7 @@ mod tests {
                 key: "descending".to_string(),
                 default: None,
             },
-            &filters,
-            &HashMap::new(),
-            &BTreeMap::new(),
+            &test_render_context(&filters, &HashMap::new(), &BTreeMap::new()),
         )
         .expect("bool filter should resolve");
 
@@ -2255,6 +2208,102 @@ mod tests {
         assert!(error.to_string().contains(
             "table 'items' request route for filters [account_id] path could not be resolved"
         ));
+    }
+
+    #[test]
+    fn backend_client_rejects_unresolved_function_request_inputs() {
+        let cases = [
+            (
+                "path",
+                json!({
+                    "path": "/{{input.ACCOUNT_ID}}/items"
+                }),
+                "function 'search_items' request path could not be resolved",
+            ),
+            (
+                "header",
+                json!({
+                    "path": "/items",
+                    "headers": [{
+                        "name": "X-Account",
+                        "from": "input",
+                        "key": "ACCOUNT_ID"
+                    }]
+                }),
+                "function 'search_items' request header 'X-Account' could not be resolved",
+            ),
+            (
+                "query",
+                json!({
+                    "path": "/items",
+                    "query": [{
+                        "name": "account_id",
+                        "from": "input",
+                        "key": "ACCOUNT_ID"
+                    }]
+                }),
+                "function 'search_items' request query param 'account_id' could not be resolved",
+            ),
+            (
+                "body",
+                json!({
+                    "method": "POST",
+                    "path": "/items",
+                    "body": [{
+                        "path": ["account", "id"],
+                        "from": "input",
+                        "key": "ACCOUNT_ID"
+                    }]
+                }),
+                "function 'search_items' request body field 'account.id' could not be resolved",
+            ),
+        ];
+
+        for (name, request, expected) in cases {
+            let manifest = parse_http_manifest(json!({
+                "dsl_version": 3,
+                "name": "alpha",
+                "version": "0.1.0",
+                "backend": "http",
+                "base_url": "https://api.example.com",
+                "inputs": {
+                    "ACCOUNT_ID": { "kind": "variable" }
+                },
+                "tables": [{
+                    "name": "items",
+                    "description": "items",
+                    "request": { "path": "/items" },
+                    "columns": [{
+                        "name": "id",
+                        "type": "Utf8"
+                    }]
+                }],
+                "functions": [{
+                    "name": "search_items",
+                    "description": "Search items",
+                    "request": request,
+                    "columns": [{
+                        "name": "id",
+                        "type": "Utf8"
+                    }]
+                }]
+            }));
+
+            let error = HttpSourceClient::from_manifest(
+                &manifest,
+                &BTreeMap::new(),
+                &BTreeMap::new(),
+                &HashMap::new(),
+            )
+            .expect_err(&format!(
+                "missing function request {name} input should fail"
+            ));
+
+            assert!(
+                error.to_string().contains(expected),
+                "unexpected error for {name}: {error}"
+            );
+        }
     }
 
     #[test]
@@ -2540,9 +2589,11 @@ mod tests {
             .expect("build test client");
         let url = format!("{base_url}/items");
         let query_pairs = vec![("api_key".to_string(), "secret-token".to_string())];
-        let request_values = HashMap::new();
+        let filters = HashMap::new();
+        let args = HashMap::new();
         let state = HashMap::new();
         let resolved_inputs = BTreeMap::new();
+        let render_context = RenderContext::new(&filters, &args, &state, &resolved_inputs);
 
         let error = execute_request(
             &http,
@@ -2561,9 +2612,7 @@ mod tests {
                 response_format: ResponseBodyFormat::default(),
                 source_schema: "demo",
                 rate_limit: &RateLimitSpec::default(),
-                request_values: &request_values,
-                state: &state,
-                resolved_inputs: &resolved_inputs,
+                render_context,
                 allow_404_empty: false,
                 link_header_require_results: false,
             },

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -1,0 +1,239 @@
+//! `DataFusion` table functions for manifest-driven HTTP-backed sources.
+//!
+//! `TableFunctionImpl::call` runs while `DataFusion` is planning a query. At
+//! that point we validate the positional call arguments and bind them into HTTP
+//! request values. The returned table provider is scanned later during
+//! execution, using the same `http_json_exec` path as manifest-backed tables.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::Arc;
+
+use coral_spec::SourceTableFunctionSpec;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::catalog::TableFunctionImpl;
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::scalar::ScalarValue;
+
+use crate::backends::http::HttpSourceClient;
+use crate::backends::http::provider::http_json_exec;
+use crate::backends::http::target::HttpFetchTarget;
+use crate::backends::schema_from_columns;
+use crate::backends::shared::filter_expr::literal_to_string;
+
+struct FunctionCallContext<'a> {
+    source_schema: &'a str,
+    function_name: &'a str,
+}
+
+/// Table-valued function that turns manifest-declared function args into an
+/// HTTP-backed result provider.
+pub(crate) struct HttpSourceTableFunction {
+    backend: HttpSourceClient,
+    source_schema: String,
+    spec: Arc<SourceTableFunctionSpec>,
+    target: Arc<HttpFetchTarget>,
+    schema: SchemaRef,
+}
+
+impl fmt::Debug for HttpSourceTableFunction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpSourceTableFunction")
+            .field("source_schema", &self.source_schema)
+            .field("function", &self.spec.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HttpSourceTableFunction {
+    pub(crate) fn new(
+        backend: HttpSourceClient,
+        source_schema: String,
+        function: SourceTableFunctionSpec,
+    ) -> Result<Self> {
+        let schema = schema_from_columns(&function.columns, &source_schema, &function.name)?;
+        let target = HttpFetchTarget::from_function(&function);
+        Ok(Self {
+            backend,
+            source_schema,
+            spec: Arc::new(function),
+            target: Arc::new(target),
+            schema,
+        })
+    }
+}
+
+impl TableFunctionImpl for HttpSourceTableFunction {
+    fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        let request_values = bind_function_args(&self.source_schema, &self.spec, args)?;
+        Ok(Arc::new(HttpSourceFunctionCallProvider {
+            backend: self.backend.clone(),
+            source_schema: self.source_schema.clone(),
+            function_name: self.spec.name.clone(),
+            target: Arc::clone(&self.target),
+            schema: self.schema.clone(),
+            request_values,
+        }))
+    }
+}
+
+struct HttpSourceFunctionCallProvider {
+    backend: HttpSourceClient,
+    source_schema: String,
+    function_name: String,
+    target: Arc<HttpFetchTarget>,
+    schema: SchemaRef,
+    request_values: HashMap<String, String>,
+}
+
+impl fmt::Debug for HttpSourceFunctionCallProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HttpSourceFunctionCallProvider")
+            .field("source_schema", &self.source_schema)
+            .field("function", &self.function_name)
+            .field("request_values", &self.request_values.keys())
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for HttpSourceFunctionCallProvider {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> Result<Vec<TableProviderFilterPushDown>> {
+        // Function arguments have already been bound into the request. WHERE
+        // filters apply to the returned rows, so DataFusion should evaluate them.
+        Ok(vec![
+            TableProviderFilterPushDown::Unsupported;
+            filters.len()
+        ])
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn datafusion::catalog::Session,
+        projection: Option<&Vec<usize>>,
+        _filters: &[Expr],
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        http_json_exec(
+            self.backend.clone(),
+            &self.source_schema,
+            (*self.target).clone(),
+            self.schema.clone(),
+            self.request_values.clone(),
+            projection,
+            limit,
+        )
+    }
+}
+
+fn bind_function_args(
+    source_schema: &str,
+    function: &SourceTableFunctionSpec,
+    args: &[Expr],
+) -> Result<HashMap<String, String>> {
+    let context = FunctionCallContext {
+        source_schema,
+        function_name: function.name.as_str(),
+    };
+    ensure_no_extra_args(&context, function.args.len(), args.len())?;
+
+    let mut required_missing = Vec::new();
+    let mut request_values = HashMap::with_capacity(function.args.len());
+
+    for (index, spec) in function.args.iter().enumerate() {
+        let Some(value) = resolve_call_arg_literal(&context, spec.name.as_str(), args.get(index))?
+        else {
+            if spec.required {
+                required_missing.push(spec.name.as_str());
+            }
+            continue;
+        };
+        ensure_call_arg_allowed_value(&context, spec.name.as_str(), &value, &spec.values)?;
+        request_values.insert(spec.bind.arg.clone(), value);
+    }
+
+    if !required_missing.is_empty() {
+        return Err(DataFusionError::Plan(format!(
+            "{}.{} missing required argument(s): {}",
+            context.source_schema,
+            context.function_name,
+            required_missing.join(", ")
+        )));
+    }
+
+    Ok(request_values)
+}
+
+fn ensure_no_extra_args(
+    context: &FunctionCallContext<'_>,
+    expected: usize,
+    actual: usize,
+) -> Result<()> {
+    if actual > expected {
+        return Err(DataFusionError::Plan(format!(
+            "{}.{} expected at most {} arguments, got {}",
+            context.source_schema, context.function_name, expected, actual
+        )));
+    }
+    Ok(())
+}
+
+fn resolve_call_arg_literal(
+    context: &FunctionCallContext<'_>,
+    arg_name: &str,
+    expr: Option<&Expr>,
+) -> Result<Option<String>> {
+    let Some(expr) = expr else {
+        return Ok(None);
+    };
+    if is_null_literal(expr) {
+        return Ok(None);
+    }
+    let Some(value) = literal_to_string(expr) else {
+        return Err(DataFusionError::Plan(format!(
+            "{}.{} argument '{}' must be a literal",
+            context.source_schema, context.function_name, arg_name
+        )));
+    };
+    Ok(Some(value))
+}
+
+fn is_null_literal(expr: &Expr) -> bool {
+    matches!(expr, Expr::Literal(ScalarValue::Null, _))
+}
+
+fn ensure_call_arg_allowed_value(
+    context: &FunctionCallContext<'_>,
+    arg: &str,
+    value: &str,
+    allowed_values: &[String],
+) -> Result<()> {
+    if !allowed_values.is_empty() && !allowed_values.iter().any(|allowed| allowed == value) {
+        return Err(DataFusionError::Plan(format!(
+            "{}.{} argument '{arg}' has invalid value '{value}'; expected one of: {}",
+            context.source_schema,
+            context.function_name,
+            allowed_values.join(", ")
+        )));
+    }
+    Ok(())
+}

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -19,7 +19,7 @@ use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
 
 use crate::backends::http::HttpSourceClient;
-use crate::backends::http::provider::http_json_exec;
+use crate::backends::http::provider::{HttpJsonExecRequest, http_json_exec};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::literal_to_string;
@@ -79,10 +79,10 @@ impl HttpSourceTableFunction {
 
 impl TableFunctionImpl for HttpSourceTableFunction {
     fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
-        let request_values = bind_function_args(&self.state.source_schema, &self.spec, args)?;
+        let arg_values = bind_function_args(&self.state.source_schema, &self.spec, args)?;
         Ok(Arc::new(HttpSourceFunctionCallTableProvider {
             state: Arc::clone(&self.state),
-            request_values,
+            arg_values,
         }))
     }
 }
@@ -91,7 +91,7 @@ impl TableFunctionImpl for HttpSourceTableFunction {
 /// already bound into HTTP request values.
 struct HttpSourceFunctionCallTableProvider {
     state: Arc<HttpSourceFunctionState>,
-    request_values: HashMap<String, String>,
+    arg_values: HashMap<String, String>,
 }
 
 impl fmt::Debug for HttpSourceFunctionCallTableProvider {
@@ -99,7 +99,7 @@ impl fmt::Debug for HttpSourceFunctionCallTableProvider {
         f.debug_struct("HttpSourceFunctionCallTableProvider")
             .field("source_schema", &self.state.source_schema)
             .field("function", &self.state.function_name)
-            .field("request_values", &self.request_values.keys())
+            .field("arg_values", &self.arg_values.keys())
             .finish_non_exhaustive()
     }
 }
@@ -137,15 +137,16 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
         _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        http_json_exec(
-            self.state.backend.clone(),
-            &self.state.source_schema,
-            (*self.state.target).clone(),
-            self.state.schema.clone(),
-            self.request_values.clone(),
+        http_json_exec(HttpJsonExecRequest {
+            backend: self.state.backend.clone(),
+            source_schema: &self.state.source_schema,
+            target: (*self.state.target).clone(),
+            schema: self.state.schema.clone(),
+            filter_values: HashMap::new(),
+            arg_values: self.arg_values.clone(),
             projection,
             limit,
-        )
+        })
     }
 }
 
@@ -161,7 +162,7 @@ fn bind_function_args(
     ensure_no_extra_args(&context, function.args.len(), args.len())?;
 
     let mut required_missing = Vec::new();
-    let mut request_values = HashMap::with_capacity(function.args.len());
+    let mut arg_values = HashMap::with_capacity(function.args.len());
 
     for (index, spec) in function.args.iter().enumerate() {
         let Some(value) = resolve_call_arg_literal(&context, spec.name.as_str(), args.get(index))?
@@ -172,7 +173,7 @@ fn bind_function_args(
             continue;
         };
         ensure_call_arg_allowed_value(&context, spec.name.as_str(), &value, &spec.values)?;
-        request_values.insert(spec.bind.arg.clone(), value);
+        arg_values.insert(spec.bind.arg.clone(), value);
     }
 
     if !required_missing.is_empty() {
@@ -184,7 +185,7 @@ fn bind_function_args(
         )));
     }
 
-    Ok(request_values)
+    Ok(arg_values)
 }
 
 fn ensure_no_extra_args(

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -17,7 +17,6 @@ use datafusion::datasource::TableProvider;
 use datafusion::error::{DataFusionError, Result};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion::scalar::ScalarValue;
 
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::provider::http_json_exec;
@@ -218,7 +217,12 @@ fn resolve_call_arg_literal(
 }
 
 fn is_null_literal(expr: &Expr) -> bool {
-    matches!(expr, Expr::Literal(ScalarValue::Null, _))
+    match expr {
+        Expr::Literal(value, _) => value.is_null(),
+        Expr::Cast(cast) => is_null_literal(cast.expr.as_ref()),
+        Expr::TryCast(cast) => is_null_literal(cast.expr.as_ref()),
+        _ => false,
+    }
 }
 
 fn ensure_call_arg_allowed_value(

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -29,21 +29,28 @@ struct FunctionCallContext<'a> {
     function_name: &'a str,
 }
 
+/// Immutable execution state shared by every invocation of one registered HTTP
+/// table function.
+struct HttpSourceFunctionState {
+    backend: HttpSourceClient,
+    source_schema: String,
+    function_name: String,
+    target: Arc<HttpFetchTarget>,
+    schema: SchemaRef,
+}
+
 /// Table-valued function that turns manifest-declared function args into an
 /// HTTP-backed result provider.
 pub(crate) struct HttpSourceTableFunction {
-    backend: HttpSourceClient,
-    source_schema: String,
     spec: Arc<SourceTableFunctionSpec>,
-    target: Arc<HttpFetchTarget>,
-    schema: SchemaRef,
+    state: Arc<HttpSourceFunctionState>,
 }
 
 impl fmt::Debug for HttpSourceTableFunction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HttpSourceTableFunction")
-            .field("source_schema", &self.source_schema)
-            .field("function", &self.spec.name)
+            .field("source_schema", &self.state.source_schema)
+            .field("function", &self.state.function_name)
             .finish_non_exhaustive()
     }
 }
@@ -56,57 +63,55 @@ impl HttpSourceTableFunction {
     ) -> Result<Self> {
         let schema = schema_from_columns(&function.columns, &source_schema, &function.name)?;
         let target = HttpFetchTarget::from_function(&function);
+        let function_name = function.name.clone();
         Ok(Self {
-            backend,
-            source_schema,
             spec: Arc::new(function),
-            target: Arc::new(target),
-            schema,
+            state: Arc::new(HttpSourceFunctionState {
+                backend,
+                source_schema,
+                function_name,
+                target: Arc::new(target),
+                schema,
+            }),
         })
     }
 }
 
 impl TableFunctionImpl for HttpSourceTableFunction {
     fn call(&self, args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
-        let request_values = bind_function_args(&self.source_schema, &self.spec, args)?;
-        Ok(Arc::new(HttpSourceFunctionCallProvider {
-            backend: self.backend.clone(),
-            source_schema: self.source_schema.clone(),
-            function_name: self.spec.name.clone(),
-            target: Arc::clone(&self.target),
-            schema: self.schema.clone(),
+        let request_values = bind_function_args(&self.state.source_schema, &self.spec, args)?;
+        Ok(Arc::new(HttpSourceFunctionCallTableProvider {
+            state: Arc::clone(&self.state),
             request_values,
         }))
     }
 }
 
-struct HttpSourceFunctionCallProvider {
-    backend: HttpSourceClient,
-    source_schema: String,
-    function_name: String,
-    target: Arc<HttpFetchTarget>,
-    schema: SchemaRef,
+/// Concrete table provider returned for one function call, with SQL arguments
+/// already bound into HTTP request values.
+struct HttpSourceFunctionCallTableProvider {
+    state: Arc<HttpSourceFunctionState>,
     request_values: HashMap<String, String>,
 }
 
-impl fmt::Debug for HttpSourceFunctionCallProvider {
+impl fmt::Debug for HttpSourceFunctionCallTableProvider {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("HttpSourceFunctionCallProvider")
-            .field("source_schema", &self.source_schema)
-            .field("function", &self.function_name)
+        f.debug_struct("HttpSourceFunctionCallTableProvider")
+            .field("source_schema", &self.state.source_schema)
+            .field("function", &self.state.function_name)
             .field("request_values", &self.request_values.keys())
             .finish_non_exhaustive()
     }
 }
 
 #[async_trait::async_trait]
-impl TableProvider for HttpSourceFunctionCallProvider {
+impl TableProvider for HttpSourceFunctionCallTableProvider {
     fn as_any(&self) -> &dyn Any {
         self
     }
 
     fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        self.state.schema.clone()
     }
 
     fn table_type(&self) -> TableType {
@@ -133,10 +138,10 @@ impl TableProvider for HttpSourceFunctionCallProvider {
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         http_json_exec(
-            self.backend.clone(),
-            &self.source_schema,
-            (*self.target).clone(),
-            self.schema.clone(),
+            self.state.backend.clone(),
+            &self.state.source_schema,
+            (*self.state.target).clone(),
+            self.state.schema.clone(),
             self.request_values.clone(),
             projection,
             limit,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -12,7 +12,7 @@ use datafusion::prelude::SessionContext;
 use crate::RequestAuthenticator;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
+    RegisteredTable, SourceTableFunctions, build_registered_inputs, build_registered_table,
     build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
     required_filter_names,
 };
@@ -94,7 +94,7 @@ impl CompiledBackendSource for HttpCompiledSource {
             table_infos.push(registered_table(table));
         }
         let mut table_functions =
-            crate::SourceTableFunctions::with_capacity(self.manifest.functions.len());
+            SourceTableFunctions::with_capacity(self.manifest.functions.len());
         let mut table_function_infos = Vec::with_capacity(self.manifest.functions.len());
         for function in &self.manifest.functions {
             let internal_name =

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -11,10 +11,10 @@ use datafusion::prelude::SessionContext;
 
 use crate::RequestAuthenticator;
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, BackendTableFunctionRegistration,
-    CompiledBackendSource, RegisteredSource, RegisteredTable, build_registered_inputs,
-    build_registered_table, build_registered_table_function, internal_table_function_name,
-    registered_columns_from_specs, required_filter_names,
+    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
+    RegisteredTable, build_registered_inputs, build_registered_table,
+    build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
+    required_filter_names,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
@@ -93,20 +93,19 @@ impl CompiledBackendSource for HttpCompiledSource {
             tables.insert(table.name().to_string(), provider);
             table_infos.push(registered_table(table));
         }
-        let mut table_functions = Vec::with_capacity(self.manifest.functions.len());
+        let mut table_functions =
+            crate::SourceTableFunctions::with_capacity(self.manifest.functions.len());
         let mut table_function_infos = Vec::with_capacity(self.manifest.functions.len());
         for function in &self.manifest.functions {
             let internal_name =
                 internal_table_function_name(&self.manifest.common.name, &function.name);
-            let function_impl = function::HttpSourceTableFunction::new(
-                backend.clone(),
-                self.manifest.common.name.clone(),
-                function.clone(),
-            )?;
-            table_functions.push(BackendTableFunctionRegistration {
-                internal_name: internal_name.clone(),
-                function: Arc::new(function_impl),
-            });
+            let function_impl: Arc<dyn datafusion::catalog::TableFunctionImpl> =
+                Arc::new(function::HttpSourceTableFunction::new(
+                    backend.clone(),
+                    self.manifest.common.name.clone(),
+                    function.clone(),
+                )?);
+            table_functions.insert(internal_name, function_impl);
             table_function_infos.push(build_registered_table_function(
                 &self.manifest.common.name,
                 function,

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -11,14 +11,16 @@ use datafusion::prelude::SessionContext;
 
 use crate::RequestAuthenticator;
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
-    build_registered_table_function, registered_columns_from_specs, required_filter_names,
+    BackendCompileRequest, BackendRegistration, BackendTableFunctionRegistration,
+    CompiledBackendSource, RegisteredSource, RegisteredTable, build_registered_inputs,
+    build_registered_table, build_registered_table_function, internal_table_function_name,
+    registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
 pub(crate) mod client;
 pub(crate) mod error;
+pub(crate) mod function;
 pub(crate) mod provider;
 mod rate_limit;
 pub(crate) mod target;
@@ -91,12 +93,25 @@ impl CompiledBackendSource for HttpCompiledSource {
             tables.insert(table.name().to_string(), provider);
             table_infos.push(registered_table(table));
         }
-        let table_function_infos = self
-            .manifest
-            .functions
-            .iter()
-            .map(|function| build_registered_table_function(&self.manifest.common.name, function))
-            .collect();
+        let mut table_functions = Vec::with_capacity(self.manifest.functions.len());
+        let mut table_function_infos = Vec::with_capacity(self.manifest.functions.len());
+        for function in &self.manifest.functions {
+            let internal_name =
+                internal_table_function_name(&self.manifest.common.name, &function.name);
+            let function_impl = function::HttpSourceTableFunction::new(
+                backend.clone(),
+                self.manifest.common.name.clone(),
+                function.clone(),
+            )?;
+            table_functions.push(BackendTableFunctionRegistration {
+                internal_name: internal_name.clone(),
+                function: Arc::new(function_impl),
+            });
+            table_function_infos.push(build_registered_table_function(
+                &self.manifest.common.name,
+                function,
+            ));
+        }
 
         let secret_keys = self.source_secrets.keys().cloned().collect();
         let inputs = build_registered_inputs(
@@ -107,6 +122,7 @@ impl CompiledBackendSource for HttpCompiledSource {
 
         Ok(BackendRegistration {
             tables,
+            table_functions,
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -185,10 +185,10 @@ impl TableProvider for HttpSourceTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let request_values = extract_filter_values(filters, self.table.filters());
+        let filter_values = extract_filter_values(filters, self.table.filters());
 
         for required in self.table.filters().iter().filter(|f| f.required) {
-            if !request_values.contains_key(&required.name) {
+            if !filter_values.contains_key(&required.name) {
                 return Err(DataFusionError::External(Box::new(
                     ProviderQueryError::MissingRequiredFilter {
                         schema: self.source_schema.clone(),
@@ -199,8 +199,8 @@ impl TableProvider for HttpSourceTableProvider {
             }
         }
 
-        let request_value_keys: HashSet<String> = request_values.keys().cloned().collect();
-        let active_request = self.table.resolve_request(&request_value_keys).clone();
+        let filter_value_keys: HashSet<String> = filter_values.keys().cloned().collect();
+        let active_request = self.table.resolve_request(&filter_value_keys).clone();
         let target = self.target.with_resolved_request(active_request);
 
         http_json_exec(HttpJsonExecRequest {
@@ -208,7 +208,7 @@ impl TableProvider for HttpSourceTableProvider {
             source_schema: &self.source_schema,
             target,
             schema: self.schema.clone(),
-            filter_values: request_values,
+            filter_values,
             arg_values: HashMap::new(),
             projection,
             limit,

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -68,43 +68,64 @@ impl HttpSourceTableProvider {
 struct HttpFetchPlan {
     backend: HttpSourceClient,
     target: Arc<HttpFetchTarget>,
-    request_values: Arc<HashMap<String, String>>,
+    filter_values: Arc<HashMap<String, String>>,
+    arg_values: Arc<HashMap<String, String>>,
     limit: Option<usize>,
+}
+
+pub(crate) struct HttpJsonExecRequest<'a> {
+    pub(crate) backend: HttpSourceClient,
+    pub(crate) source_schema: &'a str,
+    pub(crate) target: HttpFetchTarget,
+    pub(crate) schema: SchemaRef,
+    pub(crate) filter_values: HashMap<String, String>,
+    pub(crate) arg_values: HashMap<String, String>,
+    pub(crate) projection: Option<&'a Vec<usize>>,
+    pub(crate) limit: Option<usize>,
 }
 
 #[async_trait]
 impl RowFetcher for HttpFetchPlan {
     async fn fetch(&self) -> Result<Vec<Value>> {
         self.backend
-            .fetch(self.target.as_ref(), &self.request_values, self.limit)
+            .fetch(
+                self.target.as_ref(),
+                &self.filter_values,
+                &self.arg_values,
+                self.limit,
+            )
             .await
     }
 }
 
-pub(crate) fn http_json_exec(
-    backend: HttpSourceClient,
-    source_schema: &str,
-    target: HttpFetchTarget,
-    schema: SchemaRef,
-    request_values: HashMap<String, String>,
-    projection: Option<&Vec<usize>>,
-    limit: Option<usize>,
-) -> Result<Arc<dyn ExecutionPlan>> {
+pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn ExecutionPlan>> {
+    let HttpJsonExecRequest {
+        backend,
+        source_schema,
+        target,
+        schema,
+        filter_values,
+        arg_values,
+        projection,
+        limit,
+    } = request;
     let target = Arc::new(target);
-    let request_values = Arc::new(request_values);
+    let filter_values = Arc::new(filter_values);
+    let arg_values = Arc::new(arg_values);
     let fetcher = Arc::new(HttpFetchPlan {
         backend,
         target: target.clone(),
-        request_values: request_values.clone(),
+        filter_values: filter_values.clone(),
+        arg_values,
         limit,
     });
 
     let converter = {
         let target = target.clone();
         let schema = schema.clone();
-        let request_values = request_values.clone();
+        let filter_values = filter_values.clone();
         Arc::new(move |items: &[Value]| {
-            convert_items(target.columns(), schema.clone(), &request_values, items)
+            convert_items(target.columns(), schema.clone(), &filter_values, items)
         })
     };
 
@@ -182,15 +203,16 @@ impl TableProvider for HttpSourceTableProvider {
         let active_request = self.table.resolve_request(&request_value_keys).clone();
         let target = self.target.with_resolved_request(active_request);
 
-        http_json_exec(
-            self.backend.clone(),
-            &self.source_schema,
+        http_json_exec(HttpJsonExecRequest {
+            backend: self.backend.clone(),
+            source_schema: &self.source_schema,
             target,
-            self.schema.clone(),
-            request_values,
+            schema: self.schema.clone(),
+            filter_values: request_values,
+            arg_values: HashMap::new(),
             projection,
             limit,
-        )
+        })
     }
 }
 

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -81,7 +81,7 @@ impl RowFetcher for HttpFetchPlan {
     }
 }
 
-fn http_json_exec(
+pub(crate) fn http_json_exec(
     backend: HttpSourceClient,
     source_schema: &str,
     target: HttpFetchTarget,

--- a/crates/coral-engine/src/backends/http/target.rs
+++ b/crates/coral-engine/src/backends/http/target.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use coral_spec::backends::http::HttpTableSpec;
-use coral_spec::{ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec};
+use coral_spec::{ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec, SourceTableFunctionSpec};
 
 /// The HTTP request/response description needed to fetch rows.
 ///
@@ -52,6 +52,17 @@ impl HttpFetchTarget {
             resolved_request,
             response: Arc::clone(&self.response),
             pagination: Arc::clone(&self.pagination),
+        }
+    }
+
+    pub(crate) fn from_function(function: &SourceTableFunctionSpec) -> Self {
+        Self {
+            name: Arc::from(function.name.as_str()),
+            columns: Arc::from(function.columns.clone()),
+            fetch_limit_default: function.fetch_limit_default,
+            resolved_request: function.request.clone(),
+            response: Arc::new(function.response.clone()),
+            pagination: Arc::new(function.pagination.clone()),
         }
     }
 

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -305,6 +305,7 @@ impl CompiledBackendSource for JsonlCompiledSource {
 
         Ok(BackendRegistration {
             tables,
+            table_functions: vec![],
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -305,7 +305,7 @@ impl CompiledBackendSource for JsonlCompiledSource {
 
         Ok(BackendRegistration {
             tables,
-            table_functions: vec![],
+            table_functions: HashMap::default(),
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -9,7 +9,7 @@ use coral_spec::ValidatedSourceManifest;
 pub(crate) mod common;
 pub(crate) use common::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
+    RegisteredTable, SourceTableFunctions, build_registered_inputs, build_registered_table,
     build_registered_table_function, internal_table_function_name, partition_columns_to_arrow,
     registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
     schema_from_columns,

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -8,11 +8,11 @@ use coral_spec::ValidatedSourceManifest;
 
 pub(crate) mod common;
 pub(crate) use common::{
-    BackendCompileRequest, BackendRegistration, BackendTableFunctionRegistration,
-    CompiledBackendSource, RegisteredSource, RegisteredTable, build_registered_inputs,
-    build_registered_table, build_registered_table_function, internal_table_function_name,
-    partition_columns_to_arrow, registered_columns_from_schema, registered_columns_from_specs,
-    required_filter_names, schema_from_columns,
+    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
+    RegisteredTable, build_registered_inputs, build_registered_table,
+    build_registered_table_function, internal_table_function_name, partition_columns_to_arrow,
+    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
+    schema_from_columns,
 };
 
 pub(crate) mod http;

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -8,10 +8,11 @@ use coral_spec::ValidatedSourceManifest;
 
 pub(crate) mod common;
 pub(crate) use common::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
-    build_registered_table_function, partition_columns_to_arrow, registered_columns_from_schema,
-    registered_columns_from_specs, required_filter_names, schema_from_columns,
+    BackendCompileRequest, BackendRegistration, BackendTableFunctionRegistration,
+    CompiledBackendSource, RegisteredSource, RegisteredTable, build_registered_inputs,
+    build_registered_table, build_registered_table_function, internal_table_function_name,
+    partition_columns_to_arrow, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod http;

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -251,6 +251,7 @@ impl CompiledBackendSource for ParquetCompiledSource {
 
         Ok(BackendRegistration {
             tables,
+            table_functions: vec![],
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -251,7 +251,7 @@ impl CompiledBackendSource for ParquetCompiledSource {
 
         Ok(BackendRegistration {
             tables,
-            table_functions: vec![],
+            table_functions: HashMap::default(),
             source: RegisteredSource {
                 schema_name: self.manifest.common.name.clone(),
                 tables: table_infos,

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -11,53 +11,85 @@ use coral_spec::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken,
 /// Shared empty filter/state map for source-scoped rendering.
 pub(crate) static EMPTY_MAP: LazyLock<HashMap<String, String>> = LazyLock::new(HashMap::new);
 
+/// Runtime values available while rendering one backend request.
+#[derive(Clone, Copy)]
+pub(crate) struct RenderContext<'a> {
+    pub(crate) filters: &'a HashMap<String, String>,
+    pub(crate) args: &'a HashMap<String, String>,
+    pub(crate) state: &'a HashMap<String, String>,
+    pub(crate) resolved_inputs: &'a BTreeMap<String, String>,
+}
+
+impl<'a> RenderContext<'a> {
+    pub(crate) fn new(
+        filters: &'a HashMap<String, String>,
+        args: &'a HashMap<String, String>,
+        state: &'a HashMap<String, String>,
+        resolved_inputs: &'a BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            filters,
+            args,
+            state,
+            resolved_inputs,
+        }
+    }
+
+    pub(crate) fn source_scoped(resolved_inputs: &'a BTreeMap<String, String>) -> Self {
+        Self::new(&EMPTY_MAP, &EMPTY_MAP, &EMPTY_MAP, resolved_inputs)
+    }
+}
+
 /// Resolve one declarative value source into an optional JSON value.
 pub(crate) fn resolve_value_source(
     value: &ValueSourceSpec,
-    filters: &HashMap<String, String>,
-    state: &HashMap<String, String>,
-    resolved_inputs: &BTreeMap<String, String>,
+    context: &RenderContext<'_>,
 ) -> Result<Option<Value>> {
     match value {
         ValueSourceSpec::Template { template } => {
-            let rendered = render_template(template, filters, state, resolved_inputs)?;
+            let rendered = render_template(template, context)?;
             Ok(Some(Value::String(rendered)))
         }
         ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
-        ValueSourceSpec::Filter { key, default } => Ok(filters
+        ValueSourceSpec::Filter { key, default } => Ok(context
+            .filters
             .get(key)
             .map(|v| Value::String(v.clone()))
             .or_else(|| default.clone())),
-        ValueSourceSpec::Arg { key, default } => Ok(filters
+        ValueSourceSpec::Arg { key, default } => Ok(context
+            .args
             .get(key)
             .map(|v| Value::String(v.clone()))
             .or_else(|| default.clone())),
         ValueSourceSpec::FilterInt { key, default } => {
-            parse_i64_value(filters, key, *default, "filter")
+            parse_i64_value(context.filters, key, *default, "filter")
         }
         ValueSourceSpec::ArgInt { key, default } => {
-            parse_i64_value(filters, key, *default, "function argument")
+            parse_i64_value(context.args, key, *default, "function argument")
         }
         ValueSourceSpec::FilterBool { key, default } => {
-            parse_bool_value(filters, key, *default, "filter")
+            parse_bool_value(context.filters, key, *default, "filter")
         }
         ValueSourceSpec::FilterSplit {
             key,
             separator,
             part,
-        } => {
-            split_filter_part(filters, key, separator, *part).map(|value| value.map(Value::String))
-        }
+        } => split_filter_part(context.filters, key, separator, *part)
+            .map(|value| value.map(Value::String)),
         ValueSourceSpec::FilterSplitInt {
             key,
             separator,
             part,
-        } => parse_split_i64_value(filters, key, separator, *part),
+        } => parse_split_i64_value(context.filters, key, separator, *part),
         ValueSourceSpec::ArgBool { key, default } => {
-            parse_bool_value(filters, key, *default, "function argument")
+            parse_bool_value(context.args, key, *default, "function argument")
         }
-        ValueSourceSpec::Input { key } => Ok(resolved_inputs.get(key).cloned().map(Value::String)),
-        ValueSourceSpec::State { key } => Ok(state.get(key).map(|v| Value::String(v.clone()))),
+        ValueSourceSpec::Input { key } => {
+            Ok(context.resolved_inputs.get(key).cloned().map(Value::String))
+        }
+        ValueSourceSpec::State { key } => {
+            Ok(context.state.get(key).map(|v| Value::String(v.clone())))
+        }
         ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
             #[expect(
                 clippy::cast_possible_wrap,
@@ -146,37 +178,26 @@ fn split_filter_part(
 /// Render a parsed template into a concrete string.
 pub(crate) fn render_template(
     template: &ParsedTemplate,
-    filters: &HashMap<String, String>,
-    state: &HashMap<String, String>,
-    resolved_inputs: &BTreeMap<String, String>,
+    context: &RenderContext<'_>,
 ) -> Result<String> {
     let mut out = String::with_capacity(template.raw().len());
     for part in template.parts() {
         match part {
             TemplatePart::Literal(part) => out.push_str(part),
             TemplatePart::Token(token) => {
-                out.push_str(&resolve_template_token(
-                    token,
-                    filters,
-                    state,
-                    resolved_inputs,
-                )?);
+                out.push_str(&resolve_template_token(token, context)?);
             }
         }
     }
     Ok(out)
 }
 
-fn resolve_template_token(
-    token: &TemplateToken,
-    filters: &HashMap<String, String>,
-    state: &HashMap<String, String>,
-    resolved_inputs: &BTreeMap<String, String>,
-) -> Result<String> {
+fn resolve_template_token(token: &TemplateToken, context: &RenderContext<'_>) -> Result<String> {
     let default = token.default_value().map(ToString::to_string);
 
     if token.namespace() == &TemplateNamespace::Input {
-        return resolved_inputs
+        return context
+            .resolved_inputs
             .get(token.key())
             .cloned()
             .or(default)
@@ -189,7 +210,8 @@ fn resolve_template_token(
     }
 
     if token.namespace() == &TemplateNamespace::Filter {
-        return filters
+        return context
+            .filters
             .get(token.key())
             .cloned()
             .or(default)
@@ -199,7 +221,8 @@ fn resolve_template_token(
     }
 
     if token.namespace() == &TemplateNamespace::Arg {
-        return filters
+        return context
+            .args
             .get(token.key())
             .cloned()
             .or(default)
@@ -209,9 +232,14 @@ fn resolve_template_token(
     }
 
     if token.namespace() == &TemplateNamespace::State {
-        return state.get(token.key()).cloned().or(default).ok_or_else(|| {
-            DataFusionError::Execution(format!("missing state value '{}'", token.key()))
-        });
+        return context
+            .state
+            .get(token.key())
+            .cloned()
+            .or(default)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!("missing state value '{}'", token.key()))
+            });
     }
 
     Err(DataFusionError::Execution(format!(

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -28,31 +28,18 @@ pub(crate) fn resolve_value_source(
             .get(key)
             .map(|v| Value::String(v.clone()))
             .or_else(|| default.clone())),
+        ValueSourceSpec::Arg { key, default } => Ok(filters
+            .get(key)
+            .map(|v| Value::String(v.clone()))
+            .or_else(|| default.clone())),
         ValueSourceSpec::FilterInt { key, default } => {
-            let value = if let Some(filter) = filters.get(key) {
-                let parsed = filter.parse::<i64>().map_err(|error| {
-                    DataFusionError::Execution(format!(
-                        "filter '{key}' value '{filter}' is not a valid i64: {error}"
-                    ))
-                })?;
-                Some(json!(parsed))
-            } else {
-                default.map(|value| json!(value))
-            };
-            Ok(value)
+            parse_i64_value(filters, key, *default, "filter")
+        }
+        ValueSourceSpec::ArgInt { key, default } => {
+            parse_i64_value(filters, key, *default, "function argument")
         }
         ValueSourceSpec::FilterBool { key, default } => {
-            let value = if let Some(filter) = filters.get(key) {
-                let parsed = filter.parse::<bool>().map_err(|error| {
-                    DataFusionError::Execution(format!(
-                        "filter '{key}' value '{filter}' is not a valid bool: {error}"
-                    ))
-                })?;
-                Some(json!(parsed))
-            } else {
-                default.map(|value| json!(value))
-            };
-            Ok(value)
+            parse_bool_value(filters, key, *default, "filter")
         }
         ValueSourceSpec::FilterSplit {
             key,
@@ -65,22 +52,10 @@ pub(crate) fn resolve_value_source(
             key,
             separator,
             part,
-        } => {
-            let Some(raw) = split_filter_part(filters, key, separator, *part)? else {
-                return Ok(None);
-            };
-            let parsed = raw.parse::<i64>().map_err(|error| {
-                DataFusionError::Execution(format!(
-                    "filter '{key}' split part {part} value '{raw}' is not a valid i64: {error}"
-                ))
-            })?;
-            Ok(Some(json!(parsed)))
+        } => parse_split_i64_value(filters, key, separator, *part),
+        ValueSourceSpec::ArgBool { key, default } => {
+            parse_bool_value(filters, key, *default, "function argument")
         }
-        ValueSourceSpec::Arg { key, .. }
-        | ValueSourceSpec::ArgInt { key, .. }
-        | ValueSourceSpec::ArgBool { key, .. } => Err(DataFusionError::Execution(format!(
-            "function argument '{key}' cannot be resolved outside a function request"
-        ))),
         ValueSourceSpec::Input { key } => Ok(resolved_inputs.get(key).cloned().map(Value::String)),
         ValueSourceSpec::State { key } => Ok(state.get(key).map(|v| Value::String(v.clone()))),
         ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
@@ -96,6 +71,57 @@ pub(crate) fn resolve_value_source(
             Ok(Some(json!(value)))
         }
     }
+}
+
+fn parse_i64_value(
+    values: &HashMap<String, String>,
+    key: &str,
+    default: Option<i64>,
+    label: &str,
+) -> Result<Option<Value>> {
+    let Some(raw) = values.get(key) else {
+        return Ok(default.map(|value| json!(value)));
+    };
+    let parsed = raw.parse::<i64>().map_err(|error| {
+        DataFusionError::Execution(format!(
+            "{label} '{key}' value '{raw}' is not a valid i64: {error}"
+        ))
+    })?;
+    Ok(Some(json!(parsed)))
+}
+
+fn parse_bool_value(
+    values: &HashMap<String, String>,
+    key: &str,
+    default: Option<bool>,
+    label: &str,
+) -> Result<Option<Value>> {
+    let Some(raw) = values.get(key) else {
+        return Ok(default.map(|value| json!(value)));
+    };
+    let parsed = raw.parse::<bool>().map_err(|error| {
+        DataFusionError::Execution(format!(
+            "{label} '{key}' value '{raw}' is not a valid bool: {error}"
+        ))
+    })?;
+    Ok(Some(json!(parsed)))
+}
+
+fn parse_split_i64_value(
+    filters: &HashMap<String, String>,
+    key: &str,
+    separator: &str,
+    part: usize,
+) -> Result<Option<Value>> {
+    let Some(raw) = split_filter_part(filters, key, separator, part)? else {
+        return Ok(None);
+    };
+    let parsed = raw.parse::<i64>().map_err(|error| {
+        DataFusionError::Execution(format!(
+            "filter '{key}' split part {part} value '{raw}' is not a valid i64: {error}"
+        ))
+    })?;
+    Ok(Some(json!(parsed)))
 }
 
 fn split_filter_part(
@@ -169,6 +195,16 @@ fn resolve_template_token(
             .or(default)
             .ok_or_else(|| {
                 DataFusionError::Execution(format!("missing filter '{}'", token.key()))
+            });
+    }
+
+    if token.namespace() == &TemplateNamespace::Arg {
+        return filters
+            .get(token.key())
+            .cloned()
+            .or(default)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!("missing request argument '{}'", token.key()))
             });
     }
 

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 
-use crate::backends::{BackendRegistration, CompiledBackendSource, RegisteredSource};
+use crate::backends::{
+    BackendRegistration, BackendTableFunctionRegistration, CompiledBackendSource, RegisteredSource,
+};
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
@@ -102,6 +104,7 @@ pub(crate) async fn register_sources(
                     Ok(registration) => {
                         let BackendRegistration {
                             tables,
+                            table_functions,
                             source: registered_source,
                         } = registration;
                         let decorated_tables =
@@ -110,7 +113,10 @@ pub(crate) async fn register_sources(
                             compiled_source.schema_name(),
                             Arc::new(StaticSchemaProvider::new(decorated_tables)),
                         ) {
-                            Ok(_) => result.active_sources.push(registered_source),
+                            Ok(_) => {
+                                register_table_functions(ctx, table_functions);
+                                result.active_sources.push(registered_source);
+                            }
                             Err(error) => {
                                 let core_error = datafusion_to_core(&error, &[]);
                                 if handle_source_registration_failure(
@@ -120,17 +126,12 @@ pub(crate) async fn register_sources(
                                 )? {
                                     return Err(core_error);
                                 }
-                                let failure = SourceRegistrationFailure {
-                                    schema_name,
-                                    detail: core_error.to_string(),
-                                };
-                                tracing::warn!(
-                                    source = %source_name,
-                                    schema_name = %failure.schema_name,
-                                    detail = %failure.detail,
-                                    "skipping source"
+                                push_source_failure(
+                                    &mut result,
+                                    &source_name,
+                                    &schema_name,
+                                    core_error.to_string(),
                                 );
-                                result.failures.push(failure);
                             }
                         }
                     }
@@ -143,17 +144,12 @@ pub(crate) async fn register_sources(
                         )? {
                             return Err(core_error);
                         }
-                        let failure = SourceRegistrationFailure {
-                            schema_name,
-                            detail: core_error.to_string(),
-                        };
-                        tracing::warn!(
-                            source = %source_name,
-                            schema_name = %failure.schema_name,
-                            detail = %failure.detail,
-                            "skipping source"
+                        push_source_failure(
+                            &mut result,
+                            &source_name,
+                            &schema_name,
+                            core_error.to_string(),
                         );
-                        result.failures.push(failure);
                     }
                 }
             }
@@ -161,17 +157,12 @@ pub(crate) async fn register_sources(
                 if handle_source_registration_failure(source_decorators, &source, &error)? {
                     return Err(error);
                 }
-                let failure = SourceRegistrationFailure {
-                    schema_name: source.source_name().to_string(),
-                    detail: error.to_string(),
-                };
-                tracing::warn!(
-                    source = %source.source_name(),
-                    schema_name = %failure.schema_name,
-                    detail = %failure.detail,
-                    "skipping source"
+                push_source_failure(
+                    &mut result,
+                    source.source_name(),
+                    source.source_name(),
+                    error.to_string(),
                 );
-                result.failures.push(failure);
             }
         }
     }
@@ -212,6 +203,34 @@ async fn register_source(
     }
 
     source.register(ctx).await
+}
+
+fn push_source_failure(
+    result: &mut SourceRegistrationResult,
+    source_name: &str,
+    schema_name: &str,
+    detail: String,
+) {
+    let failure = SourceRegistrationFailure {
+        schema_name: schema_name.to_string(),
+        detail,
+    };
+    tracing::warn!(
+        source = %source_name,
+        schema_name = %failure.schema_name,
+        detail = %failure.detail,
+        "skipping source"
+    );
+    result.failures.push(failure);
+}
+
+fn register_table_functions(
+    ctx: &SessionContext,
+    table_functions: Vec<BackendTableFunctionRegistration>,
+) {
+    for table_function in table_functions {
+        ctx.register_udtf(&table_function.internal_name, table_function.function);
+    }
 }
 
 fn prepare_source_decorators(

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -5,12 +5,13 @@ use std::sync::Arc;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 
-use crate::backends::{
-    BackendRegistration, BackendTableFunctionRegistration, CompiledBackendSource, RegisteredSource,
-};
+use crate::backends::{BackendRegistration, CompiledBackendSource, RegisteredSource};
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
-use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
+use crate::{
+    CoreError, QuerySource, SourceCapabilities, SourceDecorator, SourceFailurePolicy,
+    SourceTableFunctions,
+};
 
 const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin"];
 
@@ -107,14 +108,23 @@ pub(crate) async fn register_sources(
                             table_functions,
                             source: registered_source,
                         } = registration;
-                        let decorated_tables =
-                            decorate_source_tables(source_decorators, query_source, tables)?;
+                        let decorated_capabilities = decorate_source_capabilities(
+                            source_decorators,
+                            query_source,
+                            SourceCapabilities {
+                                tables,
+                                table_functions,
+                            },
+                        )?;
                         match catalog.register_schema(
                             compiled_source.schema_name(),
-                            Arc::new(StaticSchemaProvider::new(decorated_tables)),
+                            Arc::new(StaticSchemaProvider::new(decorated_capabilities.tables)),
                         ) {
                             Ok(_) => {
-                                register_table_functions(ctx, table_functions);
+                                register_table_functions(
+                                    ctx,
+                                    decorated_capabilities.table_functions,
+                                );
                                 result.active_sources.push(registered_source);
                             }
                             Err(error) => {
@@ -224,12 +234,9 @@ fn push_source_failure(
     result.failures.push(failure);
 }
 
-fn register_table_functions(
-    ctx: &SessionContext,
-    table_functions: Vec<BackendTableFunctionRegistration>,
-) {
-    for table_function in table_functions {
-        ctx.register_udtf(&table_function.internal_name, table_function.function);
+fn register_table_functions(ctx: &SessionContext, table_functions: SourceTableFunctions) {
+    for (internal_name, function) in table_functions {
+        ctx.register_udtf(&internal_name, function);
     }
 }
 
@@ -245,17 +252,17 @@ fn prepare_source_decorators(
     Ok(())
 }
 
-fn decorate_source_tables(
+fn decorate_source_capabilities(
     source_decorators: &mut [Box<dyn SourceDecorator>],
     source: &QuerySource,
-    mut tables: crate::SourceTables,
-) -> std::result::Result<crate::SourceTables, CoreError> {
+    mut capabilities: SourceCapabilities,
+) -> std::result::Result<SourceCapabilities, CoreError> {
     for decorator in source_decorators {
-        tables = decorator
-            .decorate_source(source, tables)
+        capabilities = decorator
+            .decorate_source_capabilities(source, capabilities)
             .map_err(|error| source_decorator_error(decorator.name(), &error))?;
     }
-    Ok(tables)
+    Ok(capabilities)
 }
 
 fn handle_source_registration_failure(

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -5,10 +5,12 @@ use std::sync::Arc;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 
-use crate::backends::{BackendRegistration, CompiledBackendSource, RegisteredSource};
+use crate::backends::{
+    BackendRegistration, CompiledBackendSource, RegisteredSource, SourceTableFunctions,
+};
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
-use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy, SourceTableFunctions};
+use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy};
 
 const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin"];
 

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -8,10 +8,7 @@ use datafusion::prelude::SessionContext;
 use crate::backends::{BackendRegistration, CompiledBackendSource, RegisteredSource};
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
-use crate::{
-    CoreError, QuerySource, SourceCapabilities, SourceDecorator, SourceFailurePolicy,
-    SourceTableFunctions,
-};
+use crate::{CoreError, QuerySource, SourceDecorator, SourceFailurePolicy, SourceTableFunctions};
 
 const RESERVED_SCHEMA_NAMES: &[&str] = &["coral", "coral_admin"];
 
@@ -108,23 +105,14 @@ pub(crate) async fn register_sources(
                             table_functions,
                             source: registered_source,
                         } = registration;
-                        let decorated_capabilities = decorate_source_capabilities(
-                            source_decorators,
-                            query_source,
-                            SourceCapabilities {
-                                tables,
-                                table_functions,
-                            },
-                        )?;
+                        let decorated_tables =
+                            decorate_source_tables(source_decorators, query_source, tables)?;
                         match catalog.register_schema(
                             compiled_source.schema_name(),
-                            Arc::new(StaticSchemaProvider::new(decorated_capabilities.tables)),
+                            Arc::new(StaticSchemaProvider::new(decorated_tables)),
                         ) {
                             Ok(_) => {
-                                register_table_functions(
-                                    ctx,
-                                    decorated_capabilities.table_functions,
-                                );
+                                register_table_functions(ctx, table_functions);
                                 result.active_sources.push(registered_source);
                             }
                             Err(error) => {
@@ -252,17 +240,17 @@ fn prepare_source_decorators(
     Ok(())
 }
 
-fn decorate_source_capabilities(
+fn decorate_source_tables(
     source_decorators: &mut [Box<dyn SourceDecorator>],
     source: &QuerySource,
-    mut capabilities: SourceCapabilities,
-) -> std::result::Result<SourceCapabilities, CoreError> {
+    mut tables: crate::SourceTables,
+) -> std::result::Result<crate::SourceTables, CoreError> {
     for decorator in source_decorators {
-        capabilities = decorator
-            .decorate_source_capabilities(source, capabilities)
+        tables = decorator
+            .decorate_source(source, tables)
             .map_err(|error| source_decorator_error(decorator.name(), &error))?;
     }
-    Ok(capabilities)
+    Ok(tables)
 }
 
 fn handle_source_registration_failure(

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -48,6 +48,58 @@ fn base_http_manifest(name: &str, base_url: &str) -> Value {
     })
 }
 
+fn search_function_manifest(name: &str, base_url: &str) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "tables": [{
+            "name": "placeholder",
+            "description": "Placeholder table",
+            "request": {
+                "method": "GET",
+                "path": "/api/placeholder"
+            },
+            "columns": [
+                { "name": "id", "type": "Utf8" }
+            ]
+        }],
+        "functions": [{
+            "name": "search_issues",
+            "description": "Search issues",
+            "args": [
+                {
+                    "name": "q",
+                    "required": true,
+                    "bind": { "arg": "q" }
+                },
+                {
+                    "name": "mode",
+                    "values": ["lexical", "semantic", "hybrid"],
+                    "bind": { "arg": "search_type" }
+                }
+            ],
+            "request": {
+                "method": "GET",
+                "path": "/api/search/issues",
+                "query": [
+                    { "name": "q", "from": "arg", "key": "q" },
+                    { "name": "search_type", "from": "arg", "key": "search_type" }
+                ]
+            },
+            "response": {
+                "rows_path": ["items"]
+            },
+            "columns": [
+                { "name": "title", "type": "Utf8" },
+                { "name": "score", "type": "Float64" }
+            ]
+        }]
+    })
+}
+
 #[derive(Debug)]
 struct TestRequestAuthenticator;
 
@@ -239,6 +291,87 @@ async fn select_with_where_filter_pushdown() {
     );
 
     assert_eq!(rows, vec![json!({"id": 2, "name": "Grace"})]);
+}
+
+#[tokio::test]
+async fn internal_table_function_builds_http_search_request() {
+    assert_search_function_query(
+        "SELECT title, score \
+         FROM __coral_udtf_736561726368_7365617263685f697373756573(\
+           'flaky cleanup repo:withcoral/coral', 'hybrid')",
+    )
+    .await;
+}
+
+async fn assert_search_function_query(sql: &str) {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("search", &server.uri()));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(&[source], test_runtime(), sql)
+            .await
+            .expect("query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn table_function_rejects_invalid_argument_values() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("bad_mode_search", &server.uri()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM __coral_udtf_6261645f6d6f64655f736561726368_7365617263685f697373756573(\
+           'flaky', 'banana')",
+    )
+    .await
+    .expect_err("invalid function argument should fail planning");
+
+    assert!(
+        error
+            .to_string()
+            .contains("bad_mode_search.search_issues argument 'mode' has invalid value 'banana'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn table_function_does_not_expose_request_args_as_columns() {
+    let server = MockServer::start().await;
+    let source = build_source(search_function_manifest("conflict_search", &server.uri()));
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT title FROM __coral_udtf_636f6e666c6963745f736561726368_7365617263685f697373756573(\
+           'flaky') WHERE q = 'raw'",
+    )
+    .await
+    .expect_err("request args should not be queryable as result columns");
+
+    assert!(error.to_string().contains('q'), "unexpected error: {error}");
 }
 
 #[tokio::test]

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -6,12 +6,10 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 use coral_engine::{
     CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext,
-    RequestAuthenticator, RequestAuthenticatorError, SourceCapabilities, SourceDecorator,
-    SourceDecoratorError, StatusCode,
+    RequestAuthenticator, RequestAuthenticatorError, StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -124,51 +122,6 @@ fn hex_encode(value: &str) -> String {
 
 #[derive(Debug)]
 struct TestRequestAuthenticator;
-
-struct RecordingSourceDecorator {
-    saw_table_function: Arc<AtomicBool>,
-}
-
-struct TableOnlySourceDecorator;
-
-impl SourceDecorator for TableOnlySourceDecorator {
-    fn name(&self) -> &'static str {
-        "table_only"
-    }
-
-    fn decorate_source(
-        &mut self,
-        _source: &coral_engine::QuerySource,
-        tables: coral_engine::SourceTables,
-    ) -> Result<coral_engine::SourceTables, SourceDecoratorError> {
-        Ok(tables)
-    }
-}
-
-impl SourceDecorator for RecordingSourceDecorator {
-    fn name(&self) -> &'static str {
-        "recording"
-    }
-
-    fn decorate_source(
-        &mut self,
-        _source: &coral_engine::QuerySource,
-        tables: coral_engine::SourceTables,
-    ) -> Result<coral_engine::SourceTables, SourceDecoratorError> {
-        Ok(tables)
-    }
-
-    fn decorate_source_capabilities(
-        &mut self,
-        _source: &coral_engine::QuerySource,
-        capabilities: SourceCapabilities,
-    ) -> Result<SourceCapabilities, SourceDecoratorError> {
-        if !capabilities.table_functions.is_empty() {
-            self.saw_table_function.store(true, Ordering::SeqCst);
-        }
-        Ok(capabilities)
-    }
-}
 
 impl RequestAuthenticator for TestRequestAuthenticator {
     fn name(&self) -> &'static str {
@@ -537,58 +490,6 @@ async fn table_function_request_headers_do_not_resolve_filters_from_args() {
 
     assert!(
         error.to_string().contains("missing filter 'q'"),
-        "unexpected error: {error}"
-    );
-}
-
-#[tokio::test]
-async fn source_decorators_receive_table_functions() {
-    let saw_table_function = Arc::new(AtomicBool::new(false));
-    let mut extensions = EngineExtensions::default();
-    extensions
-        .source_decorators
-        .push(Box::new(RecordingSourceDecorator {
-            saw_table_function: saw_table_function.clone(),
-        }));
-
-    let source = build_source(search_function_manifest(
-        "decorated_function_source",
-        "https://api.example.com",
-    ));
-    CoralQuery::list_tables(
-        &[source],
-        QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
-        None,
-    )
-    .await
-    .expect("runtime build should succeed");
-
-    assert!(saw_table_function.load(Ordering::SeqCst));
-}
-
-#[tokio::test]
-async fn table_only_source_decorators_fail_closed_for_table_functions() {
-    let mut extensions = EngineExtensions::default();
-    extensions
-        .source_decorators
-        .push(Box::new(TableOnlySourceDecorator));
-
-    let source = build_source(search_function_manifest(
-        "table_only_decorator_source",
-        "https://api.example.com",
-    ));
-    let error = CoralQuery::list_tables(
-        &[source],
-        QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
-        None,
-    )
-    .await
-    .expect_err("table-only decorators must not silently bypass table functions");
-
-    assert!(
-        error.to_string().contains(
-            "source decorator 'table_only': source decorator does not handle table functions"
-        ),
         "unexpected error: {error}"
     );
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -6,10 +6,12 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use coral_engine::{
     CoralQuery, CoreError, EngineExtensions, QueryRuntimeConfig, QueryRuntimeContext,
-    RequestAuthenticator, RequestAuthenticatorError, StatusCode,
+    RequestAuthenticator, RequestAuthenticatorError, SourceCapabilities, SourceDecorator,
+    SourceDecoratorError, StatusCode,
 };
 use reqwest::header::{AUTHORIZATION, HeaderName, HeaderValue};
 use serde_json::{Value, json};
@@ -101,6 +103,8 @@ fn search_function_manifest(name: &str, base_url: &str) -> Value {
 }
 
 fn internal_table_function_name(schema: &str, function: &str) -> String {
+    // PR #306 only registers DataFusion's flat internal UDTF. The public
+    // source-scoped planner in the next stack PR owns this mapping for users.
     format!(
         "__coral_udtf_{}_{}",
         hex_encode(schema),
@@ -120,6 +124,51 @@ fn hex_encode(value: &str) -> String {
 
 #[derive(Debug)]
 struct TestRequestAuthenticator;
+
+struct RecordingSourceDecorator {
+    saw_table_function: Arc<AtomicBool>,
+}
+
+struct TableOnlySourceDecorator;
+
+impl SourceDecorator for TableOnlySourceDecorator {
+    fn name(&self) -> &'static str {
+        "table_only"
+    }
+
+    fn decorate_source(
+        &mut self,
+        _source: &coral_engine::QuerySource,
+        tables: coral_engine::SourceTables,
+    ) -> Result<coral_engine::SourceTables, SourceDecoratorError> {
+        Ok(tables)
+    }
+}
+
+impl SourceDecorator for RecordingSourceDecorator {
+    fn name(&self) -> &'static str {
+        "recording"
+    }
+
+    fn decorate_source(
+        &mut self,
+        _source: &coral_engine::QuerySource,
+        tables: coral_engine::SourceTables,
+    ) -> Result<coral_engine::SourceTables, SourceDecoratorError> {
+        Ok(tables)
+    }
+
+    fn decorate_source_capabilities(
+        &mut self,
+        _source: &coral_engine::QuerySource,
+        capabilities: SourceCapabilities,
+    ) -> Result<SourceCapabilities, SourceDecoratorError> {
+        if !capabilities.table_functions.is_empty() {
+            self.saw_table_function.store(true, Ordering::SeqCst);
+        }
+        Ok(capabilities)
+    }
+}
 
 impl RequestAuthenticator for TestRequestAuthenticator {
     fn name(&self) -> &'static str {
@@ -433,6 +482,113 @@ async fn table_function_does_not_expose_request_args_as_columns() {
 
     assert!(
         error.to_string().contains("No column named `q`"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn table_request_headers_do_not_resolve_args_from_filters() {
+    let server = MockServer::start().await;
+    let mut manifest = base_http_manifest("http_arg_header", &server.uri());
+    manifest["request_headers"] = json!([{
+        "name": "X-Request-Arg",
+        "from": "template",
+        "template": "{{arg.id}}"
+    }]);
+    manifest["tables"][0]["filters"] = json!([{ "name": "id" }]);
+    manifest["tables"][0]["request"]["query"] = json!([
+        { "name": "id", "from": "filter", "key": "id" }
+    ]);
+
+    let source = build_source(manifest);
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        "SELECT id FROM http_arg_header.users WHERE id = 2",
+    )
+    .await
+    .expect_err("table filters must not populate function arguments");
+
+    assert!(
+        error.to_string().contains("missing request argument 'id'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn table_function_request_headers_do_not_resolve_filters_from_args() {
+    let server = MockServer::start().await;
+    let mut manifest = search_function_manifest("function_filter_header", &server.uri());
+    manifest["request_headers"] = json!([{
+        "name": "X-Filter",
+        "from": "template",
+        "template": "{{filter.q}}"
+    }]);
+    let source = build_source(manifest);
+    let function_name = internal_table_function_name("function_filter_header", "search_issues");
+
+    let error = CoralQuery::execute_sql(
+        &[source],
+        test_runtime(),
+        &format!("SELECT title FROM {function_name}('flaky')"),
+    )
+    .await
+    .expect_err("function args must not populate table filters");
+
+    assert!(
+        error.to_string().contains("missing filter 'q'"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn source_decorators_receive_table_functions() {
+    let saw_table_function = Arc::new(AtomicBool::new(false));
+    let mut extensions = EngineExtensions::default();
+    extensions
+        .source_decorators
+        .push(Box::new(RecordingSourceDecorator {
+            saw_table_function: saw_table_function.clone(),
+        }));
+
+    let source = build_source(search_function_manifest(
+        "decorated_function_source",
+        "https://api.example.com",
+    ));
+    CoralQuery::list_tables(
+        &[source],
+        QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
+        None,
+    )
+    .await
+    .expect("runtime build should succeed");
+
+    assert!(saw_table_function.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn table_only_source_decorators_fail_closed_for_table_functions() {
+    let mut extensions = EngineExtensions::default();
+    extensions
+        .source_decorators
+        .push(Box::new(TableOnlySourceDecorator));
+
+    let source = build_source(search_function_manifest(
+        "table_only_decorator_source",
+        "https://api.example.com",
+    ));
+    let error = CoralQuery::list_tables(
+        &[source],
+        QueryRuntimeConfig::new(QueryRuntimeContext::default(), extensions),
+        None,
+    )
+    .await
+    .expect_err("table-only decorators must not silently bypass table functions");
+
+    assert!(
+        error.to_string().contains(
+            "source decorator 'table_only': source decorator does not handle table functions"
+        ),
         "unexpected error: {error}"
     );
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -100,6 +100,24 @@ fn search_function_manifest(name: &str, base_url: &str) -> Value {
     })
 }
 
+fn internal_table_function_name(schema: &str, function: &str) -> String {
+    format!(
+        "__coral_udtf_{}_{}",
+        hex_encode(schema),
+        hex_encode(function)
+    )
+}
+
+fn hex_encode(value: &str) -> String {
+    use std::fmt::Write as _;
+
+    let mut encoded = String::with_capacity(value.len() * 2);
+    for byte in value.as_bytes() {
+        write!(&mut encoded, "{byte:02x}").expect("writing to a String never fails");
+    }
+    encoded
+}
+
 #[derive(Debug)]
 struct TestRequestAuthenticator;
 
@@ -295,11 +313,11 @@ async fn select_with_where_filter_pushdown() {
 
 #[tokio::test]
 async fn internal_table_function_builds_http_search_request() {
-    assert_search_function_query(
+    let function_name = internal_table_function_name("search", "search_issues");
+    assert_search_function_query(&format!(
         "SELECT title, score \
-         FROM __coral_udtf_736561726368_7365617263685f697373756573(\
-           'flaky cleanup repo:withcoral/coral', 'hybrid')",
-    )
+         FROM {function_name}('flaky cleanup repo:withcoral/coral', 'hybrid')"
+    ))
     .await;
 }
 
@@ -336,15 +354,57 @@ async fn assert_search_function_query(sql: &str) {
 }
 
 #[tokio::test]
+async fn table_function_treats_typed_null_as_omitted_optional_argument() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param_is_missing("search_type"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [{
+                "title": "Flaky workspace cleanup",
+                "score": 9.5
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(search_function_manifest("null_arg_search", &server.uri()));
+    let function_name = internal_table_function_name("null_arg_search", "search_issues");
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            &format!(
+                "SELECT title, score FROM {function_name}(\
+                 'flaky cleanup repo:withcoral/coral', CAST(NULL AS VARCHAR))"
+            ),
+        )
+        .await
+        .expect("typed null optional argument should be omitted"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "title": "Flaky workspace cleanup",
+            "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
 async fn table_function_rejects_invalid_argument_values() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("bad_mode_search", &server.uri()));
+    let function_name = internal_table_function_name("bad_mode_search", "search_issues");
 
     let error = CoralQuery::execute_sql(
         &[source],
         test_runtime(),
-        "SELECT title FROM __coral_udtf_6261645f6d6f64655f736561726368_7365617263685f697373756573(\
-           'flaky', 'banana')",
+        &format!("SELECT title FROM {function_name}('flaky', 'banana')"),
     )
     .await
     .expect_err("invalid function argument should fail planning");
@@ -361,17 +421,20 @@ async fn table_function_rejects_invalid_argument_values() {
 async fn table_function_does_not_expose_request_args_as_columns() {
     let server = MockServer::start().await;
     let source = build_source(search_function_manifest("conflict_search", &server.uri()));
+    let function_name = internal_table_function_name("conflict_search", "search_issues");
 
     let error = CoralQuery::execute_sql(
         &[source],
         test_runtime(),
-        "SELECT title FROM __coral_udtf_636f6e666c6963745f736561726368_7365617263685f697373756573(\
-           'flaky') WHERE q = 'raw'",
+        &format!("SELECT title FROM {function_name}('flaky') WHERE q = 'raw'"),
     )
     .await
     .expect_err("request args should not be queryable as result columns");
 
-    assert!(error.to_string().contains('q'), "unexpected error: {error}");
+    assert!(
+        error.to_string().contains("No column named `q`"),
+        "unexpected error: {error}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Adds internal `DataFusion` UDTF execution for manifest-declared source table functions.

This is not the public `source.function(...)` SQL syntax. It is the engine execution substrate that turns an already-lowered internal UDTF call into an HTTP-backed table provider.

This PR and the next planner PR are intended to merge together. This branch is split out only to keep reviewable ownership boundaries: this PR handles internal execution; the next PR handles the public source-scoped SQL syntax.

## Why

The previous PR extracted the shared HTTP fetch target. This PR gives function specs a way to use that path.

Tables and functions bind SQL inputs differently:

- tables bind `WHERE` filters before scanning
- functions bind call arguments before scanning

After binding, both should use the same HTTP execution path: render request, paginate, decode response, and map rows into Arrow batches.

## What Changed

- HTTP manifests now register one hidden internal UDTF per function spec
- `HttpSourceTableFunction` validates positional call args and binds them into request values
- function scans use `http_json_exec` and `HttpFetchTarget::from_function(...)`
- function result `WHERE` predicates are not pushed down; `DataFusion` evaluates them locally
- SQL `LIMIT` still flows into HTTP fetching and pagination
- request rendering now supports function `arg`, `arg_int`, and `arg_bool` value sources
- non-HTTP backends return no table-function registrations
- internal UDTF names are hex-encoded to avoid collisions in `DataFusion`'s flat function registry

## Not in This PR

- public `github.find_issues(q => '...')` / `source.function(...)` planning; that is the next PR and should merge with this one
- bundled GitHub/Datadog function rollout
- MCP guide or docs changes
- provider-specific semantic argument design

## Validation

- `cargo test -p coral-engine --test engine table_function -- --nocapture`
- `make rust-checks`