### PR TITLE
chore(make): add install helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+install:
+	cargo install --path crates/coral-cli --locked
+
 rust-checks:
 	cargo fmt --all -- --check
 	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings


### PR DESCRIPTION
## Intent

Add a small Makefile helper so contributors can install the local Coral CLI with locked dependency resolution, matching the repository reproducibility expectations.

## Verification

- `make -n install`
