### PR TITLE
fix(spec): validate inner expr for base64_decode

### DIFF
--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -487,7 +487,7 @@ fn validate_expr(expr: &ExprSpec, known_filters: &HashSet<String>, context: &str
                 "{context} references unknown filter '{filter_key}'"
             )));
         }
-        ExprSpec::FormatTimestamp { expr, .. } => {
+        ExprSpec::FormatTimestamp { expr, .. } | ExprSpec::Base64Decode { expr } => {
             validate_expr(expr, known_filters, context)?;
         }
         ExprSpec::Replace { expr, from, .. } => {
@@ -1025,6 +1025,25 @@ mod tests {
             error
                 .to_string()
                 .contains("has replace expression with empty 'from' value")
+        );
+    }
+
+    #[test]
+    fn validate_base64_decode_propagates_inner_expr_errors() {
+        let column = column_with_expr(ExprSpec::Base64Decode {
+            expr: Box::new(ExprSpec::FromFilter {
+                key: "missing".to_string(),
+            }),
+        });
+
+        let error =
+            validate_filters_and_column_exprs(&test_filters(), &[column], "demo", "messages")
+                .expect_err("unknown filter in base64_decode should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("references unknown filter 'missing'")
         );
     }
 }


### PR DESCRIPTION
Closes #318.

Validate the inner expression of base64_decode during source-spec validation so stale from_filter references fail at lint/install time instead of only surfacing later as blank derived values at query time.

Adds a regression test covering an unknown filter nested under base64_decode.

Validation:
- cargo fmt --all -- --check
- cargo clippy -p coral-spec --all-targets --all-features --locked -- -D warnings
- cargo test -p coral-spec --all-targets --all-features --locked