### PR TITLE
feat(client): instrument local gRPC service spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "arrow",
  "coral-api",
  "coral-app",
+ "http-body 1.0.1",
  "opentelemetry",
  "opentelemetry_sdk",
  "serde_json",
@@ -1071,6 +1072,7 @@ dependencies = [
  "tonic-types",
  "tracing",
  "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ etcetera = "0.11"
 fs2 = "0.4"
 futures = "0.3"
 glob = "0.3"
+http-body = "1"
 httpdate = "1.0.3"
 jsonschema = { version = "0.18", default-features = false }
 object_store = { version = "0.13.2", features = ["aws"] }

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -71,3 +71,29 @@ pub const CORAL_ERROR_METADATA_DETAIL: &str = "detail";
 
 /// Reserved `ErrorInfo.metadata` key for actionable recovery guidance.
 pub const CORAL_ERROR_METADATA_HINT: &str = "hint";
+
+/// Returns the canonical OpenTelemetry `rpc.response.status_code` value.
+#[must_use]
+pub fn grpc_response_status_code(code: tonic::Code) -> &'static str {
+    use tonic::Code;
+
+    match code {
+        Code::Ok => "OK",
+        Code::Cancelled => "CANCELLED",
+        Code::Unknown => "UNKNOWN",
+        Code::InvalidArgument => "INVALID_ARGUMENT",
+        Code::DeadlineExceeded => "DEADLINE_EXCEEDED",
+        Code::NotFound => "NOT_FOUND",
+        Code::AlreadyExists => "ALREADY_EXISTS",
+        Code::PermissionDenied => "PERMISSION_DENIED",
+        Code::ResourceExhausted => "RESOURCE_EXHAUSTED",
+        Code::FailedPrecondition => "FAILED_PRECONDITION",
+        Code::Aborted => "ABORTED",
+        Code::OutOfRange => "OUT_OF_RANGE",
+        Code::Unimplemented => "UNIMPLEMENTED",
+        Code::Internal => "INTERNAL",
+        Code::Unavailable => "UNAVAILABLE",
+        Code::DataLoss => "DATA_LOSS",
+        Code::Unauthenticated => "UNAUTHENTICATED",
+    }
+}

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -42,6 +42,7 @@ use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
 use crate::telemetry::TelemetryConfig;
+use crate::transport::GrpcMethodAnnotatedService;
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -337,22 +338,28 @@ async fn start_server(
     let endpoint_uri = format!("http://{}", listener.local_addr()?);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
+    let source_service = GrpcMethodAnnotatedService::new(SourceServiceServer::new(source_service));
+    let feedback_service =
+        GrpcMethodAnnotatedService::new(FeedbackServiceServer::new(feedback_service));
+    let query_service = GrpcMethodAnnotatedService::new(
+        QueryServiceServer::new(query_service)
+            .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+    );
+
     let task = match mode {
         ServerMode::NativeGrpc => start_grpc_server(
             listener,
             shutdown_rx,
-            SourceServiceServer::new(source_service),
-            FeedbackServiceServer::new(feedback_service),
-            QueryServiceServer::new(query_service)
-                .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+            source_service,
+            feedback_service,
+            query_service,
         ),
         ServerMode::EmbeddedUi { assets, .. } => start_grpc_web_server(
             listener,
             shutdown_rx,
-            SourceServiceServer::new(source_service),
-            FeedbackServiceServer::new(feedback_service),
-            QueryServiceServer::new(query_service)
-                .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+            source_service,
+            feedback_service,
+            query_service,
             assets,
         ),
     };

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -6,7 +6,7 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::feedback::manager::{FeedbackManager, FeedbackReport};
-use crate::transport::{workspace_name_from_proto, workspace_to_proto};
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto, workspace_to_proto};
 
 #[derive(Clone)]
 pub(crate) struct FeedbackService {
@@ -25,20 +25,24 @@ impl FeedbackServiceApi for FeedbackService {
         &self,
         request: Request<SubmitFeedbackRequest>,
     ) -> Result<Response<SubmitFeedbackResponse>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let report = self
-            .feedback
-            .submit_feedback(
-                &workspace_name,
-                &request.trying_to_do,
-                &request.tried,
-                &request.stuck,
-            )
-            .map_err(app_status)?;
-        Ok(Response::new(SubmitFeedbackResponse {
-            report: Some(feedback_report_to_proto(report)),
-        }))
+        let span = grpc_span(&request);
+        let feedback = self.feedback.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let report = feedback
+                .submit_feedback(
+                    &workspace_name,
+                    &request.trying_to_do,
+                    &request.tried,
+                    &request.stuck,
+                )
+                .map_err(app_status)?;
+            Ok(Response::new(SubmitFeedbackResponse {
+                report: Some(feedback_report_to_proto(report)),
+            }))
+        })
+        .await
     }
 }
 

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -36,7 +36,7 @@ impl QueryServiceApi for QueryService {
         &self,
         request: Request<ListTablesRequest>,
     ) -> Result<Response<ListTablesResponse>, Status> {
-        let span = grpc_span(request.metadata(), "list_tables");
+        let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -102,7 +102,7 @@ impl QueryServiceApi for QueryService {
         &self,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
-        let span = grpc_span(request.metadata(), "execute_sql");
+        let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let inner = request.into_inner();

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -46,7 +46,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<DiscoverSourcesRequest>,
     ) -> Result<Response<DiscoverSourcesResponse>, Status> {
-        let span = grpc_span(request.metadata(), "discover_sources");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -66,7 +66,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<ListSourcesRequest>,
     ) -> Result<Response<ListSourcesResponse>, Status> {
-        let span = grpc_span(request.metadata(), "list_sources");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -86,7 +86,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<GetSourceRequest>,
     ) -> Result<Response<GetSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "get_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -106,7 +106,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<GetSourceInfoRequest>,
     ) -> Result<Response<GetSourceInfoResponse>, Status> {
-        let span = grpc_span(request.metadata(), "get_source_info");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -126,7 +126,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<CreateBundledSourceRequest>,
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "create_bundled_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -150,7 +150,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<ImportSourceRequest>,
     ) -> Result<Response<ImportSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "import_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -173,7 +173,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<DeleteSourceRequest>,
     ) -> Result<Response<DeleteSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "delete_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -191,7 +191,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<ValidateSourceRequest>,
     ) -> Result<Response<ValidateSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "validate_source");
+        let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -2,14 +2,19 @@
 
 use std::future::Future;
 
-use coral_api::v1::{
-    Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableSummary,
-    ValidateSourceResponse, Workspace, query_test_result,
+use coral_api::{
+    CORAL_ERROR_DOMAIN, grpc_response_status_code,
+    v1::{
+        Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableSummary,
+        ValidateSourceResponse, Workspace, query_test_result,
+    },
 };
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::Status as OtelStatus;
-use tonic::{Code, Status};
-use tracing::Instrument as _;
+use tonic::codegen::{Service, http};
+use tonic::{Code, Request, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
+use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::{AppError, app_status, core_status};
@@ -42,15 +47,70 @@ pub(crate) fn extract_trace_context(
     opentelemetry::global::get_text_map_propagator(|p| p.extract(&MetadataExtractor(metadata)))
 }
 
-/// Creates a span parented to the trace context extracted from `metadata`.
-pub(crate) fn grpc_span(
-    metadata: &tonic::metadata::MetadataMap,
-    name: &'static str,
-) -> tracing::Span {
-    let parent_cx = extract_trace_context(metadata);
+/// Wraps a generated tonic service and stores the inbound gRPC path on the request.
+///
+/// Tonic preserves `http::Request` extensions when it decodes the protobuf
+/// message into a `tonic::Request`, but generated server wrappers do not insert
+/// `tonic::GrpcMethod` the way generated clients do. This keeps the method
+/// data at the transport boundary and lets handlers read it from the request.
+#[derive(Clone)]
+pub(crate) struct GrpcMethodAnnotatedService<S> {
+    inner: S,
+}
+
+impl<S> GrpcMethodAnnotatedService<S> {
+    pub(crate) fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, B> Service<http::Request<B>> for GrpcMethodAnnotatedService<S>
+where
+    S: Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
+        if let Some(method) = GrpcServerMethod::from_path(request.uri().path()) {
+            request.extensions_mut().insert(method);
+        }
+        self.inner.call(request)
+    }
+}
+
+impl<S> tonic::server::NamedService for GrpcMethodAnnotatedService<S>
+where
+    S: tonic::server::NamedService,
+{
+    const NAME: &'static str = S::NAME;
+}
+
+/// Creates a span parented to the trace context extracted from a gRPC request.
+pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
+    let parent_cx = extract_trace_context(request.metadata());
+    let metadata = grpc_method(request);
+    let span_name = format!("{}/{}", metadata.service, metadata.method);
     let span = tracing::info_span!(
         "grpc",
-        grpc.method = name,
+        error.type = tracing::field::Empty,
+        exception.message = tracing::field::Empty,
+        otel.kind = "server",
+        otel.name = span_name.as_str(),
+        rpc.system = "grpc",
+        rpc.system.name = "grpc",
+        rpc.service = metadata.service.as_str(),
+        rpc.method = metadata.method.as_str(),
+        rpc.response.status_code = tracing::field::Empty,
+        grpc.method = metadata.method.as_str(),
         grpc.status_code = tracing::field::Empty,
         grpc.code = tracing::field::Empty,
         status = tracing::field::Empty,
@@ -59,49 +119,106 @@ pub(crate) fn grpc_span(
     span
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GrpcServerMethod {
+    service: String,
+    method: String,
+}
+
+impl GrpcServerMethod {
+    fn from_path(path: &str) -> Option<Self> {
+        let trimmed = path.strip_prefix('/').unwrap_or(path);
+        let (service, method) = trimmed.split_once('/')?;
+        if service.is_empty() || method.is_empty() || method.contains('/') {
+            return None;
+        }
+        Some(Self {
+            service: service.to_string(),
+            method: method.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct GrpcMethodMetadata {
+    service: String,
+    method: String,
+}
+
+impl GrpcMethodMetadata {
+    fn new(service: impl Into<String>, method: impl Into<String>) -> Self {
+        Self {
+            service: service.into(),
+            method: method.into(),
+        }
+    }
+}
+
+fn grpc_method<T>(request: &Request<T>) -> GrpcMethodMetadata {
+    if let Some(method) = request.extensions().get::<tonic::GrpcMethod<'static>>() {
+        return GrpcMethodMetadata::new(method.service(), method.method());
+    }
+    request.extensions().get::<GrpcServerMethod>().map_or_else(
+        || GrpcMethodMetadata::new("coral.v1.UnknownService", "Unknown"),
+        |method| GrpcMethodMetadata::new(method.service.as_str(), method.method.as_str()),
+    )
+}
+
 pub(crate) async fn instrument_grpc<T, F>(span: tracing::Span, future: F) -> Result<T, Status>
 where
     F: Future<Output = Result<T, Status>>,
 {
     let result = future.instrument(span.clone()).await;
     match &result {
-        Ok(_) => record_grpc_status(&span, Code::Ok),
-        Err(status) => record_grpc_status(&span, status.code()),
+        Ok(_) => record_grpc_status(&span, Code::Ok, None),
+        Err(status) => record_grpc_status(&span, status.code(), Some(status)),
     }
     result
 }
 
-fn record_grpc_status(span: &tracing::Span, code: Code) {
+fn record_grpc_status(span: &tracing::Span, code: Code, status: Option<&Status>) {
+    let response_status_code = grpc_response_status_code(code);
     span.record("grpc.status_code", code as i64);
-    span.record("grpc.code", grpc_code_label(code));
+    span.record("grpc.code", response_status_code);
+    span.record("rpc.response.status_code", response_status_code);
     if code == Code::Ok {
         span.record("status", "ok");
         span.set_status(OtelStatus::Ok);
     } else {
+        let error = status.map_or_else(
+            || GrpcErrorTelemetry {
+                error_type: response_status_code.to_string(),
+                message: response_status_code.to_string(),
+            },
+            decode_grpc_error,
+        );
         span.record("status", "error");
-        span.set_status(OtelStatus::error(grpc_code_label(code)));
+        span.record("error.type", error.error_type.as_str());
+        span.record("exception.message", field::display(error.message.as_str()));
+        span.set_status(OtelStatus::error(error.message));
     }
 }
 
-fn grpc_code_label(code: Code) -> &'static str {
-    match code {
-        Code::Ok => "ok",
-        Code::Cancelled => "cancelled",
-        Code::Unknown => "unknown",
-        Code::InvalidArgument => "invalid_argument",
-        Code::DeadlineExceeded => "deadline_exceeded",
-        Code::NotFound => "not_found",
-        Code::AlreadyExists => "already_exists",
-        Code::PermissionDenied => "permission_denied",
-        Code::ResourceExhausted => "resource_exhausted",
-        Code::FailedPrecondition => "failed_precondition",
-        Code::Aborted => "aborted",
-        Code::OutOfRange => "out_of_range",
-        Code::Unimplemented => "unimplemented",
-        Code::Internal => "internal",
-        Code::Unavailable => "unavailable",
-        Code::DataLoss => "data_loss",
-        Code::Unauthenticated => "unauthenticated",
+struct GrpcErrorTelemetry {
+    error_type: String,
+    message: String,
+}
+
+fn decode_grpc_error(status: &Status) -> GrpcErrorTelemetry {
+    for detail in status.get_error_details_vec() {
+        if let ErrorDetail::ErrorInfo(info) = detail
+            && info.domain == CORAL_ERROR_DOMAIN
+        {
+            return GrpcErrorTelemetry {
+                error_type: info.reason,
+                message: status.message().to_string(),
+            };
+        }
+    }
+
+    GrpcErrorTelemetry {
+        error_type: grpc_response_status_code(status.code()).to_string(),
+        message: status.message().to_string(),
     }
 }
 
@@ -215,12 +332,16 @@ mod tests {
         reason = "proto shape assertions intentionally fail loudly in tests"
     )]
 
-    use coral_api::v1::{QueryTestFailure, Workspace, query_test_result};
-    use tonic::Code;
+    use coral_api::{
+        grpc_response_status_code,
+        v1::{QueryTestFailure, Workspace, query_test_result},
+    };
+    use tonic::{Code, Request};
 
     use super::{
-        grpc_code_label, query_status, query_test_result_to_proto, table_summary_to_proto,
-        table_to_proto, workspace_name_from_proto, workspace_to_proto,
+        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
+        query_test_result_to_proto, table_summary_to_proto, table_to_proto,
+        workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
@@ -250,14 +371,42 @@ mod tests {
     }
 
     #[test]
-    fn grpc_code_labels_are_low_cardinality() {
-        assert_eq!(grpc_code_label(Code::Ok), "ok");
-        assert_eq!(grpc_code_label(Code::InvalidArgument), "invalid_argument");
+    fn grpc_response_status_codes_use_otel_names() {
+        assert_eq!(grpc_response_status_code(Code::Ok), "OK");
         assert_eq!(
-            grpc_code_label(Code::FailedPrecondition),
-            "failed_precondition"
+            grpc_response_status_code(Code::InvalidArgument),
+            "INVALID_ARGUMENT"
         );
-        assert_eq!(grpc_code_label(Code::Unavailable), "unavailable");
+        assert_eq!(grpc_response_status_code(Code::Unavailable), "UNAVAILABLE");
+    }
+
+    #[test]
+    fn grpc_server_method_derives_from_uri_path() {
+        assert_eq!(
+            GrpcServerMethod::from_path("/coral.v1.QueryService/ExecuteSql"),
+            Some(GrpcServerMethod {
+                service: "coral.v1.QueryService".to_string(),
+                method: "ExecuteSql".to_string(),
+            })
+        );
+        assert_eq!(GrpcServerMethod::from_path("/missing-method"), None);
+        assert_eq!(
+            GrpcServerMethod::from_path("/coral.v1.QueryService/Extra/Path"),
+            None
+        );
+    }
+
+    #[test]
+    fn grpc_method_reads_server_method_from_request_extensions() {
+        let mut request = Request::new(());
+        request
+            .extensions_mut()
+            .insert(GrpcServerMethod::from_path("/coral.v1.QueryService/ExecuteSql").unwrap());
+
+        assert_eq!(
+            grpc_method(&request),
+            GrpcMethodMetadata::new("coral.v1.QueryService", "ExecuteSql")
+        );
     }
 
     #[test]

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 arrow = { workspace = true, features = ["prettyprint"] }
+http-body.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 serde_json.workspace = true
@@ -22,3 +23,7 @@ tracing-opentelemetry.workspace = true
 
 coral-api.workspace = true
 coral-app.workspace = true
+
+[dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+tracing-subscriber.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -9,6 +9,7 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::error::ClientError;
+use crate::grpc::{GrpcClientEndpoint, InstrumentedGrpcService};
 use crate::propagation::TraceContextInterceptor;
 
 /// Default workspace used by local Coral clients.
@@ -22,19 +23,17 @@ pub fn default_workspace() -> Workspace {
     }
 }
 
+type RawGrpcService = InterceptedService<Channel, TraceContextInterceptor>;
+type GrpcService = InstrumentedGrpcService<RawGrpcService>;
+
 /// Public source-management gRPC client.
-pub type SourceClient = SourceServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
+pub type SourceClient = SourceServiceClient<GrpcService>;
 
 /// Public SQL query gRPC client.
-pub type QueryClient = QueryServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
+pub type QueryClient = QueryServiceClient<GrpcService>;
 
 /// Public feedback-submission gRPC client.
-///
-/// This stays intentionally thin for now: `coral-client` is a local transport
-/// bootstrap, so it exposes the generated typed client directly rather than
-/// wrapping it in a higher-level SDK surface.
-pub type FeedbackClient =
-    FeedbackServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
+pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
 /// Public Coral client handle.
 ///
@@ -59,14 +58,12 @@ impl AppClient {
         crate::propagation::ensure_global_propagator();
         let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
+        let grpc_endpoint = GrpcClientEndpoint::from_endpoint_uri(endpoint_uri);
         let channel = endpoint.connect().await?;
-        let source_client =
-            SourceServiceClient::with_interceptor(channel.clone(), TraceContextInterceptor);
-        let query_client =
-            QueryServiceClient::with_interceptor(channel.clone(), TraceContextInterceptor)
-                .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
-        let feedback_client =
-            FeedbackServiceClient::with_interceptor(channel, TraceContextInterceptor);
+        let source_client = SourceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
+        let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let feedback_client = FeedbackClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
             source: source_client,
             query: query_client,
@@ -91,4 +88,11 @@ impl AppClient {
     pub fn feedback_client(&self) -> FeedbackClient {
         self.feedback.clone()
     }
+}
+
+fn grpc_service(channel: Channel, endpoint: &GrpcClientEndpoint) -> GrpcService {
+    InstrumentedGrpcService::new(
+        InterceptedService::new(channel, TraceContextInterceptor),
+        endpoint.clone(),
+    )
 }

--- a/crates/coral-client/src/grpc.rs
+++ b/crates/coral-client/src/grpc.rs
@@ -1,0 +1,445 @@
+//! Instrumented tonic transport for local Coral gRPC clients.
+//!
+//! Tonic exposes final gRPC status in response trailers, after the generated
+//! client has consumed the HTTP body. The service wrapper creates the client
+//! span and the body wrapper records the final trailer status before the span
+//! closes.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use coral_api::grpc_response_status_code;
+use opentelemetry::trace::Status as OtelStatus;
+use tonic::codegen::{Body, Bytes, Service, StdError, http};
+use tonic::{Code, Status};
+use tracing::{Instrument as _, field};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+use crate::status_error::{DecodedStatusError, decode_status_error};
+
+const MISSING_GRPC_STATUS_ERROR_TYPE: &str = "MISSING_GRPC_STATUS";
+const MISSING_GRPC_STATUS_MESSAGE: &str = "missing gRPC response status";
+
+/// Tonic `Service` wrapper that records one client span per gRPC request.
+#[derive(Clone)]
+pub struct InstrumentedGrpcService<S> {
+    inner: S,
+    endpoint: GrpcClientEndpoint,
+}
+
+impl<S> InstrumentedGrpcService<S> {
+    pub(crate) fn new(inner: S, endpoint: GrpcClientEndpoint) -> Self {
+        Self { inner, endpoint }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct GrpcClientEndpoint {
+    server_address: Option<String>,
+    server_port: Option<u16>,
+}
+
+impl GrpcClientEndpoint {
+    pub(crate) fn from_endpoint_uri(endpoint_uri: &str) -> Self {
+        let Ok(uri) = endpoint_uri.parse::<http::Uri>() else {
+            return Self::default();
+        };
+        Self {
+            server_address: uri.host().map(str::to_string),
+            server_port: uri.port_u16().or_else(|| default_port(uri.scheme_str())),
+        }
+    }
+}
+
+fn default_port(scheme: Option<&str>) -> Option<u16> {
+    match scheme {
+        Some("http") => Some(80),
+        Some("https") => Some(443),
+        _ => None,
+    }
+}
+
+impl<S, B> Service<http::Request<tonic::body::Body>> for InstrumentedGrpcService<S>
+where
+    S: Service<http::Request<tonic::body::Body>, Response = http::Response<B>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<StdError> + Send + 'static,
+    B: Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<StdError> + Send + 'static,
+{
+    type Response = http::Response<InstrumentedGrpcBody<B>>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<tonic::body::Body>) -> Self::Future {
+        let metadata = GrpcClientSpanMetadata::from_request(&request);
+        let span = grpc_client_span(&metadata, &self.endpoint);
+
+        let future = {
+            let _entered = span.enter();
+            self.inner.call(request)
+        };
+
+        Box::pin(async move {
+            match future.instrument(span.clone()).await {
+                Ok(response) => {
+                    let (parts, body) = response.into_parts();
+                    let status_recorded = record_grpc_status_from_headers(&span, &parts.headers);
+                    Ok(http::Response::from_parts(
+                        parts,
+                        InstrumentedGrpcBody::new(body, span, status_recorded),
+                    ))
+                }
+                Err(error) => {
+                    record_transport_error(&span);
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+pub struct InstrumentedGrpcBody<B> {
+    inner: Pin<Box<B>>,
+    span: tracing::Span,
+    status_recorded: bool,
+}
+
+impl<B> InstrumentedGrpcBody<B> {
+    fn new(inner: B, span: tracing::Span, status_recorded: bool) -> Self {
+        Self {
+            inner: Box::pin(inner),
+            span,
+            status_recorded,
+        }
+    }
+
+    fn record_status_from_headers(&mut self, headers: &http::HeaderMap) {
+        if !self.status_recorded {
+            self.status_recorded = record_grpc_status_from_headers(&self.span, headers);
+        }
+    }
+
+    fn record_missing_status(&mut self) {
+        if !self.status_recorded {
+            record_missing_grpc_status(&self.span);
+            self.status_recorded = true;
+        }
+    }
+
+    fn record_body_error(&mut self) {
+        if !self.status_recorded {
+            record_error(&self.span, "TRANSPORT", "gRPC response body error");
+            self.status_recorded = true;
+        }
+    }
+}
+
+impl<B> Body for InstrumentedGrpcBody<B>
+where
+    B: Body<Data = Bytes>,
+{
+    type Data = Bytes;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(trailers) = frame.trailers_ref() {
+                    this.record_status_from_headers(trailers);
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(Some(Err(error))) => {
+                this.record_body_error();
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(None) => {
+                this.record_missing_status();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct GrpcClientSpanMetadata {
+    service: String,
+    method: String,
+    span_name: String,
+}
+
+impl GrpcClientSpanMetadata {
+    fn from_request(request: &http::Request<tonic::body::Body>) -> Self {
+        request
+            .extensions()
+            .get::<tonic::GrpcMethod<'static>>()
+            .map_or_else(
+                || Self::from_path(request.uri().path()),
+                |method| Self::new(method.service(), method.method()),
+            )
+    }
+
+    fn from_path(path: &str) -> Self {
+        let trimmed = path.trim_start_matches('/');
+        let (service, method) = trimmed
+            .split_once('/')
+            .unwrap_or(("coral.v1.UnknownService", "Unknown"));
+        Self::new(service, method)
+    }
+
+    fn new(service: &str, method: &str) -> Self {
+        Self {
+            service: service.to_string(),
+            method: method.to_string(),
+            span_name: format!("{service}/{method}"),
+        }
+    }
+}
+
+fn grpc_client_span(
+    metadata: &GrpcClientSpanMetadata,
+    endpoint: &GrpcClientEndpoint,
+) -> tracing::Span {
+    let span = tracing::info_span!(
+        target: "coral_client::grpc",
+        "grpc.client",
+        error.type = field::Empty,
+        exception.message = field::Empty,
+        grpc.method = metadata.method.as_str(),
+        grpc.status_code = field::Empty,
+        grpc.code = field::Empty,
+        otel.kind = "client",
+        otel.name = metadata.span_name.as_str(),
+        peer.service = "coral",
+        rpc.method = metadata.method.as_str(),
+        rpc.response.status_code = field::Empty,
+        rpc.service = metadata.service.as_str(),
+        rpc.system = "grpc",
+        rpc.system.name = "grpc",
+        server.address = field::Empty,
+        server.port = field::Empty,
+        status = field::Empty,
+    );
+    record_grpc_endpoint(&span, endpoint);
+    span
+}
+
+fn record_grpc_endpoint(span: &tracing::Span, endpoint: &GrpcClientEndpoint) {
+    if let Some(address) = endpoint.server_address.as_deref() {
+        span.record("server.address", address);
+    }
+    if let Some(port) = endpoint.server_port {
+        span.record("server.port", i64::from(port));
+    }
+}
+
+fn record_grpc_status_from_headers(span: &tracing::Span, headers: &http::HeaderMap) -> bool {
+    let Some(status) = Status::from_header_map(headers) else {
+        return false;
+    };
+    record_grpc_status(span, status.code(), Some(&status));
+    true
+}
+
+fn record_grpc_status(span: &tracing::Span, code: Code, status: Option<&Status>) {
+    let response_status_code = record_grpc_status_attributes(span, code);
+    if code == Code::Ok {
+        span.record("status", "ok");
+        span.set_status(OtelStatus::Ok);
+    } else if let Some(status) = status {
+        let error = decode_grpc_client_error(status);
+        record_error(span, error.error_type.as_str(), error.message);
+    } else {
+        record_error(span, response_status_code, response_status_code);
+    }
+}
+
+fn record_grpc_status_attributes(span: &tracing::Span, code: Code) -> &'static str {
+    let response_status_code = grpc_response_status_code(code);
+    span.record("grpc.status_code", code as i64);
+    span.record("grpc.code", response_status_code);
+    span.record("rpc.response.status_code", response_status_code);
+    response_status_code
+}
+
+fn record_missing_grpc_status(span: &tracing::Span) {
+    record_grpc_status_attributes(span, Code::Unknown);
+    record_error(
+        span,
+        MISSING_GRPC_STATUS_ERROR_TYPE,
+        MISSING_GRPC_STATUS_MESSAGE,
+    );
+}
+
+fn record_transport_error(span: &tracing::Span) {
+    record_error(span, "TRANSPORT", "gRPC transport error");
+}
+
+fn record_error(
+    span: &tracing::Span,
+    error_type: impl AsRef<str>,
+    message: impl std::fmt::Display,
+) {
+    let message = message.to_string();
+    span.record("status", "error");
+    span.record("error.type", error_type.as_ref());
+    span.record("exception.message", field::display(&message));
+    span.set_status(OtelStatus::error(message));
+}
+
+struct GrpcClientError {
+    error_type: String,
+    message: String,
+}
+
+fn decode_grpc_client_error(status: &Status) -> GrpcClientError {
+    match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => GrpcClientError {
+            error_type: error.reason,
+            message: error.message,
+        },
+        DecodedStatusError::Plain(message) => GrpcClientError {
+            error_type: grpc_response_status_code(status.code()).to_string(),
+            message,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+    use opentelemetry::{KeyValue, Value};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tonic::codegen::http;
+    use tracing_subscriber::prelude::*;
+
+    use super::{
+        GrpcClientEndpoint, GrpcClientSpanMetadata, MISSING_GRPC_STATUS_ERROR_TYPE,
+        MISSING_GRPC_STATUS_MESSAGE, grpc_client_span, record_missing_grpc_status,
+    };
+
+    #[test]
+    fn grpc_client_span_metadata_derives_names_from_path() {
+        let metadata = GrpcClientSpanMetadata::from_path("/coral.v1.QueryService/ExecuteSql");
+
+        assert_eq!(metadata.service, "coral.v1.QueryService");
+        assert_eq!(metadata.method, "ExecuteSql");
+        assert_eq!(metadata.span_name, "coral.v1.QueryService/ExecuteSql");
+    }
+
+    #[test]
+    fn grpc_client_span_metadata_prefers_tonic_extension() {
+        let mut request = http::Request::builder()
+            .uri("/fallback.Service/Fallback")
+            .body(tonic::body::Body::empty())
+            .expect("request");
+        request.extensions_mut().insert(tonic::GrpcMethod::new(
+            "coral.v1.SourceService",
+            "ListSources",
+        ));
+
+        let metadata = GrpcClientSpanMetadata::from_request(&request);
+
+        assert_eq!(metadata.service, "coral.v1.SourceService");
+        assert_eq!(metadata.method, "ListSources");
+        assert_eq!(metadata.span_name, "coral.v1.SourceService/ListSources");
+    }
+
+    #[test]
+    fn grpc_client_endpoint_derives_address_and_port() {
+        let endpoint = GrpcClientEndpoint::from_endpoint_uri("http://127.0.0.1:50051");
+
+        assert_eq!(endpoint.server_address.as_deref(), Some("127.0.0.1"));
+        assert_eq!(endpoint.server_port, Some(50051));
+
+        let endpoint = GrpcClientEndpoint::from_endpoint_uri("https://coral.example.com");
+
+        assert_eq!(
+            endpoint.server_address.as_deref(),
+            Some("coral.example.com")
+        );
+        assert_eq!(endpoint.server_port, Some(443));
+    }
+
+    #[test]
+    fn missing_grpc_status_records_unknown_error() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("coral-client-test");
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let metadata = GrpcClientSpanMetadata::new("coral.v1.QueryService", "ExecuteSql");
+            let span = grpc_client_span(&metadata, &GrpcClientEndpoint::default());
+            let _entered = span.enter();
+            record_missing_grpc_status(&span);
+        });
+
+        provider.force_flush().expect("spans should flush");
+        let spans = exporter
+            .get_finished_spans()
+            .expect("finished spans should be readable");
+        let span = spans
+            .iter()
+            .find(|span| span.name == "coral.v1.QueryService/ExecuteSql")
+            .expect("client span should export");
+
+        assert_eq!(i64_attr(&span.attributes, "grpc.status_code"), Some(2));
+        assert_eq!(string_attr(&span.attributes, "grpc.code"), Some("UNKNOWN"));
+        assert_eq!(
+            string_attr(&span.attributes, "rpc.response.status_code"),
+            Some("UNKNOWN")
+        );
+        assert_eq!(
+            string_attr(&span.attributes, "error.type"),
+            Some(MISSING_GRPC_STATUS_ERROR_TYPE)
+        );
+        assert_eq!(span.status, OtelStatus::error(MISSING_GRPC_STATUS_MESSAGE));
+    }
+
+    fn i64_attr(attributes: &[KeyValue], key: &str) -> Option<i64> {
+        attributes.iter().find_map(|attribute| {
+            if attribute.key.as_str() == key
+                && let Value::I64(value) = attribute.value
+            {
+                Some(value)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn string_attr<'a>(attributes: &'a [KeyValue], key: &str) -> Option<&'a str> {
+        attributes.iter().find_map(|attribute| {
+            if attribute.key.as_str() == key
+                && let Value::String(value) = &attribute.value
+            {
+                Some(value.as_ref())
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod client;
 mod error;
+mod grpc;
 pub mod local;
 mod propagation;
 mod status_error;


### PR DESCRIPTION
## Summary

- Instrument the local tonic client transport so CLI/MCP calls to the Coral app are represented as gRPC client spans.
- Annotate generated gRPC server services from the incoming HTTP/2 URI path so server spans use real `rpc.service` and `rpc.method` values instead of request-type inference.
- Record canonical gRPC response status attributes and structured error details on client/server spans.

## Stack

- Depends on #326.
- Followed by #328 for MCP protocol spans and top-level error telemetry.

## Validation

- `make rust-checks`

![CleanShot 2026-05-08 at 17.40.08@2x.png](https://app.graphite.com/user-attachments/assets/c22e7377-d435-4405-ae5d-59a6de8e2620.png)



