### PR TITLE
ci(build-timings): disable artifact archiving

### DIFF
--- a/.github/workflows/build-timings.yml
+++ b/.github/workflows/build-timings.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           name: cargo-timings-${{ github.sha }}
           path: target/cargo-timings/cargo-timing.html
+          archive: false
           retention-days: 30
 
       - name: Upload build output
@@ -61,6 +62,7 @@ jobs:
         with:
           name: build-output-${{ github.sha }}
           path: build-output.txt
+          archive: false
           retention-days: 30
 
       - name: Check cache quota usage


### PR DESCRIPTION
## Summary
- Set `archive: false` on the cargo-timings and build-output upload steps in the build-timings workflow to skip artifact archiving while retaining the 30-day retention.

## Test plan
- [ ] Trigger the build-timings workflow and confirm it completes successfully.
- [ ] Verify the `cargo-timings-<sha>` and `build-output-<sha>` artifacts are uploaded without archiving.
- [ ] Confirm the artifacts remain downloadable for the 30-day retention window.