### PR TITLE
docs(legal): align corporate CLA with approved source

### DIFF
--- a/docs/legal/cla-corporate.mdx
+++ b/docs/legal/cla-corporate.mdx
@@ -1,16 +1,15 @@
 ---
-title: Phoebe Technology Limited — Software Grant and Corporate Contributor License Agreement ("Agreement")
+title: Coral Software Grant and Corporate Contributor License Agreement ("Agreement")
 sidebarTitle: Corporate Contributor License Agreement
 ---
 
-
-Thank you for your interest in Coral, managed by Phoebe Technology Limited (hereinafter referred to as "Coral"). In order to clarify the intellectual property license granted with Contributions from any person or entity, Coral must have a Contributor License Agreement (CLA) on file that has been signed by each Contributor, indicating agreement to the license terms below. This license is for your protection as a Contributor as well as the protection of Coral and its users; it does not change your rights to use your own Contributions for any other purpose.
+Thank you for your interest in Coral agent data software ("Coral"). To clarify the intellectual property licence granted with Contributions from any person or entity, Coral must have on file a signed Contributor Licence Agreement ("CLA") from each Contributor, indicating agreement with the licence terms below. This agreement is for your protection as a Contributor as well as the protection of Coral and its users. It does not change your rights to use your own Contributions for any other purpose.
 
 This version of the Agreement allows an entity (the "Corporation") to submit Contributions to Coral, to authorize Contributions submitted by its designated employees to Coral, and to grant copyright and patent licenses thereto.
 
-Please use a pdf form filler, attach a signature, and email the completed pdf file of this Agreement to [legal@withcoral.com](mailto:legal@withcoral.com).
+Please print, complete, and sign this form, then email a scanned copy to [legal@withcoral.com](mailto:legal@withcoral.com).
 
-Please read this document carefully before signing and keep a copy for your records.
+Read this document carefully before signing and keep a copy for your records.
 
 Corporation name: ___________________________________________________________________
 
@@ -28,6 +27,8 @@ You accept and agree to the following terms and conditions for Your present and 
 
 1. **Definitions.**
 
+    "Coral" means the Coral agent data software project managed by Phoebe Technology Limited.
+
     "You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is making this Agreement with Coral. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
 
     "Contribution" shall mean the code, documentation or other original works of authorship expressly identified in Schedule A, as well as any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to Coral for inclusion in, or documentation of, any of the products owned or managed by Coral (the "Work"). For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to Coral or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, Coral for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
@@ -38,7 +39,6 @@ You accept and agree to the following terms and conditions for Your present and 
 5. You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of others).
 6. You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
 7. Should You wish to submit work that is not Your original creation, You may submit it to Coral separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
-8. It is your responsibility to notify Coral when any change is required to the list of designated employees authorized to submit Contributions on behalf of the Corporation, or to the Corporation's Point of Contact with Coral.
 
 Please sign: ___________________________________
 


### PR DESCRIPTION
## Summary

Align the public corporate CLA page with the approved source text so the legal docs present the current Coral project language and signing instructions.

This updates the title, opening description, submission instructions, and Coral definition, and removes a stale clause that is not present in the source text.

## Verification

- `git diff --check`
- `make docs-check`
