### PR TITLE
chore: add worktrunk config

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,2 @@
+[post-start]
+copy = "wt step copy-ignored"


### PR DESCRIPTION
When using worktrunk to manage git worktrees, automatically copy git-ignored files to new worktrees. See
https://worktrunk.dev/step/#wt-step-copy-ignored