### PR TITLE
chore(cli): show git SHA in version output

### DIFF
--- a/crates/coral-cli/build.rs
+++ b/crates/coral-cli/build.rs
@@ -1,13 +1,55 @@
-//! Build hints for optional CLI assets.
+//! Build hints for optional CLI assets and embedded version metadata.
 
 #![allow(
     clippy::disallowed_methods,
+    clippy::print_stdout,
     reason = "Cargo build scripts read build-time environment variables directly."
 )]
 
+use std::process::Command;
+
 fn main() {
+    let sha = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map_or_else(
+            || "unknown".to_owned(),
+            |out| String::from_utf8_lossy(&out.stdout).trim().to_owned(),
+        );
+    println!("cargo:rustc-env=CORAL_GIT_SHA={sha}");
+
+    // Trigger rebuilds when HEAD or the checked-out branch's ref moves so the
+    // embedded SHA stays current.
+    if let Some(head_path) = git_path("HEAD") {
+        println!("cargo:rerun-if-changed={head_path}");
+        if let Ok(head) = std::fs::read_to_string(&head_path)
+            && let Some(reference) = head.trim().strip_prefix("ref: ")
+            && let Some(reference_path) = git_path(reference)
+            && std::path::Path::new(&reference_path).exists()
+        {
+            println!("cargo:rerun-if-changed={reference_path}");
+        }
+    }
+    if let Some(packed_refs_path) = git_path("packed-refs")
+        && std::path::Path::new(&packed_refs_path).exists()
+    {
+        println!("cargo:rerun-if-changed={packed_refs_path}");
+    }
+
     if std::env::var_os("CARGO_FEATURE_EMBEDDED_UI").is_some() {
         println!("cargo:rerun-if-changed=../../ui/dist");
         println!("cargo:rerun-if-changed=../../ui/dist/index.html");
     }
+}
+
+fn git_path(path: &str) -> Option<String> {
+    Command::new("git")
+        .args(["rev-parse", "--git-path", path])
+        .output()
+        .ok()
+        .filter(|out| out.status.success())
+        .map(|out| String::from_utf8_lossy(&out.stdout).trim().to_owned())
+        .filter(|path| !path.is_empty())
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -42,7 +42,11 @@ use tempfile as _;
 const DEFAULT_SERVER_PORT: u16 = 1457;
 
 #[derive(Debug, Parser)]
-#[command(name = "coral", version, arg_required_else_help = true)]
+#[command(
+    name = "coral",
+    version = concat!(env!("CARGO_PKG_VERSION"), "+", env!("CORAL_GIT_SHA")),
+    arg_required_else_help = true
+)]
 /// A local-first SQL interface for APIs, files, and other data sources.
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

Recreates the intent of #116 on current `main`.

- embeds the current short git SHA from the `coral-cli` build script
- includes that SHA in `coral --version` as SemVer build metadata (`+<sha>`)
- resolves git watch paths with `git rev-parse --git-path` so worktrees watch the common gitdir refs correctly
- keeps the existing embedded UI rebuild hints in the same build script

## Validation

- `make rust-checks`
- `cargo run -p coral-cli -- --version` -> `coral 0.2.0+96daa462`