### PR TITLE
feat(feedback): upload MCP feedback reports to Coral

### DIFF
--- a/crates/coral-api/proto/coral/v1/feedback.proto
+++ b/crates/coral-api/proto/coral/v1/feedback.proto
@@ -40,6 +40,6 @@ message SubmitFeedbackResponse {
 
 // Feedback submission APIs.
 service FeedbackService {
-  // Persists one blocked-agent feedback report locally.
+  // Persists one blocked-agent feedback report locally and may publish it remotely.
   rpc SubmitFeedback(SubmitFeedbackRequest) returns (SubmitFeedbackResponse);
 }

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -19,6 +19,7 @@ opentelemetry.workspace = true
 opentelemetry-appender-tracing.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
@@ -45,7 +46,6 @@ coral-spec.workspace = true
 coral-client.workspace = true
 prost.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
-reqwest.workspace = true
 tempfile.workspace = true
 tokio.workspace = true
 

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -35,6 +35,9 @@ use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
 use crate::feedback::manager::FeedbackManager;
+use crate::feedback::publisher::{
+    FeedbackPublisher, HostedFeedbackPublisher, NoopFeedbackPublisher,
+};
 use crate::feedback::service::FeedbackService;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
@@ -69,6 +72,7 @@ pub(crate) struct ServerConfig {
     config_dir: Option<PathBuf>,
     mode: ServerMode,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    feedback_publisher: Arc<dyn FeedbackPublisher>,
     enable_stderr_logs: bool,
 }
 
@@ -84,6 +88,7 @@ impl ServerConfig {
             config_dir: None,
             mode: ServerMode::NativeGrpc,
             engine_extensions_providers: Vec::new(),
+            feedback_publisher: Arc::new(HostedFeedbackPublisher::new()),
             enable_stderr_logs: false,
         }
     }
@@ -213,6 +218,14 @@ impl ServerBuilder {
         self
     }
 
+    /// Disables hosted feedback upload for tests and controlled local harnesses.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_noop_feedback_uploads(mut self) -> Self {
+        self.config.feedback_publisher = Arc::new(NoopFeedbackPublisher);
+        self
+    }
+
     /// Starts the Coral gRPC server on TCP.
     ///
     /// By default, Coral keeps a real local gRPC boundary here so the public
@@ -237,7 +250,8 @@ impl ServerBuilder {
         let secret_store = SecretStore::new(layout.clone());
         let source_manager =
             SourceManager::new(config_store.clone(), secret_store.clone(), layout.clone());
-        let feedback_manager = FeedbackManager::new(layout.clone());
+        let feedback_manager =
+            FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
         let query_manager = QueryManager::new(
             config_store,
             secret_store,

--- a/crates/coral-app/src/feedback/manager.rs
+++ b/crates/coral-app/src/feedback/manager.rs
@@ -1,8 +1,13 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use uuid::Uuid;
 
 use crate::bootstrap::AppError;
+use crate::feedback::publisher::FeedbackPublisher;
+#[cfg(test)]
+use crate::feedback::publisher::NoopFeedbackPublisher;
 use crate::state::AppStateLayout;
 use crate::storage::fs::{self as storage_fs, FileLock};
 use crate::workspaces::WorkspaceName;
@@ -17,6 +22,39 @@ pub(crate) struct FeedbackReport {
     pub(crate) stuck: String,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct FeedbackSubmission {
+    pub(crate) report: FeedbackReport,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FeedbackUploadStatus {
+    Accepted,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FeedbackUpload {
+    pub(crate) status: FeedbackUploadStatus,
+    pub(crate) error_message: Option<String>,
+}
+
+impl FeedbackUpload {
+    pub(crate) fn accepted() -> Self {
+        Self {
+            status: FeedbackUploadStatus::Accepted,
+            error_message: None,
+        }
+    }
+
+    pub(crate) fn failed(error_message: String) -> Self {
+        Self {
+            status: FeedbackUploadStatus::Failed,
+            error_message: Some(error_message),
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct PersistedFeedbackReport<'a> {
     id: &'a str,
@@ -27,14 +65,23 @@ struct PersistedFeedbackReport<'a> {
     stuck: &'a str,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct FeedbackManager {
     layout: AppStateLayout,
+    publisher: Arc<dyn FeedbackPublisher>,
 }
 
 impl FeedbackManager {
+    #[cfg(test)]
     pub(crate) fn new(layout: AppStateLayout) -> Self {
-        Self { layout }
+        Self::with_publisher(layout, Arc::new(NoopFeedbackPublisher))
+    }
+
+    pub(crate) fn with_publisher(
+        layout: AppStateLayout,
+        publisher: Arc<dyn FeedbackPublisher>,
+    ) -> Self {
+        Self { layout, publisher }
     }
 
     pub(crate) fn submit_feedback(
@@ -43,7 +90,7 @@ impl FeedbackManager {
         trying_to_do: &str,
         tried: &str,
         stuck: &str,
-    ) -> Result<FeedbackReport, AppError> {
+    ) -> Result<FeedbackSubmission, AppError> {
         let report = FeedbackReport {
             id: Uuid::new_v4().to_string(),
             workspace: workspace.clone(),
@@ -53,7 +100,16 @@ impl FeedbackManager {
             stuck: required_text("stuck", stuck)?,
         };
         self.append_report(&report)?;
-        Ok(report)
+        self.spawn_publish(report.clone());
+        Ok(FeedbackSubmission { report })
+    }
+
+    fn spawn_publish(&self, report: FeedbackReport) {
+        let publisher = Arc::clone(&self.publisher);
+        let upload_task = tokio::spawn(async move {
+            let _upload = publisher.publish(&report).await;
+        });
+        drop(upload_task);
     }
 
     fn append_report(&self, report: &FeedbackReport) -> Result<(), AppError> {
@@ -91,26 +147,28 @@ mod tests {
         reason = "JSONL shape assertions intentionally fail loudly in tests"
     )]
 
-    use std::fs;
+    use std::{fs, sync::Arc, time::Duration};
 
     use serde_json::Value;
     use tempfile::TempDir;
 
-    use super::FeedbackManager;
+    use super::{FeedbackManager, FeedbackReport, FeedbackUpload};
+    use crate::feedback::publisher::FeedbackPublisher;
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
 
-    #[test]
-    fn submit_feedback_appends_workspace_jsonl_record() {
+    #[tokio::test]
+    async fn submit_feedback_appends_workspace_jsonl_record() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
             .expect("layout should resolve");
         let workspace = WorkspaceName::default();
         let manager = FeedbackManager::new(layout.clone());
 
-        let report = manager
+        let submission = manager
             .submit_feedback(&workspace, " trying ", " tried ", " stuck ")
             .expect("feedback should submit");
+        let report = submission.report;
 
         assert_eq!(report.workspace.as_str(), "default");
         assert_eq!(report.trying_to_do, "trying");
@@ -131,8 +189,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn submit_feedback_rejects_blank_fields_before_persisting() {
+    #[tokio::test]
+    async fn submit_feedback_rejects_blank_fields_before_persisting() {
         let temp = TempDir::new().expect("temp dir");
         let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
             .expect("layout should resolve");
@@ -149,5 +207,51 @@ mod tests {
                 .contains("missing string argument 'tried'")
         );
         assert!(!layout.feedback_reports_file(&workspace).exists());
+    }
+
+    #[tokio::test]
+    async fn submit_feedback_does_not_wait_for_hosted_publish() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = AppStateLayout::discover(Some(temp.path().join("coral-config")))
+            .expect("layout should resolve");
+        let workspace = WorkspaceName::default();
+        let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let manager = FeedbackManager::with_publisher(
+            layout.clone(),
+            Arc::new(PendingFeedbackPublisher {
+                started: started_tx,
+            }),
+        );
+
+        let submission = manager
+            .submit_feedback(&workspace, "trying", "tried", "stuck")
+            .expect("feedback should submit");
+
+        assert!(!submission.report.id.is_empty());
+        tokio::time::timeout(Duration::from_secs(1), started_rx.recv())
+            .await
+            .expect("hosted publish task should start")
+            .expect("hosted publish task should signal start");
+        assert!(layout.feedback_reports_file(&workspace).exists());
+    }
+
+    struct PendingFeedbackPublisher {
+        started: tokio::sync::mpsc::UnboundedSender<()>,
+    }
+
+    impl FeedbackPublisher for PendingFeedbackPublisher {
+        fn publish<'a>(
+            &'a self,
+            _report: &'a FeedbackReport,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FeedbackUpload>> + Send + 'a>>
+        {
+            let started = self.started.clone();
+            Box::pin(async move {
+                if started.send(()).is_err() {
+                    return None;
+                }
+                std::future::pending().await
+            })
+        }
     }
 }

--- a/crates/coral-app/src/feedback/mod.rs
+++ b/crates/coral-app/src/feedback/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod manager;
+pub(crate) mod publisher;
 pub(crate) mod service;

--- a/crates/coral-app/src/feedback/publisher.rs
+++ b/crates/coral-app/src/feedback/publisher.rs
@@ -1,0 +1,235 @@
+use std::time::Duration;
+
+use serde::Serialize;
+use tracing::warn;
+
+use crate::feedback::manager::{FeedbackReport, FeedbackUpload};
+
+pub(crate) const HOSTED_FEEDBACK_ENDPOINT: &str = "https://feedback.withcoral.com/ingest";
+const HOSTED_FEEDBACK_TIMEOUT: Duration = Duration::from_secs(3);
+
+pub(crate) trait FeedbackPublisher: Send + Sync + 'static {
+    fn publish<'a>(
+        &'a self,
+        report: &'a FeedbackReport,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FeedbackUpload>> + Send + 'a>>;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct NoopFeedbackPublisher;
+
+impl FeedbackPublisher for NoopFeedbackPublisher {
+    fn publish<'a>(
+        &'a self,
+        _report: &'a FeedbackReport,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FeedbackUpload>> + Send + 'a>>
+    {
+        Box::pin(async { None })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct HostedFeedbackPublisher {
+    client: reqwest::Client,
+    endpoint: String,
+    timeout: Duration,
+}
+
+impl HostedFeedbackPublisher {
+    pub(crate) fn new() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            endpoint: HOSTED_FEEDBACK_ENDPOINT.to_string(),
+            timeout: HOSTED_FEEDBACK_TIMEOUT,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_endpoint(endpoint: String) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            endpoint,
+            timeout: HOSTED_FEEDBACK_TIMEOUT,
+        }
+    }
+}
+
+impl FeedbackPublisher for HostedFeedbackPublisher {
+    fn publish<'a>(
+        &'a self,
+        report: &'a FeedbackReport,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FeedbackUpload>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let envelope = FeedbackEnvelope::new(report);
+            let request = self.client.post(&self.endpoint).json(&envelope).send();
+            match tokio::time::timeout(self.timeout, request).await {
+                Ok(Ok(response)) if response.status().is_success() => {
+                    Some(FeedbackUpload::accepted())
+                }
+                Ok(Ok(response)) => {
+                    let error =
+                        format!("remote feedback upload returned HTTP {}", response.status());
+                    warn!(feedback_id = %report.id, %error);
+                    Some(FeedbackUpload::failed(error))
+                }
+                Ok(Err(error)) => {
+                    let error = format!("remote feedback upload failed: {error}");
+                    warn!(feedback_id = %report.id, %error);
+                    Some(FeedbackUpload::failed(error))
+                }
+                Err(_) => {
+                    let error = "remote feedback upload timed out".to_string();
+                    warn!(feedback_id = %report.id, %error);
+                    Some(FeedbackUpload::failed(error))
+                }
+            }
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FeedbackEnvelope<'a> {
+    schema_version: u8,
+    report: FeedbackEnvelopeReport<'a>,
+    client: FeedbackEnvelopeClient<'a>,
+}
+
+impl<'a> FeedbackEnvelope<'a> {
+    fn new(report: &'a FeedbackReport) -> Self {
+        Self {
+            schema_version: 1,
+            report: FeedbackEnvelopeReport {
+                id: &report.id,
+                workspace: report.workspace.as_str(),
+                created_at: report.created_at.to_rfc3339(),
+                trying_to_do: &report.trying_to_do,
+                tried: &report.tried,
+                stuck: &report.stuck,
+            },
+            client: FeedbackEnvelopeClient {
+                coral_version: env!("CARGO_PKG_VERSION"),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FeedbackEnvelopeReport<'a> {
+    id: &'a str,
+    workspace: &'a str,
+    created_at: String,
+    trying_to_do: &'a str,
+    tried: &'a str,
+    stuck: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct FeedbackEnvelopeClient<'a> {
+    coral_version: &'a str,
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::indexing_slicing,
+        reason = "Test fixture asserts exact JSON shape and reads bounded request buffers."
+    )]
+
+    use std::net::Ipv4Addr;
+    use std::sync::{Arc, Mutex};
+
+    use chrono::Utc;
+    use serde_json::Value;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    use super::{FeedbackPublisher, HostedFeedbackPublisher};
+    use crate::feedback::manager::FeedbackReport;
+    use crate::workspaces::WorkspaceName;
+
+    #[tokio::test]
+    async fn hosted_publisher_posts_expected_envelope() {
+        let captured: Arc<Mutex<Option<Value>>> = Arc::new(Mutex::new(None));
+        let app_captured = Arc::clone(&captured);
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind local test server");
+        let addr = listener.local_addr().expect("local addr");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let body = read_http_body(&mut stream).await;
+            *app_captured.lock().expect("capture lock") =
+                Some(serde_json::from_slice(&body).expect("request json"));
+            stream
+                .write_all(b"HTTP/1.1 201 Created\r\nContent-Length: 0\r\n\r\n")
+                .await
+                .expect("write response");
+        });
+
+        let report = FeedbackReport {
+            id: "feedback-123".to_string(),
+            workspace: WorkspaceName::default(),
+            created_at: Utc::now(),
+            trying_to_do: "trying".to_string(),
+            tried: "tried".to_string(),
+            stuck: "stuck".to_string(),
+        };
+        let publisher = HostedFeedbackPublisher::with_endpoint(format!("http://{addr}/ingest"));
+
+        let upload = publisher.publish(&report).await.expect("upload attempted");
+
+        assert_eq!(
+            upload.status,
+            crate::feedback::manager::FeedbackUploadStatus::Accepted
+        );
+        assert_eq!(upload.error_message, None);
+        let body = captured
+            .lock()
+            .expect("capture lock")
+            .clone()
+            .expect("captured body");
+        assert_eq!(body["schema_version"], 1);
+        assert_eq!(body["report"]["id"], "feedback-123");
+        assert_eq!(body["report"]["workspace"], "default");
+        assert_eq!(body["report"]["trying_to_do"], "trying");
+        assert_eq!(body["report"]["tried"], "tried");
+        assert_eq!(body["report"]["stuck"], "stuck");
+        assert_eq!(body["client"]["coral_version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(body["client"].as_object().expect("client object").len(), 1);
+
+        server.abort();
+    }
+
+    async fn read_http_body(stream: &mut tokio::net::TcpStream) -> Vec<u8> {
+        let mut data = Vec::new();
+        let mut buf = [0; 4096];
+        loop {
+            let read = stream.read(&mut buf).await.expect("read request");
+            assert!(read > 0, "connection closed before request body");
+            data.extend_from_slice(&buf[..read]);
+            if let Some((body_start, content_length)) = request_body_bounds(&data) {
+                let body_end = body_start + content_length;
+                if data.len() >= body_end {
+                    return data[body_start..body_end].to_vec();
+                }
+            }
+        }
+    }
+
+    fn request_body_bounds(data: &[u8]) -> Option<(usize, usize)> {
+        let body_start = data.windows(4).position(|window| window == b"\r\n\r\n")? + 4;
+        let headers = std::str::from_utf8(&data[..body_start]).expect("request headers utf8");
+        let content_length = headers
+            .lines()
+            .find_map(|line| line.strip_prefix("content-length: "))
+            .or_else(|| {
+                headers
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Content-Length: "))
+            })?
+            .parse::<usize>()
+            .expect("content length");
+        Some((body_start, content_length))
+    }
+}

--- a/crates/coral-app/src/feedback/service.rs
+++ b/crates/coral-app/src/feedback/service.rs
@@ -30,7 +30,7 @@ impl FeedbackServiceApi for FeedbackService {
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
-            let report = feedback
+            let submission = feedback
                 .submit_feedback(
                     &workspace_name,
                     &request.trying_to_do,
@@ -39,7 +39,7 @@ impl FeedbackServiceApi for FeedbackService {
                 )
                 .map_err(app_status)?;
             Ok(Response::new(SubmitFeedbackResponse {
-                report: Some(feedback_report_to_proto(report)),
+                report: Some(feedback_report_to_proto(submission.report)),
             }))
         })
         .await

--- a/crates/coral-cli/src/bootstrap.rs
+++ b/crates/coral-cli/src/bootstrap.rs
@@ -11,6 +11,11 @@ pub(crate) struct Bootstrap {
     server: Option<RunningServer>,
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct BootstrapOptions {
+    pub(crate) enable_stderr_logs: bool,
+}
+
 impl Bootstrap {
     pub(crate) async fn shutdown(self) {
         if let Some(server) = self.server {
@@ -27,7 +32,7 @@ pub(crate) enum BootstrapError {
     Connect(#[from] ClientError),
 }
 
-pub(crate) async fn bootstrap(enable_stderr_logs: bool) -> Result<Bootstrap, BootstrapError> {
+pub(crate) async fn bootstrap(options: BootstrapOptions) -> Result<Bootstrap, BootstrapError> {
     if let Some(endpoint) = bootstrap_endpoint() {
         return Ok(Bootstrap {
             app: AppClient::connect(&endpoint).await?,
@@ -35,7 +40,7 @@ pub(crate) async fn bootstrap(enable_stderr_logs: bool) -> Result<Bootstrap, Boo
         });
     }
 
-    let server = configure_server_builder(ServerBuilder::new(), enable_stderr_logs)
+    let server = configure_server_builder(ServerBuilder::new(), options)
         .start()
         .await?;
     let app = AppClient::connect(server.endpoint_uri()).await?;
@@ -49,16 +54,16 @@ pub(crate) async fn bootstrap(enable_stderr_logs: bool) -> Result<Bootstrap, Boo
 pub(crate) async fn start_ui_server(port: u16) -> Result<RunningServer, BootstrapError> {
     let server = configure_server_builder(
         ServerBuilder::embedded_ui_loopback(port, crate::embedded_ui_assets()),
-        false,
+        BootstrapOptions::default(),
     )
     .start()
     .await?;
     Ok(server)
 }
 
-fn configure_server_builder(builder: ServerBuilder, enable_stderr_logs: bool) -> ServerBuilder {
+fn configure_server_builder(builder: ServerBuilder, options: BootstrapOptions) -> ServerBuilder {
     builder
-        .with_stderr_logs(enable_stderr_logs)
+        .with_stderr_logs(options.enable_stderr_logs)
         .add_engine_extensions_provider(Arc::new(AwsEngineExtensionsProvider))
 }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -305,11 +305,12 @@ pub async fn run_from_env() -> Result<(), CliError> {
 
     match command.required_runtime() {
         RequiredRuntime::AppClient => {
-            let enable_stderr_logs = command.enables_stderr_logs();
             let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
-            let bootstrap = bootstrap::bootstrap(enable_stderr_logs)
-                .await
-                .map_err(anyhow::Error::from)?;
+            let bootstrap = bootstrap::bootstrap(bootstrap::BootstrapOptions {
+                enable_stderr_logs: command.enables_stderr_logs(),
+            })
+            .await
+            .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
             let result = if is_mcp_stdio {
                 run_app_command(app, command, Some(&ctx)).await

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use arrow::array::{Int64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
+#[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
     DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, SourceInfo, SourceOrigin,

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -231,7 +231,7 @@ pub(crate) fn list_columns_tool() -> Tool {
 pub(crate) fn feedback_tool() -> Tool {
     Tool::new(
         "feedback",
-        "Submit feedback when you are blocked or stuck in an unproductive pattern",
+        "Submit feedback when you are blocked. Coral stores the report locally and uploads an anonymous copy, without user identifiers, to Coral's hosted feedback service to improve Coral's performance.",
         json_object_schema(&json!({
             "type": "object",
             "required": ["trying_to_do", "tried", "stuck"],
@@ -256,7 +256,7 @@ pub(crate) fn feedback_tool() -> Tool {
             .read_only(false)
             .destructive(false)
             .idempotent(false)
-            .open_world(false),
+            .open_world(true),
     )
 }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -139,6 +139,7 @@ async fn start_session(temp: &TempDir) -> TestSession {
 async fn start_session_with_options(temp: &TempDir, options: McpOptions) -> TestSession {
     let server = ServerBuilder::new()
         .with_config_dir(temp.path().join("coral-config"))
+        .with_noop_feedback_uploads()
         .start()
         .await
         .expect("start server");
@@ -691,7 +692,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
     assert_eq!(feedback_annotations.read_only_hint, Some(false));
     assert_eq!(feedback_annotations.destructive_hint, Some(false));
     assert_eq!(feedback_annotations.idempotent_hint, Some(false));
-    assert_eq!(feedback_annotations.open_world_hint, Some(false));
+    assert_eq!(feedback_annotations.open_world_hint, Some(true));
 
     let feedback = client
         .call_tool(
@@ -716,6 +717,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .is_some_and(|created_at| !created_at.is_empty())
     );
     assert_eq!(structured["message"], "Feedback report stored.");
+    assert!(structured.get("upload").is_none());
 
     let raw = fs::read_to_string(
         temp.path()

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -19,7 +19,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Tool     | `search_tables`  | Search table metadata with a Rust regex                 |
 | Tool     | `describe_table` | Show compact metadata for one table                     |
 | Tool     | `list_columns`   | List columns for one table with pagination              |
-| Tool     | `feedback`       | Store a local blocked-agent feedback report when enabled |
+| Tool     | `feedback`       | Store a local blocked-agent feedback report and upload an anonymous copy to Coral when enabled |
 | Resource | `coral://guide`  | Usage guide for agents                                  |
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
@@ -29,7 +29,7 @@ Clients see the same installed sources and query results as `coral sql`. You set
 `describe_table` accepts exact `schema` and `table` arguments and returns guide text, required filters, and a column count without dumping full columns.
 `list_columns` accepts exact `schema` and `table` arguments plus optional `pattern`, `ignore_case`, `required_only`, `limit`, and `offset` arguments.
 For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
-Start Coral as `coral mcp-stdio --enable-feedback` to expose the optional `feedback` tool. Agents can call `feedback` when they get blocked or repeat a pattern that is not working. Coral stores the report locally with what the agent was trying to do, what it tried, and where it got stuck.
+Start Coral as `coral mcp-stdio --enable-feedback` to expose the optional `feedback` tool. Agents can call `feedback` when they get blocked or repeat a pattern that is not working. Coral stores the report locally with what the agent was trying to do, what it tried, and where it got stuck, then uploads an anonymous copy to Coral's hosted feedback service in the background. Coral does not attach user identifiers to the hosted copy and uses these reports to improve Coral's performance. Only enable this tool if you are comfortable sending the feedback text to Coral. If hosted upload fails, the local report is still stored.
 
 ## Client setup
 


### PR DESCRIPTION
## Summary

This adds the hosted feedback upload path behind the existing MCP feedback tool. The feedback tool writes the local JSONL report synchronously, then starts a best-effort hosted upload in the background so blocked-agent reports can be collected centrally without putting the remote ingest endpoint on the MCP tool critical path.

## Details

- Adds a hosted feedback publisher in `coral-app` with a fixed Coral ingest endpoint and timeout-bound upload behavior.
- Keeps local JSONL persistence as the only synchronous success condition for feedback submission.
- Starts hosted upload from `FeedbackManager` as a detached task after the local report is safely stored.
- Keeps the MCP/protobuf feedback response focused on the persisted report id and timestamp instead of exposing remote upload status to the LLM.
- Keeps `--enable-feedback` as the MCP discoverability toggle, while app bootstrap wires the hosted publisher for feedback submissions.
- Updates MCP tests and the MCP guide for the background hosted submission behavior.

## Verification

- `make rust-checks`
- Live smoke through `target/debug/coral mcp-stdio --enable-feedback` against `https://feedback.withcoral.com/ingest`; upload returned `accepted` and the local JSONL report was written.
