### PR TITLE
ci(api): lint protobuf API with buf

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       github_actions: ${{ steps.filter.outputs.github_actions }}
       rust_checks: ${{ steps.filter.outputs.rust_checks }}
+      proto-lint: ${{ steps.filter.outputs.proto-lint }}
       source-lint: ${{ steps.filter.outputs.source-lint }}
       docs-freshness: ${{ steps.filter.outputs.docs-freshness }}
 
@@ -48,6 +49,11 @@ jobs:
               - 'rust-toolchain.toml'
               - 'rust-toolchain'
               - 'crates/**'
+            proto-lint:
+              - '.github/workflows/validate.yml'
+              - 'Makefile'
+              - 'crates/coral-api/buf.yaml'
+              - 'crates/coral-api/proto/**/*.proto'
             source-lint:
               - '.github/workflows/validate.yml'
               - '.yamllint.yaml'
@@ -86,6 +92,24 @@ jobs:
 
       - name: Run make rust-checks
         run: make rust-checks
+
+  proto-lint:
+    name: Lint protobuf API
+    runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.proto-lint == 'true' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Install buf
+        run: |
+          go install github.com/bufbuild/buf/cmd/buf@v1.69.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Run make lint-proto
+        run: make lint-proto
 
   gha-security-audit:
     name: Github Actions security audit with zizmor
@@ -158,7 +182,7 @@ jobs:
 
   validate:
     runs-on: ubuntu-latest
-    needs: [ changes, rust-checks, gha-security-audit, source-lint, docs-freshness ]
+    needs: [ changes, rust-checks, proto-lint, gha-security-audit, source-lint, docs-freshness ]
     # Run even when upstream jobs fail or are conditionally skipped so this
     # job can act as the single required status check for the workflow.
     if: ${{ always() }}
@@ -167,6 +191,7 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           RUST_CHECKS_RESULT: ${{ needs.rust-checks.result }}
+          PROTO_LINT_RESULT: ${{ needs.proto-lint.result }}
           GHA_SECURITY_AUDIT_RESULT: ${{ needs.gha-security-audit.result }}
           SOURCE_LINT_RESULT: ${{ needs.source-lint.result }}
           DOCS_FRESHNESS_RESULT: ${{ needs.docs-freshness.result }}
@@ -174,6 +199,7 @@ jobs:
           jobs=(
             "changes:$CHANGES_RESULT"
             "rust-checks:$RUST_CHECKS_RESULT"
+            "proto-lint:$PROTO_LINT_RESULT"
             "gha-security-audit:$GHA_SECURITY_AUDIT_RESULT"
             "source-lint:$SOURCE_LINT_RESULT"
             "docs-freshness:$DOCS_FRESHNESS_RESULT"

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,16 @@ rust-checks:
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
 
 # ----------------------------------------------------------------------------
+# Protobuf API linting
+# ----------------------------------------------------------------------------
+# Lints crates/coral-api/proto with Buf.
+#
+#   make lint-proto   # check protobuf style and API-shape rules
+
+lint-proto:
+	cd crates/coral-api && buf lint
+
+# ----------------------------------------------------------------------------
 # Source manifest linting
 # ----------------------------------------------------------------------------
 # Lints sources/ with ryl (Rust-native yamllint port).

--- a/crates/coral-api/buf.yaml
+++ b/crates/coral-api/buf.yaml
@@ -1,0 +1,17 @@
+# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yaml
+version: v2
+modules:
+  - path: proto
+lint:
+  use:
+    - STANDARD
+    - COMMENT_ENUM
+    - COMMENT_ENUM_VALUE
+    - COMMENT_FIELD
+    - COMMENT_MESSAGE
+    - COMMENT_ONEOF
+    - COMMENT_RPC
+    - COMMENT_SERVICE
+breaking:
+  use:
+    - FILE

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -4,12 +4,14 @@ package coral.v1;
 
 import "coral/v1/catalog.proto";
 import "coral/v1/resources.proto";
-import "google/protobuf/empty.proto";
 
 // How one installed source entered Coral ownership.
 enum SourceOrigin {
+  // Source origin was not specified.
   SOURCE_ORIGIN_UNSPECIFIED = 0;
+  // Source was installed from Coral's bundled source catalog.
   SOURCE_ORIGIN_BUNDLED = 1;
+  // Source was imported from a user-supplied manifest.
   SOURCE_ORIGIN_IMPORTED = 2;
 }
 
@@ -52,8 +54,11 @@ message Source {
 
 // Input kinds that Coral prompts for while installing or importing a source.
 enum SourceInputKind {
+  // Source input kind was not specified.
   SOURCE_INPUT_KIND_UNSPECIFIED = 0;
+  // Source input is a visible non-secret variable.
   SOURCE_INPUT_KIND_VARIABLE = 1;
+  // Source input is a secret value.
   SOURCE_INPUT_KIND_SECRET = 2;
 }
 
@@ -111,6 +116,12 @@ message CreateBundledSourceRequest {
   repeated SourceSecret secrets = 4;
 }
 
+// Returns the installed bundled source.
+message CreateBundledSourceResponse {
+  // The installed source resource.
+  Source source = 1;
+}
+
 // Imports one user-supplied source manifest into Coral ownership.
 message ImportSourceRequest {
   // Owning workspace resource.
@@ -121,6 +132,12 @@ message ImportSourceRequest {
   repeated SourceVariable variables = 3;
   // Source-owned secret values.
   repeated SourceSecret secrets = 4;
+}
+
+// Returns the imported source.
+message ImportSourceResponse {
+  // The imported source resource.
+  Source source = 1;
 }
 
 // Lists all registered sources in one workspace.
@@ -143,12 +160,24 @@ message GetSourceRequest {
   string name = 2;
 }
 
+// Returns one registered source.
+message GetSourceResponse {
+  // The registered source resource.
+  Source source = 1;
+}
+
 // Fetches source metadata by identifier.
 message GetSourceInfoRequest {
   // Owning workspace resource.
   Workspace workspace = 1;
   // Bare source name to fetch metadata for.
   string name = 2;
+}
+
+// Returns source metadata.
+message GetSourceInfoResponse {
+  // Metadata for the installed or bundled source.
+  SourceInfo source_info = 1;
 }
 
 // Deletes one registered source and its managed artifacts.
@@ -158,6 +187,9 @@ message DeleteSourceRequest {
   // Bare source name to remove.
   string name = 2;
 }
+
+// Confirms source deletion.
+message DeleteSourceResponse {}
 
 // Validates that a registered source is queryable.
 message ValidateSourceRequest {
@@ -209,15 +241,15 @@ service SourceService {
   // Lists all registered sources.
   rpc ListSources(ListSourcesRequest) returns (ListSourcesResponse);
   // Fetches one registered source.
-  rpc GetSource(GetSourceRequest) returns (Source);
+  rpc GetSource(GetSourceRequest) returns (GetSourceResponse);
   // Fetches metadata for one installed or bundled source.
-  rpc GetSourceInfo(GetSourceInfoRequest) returns (SourceInfo);
+  rpc GetSourceInfo(GetSourceInfoRequest) returns (GetSourceInfoResponse);
   // Installs one bundled source.
-  rpc CreateBundledSource(CreateBundledSourceRequest) returns (Source);
+  rpc CreateBundledSource(CreateBundledSourceRequest) returns (CreateBundledSourceResponse);
   // Imports one user-provided source manifest.
-  rpc ImportSource(ImportSourceRequest) returns (Source);
+  rpc ImportSource(ImportSourceRequest) returns (ImportSourceResponse);
   // Deletes a registered source.
-  rpc DeleteSource(DeleteSourceRequest) returns (google.protobuf.Empty);
+  rpc DeleteSource(DeleteSourceRequest) returns (DeleteSourceResponse);
   // Validates that a registered source is queryable.
   rpc ValidateSource(ValidateSourceRequest) returns (ValidateSourceResponse);
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -2,11 +2,12 @@
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
-    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
-    DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
-    ListSourcesRequest, ListSourcesResponse, Source, SourceInfo, SourceInputKind, SourceInputSpec,
-    SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
-    ValidateSourceResponse,
+    CreateBundledSourceRequest, CreateBundledSourceResponse, DeleteSourceRequest,
+    DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
+    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, Source, SourceInfo,
+    SourceInputKind, SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret,
+    SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use tonic::{Request, Response, Status};
@@ -84,7 +85,7 @@ impl SourceServiceApi for SourceService {
     async fn get_source(
         &self,
         request: Request<GetSourceRequest>,
-    ) -> Result<Response<Source>, Status> {
+    ) -> Result<Response<GetSourceResponse>, Status> {
         let span = grpc_span(request.metadata(), "get_source");
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
@@ -94,10 +95,9 @@ impl SourceServiceApi for SourceService {
             let source = sources
                 .get_source(&workspace_name, &source_name)
                 .map_err(app_status)?;
-            Ok(Response::new(installed_source_to_proto(
-                &workspace_name,
-                source,
-            )))
+            Ok(Response::new(GetSourceResponse {
+                source: Some(installed_source_to_proto(&workspace_name, source)),
+            }))
         })
         .await
     }
@@ -105,7 +105,7 @@ impl SourceServiceApi for SourceService {
     async fn get_source_info(
         &self,
         request: Request<GetSourceInfoRequest>,
-    ) -> Result<Response<SourceInfo>, Status> {
+    ) -> Result<Response<GetSourceInfoResponse>, Status> {
         let span = grpc_span(request.metadata(), "get_source_info");
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
@@ -115,7 +115,9 @@ impl SourceServiceApi for SourceService {
             let source = sources
                 .get_source_info(&workspace_name, &source_name)
                 .map_err(app_status)?;
-            Ok(Response::new(candidate_source_to_proto(source)))
+            Ok(Response::new(GetSourceInfoResponse {
+                source_info: Some(candidate_source_to_proto(source)),
+            }))
         })
         .await
     }
@@ -123,7 +125,7 @@ impl SourceServiceApi for SourceService {
     async fn create_bundled_source(
         &self,
         request: Request<CreateBundledSourceRequest>,
-    ) -> Result<Response<Source>, Status> {
+    ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         let span = grpc_span(request.metadata(), "create_bundled_source");
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
@@ -137,10 +139,9 @@ impl SourceServiceApi for SourceService {
             let installed = sources
                 .create_bundled_source(&workspace_name, &command)
                 .map_err(app_status)?;
-            Ok(Response::new(installed_source_to_proto(
-                &workspace_name,
-                installed,
-            )))
+            Ok(Response::new(CreateBundledSourceResponse {
+                source: Some(installed_source_to_proto(&workspace_name, installed)),
+            }))
         })
         .await
     }
@@ -148,7 +149,7 @@ impl SourceServiceApi for SourceService {
     async fn import_source(
         &self,
         request: Request<ImportSourceRequest>,
-    ) -> Result<Response<Source>, Status> {
+    ) -> Result<Response<ImportSourceResponse>, Status> {
         let span = grpc_span(request.metadata(), "import_source");
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
@@ -161,10 +162,9 @@ impl SourceServiceApi for SourceService {
             let installed = sources
                 .import_source(&workspace_name, &command)
                 .map_err(app_status)?;
-            Ok(Response::new(installed_source_to_proto(
-                &workspace_name,
-                installed,
-            )))
+            Ok(Response::new(ImportSourceResponse {
+                source: Some(installed_source_to_proto(&workspace_name, installed)),
+            }))
         })
         .await
     }
@@ -172,7 +172,7 @@ impl SourceServiceApi for SourceService {
     async fn delete_source(
         &self,
         request: Request<DeleteSourceRequest>,
-    ) -> Result<Response<()>, Status> {
+    ) -> Result<Response<DeleteSourceResponse>, Status> {
         let span = grpc_span(request.metadata(), "delete_source");
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
@@ -182,7 +182,7 @@ impl SourceServiceApi for SourceService {
             sources
                 .delete_source(&workspace_name, &source_name)
                 .map_err(app_status)?;
-            Ok(Response::new(()))
+            Ok(Response::new(DeleteSourceResponse {}))
         })
         .await
     }

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -87,6 +87,8 @@ impl GrpcHarness {
             .await
             .expect("import source")
             .into_inner()
+            .source
+            .expect("import source response")
     }
 
     pub(crate) async fn list_sources(&self) -> Vec<Source> {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -82,7 +82,9 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
         }))
         .await
         .expect("get source")
-        .into_inner();
+        .into_inner()
+        .source
+        .expect("get source response");
     assert_eq!(fetched.name, "secured_messages");
     assert_eq!(fetched.version, "0.1.0");
     assert_eq!(fetched.origin, SourceOrigin::Imported as i32);
@@ -108,7 +110,9 @@ async fn import_duplicate_source_overwrites_existing_source() {
         }))
         .await
         .expect("duplicate import should overwrite")
-        .into_inner();
+        .into_inner()
+        .source
+        .expect("import source response");
     assert_eq!(reimported.version, "0.2.0");
 
     let fetched = harness
@@ -119,7 +123,9 @@ async fn import_duplicate_source_overwrites_existing_source() {
         }))
         .await
         .expect("get overwritten source")
-        .into_inner();
+        .into_inner()
+        .source
+        .expect("get source response");
     assert_eq!(fetched.version, "0.2.0");
 }
 
@@ -731,7 +737,9 @@ async fn get_source_info_returns_available_bundled_metadata() {
         }))
         .await
         .expect("get source info")
-        .into_inner();
+        .into_inner()
+        .source_info
+        .expect("get source info response");
 
     assert_eq!(info.name, "github");
     assert_eq!(info.origin, SourceOrigin::Bundled as i32);
@@ -770,7 +778,9 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
         }))
         .await
         .expect("get source info")
-        .into_inner();
+        .into_inner()
+        .source_info
+        .expect("get source info response");
 
     assert_eq!(info.name, "secured_messages");
     assert_eq!(info.version, "0.1.0");
@@ -944,7 +954,9 @@ async fn create_bundled_source_does_not_persist_manifest_to_config_dir() {
         }))
         .await
         .expect("create bundled github source")
-        .into_inner();
+        .into_inner()
+        .source
+        .expect("create bundled source response");
 
     assert_eq!(created.name, "github");
     assert_eq!(created.origin, SourceOrigin::Bundled as i32);

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -80,7 +80,7 @@ pub(crate) async fn add_bundled_source(
     variables: Vec<SourceVariable>,
     secrets: Vec<SourceSecret>,
 ) -> Result<Source, anyhow::Error> {
-    Ok(app
+    let response = app
         .source_client()
         .create_bundled_source(Request::new(CreateBundledSourceRequest {
             workspace: Some(default_workspace()),
@@ -89,7 +89,10 @@ pub(crate) async fn add_bundled_source(
             secrets,
         }))
         .await?
-        .into_inner())
+        .into_inner();
+    response
+        .source
+        .ok_or_else(|| anyhow::anyhow!("create bundled source response missing source"))
 }
 
 pub(crate) async fn import_source(
@@ -98,7 +101,7 @@ pub(crate) async fn import_source(
     variables: Vec<SourceVariable>,
     secrets: Vec<SourceSecret>,
 ) -> Result<Source, anyhow::Error> {
-    Ok(app
+    let response = app
         .source_client()
         .import_source(Request::new(ImportSourceRequest {
             workspace: Some(default_workspace()),
@@ -107,7 +110,10 @@ pub(crate) async fn import_source(
             secrets,
         }))
         .await?
-        .into_inner())
+        .into_inner();
+    response
+        .source
+        .ok_or_else(|| anyhow::anyhow!("import source response missing source"))
 }
 
 pub(crate) async fn validate_source(
@@ -144,7 +150,7 @@ pub(crate) async fn print_source_info(
     name: &str,
     verbose: bool,
 ) -> Result<(), anyhow::Error> {
-    let source = app
+    let response = app
         .source_client()
         .get_source_info(Request::new(GetSourceInfoRequest {
             workspace: Some(default_workspace()),
@@ -152,6 +158,9 @@ pub(crate) async fn print_source_info(
         }))
         .await?
         .into_inner();
+    let source = response
+        .source_info
+        .ok_or_else(|| anyhow::anyhow!("get source info response missing source_info"))?;
     print_source_info_response(&source, verbose);
     Ok(())
 }

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -14,12 +14,13 @@ use assert_cmd::Command;
 use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
-    Column, CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest,
-    DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, GetSourceInfoRequest,
-    GetSourceRequest, ImportSourceRequest, ListSourcesRequest, ListSourcesResponse,
-    ListTablesRequest, ListTablesResponse, PaginationResponse, Source, SourceInfo, SourceInputKind,
-    SourceInputSpec, SourceOrigin, Table, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace,
+    Column, CreateBundledSourceRequest, CreateBundledSourceResponse, DeleteSourceRequest,
+    DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest,
+    ExecuteSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
+    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
+    ListSourcesResponse, ListTablesRequest, ListTablesResponse, PaginationResponse, Source,
+    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, Table, TableSummary,
+    ValidateSourceRequest, ValidateSourceResponse, Workspace,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -483,63 +484,71 @@ impl SourceService for MockSourceService {
     async fn get_source(
         &self,
         request: Request<GetSourceRequest>,
-    ) -> Result<Response<Source>, Status> {
+    ) -> Result<Response<GetSourceResponse>, Status> {
         self.captured
             .get_source
             .lock()
             .expect("get_source capture")
             .push(request.into_inner());
-        Ok(Response::new(mock_source()))
+        Ok(Response::new(GetSourceResponse {
+            source: Some(mock_source()),
+        }))
     }
 
     async fn get_source_info(
         &self,
         request: Request<GetSourceInfoRequest>,
-    ) -> Result<Response<SourceInfo>, Status> {
+    ) -> Result<Response<GetSourceInfoResponse>, Status> {
         let request = request.into_inner();
         self.captured
             .get_source_info
             .lock()
             .expect("get_source_info capture")
             .push(request.clone());
-        Ok(Response::new(mock_source_info(&request.name)?))
+        Ok(Response::new(GetSourceInfoResponse {
+            source_info: Some(mock_source_info(&request.name)?),
+        }))
     }
 
     async fn create_bundled_source(
         &self,
         request: Request<CreateBundledSourceRequest>,
-    ) -> Result<Response<Source>, Status> {
+    ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         self.captured
             .create_bundled_source
             .lock()
             .expect("create_bundled_source capture")
             .push(request.into_inner());
-        Ok(Response::new(mock_source()))
+        Ok(Response::new(CreateBundledSourceResponse {
+            source: Some(mock_source()),
+        }))
     }
 
     async fn import_source(
         &self,
         request: Request<ImportSourceRequest>,
-    ) -> Result<Response<Source>, Status> {
+    ) -> Result<Response<ImportSourceResponse>, Status> {
         self.captured
             .import_source
             .lock()
             .expect("import_source capture")
             .push(request.into_inner());
-        Ok(Response::new(mock_source()))
+        Ok(Response::new(ImportSourceResponse {
+            source: Some(mock_source()),
+        }))
     }
 
     async fn delete_source(
         &self,
         request: Request<DeleteSourceRequest>,
-    ) -> Result<Response<()>, Status> {
+    ) -> Result<Response<DeleteSourceResponse>, Status> {
         self.captured
             .delete_source
             .lock()
             .expect("delete_source capture")
             .push(request.into_inner());
         self.config.delete_source.clone().into_tonic_result()?;
-        Ok(Response::new(()))
+        Ok(Response::new(DeleteSourceResponse {}))
     }
 
     async fn validate_source(


### PR DESCRIPTION
## Summary

Add Buf as the protobuf contract lint gate for `coral-api` so API-shape and documentation drift are caught before merge. The new config enables Buf STANDARD plus explicit COMMENT_* rules, which forces RPC-specific response wrappers and documented enum values in the source service contract.

## Changes

- Add `crates/coral-api/buf.yaml` with the lint and breaking-change configuration.
- Update `SourceService` RPCs to return operation-specific response messages instead of shared domain messages or `google.protobuf.Empty`.
- Update Rust server, CLI, and test call sites for the generated response wrappers.
- Add `make lint-proto` and wire it into the Validate workflow as a path-filtered `proto-lint` job.

## Verification

- `buf lint`
- `make lint-proto`
- `make rust-checks`
- workflow YAML parse check
- `git diff --check`
