### PR TITLE
refactor(api): centralize default workspace id

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -60,6 +60,9 @@ pub const HTTP2_MAX_HEADER_LIST_SIZE: u32 = 128 * 1024;
 /// Coral error domain used in `google.rpc.ErrorInfo`.
 pub const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
 
+/// Canonical default workspace name used across local Coral surfaces.
+pub const DEFAULT_WORKSPACE_ID: &str = "default";
+
 /// Reserved `ErrorInfo.metadata` key for a one-line error summary.
 pub const CORAL_ERROR_METADATA_SUMMARY: &str = "summary";
 

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -1,10 +1,9 @@
 use std::fmt;
 
+pub use coral_api::DEFAULT_WORKSPACE_ID;
+
 use crate::bootstrap::AppError;
 use crate::identity::parse_path_segment;
-
-/// Canonical default workspace name used across local Coral surfaces.
-pub const DEFAULT_WORKSPACE_ID: &str = "default";
 
 /// App-owned identity for one validated workspace name.
 ///

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 workspace = true
 
 [dependencies]
-arrow.workspace = true
+arrow = { workspace = true, features = ["prettyprint"] }
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 serde_json.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -12,7 +12,7 @@ use crate::error::ClientError;
 use crate::propagation::TraceContextInterceptor;
 
 /// Default workspace used by local Coral clients.
-pub use coral_app::DEFAULT_WORKSPACE_ID;
+pub use coral_api::DEFAULT_WORKSPACE_ID;
 
 #[must_use]
 /// Returns the default workspace used by local Coral clients.


### PR DESCRIPTION
## Intent

Make the default workspace identifier a single transport-level constant instead of duplicating the same string across app and client surfaces. `coral-api` already owns the shared wire contract used by both crates, so it is the narrowest stable place for this cross-surface default.

## Changes

- Add `DEFAULT_WORKSPACE_ID` to `coral-api`.
- Re-export that constant from `coral-app` so existing app callers keep their current import path.
- Point `coral-client` at the shared `coral-api` constant instead of importing it from `coral-app`.
- Enable Arrow `prettyprint` explicitly in `coral-client`, because its rendering helper directly uses `arrow::util::pretty`.

## Validation

- `cargo check -p coral-client --locked`
- `make rust-checks`
