### PR TITLE
feat(engine): execute Notion search as table function

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1114,6 +1114,13 @@ fn build_request_body(
             }
             let mut root = Value::Object(Map::new());
             for field in fields {
+                if field
+                    .when_arg
+                    .as_ref()
+                    .is_some_and(|arg| !render_context.args.contains_key(arg))
+                {
+                    continue;
+                }
                 if let Some(value) = resolve_value_source(&field.value, render_context)? {
                     set_path_value(&mut root, &field.path, value)?;
                 }

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -76,6 +76,13 @@ enum RequestBody {
     Text(String),
 }
 
+#[derive(Debug, Clone, Copy)]
+struct FetchLimits {
+    effective_limit: Option<usize>,
+    page_size_limit: Option<usize>,
+    max_search_calls: Option<usize>,
+}
+
 struct OutgoingHttpRequest<'a> {
     auth: &'a AuthSpec,
     request_headers: &'a [HeaderSpec],
@@ -169,7 +176,7 @@ impl HttpSourceClient {
         sql_limit: Option<usize>,
     ) -> Result<Vec<Value>> {
         let mut all_rows = Vec::new();
-        let effective_limit = sql_limit.or(target.fetch_limit_default());
+        let limits = resolve_fetch_limits(target, sql_limit);
         let pagination = target
             .pagination()
             .validated(&self.source_schema, target.name())
@@ -182,7 +189,7 @@ impl HttpSourceClient {
                     detail: error.to_string(),
                 })
             })?;
-        let page_size = resolve_page_size(pagination.page_size.as_ref(), sql_limit);
+        let page_size = resolve_page_size(pagination.page_size.as_ref(), limits.page_size_limit);
 
         let active_request = target.resolved_request();
 
@@ -324,10 +331,17 @@ impl HttpSourceClient {
             let rows_on_page = rows.len();
             all_rows.append(&mut rows);
 
-            if let Some(limit) = effective_limit
+            if let Some(limit) = limits.effective_limit
                 && all_rows.len() >= limit
             {
                 all_rows.truncate(limit);
+                break;
+            }
+
+            if limits
+                .max_search_calls
+                .is_some_and(|max_calls| page_count >= max_calls)
+            {
                 break;
             }
 
@@ -1168,9 +1182,30 @@ fn apply_pagination_body_fields(
     Ok(())
 }
 
-fn resolve_page_size(spec: Option<&PageSizeSpec>, sql_limit: Option<usize>) -> Option<usize> {
+fn resolve_fetch_limits(target: &HttpFetchTarget, sql_limit: Option<usize>) -> FetchLimits {
+    let Some(search_limits) = target.search_limits() else {
+        return FetchLimits {
+            effective_limit: sql_limit.or(target.fetch_limit_default()),
+            page_size_limit: sql_limit,
+            max_search_calls: None,
+        };
+    };
+
+    let requested_top_k = sql_limit.unwrap_or(search_limits.default_top_k);
+    let max_candidates = search_limits
+        .max_top_k
+        .saturating_mul(search_limits.max_calls_per_query);
+
+    FetchLimits {
+        effective_limit: Some(requested_top_k.min(max_candidates)),
+        page_size_limit: Some(requested_top_k.min(search_limits.max_top_k)),
+        max_search_calls: Some(search_limits.max_calls_per_query),
+    }
+}
+
+fn resolve_page_size(spec: Option<&PageSizeSpec>, requested_limit: Option<usize>) -> Option<usize> {
     let spec = spec?;
-    let base = sql_limit.unwrap_or(spec.default);
+    let base = requested_limit.unwrap_or(spec.default);
     Some(base.min(spec.max).max(1))
 }
 

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -116,7 +116,7 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         backend,
         target: target.clone(),
         filter_values: filter_values.clone(),
-        arg_values,
+        arg_values: arg_values.clone(),
         limit,
     });
 
@@ -124,8 +124,15 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         let target = target.clone();
         let schema = schema.clone();
         let filter_values = filter_values.clone();
+        let arg_values = arg_values.clone();
         Arc::new(move |items: &[Value]| {
-            convert_items(target.columns(), schema.clone(), &filter_values, items)
+            convert_items(
+                target.columns(),
+                schema.clone(),
+                &filter_values,
+                &arg_values,
+                items,
+            )
         })
     };
 

--- a/crates/coral-engine/src/backends/http/target.rs
+++ b/crates/coral-engine/src/backends/http/target.rs
@@ -3,7 +3,10 @@
 use std::sync::Arc;
 
 use coral_spec::backends::http::HttpTableSpec;
-use coral_spec::{ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec, SourceTableFunctionSpec};
+use coral_spec::{
+    ColumnSpec, PaginationSpec, RequestSpec, ResponseSpec, SearchLimitsSpec,
+    SourceTableFunctionSpec,
+};
 
 /// The HTTP request/response description needed to fetch rows.
 ///
@@ -14,6 +17,7 @@ pub(crate) struct HttpFetchTarget {
     name: Arc<str>,
     columns: Arc<[ColumnSpec]>,
     fetch_limit_default: Option<usize>,
+    search_limits: Option<SearchLimitsSpec>,
     resolved_request: RequestSpec,
     response: Arc<ResponseSpec>,
     pagination: Arc<PaginationSpec>,
@@ -25,6 +29,7 @@ impl std::fmt::Debug for HttpFetchTarget {
             .field("name", &self.name)
             .field("columns", &self.columns)
             .field("fetch_limit_default", &self.fetch_limit_default)
+            .field("search_limits", &self.search_limits)
             .finish_non_exhaustive()
     }
 }
@@ -38,6 +43,7 @@ impl HttpFetchTarget {
             name: Arc::from(table.name()),
             columns: Arc::from(table.columns().to_vec()),
             fetch_limit_default: table.fetch_limit_default(),
+            search_limits: table.common.search_limits.clone(),
             resolved_request,
             response: Arc::new(table.response.clone()),
             pagination: Arc::new(table.pagination.clone()),
@@ -49,6 +55,7 @@ impl HttpFetchTarget {
             name: Arc::clone(&self.name),
             columns: Arc::clone(&self.columns),
             fetch_limit_default: self.fetch_limit_default,
+            search_limits: self.search_limits.clone(),
             resolved_request,
             response: Arc::clone(&self.response),
             pagination: Arc::clone(&self.pagination),
@@ -60,6 +67,7 @@ impl HttpFetchTarget {
             name: Arc::from(function.name.as_str()),
             columns: Arc::from(function.columns.clone()),
             fetch_limit_default: function.fetch_limit_default,
+            search_limits: function.search_limits.clone(),
             resolved_request: function.request.clone(),
             response: Arc::new(function.response.clone()),
             pagination: Arc::new(function.pagination.clone()),
@@ -76,6 +84,10 @@ impl HttpFetchTarget {
 
     pub(crate) fn fetch_limit_default(&self) -> Option<usize> {
         self.fetch_limit_default
+    }
+
+    pub(crate) fn search_limits(&self) -> Option<&SearchLimitsSpec> {
+        self.search_limits.as_ref()
     }
 
     pub(crate) fn resolved_request(&self) -> &RequestSpec {

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -456,7 +456,13 @@ impl JsonlTableProvider {
         let table = Arc::clone(&self.table);
         let filter_values = extract_filter_values(filters, table.filters());
         Arc::new(move |items: &[Value]| {
-            convert_items(table.columns(), schema.clone(), &filter_values, items)
+            convert_items(
+                table.columns(),
+                schema.clone(),
+                &filter_values,
+                &HashMap::new(),
+                items,
+            )
         })
     }
 }

--- a/crates/coral-engine/src/backends/shared/mapping.rs
+++ b/crates/coral-engine/src/backends/shared/mapping.rs
@@ -30,6 +30,7 @@ pub(crate) fn convert_items(
     columns: &[ColumnSpec],
     schema: SchemaRef,
     filters: &HashMap<String, String>,
+    args: &HashMap<String, String>,
     items: &[Value],
 ) -> Result<RecordBatch> {
     let mut arrays: Vec<Arc<dyn Array>> = Vec::with_capacity(columns.len());
@@ -44,42 +45,42 @@ pub(crate) fn convert_items(
             ManifestDataType::Utf8 => {
                 let array: StringArray = items
                     .iter()
-                    .map(|row| to_utf8(eval_expr(&expr, row, filters)))
+                    .map(|row| to_utf8(eval_expr(&expr, row, filters, args)))
                     .collect();
                 arrays.push(Arc::new(array));
             }
             ManifestDataType::Json => {
                 let array: StringArray = items
                     .iter()
-                    .map(|row| to_json_utf8(eval_expr(&expr, row, filters)))
+                    .map(|row| to_json_utf8(eval_expr(&expr, row, filters, args)))
                     .collect();
                 arrays.push(Arc::new(array));
             }
             ManifestDataType::Int64 => {
                 let array: Int64Array = items
                     .iter()
-                    .map(|row| to_i64(eval_expr(&expr, row, filters)))
+                    .map(|row| to_i64(eval_expr(&expr, row, filters, args)))
                     .collect();
                 arrays.push(Arc::new(array));
             }
             ManifestDataType::Boolean => {
                 let array: BooleanArray = items
                     .iter()
-                    .map(|row| to_bool(eval_expr(&expr, row, filters)))
+                    .map(|row| to_bool(eval_expr(&expr, row, filters, args)))
                     .collect();
                 arrays.push(Arc::new(array));
             }
             ManifestDataType::Float64 => {
                 let array: Float64Array = items
                     .iter()
-                    .map(|row| to_f64(eval_expr(&expr, row, filters)))
+                    .map(|row| to_f64(eval_expr(&expr, row, filters, args)))
                     .collect();
                 arrays.push(Arc::new(array));
             }
             ManifestDataType::Timestamp => {
                 let array: TimestampMicrosecondArray = items
                     .iter()
-                    .map(|row| to_i64(eval_expr(&expr, row, filters)))
+                    .map(|row| to_i64(eval_expr(&expr, row, filters, args)))
                     .collect();
                 let array = array.with_timezone("+00:00");
                 arrays.push(Arc::new(array));
@@ -90,12 +91,17 @@ pub(crate) fn convert_items(
     RecordBatch::try_new(schema, arrays).map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
 }
 
-fn eval_expr(expr: &ExprSpec, row: &Value, filters: &HashMap<String, String>) -> Option<Value> {
+fn eval_expr(
+    expr: &ExprSpec,
+    row: &Value,
+    filters: &HashMap<String, String>,
+    args: &HashMap<String, String>,
+) -> Option<Value> {
     match expr {
         ExprSpec::Path { path } => get_path_value(row, path).cloned(),
         ExprSpec::Coalesce { exprs } => {
             for nested in exprs {
-                let value = eval_expr(nested, row, filters);
+                let value = eval_expr(nested, row, filters, args);
                 if value.as_ref().is_some_and(|v| !v.is_null()) {
                     return value;
                 }
@@ -103,6 +109,7 @@ fn eval_expr(expr: &ExprSpec, row: &Value, filters: &HashMap<String, String>) ->
             None
         }
         ExprSpec::FromFilter { key } => filters.get(key).map(|v| Value::String(v.clone())),
+        ExprSpec::FromArg { key } => args.get(key).map(|v| Value::String(v.clone())),
         ExprSpec::Literal { value } => Some(value.clone()),
         ExprSpec::Null => None,
         ExprSpec::JoinArray { path, separator } => eval_join_array(row, path, separator),
@@ -130,7 +137,7 @@ fn eval_expr(expr: &ExprSpec, row: &Value, filters: &HashMap<String, String>) ->
             None
         }
         ExprSpec::IfPresent { check, then_value } => {
-            let value = eval_expr(check, row, filters);
+            let value = eval_expr(check, row, filters, args);
             if value.as_ref().is_some_and(|v| !v.is_null()) {
                 Some(Value::String(then_value.clone()))
             } else {
@@ -179,14 +186,16 @@ fn eval_expr(expr: &ExprSpec, row: &Value, filters: &HashMap<String, String>) ->
         }
         ExprSpec::CurrentRow => Some(row.clone()),
         ExprSpec::FormatTimestamp { expr, input } => {
-            eval_format_timestamp(expr, input, row, filters)
+            eval_format_timestamp(expr, input, row, filters, args)
         }
-        ExprSpec::Base64Decode { expr } => eval_base64_decode(expr, row, filters),
+        ExprSpec::Base64Decode { expr } => eval_base64_decode(expr, row, filters, args),
         ExprSpec::Replace { expr, from, to } => {
-            let raw = to_utf8(eval_expr(expr, row, filters))?;
+            let raw = to_utf8(eval_expr(expr, row, filters, args))?;
             Some(Value::String(raw.replace(from, to)))
         }
-        ExprSpec::Template { template, values } => eval_template(template, values, row, filters),
+        ExprSpec::Template { template, values } => {
+            eval_template(template, values, row, filters, args)
+        }
     }
 }
 
@@ -197,8 +206,9 @@ fn eval_format_timestamp(
     input: &TimestampInput,
     row: &Value,
     filters: &HashMap<String, String>,
+    args: &HashMap<String, String>,
 ) -> Option<Value> {
-    let value = eval_expr(expr, row, filters)?;
+    let value = eval_expr(expr, row, filters, args)?;
     let micros = match &value {
         Value::String(s) => parse_timestamp_micros(s, input),
         Value::Number(n) => {
@@ -249,8 +259,9 @@ fn eval_base64_decode(
     expr: &ExprSpec,
     row: &Value,
     filters: &HashMap<String, String>,
+    args: &HashMap<String, String>,
 ) -> Option<Value> {
-    let raw = to_utf8(eval_expr(expr, row, filters))?;
+    let raw = to_utf8(eval_expr(expr, row, filters, args))?;
     let compact = raw
         .chars()
         .filter(|ch| !ch.is_whitespace())
@@ -265,13 +276,14 @@ fn eval_template(
     values: &HashMap<String, ExprSpec>,
     row: &Value,
     filters: &HashMap<String, String>,
+    args: &HashMap<String, String>,
 ) -> Option<Value> {
     // Pre-evaluate every key so replacements are deterministic regardless of
     // HashMap iteration order.
     let evaluated: HashMap<&str, Option<String>> = values
         .iter()
         .map(|(key, expr)| {
-            let raw = eval_expr(expr, row, filters).and_then(|v| to_utf8(Some(v)));
+            let raw = eval_expr(expr, row, filters, args).and_then(|v| to_utf8(Some(v)));
             (key.as_str(), raw)
         })
         .collect();
@@ -297,8 +309,15 @@ fn eval_template(
                         .unwrap_or_default();
                     result.push_str(&rendered);
                 }
+                TemplateNamespace::Arg => {
+                    let rendered = args
+                        .get(token.key())
+                        .cloned()
+                        .or_else(|| token.default_value().map(ToString::to_string))
+                        .unwrap_or_default();
+                    result.push_str(&rendered);
+                }
                 TemplateNamespace::Input
-                | TemplateNamespace::Arg
                 | TemplateNamespace::State
                 | TemplateNamespace::Other(_) => return None,
             },
@@ -461,6 +480,7 @@ mod tests {
     fn expr_json(expr: &ExprSpec) -> Value {
         match expr {
             ExprSpec::Path { path } => json!({ "kind": "path", "path": path }),
+            ExprSpec::FromArg { key } => json!({ "kind": "from_arg", "key": key }),
             ExprSpec::IfPresent { check, then_value } => json!({
                 "kind": "if_present",
                 "check": expr_json(check),
@@ -530,7 +550,14 @@ mod tests {
             "created_time": "2026-03-11T12:34:56.123456Z"
         })];
 
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         let col = batch
             .column(0)
             .as_any()
@@ -565,7 +592,14 @@ mod tests {
             serde_json::json!({"status": "ok"}),
             serde_json::json!({"other": "field"}),
         ];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         assert_eq!(batch.num_rows(), 2);
         let col = batch
             .column(0)
@@ -590,7 +624,14 @@ mod tests {
         );
         let schema = schema_from_columns(table.columns(), "test", table.name()).unwrap();
         let items = vec![serde_json::json!({"status": null})];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         let col = batch
             .column(0)
             .as_any()
@@ -624,7 +665,14 @@ mod tests {
             serde_json::json!({"content": [{"type": "tool_use", "name": "Read"}]}),
             serde_json::json!({"content": "plain string"}),
         ];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         assert_eq!(batch.num_rows(), 3);
         let col = batch
             .column(0)
@@ -653,7 +701,14 @@ mod tests {
         let items = vec![serde_json::json!({
             "content": [{"type": "text", "text": "only one"}]
         })];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         assert_eq!(batch.num_rows(), 1);
         let col = batch
             .column(0)
@@ -688,7 +743,14 @@ mod tests {
             serde_json::json!({"labels": {"nodes": []}}),
             serde_json::json!({"labels": {"nodes": [{"name": null}]}}),
         ];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         assert_eq!(batch.num_rows(), 3);
         let col = batch
             .column(0)
@@ -717,7 +779,14 @@ mod tests {
             serde_json::json!({}),
             serde_json::json!({"enabled": "not-a-bool"}),
         ];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         assert_eq!(batch.num_rows(), 5);
         let col = batch
             .column(0)
@@ -746,7 +815,14 @@ mod tests {
         );
         let schema = schema_from_columns(table.columns(), "test", table.name()).unwrap();
         let items = vec![serde_json::json!({"title": "hello world"})];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         let col = batch
             .column(0)
             .as_any()
@@ -771,7 +847,14 @@ mod tests {
             serde_json::json!({"content": "aGVs\nbG8="}),
             serde_json::json!({"content": "not base64"}),
         ];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
         let col = batch
             .column(0)
             .as_any()
@@ -798,6 +881,7 @@ mod tests {
             )]),
             &json!({"title": "hello world"}),
             &HashMap::from([("org".to_string(), "acme".to_string())]),
+            &HashMap::new(),
         );
 
         assert_eq!(
@@ -817,6 +901,7 @@ mod tests {
                 },
             )]),
             &json!({"title": "hello world"}),
+            &HashMap::new(),
             &HashMap::new(),
         );
 
@@ -841,7 +926,14 @@ mod tests {
             json!({"properties": null}),
             json!({}),
         ];
-        let batch = convert_items(table.columns(), schema, &HashMap::new(), &items).unwrap();
+        let batch = convert_items(
+            table.columns(),
+            schema,
+            &HashMap::new(),
+            &HashMap::new(),
+            &items,
+        )
+        .unwrap();
 
         let col = batch
             .column(0)

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -149,6 +149,64 @@ fn split_function_manifest(name: &str, base_url: &str) -> Value {
     })
 }
 
+fn notionish_search_function_manifest(base_url: &str) -> Value {
+    json!({
+        "name": "notionish",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "functions": [{
+            "name": "search_objects",
+            "kind": "search",
+            "description": "Search objects",
+            "search_limits": {
+                "default_top_k": 10,
+                "max_top_k": 100,
+                "max_calls_per_query": 1
+            },
+            "args": [
+                {
+                    "name": "query",
+                    "required": true,
+                    "bind": { "arg": "query" }
+                },
+                {
+                    "name": "object",
+                    "values": ["page", "data_source"],
+                    "bind": { "arg": "object" }
+                }
+            ],
+            "request": {
+                "method": "POST",
+                "path": "/v1/search",
+                "body": [
+                    { "path": ["query"], "from": "arg", "key": "query" },
+                    {
+                        "path": ["filter", "property"],
+                        "when_arg": "object",
+                        "from": "literal",
+                        "value": "object"
+                    },
+                    { "path": ["filter", "value"], "from": "arg", "key": "object" }
+                ]
+            },
+            "response": {
+                "rows_path": ["results"]
+            },
+            "columns": [
+                { "name": "object", "type": "Utf8" },
+                { "name": "id", "type": "Utf8" },
+                {
+                    "name": "requested_object",
+                    "type": "Utf8",
+                    "expr": { "kind": "from_arg", "key": "object" }
+                }
+            ]
+        }]
+    })
+}
+
 fn internal_table_function_name(schema: &str, function: &str) -> String {
     // PR #306 only registers DataFusion's flat internal UDTF. The public
     // source-scoped planner in the next stack PR owns this mapping for users.
@@ -543,6 +601,80 @@ async fn source_scoped_table_function_omits_optional_named_arg() {
         vec![json!({
             "title": "Flaky workspace cleanup",
             "score": 9.5
+        })]
+    );
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_conditionally_emits_arg_body_fields() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/search"))
+        .and(body_json(json!({ "query": "Coral" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{
+                "object": "page",
+                "id": "page_1"
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/search"))
+        .and(body_json(json!({
+            "query": "Coral",
+            "filter": {
+                "property": "object",
+                "value": "data_source"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{
+                "object": "data_source",
+                "id": "data_source_1"
+            }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(notionish_search_function_manifest(&server.uri()));
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            std::slice::from_ref(&source),
+            test_runtime(),
+            "SELECT object, id, requested_object \
+             FROM notionish.search_objects(query => 'Coral')",
+        )
+        .await
+        .expect("optional body fields should be omitted when the arg is absent"),
+    );
+    assert_eq!(
+        rows,
+        vec![json!({
+            "object": "page",
+            "id": "page_1"
+        })]
+    );
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT object, id, requested_object \
+             FROM notionish.search_objects(query => 'Coral', object => 'data_source')",
+        )
+        .await
+        .expect("optional body fields should be emitted when the arg is present"),
+    );
+    assert_eq!(
+        rows,
+        vec![json!({
+            "object": "data_source",
+            "id": "data_source_1",
+            "requested_object": "data_source"
         })]
     );
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -55,20 +55,15 @@ fn search_function_manifest(name: &str, base_url: &str) -> Value {
         "dsl_version": 3,
         "backend": "http",
         "base_url": base_url,
-        "tables": [{
-            "name": "placeholder",
-            "description": "Placeholder table",
-            "request": {
-                "method": "GET",
-                "path": "/api/placeholder"
-            },
-            "columns": [
-                { "name": "id", "type": "Utf8" }
-            ]
-        }],
         "functions": [{
             "name": "search_issues",
+            "kind": "search",
             "description": "Search issues",
+            "search_limits": {
+                "default_top_k": 10,
+                "max_top_k": 100,
+                "max_calls_per_query": 1
+            },
             "args": [
                 {
                     "name": "q",
@@ -588,6 +583,59 @@ async fn source_scoped_table_function_preserves_table_alias() {
             "score": 9.5
         })]
     );
+}
+
+#[tokio::test]
+async fn source_scoped_search_function_enforces_search_limits() {
+    let server = MockServer::start().await;
+    let items: Vec<Value> = (0..100)
+        .map(|index| {
+            json!({
+                "title": format!("Issue {index}"),
+                "score": f64::from(index)
+            })
+        })
+        .collect();
+
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky cleanup repo:withcoral/coral"))
+        .and(query_param("search_type", "hybrid"))
+        .and(query_param("per_page", "100"))
+        .and(query_param("page", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": items
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = search_function_manifest("search", &server.uri());
+    manifest["functions"][0]["pagination"] = json!({
+        "mode": "page",
+        "page_size": {
+            "default": 10,
+            "max": 500,
+            "query_param": "per_page"
+        },
+        "page_param": "page",
+        "page_start": 1,
+        "page_step": 1
+    });
+    let source = build_source(manifest);
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title, score \
+             FROM search.search_issues(q => 'flaky cleanup repo:withcoral/coral', mode => 'hybrid') \
+             LIMIT 250",
+        )
+        .await
+        .expect("search limits should cap page size and total rows"),
+    );
+
+    assert_eq!(rows.len(), 100);
 }
 
 #[tokio::test]

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -322,6 +322,8 @@ pub struct QueryParamSpec {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BodyFieldSpec {
     pub path: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub when_arg: Option<String>,
     #[serde(flatten)]
     pub value: ValueSourceSpec,
 }
@@ -830,6 +832,9 @@ pub enum ExprSpec {
         exprs: Vec<ExprSpec>,
     },
     FromFilter {
+        key: String,
+    },
+    FromArg {
         key: String,
     },
     Literal {

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -594,6 +594,7 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "when_arg": { "type": "string", "minLength": 1 },
         "from": { "type": "string" },
         "template": { "type": "string" },
         "value": {},
@@ -876,6 +877,15 @@
           "required": ["kind", "key"],
           "properties": {
             "kind": { "const": "from_filter" },
+            "key": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "key"],
+          "properties": {
+            "kind": { "const": "from_arg" },
             "key": { "type": "string", "minLength": 1 }
           }
         },

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -161,9 +161,15 @@ pub(crate) fn validate_http_function(
         )?;
     }
 
-    validate_filters_and_column_exprs(
-        &[],
+    validate_columns(
         &function.columns,
+        source_name,
+        &format!("function '{}'", function.name),
+    )?;
+    validate_column_exprs(
+        &function.columns,
+        &HashSet::new(),
+        &request_arg_names,
         source_name,
         &format!("function '{}'", function.name),
     )?;
@@ -200,17 +206,29 @@ pub(crate) fn validate_filters_and_column_exprs(
         filter.manifest_data_type()?;
     }
 
+    validate_column_exprs(columns, &known_filters, &HashSet::new(), schema, table)?;
+
+    Ok(known_filters)
+}
+
+fn validate_column_exprs(
+    columns: &[ColumnSpec],
+    known_filters: &HashSet<String>,
+    known_args: &HashSet<&str>,
+    schema: &str,
+    table: &str,
+) -> Result<()> {
     for col in columns {
         if let Some(expr) = &col.expr {
             validate_expr(
                 expr,
-                &known_filters,
+                known_filters,
+                known_args,
                 &format!("{schema}.{table} column '{}'", col.name),
             )?;
         }
     }
-
-    Ok(known_filters)
+    Ok(())
 }
 
 pub(crate) struct DetailHintTargetTable<'a> {
@@ -464,6 +482,12 @@ fn validate_request_bindings(
     match &request.body {
         BodySpec::Json { fields } => {
             for field in fields {
+                if let Some(arg) = &field.when_arg {
+                    return Err(ManifestError::validation(format!(
+                        "{schema}.{table_name} request body path '{}' uses function argument condition '{arg}' outside a function request",
+                        field.path.join(".")
+                    )));
+                }
                 validate_value_source(
                     &field.value,
                     known_filters,
@@ -579,6 +603,15 @@ fn validate_function_request_bindings(
     match &function.request.body {
         BodySpec::Json { fields } => {
             for field in fields {
+                if let Some(arg) = &field.when_arg
+                    && !request_arg_names.contains(arg.as_str())
+                {
+                    return Err(ManifestError::validation(format!(
+                        "source '{source_name}' function '{}' request body path '{}' references unknown request arg '{arg}' in when_arg",
+                        function.name,
+                        field.path.join(".")
+                    )));
+                }
                 validate_arg_value_source(
                     &field.value,
                     request_arg_names,
@@ -687,20 +720,30 @@ fn validate_identifier(value: &str, context: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_expr(expr: &ExprSpec, known_filters: &HashSet<String>, context: &str) -> Result<()> {
+fn validate_expr(
+    expr: &ExprSpec,
+    known_filters: &HashSet<String>,
+    known_args: &HashSet<&str>,
+    context: &str,
+) -> Result<()> {
     match expr {
         ExprSpec::FromFilter { key } if !known_filters.contains(key) => {
             return Err(ManifestError::validation(format!(
                 "{context} references unknown filter '{key}'"
             )));
         }
+        ExprSpec::FromArg { key } if !known_args.contains(key.as_str()) => {
+            return Err(ManifestError::validation(format!(
+                "{context} references unknown request arg '{key}'"
+            )));
+        }
         ExprSpec::Coalesce { exprs } => {
             for nested in exprs {
-                validate_expr(nested, known_filters, context)?;
+                validate_expr(nested, known_filters, known_args, context)?;
             }
         }
         ExprSpec::IfPresent { check, .. } => {
-            validate_expr(check, known_filters, context)?;
+            validate_expr(check, known_filters, known_args, context)?;
         }
         ExprSpec::ObjectFilterPath { filter_key, .. } if !known_filters.contains(filter_key) => {
             return Err(ManifestError::validation(format!(
@@ -708,7 +751,7 @@ fn validate_expr(expr: &ExprSpec, known_filters: &HashSet<String>, context: &str
             )));
         }
         ExprSpec::FormatTimestamp { expr, .. } | ExprSpec::Base64Decode { expr } => {
-            validate_expr(expr, known_filters, context)?;
+            validate_expr(expr, known_filters, known_args, context)?;
         }
         ExprSpec::Replace { expr, from, .. } => {
             if from.is_empty() {
@@ -716,13 +759,14 @@ fn validate_expr(expr: &ExprSpec, known_filters: &HashSet<String>, context: &str
                     "{context} has replace expression with empty 'from' value"
                 )));
             }
-            validate_expr(expr, known_filters, context)?;
+            validate_expr(expr, known_filters, known_args, context)?;
         }
         ExprSpec::Template { template, values } => {
             for (key, value_expr) in values {
                 validate_expr(
                     value_expr,
                     known_filters,
+                    known_args,
                     &format!("{context} template value '{key}'"),
                 )?;
             }

--- a/sources/core/notion/manifest.yaml
+++ b/sources/core/notion/manifest.yaml
@@ -34,13 +34,135 @@ request_headers:
     value: "2026-03-11"
 test_queries:
   - SELECT * FROM notion.search LIMIT 1
+  - SELECT * FROM notion.search_objects(query => 'Coral') LIMIT 1
+functions:
+  - name: search_objects
+    kind: search
+    description: Provider-ranked search results for pages and data sources shared with the integration
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /v1/search
+      body:
+        - path:
+            - query
+          from: arg
+          key: query
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: cursor_body
+      cursor_body_path:
+        - start_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 10
+        max: 100
+        body_path:
+          - page_size
+    columns:
+      - name: object
+        type: Utf8
+        nullable: false
+        description: Result object type (page or data_source)
+        expr:
+          kind: path
+          path:
+            - object
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Notion object ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: created_time
+        type: Timestamp
+        nullable: true
+        description: Creation timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_time
+      - name: last_edited_time
+        type: Timestamp
+        nullable: true
+        description: Last edit timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - last_edited_time
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Notion URL for page results
+        expr:
+          kind: path
+          path:
+            - url
+      - name: public_url
+        type: Utf8
+        nullable: true
+        description: Public URL for page results, when available
+        expr:
+          kind: path
+          path:
+            - public_url
+      - name: in_trash
+        type: Boolean
+        nullable: true
+        description: Whether the result is in trash
+        expr:
+          kind: path
+          path:
+            - in_trash
+      - name: parent
+        type: Json
+        nullable: true
+        description: Parent object
+        expr:
+          kind: path
+          path:
+            - parent
+      - name: properties
+        type: Json
+        nullable: true
+        description: Page or data source properties object
+        expr:
+          kind: path
+          path:
+            - properties
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw Notion search result
+        expr:
+          kind: current_row
 tables:
   - name: search
     description: Pages and data sources shared with the integration
     guide: |
-      Start here to discover `page_id`, `database_id`, and `data_source_id`
-      values. Use `query` for title search and `object` with `page` or
-      `data_source` to narrow result types.
+      Compatibility table for discovering `page_id`, `database_id`, and
+      `data_source_id` values. Prefer `notion.search_objects(query => ...)`
+      for provider-ranked retrieval.
     filters:
       - name: query
         required: false

--- a/sources/core/notion/manifest.yaml
+++ b/sources/core/notion/manifest.yaml
@@ -49,6 +49,12 @@ functions:
         required: true
         bind:
           arg: query
+      - name: object
+        values:
+          - page
+          - data_source
+        bind:
+          arg: object
     request:
       method: POST
       path: /v1/search
@@ -57,6 +63,17 @@ functions:
             - query
           from: arg
           key: query
+        - path:
+            - filter
+            - property
+          when_arg: object
+          from: literal
+          value: object
+        - path:
+            - filter
+            - value
+          from: arg
+          key: object
     response:
       rows_path:
         - results


### PR DESCRIPTION
## Summary
- Migrates Notion's real provider search surface to the executable source-scoped table function `notion.search_objects(query => ...)`.
- Uses Notion's API argument name `query` and binds it to the `/v1/search` request body.
- Adds `kind: search` and `search_limits` for the Notion provider search function.
- Keeps the legacy `notion.search` table as a deprecated compatibility surface and points its guide to the new function.
- Updates the HTTP engine fixture so function tests exercise `kind: search` plus `search_limits`.

## Syntax
```sql
SELECT object, id, url, public_url
FROM notion.search_objects(query => 'Coral')
LIMIT 10;
```

Use returned ids with the catalog-described Notion tables when full details are needed, for example:

```sql
SELECT *
FROM notion.pages
WHERE page_id = '<returned id>';
```

## Local validation
- `cargo fmt --check`
- `cargo check -p coral-engine -p coral-mcp`
- `cargo test -p coral-engine --test engine catalog`
- `cargo test -p coral-mcp`
- `cargo test -p coral-spec`
- `cargo run --locked -p xtask -- generate-docs --check`
- `git diff --check`
