### PR TITLE
chore: add HTML code changes explainer skill

### DIFF
--- a/.codex/skills/explain-code-changes-html/SKILL.md
+++ b/.codex/skills/explain-code-changes-html/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: explain-code-changes-html
+description: Create clear standalone HTML explainers for code changes, PRs, diffs, architecture updates, migrations, refactors, new APIs, config changes, or implementation handoffs. Use when Codex is asked to make code changes understandable with an HTML document, visual walkthrough, architecture map, sequence/data-flow diagram, reviewer guide, or junior-friendly team explanation.
+---
+
+# Explain Code Changes With HTML
+
+Create one self-contained HTML reference document that helps a mixed-seniority
+engineering team understand a code change quickly and accurately.
+
+## Workflow
+
+1. Inspect the change before writing.
+   - Read the diff against the requested target branch, or infer the target
+     branch from the repo when the user does not specify one.
+   - Identify the motivation, behavior changes, files touched, runtime flow,
+     data contracts, tests, risks, and non-goals.
+   - Trace every claim to the diff, tests, or surrounding repo context.
+   - Mark uncertainty as an assumption. Omit claims that cannot be supported.
+
+2. Choose the smallest useful presentation format.
+   - Default to a single standalone `.html` file with semantic HTML,
+     responsive CSS, and inline SVG.
+   - Use Mermaid only when diagrams-as-code materially improves maintainability
+     for flowcharts, sequence diagrams, state diagrams, ER diagrams, git graphs,
+     or dependency maps.
+   - Use Reveal.js only when the user asks for a slide deck or live
+     presentation.
+   - Use Shiki or Prism only when syntax highlighting improves comprehension.
+   - Use Chart.js only for simple quantitative charts.
+   - Use D3 or Observable Plot only for rich custom visualizations that cannot
+     be explained faster with a static diagram, table, or simple chart.
+
+3. Write the file where the user requested it.
+   - If the user does not specify a path, create it under `.context/`.
+   - Keep the output durable: no build step, no hidden local dependencies, and
+     no external assets unless the chosen library is clearly justified.
+
+4. Verify the document.
+   - Open or render the HTML when practical.
+   - Check laptop and mobile widths for readable text, non-overlapping layout,
+     legible diagrams, and useful visual hierarchy.
+   - Mention any checks that could not be run.
+
+## Required Document Structure
+
+Use progressive disclosure: orient first, then go deeper.
+
+1. Title and Audience
+   - Name the change plainly.
+   - State who the document is for and what they should understand after
+     reading.
+
+2. Executive Summary
+   - Include 3 to 5 bullets or cards.
+   - Cover what changed, why it changed, and the main operational impact.
+
+3. Mental Model
+   - Explain the system in simple terms before showing details.
+   - Include a small glossary for domain-specific terms.
+
+4. Before / After
+   - Show the architecture or workflow before and after.
+   - Prefer diagrams over prose-only explanations.
+
+5. Runtime or Data Flow
+   - Walk step by step from input to output.
+   - Show exactly where the new code plugs in.
+
+6. Code Map
+   - List important files or modules.
+   - For each one, explain its responsibility, what changed, and why it matters.
+   - Avoid dumping large diffs.
+
+7. Contracts and Examples
+   - Cover any API, config, data format, CLI, schema, event, or wire contract.
+   - Include one realistic example and explain each important field.
+
+8. Testing and Verification
+   - List tests added or updated.
+   - Include commands run and their results.
+   - Explain what the tests prove and what remains unproven.
+
+9. Risks, Boundaries, and Non-Goals
+   - Call out compatibility, rollout, performance, failure modes, and operational
+     risks.
+   - Say "not covered" or "not changed" where that prevents over-reading.
+
+10. FAQ / Review Guide
+    - Answer likely reviewer questions.
+    - Include "Where should I look first in code?"
+
+## Design Requirements
+
+- Use accessible text sizes, high contrast, and responsive layout.
+- Use headings, cards, callouts, tables, and diagrams to reduce memory load.
+- Do not rely on color alone; pair color with labels or shape.
+- Do not use tiny diagram text.
+- Add captions under diagrams explaining what to notice.
+- Keep snippets short and focused; highlight changed lines only when helpful.
+- Prefer concrete file names, module names, and runtime nouns.
+- Exclude decorative visuals that do not explain the change.
+
+## Useful Components
+
+- Summary cards: `What changed`, `Why`, `Impact`, `Risk`.
+- Architecture diagram: modules as boxes, calls or data movement as arrows.
+- Sequence diagram: request or runtime lifecycle.
+- File responsibility table: path, responsibility, change, reviewer note.
+- Contract table: field, meaning, default, validation.
+- Test matrix: scenario, test name, expected result.
+- Boundary callouts: `This does not do X`.
+- FAQ: common reviewer objections with concise answers.
+
+## Final Response
+
+After creating the HTML file, return:
+
+- The full path to the HTML file.
+- A short summary of what the document covers.
+- Any external libraries used and why.
+- Checks run, plus anything that could not be verified.

--- a/.codex/skills/explain-code-changes-html/SKILL.md
+++ b/.codex/skills/explain-code-changes-html/SKILL.md
@@ -21,6 +21,10 @@ engineering team understand a code change quickly and accurately.
 2. Choose the smallest useful presentation format.
    - Default to a single standalone `.html` file with semantic HTML,
      responsive CSS, and inline SVG.
+   - Use the Seline Analytics "Crisp Data Canvas" style in
+     `references/seline-style.md` as the default visual system unless the user
+     supplies another design system or the target repo has stronger local
+     styling conventions.
    - Use Mermaid only when diagrams-as-code materially improves maintainability
      for flowcharts, sequence diagrams, state diagrams, ER diagrams, git graphs,
      or dependency maps.
@@ -92,6 +96,9 @@ Use progressive disclosure: orient first, then go deeper.
 
 ## Design Requirements
 
+- For the default visual treatment, read
+  `references/seline-style.md` and apply its light analytics-dashboard palette,
+  compact spacing, subtle elevation, and functional component patterns.
 - Use accessible text sizes, high contrast, and responsive layout.
 - Use headings, cards, callouts, tables, and diagrams to reduce memory load.
 - Do not rely on color alone; pair color with labels or shape.

--- a/.codex/skills/explain-code-changes-html/agents/openai.yaml
+++ b/.codex/skills/explain-code-changes-html/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Explain Code Changes HTML"
+  short_description: "Create clear HTML explainers for code changes"
+  default_prompt: "Use $explain-code-changes-html to turn these code changes into a clear standalone HTML explainer."

--- a/.codex/skills/explain-code-changes-html/references/seline-style.md
+++ b/.codex/skills/explain-code-changes-html/references/seline-style.md
@@ -1,0 +1,120 @@
+# Seline Analytics Style Reference
+
+Use this reference when styling the standalone HTML explainer and the user has
+not supplied a different design system. Treat it as a functional analytics
+document style, not a marketing landing page.
+
+## Visual Direction
+
+- Theme: light.
+- Mood: crisp, lightweight, airy, and utilitarian.
+- Base: monochromatic neutrals with one vivid blue accent.
+- Layout: centered max-width content on a warm off-white page background, with
+  compact cards, subtle borders, and soft shadows.
+- Visuals: use diagrams, tables, screenshots, and minimal outlined icons to
+  explain the change. Avoid decorative imagery that does not clarify the code.
+
+## Color Tokens
+
+```css
+:root {
+  --cloud-white: #ffffff;
+  --canvas-fog: #fafaf9;
+  --slate-text: #0c0a09;
+  --ash-gray: #78716c;
+  --stone-border: #e5e7eb;
+  --platinum-outline: #d6d3d1;
+  --steel-gray: #a8a29e;
+  --hover-stone: #c9c5c2;
+  --ghost-ink: #1c1917;
+  --chartwell-blue: #3ba6f1;
+  --sky-tint: #c1e1f7;
+}
+```
+
+- Use `--canvas-fog` for the page background.
+- Use `--cloud-white` for cards, tables, controls, and document surfaces.
+- Use `--slate-text` for headings and primary copy.
+- Use `--ash-gray` for secondary text, helper text, and inactive icons.
+- Use `--steel-gray` for tertiary labels and low-priority details.
+- Use `--stone-border` and `--platinum-outline` for dividers and inputs.
+- Use `--chartwell-blue` only for primary actions, active states, links,
+  important data points, and brand accents.
+- Use `--sky-tint` sparingly for cool callouts or highlighted document bands.
+
+## Typography
+
+- Prefer Inter for body text, UI labels, captions, navigation, tables, and
+  descriptions. Fall back to `system-ui`.
+- Prefer roobert for headings and prominent display text when available. Fall
+  back to `sans-serif`.
+- Use practical sizes: `12px`, `13px`, `14px`, `15px`, `16px`, `18px`, `20px`,
+  `32px`, and only use `52px` for a true first-screen title.
+- Keep body line-height near `1.5` and headings near `1.2` to `1.25`.
+- Keep type lightweight: Inter `400`, `500`, `600`; roobert `400`, `500`.
+- Avoid negative letter spacing in generated explainers unless the target repo
+  already uses exact Seline brand typography tokens.
+
+## Spacing and Shape
+
+- Base spacing unit: `4px`.
+- Default section gap: `48px`.
+- Default card padding: `24px`.
+- Default element gap: `8px`.
+- Cards: `10px` radius.
+- Feature cards: `16px` radius.
+- Inputs: `4px` radius, or `6px` for rounded search/filter fields.
+- Tags, pills, and primary buttons: `9999px` radius.
+
+## Elevation
+
+```css
+:root {
+  --shadow-card: rgba(0, 0, 0, 0.05) 0 4px 16px 0;
+  --shadow-control: rgba(0, 0, 0, 0.05) 0 1px 2px 0;
+  --shadow-feature: rgba(17, 12, 46, 0.12) 0 12px 45px 0;
+  --shadow-icon: rgba(0, 0, 0, 0.1) 0 4px 6px -1px,
+    rgba(0, 0, 0, 0.1) 0 2px 4px -2px;
+}
+```
+
+- Use `--shadow-card` for dashboard cards and pill cards.
+- Use `--shadow-control` for compact navigation and buttons.
+- Reserve `--shadow-feature` for one or two prominent summary or hero panels.
+- Avoid heavy dark shadows.
+
+## Components
+
+- Primary filled button: `--chartwell-blue` background, white text, compact
+  pill shape.
+- Light ghost button: transparent background, `--ash-gray` text, optional
+  `--stone-border` border.
+- Dark ghost button: transparent background, `--slate-text` text,
+  `--stone-border` border, `4px` radius.
+- Subtle ghost button: lightly tinted gray background, `--slate-text` text,
+  `--stone-border` border, `4px` radius.
+- Dashboard card: white background, `10px` radius, `24px` padding,
+  `--shadow-card`.
+- Pill card: white background, pill radius, `4px 12px` padding,
+  `--shadow-card`.
+- Elevated feature card: white background, `16px` radius, compact inner padding,
+  `--shadow-feature`.
+- Standard input: white background, `--slate-text` text,
+  `--platinum-outline` border, square or `4px` radius.
+- Rounded search/filter input: white background, `--ash-gray` text,
+  `--platinum-outline` border, `6px` radius, `4px 12px` padding.
+
+## HTML Explainer Application
+
+- Build the first screen as a focused document header, not a product hero.
+- Put the executive summary in compact cards near the top.
+- Use full-width document sections or constrained content bands; avoid nested
+  cards.
+- Use tables for code maps, contract fields, and test matrices.
+- Use inline SVG or Mermaid diagrams inside white cards with captions.
+- Use blue for active states and key data only; do not add extra saturated
+  accent colors.
+- Keep controls and filters compact, with predictable placement.
+- Keep mobile layout single-column with readable tables, cards, and diagrams.
+- Preserve accessibility: high contrast, labels beyond color, no tiny diagram
+  text, and no text overlap.


### PR DESCRIPTION
## Intent

Add a checked-in Codex skill for producing standalone HTML explainers of code changes, so agents have a reusable workflow for turning diffs, PRs, migrations, and architecture updates into reviewer-friendly reference documents.

## What Changed

- Added `.codex/skills/explain-code-changes-html/SKILL.md` with the audited skill instructions.
- Added `agents/openai.yaml` metadata so the skill has a display name, short description, and default invocation prompt.
- Added `references/seline-style.md` as the default visual system for generated HTML explainers.

## Skill-Practice Audit

- Kept the full trigger context in the frontmatter description, where Codex decides whether to load the skill.
- Converted the pasted prompt guide into concise imperative workflow instructions instead of a large reusable prompt block.
- Put the detailed Seline design system in a one-hop reference file so Codex loads it only when styling the generated HTML.
- Preserved the important accuracy and design constraints: traceable claims, progressive disclosure, accessible layout, concrete file/module names, and explicit validation reporting.

## Not in This PR

- No Rust, CLI, MCP, API, or runtime behavior changes.
- No generated example HTML document.
- No external library dependencies are added to the repo.

## Validation

- `quick_validate.py .codex/skills/explain-code-changes-html` passed from a temporary virtualenv with PyYAML installed.
- `make rust-checks` was not run because this PR only adds Codex skill metadata/instructions and does not touch Rust code.