### PR TITLE
feat(sources/github): add OAuth device flow

### DIFF
--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -181,10 +181,13 @@ Cloud; for GitHub Enterprise Server, use
 `GITHUB_TOKEN` (required)
 
 For GitHub Cloud, choose "Connect with GitHub OAuth app" during
-interactive install to authorize through GitHub device flow.
+interactive install to authorize through GitHub OAuth's browser
+authorization-code flow or device-code flow.
 Coral uses its bundled GitHub OAuth app client ID by default;
 enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
-No callback URL or client secret is required.
+The browser flow uses a loopback callback URL; GitHub requires
+GITHUB_OAUTH_CLIENT_SECRET for OAuth app authorization-code token
+exchange. The device-code flow does not use a client secret.
 
 The OAuth method requests `repo`, `read:org`, `read:user`, and
 `user:email` scopes. Use the token method instead if you need a

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -180,7 +180,18 @@ Cloud; for GitHub Enterprise Server, use
 
 `GITHUB_TOKEN` (required)
 
-If you're already authenticated in GitHub CLI, run
+For GitHub Cloud, choose "Connect with GitHub OAuth app" during
+interactive install to authorize through GitHub device flow.
+Coral uses its bundled GitHub OAuth app client ID by default;
+enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
+No callback URL or client secret is required.
+
+The OAuth method requests `repo`, `read:org`, `read:user`, and
+`user:email` scopes. Use the token method instead if you need a
+narrower or more elevated scope set, or if you are connecting
+to GitHub Enterprise Server.
+
+For token auth, if you're already authenticated in GitHub CLI, run
 `gh auth token`, or create a new personal access token (PAT).
 Grant read access to the repositories and organizations you plan
 to query; some admin tables require elevated scopes.

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -180,9 +180,10 @@ Cloud; for GitHub Enterprise Server, use
 
 `GITHUB_TOKEN` (required)
 
-For GitHub Cloud, choose "Connect with GitHub OAuth app" during
-interactive install to authorize through GitHub OAuth's browser
-authorization-code flow or device-code flow.
+For GitHub Cloud, choose "Connect with GitHub device code" during
+interactive install to authorize through GitHub OAuth's device-code
+flow, or choose "Connect with GitHub OAuth app" for the browser
+authorization-code flow.
 Coral uses its bundled GitHub OAuth app client ID by default;
 enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
 The browser flow uses a loopback callback URL; GitHub requires

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -180,17 +180,21 @@ Cloud; for GitHub Enterprise Server, use
 
 `GITHUB_TOKEN` (required)
 
-For GitHub Cloud, choose "Connect with GitHub device code" during
-interactive install to authorize through GitHub OAuth's device-code
-flow, or choose "Connect with GitHub OAuth app" for the browser
-authorization-code flow.
-Coral uses its bundled GitHub OAuth app client ID by default;
-enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
-The browser flow uses a loopback callback URL; GitHub requires
-GITHUB_OAUTH_CLIENT_SECRET for OAuth app authorization-code token
-exchange. The device-code flow does not use a client secret.
+For GitHub Cloud, choose "Connect with GitHub device code" for the
+simplest setup. It signs in through GitHub and does not require you
+to create an OAuth app or enter a client secret.
 
-The OAuth method requests `repo`, `read:org`, `read:user`, and
+If you want to use your own GitHub OAuth app, set
+GITHUB_OAUTH_CLIENT_ID to the app's Client ID. To create an app,
+follow GitHub's guide:
+https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app.
+Enable device flow on the app before using the device-code option.
+For the browser "Connect with GitHub OAuth app" option, set the
+app's Authorization callback URL to
+`http://127.0.0.1:53682/oauth/callback` and set
+GITHUB_OAUTH_CLIENT_SECRET to the app's Client secret.
+
+The OAuth options request `repo`, `read:org`, `read:user`, and
 `user:email` scopes. Use the token method instead if you need a
 narrower or more elevated scope set, or if you are connecting
 to GitHub Enterprise Server.

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -54,7 +54,7 @@ inputs:
               token_url: https://github.com/login/oauth/access_token
             client:
               id:
-                default: Ov23li16CvrZJuSjQ5F7
+                default: Iv23liJHis6Bs8NO1DAI
                 input: GITHUB_OAUTH_CLIENT_ID
             scopes:
               scope:
@@ -78,7 +78,7 @@ inputs:
               token_url: https://github.com/login/oauth/access_token
             client:
               id:
-                default: Ov23li16CvrZJuSjQ5F7
+                default: Iv23liJHis6Bs8NO1DAI
                 input: GITHUB_OAUTH_CLIENT_ID
               secret:
                 input: GITHUB_OAUTH_CLIENT_SECRET

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -21,9 +21,10 @@ inputs:
   GITHUB_TOKEN:
     kind: secret
     hint: |
-      For GitHub Cloud, choose "Connect with GitHub OAuth app" during
-      interactive install to authorize through GitHub OAuth's browser
-      authorization-code flow or device-code flow.
+      For GitHub Cloud, choose "Connect with GitHub device code" during
+      interactive install to authorize through GitHub OAuth's device-code
+      flow, or choose "Connect with GitHub OAuth app" for the browser
+      authorization-code flow.
       Coral uses its bundled GitHub OAuth app client ID by default;
       enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
       The browser flow uses a loopback callback URL; GitHub requires
@@ -43,33 +44,6 @@ inputs:
     credential:
       methods:
         - type: oauth
-          label: Connect with GitHub OAuth app
-          description: Authorize GitHub through authorization code flow using a GitHub OAuth app.
-          oauth:
-            flow:
-              type: authorization_code
-              pkce: required
-            redirect_uri: http://127.0.0.1/oauth/callback
-            redirect_uri_port: random
-            endpoints:
-              authorization_url: https://github.com/login/oauth/authorize
-              token_url: https://github.com/login/oauth/access_token
-            client:
-              id:
-                default: Ov23li16CvrZJuSjQ5F7
-                input: GITHUB_OAUTH_CLIENT_ID
-              secret:
-                input: GITHUB_OAUTH_CLIENT_SECRET
-                transport: request_body
-            scopes:
-              scope:
-                delimiter: space
-                values:
-                  - repo
-                  - read:org
-                  - read:user
-                  - user:email
-        - type: oauth
           label: Connect with GitHub device code
           description: Authorize GitHub through device code flow using a GitHub OAuth app.
           oauth:
@@ -82,6 +56,33 @@ inputs:
               id:
                 default: Ov23li16CvrZJuSjQ5F7
                 input: GITHUB_OAUTH_CLIENT_ID
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - repo
+                  - read:org
+                  - read:user
+                  - user:email
+        - type: oauth
+          label: Connect with GitHub OAuth app
+          description: Authorize GitHub through authorization code flow using a GitHub OAuth app.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://127.0.0.1/oauth/callback
+            redirect_uri_port_mode: random
+            endpoints:
+              authorization_url: https://github.com/login/oauth/authorize
+              token_url: https://github.com/login/oauth/access_token
+            client:
+              id:
+                default: Ov23li16CvrZJuSjQ5F7
+                input: GITHUB_OAUTH_CLIENT_ID
+              secret:
+                input: GITHUB_OAUTH_CLIENT_SECRET
+                transport: request_body
             scopes:
               scope:
                 delimiter: space

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -21,11 +21,48 @@ inputs:
   GITHUB_TOKEN:
     kind: secret
     hint: |
-      If you're already authenticated in GitHub CLI, run
+      For GitHub Cloud, choose "Connect with GitHub OAuth app" during
+      interactive install to authorize through GitHub device flow.
+      Coral uses its bundled GitHub OAuth app client ID by default;
+      enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
+      No callback URL or client secret is required.
+
+      The OAuth method requests `repo`, `read:org`, `read:user`, and
+      `user:email` scopes. Use the token method instead if you need a
+      narrower or more elevated scope set, or if you are connecting
+      to GitHub Enterprise Server.
+
+      For token auth, if you're already authenticated in GitHub CLI, run
       `gh auth token`, or create a new personal access token (PAT).
       Grant read access to the repositories and organizations you plan
       to query; some admin tables require elevated scopes.
       See [GitHub PAT docs](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens).
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with GitHub OAuth app
+          description: Authorize GitHub through device flow using a GitHub OAuth app.
+          oauth:
+            flow:
+              type: device_code
+            endpoints:
+              device_authorization_url: https://github.com/login/device/code
+              token_url: https://github.com/login/oauth/access_token
+            client:
+              id:
+                default: Ov23li16CvrZJuSjQ5F7
+                input: GITHUB_OAUTH_CLIENT_ID
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - repo
+                  - read:org
+                  - read:user
+                  - user:email
+        - type: source_config
+          label: Paste token
+          description: Paste a GitHub token or provide GITHUB_TOKEN.
 auth:
   type: HeaderAuth
   headers:

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -71,8 +71,8 @@ inputs:
             flow:
               type: authorization_code
               pkce: required
-            redirect_uri: http://127.0.0.1/oauth/callback
-            redirect_uri_port_mode: random
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            redirect_uri_port_mode: fixed
             endpoints:
               authorization_url: https://github.com/login/oauth/authorize
               token_url: https://github.com/login/oauth/access_token

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -21,17 +21,21 @@ inputs:
   GITHUB_TOKEN:
     kind: secret
     hint: |
-      For GitHub Cloud, choose "Connect with GitHub device code" during
-      interactive install to authorize through GitHub OAuth's device-code
-      flow, or choose "Connect with GitHub OAuth app" for the browser
-      authorization-code flow.
-      Coral uses its bundled GitHub OAuth app client ID by default;
-      enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
-      The browser flow uses a loopback callback URL; GitHub requires
-      GITHUB_OAUTH_CLIENT_SECRET for OAuth app authorization-code token
-      exchange. The device-code flow does not use a client secret.
+      For GitHub Cloud, choose "Connect with GitHub device code" for the
+      simplest setup. It signs in through GitHub and does not require you
+      to create an OAuth app or enter a client secret.
 
-      The OAuth method requests `repo`, `read:org`, `read:user`, and
+      If you want to use your own GitHub OAuth app, set
+      GITHUB_OAUTH_CLIENT_ID to the app's Client ID. To create an app,
+      follow GitHub's guide:
+      https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app.
+      Enable device flow on the app before using the device-code option.
+      For the browser "Connect with GitHub OAuth app" option, set the
+      app's Authorization callback URL to
+      `http://127.0.0.1:53682/oauth/callback` and set
+      GITHUB_OAUTH_CLIENT_SECRET to the app's Client secret.
+
+      The OAuth options request `repo`, `read:org`, `read:user`, and
       `user:email` scopes. Use the token method instead if you need a
       narrower or more elevated scope set, or if you are connecting
       to GitHub Enterprise Server.
@@ -45,7 +49,7 @@ inputs:
       methods:
         - type: oauth
           label: Connect with GitHub device code
-          description: Authorize GitHub through device code flow using a GitHub OAuth app.
+          description: Sign in to GitHub with a device code.
           oauth:
             flow:
               type: device_code
@@ -66,7 +70,7 @@ inputs:
                   - user:email
         - type: oauth
           label: Connect with GitHub OAuth app
-          description: Authorize GitHub through authorization code flow using a GitHub OAuth app.
+          description: Sign in through a GitHub OAuth app in your browser.
           oauth:
             flow:
               type: authorization_code

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -22,10 +22,13 @@ inputs:
     kind: secret
     hint: |
       For GitHub Cloud, choose "Connect with GitHub OAuth app" during
-      interactive install to authorize through GitHub device flow.
+      interactive install to authorize through GitHub OAuth's browser
+      authorization-code flow or device-code flow.
       Coral uses its bundled GitHub OAuth app client ID by default;
       enter GITHUB_OAUTH_CLIENT_ID only if you need to override it.
-      No callback URL or client secret is required.
+      The browser flow uses a loopback callback URL; GitHub requires
+      GITHUB_OAUTH_CLIENT_SECRET for OAuth app authorization-code token
+      exchange. The device-code flow does not use a client secret.
 
       The OAuth method requests `repo`, `read:org`, `read:user`, and
       `user:email` scopes. Use the token method instead if you need a
@@ -41,7 +44,34 @@ inputs:
       methods:
         - type: oauth
           label: Connect with GitHub OAuth app
-          description: Authorize GitHub through device flow using a GitHub OAuth app.
+          description: Authorize GitHub through authorization code flow using a GitHub OAuth app.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://127.0.0.1/oauth/callback
+            redirect_uri_port: random
+            endpoints:
+              authorization_url: https://github.com/login/oauth/authorize
+              token_url: https://github.com/login/oauth/access_token
+            client:
+              id:
+                default: Ov23li16CvrZJuSjQ5F7
+                input: GITHUB_OAUTH_CLIENT_ID
+              secret:
+                input: GITHUB_OAUTH_CLIENT_SECRET
+                transport: request_body
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - repo
+                  - read:org
+                  - read:user
+                  - user:email
+        - type: oauth
+          label: Connect with GitHub device code
+          description: Authorize GitHub through device code flow using a GitHub OAuth app.
           oauth:
             flow:
               type: device_code


### PR DESCRIPTION
## Summary
- Add an OAuth credential method to the bundled GitHub source using GitHub device flow.
- Default to Coral's bundled GitHub OAuth client ID, with `GITHUB_OAUTH_CLIENT_ID` available as an override.
- Keep pasted token auth as the fallback path for GitHub Enterprise Server or custom scope needs.
- Regenerate bundled source docs for the new GitHub OAuth instructions.

## Stack
- Base: #360 (`feat(credentials): support OAuth device flow`)
- This PR: GitHub source manifest and generated bundled-source docs only

## Validation
- `make rust-checks`
- `cargo run --locked -p coral-cli -- source lint sources/github/manifest.yaml`
- `make docs-check`
- `make lint-sources`
- `git diff --check`