### PR TITLE
feat(engine): expose search metadata catalog

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
     ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
-    SourceTableFunctionSpec, TableCommon,
+    SearchLimitsSpec, SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::catalog::TableFunctionImpl;
@@ -26,6 +26,7 @@ pub(crate) struct RegisteredColumn {
     pub(crate) nullable: bool,
     pub(crate) is_virtual: bool,
     pub(crate) is_required_filter: bool,
+    pub(crate) filter_mode: Option<String>,
     pub(crate) description: String,
 }
 
@@ -35,7 +36,9 @@ pub(crate) struct RegisteredTable {
     pub(crate) description: String,
     pub(crate) guide: String,
     pub(crate) columns: Vec<RegisteredColumn>,
+    pub(crate) filters: Vec<RegisteredFilter>,
     pub(crate) required_filters: Vec<String>,
+    pub(crate) search_limits_json: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -43,10 +46,21 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) schema_name: String,
     pub(crate) function_name: String,
     pub(crate) internal_name: String,
+    pub(crate) kind: String,
     pub(crate) description: String,
     pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
     pub(crate) result_columns: Vec<RegisteredTableFunctionResultColumn>,
     pub(crate) arg_names: Vec<String>,
+    pub(crate) search_limits_json: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RegisteredFilter {
+    pub(crate) name: String,
+    pub(crate) mode: String,
+    pub(crate) required: bool,
+    pub(crate) data_type: String,
+    pub(crate) description: String,
 }
 
 #[derive(Debug, Clone)]
@@ -140,37 +154,62 @@ pub(crate) fn required_filter_names(filters: &[FilterSpec]) -> Vec<String> {
         .collect()
 }
 
+pub(crate) fn registered_filters_from_specs(filters: &[FilterSpec]) -> Vec<RegisteredFilter> {
+    filters
+        .iter()
+        .map(|filter| RegisteredFilter {
+            name: filter.name.clone(),
+            mode: filter.mode.as_str().to_string(),
+            required: filter.required,
+            data_type: filter.data_type.clone(),
+            description: filter.description.clone(),
+        })
+        .collect()
+}
+
 pub(crate) fn registered_columns_from_specs(
     columns: &[ColumnSpec],
-    required_filters: &[String],
+    filters: &[FilterSpec],
 ) -> Vec<RegisteredColumn> {
     columns
         .iter()
-        .map(|column| RegisteredColumn {
-            name: column.name.clone(),
-            data_type: column.data_type.clone(),
-            nullable: column.nullable,
-            is_virtual: column.r#virtual,
-            is_required_filter: required_filters.iter().any(|filter| filter == &column.name),
-            description: column.description.clone(),
+        .map(|column| {
+            let filter = filters
+                .iter()
+                .find(|filter| filter.name == column.name.as_str());
+            RegisteredColumn {
+                name: column.name.clone(),
+                data_type: column.data_type.clone(),
+                nullable: column.nullable,
+                is_virtual: column.r#virtual,
+                is_required_filter: filter.is_some_and(|filter| filter.required),
+                filter_mode: filter.map(|filter| filter.mode.as_str().to_string()),
+                description: column.description.clone(),
+            }
         })
         .collect()
 }
 
 pub(crate) fn registered_columns_from_schema(
     schema: &SchemaRef,
-    required_filters: &[String],
+    filters: &[FilterSpec],
 ) -> Vec<RegisteredColumn> {
     schema
         .fields()
         .iter()
-        .map(|field| RegisteredColumn {
-            name: field.name().clone(),
-            data_type: field.data_type().to_string(),
-            nullable: field.is_nullable(),
-            is_virtual: false,
-            is_required_filter: required_filters.iter().any(|filter| filter == field.name()),
-            description: String::new(),
+        .map(|field| {
+            let filter = filters
+                .iter()
+                .find(|filter| filter.name == field.name().as_str());
+            RegisteredColumn {
+                name: field.name().clone(),
+                data_type: field.data_type().to_string(),
+                nullable: field.is_nullable(),
+                is_virtual: false,
+                is_required_filter: filter.is_some_and(|filter| filter.required),
+                filter_mode: filter.map(|filter| filter.mode.as_str().to_string()),
+                description: String::new(),
+            }
         })
         .collect()
 }
@@ -233,7 +272,9 @@ pub(crate) fn build_registered_table(
         description: common.description.clone(),
         guide: common.guide.clone(),
         columns,
+        filters: registered_filters_from_specs(&common.filters),
         required_filters,
+        search_limits_json: common.search_limits.as_ref().map(serialize_search_limits),
     }
 }
 
@@ -265,11 +306,17 @@ pub(crate) fn build_registered_table_function(
         schema_name: schema_name.to_string(),
         function_name: function.name.clone(),
         internal_name,
+        kind: function.kind.as_str().to_string(),
         description: function.description.clone(),
         arguments,
         result_columns,
         arg_names: function.args.iter().map(|arg| arg.name.clone()).collect(),
+        search_limits_json: function.search_limits.as_ref().map(serialize_search_limits),
     }
+}
+
+fn serialize_search_limits(limits: &SearchLimitsSpec) -> String {
+    serde_json::to_string(limits).expect("search limits json")
 }
 
 pub(crate) fn manifest_data_type_to_arrow(data_type: ManifestDataType) -> DataType {

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -134,7 +134,7 @@ impl CompiledBackendSource for HttpCompiledSource {
 
 fn registered_table(table: &HttpTableSpec) -> RegisteredTable {
     let required_filters = required_filter_names(table.filters());
-    let columns = registered_columns_from_specs(table.columns(), &required_filters);
+    let columns = registered_columns_from_specs(table.columns(), table.filters());
     build_registered_table(&table.common, columns, required_filters)
 }
 

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -318,7 +318,7 @@ impl CompiledBackendSource for JsonlCompiledSource {
 
 fn registered_table(table: &FileTableSpec) -> RegisteredTable {
     let required_filters = required_filter_names(table.filters());
-    let columns = registered_columns_from_specs(table.columns(), &required_filters);
+    let columns = registered_columns_from_specs(table.columns(), table.filters());
     build_registered_table(&table.common, columns, required_filters)
 }
 

--- a/crates/coral-engine/src/backends/parquet/mod.rs
+++ b/crates/coral-engine/src/backends/parquet/mod.rs
@@ -265,9 +265,9 @@ impl CompiledBackendSource for ParquetCompiledSource {
 fn registered_table(table: &FileTableSpec, inferred_schema: &SchemaRef) -> RegisteredTable {
     let required_filters = required_filter_names(table.filters());
     let columns = if table.columns().is_empty() {
-        registered_columns_from_schema(inferred_schema, &required_filters)
+        registered_columns_from_schema(inferred_schema, table.filters())
     } else {
-        registered_columns_from_specs(table.columns(), &required_filters)
+        registered_columns_from_specs(table.columns(), table.filters())
     };
 
     build_registered_table(&table.common, columns, required_filters)

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -11,7 +11,10 @@ use datafusion::error::{DataFusionError, Result};
 use datafusion::prelude::SessionContext;
 use serde::Serialize;
 
-use crate::backends::RegisteredSource;
+use crate::backends::common::{
+    RegisteredTableFunctionArgument, RegisteredTableFunctionResultColumn,
+};
+use crate::backends::{RegisteredSource, RegisteredTableFunction};
 use crate::runtime::schema_provider::StaticSchemaProvider;
 use crate::{
     ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
@@ -30,6 +33,7 @@ pub(crate) const SYSTEM_SCHEMA: &str = "coral";
 pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]) -> Result<()> {
     let tables_table = build_tables_table(active_sources)?;
     let columns_table = build_columns_table(active_sources)?;
+    let filters_table = build_filters_table(active_sources)?;
     let inputs_table = build_inputs_table(active_sources)?;
     let table_functions_table = build_table_functions_table(active_sources)?;
 
@@ -37,6 +41,7 @@ pub(crate) fn register(ctx: &SessionContext, active_sources: &[RegisteredSource]
         HashMap::new();
     meta_tables.insert("tables".to_string(), Arc::new(tables_table));
     meta_tables.insert("columns".to_string(), Arc::new(columns_table));
+    meta_tables.insert("filters".to_string(), Arc::new(filters_table));
     meta_tables.insert("inputs".to_string(), Arc::new(inputs_table));
     meta_tables.insert(
         "table_functions".to_string(),
@@ -61,16 +66,25 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
         Field::new("description", DataType::Utf8, false),
         Field::new("arguments_json", DataType::Utf8, false),
         Field::new("result_columns_json", DataType::Utf8, false),
+        Field::new("kind", DataType::Utf8, false),
+        Field::new("search_limits_json", DataType::Utf8, true),
     ]));
 
-    let rows = collect_table_functions(active_sources);
+    let mut rows = active_sources
+        .iter()
+        .flat_map(|source| source.table_functions.iter())
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
+    });
+
     let arguments_json = rows
         .iter()
-        .map(table_function_arguments_json)
+        .map(|row| table_function_arguments_json(row))
         .collect::<Result<Vec<_>>>()?;
     let result_columns_json = rows
         .iter()
-        .map(table_function_result_columns_json)
+        .map(|row| table_function_result_columns_json(row))
         .collect::<Result<Vec<_>>>()?;
 
     let batch = RecordBatch::try_new(
@@ -81,6 +95,8 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
             utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
             utf8_column(arguments_json.iter().map(|value| Some(value.as_str()))),
             utf8_column(result_columns_json.iter().map(|value| Some(value.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.kind.as_str()))),
+            utf8_column(rows.iter().map(|row| row.search_limits_json.as_deref())),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -88,7 +104,7 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
     MemTable::try_new(schema, vec![vec![batch]])
 }
 
-fn table_function_arguments_json(row: &TableFunctionInfo) -> Result<String> {
+fn table_function_arguments_json(row: &RegisteredTableFunction) -> Result<String> {
     let arguments = row
         .arguments
         .iter()
@@ -97,7 +113,7 @@ fn table_function_arguments_json(row: &TableFunctionInfo) -> Result<String> {
     serde_json::to_string(&arguments).map_err(|error| DataFusionError::External(Box::new(error)))
 }
 
-fn table_function_result_columns_json(row: &TableFunctionInfo) -> Result<String> {
+fn table_function_result_columns_json(row: &RegisteredTableFunction) -> Result<String> {
     let columns = row
         .result_columns
         .iter()
@@ -113,8 +129,8 @@ struct TableFunctionArgumentJson<'a> {
     values: &'a [String],
 }
 
-impl<'a> From<&'a TableFunctionArgumentInfo> for TableFunctionArgumentJson<'a> {
-    fn from(argument: &'a TableFunctionArgumentInfo) -> Self {
+impl<'a> From<&'a RegisteredTableFunctionArgument> for TableFunctionArgumentJson<'a> {
+    fn from(argument: &'a RegisteredTableFunctionArgument) -> Self {
         Self {
             name: &argument.name,
             required: argument.required,
@@ -132,8 +148,8 @@ struct TableFunctionResultColumnJson<'a> {
     description: &'a str,
 }
 
-impl<'a> From<&'a TableFunctionResultColumnInfo> for TableFunctionResultColumnJson<'a> {
-    fn from(column: &'a TableFunctionResultColumnInfo) -> Self {
+impl<'a> From<&'a RegisteredTableFunctionResultColumn> for TableFunctionResultColumnJson<'a> {
+    fn from(column: &'a RegisteredTableFunctionResultColumn) -> Self {
         Self {
             name: &column.name,
             data_type: &column.data_type,
@@ -232,6 +248,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
         Field::new("description", DataType::Utf8, false),
         Field::new("guide", DataType::Utf8, false),
         Field::new("required_filters", DataType::Utf8, false),
+        Field::new("search_limits_json", DataType::Utf8, true),
     ]));
 
     let mut rows = active_sources
@@ -244,6 +261,7 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
                     table.description.as_str(),
                     table.guide.as_str(),
                     table.required_filters.join(","),
+                    table.search_limits_json.as_deref(),
                 )
             })
         })
@@ -263,6 +281,74 @@ fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
                     .map(|row| Some(row.4.as_str()))
                     .collect::<StringArray>(),
             ),
+            utf8_column(rows.iter().map(|row| row.5)),
+        ],
+    )
+    .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
+
+    MemTable::try_new(schema, vec![vec![batch]])
+}
+
+struct CatalogFilter {
+    schema_name: String,
+    table_name: String,
+    filter_name: String,
+    filter_mode: String,
+    is_required: bool,
+    data_type: String,
+    description: String,
+}
+
+fn build_filters_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("schema_name", DataType::Utf8, false),
+        Field::new("table_name", DataType::Utf8, false),
+        Field::new("filter_name", DataType::Utf8, false),
+        Field::new("filter_mode", DataType::Utf8, false),
+        Field::new("is_required", DataType::Boolean, false),
+        Field::new("data_type", DataType::Utf8, false),
+        Field::new("description", DataType::Utf8, false),
+    ]));
+
+    let mut rows = active_sources
+        .iter()
+        .flat_map(|source| {
+            source.tables.iter().flat_map(move |table| {
+                table.filters.iter().map(move |filter| CatalogFilter {
+                    schema_name: source.schema_name.clone(),
+                    table_name: table.table_name.clone(),
+                    filter_name: filter.name.clone(),
+                    filter_mode: filter.mode.clone(),
+                    is_required: filter.required,
+                    data_type: filter.data_type.clone(),
+                    description: filter.description.clone(),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+
+    rows.sort_by(|left, right| {
+        (&left.schema_name, &left.table_name, &left.filter_name).cmp(&(
+            &right.schema_name,
+            &right.table_name,
+            &right.filter_name,
+        ))
+    });
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            utf8_column(rows.iter().map(|row| Some(row.schema_name.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.table_name.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.filter_name.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.filter_mode.as_str()))),
+            Arc::new(
+                rows.iter()
+                    .map(|row| Some(row.is_required))
+                    .collect::<BooleanArray>(),
+            ),
+            utf8_column(rows.iter().map(|row| Some(row.data_type.as_str()))),
+            utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -381,6 +467,7 @@ struct CatalogColumn {
     is_nullable: bool,
     is_virtual: bool,
     is_required_filter: bool,
+    filter_mode: Option<String>,
     description: String,
     ordinal_position: usize,
 }
@@ -396,6 +483,7 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
         Field::new("is_virtual", DataType::Boolean, false),
         Field::new("is_required_filter", DataType::Boolean, false),
         Field::new("description", DataType::Utf8, false),
+        Field::new("filter_mode", DataType::Utf8, true),
     ]));
 
     let mut rows = active_sources
@@ -414,6 +502,7 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
                         is_nullable: column.nullable,
                         is_virtual: column.is_virtual,
                         is_required_filter: column.is_required_filter,
+                        filter_mode: column.filter_mode.clone(),
                         description: column.description.clone(),
                         ordinal_position: position,
                     })
@@ -477,6 +566,7 @@ fn build_columns_table(active_sources: &[RegisteredSource]) -> Result<MemTable> 
                     .map(|row| Some(row.description.as_str()))
                     .collect::<StringArray>(),
             ),
+            utf8_column(rows.iter().map(|row| row.filter_mode.as_deref())),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
@@ -499,10 +589,12 @@ mod tests {
                 schema_name: "function_schema".to_string(),
                 function_name: "search".to_string(),
                 internal_name: "internal_search".to_string(),
+                kind: "search".to_string(),
                 description: String::new(),
                 arguments: Vec::new(),
                 result_columns: Vec::new(),
                 arg_names: Vec::new(),
+                search_limits_json: None,
             }],
             inputs: Vec::new(),
         }]);

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -309,20 +309,57 @@ fn http_manifest_with_function() -> Value {
         "dsl_version": 3,
         "backend": "http",
         "base_url": "https://example.com",
-        "tables": [{
-            "name": "placeholder",
-            "description": "Placeholder table",
-            "request": {
-                "method": "GET",
-                "path": "/placeholder"
+        "tables": [
+            {
+                "name": "placeholder",
+                "description": "Placeholder table",
+                "filters": [{
+                    "name": "query",
+                    "type": "Utf8",
+                    "description": "Provider-native placeholder search text",
+                    "mode": "search"
+                }],
+                "search_limits": {
+                    "default_top_k": 10,
+                    "max_top_k": 50,
+                    "max_calls_per_query": 1
+                },
+                "request": {
+                    "method": "GET",
+                    "path": "/placeholder"
+                },
+                "columns": [
+                    { "name": "id", "type": "Utf8" },
+                    {
+                        "name": "query",
+                        "type": "Utf8",
+                        "virtual": true,
+                        "expr": { "kind": "from_filter", "key": "query" }
+                    }
+                ]
             },
-            "columns": [
-                { "name": "id", "type": "Utf8" }
-            ]
-        }],
+            {
+                "name": "issue_details",
+                "description": "Issue detail rows",
+                "filters": [{ "name": "issue_id", "required": true }],
+                "request": {
+                    "method": "GET",
+                    "path": "/issues/{{filter.issue_id}}"
+                },
+                "columns": [
+                    { "name": "id", "type": "Utf8" }
+                ]
+            }
+        ],
         "functions": [{
             "name": "search_issues",
+            "kind": "search",
             "description": "Search issues",
+            "search_limits": {
+                "default_top_k": 5,
+                "max_top_k": 100,
+                "max_calls_per_query": 1
+            },
             "args": [
                 {
                     "name": "q",
@@ -347,6 +384,7 @@ fn http_manifest_with_function() -> Value {
                 "rows_path": ["items"]
             },
             "columns": [
+                { "name": "id", "type": "Utf8" },
                 { "name": "title", "type": "Utf8" },
                 { "name": "score", "type": "Float64" }
             ]
@@ -407,7 +445,7 @@ async fn coral_table_functions_lists_source_functions() {
         &CoralQuery::execute_sql(
             &sources,
             test_runtime(),
-            "SELECT schema_name, function_name, description, arguments_json, result_columns_json \
+            "SELECT schema_name, function_name, kind, description, arguments_json, result_columns_json, search_limits_json \
              FROM coral.table_functions WHERE schema_name = 'searchy'",
         )
         .await
@@ -418,6 +456,7 @@ async fn coral_table_functions_lists_source_functions() {
     let row = &rows[0];
     assert_eq!(row["schema_name"], "searchy");
     assert_eq!(row["function_name"], "search_issues");
+    assert_eq!(row["kind"], "search");
     assert_eq!(row["description"], "Search issues");
     assert_eq!(
         serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),
@@ -429,9 +468,157 @@ async fn coral_table_functions_lists_source_functions() {
     assert_eq!(
         serde_json::from_str::<Value>(row["result_columns_json"].as_str().unwrap()).unwrap(),
         json!([
+            { "name": "id", "type": "Utf8", "nullable": true, "description": "" },
             { "name": "title", "type": "Utf8", "nullable": true, "description": "" },
             { "name": "score", "type": "Float64", "nullable": true, "description": "" }
         ])
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(row["search_limits_json"].as_str().unwrap()).unwrap(),
+        json!({
+            "default_top_k": 5,
+            "max_top_k": 100,
+            "max_calls_per_query": 1
+        })
+    );
+}
+
+#[tokio::test]
+async fn coral_search_metadata_appends_columns_without_shifting_existing_ordinals() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    let table_functions = CoralQuery::execute_sql(
+        &sources,
+        test_runtime(),
+        "SELECT * FROM coral.table_functions WHERE schema_name = 'searchy'",
+    )
+    .await
+    .expect("table function catalog query should succeed");
+    assert_eq!(
+        table_functions
+            .schema()
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "schema_name",
+            "function_name",
+            "description",
+            "arguments_json",
+            "result_columns_json",
+            "kind",
+            "search_limits_json",
+        ]
+    );
+
+    let columns = CoralQuery::execute_sql(
+        &sources,
+        test_runtime(),
+        "SELECT * FROM coral.columns \
+         WHERE schema_name = 'searchy' AND table_name = 'placeholder' \
+         LIMIT 1",
+    )
+    .await
+    .expect("columns catalog query should succeed");
+    assert_eq!(
+        columns
+            .schema()
+            .iter()
+            .map(|column| column.name.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "schema_name",
+            "table_name",
+            "ordinal_position",
+            "column_name",
+            "data_type",
+            "is_nullable",
+            "is_virtual",
+            "is_required_filter",
+            "description",
+            "filter_mode",
+        ]
+    );
+}
+
+#[tokio::test]
+async fn coral_tables_exposes_search_limits() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT search_limits_json FROM coral.tables \
+             WHERE schema_name = 'searchy' AND table_name = 'placeholder'",
+        )
+        .await
+        .expect("tables catalog query should succeed"),
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        serde_json::from_str::<Value>(rows[0]["search_limits_json"].as_str().unwrap()).unwrap(),
+        json!({
+            "default_top_k": 10,
+            "max_top_k": 50,
+            "max_calls_per_query": 1
+        })
+    );
+}
+
+#[tokio::test]
+async fn coral_filters_lists_filter_metadata() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT table_name, filter_name, filter_mode, is_required, data_type, description \
+             FROM coral.filters WHERE schema_name = 'searchy' AND filter_mode = 'search'",
+        )
+        .await
+        .expect("filters catalog query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "table_name": "placeholder",
+            "filter_name": "query",
+            "filter_mode": "search",
+            "is_required": false,
+            "data_type": "Utf8",
+            "description": "Provider-native placeholder search text",
+        })]
+    );
+}
+
+#[tokio::test]
+async fn coral_columns_exposes_filter_mode_for_virtual_filters() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &sources,
+            test_runtime(),
+            "SELECT column_name, is_virtual, is_required_filter, filter_mode \
+             FROM coral.columns \
+             WHERE schema_name = 'searchy' AND table_name = 'placeholder' AND column_name = 'query'",
+        )
+        .await
+        .expect("columns catalog query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "column_name": "query",
+            "is_virtual": true,
+            "is_required_filter": false,
+            "filter_mode": "search",
+        })]
     );
 }
 
@@ -456,9 +643,10 @@ async fn list_catalog_matches_table_function_metadata() {
         function.arguments[1].values,
         ["lexical", "semantic", "hybrid"]
     );
-    assert_eq!(function.result_columns.len(), 2);
-    assert_eq!(function.result_columns[0].name, "title");
-    assert_eq!(function.result_columns[1].data_type, "Float64");
+    assert_eq!(function.result_columns.len(), 3);
+    assert_eq!(function.result_columns[0].name, "id");
+    assert_eq!(function.result_columns[1].name, "title");
+    assert_eq!(function.result_columns[2].data_type, "Float64");
 }
 
 #[tokio::test]
@@ -469,8 +657,14 @@ async fn list_catalog_collects_tables_and_functions_together() {
         .await
         .expect("list_catalog should succeed");
 
-    assert_eq!(catalog.tables.len(), 1);
-    assert_eq!(catalog.tables[0].table_name, "placeholder");
+    assert_eq!(
+        catalog
+            .tables
+            .iter()
+            .map(|table| table.table_name.as_str())
+            .collect::<Vec<_>>(),
+        ["issue_details", "placeholder"]
+    );
     assert_eq!(catalog.table_functions.len(), 1);
     assert_eq!(catalog.table_functions[0].function_name, "search_issues");
 }


### PR DESCRIPTION
Expose search/retrieval metadata through SQL catalog surfaces.

Why this metadata exists:
- The source spec now has provider-native search functions and bounded search behavior, but generic agents/tools cannot reliably use those semantics if they only exist in source YAML or prose docs.
- This metadata makes the retrieval contract queryable through the catalog: agents can ask what search functions exist, how to call them, what limits apply, which result columns come back, and which filters are available for follow-up table queries.
- This is the catalog layer needed by mechanical discovery flows such as `list_catalog` / `search_catalog`, without hardcoding provider-specific knowledge or relying on prose.
- Detail-hint catalog exposure is intentionally deferred: existing migrated sources are unambiguous enough through search result ids plus catalog-described tables, while the source-spec support can remain available for future providers with thinner or more ambiguous search results.

Changes:
- Adds `kind`, `arguments_json`, `result_columns_json`, and `search_limits_json` to `coral.table_functions`.
- Adds `search_limits_json` to `coral.tables`.
- Adds normalized `coral.filters` metadata, including filter type, mode, and descriptions.
- Exposes nullable `coral.columns.filter_mode` for columns that correspond to declared filters.

Local validation:
- `cargo fmt --check`
- `cargo check -p coral-engine -p coral-mcp`
- `cargo test -p coral-engine --test engine catalog`
- `cargo test -p coral-mcp`
- `cargo test -p coral-spec`
- `cargo run --locked -p xtask -- generate-docs --check`
- `git diff --check`
