### PR TITLE
feat(spec): harden search metadata validation

### DIFF
--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -231,6 +231,7 @@ impl RawFileTableSpec {
     fn into_validated_parquet(self, schema: &str) -> Result<FileTableSpec> {
         self.source.validate_for_parquet(schema, &self.name)?;
         validate_columns(&self.columns, schema, &self.name)?;
+        validate_filters_and_column_exprs(&self.filters, &self.columns, schema, &self.name)?;
 
         let partition_names = self
             .source
@@ -435,5 +436,28 @@ mod tests {
 
         assert!(manifest.required_secret_names().is_empty());
         assert!(manifest.declared_inputs.is_empty());
+    }
+
+    #[test]
+    fn parquet_manifest_rejects_invalid_filter_type() {
+        let error = ParquetSourceManifest::parse_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "local",
+            "version": "0.1.0",
+            "backend": "parquet",
+            "tables": [{
+                "name": "events",
+                "description": "Local events",
+                "source": { "location": "file:///tmp/local/" },
+                "filters": [{ "name": "event_type", "type": "Banana" }],
+                "columns": [],
+            }],
+        }))
+        .expect_err("parquet filter types should be validated");
+
+        assert!(
+            error.to_string().contains("unsupported data type 'Banana'"),
+            "unexpected error: {error}"
+        );
     }
 }

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -209,6 +209,13 @@ impl FilterMode {
     }
 }
 
+/// Highest per-call result count a source-spec search surface may request.
+pub(crate) const MAX_SEARCH_TOP_K: usize = 1_000;
+/// Highest number of provider search calls a single query may make.
+pub(crate) const MAX_SEARCH_CALLS_PER_QUERY: usize = 100;
+/// Highest aggregate candidate budget for one query across repeated search calls.
+pub(crate) const MAX_SEARCH_CANDIDATES_PER_QUERY: usize = 10_000;
+
 /// Bounded retrieval settings for search-like provider surfaces.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -190,6 +190,68 @@ tables:
     }
 
     #[test]
+    fn validate_manifest_schema_rejects_http_table_source() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    source:
+      location: file:///tmp/messages.jsonl
+    request:
+      method: GET
+      path: /messages
+",
+        );
+        let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
+        let message = error.to_string();
+        assert!(
+            message.starts_with("source manifest failed schema validation:"),
+            "{message}"
+        );
+        assert!(message.contains("/tables/0"), "{message}");
+        assert!(message.contains("source"), "{message}");
+    }
+
+    #[test]
+    fn validate_manifest_schema_rejects_search_limits_above_cap() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    search_limits:
+      default_top_k: 5
+      max_top_k: 1001
+      max_calls_per_query: 1
+    request:
+      method: GET
+      path: /messages
+",
+        );
+        let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
+        let message = error.to_string();
+        assert!(
+            message.starts_with("source manifest failed schema validation:"),
+            "{message}"
+        );
+        assert!(
+            message.contains("/tables/0/search_limits/max_top_k"),
+            "{message}"
+        );
+    }
+
+    #[test]
     fn validate_manifest_schema_rejects_unknown_top_level_field() {
         let manifest = manifest_json(&format!("schema: legacy\n{}", valid_http_manifest()));
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -36,6 +36,21 @@
           }
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "backend": { "not": { "enum": ["http", "jsonl", "parquet"] } }
+        },
+        "required": ["backend"]
+      },
+      "then": {
+        "properties": {
+          "tables": {
+            "items": false
+          }
+        }
+      }
     }
   ],
   "properties": {
@@ -205,7 +220,6 @@
         },
         "response": { "$ref": "#/$defs/response" },
         "pagination": { "$ref": "#/$defs/pagination" },
-        "source": { "$ref": "#/$defs/source" },
         "columns": {
           "type": "array",
           "items": { "$ref": "#/$defs/column" }
@@ -285,9 +299,9 @@
       "additionalProperties": false,
       "required": ["default_top_k", "max_top_k", "max_calls_per_query"],
       "properties": {
-        "default_top_k": { "type": "integer", "minimum": 1 },
-        "max_top_k": { "type": "integer", "minimum": 1 },
-        "max_calls_per_query": { "type": "integer", "minimum": 1 }
+        "default_top_k": { "type": "integer", "minimum": 1, "maximum": 1000 },
+        "max_top_k": { "type": "integer", "minimum": 1, "maximum": 1000 },
+        "max_calls_per_query": { "type": "integer", "minimum": 1, "maximum": 100 }
       }
     },
     "detail_hint": {

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -3,7 +3,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::common::{
-    BodySpec, ColumnSpec, DetailHintSpec, ExprSpec, FilterSpec, FunctionArgBinding, PaginationSpec,
+    BodySpec, ColumnSpec, DetailHintSpec, ExprSpec, FilterSpec, FunctionArgBinding,
+    MAX_SEARCH_CALLS_PER_QUERY, MAX_SEARCH_CANDIDATES_PER_QUERY, MAX_SEARCH_TOP_K, PaginationSpec,
     RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
     SourceTableFunctionSpec, ValueSourceSpec,
 };
@@ -326,6 +327,11 @@ fn validate_search_limits(limits: &SearchLimitsSpec, context: &str) -> Result<()
             "{context}.max_top_k must be > 0"
         )));
     }
+    if limits.max_top_k > MAX_SEARCH_TOP_K {
+        return Err(ManifestError::validation(format!(
+            "{context}.max_top_k must be <= {MAX_SEARCH_TOP_K}"
+        )));
+    }
     if limits.default_top_k > limits.max_top_k {
         return Err(ManifestError::validation(format!(
             "{context}.default_top_k must be <= max_top_k"
@@ -334,6 +340,21 @@ fn validate_search_limits(limits: &SearchLimitsSpec, context: &str) -> Result<()
     if limits.max_calls_per_query == 0 {
         return Err(ManifestError::validation(format!(
             "{context}.max_calls_per_query must be > 0"
+        )));
+    }
+    if limits.max_calls_per_query > MAX_SEARCH_CALLS_PER_QUERY {
+        return Err(ManifestError::validation(format!(
+            "{context}.max_calls_per_query must be <= {MAX_SEARCH_CALLS_PER_QUERY}"
+        )));
+    }
+    let Some(candidate_budget) = limits.max_top_k.checked_mul(limits.max_calls_per_query) else {
+        return Err(ManifestError::validation(format!(
+            "{context}.max_top_k * max_calls_per_query exceeds supported range"
+        )));
+    };
+    if candidate_budget > MAX_SEARCH_CANDIDATES_PER_QUERY {
+        return Err(ManifestError::validation(format!(
+            "{context}.max_top_k * max_calls_per_query must be <= {MAX_SEARCH_CANDIDATES_PER_QUERY}"
         )));
     }
     Ok(())
@@ -793,8 +814,9 @@ mod tests {
         validate_http_table, validate_table_names,
     };
     use crate::common::{
-        ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding, PaginationSpec,
-        QueryParamSpec, RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
+        ColumnSpec, ExprSpec, FilterMode, FilterSpec, FunctionArgBinding,
+        MAX_SEARCH_CANDIDATES_PER_QUERY, MAX_SEARCH_TOP_K, PaginationSpec, QueryParamSpec,
+        RequestRouteSpec, RequestSpec, SearchLimitsSpec, SourceTableFunctionKind,
         SourceTableFunctionSpec, TableFunctionArgSpec, ValueSourceSpec,
     };
     use crate::parse_source_manifest_value;
@@ -1337,6 +1359,56 @@ mod tests {
     }
 
     #[test]
+    fn validate_search_limits_rejects_max_top_k_above_cap() {
+        let mut function = function_with_request_value(ValueSourceSpec::Arg {
+            key: "q".to_string(),
+            default: None,
+        });
+        function.kind = SourceTableFunctionKind::Search;
+        function.search_limits = Some(SearchLimitsSpec {
+            default_top_k: 10,
+            max_top_k: MAX_SEARCH_TOP_K + 1,
+            max_calls_per_query: 1,
+        });
+        function.columns = vec![test_column()];
+
+        let error = validate_http_function("demo", &function)
+            .expect_err("overlarge search top-k cap should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("max_top_k must be <= {MAX_SEARCH_TOP_K}")),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validate_search_limits_rejects_aggregate_candidate_budget_above_cap() {
+        let mut function = function_with_request_value(ValueSourceSpec::Arg {
+            key: "q".to_string(),
+            default: None,
+        });
+        function.kind = SourceTableFunctionKind::Search;
+        function.search_limits = Some(SearchLimitsSpec {
+            default_top_k: 10,
+            max_top_k: 1_000,
+            max_calls_per_query: (MAX_SEARCH_CANDIDATES_PER_QUERY / 1_000) + 1,
+        });
+        function.columns = vec![test_column()];
+
+        let error = validate_http_function("demo", &function)
+            .expect_err("overlarge aggregate search budget should fail");
+
+        assert!(
+            error.to_string().contains(&format!(
+                "max_top_k * max_calls_per_query must be <= {MAX_SEARCH_CANDIDATES_PER_QUERY}"
+            )),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn validate_detail_hints_rejects_unknown_result_column() {
         let detail_hints = [crate::DetailHintSpec {
             table: "demo.items".to_string(),
@@ -1364,6 +1436,68 @@ mod tests {
                 .contains("references unknown search_result_column 'missing'"),
             "unexpected error: {error}"
         );
+    }
+
+    #[test]
+    fn validate_detail_hints_reject_empty_fields() {
+        let cases = [
+            (
+                "table",
+                crate::DetailHintSpec {
+                    table: String::new(),
+                    search_result_column: "id".to_string(),
+                    detail_filter: "item_id".to_string(),
+                    purpose: "Fetch full item details.".to_string(),
+                },
+            ),
+            (
+                "search_result_column",
+                crate::DetailHintSpec {
+                    table: "demo.items".to_string(),
+                    search_result_column: String::new(),
+                    detail_filter: "item_id".to_string(),
+                    purpose: "Fetch full item details.".to_string(),
+                },
+            ),
+            (
+                "detail_filter",
+                crate::DetailHintSpec {
+                    table: "demo.items".to_string(),
+                    search_result_column: "id".to_string(),
+                    detail_filter: String::new(),
+                    purpose: "Fetch full item details.".to_string(),
+                },
+            ),
+            (
+                "purpose",
+                crate::DetailHintSpec {
+                    table: "demo.items".to_string(),
+                    search_result_column: "id".to_string(),
+                    detail_filter: "item_id".to_string(),
+                    purpose: String::new(),
+                },
+            ),
+        ];
+
+        for (field_name, detail_hint) in cases {
+            let error = validate_http_table(
+                "demo",
+                "messages",
+                &test_filters(),
+                &[test_column()],
+                &base_request(),
+                &[],
+                &PaginationSpec::default(),
+                None,
+                &[detail_hint],
+            )
+            .expect_err("empty detail hint fields should fail");
+
+            assert!(
+                error.to_string().contains(&format!("empty {field_name}")),
+                "unexpected error for {field_name}: {error}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Harden the search metadata spec validation added in #311.

Changes:
- Caps `search_limits` values in Rust and JSON Schema.
- Rejects aggregate candidate budgets above 10000 with checked multiplication.
- Keeps unsupported future backend table shapes from falling through schema table validation.
- Keeps backend-specific schemas aligned with backend parsers, including rejecting file-only `source` on HTTP tables.
- Validates parquet filter types with the same filter/type validator used elsewhere.
- Adds focused regression tests for the new rejection paths.

Local validation:
- `cargo fmt --all -- --check`
- `cargo check -p coral-spec`
- `cargo clippy -p coral-spec --all-targets -- -D warnings`
- `cargo test -p coral-spec`
- `git diff --check`
