### PR TITLE
fix(mcp): return guide in table search results

### DIFF
--- a/crates/coral-mcp/src/surface/discovery.rs
+++ b/crates/coral-mcp/src/surface/discovery.rs
@@ -91,6 +91,7 @@ impl TableSummary {
             "name": format!("{}.{}", self.schema_name, self.table_name),
             "sql_reference": format_schema_table_equivalent(&self.schema_name, &self.table_name),
             "description": self.description,
+            "guide": self.guide,
             "required_filters": self.required_filters,
             "matched_fields": matched_fields,
         })
@@ -227,6 +228,7 @@ mod tests {
 
         assert_eq!(value["name"], "github.Pull.Requests");
         assert_eq!(value["sql_reference"], "github.\"Pull.Requests\"");
+        assert_eq!(value["guide"], "Query pull requests.");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This fixes an inconsistency in the new `search_tables` MCP response: matches against table guidance were reported through `matched_fields`, but the response payload dropped the actual `guide` text. That made guide-based discovery harder to trust and harder to use.

## Testing
- make rust-checks
