### PR TITLE
fix(spec): allow function-only HTTP manifests

### DIFF
--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -116,6 +116,7 @@ struct RawHttpSourceManifest {
     rate_limit: RateLimitSpec,
     #[serde(default)]
     inputs: Option<Value>,
+    #[serde(default)]
     tables: Vec<RawHttpTableSpec>,
     #[serde(default)]
     functions: Vec<SourceTableFunctionSpec>,
@@ -267,6 +268,11 @@ impl HttpSourceManifest {
             tables,
             functions,
         } = raw;
+        if tables.is_empty() && functions.is_empty() {
+            return Err(ManifestError::validation(format!(
+                "source '{name}' must define at least one table or function"
+            )));
+        }
         validate_test_queries(&name, &test_queries)?;
         validate_table_names(&name, tables.iter().map(|table| table.name.as_str()))?;
         let common =

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -248,6 +248,42 @@ tables:
     }
 
     #[test]
+    fn parse_source_manifest_accepts_http_functions_without_tables() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: searchy
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+functions:
+  - name: search_issues
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+    request:
+      method: GET
+      path: /search/issues
+      query:
+        - name: q
+          from: arg
+          key: q
+    columns:
+      - name: title
+        type: Utf8
+",
+        )
+        .expect("function-only HTTP manifest should parse");
+
+        let http = manifest.as_http().expect("HTTP manifest");
+        assert!(http.tables.is_empty());
+        assert_eq!(http.functions.len(), 1);
+        assert_eq!(http.functions[0].name, "search_issues");
+    }
+
+    #[test]
     fn parse_source_manifest_rejects_whitespace_only_test_query() {
         let error = parse_source_manifest_yaml(
             r#"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -4,7 +4,28 @@
   "title": "Coral Source Manifest",
   "type": "object",
   "additionalProperties": false,
-  "required": ["dsl_version", "name", "version", "backend", "tables"],
+  "required": ["dsl_version", "name", "version", "backend"],
+  "allOf": [
+    {
+      "if": {
+        "properties": { "backend": { "const": "http" } },
+        "required": ["backend"]
+      },
+      "then": {
+        "anyOf": [
+          { "required": ["tables"] },
+          { "required": ["functions"] }
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": { "backend": { "enum": ["jsonl", "parquet"] } },
+        "required": ["backend"]
+      },
+      "then": { "required": ["tables"] }
+    }
+  ],
   "properties": {
     "dsl_version": { "type": "integer", "const": 3 },
     "name": { "type": "string", "minLength": 1 },
@@ -30,6 +51,7 @@
     },
     "functions": {
       "type": "array",
+      "minItems": 1,
       "items": { "$ref": "#/$defs/table_function" }
     },
     "onboarding": {


### PR DESCRIPTION
## Why

Source-scoped HTTP table functions are meant to represent provider-native read operations that return rows without requiring a backing table. The new function spec and catalog support allowed that shape conceptually, but manifest parsing still required a `tables` block globally, so a function-only HTTP source failed schema validation before it could reach function validation or catalog discovery.

## What changed

- Allow HTTP manifests to define either `tables` or `functions`.
- Keep `tables` required for file-backed `jsonl` and `parquet` sources.
- Reject HTTP manifests that define neither tables nor functions.
- Add parser coverage for an HTTP manifest with functions and no tables.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p coral-spec parse_source_manifest_accepts_http_functions_without_tables --locked`
- `cargo test -p coral-spec --locked`
- `cargo test -p coral-spec validate_http_function --locked`
- `cargo test -p coral-engine --test engine catalog_tests::coral_table_functions_lists_source_functions --locked`
- `cargo test -p coral-engine --lib table_not_found --locked`
- `git diff --check`
