### PR TITLE
feat(mcp): add protocol spans and error telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,7 @@ dependencies = [
  "coral-app",
  "coral-client",
  "jsonschema",
+ "opentelemetry",
  "regex",
  "rmcp",
  "serde_json",
@@ -1122,6 +1123,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-types",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
  "arrow",
  "coral-api",
  "coral-app",
+ "http-body 1.0.1",
  "opentelemetry",
  "opentelemetry_sdk",
  "serde_json",
@@ -1071,6 +1072,7 @@ dependencies = [
  "tonic-types",
  "tracing",
  "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ etcetera = "0.11"
 fs2 = "0.4"
 futures = "0.3"
 glob = "0.3"
+http-body = "1"
 httpdate = "1.0.3"
 jsonschema = { version = "0.18", default-features = false }
 object_store = { version = "0.13.2", features = ["aws"] }

--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -71,3 +71,29 @@ pub const CORAL_ERROR_METADATA_DETAIL: &str = "detail";
 
 /// Reserved `ErrorInfo.metadata` key for actionable recovery guidance.
 pub const CORAL_ERROR_METADATA_HINT: &str = "hint";
+
+/// Returns the canonical OpenTelemetry `rpc.response.status_code` value.
+#[must_use]
+pub fn grpc_response_status_code(code: tonic::Code) -> &'static str {
+    use tonic::Code;
+
+    match code {
+        Code::Ok => "OK",
+        Code::Cancelled => "CANCELLED",
+        Code::Unknown => "UNKNOWN",
+        Code::InvalidArgument => "INVALID_ARGUMENT",
+        Code::DeadlineExceeded => "DEADLINE_EXCEEDED",
+        Code::NotFound => "NOT_FOUND",
+        Code::AlreadyExists => "ALREADY_EXISTS",
+        Code::PermissionDenied => "PERMISSION_DENIED",
+        Code::ResourceExhausted => "RESOURCE_EXHAUSTED",
+        Code::FailedPrecondition => "FAILED_PRECONDITION",
+        Code::Aborted => "ABORTED",
+        Code::OutOfRange => "OUT_OF_RANGE",
+        Code::Unimplemented => "UNIMPLEMENTED",
+        Code::Internal => "INTERNAL",
+        Code::Unavailable => "UNAVAILABLE",
+        Code::DataLoss => "DATA_LOSS",
+        Code::Unauthenticated => "UNAUTHENTICATED",
+    }
+}

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -42,6 +42,7 @@ use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
 use crate::telemetry::TelemetryConfig;
+use crate::transport::GrpcMethodAnnotatedService;
 
 /// A static asset (e.g., a built SPA file) served on the same port as
 /// gRPC-Web.
@@ -337,22 +338,28 @@ async fn start_server(
     let endpoint_uri = format!("http://{}", listener.local_addr()?);
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
+    let source_service = GrpcMethodAnnotatedService::new(SourceServiceServer::new(source_service));
+    let feedback_service =
+        GrpcMethodAnnotatedService::new(FeedbackServiceServer::new(feedback_service));
+    let query_service = GrpcMethodAnnotatedService::new(
+        QueryServiceServer::new(query_service)
+            .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+    );
+
     let task = match mode {
         ServerMode::NativeGrpc => start_grpc_server(
             listener,
             shutdown_rx,
-            SourceServiceServer::new(source_service),
-            FeedbackServiceServer::new(feedback_service),
-            QueryServiceServer::new(query_service)
-                .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+            source_service,
+            feedback_service,
+            query_service,
         ),
         ServerMode::EmbeddedUi { assets, .. } => start_grpc_web_server(
             listener,
             shutdown_rx,
-            SourceServiceServer::new(source_service),
-            FeedbackServiceServer::new(feedback_service),
-            QueryServiceServer::new(query_service)
-                .max_encoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE),
+            source_service,
+            feedback_service,
+            query_service,
             assets,
         ),
     };

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -6,7 +6,7 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::app_status;
 use crate::feedback::manager::{FeedbackManager, FeedbackReport};
-use crate::transport::{workspace_name_from_proto, workspace_to_proto};
+use crate::transport::{grpc_span, instrument_grpc, workspace_name_from_proto, workspace_to_proto};
 
 #[derive(Clone)]
 pub(crate) struct FeedbackService {
@@ -25,20 +25,24 @@ impl FeedbackServiceApi for FeedbackService {
         &self,
         request: Request<SubmitFeedbackRequest>,
     ) -> Result<Response<SubmitFeedbackResponse>, Status> {
-        let request = request.into_inner();
-        let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-        let report = self
-            .feedback
-            .submit_feedback(
-                &workspace_name,
-                &request.trying_to_do,
-                &request.tried,
-                &request.stuck,
-            )
-            .map_err(app_status)?;
-        Ok(Response::new(SubmitFeedbackResponse {
-            report: Some(feedback_report_to_proto(report)),
-        }))
+        let span = grpc_span(&request);
+        let feedback = self.feedback.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let report = feedback
+                .submit_feedback(
+                    &workspace_name,
+                    &request.trying_to_do,
+                    &request.tried,
+                    &request.stuck,
+                )
+                .map_err(app_status)?;
+            Ok(Response::new(SubmitFeedbackResponse {
+                report: Some(feedback_report_to_proto(report)),
+            }))
+        })
+        .await
     }
 }
 

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -49,5 +49,5 @@ pub use coral_engine::{EngineExtensions, QuerySource};
 pub use query::extensions::{
     AwsEngineExtensionsProvider, EngineExtensionsProvider, NoopEngineExtensionsProvider,
 };
-pub use telemetry::{RunContext, run_with_context, shutdown_tracing};
+pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
 pub use workspaces::DEFAULT_WORKSPACE_ID;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    SourceValidationReport, TableInfo,
+    SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::trace::Status as OtelStatus;
@@ -110,9 +110,13 @@ impl QueryManager {
                 .record(row_count, std::slice::from_ref(&status));
         } else if let Err(error) = &result {
             let error_kind = query_error_kind(error);
+            let error_type = query_error_type(error);
+            let error_message = query_error_message(error);
             query_span.record("status", "error");
             query_span.record("error.kind", error_kind);
-            query_span.set_status(OtelStatus::error(error_kind));
+            query_span.record("error.type", error_type.as_str());
+            query_span.record("exception.message", error_message.as_str());
+            query_span.set_status(OtelStatus::error(error_message));
         }
 
         result
@@ -226,6 +230,8 @@ fn create_query_span(workspace_name: &WorkspaceName, sql: &str) -> tracing::Span
         row_count = tracing::field::Empty,
         status = tracing::field::Empty,
         error.kind = tracing::field::Empty,
+        error.type = tracing::field::Empty,
+        exception.message = tracing::field::Empty,
     )
 }
 
@@ -233,6 +239,56 @@ fn query_error_kind(error: &QueryManagerError) -> &'static str {
     match error {
         QueryManagerError::App(_) => "app",
         QueryManagerError::Core(_) => "core",
+    }
+}
+
+fn query_error_type(error: &QueryManagerError) -> String {
+    match error {
+        QueryManagerError::App(error) => app_error_type(error).to_string(),
+        QueryManagerError::Core(error) => core_error_type(error),
+    }
+}
+
+fn query_error_message(error: &QueryManagerError) -> String {
+    match error {
+        QueryManagerError::App(error) => error.to_string(),
+        QueryManagerError::Core(CoreError::QueryFailure(error)) => error.summary().to_string(),
+        QueryManagerError::Core(error) => error.to_string(),
+    }
+}
+
+fn app_error_type(error: &AppError) -> &'static str {
+    match error {
+        AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
+        AppError::InvalidInput(_) => "INVALID_INPUT",
+        AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
+        AppError::Io(_) => "IO",
+        AppError::Yaml(_) => "YAML",
+        AppError::TomlDecode(_) => "TOML_DECODE",
+        AppError::TomlEncode(_) => "TOML_ENCODE",
+        AppError::Json(_) => "JSON",
+        AppError::Transport(_) => "TRANSPORT",
+        AppError::TaskJoin(_) => "TASK_JOIN",
+        AppError::Credentials(_) => "CREDENTIALS",
+        AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
+    }
+}
+
+fn core_error_type(error: &CoreError) -> String {
+    match error {
+        CoreError::QueryFailure(error) => error.reason().to_string(),
+        error => status_code_error_type(error.status_code()).to_string(),
+    }
+}
+
+fn status_code_error_type(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::InvalidArgument => "INVALID_ARGUMENT",
+        StatusCode::NotFound => "NOT_FOUND",
+        StatusCode::FailedPrecondition => "FAILED_PRECONDITION",
+        StatusCode::Unavailable => "UNAVAILABLE",
+        StatusCode::Unimplemented => "UNIMPLEMENTED",
+        StatusCode::Internal => "INTERNAL",
     }
 }
 

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -36,7 +36,7 @@ impl QueryServiceApi for QueryService {
         &self,
         request: Request<ListTablesRequest>,
     ) -> Result<Response<ListTablesResponse>, Status> {
-        let span = grpc_span(request.metadata(), "list_tables");
+        let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -102,7 +102,7 @@ impl QueryServiceApi for QueryService {
         &self,
         request: Request<ExecuteSqlRequest>,
     ) -> Result<Response<ExecuteSqlResponse>, Status> {
-        let span = grpc_span(request.metadata(), "execute_sql");
+        let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let inner = request.into_inner();

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -46,7 +46,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<DiscoverSourcesRequest>,
     ) -> Result<Response<DiscoverSourcesResponse>, Status> {
-        let span = grpc_span(request.metadata(), "discover_sources");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -66,7 +66,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<ListSourcesRequest>,
     ) -> Result<Response<ListSourcesResponse>, Status> {
-        let span = grpc_span(request.metadata(), "list_sources");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -86,7 +86,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<GetSourceRequest>,
     ) -> Result<Response<GetSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "get_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -106,7 +106,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<GetSourceInfoRequest>,
     ) -> Result<Response<GetSourceInfoResponse>, Status> {
-        let span = grpc_span(request.metadata(), "get_source_info");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -126,7 +126,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<CreateBundledSourceRequest>,
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "create_bundled_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -150,7 +150,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<ImportSourceRequest>,
     ) -> Result<Response<ImportSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "import_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -173,7 +173,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<DeleteSourceRequest>,
     ) -> Result<Response<DeleteSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "delete_source");
+        let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
@@ -191,7 +191,7 @@ impl SourceServiceApi for SourceService {
         &self,
         request: Request<ValidateSourceRequest>,
     ) -> Result<Response<ValidateSourceResponse>, Status> {
-        let span = grpc_span(request.metadata(), "validate_source");
+        let span = grpc_span(&request);
         let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();

--- a/crates/coral-app/src/telemetry/config.rs
+++ b/crates/coral-app/src/telemetry/config.rs
@@ -5,8 +5,7 @@ use serde::Deserialize;
 use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
 
-pub(super) const DEFAULT_TRACE_FILTER: &str =
-    "coral_app=trace,coral_engine=trace,coral_engine::datafusion=off";
+pub(super) const DEFAULT_TRACE_FILTER: &str = "coral_app=trace,coral_client=trace,coral_mcp=trace,coral_engine=trace,coral_engine::datafusion=off";
 pub(super) const DEFAULT_LOG_FILTER: &str = "coral_app=info,coral_engine=info";
 const DEFAULT_SERVICE_NAME: &str = "coral";
 

--- a/crates/coral-app/src/telemetry/mod.rs
+++ b/crates/coral-app/src/telemetry/mod.rs
@@ -1,5 +1,6 @@
 //! Tracing and OpenTelemetry initialization for the local Coral process.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
@@ -96,6 +97,15 @@ pub struct RunContext {
     pub trace_parent: Option<String>,
 }
 
+/// Error metadata recorded on the root Coral invocation span.
+pub trait RunErrorTelemetry {
+    /// Low-cardinality error class for `error.type`.
+    fn telemetry_error_type(&self) -> Cow<'_, str>;
+
+    /// Human-readable failure summary for span status and exception message.
+    fn telemetry_error_message(&self) -> Cow<'_, str>;
+}
+
 /// Runs `fut` under a root CLI span configured from `ctx`.
 ///
 /// The returned `Result` is also recorded on the root span as low-cardinality
@@ -107,11 +117,15 @@ pub struct RunContext {
 pub async fn run_with_context<T, E, F>(ctx: &RunContext, fut: F) -> Result<T, E>
 where
     F: std::future::Future<Output = Result<T, E>>,
+    E: RunErrorTelemetry,
 {
     use tracing::Instrument as _;
     let span = build_root_span(ctx.trace_parent.as_deref());
     let result = fut.instrument(span.clone()).await;
-    record_run_status(&span, result.is_ok());
+    match &result {
+        Ok(_) => record_run_success(&span),
+        Err(error) => record_run_error(&span, error),
+    }
     result
 }
 
@@ -121,7 +135,16 @@ where
 /// `None` for an unparented span. Use `.instrument(span).await` to run the
 /// CLI future under this span.
 pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
-    let span = tracing::info_span!("coral.cli", status = tracing::field::Empty);
+    let span = tracing::info_span!(
+        "coral.cli",
+        error.type = tracing::field::Empty,
+        exception.message = tracing::field::Empty,
+        otel.kind = "client",
+        process.executable.name = process_executable_name(),
+        process.exit.code = tracing::field::Empty,
+        process.pid = i64::from(std::process::id()),
+        status = tracing::field::Empty
+    );
     if let Some(tp) = traceparent {
         struct StringMapExtractor<'a>(&'a HashMap<String, String>);
         impl Extractor for StringMapExtractor<'_> {
@@ -141,14 +164,38 @@ pub fn build_root_span(traceparent: Option<&str>) -> tracing::Span {
     span
 }
 
-fn record_run_status(span: &tracing::Span, ok: bool) {
-    if ok {
-        span.record("status", "ok");
-        span.set_status(OtelStatus::Ok);
-    } else {
-        span.record("status", "error");
-        span.set_status(OtelStatus::error("error"));
-    }
+fn record_run_success(span: &tracing::Span) {
+    span.record("process.exit.code", 0_i64);
+    span.record("status", "ok");
+    span.set_status(OtelStatus::Ok);
+}
+
+fn record_run_error(span: &tracing::Span, error: &impl RunErrorTelemetry) {
+    let error_type = error.telemetry_error_type();
+    let message = error.telemetry_error_message();
+    span.record("process.exit.code", 1_i64);
+    span.record("error.type", error_type.as_ref());
+    span.record("exception.message", message.as_ref());
+    span.record("status", "error");
+    span.set_status(OtelStatus::error(message.into_owned()));
+}
+
+fn process_executable_name() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|path| {
+            path.file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+        })
+        .or_else(|| {
+            std::env::args_os().next().and_then(|arg| {
+                std::path::Path::new(&arg)
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+            })
+        })
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| "coral".to_string())
 }
 
 pub(crate) fn init_tracing(
@@ -381,6 +428,8 @@ mod tests {
         let (targets, error) = build_trace_targets(DEFAULT_TRACE_FILTER);
 
         assert!(error.is_none());
+        assert!(targets.would_enable("coral_client::grpc", &tracing::Level::TRACE));
+        assert!(targets.would_enable("coral_mcp::server", &tracing::Level::TRACE));
         assert!(targets.would_enable("coral_engine::http", &tracing::Level::TRACE));
         assert!(!targets.would_enable("coral_engine::datafusion", &tracing::Level::TRACE));
     }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -2,14 +2,19 @@
 
 use std::future::Future;
 
-use coral_api::v1::{
-    Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableSummary,
-    ValidateSourceResponse, Workspace, query_test_result,
+use coral_api::{
+    CORAL_ERROR_DOMAIN, grpc_response_status_code,
+    v1::{
+        Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableSummary,
+        ValidateSourceResponse, Workspace, query_test_result,
+    },
 };
 use opentelemetry::propagation::Extractor;
 use opentelemetry::trace::Status as OtelStatus;
-use tonic::{Code, Status};
-use tracing::Instrument as _;
+use tonic::codegen::{Service, http};
+use tonic::{Code, Request, Status};
+use tonic_types::{ErrorDetail, StatusExt as _};
+use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::{AppError, app_status, core_status};
@@ -42,15 +47,70 @@ pub(crate) fn extract_trace_context(
     opentelemetry::global::get_text_map_propagator(|p| p.extract(&MetadataExtractor(metadata)))
 }
 
-/// Creates a span parented to the trace context extracted from `metadata`.
-pub(crate) fn grpc_span(
-    metadata: &tonic::metadata::MetadataMap,
-    name: &'static str,
-) -> tracing::Span {
-    let parent_cx = extract_trace_context(metadata);
+/// Wraps a generated tonic service and stores the inbound gRPC path on the request.
+///
+/// Tonic preserves `http::Request` extensions when it decodes the protobuf
+/// message into a `tonic::Request`, but generated server wrappers do not insert
+/// `tonic::GrpcMethod` the way generated clients do. This keeps the method
+/// data at the transport boundary and lets handlers read it from the request.
+#[derive(Clone)]
+pub(crate) struct GrpcMethodAnnotatedService<S> {
+    inner: S,
+}
+
+impl<S> GrpcMethodAnnotatedService<S> {
+    pub(crate) fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, B> Service<http::Request<B>> for GrpcMethodAnnotatedService<S>
+where
+    S: Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
+        if let Some(method) = GrpcServerMethod::from_path(request.uri().path()) {
+            request.extensions_mut().insert(method);
+        }
+        self.inner.call(request)
+    }
+}
+
+impl<S> tonic::server::NamedService for GrpcMethodAnnotatedService<S>
+where
+    S: tonic::server::NamedService,
+{
+    const NAME: &'static str = S::NAME;
+}
+
+/// Creates a span parented to the trace context extracted from a gRPC request.
+pub(crate) fn grpc_span<T>(request: &Request<T>) -> tracing::Span {
+    let parent_cx = extract_trace_context(request.metadata());
+    let metadata = grpc_method(request);
+    let span_name = format!("{}/{}", metadata.service, metadata.method);
     let span = tracing::info_span!(
         "grpc",
-        grpc.method = name,
+        error.type = tracing::field::Empty,
+        exception.message = tracing::field::Empty,
+        otel.kind = "server",
+        otel.name = span_name.as_str(),
+        rpc.system = "grpc",
+        rpc.system.name = "grpc",
+        rpc.service = metadata.service.as_str(),
+        rpc.method = metadata.method.as_str(),
+        rpc.response.status_code = tracing::field::Empty,
+        grpc.method = metadata.method.as_str(),
         grpc.status_code = tracing::field::Empty,
         grpc.code = tracing::field::Empty,
         status = tracing::field::Empty,
@@ -59,49 +119,106 @@ pub(crate) fn grpc_span(
     span
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GrpcServerMethod {
+    service: String,
+    method: String,
+}
+
+impl GrpcServerMethod {
+    fn from_path(path: &str) -> Option<Self> {
+        let trimmed = path.strip_prefix('/').unwrap_or(path);
+        let (service, method) = trimmed.split_once('/')?;
+        if service.is_empty() || method.is_empty() || method.contains('/') {
+            return None;
+        }
+        Some(Self {
+            service: service.to_string(),
+            method: method.to_string(),
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct GrpcMethodMetadata {
+    service: String,
+    method: String,
+}
+
+impl GrpcMethodMetadata {
+    fn new(service: impl Into<String>, method: impl Into<String>) -> Self {
+        Self {
+            service: service.into(),
+            method: method.into(),
+        }
+    }
+}
+
+fn grpc_method<T>(request: &Request<T>) -> GrpcMethodMetadata {
+    if let Some(method) = request.extensions().get::<tonic::GrpcMethod<'static>>() {
+        return GrpcMethodMetadata::new(method.service(), method.method());
+    }
+    request.extensions().get::<GrpcServerMethod>().map_or_else(
+        || GrpcMethodMetadata::new("coral.v1.UnknownService", "Unknown"),
+        |method| GrpcMethodMetadata::new(method.service.as_str(), method.method.as_str()),
+    )
+}
+
 pub(crate) async fn instrument_grpc<T, F>(span: tracing::Span, future: F) -> Result<T, Status>
 where
     F: Future<Output = Result<T, Status>>,
 {
     let result = future.instrument(span.clone()).await;
     match &result {
-        Ok(_) => record_grpc_status(&span, Code::Ok),
-        Err(status) => record_grpc_status(&span, status.code()),
+        Ok(_) => record_grpc_status(&span, Code::Ok, None),
+        Err(status) => record_grpc_status(&span, status.code(), Some(status)),
     }
     result
 }
 
-fn record_grpc_status(span: &tracing::Span, code: Code) {
+fn record_grpc_status(span: &tracing::Span, code: Code, status: Option<&Status>) {
+    let response_status_code = grpc_response_status_code(code);
     span.record("grpc.status_code", code as i64);
-    span.record("grpc.code", grpc_code_label(code));
+    span.record("grpc.code", response_status_code);
+    span.record("rpc.response.status_code", response_status_code);
     if code == Code::Ok {
         span.record("status", "ok");
         span.set_status(OtelStatus::Ok);
     } else {
+        let error = status.map_or_else(
+            || GrpcErrorTelemetry {
+                error_type: response_status_code.to_string(),
+                message: response_status_code.to_string(),
+            },
+            decode_grpc_error,
+        );
         span.record("status", "error");
-        span.set_status(OtelStatus::error(grpc_code_label(code)));
+        span.record("error.type", error.error_type.as_str());
+        span.record("exception.message", field::display(error.message.as_str()));
+        span.set_status(OtelStatus::error(error.message));
     }
 }
 
-fn grpc_code_label(code: Code) -> &'static str {
-    match code {
-        Code::Ok => "ok",
-        Code::Cancelled => "cancelled",
-        Code::Unknown => "unknown",
-        Code::InvalidArgument => "invalid_argument",
-        Code::DeadlineExceeded => "deadline_exceeded",
-        Code::NotFound => "not_found",
-        Code::AlreadyExists => "already_exists",
-        Code::PermissionDenied => "permission_denied",
-        Code::ResourceExhausted => "resource_exhausted",
-        Code::FailedPrecondition => "failed_precondition",
-        Code::Aborted => "aborted",
-        Code::OutOfRange => "out_of_range",
-        Code::Unimplemented => "unimplemented",
-        Code::Internal => "internal",
-        Code::Unavailable => "unavailable",
-        Code::DataLoss => "data_loss",
-        Code::Unauthenticated => "unauthenticated",
+struct GrpcErrorTelemetry {
+    error_type: String,
+    message: String,
+}
+
+fn decode_grpc_error(status: &Status) -> GrpcErrorTelemetry {
+    for detail in status.get_error_details_vec() {
+        if let ErrorDetail::ErrorInfo(info) = detail
+            && info.domain == CORAL_ERROR_DOMAIN
+        {
+            return GrpcErrorTelemetry {
+                error_type: info.reason,
+                message: status.message().to_string(),
+            };
+        }
+    }
+
+    GrpcErrorTelemetry {
+        error_type: grpc_response_status_code(status.code()).to_string(),
+        message: status.message().to_string(),
     }
 }
 
@@ -215,12 +332,16 @@ mod tests {
         reason = "proto shape assertions intentionally fail loudly in tests"
     )]
 
-    use coral_api::v1::{QueryTestFailure, Workspace, query_test_result};
-    use tonic::Code;
+    use coral_api::{
+        grpc_response_status_code,
+        v1::{QueryTestFailure, Workspace, query_test_result},
+    };
+    use tonic::{Code, Request};
 
     use super::{
-        grpc_code_label, query_status, query_test_result_to_proto, table_summary_to_proto,
-        table_to_proto, workspace_name_from_proto, workspace_to_proto,
+        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
+        query_test_result_to_proto, table_summary_to_proto, table_to_proto,
+        workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
@@ -250,14 +371,42 @@ mod tests {
     }
 
     #[test]
-    fn grpc_code_labels_are_low_cardinality() {
-        assert_eq!(grpc_code_label(Code::Ok), "ok");
-        assert_eq!(grpc_code_label(Code::InvalidArgument), "invalid_argument");
+    fn grpc_response_status_codes_use_otel_names() {
+        assert_eq!(grpc_response_status_code(Code::Ok), "OK");
         assert_eq!(
-            grpc_code_label(Code::FailedPrecondition),
-            "failed_precondition"
+            grpc_response_status_code(Code::InvalidArgument),
+            "INVALID_ARGUMENT"
         );
-        assert_eq!(grpc_code_label(Code::Unavailable), "unavailable");
+        assert_eq!(grpc_response_status_code(Code::Unavailable), "UNAVAILABLE");
+    }
+
+    #[test]
+    fn grpc_server_method_derives_from_uri_path() {
+        assert_eq!(
+            GrpcServerMethod::from_path("/coral.v1.QueryService/ExecuteSql"),
+            Some(GrpcServerMethod {
+                service: "coral.v1.QueryService".to_string(),
+                method: "ExecuteSql".to_string(),
+            })
+        );
+        assert_eq!(GrpcServerMethod::from_path("/missing-method"), None);
+        assert_eq!(
+            GrpcServerMethod::from_path("/coral.v1.QueryService/Extra/Path"),
+            None
+        );
+    }
+
+    #[test]
+    fn grpc_method_reads_server_method_from_request_extensions() {
+        let mut request = Request::new(());
+        request
+            .extensions_mut()
+            .insert(GrpcServerMethod::from_path("/coral.v1.QueryService/ExecuteSql").unwrap());
+
+        assert_eq!(
+            grpc_method(&request),
+            GrpcMethodMetadata::new("coral.v1.QueryService", "ExecuteSql")
+        );
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -17,6 +17,7 @@ mod onboard;
 mod query_error;
 mod source_ops;
 
+use std::borrow::Cow;
 use std::path::PathBuf;
 #[cfg(feature = "embedded-ui")]
 use std::sync::Arc;
@@ -182,6 +183,10 @@ pub enum CliError {
     Query {
         /// Complete stderr diagnostic rendered from the query status.
         rendered_stderr: String,
+        /// Low-cardinality query failure class for telemetry.
+        error_type: String,
+        /// Human-readable query failure summary for telemetry.
+        error_message: String,
     },
     /// A source was available as a bundled source but has not been installed.
     #[error("source '{source_name}' is not installed")]
@@ -205,7 +210,9 @@ impl CliError {
     /// Returns stderr content for user-facing CLI failures.
     pub fn rendered_stderr(&self) -> Option<String> {
         match self {
-            Self::Query { rendered_stderr } => Some(rendered_stderr.clone()),
+            Self::Query {
+                rendered_stderr, ..
+            } => Some(rendered_stderr.clone()),
             Self::SourceNotInstalled { source_name } => Some(format!(
                 "source '{source_name}' is not installed. Run `coral source add {source_name}` to install it, then retry `coral source test {source_name}`.\n"
             )),
@@ -231,6 +238,30 @@ impl Command {
 
     fn enables_stderr_logs(&self) -> bool {
         matches!(self, Command::McpStdio(_))
+    }
+}
+
+impl coral_app::RunErrorTelemetry for CliError {
+    fn telemetry_error_type(&self) -> Cow<'_, str> {
+        match self {
+            Self::Query { error_type, .. } => Cow::Borrowed(error_type.as_str()),
+            Self::SourceNotInstalled { .. } => Cow::Borrowed("SOURCE_NOT_INSTALLED"),
+            Self::SourceNotFound { .. } => Cow::Borrowed("SOURCE_NOT_FOUND"),
+            Self::Internal(_) => Cow::Borrowed("INTERNAL"),
+        }
+    }
+
+    fn telemetry_error_message(&self) -> Cow<'_, str> {
+        match self {
+            Self::Query { error_message, .. } => Cow::Borrowed(error_message.as_str()),
+            Self::SourceNotInstalled { source_name } => {
+                Cow::Owned(format!("source '{source_name}' is not installed"))
+            }
+            Self::SourceNotFound { source_name } => {
+                Cow::Owned(format!("source '{source_name}' was not found"))
+            }
+            Self::Internal(error) => Cow::Owned(error.to_string()),
+        }
     }
 }
 
@@ -271,12 +302,17 @@ pub async fn run_from_env() -> Result<(), CliError> {
     match command.required_runtime() {
         RequiredRuntime::AppClient => {
             let enable_stderr_logs = command.enables_stderr_logs();
+            let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
             let bootstrap = bootstrap::bootstrap(enable_stderr_logs)
                 .await
                 .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
-            let result =
-                coral_app::run_with_context(&ctx, Box::pin(run_app_command(app, command))).await;
+            let result = if is_mcp_stdio {
+                run_app_command(app, command, Some(&ctx)).await
+            } else {
+                coral_app::run_with_context(&ctx, Box::pin(run_app_command(app, command, None)))
+                    .await
+            };
             bootstrap.shutdown().await;
             result
         }
@@ -337,16 +373,19 @@ async fn run_ui(args: UiArgs) -> Result<(), anyhow::Error> {
 /// formatting fails.
 pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), CliError> {
     let Cli { command } = Cli::parse();
-    coral_app::run_with_context(
-        &ctx,
-        Box::pin(async move {
-            match command.required_runtime() {
-                RequiredRuntime::AppClient => run_app_command(app, command).await,
-                RequiredRuntime::None => run_no_runtime_command(command).await,
-            }
-        }),
-    )
-    .await
+    let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
+
+    match command.required_runtime() {
+        RequiredRuntime::AppClient if is_mcp_stdio => {
+            run_app_command(app, command, Some(&ctx)).await
+        }
+        RequiredRuntime::AppClient => {
+            coral_app::run_with_context(&ctx, Box::pin(run_app_command(app, command, None))).await
+        }
+        RequiredRuntime::None => {
+            coral_app::run_with_context(&ctx, Box::pin(run_no_runtime_command(command))).await
+        }
+    }
 }
 
 async fn run_no_runtime_command(command: Command) -> Result<(), CliError> {
@@ -365,7 +404,11 @@ async fn run_no_runtime_command(command: Command) -> Result<(), CliError> {
     }
 }
 
-async fn run_app_command(app: AppClient, command: Command) -> Result<(), CliError> {
+async fn run_app_command(
+    app: AppClient,
+    command: Command,
+    ctx: Option<&coral_app::RunContext>,
+) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
             let response = match app
@@ -379,6 +422,8 @@ async fn run_app_command(app: AppClient, command: Command) -> Result<(), CliErro
                 Ok(response) => response.into_inner(),
                 Err(status) => {
                     return Err(CliError::Query {
+                        error_message: query_error::telemetry_error_message(&status),
+                        error_type: query_error::telemetry_error_type(&status),
                         rendered_stderr: query_error::render_query_error(&status),
                     });
                 }
@@ -391,12 +436,13 @@ async fn run_app_command(app: AppClient, command: Command) -> Result<(), CliErro
             onboard::run(&app).await?;
         }
         Command::McpStdio(args) => {
-            coral_mcp::run_stdio_with_client(
+            Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {
                     feedback_enabled: args.enable_feedback,
+                    trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                 },
-            )
+            ))
             .await
             .map_err(anyhow::Error::from)?;
         }

--- a/crates/coral-cli/src/query_error.rs
+++ b/crates/coral-cli/src/query_error.rs
@@ -7,6 +7,7 @@
 
 use std::fmt::Write as _;
 
+use coral_api::grpc_response_status_code;
 use coral_client::{CoralQueryError, DecodedStatusError, decode_status_error};
 
 /// Renders a `tonic::Status` as a user-facing stderr block.
@@ -23,6 +24,20 @@ pub(crate) fn render_query_error(status: &tonic::Status) -> String {
     match decode_status_error(status) {
         DecodedStatusError::Structured(error) => render_structured(&error),
         DecodedStatusError::Plain(message) => render_plain(status.code(), &message),
+    }
+}
+
+pub(crate) fn telemetry_error_type(status: &tonic::Status) -> String {
+    match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => error.reason,
+        DecodedStatusError::Plain(_) => grpc_response_status_code(status.code()).to_string(),
+    }
+}
+
+pub(crate) fn telemetry_error_message(status: &tonic::Status) -> String {
+    match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => error.summary,
+        DecodedStatusError::Plain(message) => message,
     }
 }
 
@@ -110,6 +125,27 @@ mod tests {
     }
 
     #[test]
+    fn structured_telemetry_uses_reason_and_summary() {
+        let status = build_coral_status(
+            "MISSING_REQUIRED_FILTER",
+            vec![
+                (
+                    "summary",
+                    "github.files requires `WHERE pull_number = <constant>`",
+                ),
+                ("detail", "missing required filter"),
+            ],
+            false,
+        );
+
+        assert_eq!(telemetry_error_type(&status), "MISSING_REQUIRED_FILTER");
+        assert_eq!(
+            telemetry_error_message(&status),
+            "github.files requires `WHERE pull_number = <constant>`"
+        );
+    }
+
+    #[test]
     fn structured_omits_detail_when_absent() {
         let status = build_coral_status(
             "PROVIDER_REQUEST_FAILED",
@@ -168,6 +204,14 @@ mod tests {
     fn plain_status_includes_grpc_code() {
         let rendered = render_plain(Code::Internal, "legacy opaque failure");
         assert_eq!(rendered, "Error (internal error): legacy opaque failure\n");
+    }
+
+    #[test]
+    fn plain_telemetry_uses_grpc_code_and_message() {
+        let status = Status::new(Code::FailedPrecondition, "missing source setup");
+
+        assert_eq!(telemetry_error_type(&status), "FAILED_PRECONDITION");
+        assert_eq!(telemetry_error_message(&status), "missing source setup");
     }
 
     #[test]

--- a/crates/coral-client/Cargo.toml
+++ b/crates/coral-client/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 
 [dependencies]
 arrow = { workspace = true, features = ["prettyprint"] }
+http-body.workspace = true
 opentelemetry.workspace = true
 opentelemetry_sdk.workspace = true
 serde_json.workspace = true
@@ -22,3 +23,7 @@ tracing-opentelemetry.workspace = true
 
 coral-api.workspace = true
 coral-app.workspace = true
+
+[dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+tracing-subscriber.workspace = true

--- a/crates/coral-client/src/client.rs
+++ b/crates/coral-client/src/client.rs
@@ -9,6 +9,7 @@ use tonic::service::interceptor::InterceptedService;
 use tonic::transport::{Channel, Endpoint};
 
 use crate::error::ClientError;
+use crate::grpc::{GrpcClientEndpoint, InstrumentedGrpcService};
 use crate::propagation::TraceContextInterceptor;
 
 /// Default workspace used by local Coral clients.
@@ -22,19 +23,17 @@ pub fn default_workspace() -> Workspace {
     }
 }
 
+type RawGrpcService = InterceptedService<Channel, TraceContextInterceptor>;
+type GrpcService = InstrumentedGrpcService<RawGrpcService>;
+
 /// Public source-management gRPC client.
-pub type SourceClient = SourceServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
+pub type SourceClient = SourceServiceClient<GrpcService>;
 
 /// Public SQL query gRPC client.
-pub type QueryClient = QueryServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
+pub type QueryClient = QueryServiceClient<GrpcService>;
 
 /// Public feedback-submission gRPC client.
-///
-/// This stays intentionally thin for now: `coral-client` is a local transport
-/// bootstrap, so it exposes the generated typed client directly rather than
-/// wrapping it in a higher-level SDK surface.
-pub type FeedbackClient =
-    FeedbackServiceClient<InterceptedService<Channel, TraceContextInterceptor>>;
+pub type FeedbackClient = FeedbackServiceClient<GrpcService>;
 
 /// Public Coral client handle.
 ///
@@ -59,14 +58,12 @@ impl AppClient {
         crate::propagation::ensure_global_propagator();
         let endpoint = Endpoint::from_shared(endpoint_uri.to_string())?
             .http2_max_header_list_size(HTTP2_MAX_HEADER_LIST_SIZE);
+        let grpc_endpoint = GrpcClientEndpoint::from_endpoint_uri(endpoint_uri);
         let channel = endpoint.connect().await?;
-        let source_client =
-            SourceServiceClient::with_interceptor(channel.clone(), TraceContextInterceptor);
-        let query_client =
-            QueryServiceClient::with_interceptor(channel.clone(), TraceContextInterceptor)
-                .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
-        let feedback_client =
-            FeedbackServiceClient::with_interceptor(channel, TraceContextInterceptor);
+        let source_client = SourceClient::new(grpc_service(channel.clone(), &grpc_endpoint));
+        let query_client = QueryClient::new(grpc_service(channel.clone(), &grpc_endpoint))
+            .max_decoding_message_size(QUERY_RESPONSE_MAX_MESSAGE_SIZE);
+        let feedback_client = FeedbackClient::new(grpc_service(channel, &grpc_endpoint));
         Ok(Self {
             source: source_client,
             query: query_client,
@@ -91,4 +88,11 @@ impl AppClient {
     pub fn feedback_client(&self) -> FeedbackClient {
         self.feedback.clone()
     }
+}
+
+fn grpc_service(channel: Channel, endpoint: &GrpcClientEndpoint) -> GrpcService {
+    InstrumentedGrpcService::new(
+        InterceptedService::new(channel, TraceContextInterceptor),
+        endpoint.clone(),
+    )
 }

--- a/crates/coral-client/src/grpc.rs
+++ b/crates/coral-client/src/grpc.rs
@@ -1,0 +1,445 @@
+//! Instrumented tonic transport for local Coral gRPC clients.
+//!
+//! Tonic exposes final gRPC status in response trailers, after the generated
+//! client has consumed the HTTP body. The service wrapper creates the client
+//! span and the body wrapper records the final trailer status before the span
+//! closes.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use coral_api::grpc_response_status_code;
+use opentelemetry::trace::Status as OtelStatus;
+use tonic::codegen::{Body, Bytes, Service, StdError, http};
+use tonic::{Code, Status};
+use tracing::{Instrument as _, field};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+use crate::status_error::{DecodedStatusError, decode_status_error};
+
+const MISSING_GRPC_STATUS_ERROR_TYPE: &str = "MISSING_GRPC_STATUS";
+const MISSING_GRPC_STATUS_MESSAGE: &str = "missing gRPC response status";
+
+/// Tonic `Service` wrapper that records one client span per gRPC request.
+#[derive(Clone)]
+pub struct InstrumentedGrpcService<S> {
+    inner: S,
+    endpoint: GrpcClientEndpoint,
+}
+
+impl<S> InstrumentedGrpcService<S> {
+    pub(crate) fn new(inner: S, endpoint: GrpcClientEndpoint) -> Self {
+        Self { inner, endpoint }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct GrpcClientEndpoint {
+    server_address: Option<String>,
+    server_port: Option<u16>,
+}
+
+impl GrpcClientEndpoint {
+    pub(crate) fn from_endpoint_uri(endpoint_uri: &str) -> Self {
+        let Ok(uri) = endpoint_uri.parse::<http::Uri>() else {
+            return Self::default();
+        };
+        Self {
+            server_address: uri.host().map(str::to_string),
+            server_port: uri.port_u16().or_else(|| default_port(uri.scheme_str())),
+        }
+    }
+}
+
+fn default_port(scheme: Option<&str>) -> Option<u16> {
+    match scheme {
+        Some("http") => Some(80),
+        Some("https") => Some(443),
+        _ => None,
+    }
+}
+
+impl<S, B> Service<http::Request<tonic::body::Body>> for InstrumentedGrpcService<S>
+where
+    S: Service<http::Request<tonic::body::Body>, Response = http::Response<B>> + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Into<StdError> + Send + 'static,
+    B: Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<StdError> + Send + 'static,
+{
+    type Response = http::Response<InstrumentedGrpcBody<B>>;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: http::Request<tonic::body::Body>) -> Self::Future {
+        let metadata = GrpcClientSpanMetadata::from_request(&request);
+        let span = grpc_client_span(&metadata, &self.endpoint);
+
+        let future = {
+            let _entered = span.enter();
+            self.inner.call(request)
+        };
+
+        Box::pin(async move {
+            match future.instrument(span.clone()).await {
+                Ok(response) => {
+                    let (parts, body) = response.into_parts();
+                    let status_recorded = record_grpc_status_from_headers(&span, &parts.headers);
+                    Ok(http::Response::from_parts(
+                        parts,
+                        InstrumentedGrpcBody::new(body, span, status_recorded),
+                    ))
+                }
+                Err(error) => {
+                    record_transport_error(&span);
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+pub struct InstrumentedGrpcBody<B> {
+    inner: Pin<Box<B>>,
+    span: tracing::Span,
+    status_recorded: bool,
+}
+
+impl<B> InstrumentedGrpcBody<B> {
+    fn new(inner: B, span: tracing::Span, status_recorded: bool) -> Self {
+        Self {
+            inner: Box::pin(inner),
+            span,
+            status_recorded,
+        }
+    }
+
+    fn record_status_from_headers(&mut self, headers: &http::HeaderMap) {
+        if !self.status_recorded {
+            self.status_recorded = record_grpc_status_from_headers(&self.span, headers);
+        }
+    }
+
+    fn record_missing_status(&mut self) {
+        if !self.status_recorded {
+            record_missing_grpc_status(&self.span);
+            self.status_recorded = true;
+        }
+    }
+
+    fn record_body_error(&mut self) {
+        if !self.status_recorded {
+            record_error(&self.span, "TRANSPORT", "gRPC response body error");
+            self.status_recorded = true;
+        }
+    }
+}
+
+impl<B> Body for InstrumentedGrpcBody<B>
+where
+    B: Body<Data = Bytes>,
+{
+    type Data = Bytes;
+    type Error = B::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.get_mut();
+        match this.inner.as_mut().poll_frame(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                if let Some(trailers) = frame.trailers_ref() {
+                    this.record_status_from_headers(trailers);
+                }
+                Poll::Ready(Some(Ok(frame)))
+            }
+            Poll::Ready(Some(Err(error))) => {
+                this.record_body_error();
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(None) => {
+                this.record_missing_status();
+                Poll::Ready(None)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct GrpcClientSpanMetadata {
+    service: String,
+    method: String,
+    span_name: String,
+}
+
+impl GrpcClientSpanMetadata {
+    fn from_request(request: &http::Request<tonic::body::Body>) -> Self {
+        request
+            .extensions()
+            .get::<tonic::GrpcMethod<'static>>()
+            .map_or_else(
+                || Self::from_path(request.uri().path()),
+                |method| Self::new(method.service(), method.method()),
+            )
+    }
+
+    fn from_path(path: &str) -> Self {
+        let trimmed = path.trim_start_matches('/');
+        let (service, method) = trimmed
+            .split_once('/')
+            .unwrap_or(("coral.v1.UnknownService", "Unknown"));
+        Self::new(service, method)
+    }
+
+    fn new(service: &str, method: &str) -> Self {
+        Self {
+            service: service.to_string(),
+            method: method.to_string(),
+            span_name: format!("{service}/{method}"),
+        }
+    }
+}
+
+fn grpc_client_span(
+    metadata: &GrpcClientSpanMetadata,
+    endpoint: &GrpcClientEndpoint,
+) -> tracing::Span {
+    let span = tracing::info_span!(
+        target: "coral_client::grpc",
+        "grpc.client",
+        error.type = field::Empty,
+        exception.message = field::Empty,
+        grpc.method = metadata.method.as_str(),
+        grpc.status_code = field::Empty,
+        grpc.code = field::Empty,
+        otel.kind = "client",
+        otel.name = metadata.span_name.as_str(),
+        peer.service = "coral",
+        rpc.method = metadata.method.as_str(),
+        rpc.response.status_code = field::Empty,
+        rpc.service = metadata.service.as_str(),
+        rpc.system = "grpc",
+        rpc.system.name = "grpc",
+        server.address = field::Empty,
+        server.port = field::Empty,
+        status = field::Empty,
+    );
+    record_grpc_endpoint(&span, endpoint);
+    span
+}
+
+fn record_grpc_endpoint(span: &tracing::Span, endpoint: &GrpcClientEndpoint) {
+    if let Some(address) = endpoint.server_address.as_deref() {
+        span.record("server.address", address);
+    }
+    if let Some(port) = endpoint.server_port {
+        span.record("server.port", i64::from(port));
+    }
+}
+
+fn record_grpc_status_from_headers(span: &tracing::Span, headers: &http::HeaderMap) -> bool {
+    let Some(status) = Status::from_header_map(headers) else {
+        return false;
+    };
+    record_grpc_status(span, status.code(), Some(&status));
+    true
+}
+
+fn record_grpc_status(span: &tracing::Span, code: Code, status: Option<&Status>) {
+    let response_status_code = record_grpc_status_attributes(span, code);
+    if code == Code::Ok {
+        span.record("status", "ok");
+        span.set_status(OtelStatus::Ok);
+    } else if let Some(status) = status {
+        let error = decode_grpc_client_error(status);
+        record_error(span, error.error_type.as_str(), error.message);
+    } else {
+        record_error(span, response_status_code, response_status_code);
+    }
+}
+
+fn record_grpc_status_attributes(span: &tracing::Span, code: Code) -> &'static str {
+    let response_status_code = grpc_response_status_code(code);
+    span.record("grpc.status_code", code as i64);
+    span.record("grpc.code", response_status_code);
+    span.record("rpc.response.status_code", response_status_code);
+    response_status_code
+}
+
+fn record_missing_grpc_status(span: &tracing::Span) {
+    record_grpc_status_attributes(span, Code::Unknown);
+    record_error(
+        span,
+        MISSING_GRPC_STATUS_ERROR_TYPE,
+        MISSING_GRPC_STATUS_MESSAGE,
+    );
+}
+
+fn record_transport_error(span: &tracing::Span) {
+    record_error(span, "TRANSPORT", "gRPC transport error");
+}
+
+fn record_error(
+    span: &tracing::Span,
+    error_type: impl AsRef<str>,
+    message: impl std::fmt::Display,
+) {
+    let message = message.to_string();
+    span.record("status", "error");
+    span.record("error.type", error_type.as_ref());
+    span.record("exception.message", field::display(&message));
+    span.set_status(OtelStatus::error(message));
+}
+
+struct GrpcClientError {
+    error_type: String,
+    message: String,
+}
+
+fn decode_grpc_client_error(status: &Status) -> GrpcClientError {
+    match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => GrpcClientError {
+            error_type: error.reason,
+            message: error.message,
+        },
+        DecodedStatusError::Plain(message) => GrpcClientError {
+            error_type: grpc_response_status_code(status.code()).to_string(),
+            message,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use opentelemetry::trace::{Status as OtelStatus, TracerProvider as _};
+    use opentelemetry::{KeyValue, Value};
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+    use tonic::codegen::http;
+    use tracing_subscriber::prelude::*;
+
+    use super::{
+        GrpcClientEndpoint, GrpcClientSpanMetadata, MISSING_GRPC_STATUS_ERROR_TYPE,
+        MISSING_GRPC_STATUS_MESSAGE, grpc_client_span, record_missing_grpc_status,
+    };
+
+    #[test]
+    fn grpc_client_span_metadata_derives_names_from_path() {
+        let metadata = GrpcClientSpanMetadata::from_path("/coral.v1.QueryService/ExecuteSql");
+
+        assert_eq!(metadata.service, "coral.v1.QueryService");
+        assert_eq!(metadata.method, "ExecuteSql");
+        assert_eq!(metadata.span_name, "coral.v1.QueryService/ExecuteSql");
+    }
+
+    #[test]
+    fn grpc_client_span_metadata_prefers_tonic_extension() {
+        let mut request = http::Request::builder()
+            .uri("/fallback.Service/Fallback")
+            .body(tonic::body::Body::empty())
+            .expect("request");
+        request.extensions_mut().insert(tonic::GrpcMethod::new(
+            "coral.v1.SourceService",
+            "ListSources",
+        ));
+
+        let metadata = GrpcClientSpanMetadata::from_request(&request);
+
+        assert_eq!(metadata.service, "coral.v1.SourceService");
+        assert_eq!(metadata.method, "ListSources");
+        assert_eq!(metadata.span_name, "coral.v1.SourceService/ListSources");
+    }
+
+    #[test]
+    fn grpc_client_endpoint_derives_address_and_port() {
+        let endpoint = GrpcClientEndpoint::from_endpoint_uri("http://127.0.0.1:50051");
+
+        assert_eq!(endpoint.server_address.as_deref(), Some("127.0.0.1"));
+        assert_eq!(endpoint.server_port, Some(50051));
+
+        let endpoint = GrpcClientEndpoint::from_endpoint_uri("https://coral.example.com");
+
+        assert_eq!(
+            endpoint.server_address.as_deref(),
+            Some("coral.example.com")
+        );
+        assert_eq!(endpoint.server_port, Some(443));
+    }
+
+    #[test]
+    fn missing_grpc_status_records_unknown_error() {
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let tracer = provider.tracer("coral-client-test");
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let metadata = GrpcClientSpanMetadata::new("coral.v1.QueryService", "ExecuteSql");
+            let span = grpc_client_span(&metadata, &GrpcClientEndpoint::default());
+            let _entered = span.enter();
+            record_missing_grpc_status(&span);
+        });
+
+        provider.force_flush().expect("spans should flush");
+        let spans = exporter
+            .get_finished_spans()
+            .expect("finished spans should be readable");
+        let span = spans
+            .iter()
+            .find(|span| span.name == "coral.v1.QueryService/ExecuteSql")
+            .expect("client span should export");
+
+        assert_eq!(i64_attr(&span.attributes, "grpc.status_code"), Some(2));
+        assert_eq!(string_attr(&span.attributes, "grpc.code"), Some("UNKNOWN"));
+        assert_eq!(
+            string_attr(&span.attributes, "rpc.response.status_code"),
+            Some("UNKNOWN")
+        );
+        assert_eq!(
+            string_attr(&span.attributes, "error.type"),
+            Some(MISSING_GRPC_STATUS_ERROR_TYPE)
+        );
+        assert_eq!(span.status, OtelStatus::error(MISSING_GRPC_STATUS_MESSAGE));
+    }
+
+    fn i64_attr(attributes: &[KeyValue], key: &str) -> Option<i64> {
+        attributes.iter().find_map(|attribute| {
+            if attribute.key.as_str() == key
+                && let Value::I64(value) = attribute.value
+            {
+                Some(value)
+            } else {
+                None
+            }
+        })
+    }
+
+    fn string_attr<'a>(attributes: &'a [KeyValue], key: &str) -> Option<&'a str> {
+        attributes.iter().find_map(|attribute| {
+            if attribute.key.as_str() == key
+                && let Value::String(value) = &attribute.value
+            {
+                Some(value.as_ref())
+            } else {
+                None
+            }
+        })
+    }
+}

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -16,6 +16,7 @@
 
 mod client;
 mod error;
+mod grpc;
 pub mod local;
 mod propagation;
 mod status_error;

--- a/crates/coral-mcp/Cargo.toml
+++ b/crates/coral-mcp/Cargo.toml
@@ -16,6 +16,9 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tonic.workspace = true
+tracing.workspace = true
+tracing-opentelemetry.workspace = true
+opentelemetry.workspace = true
 
 coral-api.workspace = true
 coral-client.workspace = true

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -25,6 +25,7 @@
 mod error;
 mod server;
 mod surface;
+mod telemetry;
 
 #[cfg(test)]
 mod tests;
@@ -36,10 +37,12 @@ pub use error::McpError;
 pub(crate) use server::CoralMcpServer;
 
 /// Optional MCP surface features.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct McpOptions {
     /// Expose the feedback submission tool.
     pub feedback_enabled: bool,
+    /// Optional W3C traceparent used to parent each MCP request span.
+    pub trace_parent: Option<String>,
 }
 
 /// Runs the `MCP` stdio server using an existing Coral client.
@@ -49,9 +52,10 @@ pub struct McpOptions {
 /// Returns [`McpError`] if the stdio server cannot complete its `MCP`
 /// lifecycle.
 pub async fn run_stdio_with_client(app: AppClient, options: McpOptions) -> Result<(), McpError> {
-    let server = CoralMcpServer::new(&app, options)
-        .serve((tokio::io::stdin(), tokio::io::stdout()))
-        .await?;
+    let server = Box::pin(
+        CoralMcpServer::new(&app, options).serve((tokio::io::stdin(), tokio::io::stdout())),
+    )
+    .await?;
     let _ = server.waiting().await?;
     Ok(())
 }

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -33,6 +33,7 @@ use crate::{
         search_tables_arguments, search_tables_tool, sql_tool, status_to_error_data,
         tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
     },
+    telemetry,
 };
 
 const LIST_TABLES_COUNT_LIMIT: u32 = 1;
@@ -43,6 +44,23 @@ struct LoadTablesParams<'a> {
     table_name: Option<&'a str>,
     pagination: PaginationRequest,
     omit_columns: bool,
+}
+
+enum ToolCallOutcome {
+    Success(Value),
+    ToolError {
+        operation: &'static str,
+        status: tonic::Status,
+    },
+}
+
+impl ToolCallOutcome {
+    fn from_value_result(operation: &'static str, result: Result<Value, tonic::Status>) -> Self {
+        match result {
+            Ok(value) => Self::Success(value),
+            Err(status) => Self::ToolError { operation, status },
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -212,7 +230,7 @@ impl CoralMcpServer {
     async fn search_tables_tool_result(
         &self,
         request_arguments: Option<&Map<String, Value>>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<ToolCallOutcome, ErrorData> {
         let arguments = search_tables_arguments(request_arguments)?;
         let regex = compile_metadata_regex(&arguments.pattern, arguments.ignore_case)?;
         match self.load_table_summaries(arguments.schema.as_deref()).await {
@@ -225,49 +243,103 @@ impl CoralMcpServer {
                         matches.push(summary.search_result_value(&matched_fields));
                     }
                 }
-                build_tool_result(paged_value(
+                Ok(ToolCallOutcome::Success(paged_value(
                     "tables",
                     page_items(matches, arguments.pagination),
-                ))
+                )))
             }
-            Err(status) => Ok(tool_error_result(tool_error_from_status(
-                "Table search",
-                &status,
-            ))),
+            Err(status) => Ok(ToolCallOutcome::ToolError {
+                operation: "Table search",
+                status,
+            }),
         }
     }
 
     async fn describe_table_tool_result(
         &self,
         request_arguments: Option<&Map<String, Value>>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<ToolCallOutcome, ErrorData> {
         let arguments = describe_table_arguments(request_arguments)?;
         match self
             .load_exact_table(&arguments.schema, &arguments.table)
             .await
         {
-            Ok(Some(table)) => build_tool_result(describe_found_table_value(&table)),
+            Ok(Some(table)) => Ok(ToolCallOutcome::Success(describe_found_table_value(&table))),
             Ok(None) => {
                 let all_tables = match self.load_all_table_summaries().await {
                     Ok(tables) => tables,
                     Err(status) => {
-                        return Ok(tool_error_result(tool_error_from_status(
-                            "Table description",
-                            &status,
-                        )));
+                        return Ok(ToolCallOutcome::ToolError {
+                            operation: "Table description",
+                            status,
+                        });
                     }
                 };
                 let all_summaries = table_summaries_from_proto(&all_tables);
-                build_tool_result(describe_missing_table_value(
+                Ok(ToolCallOutcome::Success(describe_missing_table_value(
                     &arguments.schema,
                     &arguments.table,
                     &all_summaries,
+                )))
+            }
+            Err(status) => Ok(ToolCallOutcome::ToolError {
+                operation: "Table description",
+                status,
+            }),
+        }
+    }
+
+    async fn dispatch_tool(
+        &self,
+        request: CallToolRequestParams,
+    ) -> Result<ToolCallOutcome, ErrorData> {
+        match request.name.as_ref() {
+            "sql" => {
+                let sql = required_string_argument(request.arguments.as_ref(), "sql")?;
+                Ok(ToolCallOutcome::from_value_result(
+                    "Query",
+                    self.execute_sql_value(&sql).await,
                 ))
             }
-            Err(status) => Ok(tool_error_result(tool_error_from_status(
-                "Table description",
-                &status,
-            ))),
+            "list_tables" => {
+                let arguments = list_tables_arguments(request.arguments.as_ref())?;
+                let result = self
+                    .load_tables(LoadTablesParams {
+                        schema_name: arguments.schema.as_deref(),
+                        table_name: None,
+                        pagination: PaginationRequest {
+                            limit: arguments.limit,
+                            offset: arguments.offset,
+                        },
+                        omit_columns: true,
+                    })
+                    .await
+                    .map(|response| list_tables_value(&response));
+                Ok(ToolCallOutcome::from_value_result("Table listing", result))
+            }
+            "search_tables" => {
+                self.search_tables_tool_result(request.arguments.as_ref())
+                    .await
+            }
+            "describe_table" => {
+                self.describe_table_tool_result(request.arguments.as_ref())
+                    .await
+            }
+            "feedback" if self.options.feedback_enabled => {
+                let trying_to_do =
+                    required_string_argument(request.arguments.as_ref(), "trying_to_do")?;
+                let tried = required_string_argument(request.arguments.as_ref(), "tried")?;
+                let stuck = required_string_argument(request.arguments.as_ref(), "stuck")?;
+                Ok(ToolCallOutcome::from_value_result(
+                    "Feedback submission",
+                    self.submit_feedback_value(&trying_to_do, &tried, &stuck)
+                        .await,
+                ))
+            }
+            _ => Err(ErrorData::invalid_params(
+                format!("tool '{}' not found", request.name),
+                None,
+            )),
         }
     }
 }
@@ -356,20 +428,24 @@ impl ServerHandler for CoralMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        let (sources, visible_table_count) = self
-            .load_sources_and_table_count()
-            .await
-            .map_err(|status| status_to_error_data(&status))?;
-        let mut tools = vec![
-            sql_tool(&sources, visible_table_count),
-            list_tables_tool(visible_table_count),
-            search_tables_tool(visible_table_count),
-            describe_table_tool(),
-        ];
-        if self.options.feedback_enabled {
-            tools.push(feedback_tool());
-        }
-        Ok(ListToolsResult::with_all_items(tools))
+        let span = telemetry::list_tools_span(self.options.trace_parent.as_deref());
+        telemetry::instrument_protocol(span, async {
+            let (sources, visible_table_count) = self
+                .load_sources_and_table_count()
+                .await
+                .map_err(|status| status_to_error_data(&status))?;
+            let mut tools = vec![
+                sql_tool(&sources, visible_table_count),
+                list_tables_tool(visible_table_count),
+                search_tables_tool(visible_table_count),
+                describe_table_tool(),
+            ];
+            if self.options.feedback_enabled {
+                tools.push(feedback_tool());
+            }
+            Ok(ListToolsResult::with_all_items(tools))
+        })
+        .await
     }
 
     async fn call_tool(
@@ -377,64 +453,10 @@ impl ServerHandler for CoralMcpServer {
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<CallToolResult, ErrorData> {
-        match request.name.as_ref() {
-            "sql" => {
-                let sql = required_string_argument(request.arguments.as_ref(), "sql")?;
-                match self.execute_sql_value(&sql).await {
-                    Ok(value) => build_tool_result(value),
-                    Err(status) => Ok(tool_error_result(tool_error_from_status("Query", &status))),
-                }
-            }
-            "list_tables" => {
-                let arguments = list_tables_arguments(request.arguments.as_ref())?;
-                match self
-                    .load_tables(LoadTablesParams {
-                        schema_name: arguments.schema.as_deref(),
-                        table_name: None,
-                        pagination: PaginationRequest {
-                            limit: arguments.limit,
-                            offset: arguments.offset,
-                        },
-                        omit_columns: true,
-                    })
-                    .await
-                {
-                    Ok(response) => build_tool_result(list_tables_value(&response)),
-                    Err(status) => Ok(tool_error_result(tool_error_from_status(
-                        "Table listing",
-                        &status,
-                    ))),
-                }
-            }
-            "search_tables" => {
-                self.search_tables_tool_result(request.arguments.as_ref())
-                    .await
-            }
-            "describe_table" => {
-                self.describe_table_tool_result(request.arguments.as_ref())
-                    .await
-            }
-            "feedback" if self.options.feedback_enabled => {
-                let trying_to_do =
-                    required_string_argument(request.arguments.as_ref(), "trying_to_do")?;
-                let tried = required_string_argument(request.arguments.as_ref(), "tried")?;
-                let stuck = required_string_argument(request.arguments.as_ref(), "stuck")?;
-                match self
-                    .submit_feedback_value(&trying_to_do, &tried, &stuck)
-                    .await
-                {
-                    Ok(value) => build_tool_result(value),
-                    Err(status) => Ok(tool_error_result(tool_error_from_status(
-                        "Feedback submission",
-                        &status,
-                    ))),
-                }
-            }
-            _ => Err(ErrorData::invalid_params(
-                format!("tool '{}' not found", request.name),
-                None,
-            )),
-        }
+        let span =
+            telemetry::call_tool_span(request.name.as_ref(), self.options.trace_parent.as_deref());
+        let outcome = telemetry::instrument(span.clone(), self.dispatch_tool(request)).await;
+        finish_tool_call(&span, outcome)
     }
 
     async fn list_resources(
@@ -442,14 +464,18 @@ impl ServerHandler for CoralMcpServer {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListResourcesResult, ErrorData> {
-        let (sources, visible_table_count) = self
-            .load_sources_and_table_count()
-            .await
-            .map_err(|status| status_to_error_data(&status))?;
-        Ok(ListResourcesResult::with_all_items(vec![
-            guide_resource(&sources, visible_table_count),
-            tables_resource(visible_table_count),
-        ]))
+        let span = telemetry::list_resources_span(self.options.trace_parent.as_deref());
+        telemetry::instrument_protocol(span, async {
+            let (sources, visible_table_count) = self
+                .load_sources_and_table_count()
+                .await
+                .map_err(|status| status_to_error_data(&status))?;
+            Ok(ListResourcesResult::with_all_items(vec![
+                guide_resource(&sources, visible_table_count),
+                tables_resource(visible_table_count),
+            ]))
+        })
+        .await
     }
 
     async fn read_resource(
@@ -457,33 +483,67 @@ impl ServerHandler for CoralMcpServer {
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResult, ErrorData> {
-        match request.uri.as_str() {
-            "coral://guide" => {
-                let (sources, tables) = self
-                    .load_sources_and_table_summaries()
-                    .await
-                    .map_err(|status| status_to_error_data(&status))?;
-                Ok(ReadResourceResult::new(vec![
-                    ResourceContents::text(guide_resource_content(&sources, &tables), request.uri)
+        let span = telemetry::read_resource_span(
+            request.uri.as_str(),
+            self.options.trace_parent.as_deref(),
+        );
+        telemetry::instrument_protocol(span, async {
+            match request.uri.as_str() {
+                "coral://guide" => {
+                    let (sources, tables) = self
+                        .load_sources_and_table_summaries()
+                        .await
+                        .map_err(|status| status_to_error_data(&status))?;
+                    Ok(ReadResourceResult::new(vec![
+                        ResourceContents::text(
+                            guide_resource_content(&sources, &tables),
+                            request.uri,
+                        )
                         .with_mime_type("text/markdown"),
-                ]))
+                    ]))
+                }
+                "coral://tables" => {
+                    let tables = self
+                        .load_all_table_summaries()
+                        .await
+                        .map_err(|status| status_to_error_data(&status))?;
+                    let text = tables_resource_content(&tables)
+                        .map_err(|error| internal_status(&error))
+                        .map_err(|status| status_to_error_data(&status))?;
+                    Ok(ReadResourceResult::new(vec![
+                        ResourceContents::text(text, request.uri)
+                            .with_mime_type("application/json"),
+                    ]))
+                }
+                _ => Err(ErrorData::resource_not_found(
+                    format!("resource '{}' not found", request.uri),
+                    None,
+                )),
             }
-            "coral://tables" => {
-                let tables = self
-                    .load_all_table_summaries()
-                    .await
-                    .map_err(|status| status_to_error_data(&status))?;
-                let text = tables_resource_content(&tables)
-                    .map_err(|error| internal_status(&error))
-                    .map_err(|status| status_to_error_data(&status))?;
-                Ok(ReadResourceResult::new(vec![
-                    ResourceContents::text(text, request.uri).with_mime_type("application/json"),
-                ]))
-            }
-            _ => Err(ErrorData::resource_not_found(
-                format!("resource '{}' not found", request.uri),
-                None,
-            )),
+        })
+        .await
+    }
+}
+
+fn finish_tool_call(
+    span: &tracing::Span,
+    outcome: Result<ToolCallOutcome, ErrorData>,
+) -> Result<CallToolResult, ErrorData> {
+    match outcome {
+        Ok(ToolCallOutcome::Success(value)) => {
+            let result = build_tool_result(value);
+            telemetry::record_protocol_result(span, &result);
+            result
+        }
+        Ok(ToolCallOutcome::ToolError { operation, status }) => {
+            telemetry::record_tonic_status(span, &status);
+            Ok(tool_error_result(tool_error_from_status(
+                operation, &status,
+            )))
+        }
+        Err(error) => {
+            telemetry::record_protocol_error(span, &error);
+            Err(error)
         }
     }
 }

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -312,6 +312,7 @@ fn search_tables_output_schema() -> Arc<Map<String, Value>> {
             "name",
             "sql_reference",
             "description",
+            "guide",
             "required_filters",
             "matched_fields"
         ],
@@ -322,6 +323,7 @@ fn search_tables_output_schema() -> Arc<Map<String, Value>> {
             "name": { "type": "string" },
             "sql_reference": { "type": "string" },
             "description": { "type": "string" },
+            "guide": { "type": "string" },
             "required_filters": {
                 "type": "array",
                 "items": { "type": "string" }

--- a/crates/coral-mcp/src/telemetry.rs
+++ b/crates/coral-mcp/src/telemetry.rs
@@ -1,0 +1,163 @@
+//! OpenTelemetry helpers for MCP protocol spans.
+
+use std::collections::HashMap;
+use std::future::Future;
+
+use coral_api::grpc_response_status_code;
+use coral_client::{DecodedStatusError, decode_status_error};
+use opentelemetry::{propagation::Extractor, trace::Status as OtelStatus};
+use rmcp::{ErrorData, model::ErrorCode};
+use tracing::{Instrument as _, field};
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+struct StringMapExtractor<'a>(&'a HashMap<String, String>);
+
+impl Extractor for StringMapExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(String::as_str).collect()
+    }
+}
+
+pub(crate) async fn instrument<T, F>(span: tracing::Span, future: F) -> T
+where
+    F: Future<Output = T>,
+{
+    future.instrument(span).await
+}
+
+pub(crate) async fn instrument_protocol<T, F>(
+    span: tracing::Span,
+    future: F,
+) -> Result<T, ErrorData>
+where
+    F: Future<Output = Result<T, ErrorData>>,
+{
+    let result = instrument(span.clone(), future).await;
+    record_protocol_result(&span, &result);
+    result
+}
+
+pub(crate) fn list_tools_span(trace_parent: Option<&str>) -> tracing::Span {
+    let span = tracing::info_span!(
+        target: "coral_mcp::server",
+        "coral.mcp.list_tools",
+        error.type = field::Empty,
+        exception.message = field::Empty,
+        mcp.method = "tools/list",
+        otel.kind = "server",
+        otel.name = "coral.mcp.list_tools",
+        status = field::Empty,
+    );
+    apply_trace_parent(&span, trace_parent);
+    span
+}
+
+pub(crate) fn call_tool_span(tool_name: &str, trace_parent: Option<&str>) -> tracing::Span {
+    let span = tracing::info_span!(
+        target: "coral_mcp::server",
+        "coral.mcp.call_tool",
+        error.type = field::Empty,
+        exception.message = field::Empty,
+        mcp.method = "tools/call",
+        mcp.tool.name = tool_name,
+        otel.kind = "server",
+        otel.name = "coral.mcp.call_tool",
+        status = field::Empty,
+    );
+    apply_trace_parent(&span, trace_parent);
+    span
+}
+
+pub(crate) fn list_resources_span(trace_parent: Option<&str>) -> tracing::Span {
+    let span = tracing::info_span!(
+        target: "coral_mcp::server",
+        "coral.mcp.list_resources",
+        error.type = field::Empty,
+        exception.message = field::Empty,
+        mcp.method = "resources/list",
+        otel.kind = "server",
+        otel.name = "coral.mcp.list_resources",
+        status = field::Empty,
+    );
+    apply_trace_parent(&span, trace_parent);
+    span
+}
+
+pub(crate) fn read_resource_span(uri: &str, trace_parent: Option<&str>) -> tracing::Span {
+    let span = tracing::info_span!(
+        target: "coral_mcp::server",
+        "coral.mcp.read_resource",
+        error.type = field::Empty,
+        exception.message = field::Empty,
+        mcp.method = "resources/read",
+        mcp.resource.uri = uri,
+        otel.kind = "server",
+        otel.name = "coral.mcp.read_resource",
+        status = field::Empty,
+    );
+    apply_trace_parent(&span, trace_parent);
+    span
+}
+
+fn apply_trace_parent(span: &tracing::Span, trace_parent: Option<&str>) {
+    let Some(trace_parent) = trace_parent else {
+        return;
+    };
+    let carrier = HashMap::from([("traceparent".to_string(), trace_parent.to_string())]);
+    let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+        propagator.extract(&StringMapExtractor(&carrier))
+    });
+    drop(span.set_parent(parent_cx));
+}
+
+pub(crate) fn record_protocol_result<T>(span: &tracing::Span, result: &Result<T, ErrorData>) {
+    match result {
+        Ok(_) => record_success(span),
+        Err(error) => record_protocol_error(span, error),
+    }
+}
+
+pub(crate) fn record_protocol_error(span: &tracing::Span, error: &ErrorData) {
+    record_error(span, mcp_error_type(error.code), error.message.as_ref());
+}
+
+pub(crate) fn record_tonic_status(span: &tracing::Span, status: &tonic::Status) {
+    match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => {
+            record_error(span, error.reason.as_str(), error.summary);
+        }
+        DecodedStatusError::Plain(message) => {
+            record_error(span, grpc_response_status_code(status.code()), message);
+        }
+    }
+}
+
+pub(crate) fn record_success(span: &tracing::Span) {
+    span.record("status", "ok");
+    span.set_status(OtelStatus::Ok);
+}
+
+fn record_error(span: &tracing::Span, error_type: &str, message: impl std::fmt::Display) {
+    let message = message.to_string();
+    span.record("status", "error");
+    span.record("error.type", error_type);
+    span.record("exception.message", field::display(&message));
+    span.set_status(OtelStatus::error(message));
+}
+
+fn mcp_error_type(code: ErrorCode) -> &'static str {
+    match code {
+        ErrorCode::RESOURCE_NOT_FOUND => "RESOURCE_NOT_FOUND",
+        ErrorCode::INVALID_REQUEST => "INVALID_REQUEST",
+        ErrorCode::METHOD_NOT_FOUND => "METHOD_NOT_FOUND",
+        ErrorCode::INVALID_PARAMS => "INVALID_PARAMS",
+        ErrorCode::INTERNAL_ERROR => "INTERNAL_ERROR",
+        ErrorCode::PARSE_ERROR => "PARSE_ERROR",
+        ErrorCode::URL_ELICITATION_REQUIRED => "URL_ELICITATION_REQUIRED",
+        _ => "MCP_PROTOCOL",
+    }
+}

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -146,9 +146,7 @@ async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> Test
 
     let (server_transport, client_transport) = tokio::io::duplex(4096);
     let mcp_server_task = tokio::spawn(async move {
-        let server = CoralMcpServer::new(&app, options)
-            .serve(server_transport)
-            .await?;
+        let server = Box::pin(CoralMcpServer::new(&app, options).serve(server_transport)).await?;
         server.waiting().await?;
         Ok::<(), Box<dyn std::error::Error + Send + Sync>>(())
     });
@@ -530,6 +528,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
         &temp,
         McpOptions {
             feedback_enabled: true,
+            ..McpOptions::default()
         },
     )
     .await;

--- a/docs/guides/observe-with-opentelemetry.mdx
+++ b/docs/guides/observe-with-opentelemetry.mdx
@@ -27,7 +27,7 @@ All telemetry settings live under `[otel]` in `config.toml`. There are no enviro
 | `endpoint`     | string | unset                                                                  | OTLP/HTTP base URL. When unset, no traces, logs, or metrics are exported.         |
 | `headers`      | string | unset                                                                  | Comma-separated `key=value` pairs sent on every OTLP request (e.g. auth headers). |
 | `log_filter`   | string | `coral_app=info,coral_engine=info`                                     | `tracing-subscriber` filter applied to logs (OTLP and stderr).                    |
-| `trace_filter` | string | `coral_app=trace,coral_engine=trace,coral_engine::datafusion=off`      | `tracing-subscriber` filter applied to OTLP spans.                                |
+| `trace_filter` | string | `coral_app=trace,coral_client=trace,coral_mcp=trace,coral_engine=trace,coral_engine::datafusion=off` | `tracing-subscriber` filter applied to OTLP spans.                                |
 | `service_name` | string | `coral`                                                                | Value of the `service.name` resource attribute on every signal.                   |
 
 Example with auth headers and a hosted endpoint:
@@ -37,21 +37,25 @@ Example with auth headers and a hosted endpoint:
 endpoint = "https://otlp.example.com"
 headers = "x-api-key=secret, x-tenant=acme"
 service_name = "coral-laptop"
-trace_filter = "coral_app=trace,coral_engine=trace"
+trace_filter = "coral_app=trace,coral_client=trace,coral_mcp=trace,coral_engine=trace"
 ```
 
 ## What gets emitted
 
 ### Traces
 
-Each query produces a `coral.cli` root span with child spans for query orchestration, source loading, HTTP backend calls, and (optionally) DataFusion execution. Spans are exported with the W3C Trace Context propagator.
+Each CLI query produces a `coral.cli` root span exported as an OpenTelemetry `client` span, with child spans for query orchestration, source loading, HTTP backend calls, and (optionally) DataFusion execution. The root span includes CLI process attributes such as `process.executable.name`, `process.pid`, and `process.exit.code`; Coral does not collect raw `process.command_args` by default. Spans are exported with the W3C Trace Context propagator.
+
+When Coral runs over MCP, each MCP tool or resource request produces a `coral.mcp.*` server span before the request calls into the local Coral app. The MCP adapter then emits `grpc.client.*` client spans for its local gRPC calls, which parent the app's gRPC server handler spans. This keeps MCP discovery such as `list_sources` and `list_tables` attached to Coral-owned request spans without turning the long-running `mcp-stdio` process into one giant CLI trace.
+
+Inbound Coral gRPC handler spans are exported as OpenTelemetry `server` spans with `rpc.system.name`, `rpc.method`, and `rpc.response.status_code`. HTTP source calls are exported as OpenTelemetry `client` spans with upstream dependency attributes including `peer.service`, `server.address`, `server.port`, `http.host`, `net.peer.name`, `http.request.method`, `http.request.resend_count` on retries, `http.response.status_code`, low-cardinality `error.type` on failures, and sanitized `url.full`. Coral also injects W3C Trace Context headers into outbound source requests, so an instrumented upstream API can emit a related `server` span in the same trace. Service-map tools that support virtual peer nodes can draw edges directly from Coral's HTTP client spans; tools that require related client/server span pairs, such as HyperDX, need the upstream service to emit the matching server span. Tools that group strictly by resource `service.name` may still display a single `coral` service for local CLI runs, because the CLI client span and local server span are emitted by the same Coral process.
 
 By default, the `coral_engine::datafusion` target is disabled to keep span volume low. Enable it when you want to see DataFusion physical-plan execution and optimizer-rule spans alongside the rest of the query trace:
 
 ```toml
 [otel]
 endpoint = "http://localhost:4318"
-trace_filter = "coral_app=trace,coral_engine=trace,coral_engine::datafusion=trace"
+trace_filter = "coral_app=trace,coral_client=trace,coral_mcp=trace,coral_engine=trace,coral_engine::datafusion=trace"
 ```
 
 Conversely, you can silence noisy targets. The HTTP backend instrumentation lives under `coral_engine::http` and can be disabled while keeping the rest of the engine spans:
@@ -59,7 +63,7 @@ Conversely, you can silence noisy targets. The HTTP backend instrumentation live
 ```toml
 [otel]
 endpoint = "http://localhost:4318"
-trace_filter = "coral_app=trace,coral_engine=trace,coral_engine::http=off"
+trace_filter = "coral_app=trace,coral_client=trace,coral_mcp=trace,coral_engine=trace,coral_engine::http=off"
 ```
 
 The filter syntax is the same one accepted by [`tracing-subscriber`'s `Targets`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Targets.html). If the filter fails to parse, Coral logs a warning and falls back to the default.


### PR DESCRIPTION
## Summary

- Add MCP protocol spans around tool/resource handling so the MCP adapter has its own useful boundary in traces.
- Carry trace parent context through MCP execution while avoiding duplicate CLI root spans for `mcp-stdio`.
- Normalize CLI/MCP error telemetry to stable uppercase error types and document the resulting OpenTelemetry behavior.

## Stack

- Depends on #327, which depends on #326.
- This is the top PR in the telemetry stack.

## Validation

- `make rust-checks`

![CleanShot 2026-05-08 at 17.40.47@2x.png](https://app.graphite.com/user-attachments/assets/3276d47a-23b6-48c3-b14c-f4414f98c84b.png)

![CleanShot 2026-05-08 at 17.41.33@2x.png](https://app.graphite.com/user-attachments/assets/579c7c0f-6ab1-4c9d-bbe6-599e54afac1e.png)



