### PR TITLE
fix(mcp): align search table output schema with response

### DIFF
--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -312,6 +312,7 @@ fn search_tables_output_schema() -> Arc<Map<String, Value>> {
             "name",
             "sql_reference",
             "description",
+            "guide",
             "required_filters",
             "matched_fields"
         ],
@@ -322,6 +323,7 @@ fn search_tables_output_schema() -> Arc<Map<String, Value>> {
             "name": { "type": "string" },
             "sql_reference": { "type": "string" },
             "description": { "type": "string" },
+            "guide": { "type": "string" },
             "required_filters": {
                 "type": "array",
                 "items": { "type": "string" }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -407,6 +407,10 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         "local_messages.messages"
     );
     assert!(
+        search["tables"][0]["guide"].is_string(),
+        "search results should always expose guide text, even when empty"
+    );
+    assert!(
         search["tables"][0]["matched_fields"]
             .as_array()
             .expect("matched fields")


### PR DESCRIPTION
## Summary
This fixes the `main` break introduced by #340. The `search_tables` tool started returning a `guide` field in its structured response, but the advertised output schema still rejected that field as an unexpected property. That caused `tests::mcp_surface_refreshes_and_renders_dynamic_guide` to fail during `make rust-checks` on `main`.

This patch updates the `search_tables` output schema to include `guide` and keeps the end-to-end test focused on the real contract: the field must be present and schema-valid, even when a fixture does not declare non-empty guide text.

## Testing
- make rust-checks
