### PR TITLE
feat: error message audit

### DIFF
--- a/crates/coral-api/src/lib.rs
+++ b/crates/coral-api/src/lib.rs
@@ -73,11 +73,44 @@ pub const HTTP2_MAX_HEADER_LIST_SIZE: u32 = 128 * 1024;
 /// Coral error domain used in `google.rpc.ErrorInfo`.
 pub const CORAL_ERROR_DOMAIN: &str = "coral.withcoral.com";
 
+/// `ErrorInfo.reason` for a source name that does not resolve.
+pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
+
+/// `ErrorInfo.reason` for invalid request input.
+pub const CORAL_ERROR_REASON_INVALID_INPUT: &str = "INVALID_INPUT";
+
+/// `ErrorInfo.reason` for an incomplete source or app setup.
+pub const CORAL_ERROR_REASON_SETUP_REQUIRED: &str = "SETUP_REQUIRED";
+
+/// `ErrorInfo.reason` for unreadable or invalid saved credentials.
+pub const CORAL_ERROR_REASON_INVALID_SECRETS_FILE: &str = "INVALID_SECRETS_FILE";
+
+/// `ErrorInfo.reason` for an unavailable Coral config directory.
+pub const CORAL_ERROR_REASON_CONFIG_DIR_NOT_FOUND: &str = "CONFIG_DIR_NOT_FOUND";
+
+/// `ErrorInfo.reason` for local filesystem failures.
+pub const CORAL_ERROR_REASON_LOCAL_FILE_ERROR: &str = "LOCAL_FILE_ERROR";
+
+/// `ErrorInfo.reason` for Coral config write failures.
+pub const CORAL_ERROR_REASON_CONFIG_WRITE_FAILED: &str = "CONFIG_WRITE_FAILED";
+
+/// `ErrorInfo.reason` for saved credential read/write failures.
+pub const CORAL_ERROR_REASON_SECRETS_FILE_ERROR: &str = "SECRETS_FILE_ERROR";
+
+/// `ErrorInfo.reason` for an empty SQL request.
+pub const CORAL_ERROR_REASON_EMPTY_SQL: &str = "EMPTY_SQL";
+
+/// `ErrorInfo.reason` for SQL parser failures.
+pub const CORAL_ERROR_REASON_SQL_PARSE_ERROR: &str = "SQL_PARSE_ERROR";
+
+/// `ErrorInfo.reason` for an unknown SQL column reference.
+pub const CORAL_ERROR_REASON_UNKNOWN_COLUMN: &str = "UNKNOWN_COLUMN";
+
+/// `ErrorInfo.reason` for an unknown SQL table reference.
+pub const CORAL_ERROR_REASON_TABLE_NOT_FOUND: &str = "TABLE_NOT_FOUND";
+
 /// Canonical default workspace name used across local Coral surfaces.
 pub const DEFAULT_WORKSPACE_ID: &str = "default";
-
-/// Machine-readable reason for a configured source lookup miss.
-pub const CORAL_ERROR_REASON_SOURCE_NOT_FOUND: &str = "SOURCE_NOT_FOUND";
 
 /// Reserved `ErrorInfo.metadata` key for a one-line error summary.
 pub const CORAL_ERROR_METADATA_SUMMARY: &str = "summary";

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -68,31 +68,31 @@ impl AppError {
                 reason: CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
                 summary: format!("Source `{source}` was not found"),
                 detail: format!("No source named `{source}` is installed in this workspace."),
-                hint: Some("Run `coral source list` to see installed sources or `coral source discover` to see sources you can add.".to_string()),
+                hint: Some("List installed sources or discover available sources, then retry with a source that exists.".to_string()),
             },
             AppError::InvalidInput(detail) => ErrorDiagnostic {
                 reason: "INVALID_INPUT",
                 summary: "Input is invalid".to_string(),
                 detail: detail.clone(),
-                hint: Some("Check the command input and retry. Run `coral --help` or the subcommand help for valid values.".to_string()),
+                hint: Some("Check the request input and retry with valid values.".to_string()),
             },
             AppError::FailedPrecondition(detail) => ErrorDiagnostic {
                 reason: "SETUP_REQUIRED",
                 summary: "Setup is incomplete".to_string(),
                 detail: detail.clone(),
-                hint: Some("Run `coral source list` to inspect configured sources, then `coral source test <source>` for the source you are trying to use.".to_string()),
+                hint: Some("Inspect configured sources, then test the source you are trying to use.".to_string()),
             },
             AppError::MissingConfigDir => ErrorDiagnostic {
                 reason: "CONFIG_DIR_NOT_FOUND",
                 summary: "Coral could not find a config directory".to_string(),
                 detail: "The operating system did not provide a usable app config directory.".to_string(),
-                hint: Some("Set `CORAL_CONFIG_DIR` to a writable directory and retry.".to_string()),
+                hint: Some("Configure Coral with a writable config directory, then retry.".to_string()),
             },
             AppError::Io(error) => ErrorDiagnostic {
                 reason: "LOCAL_FILE_ERROR",
                 summary: "Coral could not read or write a local file".to_string(),
                 detail: error.to_string(),
-                hint: Some("Check that the path exists and that Coral can read and write its config directory. You can set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+                hint: Some("Check that the path exists and that Coral can read and write its config directory.".to_string()),
             },
             AppError::Yaml(error) => ErrorDiagnostic {
                 reason: "INVALID_YAML",
@@ -116,7 +116,7 @@ impl AppError {
                 reason: "CONFIG_WRITE_FAILED",
                 summary: "Coral could not write its config file".to_string(),
                 detail: error.to_string(),
-                hint: Some("Check permissions on the Coral config directory, or set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+                hint: Some("Check permissions on the Coral config directory, or use a writable config directory.".to_string()),
             },
             AppError::Json(error) => ErrorDiagnostic {
                 reason: "INVALID_JSON",
@@ -141,13 +141,13 @@ impl AppError {
                     reason: "INVALID_SECRETS_FILE",
                     summary: "Coral could not read saved source credentials".to_string(),
                     detail: detail.clone(),
-                    hint: Some("Re-run `coral source add <source> --interactive` for the affected source to refresh its saved credentials.".to_string()),
+                    hint: Some("Refresh the saved credentials for the affected source.".to_string()),
                 },
                 CredentialsError::Io(error) => ErrorDiagnostic {
                     reason: "SECRETS_FILE_ERROR",
                     summary: "Coral could not read or write saved source credentials".to_string(),
                     detail: error.to_string(),
-                    hint: Some("Check permissions on the Coral config directory, or set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+                    hint: Some("Check permissions on the Coral config directory, or use a writable config directory.".to_string()),
                 },
                 CredentialsError::Unavailable(detail) => ErrorDiagnostic {
                     reason: "SECRETS_STORE_UNAVAILABLE",
@@ -422,11 +422,8 @@ mod tests {
         assert_eq!(error.reason, "SOURCE_NOT_FOUND");
         assert_eq!(error.summary, "Source `github` was not found");
         assert!(error.detail.contains("No source named `github`"));
-        assert!(
-            error
-                .hint
-                .as_deref()
-                .is_some_and(|hint| hint.contains("coral source list"))
-        );
+        let hint = error.hint.as_deref().expect("hint");
+        assert!(hint.contains("List installed sources"));
+        assert!(!hint.contains("coral "));
     }
 }

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -10,6 +10,13 @@ use tonic_types::{ErrorDetail, StatusExt as _};
 
 use crate::credentials::CredentialsError;
 
+struct ErrorDiagnostic {
+    reason: &'static str,
+    summary: String,
+    detail: String,
+    hint: Option<String>,
+}
+
 /// Errors surfaced by the local application layer.
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
@@ -54,7 +61,115 @@ pub enum AppError {
     MissingConfigDir,
 }
 
-/// Upper bound on the byte length of a `tonic::Status` message (detail).
+impl AppError {
+    fn diagnostic(&self) -> ErrorDiagnostic {
+        match self {
+            AppError::SourceNotFound(source) => ErrorDiagnostic {
+                reason: CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+                summary: format!("Source `{source}` was not found"),
+                detail: format!("No source named `{source}` is installed in this workspace."),
+                hint: Some("Run `coral source list` to see installed sources or `coral source discover` to see sources you can add.".to_string()),
+            },
+            AppError::InvalidInput(detail) => ErrorDiagnostic {
+                reason: "INVALID_INPUT",
+                summary: "Input is invalid".to_string(),
+                detail: detail.clone(),
+                hint: Some("Check the command input and retry. Run `coral --help` or the subcommand help for valid values.".to_string()),
+            },
+            AppError::FailedPrecondition(detail) => ErrorDiagnostic {
+                reason: "SETUP_REQUIRED",
+                summary: "Setup is incomplete".to_string(),
+                detail: detail.clone(),
+                hint: Some("Run `coral source list` to inspect configured sources, then `coral source test <source>` for the source you are trying to use.".to_string()),
+            },
+            AppError::MissingConfigDir => ErrorDiagnostic {
+                reason: "CONFIG_DIR_NOT_FOUND",
+                summary: "Coral could not find a config directory".to_string(),
+                detail: "The operating system did not provide a usable app config directory.".to_string(),
+                hint: Some("Set `CORAL_CONFIG_DIR` to a writable directory and retry.".to_string()),
+            },
+            AppError::Io(error) => ErrorDiagnostic {
+                reason: "LOCAL_FILE_ERROR",
+                summary: "Coral could not read or write a local file".to_string(),
+                detail: error.to_string(),
+                hint: Some("Check that the path exists and that Coral can read and write its config directory. You can set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+            },
+            AppError::Yaml(error) => ErrorDiagnostic {
+                reason: "INVALID_YAML",
+                summary: "Source manifest YAML is invalid".to_string(),
+                detail: error.to_string(),
+                hint: Some("Fix the YAML file, then rerun the command.".to_string()),
+            },
+            AppError::TomlDecode(error) => ErrorDiagnostic {
+                reason: "INVALID_CONFIG",
+                summary: "Coral config file is invalid".to_string(),
+                detail: error.to_string(),
+                hint: Some("Fix the Coral config file or move it aside, then retry.".to_string()),
+            },
+            AppError::TomlEncode(error) => ErrorDiagnostic {
+                reason: "CONFIG_WRITE_FAILED",
+                summary: "Coral could not write its config file".to_string(),
+                detail: error.to_string(),
+                hint: Some("Check permissions on the Coral config directory, or set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+            },
+            AppError::Json(error) => ErrorDiagnostic {
+                reason: "INVALID_JSON",
+                summary: "Coral could not read or write JSON data".to_string(),
+                detail: error.to_string(),
+                hint: Some("Retry the command. If it keeps failing, check local Coral state files for invalid JSON.".to_string()),
+            },
+            AppError::Transport(error) => ErrorDiagnostic {
+                reason: "LOCAL_SERVER_ERROR",
+                summary: "Coral could not start or use the local server".to_string(),
+                detail: error.to_string(),
+                hint: Some("Retry the command. If you are starting the UI, check whether the selected port is already in use.".to_string()),
+            },
+            AppError::TaskJoin(error) => ErrorDiagnostic {
+                reason: "LOCAL_SERVER_TASK_FAILED",
+                summary: "The local Coral server stopped unexpectedly".to_string(),
+                detail: error.to_string(),
+                hint: Some("Retry the command. If it keeps failing, restart the terminal session and try again.".to_string()),
+            },
+            AppError::Credentials(error) => match error {
+                CredentialsError::Parse(detail) => ErrorDiagnostic {
+                    reason: "INVALID_SECRETS_FILE",
+                    summary: "Coral could not read saved source credentials".to_string(),
+                    detail: detail.clone(),
+                    hint: Some("Re-run `coral source add <source> --interactive` for the affected source to refresh its saved credentials.".to_string()),
+                },
+                CredentialsError::Io(error) => ErrorDiagnostic {
+                    reason: "SECRETS_FILE_ERROR",
+                    summary: "Coral could not read or write saved source credentials".to_string(),
+                    detail: error.to_string(),
+                    hint: Some("Check permissions on the Coral config directory, or set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+                },
+                CredentialsError::Unavailable(detail) => ErrorDiagnostic {
+                    reason: "SECRETS_STORE_UNAVAILABLE",
+                    summary: "Coral could not access saved source credentials".to_string(),
+                    detail: detail.clone(),
+                    hint: Some("Unlock or configure the system credential store, then retry.".to_string()),
+                },
+                CredentialsError::SnapshotStorageMismatch {
+                    snapshot,
+                    requested,
+                } => ErrorDiagnostic {
+                    reason: "SECRETS_STORAGE_MISMATCH",
+                    summary: "Saved source credentials use a different storage backend".to_string(),
+                    detail: format!(
+                        "The credential snapshot is stored in `{snapshot}`, but `{requested}` was requested."
+                    ),
+                    hint: Some(
+                        "Use the same credential storage backend or re-add the source credentials."
+                            .to_string(),
+                    ),
+                },
+            },
+        }
+    }
+}
+
+/// Upper bound on the byte length of a `tonic::Status` message or one
+/// structured presentation metadata value.
 ///
 /// gRPC `Status` details travel in HTTP/2 trailers; peers bound the total
 /// trailer set via `MAX_HEADER_LIST_SIZE` (default ~16 KiB on hyper/h2).
@@ -62,25 +177,25 @@ pub enum AppError {
 /// client's h2 stack reports `PROTOCOL_ERROR` instead of surfacing the
 /// status. 4 KiB leaves ample room for other trailer entries
 /// (`grpc-status`, `grpc-status-details-bin`, `content-type`, …).
-pub(crate) const MAX_STATUS_DETAIL_BYTES: usize = 4 * 1024;
+pub(crate) const MAX_STATUS_VALUE_BYTES: usize = 4 * 1024;
 
-/// Generic safety-net truncation for `tonic::Status` details.
+/// Generic safety-net truncation for `tonic::Status` values.
 ///
 /// Intentionally format-agnostic: no string heuristics on `DataFusion`
 /// error shapes, no "did you mean?" hints (those live in the structured
 /// error-conversion path where we have typed `Column` data — see
 /// `coral_engine::runtime::query`). This function's only job is to keep
 /// whatever string it's given under the trailer budget.
-fn truncate_status_detail(detail: String) -> String {
+fn truncate_status_value(value: String) -> String {
     const MARKER: &str = "… (truncated)";
-    if detail.len() <= MAX_STATUS_DETAIL_BYTES {
-        return detail;
+    if value.len() <= MAX_STATUS_VALUE_BYTES {
+        return value;
     }
-    let mut cut = MAX_STATUS_DETAIL_BYTES.saturating_sub(MARKER.len());
-    while cut > 0 && !detail.is_char_boundary(cut) {
+    let mut cut = MAX_STATUS_VALUE_BYTES.saturating_sub(MARKER.len());
+    while cut > 0 && !value.is_char_boundary(cut) {
         cut -= 1;
     }
-    let truncated = detail
+    let truncated = value
         .get(..cut)
         .expect("cut is adjusted to a UTF-8 character boundary");
     format!("{truncated}{MARKER}")
@@ -91,26 +206,43 @@ fn truncate_status_detail(detail: String) -> String {
     reason = "used directly as a map_err adapter across tonic service handlers"
 )]
 pub(crate) fn app_status(error: AppError) -> Status {
-    if matches!(error, AppError::SourceNotFound(_)) {
-        // The `reason` alone discriminates `SOURCE_NOT_FOUND` from other
-        // `Code::NotFound` causes (e.g. `io::ErrorKind::NotFound` raised
-        // when a manifest file is missing). The qualified name already
-        // appears in the truncated status message; we deliberately do
-        // not duplicate it into structured metadata so unbounded
-        // identifiers cannot push the `grpc-status-details-bin` trailer
-        // past the h2 `MAX_HEADER_LIST_SIZE` budget.
-        let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
-            CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
-            CORAL_ERROR_DOMAIN,
-            std::collections::HashMap::new(),
-        ))];
-        return Status::with_error_details_vec(
-            Code::NotFound,
-            truncate_status_detail(error.to_string()),
-            details,
+    let code = app_code(&error);
+    let diagnostic = error.diagnostic();
+    let mut metadata = std::collections::HashMap::new();
+    metadata.insert(
+        CORAL_ERROR_METADATA_SUMMARY.to_string(),
+        truncate_status_value(diagnostic.summary.clone()),
+    );
+
+    if !diagnostic.detail.is_empty() {
+        metadata.insert(
+            CORAL_ERROR_METADATA_DETAIL.to_string(),
+            truncate_status_value(diagnostic.detail.clone()),
         );
     }
-    Status::new(app_code(&error), truncate_status_detail(error.to_string()))
+
+    if let Some(hint) = &diagnostic.hint {
+        metadata.insert(
+            CORAL_ERROR_METADATA_HINT.to_string(),
+            truncate_status_value(hint.clone()),
+        );
+    }
+
+    let details = vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+        diagnostic.reason,
+        CORAL_ERROR_DOMAIN,
+        metadata,
+    ))];
+
+    Status::with_error_details_vec(
+        code,
+        truncate_status_value(render_plain_message(
+            &diagnostic.summary,
+            &diagnostic.detail,
+            diagnostic.hint.as_deref(),
+        )),
+        details,
+    )
 }
 
 pub(crate) fn core_status(error: CoreError) -> Status {
@@ -119,16 +251,19 @@ pub(crate) fn core_status(error: CoreError) -> Status {
             let mut metadata = sqe.metadata().clone();
             metadata.insert(
                 CORAL_ERROR_METADATA_SUMMARY.to_string(),
-                sqe.summary().to_string(),
+                truncate_status_value(sqe.summary().to_string()),
             );
             if !sqe.detail().is_empty() {
                 metadata.insert(
                     CORAL_ERROR_METADATA_DETAIL.to_string(),
-                    truncate_status_detail(sqe.detail().to_string()),
+                    truncate_status_value(sqe.detail().to_string()),
                 );
             }
             if let Some(hint) = sqe.hint() {
-                metadata.insert(CORAL_ERROR_METADATA_HINT.to_string(), hint.to_string());
+                metadata.insert(
+                    CORAL_ERROR_METADATA_HINT.to_string(),
+                    truncate_status_value(hint.to_string()),
+                );
             }
 
             let mut details: Vec<ErrorDetail> = vec![ErrorDetail::ErrorInfo(
@@ -141,13 +276,13 @@ pub(crate) fn core_status(error: CoreError) -> Status {
             let plain = render_plain_message(sqe.summary(), sqe.detail(), sqe.hint());
             Status::with_error_details_vec(
                 grpc_code(sqe.status()),
-                truncate_status_detail(plain),
+                truncate_status_value(plain),
                 details,
             )
         }
         other => Status::new(
             grpc_code(other.status_code()),
-            truncate_status_detail(other.to_string()),
+            truncate_status_value(other.to_string()),
         ),
     }
 }
@@ -203,16 +338,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn truncate_status_detail_leaves_short_detail_unchanged() {
-        let detail = "short message".to_string();
-        assert_eq!(truncate_status_detail(detail.clone()), detail);
+    fn truncate_status_value_leaves_short_value_unchanged() {
+        let value = "short message".to_string();
+        assert_eq!(truncate_status_value(value.clone()), value);
     }
 
     #[test]
-    fn truncate_status_detail_caps_long_ascii_and_marks_it() {
-        let detail = "x".repeat(20 * 1024);
-        let out = truncate_status_detail(detail);
-        assert!(out.len() <= MAX_STATUS_DETAIL_BYTES);
+    fn truncate_status_value_caps_long_ascii_and_marks_it() {
+        let value = "x".repeat(20 * 1024);
+        let out = truncate_status_value(value);
+        assert!(out.len() <= MAX_STATUS_VALUE_BYTES);
         assert!(out.ends_with("… (truncated)"), "missing marker: {out:?}");
     }
 
@@ -231,38 +366,61 @@ mod tests {
             .expect("source-not-found status must carry an ErrorInfo detail");
         assert_eq!(info.reason, CORAL_ERROR_REASON_SOURCE_NOT_FOUND);
         assert_eq!(info.domain, CORAL_ERROR_DOMAIN);
-        // The reason alone is the discriminator; we intentionally do
-        // not echo unbounded identifiers into structured metadata.
         assert!(
-            info.metadata.is_empty(),
-            "SOURCE_NOT_FOUND must not carry unbounded identifier metadata: {:?}",
+            info.metadata
+                .get(CORAL_ERROR_METADATA_SUMMARY)
+                .is_some_and(|summary| summary.contains("default:hn")),
+            "SOURCE_NOT_FOUND should carry bounded presentation metadata: {:?}",
             info.metadata
         );
     }
 
     #[test]
-    fn app_status_does_not_attach_structured_reason_for_io_not_found() {
+    fn app_status_does_not_attach_source_not_found_reason_for_io_not_found() {
         let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "manifest missing");
         let status = app_status(AppError::Io(io_error));
-        // Same gRPC code as SourceNotFound — but no Coral ErrorInfo, so
-        // clients can't confuse a broken local manifest for a missing
-        // catalog entry.
         assert_eq!(status.code(), Code::NotFound);
-        assert!(
-            status.get_error_details_vec().is_empty(),
-            "io::NotFound must not carry SOURCE_NOT_FOUND details"
-        );
+
+        let details = status.get_error_details_vec();
+        let info = details
+            .iter()
+            .find_map(|detail| match detail {
+                ErrorDetail::ErrorInfo(info) => Some(info),
+                _ => None,
+            })
+            .expect("io::NotFound status should carry diagnostic details");
+        assert_ne!(info.reason, CORAL_ERROR_REASON_SOURCE_NOT_FOUND);
     }
 
     #[test]
-    fn truncate_status_detail_preserves_utf8_boundaries() {
+    fn truncate_status_value_preserves_utf8_boundaries() {
         // Fill with a 4-byte codepoint so the raw-byte cut point is
         // guaranteed to land mid-codepoint and must be walked backwards.
-        let detail = "𝕏".repeat(2 * 1024); // 4 bytes per char → 8 KiB total
-        let out = truncate_status_detail(detail);
-        assert!(out.len() <= MAX_STATUS_DETAIL_BYTES);
+        let value = "𝕏".repeat(2 * 1024); // 4 bytes per char → 8 KiB total
+        let out = truncate_status_value(value);
+        assert!(out.len() <= MAX_STATUS_VALUE_BYTES);
         // Result must still be valid UTF-8 (guaranteed by String type) and
         // end with the truncation marker.
         assert!(out.ends_with("… (truncated)"));
+    }
+
+    #[test]
+    fn app_status_source_not_found_is_structured() {
+        let status = app_status(AppError::SourceNotFound("github".to_string()));
+        let decoded = coral_client::decode_status_error(&status);
+
+        let coral_client::DecodedStatusError::Structured(error) = decoded else {
+            panic!("expected structured error");
+        };
+
+        assert_eq!(error.reason, "SOURCE_NOT_FOUND");
+        assert_eq!(error.summary, "Source `github` was not found");
+        assert!(error.detail.contains("No source named `github`"));
+        assert!(
+            error
+                .hint
+                .as_deref()
+                .is_some_and(|hint| hint.contains("coral source list"))
+        );
     }
 }

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -2,7 +2,11 @@
 
 use coral_api::{
     CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
-    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_CONFIG_DIR_NOT_FOUND,
+    CORAL_ERROR_REASON_CONFIG_WRITE_FAILED, CORAL_ERROR_REASON_INVALID_INPUT,
+    CORAL_ERROR_REASON_INVALID_SECRETS_FILE, CORAL_ERROR_REASON_LOCAL_FILE_ERROR,
+    CORAL_ERROR_REASON_SECRETS_FILE_ERROR, CORAL_ERROR_REASON_SETUP_REQUIRED,
+    CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
 };
 use coral_engine::{CoreError, StatusCode};
 use tonic::{Code, Status};
@@ -71,25 +75,25 @@ impl AppError {
                 hint: Some("List installed sources or discover available sources, then retry with a source that exists.".to_string()),
             },
             AppError::InvalidInput(detail) => ErrorDiagnostic {
-                reason: "INVALID_INPUT",
+                reason: CORAL_ERROR_REASON_INVALID_INPUT,
                 summary: "Input is invalid".to_string(),
                 detail: detail.clone(),
                 hint: Some("Check the request input and retry with valid values.".to_string()),
             },
             AppError::FailedPrecondition(detail) => ErrorDiagnostic {
-                reason: "SETUP_REQUIRED",
+                reason: CORAL_ERROR_REASON_SETUP_REQUIRED,
                 summary: "Setup is incomplete".to_string(),
                 detail: detail.clone(),
                 hint: Some("Inspect configured sources, then test the source you are trying to use.".to_string()),
             },
             AppError::MissingConfigDir => ErrorDiagnostic {
-                reason: "CONFIG_DIR_NOT_FOUND",
+                reason: CORAL_ERROR_REASON_CONFIG_DIR_NOT_FOUND,
                 summary: "Coral could not find a config directory".to_string(),
                 detail: "The operating system did not provide a usable app config directory.".to_string(),
                 hint: Some("Configure Coral with a writable config directory, then retry.".to_string()),
             },
             AppError::Io(error) => ErrorDiagnostic {
-                reason: "LOCAL_FILE_ERROR",
+                reason: CORAL_ERROR_REASON_LOCAL_FILE_ERROR,
                 summary: "Coral could not read or write a local file".to_string(),
                 detail: error.to_string(),
                 hint: Some("Check that the path exists and that Coral can read and write its config directory.".to_string()),
@@ -113,7 +117,7 @@ impl AppError {
                 hint: Some("Fix the Coral config file or move it aside, then retry.".to_string()),
             },
             AppError::TomlEncode(error) => ErrorDiagnostic {
-                reason: "CONFIG_WRITE_FAILED",
+                reason: CORAL_ERROR_REASON_CONFIG_WRITE_FAILED,
                 summary: "Coral could not write its config file".to_string(),
                 detail: error.to_string(),
                 hint: Some("Check permissions on the Coral config directory, or use a writable config directory.".to_string()),
@@ -138,13 +142,13 @@ impl AppError {
             },
             AppError::Credentials(error) => match error {
                 CredentialsError::Parse(detail) => ErrorDiagnostic {
-                    reason: "INVALID_SECRETS_FILE",
+                    reason: CORAL_ERROR_REASON_INVALID_SECRETS_FILE,
                     summary: "Coral could not read saved source credentials".to_string(),
                     detail: detail.clone(),
                     hint: Some("Refresh the saved credentials for the affected source.".to_string()),
                 },
                 CredentialsError::Io(error) => ErrorDiagnostic {
-                    reason: "SECRETS_FILE_ERROR",
+                    reason: CORAL_ERROR_REASON_SECRETS_FILE_ERROR,
                     summary: "Coral could not read or write saved source credentials".to_string(),
                     detail: error.to_string(),
                     hint: Some("Check permissions on the Coral config directory, or use a writable config directory.".to_string()),

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -140,41 +140,45 @@ impl AppError {
                 detail: error.to_string(),
                 hint: Some("Retry the command. If it keeps failing, restart the terminal session and try again.".to_string()),
             },
-            AppError::Credentials(error) => match error {
-                CredentialsError::Parse(detail) => ErrorDiagnostic {
-                    reason: CORAL_ERROR_REASON_INVALID_SECRETS_FILE,
-                    summary: "Coral could not read saved source credentials".to_string(),
-                    detail: detail.clone(),
-                    hint: Some("Refresh the saved credentials for the affected source.".to_string()),
-                },
-                CredentialsError::Io(error) => ErrorDiagnostic {
-                    reason: CORAL_ERROR_REASON_SECRETS_FILE_ERROR,
-                    summary: "Coral could not read or write saved source credentials".to_string(),
-                    detail: error.to_string(),
-                    hint: Some("Check permissions on the Coral config directory, or use a writable config directory.".to_string()),
-                },
-                CredentialsError::Unavailable(detail) => ErrorDiagnostic {
-                    reason: "SECRETS_STORE_UNAVAILABLE",
-                    summary: "Coral could not access saved source credentials".to_string(),
-                    detail: detail.clone(),
-                    hint: Some("Unlock or configure the system credential store, then retry.".to_string()),
-                },
-                CredentialsError::SnapshotStorageMismatch {
-                    snapshot,
-                    requested,
-                } => ErrorDiagnostic {
-                    reason: "SECRETS_STORAGE_MISMATCH",
-                    summary: "Saved source credentials use a different storage backend".to_string(),
-                    detail: format!(
-                        "The credential snapshot is stored in `{snapshot}`, but `{requested}` was requested."
-                    ),
-                    hint: Some(
-                        "Use the same credential storage backend or re-add the source credentials."
-                            .to_string(),
-                    ),
-                },
-            },
+            AppError::Credentials(error) => credentials_diagnostic(error),
         }
+    }
+}
+
+fn credentials_diagnostic(error: &CredentialsError) -> ErrorDiagnostic {
+    match error {
+        CredentialsError::Parse(detail) => ErrorDiagnostic {
+            reason: CORAL_ERROR_REASON_INVALID_SECRETS_FILE,
+            summary: "Coral could not read saved source credentials".to_string(),
+            detail: detail.clone(),
+            hint: Some("Refresh the saved credentials for the affected source.".to_string()),
+        },
+        CredentialsError::Io(error) => ErrorDiagnostic {
+            reason: CORAL_ERROR_REASON_SECRETS_FILE_ERROR,
+            summary: "Coral could not read or write saved source credentials".to_string(),
+            detail: error.to_string(),
+            hint: Some("Check permissions on the Coral config directory, or use a writable config directory.".to_string()),
+        },
+        CredentialsError::Unavailable(detail) => ErrorDiagnostic {
+            reason: "SECRETS_STORE_UNAVAILABLE",
+            summary: "Coral could not access saved source credentials".to_string(),
+            detail: detail.clone(),
+            hint: Some("Unlock or configure the system credential store, then retry.".to_string()),
+        },
+        CredentialsError::SnapshotStorageMismatch {
+            snapshot,
+            requested,
+        } => ErrorDiagnostic {
+            reason: "SECRETS_STORAGE_MISMATCH",
+            summary: "Saved source credentials use a different storage backend".to_string(),
+            detail: format!(
+                "The credential snapshot is stored in `{snapshot}`, but `{requested}` was requested."
+            ),
+            hint: Some(
+                "Use the same credential storage backend or re-add the source credentials."
+                    .to_string(),
+            ),
+        },
     }
 }
 

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -106,6 +106,12 @@ impl AppError {
                 detail: error.to_string(),
                 hint: Some("Fix the Coral config file or move it aside, then retry.".to_string()),
             },
+            AppError::TomlEditDecode(error) => ErrorDiagnostic {
+                reason: "INVALID_CONFIG",
+                summary: "Coral config file is invalid".to_string(),
+                detail: error.to_string(),
+                hint: Some("Fix the Coral config file or move it aside, then retry.".to_string()),
+            },
             AppError::TomlEncode(error) => ErrorDiagnostic {
                 reason: "CONFIG_WRITE_FAILED",
                 summary: "Coral could not write its config file".to_string(),

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -10,7 +10,7 @@ mod server;
 use crate::state::AppStateLayout;
 
 #[cfg(test)]
-pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
+pub(crate) use error::MAX_STATUS_VALUE_BYTES;
 pub(crate) use error::{app_status, core_status};
 
 pub use error::AppError;

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -1250,7 +1250,7 @@ tables:
     async fn invalid_column_on_wide_manifest_returns_clean_status() {
         use std::fmt::Write as _;
 
-        use crate::bootstrap::MAX_STATUS_DETAIL_BYTES;
+        use crate::bootstrap::MAX_STATUS_VALUE_BYTES;
 
         let temp = TempDir::new().expect("temp dir");
         let config_dir = temp.path().join("coral-config");
@@ -1350,8 +1350,8 @@ tables:
             status.message()
         );
         assert!(
-            status.message().len() <= MAX_STATUS_DETAIL_BYTES,
-            "status message was {} bytes; truncator should have clipped it to <= {MAX_STATUS_DETAIL_BYTES}",
+            status.message().len() <= MAX_STATUS_VALUE_BYTES,
+            "status message was {} bytes; truncator should have clipped it to <= {MAX_STATUS_VALUE_BYTES}",
             status.message().len(),
         );
         assert!(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
+use coral_api::{CORAL_ERROR_REASON_INVALID_INPUT, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,
     QueryRuntimeContext, QuerySource, SourceValidationReport, StatusCode, TableInfo,
@@ -346,8 +347,8 @@ fn query_error_message(error: &QueryManagerError) -> String {
 
 fn app_error_type(error: &AppError) -> &'static str {
     match error {
-        AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
-        AppError::InvalidInput(_) => "INVALID_INPUT",
+        AppError::SourceNotFound(_) => CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+        AppError::InvalidInput(_) => CORAL_ERROR_REASON_INVALID_INPUT,
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
         AppError::Io(_) => "IO",
         AppError::Yaml(_) => "YAML",

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -167,9 +167,11 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<QuerySource>, AppError> {
         let catalog = self.config_store.load_catalog()?;
+        let sources = catalog.workspace_sources(workspace_name);
         let mut query_sources = Vec::new();
-        for source in catalog.workspace_sources(workspace_name) {
-            match self.load_query_source(workspace_name, &source) {
+        let mut load_failures = Vec::new();
+        for source in &sources {
+            match self.load_query_source(workspace_name, source) {
                 Ok((query_source, _version)) => query_sources.push(query_source),
                 Err(error @ AppError::Credentials(CredentialsError::Unavailable(_))) => {
                     return Err(error);
@@ -180,8 +182,16 @@ impl QueryManager {
                         detail = %error,
                         "skipping source during query-source load"
                     );
+                    load_failures.push(format!("{}: {error}", source.name));
                 }
             }
+        }
+        if !sources.is_empty() && query_sources.is_empty() {
+            return Err(AppError::FailedPrecondition(format!(
+                "no installed sources could be loaded for workspace '{}': {}",
+                workspace_name.as_str(),
+                load_failures.join("; ")
+            )));
         }
         Ok(query_sources)
     }

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -505,7 +505,9 @@ mod tests {
                     error.detail,
                     "No source named `users` is installed in this workspace."
                 );
-                assert!(error.hint.as_deref().unwrap().contains("coral source list"));
+                let hint = error.hint.as_deref().expect("hint");
+                assert!(hint.contains("List installed sources"));
+                assert!(!hint.contains("coral "));
             }
             DecodedStatusError::Plain(message) => {
                 panic!("expected structured app status, got plain message: {message}")
@@ -572,7 +574,9 @@ mod tests {
                 assert_eq!(error.reason, "INVALID_INPUT");
                 assert_eq!(error.summary, "Input is invalid");
                 assert_eq!(error.detail, "missing workspace");
-                assert!(error.hint.as_deref().unwrap().contains("coral --help"));
+                let hint = error.hint.as_deref().expect("hint");
+                assert!(hint.contains("Check the request input"));
+                assert!(!hint.contains("coral "));
             }
             DecodedStatusError::Plain(message) => {
                 panic!("expected structured app status, got plain message: {message}")

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -485,6 +485,7 @@ mod tests {
     use crate::bootstrap::AppError;
     use crate::query::manager::QueryManagerError;
     use crate::workspaces::WorkspaceName;
+    use coral_client::{DecodedStatusError, decode_status_error};
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo,
     };
@@ -496,7 +497,20 @@ mod tests {
         )));
 
         assert_eq!(status.code(), Code::NotFound);
-        assert_eq!(status.message(), "source 'users' not found");
+        match decode_status_error(&status) {
+            DecodedStatusError::Structured(error) => {
+                assert_eq!(error.reason, "SOURCE_NOT_FOUND");
+                assert_eq!(error.summary, "Source `users` was not found");
+                assert_eq!(
+                    error.detail,
+                    "No source named `users` is installed in this workspace."
+                );
+                assert!(error.hint.as_deref().unwrap().contains("coral source list"));
+            }
+            DecodedStatusError::Plain(message) => {
+                panic!("expected structured app status, got plain message: {message}")
+            }
+        }
     }
 
     #[test]
@@ -553,7 +567,17 @@ mod tests {
         let status = workspace_name_from_proto(None).expect_err("workspace should be required");
 
         assert_eq!(status.code(), Code::InvalidArgument);
-        assert_eq!(status.message(), "invalid input: missing workspace");
+        match decode_status_error(&status) {
+            DecodedStatusError::Structured(error) => {
+                assert_eq!(error.reason, "INVALID_INPUT");
+                assert_eq!(error.summary, "Input is invalid");
+                assert_eq!(error.detail, "missing workspace");
+                assert!(error.hint.as_deref().unwrap().contains("coral --help"));
+            }
+            DecodedStatusError::Plain(message) => {
+                panic!("expected structured app status, got plain message: {message}")
+            }
+        }
     }
 
     #[test]

--- a/crates/coral-app/tests/grpc/resilience_tests.rs
+++ b/crates/coral-app/tests/grpc/resilience_tests.rs
@@ -7,7 +7,10 @@
 use std::fs;
 
 use coral_api::v1::{ExecuteSqlRequest, SourceSecret, SourceVariable};
-use coral_client::{batches_to_json_rows, decode_execute_sql_response, default_workspace};
+use coral_client::{
+    DecodedStatusError, batches_to_json_rows, decode_execute_sql_response, decode_status_error,
+    default_workspace,
+};
 use tonic::Request;
 
 use crate::harness::{GrpcHarness, fixture_manifest_with_inputs_yaml, fixture_manifest_yaml};
@@ -88,4 +91,69 @@ async fn broken_source_does_not_block_healthy_sources() {
         .await
         .expect_err("broken source query should fail");
     assert_eq!(broken.code(), tonic::Code::NotFound);
+}
+
+#[tokio::test]
+async fn all_broken_sources_return_setup_error_instead_of_empty_catalog() {
+    let harness = GrpcHarness::new().await;
+
+    harness
+        .import_source(
+            fixture_manifest_with_inputs_yaml(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
+            }],
+        )
+        .await;
+
+    fs::remove_file(
+        harness
+            .config_dir()
+            .join("workspaces")
+            .join("default")
+            .join("sources")
+            .join("secured_messages")
+            .join("secrets.env"),
+    )
+    .expect("remove broken source secret file");
+
+    let status = harness
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SELECT * FROM secured_messages.messages".to_string(),
+        }))
+        .await
+        .expect_err("query should fail before empty catalog fallback");
+
+    assert_eq!(status.code(), tonic::Code::FailedPrecondition);
+    match decode_status_error(&status) {
+        DecodedStatusError::Structured(error) => {
+            assert_eq!(error.reason, "SETUP_REQUIRED");
+            assert!(
+                error
+                    .detail
+                    .contains("no installed sources could be loaded"),
+                "expected load-failure detail: {}",
+                error.detail
+            );
+            assert!(
+                error.detail.contains("secured_messages"),
+                "expected source name in detail: {}",
+                error.detail
+            );
+            assert!(
+                !error.metadata.contains_key("catalog_empty"),
+                "setup failures must not masquerade as an empty queryable catalog"
+            );
+        }
+        DecodedStatusError::Plain(message) => {
+            panic!("expected structured setup error, got plain message: {message}");
+        }
+    }
 }

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -28,22 +28,33 @@ impl Bootstrap {
 pub(crate) enum BootstrapError {
     #[error(transparent)]
     Startup(#[from] LocalServerError),
-    #[error(transparent)]
-    Connect(#[from] ClientError),
+    #[error("failed to connect to Coral endpoint '{endpoint}': {source}")]
+    Connect {
+        endpoint: String,
+        #[source]
+        source: ClientError,
+    },
 }
 
 pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, BootstrapError> {
     if let Some(endpoint) = bootstrap_endpoint() {
-        return Ok(Bootstrap {
-            app: AppClient::connect(&endpoint).await?,
-            server: None,
-        });
+        let app =
+            AppClient::connect(&endpoint)
+                .await
+                .map_err(|source| BootstrapError::Connect {
+                    endpoint: endpoint.clone(),
+                    source,
+                })?;
+        return Ok(Bootstrap { app, server: None });
     }
 
     let server = configure_server_builder(ServerBuilder::new(), options)
         .start()
         .await?;
-    let app = AppClient::connect(server.endpoint_uri()).await?;
+    let endpoint = server.endpoint_uri().to_string();
+    let app = AppClient::connect(&endpoint)
+        .await
+        .map_err(|source| BootstrapError::Connect { endpoint, source })?;
     Ok(Bootstrap {
         app,
         server: Some(server),

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -418,24 +418,60 @@ fn render_diagnostic(
 
 fn render_status_diagnostic(status: &tonic::Status) -> String {
     match decode_status_error(status) {
-        DecodedStatusError::Structured(error) => render_diagnostic(
-            error.summary,
-            if error.detail.is_empty() {
+        DecodedStatusError::Structured(error) => {
+            let coral_client::CoralQueryError {
+                reason,
+                summary,
+                detail,
+                hint: server_hint,
+                ..
+            } = *error;
+            let hint = cli_hint_for_app_reason(&reason).map_or_else(
+                || server_hint.unwrap_or_else(|| default_server_status_hint().to_string()),
+                str::to_string,
+            );
+            let detail = if detail.is_empty() {
                 status.message().to_string()
             } else {
-                error.detail
-            },
-            error.hint.unwrap_or_else(|| {
-                "Retry the command. If it keeps failing, check source setup and local Coral state."
-                    .to_string()
-            }),
-        ),
+                detail
+            };
+            render_diagnostic(summary, detail, hint)
+        }
         DecodedStatusError::Plain(message) => render_diagnostic(
             "Coral server request failed",
             message,
-            "Retry the command. If it keeps failing, check source setup and local Coral state.",
+            default_server_status_hint(),
         ),
     }
+}
+
+pub(crate) fn cli_hint_for_app_reason(reason: &str) -> Option<&'static str> {
+    match reason {
+        "SOURCE_NOT_FOUND" => Some(
+            "Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.",
+        ),
+        "INVALID_INPUT" => Some(
+            "Check the command input and retry. Run `coral --help` or the subcommand help for valid values.",
+        ),
+        "SETUP_REQUIRED" => Some(
+            "Run `coral source list` to inspect configured sources, then `coral source test <source>` for the source you are trying to use.",
+        ),
+        "INVALID_SECRETS_FILE" => Some(
+            "Re-run `coral source add <source> --interactive` for the affected source to refresh its saved credentials.",
+        ),
+        "CONFIG_DIR_NOT_FOUND" => Some("Set `CORAL_CONFIG_DIR` to a writable directory and retry."),
+        "LOCAL_FILE_ERROR" => Some(
+            "Check that the path exists and that Coral can read and write its config directory. You can set `CORAL_CONFIG_DIR` to a writable directory.",
+        ),
+        "CONFIG_WRITE_FAILED" | "SECRETS_FILE_ERROR" => Some(
+            "Check permissions on the Coral config directory, or set `CORAL_CONFIG_DIR` to a writable directory.",
+        ),
+        _ => None,
+    }
+}
+
+fn default_server_status_hint() -> &'static str {
+    "Retry the command. If it keeps failing, check source setup and local Coral state."
 }
 
 impl Command {

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -31,8 +31,8 @@ use coral_api::v1::ExecuteSqlRequest;
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
-    AppClient, decode_execute_sql_response, default_workspace, format_batches_json,
-    format_batches_table, manifest_input_from_proto,
+    AppClient, DecodedStatusError, decode_execute_sql_response, decode_status_error,
+    default_workspace, format_batches_json, format_batches_table, manifest_input_from_proto,
 };
 use dialoguer::console::measure_text_width;
 use tonic::Request;
@@ -328,24 +328,55 @@ pub enum CliError {
         /// Normalized source name requested by the user.
         source_name: String,
     },
+    /// A non-query command failed with a rendered user-facing diagnostic.
+    #[error("command failed")]
+    Diagnostic {
+        /// Complete stderr diagnostic rendered for the command failure.
+        rendered_stderr: String,
+    },
     /// Any non-renderable internal command failure.
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }
 
 impl CliError {
+    pub(crate) fn diagnostic(
+        summary: impl AsRef<str>,
+        detail: impl AsRef<str>,
+        hint: impl AsRef<str>,
+    ) -> Self {
+        Self::Diagnostic {
+            rendered_stderr: render_diagnostic(summary, detail, hint),
+        }
+    }
+
+    pub(crate) fn server_status(status: &tonic::Status) -> Self {
+        Self::Diagnostic {
+            rendered_stderr: render_status_diagnostic(status),
+        }
+    }
+
     #[must_use]
     /// Returns stderr content for user-facing CLI failures.
     pub fn rendered_stderr(&self) -> Option<String> {
         match self {
             Self::Query {
                 rendered_stderr, ..
-            } => Some(rendered_stderr.clone()),
-            Self::SourceNotInstalled { source_name } => Some(format!(
-                "source '{source_name}' is not installed. Run `coral source add {source_name}` to install it, then retry `coral source test {source_name}`.\n"
+            }
+            | Self::Diagnostic { rendered_stderr } => Some(rendered_stderr.clone()),
+            Self::SourceNotInstalled { source_name } => Some(render_diagnostic(
+                format!("Source `{source_name}` is not installed"),
+                format!(
+                    "`{source_name}` is available as a bundled source, but it has not been added to this workspace."
+                ),
+                format!(
+                    "Run `coral source add {source_name}`, then retry `coral source test {source_name}`."
+                ),
             )),
-            Self::SourceNotFound { source_name } => Some(format!(
-                "source '{source_name}' was not found. Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.\n"
+            Self::SourceNotFound { source_name } => Some(render_diagnostic(
+                format!("Source `{source_name}` was not found"),
+                format!("No installed or bundled source named `{source_name}` exists."),
+                "Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.",
             )),
             Self::SourceRemoveNotFound { source_name } => Some(format!(
                 "source '{source_name}' was not found. Run `coral source list` to see installed sources.\n"
@@ -355,13 +386,69 @@ impl CliError {
     }
 }
 
+impl From<bootstrap::BootstrapError> for CliError {
+    fn from(error: bootstrap::BootstrapError) -> Self {
+        match error {
+            bootstrap::BootstrapError::Startup(error) => Self::diagnostic(
+                "Coral could not start the local server",
+                error.to_string(),
+                "Retry the command. If it keeps failing, set `CORAL_CONFIG_DIR` to a writable directory and try again.",
+            ),
+            bootstrap::BootstrapError::Connect { endpoint, source } => Self::diagnostic(
+                "Coral could not connect to the local server",
+                format!("Failed to connect to `{endpoint}`: {source}"),
+                "Retry the command. If you set `CORAL_ENDPOINT`, check that it points to a running Coral server.",
+            ),
+        }
+    }
+}
+
+fn render_diagnostic(
+    summary: impl AsRef<str>,
+    detail: impl AsRef<str>,
+    hint: impl AsRef<str>,
+) -> String {
+    format!(
+        "Error: {}\nDetail: {}\nHint: {}\n",
+        summary.as_ref(),
+        detail.as_ref(),
+        hint.as_ref()
+    )
+}
+
+fn render_status_diagnostic(status: &tonic::Status) -> String {
+    match decode_status_error(status) {
+        DecodedStatusError::Structured(error) => render_diagnostic(
+            error.summary,
+            if error.detail.is_empty() {
+                status.message().to_string()
+            } else {
+                error.detail
+            },
+            error.hint.unwrap_or_else(|| {
+                "Retry the command. If it keeps failing, check source setup and local Coral state."
+                    .to_string()
+            }),
+        ),
+        DecodedStatusError::Plain(message) => render_diagnostic(
+            "Coral server request failed",
+            message,
+            "Retry the command. If it keeps failing, check source setup and local Coral state.",
+        ),
+    }
+}
+
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
+            Command::Source(SourceArgs {
+                command: SourceCommand::Lint { .. },
+            })
+            | Command::Features(_)
+            | Command::Completion(_) => RequiredRuntime::None,
             Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
                 RequiredRuntime::AppClient
             }
-            Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
         }
@@ -380,6 +467,7 @@ impl coral_app::RunErrorTelemetry for CliError {
             Self::SourceNotFound { .. } | Self::SourceRemoveNotFound { .. } => {
                 Cow::Borrowed("SOURCE_NOT_FOUND")
             }
+            Self::Diagnostic { .. } => Cow::Borrowed("COMMAND_FAILED"),
             Self::Internal(_) => Cow::Borrowed("INTERNAL"),
         }
     }
@@ -393,9 +481,19 @@ impl coral_app::RunErrorTelemetry for CliError {
             Self::SourceNotFound { source_name } | Self::SourceRemoveNotFound { source_name } => {
                 Cow::Owned(format!("source '{source_name}' was not found"))
             }
+            Self::Diagnostic { rendered_stderr } => Cow::Owned(diagnostic_summary(rendered_stderr)),
             Self::Internal(error) => Cow::Owned(error.to_string()),
         }
     }
+}
+
+fn diagnostic_summary(rendered_stderr: &str) -> String {
+    rendered_stderr
+        .lines()
+        .next()
+        .and_then(|line| line.strip_prefix("Error: "))
+        .unwrap_or("command failed")
+        .to_string()
 }
 
 /// Returns whether this CLI invocation should render telemetry logs to stderr.
@@ -442,8 +540,7 @@ pub async fn run_from_env() -> Result<(), CliError> {
             let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
                 enable_stderr_logs: command.enables_stderr_logs(),
             })
-            .await
-            .map_err(anyhow::Error::from)?;
+            .await?;
             let app = bootstrap.app.clone();
             let result = if is_mcp_stdio {
                 run_app_command(app, command, Some(&ctx), &feature_overrides).await
@@ -554,15 +651,21 @@ async fn run_no_runtime_command(
             let mut cmd = Cli::command();
             let bin_name = cmd.get_name().to_string();
             generate(args.shell, &mut cmd, bin_name, &mut std::io::stdout());
-            Ok(())
         }
-        Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
+        Command::Features(args) => run_features(args, feature_overrides)?,
         #[cfg(feature = "embedded-ui")]
-        Command::Ui(args) => run_ui(args).await.map_err(Into::into),
+        Command::Ui(args) => run_ui(args).await?,
+        Command::Source(SourceArgs {
+            command: SourceCommand::Lint { file },
+        }) => {
+            source_ops::load_validated_manifest_file(&file)?;
+            println!("Manifest is valid");
+        }
         Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
+    Ok(())
 }
 
 async fn run_app_command(
@@ -697,10 +800,7 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
             source_ops::print_source_info(app, &name, verbose).await?;
         }
         SourceCommand::Add(args) => run_source_add(app, args).await?,
-        SourceCommand::Lint { file } => {
-            source_ops::load_validated_manifest_file(&file)?;
-            println!("Manifest is valid");
-        }
+        SourceCommand::Lint { .. } => unreachable!("source lint is routed without app bootstrap"),
         SourceCommand::Test { name } => {
             source_ops::test_and_print(
                 app,
@@ -813,6 +913,7 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
     if interactive {
         source_ops::require_interactive()?;
     }
+
     let response = match (name, file) {
         (Some(name), None) => {
             let bundled_name = source_ops::source_name_arg(Some(&name))?;
@@ -820,7 +921,9 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
             let available = discover
                 .into_iter()
                 .find(|source| source.name == bundled_name)
-                .ok_or_else(|| anyhow::anyhow!("unknown bundled source '{bundled_name}'"))?;
+                .ok_or_else(|| CliError::SourceNotFound {
+                    source_name: bundled_name.clone(),
+                })?;
             let inputs = available
                 .inputs
                 .iter()
@@ -834,7 +937,10 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
             } else {
                 let (variables, secrets) = source_ops::collect_inputs_from_env(
                     &inputs,
-                    format!("coral source add --interactive {}", available.name),
+                    format!(
+                        "coral source add {} --interactive",
+                        shell_quote_arg(&available.name)
+                    ),
                 )?;
                 source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
             }
@@ -850,8 +956,8 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
                 let (variables, secrets) = source_ops::collect_inputs_from_env(
                     manifest.declared_inputs(),
                     format!(
-                        "coral source add --interactive --file {}",
-                        source_ops::shell_quote_arg(&file.display().to_string())
+                        "coral source add --file {} --interactive",
+                        shell_quote_arg(&file.display().to_string())
                     ),
                 )?;
                 source_ops::import_source(app, manifest_yaml, variables, secrets).await?
@@ -869,11 +975,23 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
         .map_err(Into::into)
 }
 
+fn shell_quote_arg(argument: &str) -> String {
+    if !argument.is_empty()
+        && argument
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-' | b'.' | b'/'))
+    {
+        return argument.to_string();
+    }
+
+    format!("'{}'", argument.replace('\'', "'\\''"))
+}
+
 #[cfg(test)]
 mod tests {
     use clap::{CommandFactory, Parser};
 
-    use super::{Cli, RequiredRuntime, command_enables_stderr_logs};
+    use super::{Cli, RequiredRuntime, command_enables_stderr_logs, shell_quote_arg};
 
     #[test]
     fn server_command_is_not_available() {
@@ -912,6 +1030,14 @@ mod tests {
     fn features_command_requires_no_runtime() {
         let cli =
             Cli::try_parse_from(["coral", "features", "list"]).expect("features args should parse");
+
+        assert_eq!(cli.command.required_runtime(), RequiredRuntime::None);
+    }
+
+    #[test]
+    fn source_lint_requires_no_runtime() {
+        let cli = Cli::try_parse_from(["coral", "source", "lint", "manifest.yaml"])
+            .expect("source lint parses");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::None);
     }
@@ -979,5 +1105,17 @@ mod tests {
     #[test]
     fn non_mcp_invocation_disables_stderr_logs() {
         assert!(!command_enables_stderr_logs(["coral", "sql", "SELECT 1"]));
+    }
+
+    #[test]
+    fn shell_quote_arg_quotes_paths_with_shell_metacharacters() {
+        assert_eq!(
+            shell_quote_arg("/tmp/my spec/manifest`demo`.yaml"),
+            "'/tmp/my spec/manifest`demo`.yaml'"
+        );
+        assert_eq!(
+            shell_quote_arg("/tmp/bob's spec.yaml"),
+            "'/tmp/bob'\\''s spec.yaml'"
+        );
     }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -27,7 +27,13 @@ use clap::{
     Parser, Subcommand, ValueEnum,
 };
 use clap_complete::{Shell, generate};
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::{
+    CORAL_ERROR_REASON_CONFIG_DIR_NOT_FOUND, CORAL_ERROR_REASON_CONFIG_WRITE_FAILED,
+    CORAL_ERROR_REASON_EMPTY_SQL, CORAL_ERROR_REASON_INVALID_INPUT,
+    CORAL_ERROR_REASON_INVALID_SECRETS_FILE, CORAL_ERROR_REASON_LOCAL_FILE_ERROR,
+    CORAL_ERROR_REASON_SECRETS_FILE_ERROR, CORAL_ERROR_REASON_SETUP_REQUIRED,
+    CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_ERROR_REASON_TABLE_NOT_FOUND, v1::ExecuteSqlRequest,
+};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -424,12 +430,12 @@ fn render_status_diagnostic(status: &tonic::Status) -> String {
                 summary,
                 detail,
                 hint: server_hint,
+                metadata,
                 ..
             } = *error;
-            let hint = cli_hint_for_app_reason(&reason).map_or_else(
-                || server_hint.unwrap_or_else(|| default_server_status_hint().to_string()),
-                str::to_string,
-            );
+            let hint = cli_hint_for_reason(&reason, &metadata).unwrap_or_else(|| {
+                server_hint.unwrap_or_else(|| default_server_status_hint().to_string())
+            });
             let detail = if detail.is_empty() {
                 status.message().to_string()
             } else {
@@ -445,29 +451,55 @@ fn render_status_diagnostic(status: &tonic::Status) -> String {
     }
 }
 
-pub(crate) fn cli_hint_for_app_reason(reason: &str) -> Option<&'static str> {
+pub(crate) fn cli_hint_for_reason(
+    reason: &str,
+    metadata: &std::collections::HashMap<String, String>,
+) -> Option<String> {
     match reason {
-        "SOURCE_NOT_FOUND" => Some(
-            "Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.",
-        ),
-        "INVALID_INPUT" => Some(
-            "Check the command input and retry. Run `coral --help` or the subcommand help for valid values.",
-        ),
-        "SETUP_REQUIRED" => Some(
-            "Run `coral source list` to inspect configured sources, then `coral source test <source>` for the source you are trying to use.",
-        ),
-        "INVALID_SECRETS_FILE" => Some(
-            "Re-run `coral source add <source> --interactive` for the affected source to refresh its saved credentials.",
-        ),
-        "CONFIG_DIR_NOT_FOUND" => Some("Set `CORAL_CONFIG_DIR` to a writable directory and retry."),
-        "LOCAL_FILE_ERROR" => Some(
-            "Check that the path exists and that Coral can read and write its config directory. You can set `CORAL_CONFIG_DIR` to a writable directory.",
-        ),
-        "CONFIG_WRITE_FAILED" | "SECRETS_FILE_ERROR" => Some(
-            "Check permissions on the Coral config directory, or set `CORAL_CONFIG_DIR` to a writable directory.",
-        ),
+        CORAL_ERROR_REASON_SOURCE_NOT_FOUND => Some("Run `coral source list` to see installed sources or `coral source discover` to see bundled sources available to install.".to_string()),
+        CORAL_ERROR_REASON_INVALID_INPUT => Some("Check the command input and retry. Run `coral --help` or the subcommand help for valid values.".to_string()),
+        CORAL_ERROR_REASON_SETUP_REQUIRED => Some("Run `coral source list` to inspect configured sources, then `coral source test <source>` for the source you are trying to use.".to_string()),
+        CORAL_ERROR_REASON_INVALID_SECRETS_FILE => Some("Re-run `coral source add <source> --interactive` for the affected source to refresh its saved credentials.".to_string()),
+        CORAL_ERROR_REASON_CONFIG_DIR_NOT_FOUND => {
+            Some("Set `CORAL_CONFIG_DIR` to a writable directory and retry.".to_string())
+        }
+        CORAL_ERROR_REASON_LOCAL_FILE_ERROR => Some("Check that the path exists and that Coral can read and write its config directory. You can set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+        CORAL_ERROR_REASON_CONFIG_WRITE_FAILED | CORAL_ERROR_REASON_SECRETS_FILE_ERROR => Some("Check permissions on the Coral config directory, or set `CORAL_CONFIG_DIR` to a writable directory.".to_string()),
+        CORAL_ERROR_REASON_EMPTY_SQL => {
+            Some("Run `coral sql \"SELECT * FROM coral.tables LIMIT 10\"`.".to_string())
+        }
+        CORAL_ERROR_REASON_TABLE_NOT_FOUND
+            if metadata
+                .get("catalog_empty")
+                .is_some_and(|value| value == "true") =>
+        {
+            Some("Run `coral source discover` to see bundled sources, then `coral source add <source>` to connect one.".to_string())
+        }
+        "PROVIDER_REQUEST_FAILED" => cli_provider_request_hint(metadata),
         _ => None,
     }
+}
+
+fn cli_provider_request_hint(
+    metadata: &std::collections::HashMap<String, String>,
+) -> Option<String> {
+    match metadata.get("http_status").map(String::as_str) {
+        Some("401") => Some(cli_auth_refresh_hint(metadata)),
+        Some("403") => Some(format!(
+            "{} If the refreshed credential still fails, check that it has access to this resource.",
+            cli_auth_refresh_hint(metadata)
+        )),
+        _ => None,
+    }
+}
+
+fn cli_auth_refresh_hint(metadata: &std::collections::HashMap<String, String>) -> String {
+    let source = metadata
+        .get("source")
+        .map_or_else(|| "<source>".to_string(), |source| shell_quote_arg(source));
+    format!(
+        "Run `coral source add {source} --interactive` to refresh saved credentials for bundled sources. For imported sources, run `coral source add --file <manifest-path> --interactive` with the manifest used to install the source."
+    )
 }
 
 fn default_server_status_hint() -> &'static str {
@@ -501,7 +533,7 @@ impl coral_app::RunErrorTelemetry for CliError {
             Self::Query { error_type, .. } => Cow::Borrowed(error_type.as_str()),
             Self::SourceNotInstalled { .. } => Cow::Borrowed("SOURCE_NOT_INSTALLED"),
             Self::SourceNotFound { .. } | Self::SourceRemoveNotFound { .. } => {
-                Cow::Borrowed("SOURCE_NOT_FOUND")
+                Cow::Borrowed(CORAL_ERROR_REASON_SOURCE_NOT_FOUND)
             }
             Self::Diagnostic { .. } => Cow::Borrowed("COMMAND_FAILED"),
             Self::Internal(_) => Cow::Borrowed("INTERNAL"),

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -37,7 +37,7 @@ enum InstalledSourceAction {
     Back,
 }
 
-pub(crate) async fn run(app: &AppClient) -> Result<(), anyhow::Error> {
+pub(crate) async fn run(app: &AppClient) -> Result<(), crate::CliError> {
     source_ops::require_interactive()?;
     let theme = ColorfulTheme::default();
 

--- a/crates/coral-cli/src/query_error.rs
+++ b/crates/coral-cli/src/query_error.rs
@@ -80,7 +80,8 @@ fn render_structured(error: &CoralQueryError) -> String {
     if !error.detail.is_empty() {
         write!(text, "\nDetail: {}", error.detail).expect("writing to String cannot fail");
     }
-    if let Some(hint) = &error.hint {
+    let hint = crate::cli_hint_for_app_reason(&error.reason).or(error.hint.as_deref());
+    if let Some(hint) = hint {
         write!(text, "\nHint: {hint}").expect("writing to String cannot fail");
     }
     text.push('\n');
@@ -215,6 +216,27 @@ mod tests {
             rendered.contains("Error: plain fallback"),
             "should fall back to Status::message(): {rendered}"
         );
+    }
+
+    #[test]
+    fn structured_app_reason_uses_cli_specific_hint() {
+        let status = build_coral_status(
+            "SOURCE_NOT_FOUND",
+            vec![
+                ("summary", "Source `github` was not found"),
+                ("detail", "No source named `github` is installed."),
+                ("hint", "List installed sources, then retry."),
+            ],
+            false,
+        );
+        let error = match decode_status_error(&status) {
+            DecodedStatusError::Structured(e) => e,
+            DecodedStatusError::Plain(_) => panic!("expected Structured"),
+        };
+        let rendered = render_structured(&error);
+
+        assert!(rendered.contains("Hint: Run `coral source list`"));
+        assert!(!rendered.contains("List installed sources, then retry."));
     }
 
     #[test]

--- a/crates/coral-cli/src/query_error.rs
+++ b/crates/coral-cli/src/query_error.rs
@@ -13,9 +13,9 @@ use coral_client::{CoralQueryError, DecodedStatusError, decode_status_error};
 /// Renders a `tonic::Status` as a user-facing stderr block.
 ///
 /// Structured errors produce labelled `Error:` / `Detail:` / `Hint:` lines.
-/// Plain fallback errors include the gRPC status code so distinct failure
-/// modes (transport, auth, not-found) remain distinguishable. The returned
-/// string always terminates with a newline.
+/// Plain fallback errors use the same labelled block with a generic hint so
+/// legacy server statuses stay consistent with structured diagnostics. The
+/// returned string always terminates with a newline.
 ///
 /// The caller is responsible for writing the result to stderr and exiting
 /// with a non-zero code — keeping this function side-effect-free so the
@@ -42,19 +42,36 @@ pub(crate) fn telemetry_error_message(status: &tonic::Status) -> String {
 }
 
 fn render_plain(code: tonic::Code, message: &str) -> String {
-    let label = grpc_code_label(code);
-    format!("Error ({label}): {message}\n")
+    let (summary, hint) = plain_diagnostic(code);
+    format!("Error: {summary}\nDetail: {message}\nHint: {hint}\n")
 }
 
-fn grpc_code_label(code: tonic::Code) -> &'static str {
+fn plain_diagnostic(code: tonic::Code) -> (&'static str, &'static str) {
     match code {
-        tonic::Code::InvalidArgument => "invalid argument",
-        tonic::Code::NotFound => "not found",
-        tonic::Code::FailedPrecondition => "failed precondition",
-        tonic::Code::Unavailable => "unavailable",
-        tonic::Code::Unimplemented => "unimplemented",
-        tonic::Code::Internal => "internal error",
-        _ => "error",
+        tonic::Code::InvalidArgument => (
+            "Query request is invalid",
+            "Check the SQL syntax and retry. Use `SELECT * FROM coral.tables LIMIT 10` to inspect available tables.",
+        ),
+        tonic::Code::NotFound => (
+            "Query target was not found",
+            "Use `SELECT * FROM coral.tables LIMIT 10` to confirm the available source, schema, and table names.",
+        ),
+        tonic::Code::FailedPrecondition => (
+            "Query prerequisites are not satisfied",
+            "Check source setup and required filters, then retry the query.",
+        ),
+        tonic::Code::Unavailable => (
+            "Query runtime is unavailable",
+            "Retry once the local Coral server is running.",
+        ),
+        tonic::Code::Unimplemented => (
+            "Query feature is not supported",
+            "Adjust the SQL to use supported read-only query features, then retry.",
+        ),
+        _ => (
+            "Query failed",
+            "Retry the query. If it keeps failing, run `coral source test <source>` for the source you are querying.",
+        ),
     }
 }
 
@@ -201,9 +218,11 @@ mod tests {
     }
 
     #[test]
-    fn plain_status_includes_grpc_code() {
+    fn plain_status_renders_diagnostic_block() {
         let rendered = render_plain(Code::Internal, "legacy opaque failure");
-        assert_eq!(rendered, "Error (internal error): legacy opaque failure\n");
+        assert!(rendered.contains("Error: Query failed"));
+        assert!(rendered.contains("Detail: legacy opaque failure"));
+        assert!(rendered.contains("Hint: Retry the query."));
     }
 
     #[test]
@@ -215,23 +234,26 @@ mod tests {
     }
 
     #[test]
-    fn plain_not_found_shows_code() {
+    fn plain_not_found_has_discovery_hint() {
         let rendered = render_plain(Code::NotFound, "resource not found: github.issues");
-        assert!(rendered.starts_with("Error (not found):"));
+        assert!(rendered.starts_with("Error: Query target was not found"));
         assert!(rendered.contains("github.issues"));
+        assert!(rendered.contains("Hint: Use `SELECT * FROM coral.tables LIMIT 10`"));
     }
 
     #[test]
-    fn plain_unavailable_shows_code() {
+    fn plain_unavailable_has_runtime_hint() {
         let rendered = render_plain(Code::Unavailable, "transport error");
-        assert_eq!(rendered, "Error (unavailable): transport error\n");
+        assert!(rendered.contains("Error: Query runtime is unavailable"));
+        assert!(rendered.contains("Detail: transport error"));
+        assert!(rendered.contains("Hint: Retry once the local Coral server is running."));
     }
 
     #[test]
     fn plain_fallback_preserves_multi_line_server_message() {
         let multi_line = "Source authentication failed (401)\nbad credentials [GET] https://api.github.com/issues\nHint: Re-install the source.";
         let rendered = render_plain(Code::FailedPrecondition, multi_line);
-        assert!(rendered.starts_with("Error (failed precondition):"));
+        assert!(rendered.starts_with("Error: Query prerequisites are not satisfied"));
         assert!(rendered.contains("Source authentication failed (401)"));
         assert!(rendered.contains("Hint: Re-install the source."));
     }

--- a/crates/coral-cli/src/query_error.rs
+++ b/crates/coral-cli/src/query_error.rs
@@ -80,7 +80,8 @@ fn render_structured(error: &CoralQueryError) -> String {
     if !error.detail.is_empty() {
         write!(text, "\nDetail: {}", error.detail).expect("writing to String cannot fail");
     }
-    let hint = crate::cli_hint_for_app_reason(&error.reason).or(error.hint.as_deref());
+    let hint =
+        crate::cli_hint_for_reason(&error.reason, &error.metadata).or_else(|| error.hint.clone());
     if let Some(hint) = hint {
         write!(text, "\nHint: {hint}").expect("writing to String cannot fail");
     }
@@ -237,6 +238,115 @@ mod tests {
 
         assert!(rendered.contains("Hint: Run `coral source list`"));
         assert!(!rendered.contains("List installed sources, then retry."));
+    }
+
+    #[test]
+    fn structured_empty_sql_uses_cli_specific_hint() {
+        let status = build_coral_status(
+            "EMPTY_SQL",
+            vec![
+                ("summary", "SQL query is empty"),
+                ("detail", "Coral cannot run an empty SQL string."),
+                (
+                    "hint",
+                    "Try the SQL statement `SELECT * FROM coral.tables LIMIT 10`.",
+                ),
+            ],
+            false,
+        );
+        let error = match decode_status_error(&status) {
+            DecodedStatusError::Structured(e) => e,
+            DecodedStatusError::Plain(_) => panic!("expected Structured"),
+        };
+        let rendered = render_structured(&error);
+
+        assert!(rendered.contains("Hint: Run `coral sql"));
+        assert!(!rendered.contains("Try the SQL statement"));
+    }
+
+    #[test]
+    fn structured_empty_catalog_table_not_found_uses_cli_hint() {
+        let status = build_coral_status(
+            "TABLE_NOT_FOUND",
+            vec![
+                ("summary", "Table `github.issues` not found"),
+                ("detail", "No table `issues` exists in schema `github`."),
+                ("catalog_empty", "true"),
+                (
+                    "hint",
+                    "No source tables are currently queryable. Discover available sources, connect one, then retry the query.",
+                ),
+            ],
+            false,
+        );
+        let error = match decode_status_error(&status) {
+            DecodedStatusError::Structured(e) => e,
+            DecodedStatusError::Plain(_) => panic!("expected Structured"),
+        };
+        let rendered = render_structured(&error);
+
+        assert!(rendered.contains("Hint: Run `coral source discover`"));
+        assert!(!rendered.contains("Discover available sources, connect one"));
+    }
+
+    #[test]
+    fn structured_provider_auth_failure_uses_cli_hint() {
+        let status = build_coral_status(
+            "PROVIDER_REQUEST_FAILED",
+            vec![
+                ("summary", "Source credentials were rejected"),
+                (
+                    "detail",
+                    "The upstream API rejected the saved credentials for `github`.",
+                ),
+                (
+                    "hint",
+                    "Refresh the saved credentials for `github`. If this is an imported source, refresh it from the manifest used to install it.",
+                ),
+                ("source", "github"),
+                ("http_status", "401"),
+            ],
+            false,
+        );
+        let error = match decode_status_error(&status) {
+            DecodedStatusError::Structured(e) => e,
+            DecodedStatusError::Plain(_) => panic!("expected Structured"),
+        };
+        let rendered = render_structured(&error);
+
+        assert!(rendered.contains("Hint: Run `coral source add github --interactive`"));
+        assert!(rendered.contains("coral source add --file <manifest-path> --interactive"));
+        assert!(!rendered.contains("Refresh the saved credentials for `github`"));
+    }
+
+    #[test]
+    fn structured_provider_forbidden_keeps_access_hint() {
+        let status = build_coral_status(
+            "PROVIDER_REQUEST_FAILED",
+            vec![
+                ("summary", "Source access was denied"),
+                (
+                    "detail",
+                    "The upstream API rejected the saved credentials for `github`.",
+                ),
+                (
+                    "hint",
+                    "Refresh the saved credentials for `github`. If the refreshed credential still fails, check that it has access to this resource.",
+                ),
+                ("source", "github"),
+                ("http_status", "403"),
+            ],
+            false,
+        );
+        let error = match decode_status_error(&status) {
+            DecodedStatusError::Structured(e) => e,
+            DecodedStatusError::Plain(_) => panic!("expected Structured"),
+        };
+        let rendered = render_structured(&error);
+
+        assert!(rendered.contains("Hint: Run `coral source add github --interactive`"));
+        assert!(rendered.contains("check that it has access to this resource"));
+        assert!(!rendered.contains("Refresh the saved credentials for `github`"));
     }
 
     #[test]

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -355,7 +355,7 @@ pub(crate) async fn print_source_info(
         .await
     {
         Ok(response) => response.into_inner(),
-        Err(status) if status.code() == tonic::Code::NotFound => {
+        Err(status) if is_structured_source_not_found(&status) => {
             // Normalize server NotFound details so CLI users see the source
             // name they typed, not workspace-qualified or transport-specific
             // context from the app layer.
@@ -437,13 +437,8 @@ pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), cra
         .await
     {
         Ok(_) => Ok(()),
-        Err(status) if is_source_missing_status(&status) => {
-            // Normalize server NotFound details so CLI users see the source
-            // name they typed, not workspace-qualified or transport-specific
-            // context from the app layer.
-            Err(crate::CliError::SourceNotFound {
-                source_name: normalized,
-            })
+        Err(status) if is_structured_source_not_found(&status) => {
+            Err(source_remove_not_installed_error(&normalized))
         }
         Err(status) => Err(crate::CliError::server_status(&status)),
     }?;
@@ -691,7 +686,7 @@ pub(crate) async fn test_and_print(
     let normalized = source_name_arg(Some(source_name))?;
     let response = match validate_source_request(app, normalized.clone()).await {
         Ok(response) => response,
-        Err(status) if is_source_missing_status(&status) => {
+        Err(status) if is_structured_source_not_found(&status) => {
             return source_test_not_found_error(app, &normalized, status).await;
         }
         Err(status) => return Err(crate::CliError::server_status(&status)),
@@ -736,30 +731,26 @@ pub(crate) async fn remove_and_print(
     source_name: &str,
 ) -> Result<(), crate::CliError> {
     let normalized = source_name_arg(Some(source_name))?;
-    match delete_source(app, &normalized).await {
-        Ok(()) => {
-            println!("Removed source {normalized}");
-            Ok(())
-        }
-        Err(crate::CliError::SourceNotFound { .. }) => Err(crate::CliError::SourceRemoveNotFound {
-            source_name: normalized,
-        }),
-        Err(err) => Err(err),
-    }
+    delete_source(app, &normalized).await?;
+    println!("Removed source {normalized}");
+    Ok(())
 }
 
-/// Returns `true` only when the gRPC status carries the server's
-/// `SOURCE_NOT_FOUND` AIP-193 reason. Other `Code::NotFound` causes
-/// (e.g. a missing manifest file mapped from `io::ErrorKind::NotFound`)
-/// have no Coral `ErrorInfo` attached, so they remain diagnosable instead
-/// of being rewritten into the friendly "source not found" message.
-fn is_source_missing_status(status: &tonic::Status) -> bool {
-    match decode_status_error(status) {
-        DecodedStatusError::Structured(error) => {
-            error.reason == CORAL_ERROR_REASON_SOURCE_NOT_FOUND
-        }
-        DecodedStatusError::Plain(_) => false,
-    }
+fn is_structured_source_not_found(status: &tonic::Status) -> bool {
+    matches!(
+        decode_status_error(status),
+        DecodedStatusError::Structured(error) if error.reason == CORAL_ERROR_REASON_SOURCE_NOT_FOUND
+    )
+}
+
+fn source_remove_not_installed_error(source_name: &str) -> crate::CliError {
+    crate::CliError::diagnostic(
+        format!("Source `{source_name}` is not installed"),
+        format!(
+            "`{source_name}` is not installed in this workspace, so there is nothing to remove."
+        ),
+        "Run `coral source list` to see installed sources.",
+    )
 }
 
 pub(crate) fn print_validation_pretty(
@@ -1127,14 +1118,49 @@ mod tests {
     )]
 
     use coral_api::v1::ValidateSourceResponse;
+    use coral_api::{
+        CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_LOCAL_FILE_ERROR,
+        CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+    };
     use coral_spec::{ManifestInputKind, ManifestInputSpec};
+    use tonic::{Code, Status};
+    use tonic_types::{ErrorDetail, StatusExt as _};
 
     use std::collections::HashMap;
 
     use super::{
         ValidationFollowUp, ValidationSeverityMode, collect_inputs_with_hint, finalize_input_value,
-        shell_quote_arg, source_name_arg, validation_follow_up,
+        is_structured_source_not_found, shell_quote_arg, source_name_arg, validation_follow_up,
     };
+
+    fn structured_status(reason: &'static str) -> Status {
+        let metadata = HashMap::from([(
+            CORAL_ERROR_METADATA_SUMMARY.to_string(),
+            "test summary".to_string(),
+        )]);
+        Status::with_error_details_vec(
+            Code::NotFound,
+            "plain message",
+            vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+                reason,
+                CORAL_ERROR_DOMAIN,
+                metadata,
+            ))],
+        )
+    }
+
+    #[test]
+    fn source_not_found_normalizer_requires_structured_reason() {
+        assert!(is_structured_source_not_found(&structured_status(
+            CORAL_ERROR_REASON_SOURCE_NOT_FOUND
+        )));
+        assert!(!is_structured_source_not_found(&structured_status(
+            CORAL_ERROR_REASON_LOCAL_FILE_ERROR
+        )));
+        assert!(!is_structured_source_not_found(&Status::not_found(
+            "legacy plain not found"
+        )));
+    }
 
     #[test]
     fn collect_inputs_reads_variables_and_secrets_from_lookup() {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -321,9 +321,22 @@ async fn validate_source_request(
 
 pub(crate) fn load_validated_manifest_file(
     file: &Path,
-) -> Result<(String, ValidatedSourceManifest), anyhow::Error> {
-    let manifest_yaml = std::fs::read_to_string(file)?;
-    let manifest = parse_source_manifest_yaml(manifest_yaml.as_str())?;
+) -> Result<(String, ValidatedSourceManifest), crate::CliError> {
+    let path = file.display().to_string();
+    let manifest_yaml = std::fs::read_to_string(file).map_err(|error| {
+        crate::CliError::diagnostic(
+            "Source manifest could not be read",
+            format!("Coral could not read `{path}`: {error}"),
+            "Check that the file exists and is readable, then rerun the command.",
+        )
+    })?;
+    let manifest = parse_source_manifest_yaml(manifest_yaml.as_str()).map_err(|error| {
+        crate::CliError::diagnostic(
+            "Source manifest is invalid",
+            format!("`{path}` is not a valid source spec: {error}"),
+            "Fix the YAML or source-spec error shown above, then rerun the command.",
+        )
+    })?;
     Ok((manifest_yaml, manifest))
 }
 
@@ -331,15 +344,27 @@ pub(crate) async fn print_source_info(
     app: &AppClient,
     name: &str,
     verbose: bool,
-) -> Result<(), anyhow::Error> {
-    let response = app
+) -> Result<(), crate::CliError> {
+    let normalized = source_name_arg(Some(name))?;
+    let response = match app
         .source_client()
         .get_source_info(Request::new(GetSourceInfoRequest {
             workspace: Some(default_workspace()),
-            name: source_name_arg(Some(name))?,
+            name: normalized.clone(),
         }))
-        .await?
-        .into_inner();
+        .await
+    {
+        Ok(response) => response.into_inner(),
+        Err(status) if status.code() == tonic::Code::NotFound => {
+            // Normalize server NotFound details so CLI users see the source
+            // name they typed, not workspace-qualified or transport-specific
+            // context from the app layer.
+            return Err(crate::CliError::SourceNotFound {
+                source_name: normalized,
+            });
+        }
+        Err(status) => return Err(crate::CliError::server_status(&status)),
+    };
     let source = response
         .source_info
         .ok_or_else(|| anyhow::anyhow!("get source info response missing source_info"))?;
@@ -401,40 +426,66 @@ fn print_source_info_response(source: &SourceInfo, verbose: bool) {
     }
 }
 
-pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), anyhow::Error> {
-    app.source_client()
+pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), crate::CliError> {
+    let normalized = source_name_arg(Some(name))?;
+    match app
+        .source_client()
         .delete_source(Request::new(DeleteSourceRequest {
             workspace: Some(default_workspace()),
-            name: source_name_arg(Some(name))?,
+            name: normalized.clone(),
         }))
-        .await?;
+        .await
+    {
+        Ok(_) => Ok(()),
+        Err(status) if is_source_missing_status(&status) => {
+            // Normalize server NotFound details so CLI users see the source
+            // name they typed, not workspace-qualified or transport-specific
+            // context from the app layer.
+            Err(crate::CliError::SourceNotFound {
+                source_name: normalized,
+            })
+        }
+        Err(status) => Err(crate::CliError::server_status(&status)),
+    }?;
     Ok(())
 }
 
-pub(crate) fn require_interactive() -> Result<(), anyhow::Error> {
+pub(crate) fn require_interactive() -> Result<(), crate::CliError> {
     if !stdin().is_terminal() || !stdout().is_terminal() {
-        return Err(anyhow::anyhow!("interactive source install requires a TTY"));
+        return Err(crate::CliError::diagnostic(
+            "Interactive input is not available",
+            "`--interactive` needs a terminal so Coral can prompt for source inputs.",
+            "Re-run the command in a terminal, or set the required environment variables and omit `--interactive`.",
+        ));
     }
     Ok(())
 }
 
-pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Error> {
+pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, crate::CliError> {
     let Some(name) = name else {
-        return Err(anyhow::anyhow!("missing source name"));
+        return Err(invalid_source_name("missing source name"));
     };
     let name = name.trim();
     if name.is_empty() {
-        return Err(anyhow::anyhow!("missing source name"));
+        return Err(invalid_source_name("missing source name"));
     }
     if name.contains('/') || name.contains('\\') {
-        return Err(anyhow::anyhow!(
-            "source name must not contain '/' or '\\\\'"
+        return Err(invalid_source_name(
+            "source name must not contain '/' or '\\\\'",
         ));
     }
     if name == "." || name == ".." {
-        return Err(anyhow::anyhow!("source name must not be '.' or '..'"));
+        return Err(invalid_source_name("source name must not be '.' or '..'"));
     }
     Ok(name.to_string())
+}
+
+fn invalid_source_name(detail: impl AsRef<str>) -> crate::CliError {
+    crate::CliError::diagnostic(
+        "Source name is invalid",
+        detail,
+        "Use a source name without path separators, such as `github` or `my_source`.",
+    )
 }
 
 pub(crate) fn prompt_for_inputs(
@@ -507,12 +558,13 @@ pub(crate) fn prompt_for_inputs_with_credential_methods(
 
 pub(crate) fn collect_inputs_from_env(
     inputs: &[ManifestInputSpec],
-    interactive_command: String,
-) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
+    interactive_command: impl Into<String>,
+) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), crate::CliError> {
+    let interactive_command = interactive_command.into();
     collect_inputs_with_hint(
         inputs,
         |key| read_source_input_env(key).unwrap_or_default(),
-        Some(interactive_command),
+        &interactive_command,
     )
 }
 
@@ -537,8 +589,8 @@ fn read_source_input_env(key: &str) -> Option<String> {
 fn collect_inputs_with_hint(
     inputs: &[ManifestInputSpec],
     mut lookup: impl FnMut(&str) -> String,
-    interactive_command: Option<String>,
-) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
+    interactive_command: &str,
+) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), crate::CliError> {
     let mut variables = Vec::new();
     let mut secrets = Vec::new();
     let mut missing = Vec::new();
@@ -569,15 +621,13 @@ fn collect_inputs_with_hint(
     }
 
     if !missing.is_empty() {
-        let interactive_hint = interactive_command.map_or_else(
-            || "--interactive".to_string(),
-            |command| format!("`{command}`"),
-        );
-        return Err(anyhow::anyhow!(
-            "missing required environment variable{}: {}. Set the variable{} or run {interactive_hint}.",
-            if missing.len() == 1 { "" } else { "s" },
-            missing.join(", "),
-            if missing.len() == 1 { "" } else { "s" },
+        return Err(crate::CliError::diagnostic(
+            "Required source input is missing",
+            format!(
+                "Missing required environment variable(s): {}.",
+                missing.join(", ")
+            ),
+            format!("Set the variable(s), or run `{interactive_command}`."),
         ));
     }
 
@@ -644,7 +694,7 @@ pub(crate) async fn test_and_print(
         Err(status) if is_source_missing_status(&status) => {
             return source_test_not_found_error(app, &normalized, status).await;
         }
-        Err(status) => return Err(anyhow::Error::from(status).into()),
+        Err(status) => return Err(crate::CliError::server_status(&status)),
     };
 
     print_validation_pretty(&response, limit)?;
@@ -665,7 +715,7 @@ async fn source_test_not_found_error(
 ) -> Result<(), crate::CliError> {
     // Discovery failure must not mask the original validation error.
     let Ok(available) = discover_sources(app).await else {
-        return Err(anyhow::Error::from(original_status).into());
+        return Err(crate::CliError::server_status(&original_status));
     };
     if available
         .iter()
@@ -691,18 +741,10 @@ pub(crate) async fn remove_and_print(
             println!("Removed source {normalized}");
             Ok(())
         }
-        Err(err) => {
-            if err
-                .downcast_ref::<tonic::Status>()
-                .is_some_and(is_source_missing_status)
-            {
-                Err(crate::CliError::SourceRemoveNotFound {
-                    source_name: normalized,
-                })
-            } else {
-                Err(err.into())
-            }
-        }
+        Err(crate::CliError::SourceNotFound { .. }) => Err(crate::CliError::SourceRemoveNotFound {
+            source_name: normalized,
+        }),
+        Err(err) => Err(err),
     }
 }
 
@@ -1118,7 +1160,7 @@ mod tests {
         let (variables, secrets) = collect_inputs_with_hint(
             &inputs,
             |key| env.get(key).map(|v| (*v).to_string()).unwrap_or_default(),
-            None,
+            "coral source add linear --interactive",
         )
         .expect("should succeed");
         assert_eq!(variables.len(), 1);
@@ -1139,9 +1181,12 @@ mod tests {
             hint: None,
             credential: None,
         }];
-        let (variables, _) =
-            collect_inputs_with_hint(&inputs, |_| "https://override.test".to_string(), None)
-                .expect("env should override default");
+        let (variables, _) = collect_inputs_with_hint(
+            &inputs,
+            |_| "https://override.test".to_string(),
+            "coral source add demo --interactive",
+        )
+        .expect("env should override default");
         assert_eq!(variables.len(), 1);
         assert_eq!(variables[0].value, "https://override.test");
     }
@@ -1156,8 +1201,12 @@ mod tests {
             hint: None,
             credential: None,
         }];
-        let (variables, secrets) = collect_inputs_with_hint(&inputs, |_| String::new(), None)
-            .expect("default should satisfy required");
+        let (variables, secrets) = collect_inputs_with_hint(
+            &inputs,
+            |_| String::new(),
+            "coral source add demo --interactive",
+        )
+        .expect("default should satisfy required");
         assert_eq!(secrets.len(), 0);
         assert_eq!(variables.len(), 1);
         assert_eq!(variables[0].value, "https://example.com");
@@ -1183,21 +1232,27 @@ mod tests {
                 credential: None,
             },
         ];
-        let error = collect_inputs_with_hint(&inputs, |_| String::new(), None)
-            .expect_err("missing required inputs should fail");
-        let message = error.to_string();
+        let error = collect_inputs_with_hint(
+            &inputs,
+            |_| String::new(),
+            "coral source add linear --interactive",
+        )
+        .expect_err("missing required inputs should fail");
+        let message = error.rendered_stderr().expect("rendered stderr");
+        assert!(message.contains("Required source input is missing"));
         assert!(message.contains("LINEAR_API_KEY"));
         assert!(message.contains("OTHER_KEY"));
-        assert!(message.contains("--interactive"));
     }
 
     #[test]
     fn source_name_arg_rejects_dot_segments() {
         let error = source_name_arg(Some("..")).expect_err("dot segment should fail");
-        assert!(error.to_string().contains("must not be '.' or '..'"));
+        let message = error.rendered_stderr().expect("rendered stderr");
+        assert!(message.contains("must not be '.' or '..'"));
 
         let error = source_name_arg(Some(" . ")).expect_err("dot segment should fail");
-        assert!(error.to_string().contains("must not be '.' or '..'"));
+        let message = error.rendered_stderr().expect("rendered stderr");
+        assert!(message.contains("must not be '.' or '..'"));
     }
 
     #[test]
@@ -1210,8 +1265,12 @@ mod tests {
             hint: None,
             credential: None,
         }];
-        let (variables, secrets) = collect_inputs_with_hint(&inputs, |_| String::new(), None)
-            .expect("optional should be omitted");
+        let (variables, secrets) = collect_inputs_with_hint(
+            &inputs,
+            |_| String::new(),
+            "coral source add demo --interactive",
+        )
+        .expect("optional should be omitted");
         assert!(variables.is_empty());
         assert!(secrets.is_empty());
     }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -563,6 +563,7 @@ pub(crate) fn collect_inputs_from_env(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn shell_quote_arg(value: &str) -> String {
     if value
         .chars()

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -48,6 +48,34 @@ fn ui_help_does_not_require_app_bootstrap() {
     );
 }
 
+#[test]
+fn malformed_coral_endpoint_renders_bootstrap_diagnostic() {
+    let assert = Command::cargo_bin("coral")
+        .expect("cargo bin")
+        .args(["source", "list"])
+        .env("CORAL_ENDPOINT", "not a uri")
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Error: Coral could not connect to the local server"),
+        "expected bootstrap connect error: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: Failed to connect to `not a uri`:"),
+        "expected endpoint detail: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Retry the command"),
+        "expected retry hint: {stderr}"
+    );
+    assert!(
+        stderr.contains("CORAL_ENDPOINT"),
+        "expected endpoint env hint: {stderr}"
+    );
+}
+
 fn nonempty_lines(output: &str) -> Vec<&str> {
     output
         .lines()
@@ -310,8 +338,12 @@ async fn source_info_errors_for_unknown_source() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("unknown source 'nope'"),
-        "expected unknown source error: {stderr}"
+        stderr.contains("Error: Source `nope` was not found"),
+        "expected source-not-found diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Run `coral source list`"),
+        "expected source-not-found hint: {stderr}"
     );
 
     server.shutdown().await;
@@ -415,8 +447,16 @@ async fn sql_command_surfaces_server_errors() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
+        stderr.contains("Error: Query failed"),
+        "expected query diagnostic summary in stderr: {stderr}"
+    );
+    assert!(
         stderr.contains("mock SQL failure"),
         "expected server error in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Retry the query."),
+        "expected query diagnostic hint in stderr: {stderr}"
     );
 
     let requests = server.execute_sql_requests();
@@ -682,6 +722,29 @@ async fn source_add_rejects_name_and_file_together() {
     server.shutdown().await;
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn source_add_unknown_bundled_source_renders_diagnostic() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "add", "totally_unknown"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Error: Source `totally_unknown` was not found"),
+        "expected source-not-found diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Run `coral source list`"),
+        "expected discovery hint: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
 // ---------------------------------------------------------------------------
 // Name validation
 // ---------------------------------------------------------------------------
@@ -698,8 +761,16 @@ async fn source_test_rejects_invalid_name() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("must not contain"),
+        stderr.contains("Error: Source name is invalid"),
         "expected name validation error: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: source name must not contain"),
+        "expected name validation detail: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Use a source name without path separators"),
+        "expected name validation hint: {stderr}"
     );
 
     server.shutdown().await;
@@ -717,8 +788,42 @@ async fn source_remove_rejects_invalid_name() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("must not contain"),
+        stderr.contains("Error: Source name is invalid"),
         "expected name validation error: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: source name must not contain"),
+        "expected name validation detail: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Use a source name without path separators"),
+        "expected name validation hint: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_remove_unknown_source_renders_diagnostic() {
+    let server = MockServer::start_with_config(
+        MockServerConfig::default().with_delete_source_error(Code::NotFound, "unknown source"),
+    )
+    .await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "remove", "nope"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Error: Source `nope` was not found"),
+        "expected source-not-found diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Run `coral source list`"),
+        "expected source-not-found hint: {stderr}"
     );
 
     server.shutdown().await;
@@ -741,16 +846,17 @@ async fn source_add_reports_missing_env_vars_without_interactive() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("missing required environment variable"),
+        stderr.contains("Error: Required source input is missing"),
         "expected missing env var error: {stderr}"
     );
     assert!(
-        stderr.contains("GITHUB_TOKEN"),
+        stderr.contains("Detail: Missing required environment variable(s): GITHUB_TOKEN."),
         "expected missing env var to name GITHUB_TOKEN: {stderr}"
     );
     assert!(
-        stderr.contains("coral source add --interactive github"),
-        "expected exact interactive recovery command: {stderr}"
+        stderr
+            .contains("Hint: Set the variable(s), or run `coral source add github --interactive`."),
+        "expected interactive hint in stderr: {stderr}"
     );
 
     server.shutdown().await;
@@ -768,8 +874,16 @@ async fn source_add_interactive_requires_tty() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("requires a TTY"),
+        stderr.contains("Error: Interactive input is not available"),
         "expected TTY requirement error: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: `--interactive` needs a terminal"),
+        "expected TTY detail in stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Re-run the command in a terminal"),
+        "expected TTY hint in stderr: {stderr}"
     );
 
     server.shutdown().await;
@@ -802,7 +916,7 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("source 'demo_bundled' is not installed"),
+        stderr.contains("Error: Source `demo_bundled` is not installed"),
         "expected not-installed error in stderr: {stderr}"
     );
     assert!(
@@ -836,7 +950,7 @@ async fn source_test_normalizes_error_for_unknown_source() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("source 'totally_unknown' was not found"),
+        stderr.contains("Error: Source `totally_unknown` was not found"),
         "expected normalized not-found error in stderr: {stderr}"
     );
     assert!(

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
-#[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
     DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, SourceCredentialStorage,
@@ -22,7 +21,10 @@ use coral_api::v1::{
 };
 use tonic::Code;
 
-use harness::{MockServer, MockServerConfig, encode_arrow_ipc_stream};
+use harness::{
+    MockServer, MockServerConfig, coral_local_file_not_found_status, coral_source_not_found_status,
+    encode_arrow_ipc_stream,
+};
 
 #[cfg(feature = "embedded-ui")]
 #[test]
@@ -806,7 +808,8 @@ async fn source_remove_rejects_invalid_name() {
 #[tokio::test(flavor = "multi_thread")]
 async fn source_remove_unknown_source_renders_diagnostic() {
     let server = MockServer::start_with_config(
-        MockServerConfig::default().with_delete_source_error(Code::NotFound, "unknown source"),
+        MockServerConfig::default()
+            .with_delete_source_status(coral_source_not_found_status("nope")),
     )
     .await;
 
@@ -818,12 +821,47 @@ async fn source_remove_unknown_source_renders_diagnostic() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("Error: Source `nope` was not found"),
-        "expected source-not-found diagnostic: {stderr}"
+        stderr.contains("Error: Source `nope` is not installed"),
+        "expected source-not-installed diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: `nope` is not installed in this workspace"),
+        "expected source-not-installed detail: {stderr}"
     );
     assert!(
         stderr.contains("Hint: Run `coral source list`"),
-        "expected source-not-found hint: {stderr}"
+        "expected installed-source hint: {stderr}"
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn source_remove_preserves_local_file_not_found_diagnostic() {
+    let server =
+        MockServer::start_with_config(MockServerConfig::default().with_delete_source_status(
+            coral_local_file_not_found_status("workspaces/default/sources/jira/source.yaml"),
+        ))
+        .await;
+
+    let assert = server
+        .cmd()
+        .args(["source", "remove", "jira"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("Error: Coral could not read or write a local file"),
+        "expected local-file diagnostic: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: No such file or directory"),
+        "expected local-file detail: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Source `jira` was not found"),
+        "must not collapse local file NotFound into missing source: {stderr}"
     );
 
     server.shutdown().await;
@@ -893,7 +931,7 @@ async fn source_add_interactive_requires_tty() {
 async fn source_test_suggests_add_for_uninstalled_bundled_source() {
     let server = MockServer::start_with_config(
         MockServerConfig::default()
-            .with_validate_source_not_found("default:demo_bundled")
+            .with_validate_source_status(coral_source_not_found_status("demo_bundled"))
             .with_discover_sources(DiscoverSourcesResponse {
                 sources: vec![SourceInfo {
                     name: "demo_bundled".to_string(),
@@ -935,7 +973,7 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
 async fn source_test_normalizes_error_for_unknown_source() {
     let server = MockServer::start_with_config(
         MockServerConfig::default()
-            .with_validate_source_not_found("default:totally_unknown")
+            .with_validate_source_status(coral_source_not_found_status("totally_unknown"))
             .with_discover_sources(DiscoverSourcesResponse {
                 sources: Vec::new(),
             }),

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -1018,7 +1018,7 @@ async fn source_remove_normalizes_error_for_unknown_source() {
 
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
     assert!(
-        stderr.contains("source 'unknown_source' was not found"),
+        stderr.contains("Error: Source `unknown_source` is not installed"),
         "expected normalized not-found error in stderr: {stderr}"
     );
     assert!(

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -31,7 +31,11 @@ use coral_api::v1::{
     create_bundled_source_with_o_auth_response, import_source_response,
     source_input_spec::Input as ProtoSourceInput,
 };
-use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
+use coral_api::{
+    CORAL_ERROR_DOMAIN, CORAL_ERROR_METADATA_DETAIL, CORAL_ERROR_METADATA_HINT,
+    CORAL_ERROR_METADATA_SUMMARY, CORAL_ERROR_REASON_LOCAL_FILE_ERROR,
+    CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+};
 use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -351,8 +355,62 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             origin: SourceOrigin::Imported as i32,
             credential_storage: SourceCredentialStorage::File as i32,
         }),
-        _ => Err(Status::not_found(format!("unknown source '{name}'"))),
+        _ => Err(coral_source_not_found_status(name)),
     }
+}
+
+pub(crate) fn coral_source_not_found_status(name: &str) -> Status {
+    let metadata = std::collections::HashMap::from([
+        (
+            CORAL_ERROR_METADATA_SUMMARY.to_string(),
+            format!("Source `{name}` was not found"),
+        ),
+        (
+            CORAL_ERROR_METADATA_DETAIL.to_string(),
+            format!("No source named `{name}` is installed in this workspace."),
+        ),
+        (
+            CORAL_ERROR_METADATA_HINT.to_string(),
+            "List installed sources or discover available sources, then retry with a source that exists."
+                .to_string(),
+        ),
+    ]);
+    Status::with_error_details_vec(
+        Code::NotFound,
+        format!("Source `{name}` was not found"),
+        vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+            CORAL_ERROR_REASON_SOURCE_NOT_FOUND,
+            CORAL_ERROR_DOMAIN,
+            metadata,
+        ))],
+    )
+}
+
+pub(crate) fn coral_local_file_not_found_status(path: &str) -> Status {
+    let metadata = std::collections::HashMap::from([
+        (
+            CORAL_ERROR_METADATA_SUMMARY.to_string(),
+            "Coral could not read or write a local file".to_string(),
+        ),
+        (
+            CORAL_ERROR_METADATA_DETAIL.to_string(),
+            format!("No such file or directory: {path}"),
+        ),
+        (
+            CORAL_ERROR_METADATA_HINT.to_string(),
+            "Check that the path exists and that Coral can read and write its config directory."
+                .to_string(),
+        ),
+    ]);
+    Status::with_error_details_vec(
+        Code::NotFound,
+        "Coral could not read or write a local file",
+        vec![ErrorDetail::ErrorInfo(tonic_types::ErrorInfo::new(
+            CORAL_ERROR_REASON_LOCAL_FILE_ERROR,
+            CORAL_ERROR_DOMAIN,
+            metadata,
+        ))],
+    )
 }
 
 #[derive(Clone, Debug)]
@@ -404,6 +462,7 @@ impl MockError {
 enum MockResult<T> {
     Ok(T),
     Err(MockError),
+    Status(Status),
 }
 
 impl<T> MockResult<T> {
@@ -419,10 +478,15 @@ impl<T> MockResult<T> {
         Self::Err(MockError::source_not_found(qualified))
     }
 
+    fn status(status: Status) -> Self {
+        Self::Status(status)
+    }
+
     fn into_tonic_result(self) -> Result<T, Status> {
         match self {
             Self::Ok(value) => Ok(value),
             Self::Err(error) => Err(error.status()),
+            Self::Status(status) => Err(status),
         }
     }
 }
@@ -499,6 +563,11 @@ impl MockServerConfig {
         self
     }
 
+    pub(crate) fn with_validate_source_status(mut self, status: Status) -> Self {
+        self.validate_source = MockResult::status(status);
+        self
+    }
+
     pub(crate) fn with_validate_source_response(
         mut self,
         response: ValidateSourceResponse,
@@ -529,6 +598,11 @@ impl MockServerConfig {
     /// AIP-193 `ErrorInfo` with `reason = "SOURCE_NOT_FOUND"`).
     pub(crate) fn with_delete_source_not_found(mut self, qualified: impl Into<String>) -> Self {
         self.delete_source = MockResult::source_not_found(qualified);
+        self
+    }
+
+    pub(crate) fn with_delete_source_status(mut self, status: Status) -> Self {
+        self.delete_source = MockResult::status(status);
         self
     }
 }

--- a/crates/coral-cli/tests/lint.rs
+++ b/crates/coral-cli/tests/lint.rs
@@ -81,8 +81,20 @@ tables:
     assert!(!output.status.success(), "expected non-zero exit status");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
+        stderr.contains("Error: Source manifest is invalid"),
+        "expected manifest diagnostic summary, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail:"),
+        "expected manifest diagnostic detail, got: {stderr}"
+    );
+    assert!(
         stderr.contains("\"backend\" is a required property"),
         "expected missing-backend schema error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Fix the YAML or source-spec error"),
+        "expected manifest diagnostic hint, got: {stderr}"
     );
 }
 
@@ -112,7 +124,37 @@ tables:
     assert!(!output.status.success(), "expected non-zero exit status");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
+        stderr.contains("Error: Source manifest is invalid"),
+        "expected manifest diagnostic summary, got: {stderr}"
+    );
+    assert!(
         stderr.contains("duplicate column 'id'"),
         "expected duplicate-column error, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Fix the YAML or source-spec error"),
+        "expected manifest diagnostic hint, got: {stderr}"
+    );
+}
+
+#[test]
+fn lint_reports_missing_manifest_file_with_hint() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("missing.yaml");
+    let output = coral_lint(&path);
+
+    assert!(!output.status.success(), "expected non-zero exit status");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Error: Source manifest could not be read"),
+        "expected read diagnostic summary, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: Coral could not read"),
+        "expected read diagnostic detail, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Check that the file exists and is readable"),
+        "expected read diagnostic hint, got: {stderr}"
     );
 }

--- a/crates/coral-cli/tests/onboard.rs
+++ b/crates/coral-cli/tests/onboard.rs
@@ -21,7 +21,15 @@ fn onboard_rejects_non_interactive_terminals() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(!output.status.success(), "expected non-zero exit status");
     assert!(
-        stderr.contains("interactive source install requires a TTY"),
+        stderr.contains("Error: Interactive input is not available"),
         "expected TTY error in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Detail: `--interactive` needs a terminal"),
+        "expected TTY detail in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Hint: Re-run the command in a terminal"),
+        "expected TTY hint in stderr, got: {stderr}"
     );
 }

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -224,7 +224,6 @@ fn http_request_to_structured(
     filters: &HashMap<String, String>,
     raw_detail: &str,
 ) -> StructuredQueryError {
-    let source_shell = shell_arg(source);
     let sanitized_url = url.and_then(sanitize_request_url);
 
     let (reason, summary, hint, status) = match http_status {
@@ -237,7 +236,7 @@ fn http_request_to_structured(
         Some(UNAUTHORIZED) => (
             "PROVIDER_REQUEST_FAILED",
             "Source credentials were rejected".to_string(),
-            Some(auth_refresh_hint(&source_shell)),
+            Some(auth_refresh_hint(source)),
             StatusCode::FailedPrecondition,
         ),
         Some(FORBIDDEN) => (
@@ -245,7 +244,7 @@ fn http_request_to_structured(
             "Source access was denied".to_string(),
             Some(format!(
                 "{} If the refreshed credential still fails, check that it has access to this resource.",
-                auth_refresh_hint(&source_shell)
+                auth_refresh_hint(source)
             )),
             StatusCode::FailedPrecondition,
         ),
@@ -325,9 +324,9 @@ fn http_request_to_structured(
     )
 }
 
-fn auth_refresh_hint(source_shell: &str) -> String {
+fn auth_refresh_hint(source: &str) -> String {
     format!(
-        "Refresh the saved credentials with `coral source add {source_shell} --interactive` for bundled sources, or `coral source add --file <manifest-path> --interactive` for imported sources."
+        "Refresh the saved credentials for `{source}`. If this is an imported source, refresh it from the manifest used to install it."
     )
 }
 
@@ -492,19 +491,6 @@ fn is_server_error(status: u16) -> bool {
 // String helpers
 // ---------------------------------------------------------------------------
 
-fn shell_arg(value: &str) -> String {
-    let is_safe = !value.is_empty()
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'));
-    if is_safe {
-        value.to_string()
-    } else {
-        let escaped = value.replace('\'', "'\\''");
-        format!("'{escaped}'")
-    }
-}
-
 fn sanitize_request_url(raw: &str) -> Option<String> {
     let without_fragment = raw.split_once('#').map_or(raw, |(before, _)| before);
     let without_query = without_fragment
@@ -581,8 +567,9 @@ mod tests {
         assert_eq!(error.metadata().get("http_status").unwrap(), "401");
         assert!(!error.retryable());
         let hint = error.hint().expect("401 should have a hint");
-        assert!(hint.contains("coral source add github --interactive"));
-        assert!(hint.contains("coral source add --file <manifest-path> --interactive"));
+        assert!(hint.contains("Refresh the saved credentials for `github`"));
+        assert!(hint.contains("manifest used to install it"));
+        assert!(!hint.contains("coral source"));
     }
 
     #[test]
@@ -602,8 +589,9 @@ mod tests {
         assert!(error.detail().contains("saved credentials for `github`"));
         assert_eq!(error.metadata().get("http_status").unwrap(), "403");
         let hint = error.hint().expect("403 should have a hint");
-        assert!(hint.contains("coral source add github --interactive"));
+        assert!(hint.contains("Refresh the saved credentials for `github`"));
         assert!(hint.contains("has access to this resource"));
+        assert!(!hint.contains("coral source"));
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/error.rs
+++ b/crates/coral-engine/src/backends/http/error.rs
@@ -236,21 +236,17 @@ fn http_request_to_structured(
         ),
         Some(UNAUTHORIZED) => (
             "PROVIDER_REQUEST_FAILED",
-            "Source authentication failed".to_string(),
-            Some(format!(
-                "Credentials for this source are invalid or expired. Re-install it to refresh: \
-                 `coral source add {source_shell}` for bundled sources, or \
-                 `coral source add --file <manifest-path>` for imported sources."
-            )),
+            "Source credentials were rejected".to_string(),
+            Some(auth_refresh_hint(&source_shell)),
             StatusCode::FailedPrecondition,
         ),
         Some(FORBIDDEN) => (
             "PROVIDER_REQUEST_FAILED",
-            "Source request was rejected".to_string(),
-            Some(
-                "Check the configured credentials and whether they have access to this resource."
-                    .to_string(),
-            ),
+            "Source access was denied".to_string(),
+            Some(format!(
+                "{} If the refreshed credential still fails, check that it has access to this resource.",
+                auth_refresh_hint(&source_shell)
+            )),
             StatusCode::FailedPrecondition,
         ),
         Some(NOT_FOUND) => (
@@ -288,10 +284,17 @@ fn http_request_to_structured(
     };
 
     let summary = match http_status {
+        Some(UNAUTHORIZED | FORBIDDEN) | None => summary,
         Some(s) => format!("{summary} ({s})"),
-        None => summary,
     };
     let detail = enrich_provider_detail(raw_detail, method, sanitized_url.as_deref());
+    let detail = if matches!(http_status, Some(UNAUTHORIZED | FORBIDDEN)) {
+        format!(
+            "The upstream API rejected the saved credentials for `{source}`. Provider detail: {detail}"
+        )
+    } else {
+        detail
+    };
     let is_retryable =
         matches!(http_status, Some(s) if s == TOO_MANY_REQUESTS || is_server_error(s));
 
@@ -319,6 +322,12 @@ fn http_request_to_structured(
         is_retryable,
         status,
         metadata,
+    )
+}
+
+fn auth_refresh_hint(source_shell: &str) -> String {
+    format!(
+        "Refresh the saved credentials with `coral source add {source_shell} --interactive` for bundled sources, or `coral source add --file <manifest-path> --interactive` for imported sources."
     )
 }
 
@@ -554,7 +563,7 @@ mod tests {
     }
 
     #[test]
-    fn http_401_includes_both_install_paths() {
+    fn http_401_has_actionable_credential_refresh_hint() {
         let error = ProviderQueryError::ApiRequest {
             source_schema: "github".to_string(),
             table: "issues".to_string(),
@@ -566,11 +575,35 @@ mod tests {
         }
         .to_structured();
         assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.summary(), "Source credentials were rejected");
+        assert!(error.detail().contains("saved credentials for `github`"));
+        assert!(error.detail().contains("Provider detail: Bad credentials"));
         assert_eq!(error.metadata().get("http_status").unwrap(), "401");
         assert!(!error.retryable());
         let hint = error.hint().expect("401 should have a hint");
-        assert!(hint.contains("coral source add github"));
-        assert!(hint.contains("coral source add --file"));
+        assert!(hint.contains("coral source add github --interactive"));
+        assert!(hint.contains("coral source add --file <manifest-path> --interactive"));
+    }
+
+    #[test]
+    fn http_403_uses_access_denied_summary_and_scope_hint() {
+        let error = ProviderQueryError::ApiRequest {
+            source_schema: "github".to_string(),
+            table: "issues".to_string(),
+            status: Some(403),
+            method: Some("GET".to_string()),
+            url: Some("https://api.github.com/repos/coral/coral/issues".to_string()),
+            filters: HashMap::new(),
+            detail: "Resource not accessible by integration".to_string(),
+        }
+        .to_structured();
+        assert_eq!(error.reason(), "PROVIDER_REQUEST_FAILED");
+        assert_eq!(error.summary(), "Source access was denied");
+        assert!(error.detail().contains("saved credentials for `github`"));
+        assert_eq!(error.metadata().get("http_status").unwrap(), "403");
+        let hint = error.hint().expect("403 should have a hint");
+        assert!(hint.contains("coral source add github --interactive"));
+        assert!(hint.contains("has access to this resource"));
     }
 
     #[test]

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -17,4 +17,4 @@ pub use query::{
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 
 #[cfg(test)]
-pub(crate) use query_error::UNKNOWN_COLUMN_REASON;
+pub(crate) use query_error::{SQL_PARSE_ERROR_REASON, UNKNOWN_COLUMN_REASON};

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -155,10 +155,7 @@ impl StructuredQueryError {
             SQL_PARSE_ERROR_REASON,
             "SQL query could not be parsed",
             detail,
-            Some(
-                "Check the SQL syntax and retry. Use `SELECT * FROM coral.tables LIMIT 10` to inspect available tables."
-                    .to_string(),
-            ),
+            None,
             false,
             StatusCode::InvalidArgument,
             HashMap::new(),
@@ -700,15 +697,14 @@ mod tests {
     }
 
     #[test]
-    fn sql_parse_error_points_to_discovery_query() {
+    fn sql_parse_error_has_no_hint() {
         let err = StructuredQueryError::sql_parse_error("Expected end of statement");
 
         assert_eq!(err.reason(), SQL_PARSE_ERROR_REASON);
         assert_eq!(err.summary(), "SQL query could not be parsed");
         assert_eq!(err.status(), StatusCode::InvalidArgument);
         assert!(err.detail().contains("Expected end of statement"));
-        let hint = err.hint().expect("hint should be present");
-        assert!(hint.contains("coral.tables"), "got: {hint}");
+        assert!(err.hint().is_none());
     }
 
     #[test]

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -19,6 +19,8 @@ pub(crate) const EMPTY_SQL_REASON: &str = "EMPTY_SQL";
 /// Wire-stable `reason` code for SQL parse errors.
 pub(crate) const SQL_PARSE_ERROR_REASON: &str = "SQL_PARSE_ERROR";
 
+const METADATA_CATALOG_EMPTY: &str = "catalog_empty";
+
 /// Minimum `strsim::normalized_levenshtein` score for a "did you mean?"
 /// suggestion to surface.
 ///
@@ -142,7 +144,7 @@ impl StructuredQueryError {
             EMPTY_SQL_REASON,
             "SQL query is empty",
             "Coral cannot run an empty SQL string.",
-            Some("Try `coral sql \"SELECT * FROM coral.tables LIMIT 10\"`.".to_string()),
+            Some("Try the SQL statement `SELECT * FROM coral.tables LIMIT 10`.".to_string()),
             false,
             StatusCode::InvalidArgument,
             HashMap::new(),
@@ -224,6 +226,9 @@ impl StructuredQueryError {
             metadata.insert("schema".to_string(), schema.clone());
         }
         metadata.insert("table".to_string(), table.clone());
+        if known_tables.is_empty() {
+            metadata.insert(METADATA_CATALOG_EMPTY.to_string(), "true".to_string());
+        }
 
         let detail = match schema.as_deref() {
             Some(schema) => format!("No table `{table}` exists in schema `{schema}`."),
@@ -379,7 +384,7 @@ fn table_not_found_hint(
 ) -> Option<String> {
     if known_tables.is_empty() {
         return Some(
-            "No source tables are currently queryable. Run `coral source discover`, then `coral source add <source>` to connect a source.".to_string(),
+            "No source tables are currently queryable. Discover available sources, connect one, then retry the query.".to_string(),
         );
     }
 
@@ -804,8 +809,19 @@ mod tests {
 
         assert_eq!(err.reason(), TABLE_NOT_FOUND_REASON);
         let hint = err.hint().expect("hint should be present");
-        assert!(hint.contains("coral source discover"), "got: {hint}");
-        assert!(hint.contains("coral source add <source>"), "got: {hint}");
+        assert!(
+            hint.contains("No source tables are currently queryable"),
+            "got: {hint}"
+        );
+        assert!(hint.contains("Discover available sources"), "got: {hint}");
+        assert_eq!(
+            err.metadata().get(METADATA_CATALOG_EMPTY),
+            Some(&"true".to_string())
+        );
+        assert!(
+            !hint.contains("coral source"),
+            "engine hint must stay transport-neutral, got: {hint}"
+        );
     }
 
     #[test]

--- a/crates/coral-engine/src/contracts/query_error.rs
+++ b/crates/coral-engine/src/contracts/query_error.rs
@@ -13,6 +13,12 @@ pub(crate) const UNKNOWN_COLUMN_REASON: &str = "UNKNOWN_COLUMN";
 /// Wire-stable `reason` code for table-not-found errors.
 pub(crate) const TABLE_NOT_FOUND_REASON: &str = "TABLE_NOT_FOUND";
 
+/// Wire-stable `reason` code for empty SQL errors.
+pub(crate) const EMPTY_SQL_REASON: &str = "EMPTY_SQL";
+
+/// Wire-stable `reason` code for SQL parse errors.
+pub(crate) const SQL_PARSE_ERROR_REASON: &str = "SQL_PARSE_ERROR";
+
 /// Minimum `strsim::normalized_levenshtein` score for a "did you mean?"
 /// suggestion to surface.
 ///
@@ -128,6 +134,35 @@ impl StructuredQueryError {
             status,
             metadata,
         }
+    }
+
+    /// Builds a structured `EMPTY_SQL` error.
+    pub(crate) fn empty_sql() -> Self {
+        Self::new(
+            EMPTY_SQL_REASON,
+            "SQL query is empty",
+            "Coral cannot run an empty SQL string.",
+            Some("Try `coral sql \"SELECT * FROM coral.tables LIMIT 10\"`.".to_string()),
+            false,
+            StatusCode::InvalidArgument,
+            HashMap::new(),
+        )
+    }
+
+    /// Builds a structured `SQL_PARSE_ERROR` error.
+    pub(crate) fn sql_parse_error(detail: &str) -> Self {
+        Self::new(
+            SQL_PARSE_ERROR_REASON,
+            "SQL query could not be parsed",
+            detail,
+            Some(
+                "Check the SQL syntax and retry. Use `SELECT * FROM coral.tables LIMIT 10` to inspect available tables."
+                    .to_string(),
+            ),
+            false,
+            StatusCode::InvalidArgument,
+            HashMap::new(),
+        )
     }
 
     /// Builds a structured `UNKNOWN_COLUMN` error from a missing column and
@@ -345,6 +380,12 @@ fn table_not_found_hint(
     table: &str,
     known_tables: &[TableInfo],
 ) -> Option<String> {
+    if known_tables.is_empty() {
+        return Some(
+            "No source tables are currently queryable. Run `coral source discover`, then `coral source add <source>` to connect a source.".to_string(),
+        );
+    }
+
     let Some(schema) = schema else {
         // Unqualified `FROM X` could not be resolved. Before falling back to
         // the generic catalog pointer, scan every known table across every
@@ -643,6 +684,31 @@ mod tests {
         // that pattern-matches on reason codes.
         assert_eq!(UNKNOWN_COLUMN_REASON, "UNKNOWN_COLUMN");
         assert_eq!(TABLE_NOT_FOUND_REASON, "TABLE_NOT_FOUND");
+        assert_eq!(EMPTY_SQL_REASON, "EMPTY_SQL");
+        assert_eq!(SQL_PARSE_ERROR_REASON, "SQL_PARSE_ERROR");
+    }
+
+    #[test]
+    fn empty_sql_has_actionable_hint() {
+        let err = StructuredQueryError::empty_sql();
+
+        assert_eq!(err.reason(), EMPTY_SQL_REASON);
+        assert_eq!(err.summary(), "SQL query is empty");
+        assert_eq!(err.status(), StatusCode::InvalidArgument);
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("coral.tables"), "got: {hint}");
+    }
+
+    #[test]
+    fn sql_parse_error_points_to_discovery_query() {
+        let err = StructuredQueryError::sql_parse_error("Expected end of statement");
+
+        assert_eq!(err.reason(), SQL_PARSE_ERROR_REASON);
+        assert_eq!(err.summary(), "SQL query could not be parsed");
+        assert_eq!(err.status(), StatusCode::InvalidArgument);
+        assert!(err.detail().contains("Expected end of statement"));
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("coral.tables"), "got: {hint}");
     }
 
     #[test]
@@ -733,6 +799,17 @@ mod tests {
             !hint.contains("coral source"),
             "hint must stay transport-neutral (no CLI-specific commands), got: {hint}"
         );
+    }
+
+    #[test]
+    fn table_not_found_with_no_tables_points_to_source_setup() {
+        let err =
+            StructuredQueryError::table_not_found(&tr(&["datafusion", "github", "issues"]), &[]);
+
+        assert_eq!(err.reason(), TABLE_NOT_FOUND_REASON);
+        let hint = err.hint().expect("hint should be present");
+        assert!(hint.contains("coral source discover"), "got: {hint}");
+        assert!(hint.contains("coral source add <source>"), "got: {hint}");
     }
 
     #[test]

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -131,7 +131,9 @@ impl CoralQuery {
         sql: &str,
     ) -> Result<QueryExecution, CoreError> {
         if sql.trim().is_empty() {
-            return Err(CoreError::InvalidInput("SQL must not be empty".to_string()));
+            return Err(CoreError::QueryFailure(Box::new(
+                StructuredQueryError::empty_sql(),
+            )));
         }
 
         runtime::query::build_runtime(sources, runtime)

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -309,7 +309,7 @@ mod tests {
             CoreError::QueryFailure(sqe) => {
                 assert_eq!(sqe.reason(), crate::contracts::SQL_PARSE_ERROR_REASON);
                 assert_eq!(sqe.summary(), "SQL query could not be parsed");
-                assert!(sqe.hint().is_some_and(|hint| hint.contains("coral.tables")));
+                assert!(sqe.hint().is_none());
             }
             other => panic!("expected CoreError::QueryFailure, got {other:?}"),
         }

--- a/crates/coral-engine/src/runtime/error.rs
+++ b/crates/coral-engine/src/runtime/error.rs
@@ -27,7 +27,10 @@ pub(crate) fn datafusion_to_core_with_sql(
     // SchemaError in `Context`/`Execution`, hiding the structured variant
     // from the match arms below.
     match error.find_root() {
-        DataFusionError::SQL(detail, _) => CoreError::InvalidInput(detail.to_string()),
+        DataFusionError::SQL(detail, _) => {
+            let detail = detail.to_string();
+            CoreError::QueryFailure(Box::new(StructuredQueryError::sql_parse_error(&detail)))
+        }
         DataFusionError::Plan(detail) => plan_error_to_core(detail, error, tables, sql),
         DataFusionError::SchemaError(schema_error, _) => schema_error_to_core(schema_error),
         DataFusionError::NotImplemented(detail) => CoreError::Unimplemented(detail.clone()),
@@ -240,6 +243,8 @@ fn mcp_provider_error_to_core(error: &McpProviderQueryError) -> CoreError {
 
 #[cfg(test)]
 mod tests {
+    use datafusion::sql::sqlparser::parser::ParserError;
+
     use super::*;
     use crate::contracts::UNKNOWN_COLUMN_REASON;
 
@@ -286,6 +291,27 @@ mod tests {
         match core {
             CoreError::InvalidInput(detail) => assert!(detail.contains("syntax error")),
             other => panic!("expected CoreError::InvalidInput, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sql_error_maps_to_structured_parse_error() {
+        let error = DataFusionError::SQL(
+            Box::new(ParserError::ParserError(
+                "Expected end of statement".to_string(),
+            )),
+            None,
+        );
+
+        let core = datafusion_to_core(&error, &[]);
+
+        match core {
+            CoreError::QueryFailure(sqe) => {
+                assert_eq!(sqe.reason(), crate::contracts::SQL_PARSE_ERROR_REASON);
+                assert_eq!(sqe.summary(), "SQL query could not be parsed");
+                assert!(sqe.hint().is_some_and(|hint| hint.contains("coral.tables")));
+            }
+            other => panic!("expected CoreError::QueryFailure, got {other:?}"),
         }
     }
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -1407,7 +1407,9 @@ async fn api_returns_401() {
             assert!(!sqe.retryable());
             assert_eq!(sqe.metadata().get("http_status").unwrap(), "401");
             assert_eq!(sqe.metadata().get("source").unwrap(), "http_401");
-            assert!(sqe.hint().unwrap().contains("coral source add http_401"));
+            let hint = sqe.hint().expect("401 should include credential hint");
+            assert!(hint.contains("Refresh the saved credentials for `http_401`"));
+            assert!(!hint.contains("coral source"));
             assert!(sqe.detail().contains("unauthorized"));
         }
         other => panic!("unexpected 401 error variant: {other:?}"),

--- a/crates/coral-engine/tests/engine/json_tests.rs
+++ b/crates/coral-engine/tests/engine/json_tests.rs
@@ -286,12 +286,13 @@ async fn json_operators_are_rejected() {
             .await
             .expect_err("query should reject JSON operators");
 
-        assert!(
-            matches!(
-                error,
-                CoreError::InvalidInput(_) | CoreError::Unimplemented(_) | CoreError::Internal(_)
-            ),
-            "expected a planning failure for `{sql}`, got {error:?}"
-        );
+        match error {
+            CoreError::QueryFailure(sqe) => {
+                assert_eq!(sqe.reason(), "SQL_PARSE_ERROR");
+                assert!(sqe.hint().is_some());
+            }
+            CoreError::InvalidInput(_) | CoreError::Unimplemented(_) | CoreError::Internal(_) => {}
+            other => panic!("expected a planning failure for `{sql}`, got {other:?}"),
+        }
     }
 }

--- a/crates/coral-engine/tests/engine/json_tests.rs
+++ b/crates/coral-engine/tests/engine/json_tests.rs
@@ -289,7 +289,7 @@ async fn json_operators_are_rejected() {
         match error {
             CoreError::QueryFailure(sqe) => {
                 assert_eq!(sqe.reason(), "SQL_PARSE_ERROR");
-                assert!(sqe.hint().is_some());
+                assert!(sqe.hint().is_none());
             }
             CoreError::InvalidInput(_) | CoreError::Unimplemented(_) | CoreError::Internal(_) => {}
             other => panic!("expected a planning failure for `{sql}`, got {other:?}"),

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -63,7 +63,9 @@ pub(crate) fn tool_error_from_status(operation: &str, status: &tonic::Status) ->
         DecodedStatusError::Structured(error) => ToolError {
             summary: error.summary.clone(),
             detail: error.detail.clone(),
-            hint: error.hint.clone(),
+            hint: mcp_hint_for_app_reason(&error.reason)
+                .map(str::to_string)
+                .or_else(|| error.hint.clone()),
             grpc_code,
             reason: Some(error.reason.clone()),
             retryable: error.retryable,
@@ -116,13 +118,16 @@ fn plain_fallback(operation: &str, code: tonic::Code) -> (String, Option<String>
 pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
     match decode_status_error(status) {
         DecodedStatusError::Structured(error) => {
+            let hint = mcp_hint_for_app_reason(&error.reason)
+                .map(str::to_string)
+                .or(error.hint);
             let data = serde_json::to_value(StatusErrorDataValue {
                 detail: &error.detail,
                 grpc_code: status.code().to_string(),
                 reason: &error.reason,
                 retryable: error.retryable,
                 metadata: &error.metadata,
-                hint: error.hint.as_deref(),
+                hint: hint.as_deref(),
             })
             .expect("status error data value serializes");
             match status.code() {
@@ -138,6 +143,30 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
             tonic::Code::InvalidArgument => ErrorData::invalid_params(message, None),
             _ => ErrorData::internal_error(message, None),
         },
+    }
+}
+
+fn mcp_hint_for_app_reason(reason: &str) -> Option<&'static str> {
+    match reason {
+        "SOURCE_NOT_FOUND" => Some(
+            "Use `list_tables` or `search_tables` to inspect visible tables and sources before retrying.",
+        ),
+        "INVALID_INPUT" => {
+            Some("Check the tool arguments and retry with values that match the tool schema.")
+        }
+        "SETUP_REQUIRED" => Some(
+            "Use `list_tables` to inspect configured sources, then retry once the source is ready.",
+        ),
+        "INVALID_SECRETS_FILE" => Some(
+            "Ask the user to refresh saved credentials for the affected source before retrying.",
+        ),
+        "CONFIG_DIR_NOT_FOUND"
+        | "LOCAL_FILE_ERROR"
+        | "CONFIG_WRITE_FAILED"
+        | "SECRETS_FILE_ERROR" => Some(
+            "Ask the host process owner to check Coral's config directory and file permissions.",
+        ),
+        _ => None,
     }
 }
 
@@ -253,6 +282,36 @@ mod tests {
         assert_eq!(error.reason.as_deref(), Some("MISSING_REQUIRED_FILTER"));
         assert!(!error.retryable);
         assert_eq!(error.metadata.get("schema").unwrap(), "github");
+    }
+
+    #[test]
+    fn structured_app_reason_uses_mcp_specific_hint() {
+        let status = build_coral_status(
+            "SOURCE_NOT_FOUND",
+            vec![
+                ("summary", "Source `github` was not found"),
+                ("detail", "No source named `github` is installed."),
+                (
+                    "hint",
+                    "List installed sources or discover available sources, then retry.",
+                ),
+            ],
+            false,
+        );
+
+        let error = tool_error_from_status("Query", &status);
+        assert_eq!(
+            error.hint.as_deref(),
+            Some(
+                "Use `list_tables` or `search_tables` to inspect visible tables and sources before retrying."
+            )
+        );
+
+        let data = status_to_error_data(&status).data.expect("error data");
+        assert_eq!(
+            data["hint"],
+            "Use `list_tables` or `search_tables` to inspect visible tables and sources before retrying."
+        );
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -1,6 +1,13 @@
 use std::collections::HashMap;
 use std::fmt::Write as _;
 
+use coral_api::{
+    CORAL_ERROR_REASON_CONFIG_DIR_NOT_FOUND, CORAL_ERROR_REASON_CONFIG_WRITE_FAILED,
+    CORAL_ERROR_REASON_EMPTY_SQL, CORAL_ERROR_REASON_INVALID_INPUT,
+    CORAL_ERROR_REASON_INVALID_SECRETS_FILE, CORAL_ERROR_REASON_LOCAL_FILE_ERROR,
+    CORAL_ERROR_REASON_SECRETS_FILE_ERROR, CORAL_ERROR_REASON_SETUP_REQUIRED,
+    CORAL_ERROR_REASON_SOURCE_NOT_FOUND, CORAL_ERROR_REASON_TABLE_NOT_FOUND,
+};
 use coral_client::{DecodedStatusError, decode_status_error};
 use rmcp::{
     ErrorData,
@@ -63,7 +70,7 @@ pub(crate) fn tool_error_from_status(operation: &str, status: &tonic::Status) ->
         DecodedStatusError::Structured(error) => ToolError {
             summary: error.summary.clone(),
             detail: error.detail.clone(),
-            hint: mcp_hint_for_app_reason(&error.reason)
+            hint: mcp_hint_for_reason(&error.reason, &error.metadata)
                 .map(str::to_string)
                 .or_else(|| error.hint.clone()),
             grpc_code,
@@ -118,7 +125,7 @@ fn plain_fallback(operation: &str, code: tonic::Code) -> (String, Option<String>
 pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
     match decode_status_error(status) {
         DecodedStatusError::Structured(error) => {
-            let hint = mcp_hint_for_app_reason(&error.reason)
+            let hint = mcp_hint_for_reason(&error.reason, &error.metadata)
                 .map(str::to_string)
                 .or(error.hint);
             let data = serde_json::to_value(StatusErrorDataValue {
@@ -146,26 +153,36 @@ pub(crate) fn status_to_error_data(status: &tonic::Status) -> ErrorData {
     }
 }
 
-fn mcp_hint_for_app_reason(reason: &str) -> Option<&'static str> {
+fn mcp_hint_for_reason(reason: &str, metadata: &HashMap<String, String>) -> Option<&'static str> {
     match reason {
-        "SOURCE_NOT_FOUND" => Some(
+        CORAL_ERROR_REASON_SOURCE_NOT_FOUND => Some(
             "Use `list_tables` or `search_tables` to inspect visible tables and sources before retrying.",
         ),
-        "INVALID_INPUT" => {
+        CORAL_ERROR_REASON_INVALID_INPUT => {
             Some("Check the tool arguments and retry with values that match the tool schema.")
         }
-        "SETUP_REQUIRED" => Some(
+        CORAL_ERROR_REASON_SETUP_REQUIRED => Some(
             "Use `list_tables` to inspect configured sources, then retry once the source is ready.",
         ),
-        "INVALID_SECRETS_FILE" => Some(
+        CORAL_ERROR_REASON_INVALID_SECRETS_FILE => Some(
             "Ask the user to refresh saved credentials for the affected source before retrying.",
         ),
-        "CONFIG_DIR_NOT_FOUND"
-        | "LOCAL_FILE_ERROR"
-        | "CONFIG_WRITE_FAILED"
-        | "SECRETS_FILE_ERROR" => Some(
+        CORAL_ERROR_REASON_CONFIG_DIR_NOT_FOUND
+        | CORAL_ERROR_REASON_LOCAL_FILE_ERROR
+        | CORAL_ERROR_REASON_CONFIG_WRITE_FAILED
+        | CORAL_ERROR_REASON_SECRETS_FILE_ERROR => Some(
             "Ask the host process owner to check Coral's config directory and file permissions.",
         ),
+        CORAL_ERROR_REASON_EMPTY_SQL => Some(
+            "Retry with a non-empty SQL statement, for example `SELECT * FROM coral.tables LIMIT 10`.",
+        ),
+        CORAL_ERROR_REASON_TABLE_NOT_FOUND
+            if metadata
+                .get("catalog_empty")
+                .is_some_and(|value| value == "true") =>
+        {
+            Some("Use `list_tables` or `search_tables` to inspect visible tables before retrying.")
+        }
         _ => None,
     }
 }
@@ -311,6 +328,45 @@ mod tests {
         assert_eq!(
             data["hint"],
             "Use `list_tables` or `search_tables` to inspect visible tables and sources before retrying."
+        );
+    }
+
+    #[test]
+    fn table_not_found_preserves_engine_hint_when_catalog_is_not_empty() {
+        let status = build_coral_status(
+            "TABLE_NOT_FOUND",
+            vec![
+                ("summary", "Table `github.issuse` not found"),
+                ("detail", "No table `issuse` exists in schema `github`."),
+                ("hint", "Did you mean `github.issues`?"),
+            ],
+            false,
+        );
+
+        let error = tool_error_from_status("Query", &status);
+        assert_eq!(error.hint.as_deref(), Some("Did you mean `github.issues`?"));
+    }
+
+    #[test]
+    fn empty_catalog_table_not_found_uses_mcp_hint() {
+        let status = build_coral_status(
+            "TABLE_NOT_FOUND",
+            vec![
+                ("summary", "Table `github.issues` not found"),
+                ("detail", "No table `issues` exists in schema `github`."),
+                ("catalog_empty", "true"),
+                (
+                    "hint",
+                    "No source tables are currently queryable. Discover available sources, connect one, then retry the query.",
+                ),
+            ],
+            false,
+        );
+
+        let error = tool_error_from_status("Query", &status);
+        assert_eq!(
+            error.hint.as_deref(),
+            Some("Use `list_tables` or `search_tables` to inspect visible tables before retrying.")
         );
     }
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -240,3 +240,9 @@ The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` 
 
 - **`coral` not found:** Make sure `coral` is on your `PATH`, or use the full path from `which coral` on macOS or Linux or `(Get-Command coral).Source` in PowerShell.
 - **No tables visible:** Run `coral source list` in your terminal to confirm you have sources installed. If empty, add one with `coral source add`.
+
+Tool errors use structured Coral diagnostics when the local server provides
+them. MCP-facing hints avoid CLI-only commands where possible and point agents
+at MCP tools such as `list_tables` or `search_tables`; host-level setup and
+credential repairs may still require the user to run Coral CLI commands outside
+the MCP session.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -34,6 +34,12 @@ coral sql "<SQL>"
 
 JSON output is an array of row objects. Selected nullable columns are included with explicit `null` values when the row value is null.
 
+Query failures are rendered as a diagnostic block with `Error`, `Detail`, and,
+when Coral has a specific remediation, `Hint`. Structured query diagnostics keep
+SQL-level guidance in the engine while the CLI renders command-oriented hints,
+such as using `coral source list`, `coral source discover`, or a sample
+`coral sql` command when that is the most direct terminal action.
+
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.
@@ -136,6 +142,11 @@ Remove an installed source.
 ```shellscript
 coral source remove github
 ```
+
+If the source is not installed, Coral reports that there is nothing to remove.
+If the source exists but local state files are missing or unreadable, Coral
+preserves the underlying local-file diagnostic instead of treating it as an
+unknown source.
 
 ## `coral onboard`
 


### PR DESCRIPTION
This is a proposal for error message audit it's aim is to provide user with the following 

- A clear, jargon-free message explaining what went wrong
- A hint field with an actionable next step
- Consistent formatting across CLI and server errors

What this PR does:
  - Adds a reusable `CliError::Diagnostic` path instead of many one-off CLI error variants.
  - Preserves existing semantic errors for `SourceNotInstalled` and `SourceNotFound`.
  - Improves source `install/test/lint` errors for missing inputs, invalid source names, manifest read/parse failures, server startup/connect failures, and non-query server statuses.
  - Reuses structured server ErrorInfo when available instead of falling back to unstructured anyhow output.
  - Quotes shell paths in interactive command hints so paths with spaces or shell meta characters are copyable.
  
  ```
   coral sql 'SELECT * FROM github.issuues LIMIT 1'
  └ Error: Table `github.issuues` not found
    Detail: No table `issues` exists in schema `github`.
    Hint: No source tables are currently queryable. Run `coral source discover`
    
    
    coral sql 'SELEC 1'
  └ Error: SQL query could not be parsed
    Detail: sql parser error: Expected: an SQL statement, found: SELEC at Line: 1, Column: 1
    Hint: Check the SQL syntax and retry. Use `SELECT * FROM coral.tables LIMIT 10` to inspect available tables.
```

- [ ] Run benchmarks, and check the impact of this change 