### PR TITLE
feat(spec): add typed auth fallback sources

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -221,14 +221,10 @@ impl QueryManager {
                 source.name
             )));
         }
-        for secret_name in source_spec.required_secret_names() {
-            let value = stored_secrets.get(&secret_name).cloned().ok_or_else(|| {
-                AppError::FailedPrecondition(format!(
-                    "source '{}' is missing secret '{secret_name}'",
-                    source.name
-                ))
-            })?;
-            resolved_secrets.insert(secret_name, value);
+        for secret_name in source_spec.declared_secret_names() {
+            if let Some(value) = stored_secrets.get(&secret_name) {
+                resolved_secrets.insert(secret_name, value.clone());
+            }
         }
         Ok((
             QuerySource::new(source_spec, source.variables.clone(), resolved_secrets),
@@ -454,6 +450,89 @@ mod tests {
             .http_body_capture_max_bytes
             .expect("body capture config");
         assert_eq!(config, 42);
+    }
+
+    #[test]
+    fn load_query_source_passes_present_optional_secrets_to_runtime() {
+        let fixture = query_manager_with(QueryRuntimeContext::default(), Vec::new());
+        fixture.manager.layout.ensure().expect("ensure layout");
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("optional_auth").expect("source name");
+        let manifest_path = fixture
+            .manager
+            .layout
+            .manifest_file(&workspace_name, &source_name);
+        std::fs::create_dir_all(manifest_path.parent().expect("manifest parent"))
+            .expect("create source dir");
+        std::fs::write(
+            &manifest_path,
+            r"
+name: optional_auth
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://api.example.com
+inputs:
+  API_KEY:
+    kind: secret
+    required: false
+  OAUTH_TOKEN:
+    kind: secret
+    required: false
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: one_of
+      values:
+        - from: input
+          key: API_KEY
+        - from: bearer
+          key: OAUTH_TOKEN
+tables:
+  - name: items
+    description: Items
+    request:
+      path: /items
+    columns:
+      - name: id
+        type: Utf8
+",
+        )
+        .expect("write manifest");
+        let source = InstalledSource {
+            name: source_name.clone(),
+            version: Some("0.1.0".to_string()),
+            variables: BTreeMap::new(),
+            secrets: vec!["API_KEY".to_string(), "OAUTH_TOKEN".to_string()],
+            credential_storage: Some(CredentialStorageKind::File),
+            origin: SourceOrigin::Imported,
+        };
+        fixture
+            .manager
+            .config_store
+            .upsert_source(&workspace_name, source.clone())
+            .expect("persist source");
+        fixture
+            .manager
+            .credential_manager
+            .replace_material(
+                &workspace_name,
+                &CredentialSetId::for_source(&source_name),
+                CredentialStorageKind::File,
+                &BTreeMap::from([("OAUTH_TOKEN".to_string(), "oauth-token".to_string())]),
+            )
+            .expect("persist secret material");
+
+        let (query_source, _) = fixture
+            .manager
+            .load_query_source(&workspace_name, &source)
+            .expect("optional secret should load when present");
+
+        assert_eq!(
+            query_source.secrets(),
+            &BTreeMap::from([("OAUTH_TOKEN".to_string(), "oauth-token".to_string())])
+        );
     }
 
     #[test]

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -174,9 +174,9 @@ async fn run_installed_source_menu(
                 .iter()
                 .map(manifest_input_from_proto)
                 .collect::<Result<Vec<_>, _>>()?;
-            let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
+            let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
             let result =
-                source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
+                source_ops::add_bundled_source_with_credentials(app, &source.name, inputs).await?;
             println!("Reconfigured source {}", result.name);
             source_ops::validate_and_warn(
                 app,
@@ -197,8 +197,8 @@ async fn run_add_bundled_source(app: &AppClient, source: &SourceInfo) -> Result<
         .iter()
         .map(manifest_input_from_proto)
         .collect::<Result<Vec<_>, _>>()?;
-    let (variables, secrets) = source_ops::prompt_for_inputs(&inputs)?;
-    let result = source_ops::add_bundled_source(app, &source.name, variables, secrets).await?;
+    let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
+    let result = source_ops::add_bundled_source_with_credentials(app, &source.name, inputs).await?;
     println!("Added source {}", result.name);
     source_ops::validate_and_warn(app, &result.name, source_ops::TableDisplayLimit::DEFAULT).await
 }

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -174,7 +174,10 @@ async fn run_installed_source_menu(
                 .iter()
                 .map(manifest_input_from_proto)
                 .collect::<Result<Vec<_>, _>>()?;
-            let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
+            let inputs = source_ops::prompt_for_inputs_with_credential_methods_in_mode(
+                &inputs,
+                source_ops::CredentialPromptMode::CredentialMethodFirst,
+            )?;
             let result =
                 source_ops::add_bundled_source_with_credentials(app, &source.name, inputs).await?;
             println!("Reconfigured source {}", result.name);
@@ -197,7 +200,10 @@ async fn run_add_bundled_source(app: &AppClient, source: &SourceInfo) -> Result<
         .iter()
         .map(manifest_input_from_proto)
         .collect::<Result<Vec<_>, _>>()?;
-    let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
+    let inputs = source_ops::prompt_for_inputs_with_credential_methods_in_mode(
+        &inputs,
+        source_ops::CredentialPromptMode::CredentialMethodFirst,
+    )?;
     let result = source_ops::add_bundled_source_with_credentials(app, &source.name, inputs).await?;
     println!("Added source {}", result.name);
     source_ops::validate_and_warn(app, &result.name, source_ops::TableDisplayLimit::DEFAULT).await

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -437,30 +437,6 @@ pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Erro
     Ok(name.to_string())
 }
 
-pub(crate) fn prompt_for_inputs(
-    inputs: &[ManifestInputSpec],
-) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
-    let mut variables = Vec::new();
-    let mut secrets = Vec::new();
-
-    for input in inputs {
-        match input.kind {
-            ManifestInputKind::Variable => {
-                if let Some(variable) = prompt_variable(input)? {
-                    variables.push(variable);
-                }
-            }
-            ManifestInputKind::Secret => {
-                if let Some(secret) = prompt_secret(input)? {
-                    secrets.push(secret);
-                }
-            }
-        }
-    }
-
-    Ok((variables, secrets))
-}
-
 pub(crate) fn prompt_for_inputs_with_credential_methods(
     inputs: &[ManifestInputSpec],
 ) -> Result<CollectedSourceInputs, anyhow::Error> {
@@ -488,7 +464,10 @@ pub(crate) fn prompt_for_inputs_with_credential_methods(
                     collected.variables.push(variable);
                 }
             }
-            ManifestInputKind::Secret => match prompt_secret_with_methods(input)? {
+            ManifestInputKind::Secret => match prompt_secret_with_methods(
+                input,
+                !collected.secrets.is_empty() || !collected.oauth_credentials.is_empty(),
+            )? {
                 SecretInputOutcome::SourceConfig(secret) => {
                     if let Some(secret) = secret {
                         collected.secrets.push(secret);
@@ -921,11 +900,14 @@ enum SecretInputOutcome {
 
 fn prompt_secret_with_methods(
     input: &ManifestInputSpec,
+    prefer_skip: bool,
 ) -> Result<SecretInputOutcome, anyhow::Error> {
     let Some(credential) = input.credential.as_ref() else {
         return Ok(SecretInputOutcome::SourceConfig(prompt_secret(input)?));
     };
-    let selected = select_credential_method(input, credential)?;
+    let Some(selected) = select_credential_method(input, credential, prefer_skip)? else {
+        return Ok(SecretInputOutcome::SourceConfig(None));
+    };
     let method = credential
         .methods
         .get(selected)
@@ -944,22 +926,34 @@ fn prompt_secret_with_methods(
 fn select_credential_method(
     input: &ManifestInputSpec,
     credential: &ManifestCredentialSpec,
-) -> Result<usize, anyhow::Error> {
-    if credential.methods.len() == 1 {
-        return Ok(0);
+    prefer_skip: bool,
+) -> Result<Option<usize>, anyhow::Error> {
+    if credential.methods.len() == 1 && input.required {
+        return Ok(Some(0));
     }
     let theme = ColorfulTheme::default();
-    let items = credential
+    let mut items = credential
         .methods
         .iter()
         .map(credential_method_label)
         .collect::<Vec<_>>();
+    if !input.required {
+        items.push("Skip".to_string());
+    }
+    let skip_index = items.len().saturating_sub(1);
     let selected = Select::with_theme(&theme)
         .with_prompt(format!("{} credential", input.key))
         .items(&items)
-        .default(0)
+        .default(if !input.required && prefer_skip {
+            skip_index
+        } else {
+            0
+        })
         .interact()?;
-    Ok(selected)
+    if !input.required && selected == skip_index {
+        return Ok(None);
+    }
+    Ok(Some(selected))
 }
 
 fn credential_method_label(method: &ManifestCredentialMethod) -> String {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -466,7 +466,7 @@ pub(crate) fn prompt_for_inputs_with_credential_methods(
             }
             ManifestInputKind::Secret => match prompt_secret_with_methods(
                 input,
-                !collected.secrets.is_empty() || !collected.oauth_credentials.is_empty(),
+                !collected.secrets.is_empty() || !collected.oauth_credential_retrievals.is_empty(),
             )? {
                 SecretInputOutcome::SourceConfig(secret) => {
                     if let Some(secret) = secret {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -144,6 +144,23 @@ impl CollectedSourceInputs {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CredentialPromptMode {
+    EnvFirst,
+    CredentialMethodFirst,
+}
+
+impl CredentialPromptMode {
+    fn reads_env_before_prompt(self, input: &ManifestInputSpec) -> bool {
+        match self {
+            Self::EnvFirst => true,
+            Self::CredentialMethodFirst => {
+                input.kind == ManifestInputKind::Variable || input.credential.is_none()
+            }
+        }
+    }
+}
+
 pub(crate) async fn add_bundled_source_with_credentials(
     app: &AppClient,
     name: &str,
@@ -440,22 +457,22 @@ pub(crate) fn source_name_arg(name: Option<&str>) -> Result<String, anyhow::Erro
 pub(crate) fn prompt_for_inputs_with_credential_methods(
     inputs: &[ManifestInputSpec],
 ) -> Result<CollectedSourceInputs, anyhow::Error> {
+    prompt_for_inputs_with_credential_methods_in_mode(inputs, CredentialPromptMode::EnvFirst)
+}
+
+pub(crate) fn prompt_for_inputs_with_credential_methods_in_mode(
+    inputs: &[ManifestInputSpec],
+    mode: CredentialPromptMode,
+) -> Result<CollectedSourceInputs, anyhow::Error> {
     let mut collected = CollectedSourceInputs::new();
 
     for input in inputs {
-        let env_value = read_source_input_env(&input.key).unwrap_or_default();
-        if !env_value.is_empty() {
-            match input.kind {
-                ManifestInputKind::Variable => collected.variables.push(SourceVariable {
-                    key: input.key.clone(),
-                    value: env_value,
-                }),
-                ManifestInputKind::Secret => collected.secrets.push(SourceSecret {
-                    key: input.key.clone(),
-                    value: env_value,
-                }),
+        if mode.reads_env_before_prompt(input) {
+            let env_value = read_source_input_env(&input.key).unwrap_or_default();
+            if !env_value.is_empty() {
+                push_collected_input(&mut collected, input, env_value);
+                continue;
             }
-            continue;
         }
 
         match input.kind {
@@ -482,6 +499,23 @@ pub(crate) fn prompt_for_inputs_with_credential_methods(
     }
 
     Ok(collected)
+}
+
+fn push_collected_input(
+    collected: &mut CollectedSourceInputs,
+    input: &ManifestInputSpec,
+    value: String,
+) {
+    match input.kind {
+        ManifestInputKind::Variable => collected.variables.push(SourceVariable {
+            key: input.key.clone(),
+            value,
+        }),
+        ManifestInputKind::Secret => collected.secrets.push(SourceSecret {
+            key: input.key.clone(),
+            value,
+        }),
+    }
 }
 
 pub(crate) fn collect_inputs_from_env(
@@ -890,6 +924,19 @@ fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyh
     }))
 }
 
+fn prompt_source_config_secret(
+    input: &ManifestInputSpec,
+) -> Result<Option<SourceSecret>, anyhow::Error> {
+    let env_value = read_source_input_env(&input.key).unwrap_or_default();
+    if !env_value.is_empty() {
+        return Ok(Some(SourceSecret {
+            key: input.key.clone(),
+            value: env_value,
+        }));
+    }
+    prompt_secret(input)
+}
+
 enum SecretInputOutcome {
     SourceConfig(Option<SourceSecret>),
     OAuth {
@@ -903,7 +950,9 @@ fn prompt_secret_with_methods(
     prefer_skip: bool,
 ) -> Result<SecretInputOutcome, anyhow::Error> {
     let Some(credential) = input.credential.as_ref() else {
-        return Ok(SecretInputOutcome::SourceConfig(prompt_secret(input)?));
+        return Ok(SecretInputOutcome::SourceConfig(
+            prompt_source_config_secret(input)?,
+        ));
     };
     let Some(selected) = select_credential_method(input, credential, prefer_skip)? else {
         return Ok(SecretInputOutcome::SourceConfig(None));
@@ -913,9 +962,9 @@ fn prompt_secret_with_methods(
         .get(selected)
         .ok_or_else(|| anyhow::anyhow!("credential method index {selected} is out of range"))?;
     match method.kind {
-        ManifestCredentialMethodKind::SourceConfig => {
-            Ok(SecretInputOutcome::SourceConfig(prompt_secret(input)?))
-        }
+        ManifestCredentialMethodKind::SourceConfig => Ok(SecretInputOutcome::SourceConfig(
+            prompt_source_config_secret(input)?,
+        )),
         ManifestCredentialMethodKind::OAuth => Ok(SecretInputOutcome::OAuth {
             credential: collect_oauth_credential_method(input, selected, method)?,
             label: credential_method_label(method),
@@ -1079,13 +1128,16 @@ mod tests {
     )]
 
     use coral_api::v1::ValidateSourceResponse;
-    use coral_spec::{ManifestInputKind, ManifestInputSpec};
+    use coral_spec::{
+        ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
+        ManifestInputKind, ManifestInputSpec,
+    };
 
     use std::collections::HashMap;
 
     use super::{
-        ValidationFollowUp, ValidationSeverityMode, collect_inputs_with_hint, finalize_input_value,
-        shell_quote_arg, source_name_arg, validation_follow_up,
+        CredentialPromptMode, ValidationFollowUp, ValidationSeverityMode, collect_inputs_with_hint,
+        finalize_input_value, shell_quote_arg, source_name_arg, validation_follow_up,
     };
 
     #[test]
@@ -1121,6 +1173,51 @@ mod tests {
         assert_eq!(secrets.len(), 1);
         assert_eq!(secrets[0].key, "LINEAR_API_KEY");
         assert_eq!(secrets[0].value, "lin_token");
+    }
+
+    #[test]
+    fn credential_method_first_defers_env_for_secrets_with_credential_methods() {
+        let input = ManifestInputSpec {
+            key: "LINEAR_OAUTH_ACCESS_TOKEN".to_string(),
+            kind: ManifestInputKind::Secret,
+            required: false,
+            default_value: String::new(),
+            hint: None,
+            credential: Some(ManifestCredentialSpec {
+                methods: vec![ManifestCredentialMethod {
+                    kind: ManifestCredentialMethodKind::SourceConfig,
+                    label: Some("Paste token".to_string()),
+                    description: None,
+                    oauth: None,
+                }],
+            }),
+        };
+
+        assert!(CredentialPromptMode::EnvFirst.reads_env_before_prompt(&input));
+        assert!(!CredentialPromptMode::CredentialMethodFirst.reads_env_before_prompt(&input));
+    }
+
+    #[test]
+    fn credential_method_first_keeps_env_for_plain_inputs() {
+        let variable = ManifestInputSpec {
+            key: "LINEAR_API_BASE".to_string(),
+            kind: ManifestInputKind::Variable,
+            required: false,
+            default_value: String::new(),
+            hint: None,
+            credential: None,
+        };
+        let plain_secret = ManifestInputSpec {
+            key: "LINEAR_API_KEY".to_string(),
+            kind: ManifestInputKind::Secret,
+            required: false,
+            default_value: String::new(),
+            hint: None,
+            credential: None,
+        };
+
+        assert!(CredentialPromptMode::CredentialMethodFirst.reads_env_before_prompt(&variable));
+        assert!(CredentialPromptMode::CredentialMethodFirst.reads_env_before_prompt(&plain_secret));
     }
 
     #[test]

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -195,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn required_secret_names_exclude_variable_inputs() {
+    fn required_secret_names_exclude_optional_and_variable_inputs() {
         let manifest = parse_source_manifest_value(json!({
             "dsl_version": 3,
             "name": "alpha",
@@ -203,7 +203,8 @@ mod tests {
             "backend": "http",
             "base_url": "https://api.example.com",
             "inputs": {
-                "API_BASE": { "kind": "variable", "default": "https://api.example.com" }
+                "API_BASE": { "kind": "variable", "default": "https://api.example.com" },
+                "OPTIONAL_TOKEN": { "kind": "secret", "required": false }
             },
             "tables": [{
                 "name": "items",

--- a/crates/coral-engine/src/backends/http/registration_checks.rs
+++ b/crates/coral-engine/src/backends/http/registration_checks.rs
@@ -106,7 +106,7 @@ fn table_request_route_label(table_name: &str, route: &RequestRouteSpec) -> Stri
     }
 }
 
-/// Auth is source-scoped: all template dependencies must resolve from inputs
+/// Auth is source-scoped: all value-source input dependencies must resolve
 /// before any request is issued.
 fn check_auth_inputs(
     manifest: &HttpSourceManifest,

--- a/crates/coral-engine/src/backends/http/test_support.rs
+++ b/crates/coral-engine/src/backends/http/test_support.rs
@@ -77,6 +77,10 @@ fn value_source_json(value: &ValueSourceSpec) -> serde_json::Value {
             "from": "literal",
             "value": value,
         }),
+        ValueSourceSpec::OneOf { values } => json!({
+            "from": "one_of",
+            "values": values.iter().map(value_source_json).collect::<Vec<_>>(),
+        }),
         ValueSourceSpec::Filter { key, default } => json!({
             "from": "filter",
             "key": key,
@@ -149,6 +153,10 @@ fn value_source_json(value: &ValueSourceSpec) -> serde_json::Value {
         }),
         ValueSourceSpec::Input { key } => json!({
             "from": "input",
+            "key": key,
+        }),
+        ValueSourceSpec::Bearer { key } => json!({
+            "from": "bearer",
             "key": key,
         }),
         ValueSourceSpec::Template { template } => json!({

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -278,6 +278,15 @@ pub(crate) fn render_template(
 }
 
 fn resolve_template_token(token: &TemplateToken, context: &RenderContext<'_>) -> Result<String> {
+    if is_expression_token(token.raw()) {
+        return resolve_template_expr(token.raw(), context)?.ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "missing source input for template expression '{}'",
+                token.raw()
+            ))
+        });
+    }
+
     let default = token.default_value().map(ToString::to_string);
 
     if token.namespace() == &TemplateNamespace::Input {
@@ -333,6 +342,158 @@ fn resolve_template_token(token: &TemplateToken, context: &RenderContext<'_>) ->
     )))
 }
 
+fn resolve_template_expr(raw: &str, context: &RenderContext<'_>) -> Result<Option<String>> {
+    for branch in split_top_level(raw, "||")? {
+        if let Some(value) = resolve_expr(branch.trim(), context)? {
+            return Ok(Some(value));
+        }
+    }
+    Ok(None)
+}
+
+fn resolve_expr(raw: &str, context: &RenderContext<'_>) -> Result<Option<String>> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(DataFusionError::Execution(
+            "empty template expression".to_string(),
+        ));
+    }
+    if let Some(inner) = raw
+        .strip_prefix("concat(")
+        .and_then(|value| value.strip_suffix(')'))
+    {
+        let mut out = String::new();
+        for arg in split_top_level(inner, ",")? {
+            let Some(value) = resolve_expr(arg.trim(), context)? else {
+                return Ok(None);
+            };
+            out.push_str(&value);
+        }
+        return Ok(Some(out));
+    }
+    if let Some(literal) = parse_string_literal(raw)? {
+        return Ok(Some(literal));
+    }
+    if let Some(key) = raw.strip_prefix("input.") {
+        return Ok(context.resolved_inputs.get(key).cloned());
+    }
+    if let Some(key) = raw.strip_prefix("filter.") {
+        return Ok(context.filters.get(key).cloned());
+    }
+    if let Some(key) = raw.strip_prefix("arg.") {
+        return Ok(context.args.get(key).cloned());
+    }
+    if let Some(key) = raw.strip_prefix("state.") {
+        return Ok(context.state.get(key).cloned());
+    }
+    Err(DataFusionError::Execution(format!(
+        "unsupported template expression '{raw}'"
+    )))
+}
+
+fn parse_string_literal(raw: &str) -> Result<Option<String>> {
+    let Some(quote) = raw.as_bytes().first().copied() else {
+        return Ok(None);
+    };
+    if quote != b'"' && quote != b'\'' {
+        return Ok(None);
+    }
+    if raw.as_bytes().last().copied() != Some(quote) {
+        return Err(DataFusionError::Execution(format!(
+            "unterminated template string literal '{raw}'"
+        )));
+    }
+    let inner = raw
+        .get(1..raw.len().saturating_sub(1))
+        .ok_or_else(|| DataFusionError::Execution("invalid string literal".to_string()))?;
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            let Some(escaped) = chars.next() else {
+                return Err(DataFusionError::Execution(format!(
+                    "unterminated escape in template string literal '{raw}'"
+                )));
+            };
+            out.push(escaped);
+        } else {
+            out.push(ch);
+        }
+    }
+    Ok(Some(out))
+}
+
+fn is_expression_token(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    trimmed.contains("||") || trimmed.starts_with("concat(")
+}
+
+fn split_top_level<'a>(raw: &'a str, delimiter: &str) -> Result<Vec<&'a str>> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut depth = 0usize;
+    let mut in_quote: Option<char> = None;
+    let mut escaped = false;
+    for (index, ch) in raw.char_indices() {
+        if let Some(quote) = in_quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '"' | '\'' => in_quote = Some(ch),
+            '(' => depth = depth.saturating_add(1),
+            ')' => {
+                depth = depth.checked_sub(1).ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "unbalanced ')' in template expression '{raw}'"
+                    ))
+                })?;
+            }
+            _ if depth == 0
+                && raw
+                    .get(index..)
+                    .is_some_and(|rest| rest.starts_with(delimiter)) =>
+            {
+                parts.push(
+                    raw.get(start..index)
+                        .ok_or_else(|| {
+                            DataFusionError::Execution(
+                                "invalid template expression boundary".to_string(),
+                            )
+                        })?
+                        .trim(),
+                );
+                start = index + delimiter.len();
+            }
+            _ => {}
+        }
+    }
+    if in_quote.is_some() {
+        return Err(DataFusionError::Execution(format!(
+            "unterminated quote in template expression '{raw}'"
+        )));
+    }
+    if depth != 0 {
+        return Err(DataFusionError::Execution(format!(
+            "unbalanced '(' in template expression '{raw}'"
+        )));
+    }
+    parts.push(
+        raw.get(start..)
+            .ok_or_else(|| {
+                DataFusionError::Execution("invalid template expression boundary".to_string())
+            })?
+            .trim(),
+    );
+    Ok(parts)
+}
+
 /// Flatten a JSON value into a plain string suitable for header/query use.
 pub(crate) fn value_to_string(value: &Value) -> String {
     match value {
@@ -350,18 +511,84 @@ pub(crate) fn validate_input_dependencies(
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<()> {
     for part in template.parts() {
-        if let TemplatePart::Token(token) = part
-            && token.namespace() == &TemplateNamespace::Input
-            && token.default_value().is_none()
-            && !resolved_inputs.contains_key(token.key())
-        {
-            return Err(DataFusionError::Execution(format!(
-                "missing source input '{}' for template token",
-                token.key()
-            )));
+        if let TemplatePart::Token(token) = part {
+            if is_expression_token(token.raw()) {
+                if !expression_input_dependencies_satisfied(token.raw(), resolved_inputs)? {
+                    return Err(DataFusionError::Execution(format!(
+                        "missing source input for template expression '{}'",
+                        token.raw()
+                    )));
+                }
+            } else if token.namespace() == &TemplateNamespace::Input
+                && token.default_value().is_none()
+                && !resolved_inputs.contains_key(token.key())
+            {
+                return Err(DataFusionError::Execution(format!(
+                    "missing source input '{}' for template token",
+                    token.key()
+                )));
+            }
         }
     }
     Ok(())
+}
+
+fn expression_input_dependencies_satisfied(
+    raw: &str,
+    resolved_inputs: &BTreeMap<String, String>,
+) -> Result<bool> {
+    for branch in split_top_level(raw, "||")? {
+        if expression_input_keys(branch)
+            .iter()
+            .all(|key| resolved_inputs.contains_key(*key))
+        {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn expression_input_keys(raw: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    let bytes = raw.as_bytes();
+    let mut in_quote: Option<u8> = None;
+    while cursor < bytes.len() {
+        let Some(&byte) = bytes.get(cursor) else {
+            break;
+        };
+        if let Some(quote) = in_quote {
+            if byte == b'\\' {
+                cursor = cursor.saturating_add(2);
+                continue;
+            }
+            if byte == quote {
+                in_quote = None;
+            }
+            cursor += 1;
+            continue;
+        }
+        if byte == b'\'' || byte == b'"' {
+            in_quote = Some(byte);
+            cursor += 1;
+            continue;
+        }
+        let rest = raw.get(cursor..).unwrap_or_default();
+        if let Some(after_prefix) = rest.strip_prefix("input.") {
+            let key_len = after_prefix
+                .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
+                .unwrap_or(after_prefix.len());
+            if key_len > 0
+                && let Some(key) = after_prefix.get(..key_len)
+            {
+                out.push(key);
+            }
+            cursor += "input.".len() + key_len;
+            continue;
+        }
+        cursor += 1;
+    }
+    out
 }
 
 /// Validate only the input-token dependencies for a value source.
@@ -402,10 +629,21 @@ pub(crate) fn validate_value_source_inputs(
 mod tests {
     use std::collections::{BTreeMap, HashMap};
 
+    use coral_spec::{ParsedTemplate, ValueSourceSpec};
+    use datafusion::error::Result;
     use serde_json::json;
 
-    use super::{EMPTY_MAP, RenderContext, resolve_value_source};
-    use coral_spec::ValueSourceSpec;
+    use super::{
+        EMPTY_MAP, RenderContext, render_template, resolve_value_source,
+        validate_input_dependencies,
+    };
+
+    fn inputs(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
 
     fn test_render_context<'a>(
         filters: &'a HashMap<String, String>,
@@ -413,6 +651,11 @@ mod tests {
         resolved_inputs: &'a BTreeMap<String, String>,
     ) -> RenderContext<'a> {
         RenderContext::new(filters, args, &EMPTY_MAP, resolved_inputs)
+    }
+
+    fn render_with_inputs(template: &ParsedTemplate, pairs: &[(&str, &str)]) -> Result<String> {
+        let resolved_inputs = inputs(pairs);
+        render_template(template, &RenderContext::source_scoped(&resolved_inputs))
     }
 
     #[test]
@@ -633,5 +876,87 @@ mod tests {
         .expect("bool filter should resolve");
 
         assert_eq!(value, Some(json!(false)));
+    }
+
+    #[test]
+    fn expression_templates_prefer_first_available_branch() {
+        let template =
+            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
+                .expect("template");
+
+        let rendered = render_with_inputs(
+            &template,
+            &[("API_KEY", "lin_api_key"), ("OAUTH_TOKEN", "oauth_access")],
+        )
+        .expect("render");
+
+        assert_eq!(rendered, "lin_api_key");
+    }
+
+    #[test]
+    fn expression_templates_concat_fallback_branch() {
+        let template =
+            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
+                .expect("template");
+
+        let rendered =
+            render_with_inputs(&template, &[("OAUTH_TOKEN", "oauth_access")]).expect("render");
+
+        assert_eq!(rendered, "Bearer oauth_access");
+    }
+
+    #[test]
+    fn expression_templates_error_when_no_branch_resolves() {
+        let template =
+            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
+                .expect("template");
+
+        let error = render_with_inputs(&template, &[]).expect_err("missing inputs should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing source input for template expression")
+        );
+    }
+
+    #[test]
+    fn expression_input_dependency_validation_accepts_any_resolved_branch() {
+        let template =
+            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
+                .expect("template");
+
+        validate_input_dependencies(&template, &inputs(&[("API_KEY", "lin_api_key")]))
+            .expect("api key should satisfy expression");
+        validate_input_dependencies(&template, &inputs(&[("OAUTH_TOKEN", "oauth_access")]))
+            .expect("oauth token should satisfy expression");
+        assert!(
+            validate_input_dependencies(&template, &inputs(&[]))
+                .expect_err("missing both should fail")
+                .to_string()
+                .contains("missing source input for template expression")
+        );
+    }
+
+    #[test]
+    fn expression_input_dependency_validation_tolerates_runtime_values() {
+        let filter_only = ParsedTemplate::parse(r#"{{concat(filter.team, "-", state.cursor)}}"#)
+            .expect("template");
+        validate_input_dependencies(&filter_only, &inputs(&[]))
+            .expect("filter and state values resolve per request");
+
+        let filter_fallback =
+            ParsedTemplate::parse(r"{{input.API_KEY || filter.team}}").expect("template");
+        validate_input_dependencies(&filter_fallback, &inputs(&[]))
+            .expect("runtime fallback can satisfy expression");
+
+        let missing_input =
+            ParsedTemplate::parse(r"{{concat(filter.team, input.API_KEY)}}").expect("template");
+        assert!(
+            validate_input_dependencies(&missing_input, &inputs(&[]))
+                .expect_err("concat input dependency is still required")
+                .to_string()
+                .contains("missing source input for template expression")
+        );
     }
 }

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -72,6 +72,7 @@ pub(crate) fn resolve_value_source(
             let rendered = render_template(template, context)?;
             Ok(Some(Value::String(rendered)))
         }
+        ValueSourceSpec::OneOf { values } => resolve_one_of(values, context),
         ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
         ValueSourceSpec::Filter { key, default } => Ok(string_runtime_value(
             context,
@@ -152,11 +153,31 @@ pub(crate) fn resolve_value_source(
         ValueSourceSpec::Input { key } => {
             Ok(context.resolved_inputs.get(key).cloned().map(Value::String))
         }
+        ValueSourceSpec::Bearer { key } => Ok(context
+            .resolved_inputs
+            .get(key)
+            .filter(|value| !value.is_empty())
+            .map(|value| Value::String(format!("Bearer {value}")))),
         ValueSourceSpec::State { key } => {
             Ok(context.state.get(key).map(|v| Value::String(v.clone())))
         }
         ValueSourceSpec::NowEpochMinusSeconds { seconds } => Ok(Some(now_minus_seconds(*seconds))),
     }
+}
+
+fn resolve_one_of(
+    values: &[ValueSourceSpec],
+    context: &RenderContext<'_>,
+) -> Result<Option<Value>> {
+    for value in values {
+        let Some(resolved) = resolve_value_source(value, context)? else {
+            continue;
+        };
+        if !value_to_string(&resolved).is_empty() {
+            return Ok(Some(resolved));
+        }
+    }
+    Ok(None)
 }
 
 fn string_runtime_value(
@@ -278,15 +299,6 @@ pub(crate) fn render_template(
 }
 
 fn resolve_template_token(token: &TemplateToken, context: &RenderContext<'_>) -> Result<String> {
-    if is_expression_token(token.raw()) {
-        return resolve_template_expr(token.raw(), context)?.ok_or_else(|| {
-            DataFusionError::Execution(format!(
-                "missing source input for template expression '{}'",
-                token.raw()
-            ))
-        });
-    }
-
     let default = token.default_value().map(ToString::to_string);
 
     if token.namespace() == &TemplateNamespace::Input {
@@ -342,158 +354,6 @@ fn resolve_template_token(token: &TemplateToken, context: &RenderContext<'_>) ->
     )))
 }
 
-fn resolve_template_expr(raw: &str, context: &RenderContext<'_>) -> Result<Option<String>> {
-    for branch in split_top_level(raw, "||")? {
-        if let Some(value) = resolve_expr(branch.trim(), context)? {
-            return Ok(Some(value));
-        }
-    }
-    Ok(None)
-}
-
-fn resolve_expr(raw: &str, context: &RenderContext<'_>) -> Result<Option<String>> {
-    let raw = raw.trim();
-    if raw.is_empty() {
-        return Err(DataFusionError::Execution(
-            "empty template expression".to_string(),
-        ));
-    }
-    if let Some(inner) = raw
-        .strip_prefix("concat(")
-        .and_then(|value| value.strip_suffix(')'))
-    {
-        let mut out = String::new();
-        for arg in split_top_level(inner, ",")? {
-            let Some(value) = resolve_expr(arg.trim(), context)? else {
-                return Ok(None);
-            };
-            out.push_str(&value);
-        }
-        return Ok(Some(out));
-    }
-    if let Some(literal) = parse_string_literal(raw)? {
-        return Ok(Some(literal));
-    }
-    if let Some(key) = raw.strip_prefix("input.") {
-        return Ok(context.resolved_inputs.get(key).cloned());
-    }
-    if let Some(key) = raw.strip_prefix("filter.") {
-        return Ok(context.filters.get(key).cloned());
-    }
-    if let Some(key) = raw.strip_prefix("arg.") {
-        return Ok(context.args.get(key).cloned());
-    }
-    if let Some(key) = raw.strip_prefix("state.") {
-        return Ok(context.state.get(key).cloned());
-    }
-    Err(DataFusionError::Execution(format!(
-        "unsupported template expression '{raw}'"
-    )))
-}
-
-fn parse_string_literal(raw: &str) -> Result<Option<String>> {
-    let Some(quote) = raw.as_bytes().first().copied() else {
-        return Ok(None);
-    };
-    if quote != b'"' && quote != b'\'' {
-        return Ok(None);
-    }
-    if raw.as_bytes().last().copied() != Some(quote) {
-        return Err(DataFusionError::Execution(format!(
-            "unterminated template string literal '{raw}'"
-        )));
-    }
-    let inner = raw
-        .get(1..raw.len().saturating_sub(1))
-        .ok_or_else(|| DataFusionError::Execution("invalid string literal".to_string()))?;
-    let mut out = String::with_capacity(inner.len());
-    let mut chars = inner.chars();
-    while let Some(ch) = chars.next() {
-        if ch == '\\' {
-            let Some(escaped) = chars.next() else {
-                return Err(DataFusionError::Execution(format!(
-                    "unterminated escape in template string literal '{raw}'"
-                )));
-            };
-            out.push(escaped);
-        } else {
-            out.push(ch);
-        }
-    }
-    Ok(Some(out))
-}
-
-fn is_expression_token(raw: &str) -> bool {
-    let trimmed = raw.trim();
-    trimmed.contains("||") || trimmed.starts_with("concat(")
-}
-
-fn split_top_level<'a>(raw: &'a str, delimiter: &str) -> Result<Vec<&'a str>> {
-    let mut parts = Vec::new();
-    let mut start = 0;
-    let mut depth = 0usize;
-    let mut in_quote: Option<char> = None;
-    let mut escaped = false;
-    for (index, ch) in raw.char_indices() {
-        if let Some(quote) = in_quote {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == quote {
-                in_quote = None;
-            }
-            continue;
-        }
-        match ch {
-            '"' | '\'' => in_quote = Some(ch),
-            '(' => depth = depth.saturating_add(1),
-            ')' => {
-                depth = depth.checked_sub(1).ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "unbalanced ')' in template expression '{raw}'"
-                    ))
-                })?;
-            }
-            _ if depth == 0
-                && raw
-                    .get(index..)
-                    .is_some_and(|rest| rest.starts_with(delimiter)) =>
-            {
-                parts.push(
-                    raw.get(start..index)
-                        .ok_or_else(|| {
-                            DataFusionError::Execution(
-                                "invalid template expression boundary".to_string(),
-                            )
-                        })?
-                        .trim(),
-                );
-                start = index + delimiter.len();
-            }
-            _ => {}
-        }
-    }
-    if in_quote.is_some() {
-        return Err(DataFusionError::Execution(format!(
-            "unterminated quote in template expression '{raw}'"
-        )));
-    }
-    if depth != 0 {
-        return Err(DataFusionError::Execution(format!(
-            "unbalanced '(' in template expression '{raw}'"
-        )));
-    }
-    parts.push(
-        raw.get(start..)
-            .ok_or_else(|| {
-                DataFusionError::Execution("invalid template expression boundary".to_string())
-            })?
-            .trim(),
-    );
-    Ok(parts)
-}
-
 /// Flatten a JSON value into a plain string suitable for header/query use.
 pub(crate) fn value_to_string(value: &Value) -> String {
     match value {
@@ -511,84 +371,18 @@ pub(crate) fn validate_input_dependencies(
     resolved_inputs: &BTreeMap<String, String>,
 ) -> Result<()> {
     for part in template.parts() {
-        if let TemplatePart::Token(token) = part {
-            if is_expression_token(token.raw()) {
-                if !expression_input_dependencies_satisfied(token.raw(), resolved_inputs)? {
-                    return Err(DataFusionError::Execution(format!(
-                        "missing source input for template expression '{}'",
-                        token.raw()
-                    )));
-                }
-            } else if token.namespace() == &TemplateNamespace::Input
-                && token.default_value().is_none()
-                && !resolved_inputs.contains_key(token.key())
-            {
-                return Err(DataFusionError::Execution(format!(
-                    "missing source input '{}' for template token",
-                    token.key()
-                )));
-            }
+        if let TemplatePart::Token(token) = part
+            && token.namespace() == &TemplateNamespace::Input
+            && token.default_value().is_none()
+            && !resolved_inputs.contains_key(token.key())
+        {
+            return Err(DataFusionError::Execution(format!(
+                "missing source input '{}' for template token",
+                token.key()
+            )));
         }
     }
     Ok(())
-}
-
-fn expression_input_dependencies_satisfied(
-    raw: &str,
-    resolved_inputs: &BTreeMap<String, String>,
-) -> Result<bool> {
-    for branch in split_top_level(raw, "||")? {
-        if expression_input_keys(branch)
-            .iter()
-            .all(|key| resolved_inputs.contains_key(*key))
-        {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
-fn expression_input_keys(raw: &str) -> Vec<&str> {
-    let mut out = Vec::new();
-    let mut cursor = 0;
-    let bytes = raw.as_bytes();
-    let mut in_quote: Option<u8> = None;
-    while cursor < bytes.len() {
-        let Some(&byte) = bytes.get(cursor) else {
-            break;
-        };
-        if let Some(quote) = in_quote {
-            if byte == b'\\' {
-                cursor = cursor.saturating_add(2);
-                continue;
-            }
-            if byte == quote {
-                in_quote = None;
-            }
-            cursor += 1;
-            continue;
-        }
-        if byte == b'\'' || byte == b'"' {
-            in_quote = Some(byte);
-            cursor += 1;
-            continue;
-        }
-        let rest = raw.get(cursor..).unwrap_or_default();
-        if let Some(after_prefix) = rest.strip_prefix("input.") {
-            let key_len = after_prefix
-                .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
-                .unwrap_or(after_prefix.len());
-            if key_len > 0
-                && let Some(key) = after_prefix.get(..key_len)
-            {
-                out.push(key);
-            }
-            cursor += "input.".len() + key_len;
-            continue;
-        }
-        cursor += 1;
-    }
-    out
 }
 
 /// Validate only the input-token dependencies for a value source.
@@ -600,12 +394,33 @@ pub(crate) fn validate_value_source_inputs(
         ValueSourceSpec::Template { template } => {
             validate_input_dependencies(template, resolved_inputs)
         }
+        ValueSourceSpec::OneOf { values } => {
+            let mut last_error = None;
+            for value in values {
+                match validate_value_source_inputs(value, resolved_inputs) {
+                    Ok(()) => return Ok(()),
+                    Err(error) => last_error = Some(error),
+                }
+            }
+            Err(last_error.unwrap_or_else(|| {
+                DataFusionError::Execution("`from: one_of` value source has no values".to_string())
+            }))
+        }
         ValueSourceSpec::Input { key } => {
             if resolved_inputs.contains_key(key) {
                 Ok(())
             } else {
                 Err(DataFusionError::Execution(format!(
                     "missing source input '{key}' for `from: input` value source"
+                )))
+            }
+        }
+        ValueSourceSpec::Bearer { key } => {
+            if resolved_inputs.contains_key(key) {
+                Ok(())
+            } else {
+                Err(DataFusionError::Execution(format!(
+                    "missing source input '{key}' for `from: bearer` value source"
                 )))
             }
         }
@@ -629,14 +444,10 @@ pub(crate) fn validate_value_source_inputs(
 mod tests {
     use std::collections::{BTreeMap, HashMap};
 
-    use coral_spec::{ParsedTemplate, ValueSourceSpec};
-    use datafusion::error::Result;
+    use coral_spec::ValueSourceSpec;
     use serde_json::json;
 
-    use super::{
-        EMPTY_MAP, RenderContext, render_template, resolve_value_source,
-        validate_input_dependencies,
-    };
+    use super::{EMPTY_MAP, RenderContext, resolve_value_source, validate_value_source_inputs};
 
     fn inputs(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
         pairs
@@ -651,11 +462,6 @@ mod tests {
         resolved_inputs: &'a BTreeMap<String, String>,
     ) -> RenderContext<'a> {
         RenderContext::new(filters, args, &EMPTY_MAP, resolved_inputs)
-    }
-
-    fn render_with_inputs(template: &ParsedTemplate, pairs: &[(&str, &str)]) -> Result<String> {
-        let resolved_inputs = inputs(pairs);
-        render_template(template, &RenderContext::source_scoped(&resolved_inputs))
     }
 
     #[test]
@@ -879,84 +685,88 @@ mod tests {
     }
 
     #[test]
-    fn expression_templates_prefer_first_available_branch() {
-        let template =
-            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
-                .expect("template");
+    fn one_of_prefers_first_present_value() {
+        let resolved_inputs = inputs(&[("API_KEY", "lin_api_key"), ("OAUTH_TOKEN", "oauth")]);
 
-        let rendered = render_with_inputs(
-            &template,
-            &[("API_KEY", "lin_api_key"), ("OAUTH_TOKEN", "oauth_access")],
+        let value = resolve_value_source(
+            &ValueSourceSpec::OneOf {
+                values: vec![
+                    ValueSourceSpec::Input {
+                        key: "API_KEY".to_string(),
+                    },
+                    ValueSourceSpec::Bearer {
+                        key: "OAUTH_TOKEN".to_string(),
+                    },
+                ],
+            },
+            &RenderContext::source_scoped(&resolved_inputs),
         )
-        .expect("render");
+        .expect("one_of should resolve");
 
-        assert_eq!(rendered, "lin_api_key");
+        assert_eq!(value, Some(json!("lin_api_key")));
     }
 
     #[test]
-    fn expression_templates_concat_fallback_branch() {
-        let template =
-            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
-                .expect("template");
+    fn one_of_uses_bearer_fallback_value() {
+        let resolved_inputs = inputs(&[("OAUTH_TOKEN", "oauth")]);
 
-        let rendered =
-            render_with_inputs(&template, &[("OAUTH_TOKEN", "oauth_access")]).expect("render");
+        let value = resolve_value_source(
+            &ValueSourceSpec::OneOf {
+                values: vec![
+                    ValueSourceSpec::Input {
+                        key: "API_KEY".to_string(),
+                    },
+                    ValueSourceSpec::Bearer {
+                        key: "OAUTH_TOKEN".to_string(),
+                    },
+                ],
+            },
+            &RenderContext::source_scoped(&resolved_inputs),
+        )
+        .expect("one_of should resolve");
 
-        assert_eq!(rendered, "Bearer oauth_access");
+        assert_eq!(value, Some(json!("Bearer oauth")));
     }
 
     #[test]
-    fn expression_templates_error_when_no_branch_resolves() {
-        let template =
-            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
-                .expect("template");
+    fn one_of_ignores_empty_bearer_values() {
+        let resolved_inputs = inputs(&[("OAUTH_TOKEN", "")]);
 
-        let error = render_with_inputs(&template, &[]).expect_err("missing inputs should fail");
+        let value = resolve_value_source(
+            &ValueSourceSpec::OneOf {
+                values: vec![ValueSourceSpec::Bearer {
+                    key: "OAUTH_TOKEN".to_string(),
+                }],
+            },
+            &RenderContext::source_scoped(&resolved_inputs),
+        )
+        .expect("one_of should resolve");
 
+        assert_eq!(value, None);
+    }
+
+    #[test]
+    fn one_of_input_dependency_validation_accepts_any_resolved_branch() {
+        let value = ValueSourceSpec::OneOf {
+            values: vec![
+                ValueSourceSpec::Input {
+                    key: "API_KEY".to_string(),
+                },
+                ValueSourceSpec::Bearer {
+                    key: "OAUTH_TOKEN".to_string(),
+                },
+            ],
+        };
+
+        validate_value_source_inputs(&value, &inputs(&[("API_KEY", "lin_api_key")]))
+            .expect("api key should satisfy one_of");
+        validate_value_source_inputs(&value, &inputs(&[("OAUTH_TOKEN", "oauth_access")]))
+            .expect("oauth token should satisfy one_of");
         assert!(
-            error
-                .to_string()
-                .contains("missing source input for template expression")
-        );
-    }
-
-    #[test]
-    fn expression_input_dependency_validation_accepts_any_resolved_branch() {
-        let template =
-            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
-                .expect("template");
-
-        validate_input_dependencies(&template, &inputs(&[("API_KEY", "lin_api_key")]))
-            .expect("api key should satisfy expression");
-        validate_input_dependencies(&template, &inputs(&[("OAUTH_TOKEN", "oauth_access")]))
-            .expect("oauth token should satisfy expression");
-        assert!(
-            validate_input_dependencies(&template, &inputs(&[]))
+            validate_value_source_inputs(&value, &inputs(&[]))
                 .expect_err("missing both should fail")
                 .to_string()
-                .contains("missing source input for template expression")
-        );
-    }
-
-    #[test]
-    fn expression_input_dependency_validation_tolerates_runtime_values() {
-        let filter_only = ParsedTemplate::parse(r#"{{concat(filter.team, "-", state.cursor)}}"#)
-            .expect("template");
-        validate_input_dependencies(&filter_only, &inputs(&[]))
-            .expect("filter and state values resolve per request");
-
-        let filter_fallback =
-            ParsedTemplate::parse(r"{{input.API_KEY || filter.team}}").expect("template");
-        validate_input_dependencies(&filter_fallback, &inputs(&[]))
-            .expect("runtime fallback can satisfy expression");
-
-        let missing_input =
-            ParsedTemplate::parse(r"{{concat(filter.team, input.API_KEY)}}").expect("template");
-        assert!(
-            validate_input_dependencies(&missing_input, &inputs(&[]))
-                .expect_err("concat input dependency is still required")
-                .to_string()
-                .contains("missing source input for template expression")
+                .contains("missing source input 'OAUTH_TOKEN' for `from: bearer` value source")
         );
     }
 }

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -60,7 +60,7 @@ impl QuerySource {
     }
 
     #[must_use]
-    /// Returns resolved source secrets required by the manifest.
+    /// Returns resolved declared source secrets that are available at runtime.
     pub fn secrets(&self) -> &BTreeMap<String, String> {
         &self.secrets
     }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -1256,8 +1256,8 @@ async fn auth_headers_sent_correctly() {
         "type": "HeaderAuth",
         "headers": [{
             "name": "Authorization",
-            "from": "template",
-            "template": "Bearer {{input.API_TOKEN}}"
+            "from": "bearer",
+            "key": "API_TOKEN"
         }]
     });
     let source = build_source_with_secrets(manifest, [("API_TOKEN", "secret-token")]);
@@ -1267,6 +1267,48 @@ async fn auth_headers_sent_correctly() {
             &[source],
             test_runtime(),
             "SELECT COUNT(*) AS n FROM http_auth.users",
+        )
+        .await
+        .expect("query should succeed"),
+    );
+
+    assert_eq!(rows, vec![json!({"n": 3})]);
+}
+
+#[tokio::test]
+async fn auth_header_one_of_uses_bearer_fallback() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/users"))
+        .and(header("authorization", "Bearer oauth-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "data": users_rows() })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = base_http_manifest("http_auth_fallback", &server.uri());
+    manifest["inputs"] = json!({
+        "API_KEY": { "kind": "secret", "required": false },
+        "OAUTH_TOKEN": { "kind": "secret", "required": false }
+    });
+    manifest["auth"] = json!({
+        "type": "HeaderAuth",
+        "headers": [{
+            "name": "Authorization",
+            "from": "one_of",
+            "values": [
+                { "from": "input", "key": "API_KEY" },
+                { "from": "bearer", "key": "OAUTH_TOKEN" }
+            ]
+        }]
+    });
+    let source = build_source_with_secrets(manifest, [("OAUTH_TOKEN", "oauth-token")]);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT COUNT(*) AS n FROM http_auth_fallback.users",
         )
         .await
         .expect("query should succeed"),

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -17,11 +17,13 @@ use std::fmt;
 use url::Url;
 
 use crate::common::parse_manifest_data_type;
-use crate::inputs::collect_source_inputs_value;
+use crate::inputs::{
+    collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
+};
 use crate::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ManifestInputKind, ManifestInputSpec,
-    ParsedTemplate, Result, SourceBackend, SourceManifestCommon, TableCommon, TemplateNamespace,
-    TemplatePart, validate_columns, validate_table_names, validate_test_queries,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestError, ManifestInputSpec, ParsedTemplate,
+    Result, SourceBackend, SourceManifestCommon, TableCommon, TemplateNamespace, TemplatePart,
+    validate_columns, validate_table_names, validate_test_queries,
 };
 
 /// Validated top-level manifest for a native file-backed source.
@@ -33,16 +35,17 @@ pub struct FileSourceManifest {
 }
 
 impl FileSourceManifest {
+    /// Returns all source secrets declared by this manifest.
+    pub fn declared_secret_names(&self) -> BTreeSet<String> {
+        declared_secret_input_names(&self.declared_inputs)
+    }
+
     /// Returns the source secrets required by this manifest.
     ///
     /// Required declared inputs with `kind: secret` must be available before a
     /// source can compile or authenticate.
     pub fn required_secret_names(&self) -> BTreeSet<String> {
-        self.declared_inputs
-            .iter()
-            .filter(|input| input.kind == ManifestInputKind::Secret && input.required)
-            .map(|input| input.key.clone())
-            .collect()
+        required_secret_input_names(&self.declared_inputs)
     }
 }
 

--- a/crates/coral-spec/src/backends/file.rs
+++ b/crates/coral-spec/src/backends/file.rs
@@ -35,12 +35,12 @@ pub struct FileSourceManifest {
 impl FileSourceManifest {
     /// Returns the source secrets required by this manifest.
     ///
-    /// Every declared input with `kind: secret` is required; secrets cannot
-    /// carry defaults.
+    /// Required declared inputs with `kind: secret` must be available before a
+    /// source can compile or authenticate.
     pub fn required_secret_names(&self) -> BTreeSet<String> {
         self.declared_inputs
             .iter()
-            .filter(|input| input.kind == ManifestInputKind::Secret)
+            .filter(|input| input.kind == ManifestInputKind::Secret && input.required)
             .map(|input| input.key.clone())
             .collect()
     }
@@ -652,6 +652,7 @@ mod tests {
             "inputs": {
                 "api_token": { "kind": "secret" },
                 "signing_key": { "kind": "secret" },
+                "optional_token": { "kind": "secret", "required": false },
                 "region": { "kind": "variable", "default": "us-east-1" },
             },
             "tables": [{
@@ -667,6 +668,7 @@ mod tests {
         let required = manifest.required_secret_names();
         assert!(required.contains("api_token"));
         assert!(required.contains("signing_key"));
+        assert!(!required.contains("optional_token"));
         assert_eq!(required.len(), 2);
 
         let kinds: Vec<(&str, ManifestInputKind)> = manifest

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -17,10 +17,13 @@ use serde_json::{Map, Value};
 
 use crate::{
     ColumnSpec, DetailHintDeclaringSurface, DetailHintSpec, DetailHintTargetTable, FilterSpec,
-    HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec, PaginationSpec,
-    ParsedTemplate, RequestRouteSpec, RequestSpec, ResponseSpec, Result, SearchLimitsSpec,
-    SourceBackend, SourceManifestCommon, SourceTableFunctionSpec, TableCommon,
-    inputs::collect_source_inputs_value, validate::validate_template,
+    HeaderSpec, ManifestError, ManifestInputSpec, PaginationSpec, ParsedTemplate, RequestRouteSpec,
+    RequestSpec, ResponseSpec, Result, SearchLimitsSpec, SourceBackend, SourceManifestCommon,
+    SourceTableFunctionSpec, TableCommon,
+    inputs::{
+        collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
+    },
+    validate::validate_template,
     validate_detail_hint_references, validate_http_function, validate_http_function_names,
     validate_http_table, validate_table_names, validate_test_queries,
 };
@@ -212,16 +215,17 @@ impl HttpTableSpec {
 }
 
 impl HttpSourceManifest {
+    /// Returns all source secrets declared by this manifest.
+    pub fn declared_secret_names(&self) -> BTreeSet<String> {
+        declared_secret_input_names(&self.declared_inputs)
+    }
+
     /// Returns the source secrets required by this manifest.
     ///
     /// In the new input model, required declared inputs with `kind: secret`
     /// must be available before a source can compile or authenticate.
     pub fn required_secret_names(&self) -> BTreeSet<String> {
-        self.declared_inputs
-            .iter()
-            .filter(|input| input.kind == ManifestInputKind::Secret && input.required)
-            .map(|input| input.key.clone())
-            .collect()
+        required_secret_input_names(&self.declared_inputs)
     }
 }
 

--- a/crates/coral-spec/src/backends/http.rs
+++ b/crates/coral-spec/src/backends/http.rs
@@ -214,12 +214,12 @@ impl HttpTableSpec {
 impl HttpSourceManifest {
     /// Returns the source secrets required by this manifest.
     ///
-    /// In the new input model, every declared input with `kind: secret` is
-    /// required because secrets cannot carry defaults.
+    /// In the new input model, required declared inputs with `kind: secret`
+    /// must be available before a source can compile or authenticate.
     pub fn required_secret_names(&self) -> BTreeSet<String> {
         self.declared_inputs
             .iter()
-            .filter(|input| input.kind == ManifestInputKind::Secret)
+            .filter(|input| input.kind == ManifestInputKind::Secret && input.required)
             .map(|input| input.key.clone())
             .collect()
     }

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -715,6 +715,17 @@ fn validate_table_tool_arg_value_source(
             }
             Ok(())
         }
+        ValueSourceSpec::OneOf { values } => {
+            if values.is_empty() {
+                return Err(ManifestError::validation(format!(
+                    "{context} one_of values must not be empty"
+                )));
+            }
+            for value in values {
+                validate_table_tool_arg_value_source(source_name, table_name, arg_name, value)?;
+            }
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -770,8 +781,20 @@ fn validate_source_scoped_value_source(source: &ValueSourceSpec, context: &str) 
             }
             Ok(())
         }
+        ValueSourceSpec::OneOf { values } => {
+            if values.is_empty() {
+                return Err(ManifestError::validation(format!(
+                    "{context} one_of values must not be empty"
+                )));
+            }
+            for value in values {
+                validate_source_scoped_value_source(value, context)?;
+            }
+            Ok(())
+        }
         ValueSourceSpec::Literal { .. }
         | ValueSourceSpec::Input { .. }
+        | ValueSourceSpec::Bearer { .. }
         | ValueSourceSpec::NowEpochMinusSeconds { .. } => Ok(()),
     }
 }

--- a/crates/coral-spec/src/backends/mcp.rs
+++ b/crates/coral-spec/src/backends/mcp.rs
@@ -11,11 +11,14 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    ColumnSpec, FilterMode, FilterSpec, FunctionArgBinding, ManifestError, ManifestInputKind,
-    ManifestInputSpec, PaginationSpec, RequestSpec, ResponseSpec, Result, SourceBackend,
-    SourceManifestCommon, SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon,
-    TableFunctionArgSpec, ValueSourceSpec, inputs::collect_source_inputs_value, validate_columns,
-    validate_filters_and_column_exprs, validate_test_queries,
+    ColumnSpec, FilterMode, FilterSpec, FunctionArgBinding, ManifestError, ManifestInputSpec,
+    PaginationSpec, RequestSpec, ResponseSpec, Result, SourceBackend, SourceManifestCommon,
+    SourceTableFunctionKind, SourceTableFunctionSpec, TableCommon, TableFunctionArgSpec,
+    ValueSourceSpec,
+    inputs::{
+        collect_source_inputs_value, declared_secret_input_names, required_secret_input_names,
+    },
+    validate_columns, validate_filters_and_column_exprs, validate_test_queries,
 };
 
 /// Validated top-level manifest for a Model Context Protocol-backed source.
@@ -329,13 +332,14 @@ impl RawMcpTableSpec {
 }
 
 impl McpSourceManifest {
+    /// Returns all source secrets declared by this manifest.
+    pub fn declared_secret_names(&self) -> BTreeSet<String> {
+        declared_secret_input_names(&self.declared_inputs)
+    }
+
     /// Returns the source secrets required by this manifest.
     pub fn required_secret_names(&self) -> BTreeSet<String> {
-        self.declared_inputs
-            .iter()
-            .filter(|input| input.kind == ManifestInputKind::Secret)
-            .map(|input| input.key.clone())
-            .collect()
+        required_secret_input_names(&self.declared_inputs)
     }
 
     pub(crate) fn parse_manifest_value(value: Value) -> Result<Self> {
@@ -853,6 +857,8 @@ fn validate_identifier(value: &str, context: &str) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use super::McpSourceManifest;
     use serde_json::json;
 
@@ -864,7 +870,8 @@ mod tests {
             "version": "0.1.0",
             "backend": "mcp",
             "inputs": {
-                "GITHUB_TOKEN": { "kind": "secret" }
+                "GITHUB_TOKEN": { "kind": "secret" },
+                "OPTIONAL_TOKEN": { "kind": "secret", "required": false }
             },
             "server": {
                 "transport": "stdio",
@@ -891,7 +898,14 @@ mod tests {
         assert_eq!(manifest.common.name, "github_mcp");
         let function = manifest.functions.first().expect("function should parse");
         assert_eq!(function.tool, "search_issues");
-        assert!(manifest.required_secret_names().contains("GITHUB_TOKEN"));
+        assert_eq!(
+            manifest.declared_secret_names(),
+            BTreeSet::from(["GITHUB_TOKEN".to_string(), "OPTIONAL_TOKEN".to_string()])
+        );
+        assert_eq!(
+            manifest.required_secret_names(),
+            BTreeSet::from(["GITHUB_TOKEN".to_string()])
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -426,6 +426,9 @@ pub enum ValueSourceSpec {
     Template {
         template: ParsedTemplate,
     },
+    OneOf {
+        values: Vec<ValueSourceSpec>,
+    },
     Literal {
         value: Value,
     },
@@ -480,6 +483,9 @@ pub enum ValueSourceSpec {
         part: usize,
     },
     Input {
+        key: String,
+    },
+    Bearer {
         key: String,
     },
     State {

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -1759,6 +1759,29 @@ tables: []
     }
 
     #[test]
+    fn expression_template_input_references_are_boundary_aware() {
+        let manifest = r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  OAUTH_TOKEN:
+    kind: secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: '{{filter.input.API_KEY || input.OAUTH_TOKEN}}'
+tables: []
+";
+        let inputs = collect(manifest).expect("filter key should not be read as an input key");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].key, "OAUTH_TOKEN");
+    }
+
+    #[test]
     fn inline_template_defaults_are_rejected() {
         let manifest = r#"
 name: demo

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -308,6 +308,17 @@ fn collect_declared_inputs(root: &Value) -> Result<Vec<ManifestInputSpec>> {
             .get("credential")
             .map(|value| parse_credential(key, value))
             .transpose()?;
+        let required = input
+            .get("required")
+            .map(|value| {
+                value.as_bool().ok_or_else(|| {
+                    ManifestError::validation(format!(
+                        "manifest input '{key}' required must be a boolean"
+                    ))
+                })
+            })
+            .transpose()?
+            .unwrap_or(default_value.is_none());
         if kind != ManifestInputKind::Secret && credential.is_some() {
             return Err(ManifestError::validation(format!(
                 "manifest input '{key}' declares credential methods but is not a secret"
@@ -316,7 +327,7 @@ fn collect_declared_inputs(root: &Value) -> Result<Vec<ManifestInputSpec>> {
         ordered.push(ManifestInputSpec {
             key: key.clone(),
             kind,
-            required: default_value.is_none(),
+            required,
             default_value: default_value.unwrap_or_default(),
             hint,
             credential,
@@ -1000,16 +1011,15 @@ fn validate_mapping(map: &Map<String, Value>, declared: &BTreeSet<String>) -> Re
 fn validate_template(template: &str, declared: &BTreeSet<String>) -> Result<()> {
     let template = ParsedTemplate::parse(template)?;
     for token in template.tokens() {
-        if !matches!(token.namespace(), TemplateNamespace::Input) {
-            continue;
+        for key in token.input_keys() {
+            if !declared.contains(key) {
+                return Err(ManifestError::validation(format!(
+                    "manifest input '{key}' is referenced but not declared under top-level inputs"
+                )));
+            }
         }
-        if !declared.contains(token.key()) {
-            return Err(ManifestError::validation(format!(
-                "manifest input '{}' is referenced but not declared under top-level inputs",
-                token.key()
-            )));
-        }
-        if token.default_value().is_some() {
+        if matches!(token.namespace(), TemplateNamespace::Input) && token.default_value().is_some()
+        {
             return Err(ManifestError::validation(format!(
                 "manifest input '{}' must declare defaults under top-level inputs",
                 token.key()
@@ -1172,6 +1182,21 @@ tables: []
         );
         assert_eq!(credential.methods[0].label.as_deref(), Some("Paste token"));
         assert!(credential.methods[0].oauth.is_none());
+    }
+
+    #[test]
+    fn parses_optional_secret_input() {
+        let inputs = collect(&manifest_with_input(
+            r"
+  API_TOKEN:
+    kind: secret
+    required: false
+",
+        ))
+        .expect("inputs");
+        assert_eq!(inputs[0].key, "API_TOKEN");
+        assert_eq!(inputs[0].kind, ManifestInputKind::Secret);
+        assert!(!inputs[0].required);
     }
 
     #[test]
@@ -1671,6 +1696,58 @@ inputs:
   GITHUB_TOKEN:
     kind: secret
 base_url: "{{input.GITHUB_API_BASE}}"
+tables: []
+"#;
+        let error = collect(manifest).expect_err("undeclared input");
+        assert!(
+            error
+                .to_string()
+                .contains("referenced but not declared under top-level inputs")
+        );
+    }
+
+    #[test]
+    fn expression_template_input_references_resolve_against_declarations() {
+        let manifest = r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  API_KEY:
+    kind: secret
+    required: false
+  OAUTH_TOKEN:
+    kind: secret
+    required: false
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: '{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}'
+tables: []
+"#;
+        let inputs = collect(manifest).expect("inputs");
+        assert_eq!(inputs.len(), 2);
+    }
+
+    #[test]
+    fn expression_template_undeclared_input_references_are_rejected() {
+        let manifest = r#"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  API_KEY:
+    kind: secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: '{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}'
 tables: []
 "#;
         let error = collect(manifest).expect_err("undeclared input");

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -3,10 +3,10 @@
 //! Sources that need interactive configuration declare their inputs under a
 //! top-level `inputs` map. Each entry fixes the input's kind (`variable` or
 //! `secret`), an optional default, and an optional hint. References elsewhere
-//! in the manifest use `{{input.KEY}}` templates or `from: input` value
-//! sources; the declared kind determines whether the value is resolved from
-//! the variable or secret store. Manifests that take no interactive inputs
-//! may omit the block entirely.
+//! in the manifest use `{{input.KEY}}` templates, `from: input`, or typed
+//! wrappers such as `from: bearer`; the declared kind determines whether the
+//! value is resolved from the variable or secret store. Manifests that take no
+//! interactive inputs may omit the block entirely.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -987,14 +987,15 @@ fn validate_value(value: &Value, is_root: bool, declared: &BTreeSet<String>) -> 
 }
 
 fn validate_mapping(map: &Map<String, Value>, declared: &BTreeSet<String>) -> Result<()> {
-    if map.get("from").and_then(Value::as_str) != Some("input") {
+    let Some(source_kind @ ("input" | "bearer")) = map.get("from").and_then(Value::as_str) else {
         return Ok(());
-    }
+    };
 
-    let key = map
-        .get("key")
-        .and_then(Value::as_str)
-        .ok_or_else(|| ManifestError::validation("manifest 'input' value source is missing key"))?;
+    let key = map.get("key").and_then(Value::as_str).ok_or_else(|| {
+        ManifestError::validation(format!(
+            "manifest '{source_kind}' value source is missing key"
+        ))
+    })?;
     if !declared.contains(key) {
         return Err(ManifestError::validation(format!(
             "manifest input '{key}' is referenced but not declared under top-level inputs"
@@ -1707,8 +1708,8 @@ tables: []
     }
 
     #[test]
-    fn expression_template_input_references_resolve_against_declarations() {
-        let manifest = r#"
+    fn one_of_value_source_input_references_resolve_against_declarations() {
+        let manifest = r"
 name: demo
 version: 1.0.0
 dsl_version: 3
@@ -1724,17 +1725,21 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: '{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}'
+      from: one_of
+      values:
+        - from: input
+          key: API_KEY
+        - from: bearer
+          key: OAUTH_TOKEN
 tables: []
-"#;
+";
         let inputs = collect(manifest).expect("inputs");
         assert_eq!(inputs.len(), 2);
     }
 
     #[test]
-    fn expression_template_undeclared_input_references_are_rejected() {
-        let manifest = r#"
+    fn one_of_value_source_undeclared_input_references_are_rejected() {
+        let manifest = r"
 name: demo
 version: 1.0.0
 dsl_version: 3
@@ -1746,10 +1751,14 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: '{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}'
+      from: one_of
+      values:
+        - from: input
+          key: API_KEY
+        - from: bearer
+          key: OAUTH_TOKEN
 tables: []
-"#;
+";
         let error = collect(manifest).expect_err("undeclared input");
         assert!(
             error
@@ -1759,7 +1768,7 @@ tables: []
     }
 
     #[test]
-    fn expression_template_input_references_are_boundary_aware() {
+    fn from_bearer_value_source_resolves_against_declarations() {
         let manifest = r"
 name: demo
 version: 1.0.0
@@ -1772,11 +1781,11 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: '{{filter.input.API_KEY || input.OAUTH_TOKEN}}'
+      from: bearer
+      key: OAUTH_TOKEN
 tables: []
 ";
-        let inputs = collect(manifest).expect("filter key should not be read as an input key");
+        let inputs = collect(manifest).expect("bearer key should resolve as an input key");
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].key, "OAUTH_TOKEN");
     }

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -253,6 +253,22 @@ pub(crate) fn collect_source_inputs_value(root: &Value) -> Result<Vec<ManifestIn
     Ok(inputs)
 }
 
+pub(crate) fn declared_secret_input_names(inputs: &[ManifestInputSpec]) -> BTreeSet<String> {
+    inputs
+        .iter()
+        .filter(|input| input.kind == ManifestInputKind::Secret)
+        .map(|input| input.key.clone())
+        .collect()
+}
+
+pub(crate) fn required_secret_input_names(inputs: &[ManifestInputSpec]) -> BTreeSet<String> {
+    inputs
+        .iter()
+        .filter(|input| input.kind == ManifestInputKind::Secret && input.required)
+        .map(|input| input.key.clone())
+        .collect()
+}
+
 fn collect_declared_inputs(root: &Value) -> Result<Vec<ManifestInputSpec>> {
     let root = root
         .as_object()
@@ -960,11 +976,18 @@ fn validate_input_key(label: &str, value: &str) -> Result<()> {
 }
 
 fn validate_input_references(root: &Value, inputs: &[ManifestInputSpec]) -> Result<()> {
-    let declared: BTreeSet<String> = inputs.iter().map(|input| input.key.clone()).collect();
+    let declared: BTreeMap<String, ManifestInputKind> = inputs
+        .iter()
+        .map(|input| (input.key.clone(), input.kind))
+        .collect();
     validate_value(root, true, &declared)
 }
 
-fn validate_value(value: &Value, is_root: bool, declared: &BTreeSet<String>) -> Result<()> {
+fn validate_value(
+    value: &Value,
+    is_root: bool,
+    declared: &BTreeMap<String, ManifestInputKind>,
+) -> Result<()> {
     match value {
         Value::Object(map) => {
             validate_mapping(map, declared)?;
@@ -986,7 +1009,10 @@ fn validate_value(value: &Value, is_root: bool, declared: &BTreeSet<String>) -> 
     Ok(())
 }
 
-fn validate_mapping(map: &Map<String, Value>, declared: &BTreeSet<String>) -> Result<()> {
+fn validate_mapping(
+    map: &Map<String, Value>,
+    declared: &BTreeMap<String, ManifestInputKind>,
+) -> Result<()> {
     let Some(source_kind @ ("input" | "bearer")) = map.get("from").and_then(Value::as_str) else {
         return Ok(());
     };
@@ -996,9 +1022,14 @@ fn validate_mapping(map: &Map<String, Value>, declared: &BTreeSet<String>) -> Re
             "manifest '{source_kind}' value source is missing key"
         ))
     })?;
-    if !declared.contains(key) {
+    let Some(kind) = declared.get(key) else {
         return Err(ManifestError::validation(format!(
             "manifest input '{key}' is referenced but not declared under top-level inputs"
+        )));
+    };
+    if source_kind == "bearer" && *kind != ManifestInputKind::Secret {
+        return Err(ManifestError::validation(format!(
+            "manifest bearer value source '{key}' must reference a secret input"
         )));
     }
     if map.contains_key("default") {
@@ -1009,11 +1040,11 @@ fn validate_mapping(map: &Map<String, Value>, declared: &BTreeSet<String>) -> Re
     Ok(())
 }
 
-fn validate_template(template: &str, declared: &BTreeSet<String>) -> Result<()> {
+fn validate_template(template: &str, declared: &BTreeMap<String, ManifestInputKind>) -> Result<()> {
     let template = ParsedTemplate::parse(template)?;
     for token in template.tokens() {
         for key in token.input_keys() {
-            if !declared.contains(key) {
+            if !declared.contains_key(key) {
                 return Err(ManifestError::validation(format!(
                     "manifest input '{key}' is referenced but not declared under top-level inputs"
                 )));
@@ -1788,6 +1819,33 @@ tables: []
         let inputs = collect(manifest).expect("bearer key should resolve as an input key");
         assert_eq!(inputs.len(), 1);
         assert_eq!(inputs[0].key, "OAUTH_TOKEN");
+    }
+
+    #[test]
+    fn from_bearer_value_source_requires_secret_input() {
+        let manifest = r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  HEADER_VALUE:
+    kind: variable
+    default: not-secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: bearer
+      key: HEADER_VALUE
+tables: []
+";
+        let error = collect(manifest).expect_err("bearer key must point at a secret input");
+        let message = error.to_string();
+        assert!(
+            message.contains("bearer value source 'HEADER_VALUE' must reference a secret input"),
+            "unexpected error: {message}"
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -980,27 +980,33 @@ fn validate_input_references(root: &Value, inputs: &[ManifestInputSpec]) -> Resu
         .iter()
         .map(|input| (input.key.clone(), input.kind))
         .collect();
-    validate_value(root, true, &declared)
+    validate_value(root, true, &declared, false)
 }
 
 fn validate_value(
     value: &Value,
     is_root: bool,
     declared: &BTreeMap<String, ManifestInputKind>,
+    in_auth: bool,
 ) -> Result<()> {
     match value {
         Value::Object(map) => {
-            validate_mapping(map, declared)?;
+            validate_mapping(map, declared, in_auth)?;
             for (key, nested) in map {
                 if is_root && key == "inputs" {
                     continue;
                 }
-                validate_value(nested, false, declared)?;
+                validate_value(
+                    nested,
+                    false,
+                    declared,
+                    in_auth || (is_root && key == "auth"),
+                )?;
             }
         }
         Value::Array(items) => {
             for item in items {
-                validate_value(item, false, declared)?;
+                validate_value(item, false, declared, in_auth)?;
             }
         }
         Value::String(raw) => validate_template(raw, declared)?,
@@ -1012,6 +1018,7 @@ fn validate_value(
 fn validate_mapping(
     map: &Map<String, Value>,
     declared: &BTreeMap<String, ManifestInputKind>,
+    in_auth: bool,
 ) -> Result<()> {
     let Some(source_kind @ ("input" | "bearer")) = map.get("from").and_then(Value::as_str) else {
         return Ok(());
@@ -1030,6 +1037,11 @@ fn validate_mapping(
     if source_kind == "bearer" && *kind != ManifestInputKind::Secret {
         return Err(ManifestError::validation(format!(
             "manifest bearer value source '{key}' must reference a secret input"
+        )));
+    }
+    if source_kind == "input" && in_auth && *kind != ManifestInputKind::Secret {
+        return Err(ManifestError::validation(format!(
+            "manifest auth input value source '{key}' must reference a secret input"
         )));
     }
     if map.contains_key("default") {
@@ -1846,6 +1858,58 @@ tables: []
             message.contains("bearer value source 'HEADER_VALUE' must reference a secret input"),
             "unexpected error: {message}"
         );
+    }
+
+    #[test]
+    fn auth_input_value_source_requires_secret_input() {
+        let manifest = r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  HEADER_VALUE:
+    kind: variable
+    default: not-secret
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: one_of
+      values:
+        - from: input
+          key: HEADER_VALUE
+tables: []
+";
+        let error = collect(manifest).expect_err("auth input key must point at a secret input");
+        let message = error.to_string();
+        assert!(
+            message
+                .contains("auth input value source 'HEADER_VALUE' must reference a secret input"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn non_auth_input_value_source_allows_variable_input() {
+        let manifest = r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  API_VERSION:
+    kind: variable
+    default: 2026-01-01
+request_headers:
+  - name: API-Version
+    from: input
+    key: API_VERSION
+tables: []
+";
+        let inputs = collect(manifest).expect("non-auth request header can use variable inputs");
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].key, "API_VERSION");
     }
 
     #[test]

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -97,6 +97,16 @@ impl ValidatedSourceManifest {
         }
     }
 
+    /// Returns the set of declared source secrets that may be passed to runtime.
+    #[must_use]
+    pub fn declared_secret_names(&self) -> BTreeSet<String> {
+        match &self.inner {
+            ValidatedManifestKind::Http(manifest) => manifest.declared_secret_names(),
+            ValidatedManifestKind::File(manifest) => manifest.declared_secret_names(),
+            ValidatedManifestKind::Mcp(manifest) => manifest.declared_secret_names(),
+        }
+    }
+
     /// Returns the declared top-level inputs for this manifest in authored order.
     #[must_use]
     pub fn declared_inputs(&self) -> &[ManifestInputSpec] {

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -67,6 +67,37 @@ tables:
     }
 
     #[test]
+    fn validate_manifest_schema_accepts_one_of_bearer_auth_headers() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: one_of
+      values:
+        - from: input
+          key: API_KEY
+        - from: bearer
+          key: OAUTH_TOKEN
+tables:
+  - name: messages
+    description: Demo messages
+    request:
+      method: GET
+      path: /messages
+",
+        );
+        validate_manifest_schema(&manifest)
+            .expect("one_of bearer auth header should pass schema validation");
+    }
+
+    #[test]
     fn validate_manifest_schema_accepts_legacy_search_filter_mode() {
         let manifest = manifest_json(
             r"

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -698,6 +698,11 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/value_source" }
+        },
         "default": {},
         "seconds": { "type": "integer" },
         "separator": { "type": "string", "minLength": 1 },
@@ -736,6 +741,11 @@
           "type": "array",
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/value_source" }
         },
         "default": {},
         "seconds": { "type": "integer" },
@@ -828,6 +838,11 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/value_source" }
+        },
         "default": {},
         "seconds": { "type": "integer" },
         "separator": { "type": "string", "minLength": 1 },
@@ -850,6 +865,11 @@
           "type": "array",
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/value_source" }
         },
         "default": {},
         "seconds": { "type": "integer" },
@@ -878,6 +898,11 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/value_source" }
+        },
         "default": {},
         "seconds": { "type": "integer" },
         "separator": { "type": "string", "minLength": 1 },
@@ -900,6 +925,37 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/value_source" }
+        },
+        "default": {},
+        "seconds": { "type": "integer" },
+        "separator": { "type": "string", "minLength": 1 },
+        "part": { "type": "integer", "minimum": 0 }
+      },
+      "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
+    },
+    "value_source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["from"],
+      "properties": {
+        "from": { "type": "string" },
+        "template": { "type": "string" },
+        "value": {},
+        "key": { "type": "string", "minLength": 1 },
+        "keys": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/value_source" }
+        },
         "default": {},
         "seconds": { "type": "integer" },
         "separator": { "type": "string", "minLength": 1 },
@@ -915,6 +971,17 @@
             "template": { "type": "string" }
           },
           "required": ["template"]
+        },
+        {
+          "properties": {
+            "from": { "const": "one_of" },
+            "values": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/value_source" }
+            }
+          },
+          "required": ["values"]
         },
         {
           "properties": {
@@ -1008,6 +1075,13 @@
         {
           "properties": {
             "from": { "const": "input" },
+            "key": { "type": "string", "minLength": 1 }
+          },
+          "required": ["key"]
+        },
+        {
+          "properties": {
+            "from": { "const": "bearer" },
             "key": { "type": "string", "minLength": 1 }
           },
           "required": ["key"]

--- a/crates/coral-spec/src/template.rs
+++ b/crates/coral-spec/src/template.rs
@@ -33,16 +33,15 @@ impl ParsedTemplate {
                 )));
             };
             let token = raw_token.trim();
-            let (raw_key, default_value) = if is_expression_token(token) {
-                (token, None)
-            } else {
-                match token.split_once('|') {
-                    Some((key, default)) => (key.trim(), Some(default.to_string())),
-                    None => (token, None),
+            let (raw_key, default_value) = match split_default(token) {
+                Some((key, default)) if !is_expression_token(key) => {
+                    (key.trim(), Some(default.to_string()))
                 }
+                _ => (token, None),
             };
+            let is_expression = is_expression_token(raw_key);
             let (namespace, key) = match raw_key.split_once('.') {
-                _ if is_expression_token(raw_key) => {
+                _ if is_expression => {
                     (TemplateNamespace::Other(raw_key.to_string()), String::new())
                 }
                 Some((namespace, key)) => (TemplateNamespace::parse(namespace), key.to_string()),
@@ -170,7 +169,7 @@ impl TemplateToken {
     #[must_use]
     /// Returns whether this token uses expression syntax.
     pub fn is_expression(&self) -> bool {
-        is_expression_token(self.raw.as_str())
+        is_expression_token(self.raw_key.as_str())
     }
 
     /// Returns the input keys referenced by this token.
@@ -180,7 +179,7 @@ impl TemplateToken {
     /// syntax used by the renderer: fallbacks with `||` and `concat(...)`.
     pub fn input_keys(&self) -> Vec<&str> {
         if self.is_expression() {
-            return expression_keys(self.raw.as_str(), "input.");
+            return expression_keys(self.raw_key.as_str(), "input.");
         }
         if self.namespace == TemplateNamespace::Input {
             return vec![self.key.as_str()];
@@ -191,7 +190,7 @@ impl TemplateToken {
     /// Returns the filter keys referenced by this token.
     pub fn filter_keys(&self) -> Vec<&str> {
         if self.is_expression() {
-            expression_keys(self.raw.as_str(), "filter.")
+            expression_keys(self.raw_key.as_str(), "filter.")
         } else if self.namespace == TemplateNamespace::Filter {
             vec![self.key.as_str()]
         } else {
@@ -202,8 +201,19 @@ impl TemplateToken {
     /// Returns the state keys referenced by this token.
     pub fn state_keys(&self) -> Vec<&str> {
         if self.is_expression() {
-            expression_keys(self.raw.as_str(), "state.")
+            expression_keys(self.raw_key.as_str(), "state.")
         } else if self.namespace == TemplateNamespace::State {
+            vec![self.key.as_str()]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Returns the source function argument keys referenced by this token.
+    pub fn arg_keys(&self) -> Vec<&str> {
+        if self.is_expression() {
+            expression_keys(self.raw_key.as_str(), "arg.")
+        } else if self.namespace == TemplateNamespace::Arg {
             vec![self.key.as_str()]
         } else {
             Vec::new()
@@ -245,7 +255,81 @@ impl TemplateNamespace {
 
 fn is_expression_token(raw: &str) -> bool {
     let trimmed = raw.trim();
-    trimmed.contains("||") || trimmed.starts_with("concat(")
+    has_top_level_delimiter(trimmed, "||") || trimmed.starts_with("concat(")
+}
+
+fn split_default(raw: &str) -> Option<(&str, &str)> {
+    let mut depth = 0usize;
+    let mut in_quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (index, ch) in raw.char_indices() {
+        if let Some(quote) = in_quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => in_quote = Some(ch),
+            '(' => depth = depth.saturating_add(1),
+            ')' => depth = depth.saturating_sub(1),
+            '|' if depth == 0 => {
+                let prev_is_pipe = raw
+                    .get(..index)
+                    .and_then(|prefix| prefix.chars().next_back())
+                    == Some('|');
+                let next_is_pipe = raw
+                    .get(index + ch.len_utf8()..)
+                    .and_then(|suffix| suffix.chars().next())
+                    == Some('|');
+                if !prev_is_pipe && !next_is_pipe {
+                    return raw.get(..index).zip(raw.get(index + ch.len_utf8()..));
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn has_top_level_delimiter(raw: &str, delimiter: &str) -> bool {
+    let mut depth = 0usize;
+    let mut in_quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (index, ch) in raw.char_indices() {
+        if let Some(quote) = in_quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => in_quote = Some(ch),
+            '(' => depth = depth.saturating_add(1),
+            ')' => depth = depth.saturating_sub(1),
+            _ if depth == 0
+                && raw
+                    .get(index..)
+                    .is_some_and(|rest| rest.starts_with(delimiter)) =>
+            {
+                return true;
+            }
+            _ => {}
+        }
+    }
+    false
 }
 
 fn expression_keys<'a>(raw: &'a str, prefix: &str) -> Vec<&'a str> {
@@ -274,7 +358,9 @@ fn expression_keys<'a>(raw: &'a str, prefix: &str) -> Vec<&'a str> {
             continue;
         }
         let rest = raw.get(cursor..).unwrap_or_default();
-        if let Some(after_prefix) = rest.strip_prefix(prefix) {
+        if reference_starts_at(raw, cursor, prefix)
+            && let Some(after_prefix) = rest.strip_prefix(prefix)
+        {
             let key_len = after_prefix
                 .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
                 .unwrap_or(after_prefix.len());
@@ -289,6 +375,18 @@ fn expression_keys<'a>(raw: &'a str, prefix: &str) -> Vec<&'a str> {
         cursor += 1;
     }
     out
+}
+
+fn reference_starts_at(raw: &str, cursor: usize, prefix: &str) -> bool {
+    if !raw
+        .get(cursor..)
+        .is_some_and(|rest| rest.starts_with(prefix))
+    {
+        return false;
+    }
+    raw.get(..cursor)
+        .and_then(|prefix| prefix.chars().next_back())
+        .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
 }
 
 #[cfg(test)]
@@ -373,5 +471,39 @@ mod tests {
         assert!(token.is_expression());
         assert_eq!(token.filter_keys(), vec!["team"]);
         assert_eq!(token.state_keys(), vec!["cursor"]);
+    }
+
+    #[test]
+    fn token_reports_expression_arg_keys() {
+        let template =
+            ParsedTemplate::parse(r#"{{arg.query || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
+                .expect("template");
+        let token = template.tokens().next().expect("token");
+        assert!(token.is_expression());
+        assert_eq!(token.arg_keys(), vec!["query"]);
+        assert_eq!(token.input_keys(), vec!["OAUTH_TOKEN"]);
+    }
+
+    #[test]
+    fn default_values_can_contain_fallback_operator() {
+        let template = ParsedTemplate::parse("{{input.API_KEY|foo||bar}}").expect("template");
+        let token = template.tokens().next().expect("token");
+
+        assert!(!token.is_expression());
+        assert_eq!(token.namespace(), &TemplateNamespace::Input);
+        assert_eq!(token.key(), "API_KEY");
+        assert_eq!(token.default_value(), Some("foo||bar"));
+        assert_eq!(token.input_keys(), vec!["API_KEY"]);
+    }
+
+    #[test]
+    fn expression_references_require_namespace_boundary() {
+        let template = ParsedTemplate::parse(r"{{filter.input.API_KEY || input.OAUTH_TOKEN}}")
+            .expect("template");
+        let token = template.tokens().next().expect("token");
+
+        assert!(token.is_expression());
+        assert_eq!(token.filter_keys(), vec!["input.API_KEY"]);
+        assert_eq!(token.input_keys(), vec!["OAUTH_TOKEN"]);
     }
 }

--- a/crates/coral-spec/src/template.rs
+++ b/crates/coral-spec/src/template.rs
@@ -33,11 +33,18 @@ impl ParsedTemplate {
                 )));
             };
             let token = raw_token.trim();
-            let (raw_key, default_value) = match token.split_once('|') {
-                Some((key, default)) => (key.trim(), Some(default.to_string())),
-                None => (token, None),
+            let (raw_key, default_value) = if is_expression_token(token) {
+                (token, None)
+            } else {
+                match token.split_once('|') {
+                    Some((key, default)) => (key.trim(), Some(default.to_string())),
+                    None => (token, None),
+                }
             };
             let (namespace, key) = match raw_key.split_once('.') {
+                _ if is_expression_token(raw_key) => {
+                    (TemplateNamespace::Other(raw_key.to_string()), String::new())
+                }
                 Some((namespace, key)) => (TemplateNamespace::parse(namespace), key.to_string()),
                 None => (TemplateNamespace::Other(raw_key.to_string()), String::new()),
             };
@@ -159,6 +166,49 @@ impl TemplateToken {
     pub fn default_value(&self) -> Option<&str> {
         self.default_value.as_deref()
     }
+
+    #[must_use]
+    /// Returns whether this token uses expression syntax.
+    pub fn is_expression(&self) -> bool {
+        is_expression_token(self.raw.as_str())
+    }
+
+    /// Returns the input keys referenced by this token.
+    ///
+    /// For simple tokens this is either the single `input.KEY` reference or
+    /// empty. Expression tokens support the small auth-template expression
+    /// syntax used by the renderer: fallbacks with `||` and `concat(...)`.
+    pub fn input_keys(&self) -> Vec<&str> {
+        if self.is_expression() {
+            return expression_keys(self.raw.as_str(), "input.");
+        }
+        if self.namespace == TemplateNamespace::Input {
+            return vec![self.key.as_str()];
+        }
+        Vec::new()
+    }
+
+    /// Returns the filter keys referenced by this token.
+    pub fn filter_keys(&self) -> Vec<&str> {
+        if self.is_expression() {
+            expression_keys(self.raw.as_str(), "filter.")
+        } else if self.namespace == TemplateNamespace::Filter {
+            vec![self.key.as_str()]
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Returns the state keys referenced by this token.
+    pub fn state_keys(&self) -> Vec<&str> {
+        if self.is_expression() {
+            expression_keys(self.raw.as_str(), "state.")
+        } else if self.namespace == TemplateNamespace::State {
+            vec![self.key.as_str()]
+        } else {
+            Vec::new()
+        }
+    }
 }
 
 /// The namespace component of one template token.
@@ -191,6 +241,54 @@ impl TemplateNamespace {
             other => Self::Other(other.to_string()),
         }
     }
+}
+
+fn is_expression_token(raw: &str) -> bool {
+    let trimmed = raw.trim();
+    trimmed.contains("||") || trimmed.starts_with("concat(")
+}
+
+fn expression_keys<'a>(raw: &'a str, prefix: &str) -> Vec<&'a str> {
+    let mut out = Vec::new();
+    let mut cursor = 0;
+    let bytes = raw.as_bytes();
+    let mut in_quote: Option<u8> = None;
+    while cursor < bytes.len() {
+        let Some(&byte) = bytes.get(cursor) else {
+            break;
+        };
+        if let Some(quote) = in_quote {
+            if byte == b'\\' {
+                cursor = cursor.saturating_add(2);
+                continue;
+            }
+            if byte == quote {
+                in_quote = None;
+            }
+            cursor += 1;
+            continue;
+        }
+        if byte == b'\'' || byte == b'"' {
+            in_quote = Some(byte);
+            cursor += 1;
+            continue;
+        }
+        let rest = raw.get(cursor..).unwrap_or_default();
+        if let Some(after_prefix) = rest.strip_prefix(prefix) {
+            let key_len = after_prefix
+                .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
+                .unwrap_or(after_prefix.len());
+            if key_len > 0
+                && let Some(key) = after_prefix.get(..key_len)
+            {
+                out.push(key);
+            }
+            cursor += prefix.len() + key_len;
+            continue;
+        }
+        cursor += 1;
+    }
+    out
 }
 
 #[cfg(test)]
@@ -255,5 +353,25 @@ mod tests {
     fn rejects_unclosed_tokens() {
         let error = ParsedTemplate::parse("{{input.API_TOKEN").expect_err("unclosed token");
         assert!(error.to_string().contains("unclosed template token"));
+    }
+
+    #[test]
+    fn token_reports_expression_input_keys() {
+        let template =
+            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
+                .expect("template");
+        let token = template.tokens().next().expect("token");
+        assert!(token.is_expression());
+        assert_eq!(token.input_keys(), vec!["API_KEY", "OAUTH_TOKEN"]);
+    }
+
+    #[test]
+    fn token_reports_expression_filter_and_state_keys() {
+        let template = ParsedTemplate::parse(r#"{{concat(filter.team, "-", state.cursor)}}"#)
+            .expect("template");
+        let token = template.tokens().next().expect("token");
+        assert!(token.is_expression());
+        assert_eq!(token.filter_keys(), vec!["team"]);
+        assert_eq!(token.state_keys(), vec!["cursor"]);
     }
 }

--- a/crates/coral-spec/src/template.rs
+++ b/crates/coral-spec/src/template.rs
@@ -33,17 +33,11 @@ impl ParsedTemplate {
                 )));
             };
             let token = raw_token.trim();
-            let (raw_key, default_value) = match split_default(token) {
-                Some((key, default)) if !is_expression_token(key) => {
+            let (raw_key, default_value) = split_default(token)
+                .map_or((token, None), |(key, default)| {
                     (key.trim(), Some(default.to_string()))
-                }
-                _ => (token, None),
-            };
-            let is_expression = is_expression_token(raw_key);
+                });
             let (namespace, key) = match raw_key.split_once('.') {
-                _ if is_expression => {
-                    (TemplateNamespace::Other(raw_key.to_string()), String::new())
-                }
                 Some((namespace, key)) => (TemplateNamespace::parse(namespace), key.to_string()),
                 None => (TemplateNamespace::Other(raw_key.to_string()), String::new()),
             };
@@ -166,21 +160,8 @@ impl TemplateToken {
         self.default_value.as_deref()
     }
 
-    #[must_use]
-    /// Returns whether this token uses expression syntax.
-    pub fn is_expression(&self) -> bool {
-        is_expression_token(self.raw_key.as_str())
-    }
-
     /// Returns the input keys referenced by this token.
-    ///
-    /// For simple tokens this is either the single `input.KEY` reference or
-    /// empty. Expression tokens support the small auth-template expression
-    /// syntax used by the renderer: fallbacks with `||` and `concat(...)`.
     pub fn input_keys(&self) -> Vec<&str> {
-        if self.is_expression() {
-            return expression_keys(self.raw_key.as_str(), "input.");
-        }
         if self.namespace == TemplateNamespace::Input {
             return vec![self.key.as_str()];
         }
@@ -189,9 +170,7 @@ impl TemplateToken {
 
     /// Returns the filter keys referenced by this token.
     pub fn filter_keys(&self) -> Vec<&str> {
-        if self.is_expression() {
-            expression_keys(self.raw_key.as_str(), "filter.")
-        } else if self.namespace == TemplateNamespace::Filter {
+        if self.namespace == TemplateNamespace::Filter {
             vec![self.key.as_str()]
         } else {
             Vec::new()
@@ -200,20 +179,7 @@ impl TemplateToken {
 
     /// Returns the state keys referenced by this token.
     pub fn state_keys(&self) -> Vec<&str> {
-        if self.is_expression() {
-            expression_keys(self.raw_key.as_str(), "state.")
-        } else if self.namespace == TemplateNamespace::State {
-            vec![self.key.as_str()]
-        } else {
-            Vec::new()
-        }
-    }
-
-    /// Returns the source function argument keys referenced by this token.
-    pub fn arg_keys(&self) -> Vec<&str> {
-        if self.is_expression() {
-            expression_keys(self.raw_key.as_str(), "arg.")
-        } else if self.namespace == TemplateNamespace::Arg {
+        if self.namespace == TemplateNamespace::State {
             vec![self.key.as_str()]
         } else {
             Vec::new()
@@ -253,140 +219,24 @@ impl TemplateNamespace {
     }
 }
 
-fn is_expression_token(raw: &str) -> bool {
-    let trimmed = raw.trim();
-    has_top_level_delimiter(trimmed, "||") || trimmed.starts_with("concat(")
-}
-
 fn split_default(raw: &str) -> Option<(&str, &str)> {
-    let mut depth = 0usize;
-    let mut in_quote: Option<char> = None;
-    let mut escaped = false;
-
     for (index, ch) in raw.char_indices() {
-        if let Some(quote) = in_quote {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == quote {
-                in_quote = None;
-            }
+        if ch != '|' {
             continue;
         }
-
-        match ch {
-            '"' | '\'' => in_quote = Some(ch),
-            '(' => depth = depth.saturating_add(1),
-            ')' => depth = depth.saturating_sub(1),
-            '|' if depth == 0 => {
-                let prev_is_pipe = raw
-                    .get(..index)
-                    .and_then(|prefix| prefix.chars().next_back())
-                    == Some('|');
-                let next_is_pipe = raw
-                    .get(index + ch.len_utf8()..)
-                    .and_then(|suffix| suffix.chars().next())
-                    == Some('|');
-                if !prev_is_pipe && !next_is_pipe {
-                    return raw.get(..index).zip(raw.get(index + ch.len_utf8()..));
-                }
-            }
-            _ => {}
+        let prev_is_pipe = raw
+            .get(..index)
+            .and_then(|prefix| prefix.chars().next_back())
+            == Some('|');
+        let next_is_pipe = raw
+            .get(index + ch.len_utf8()..)
+            .and_then(|suffix| suffix.chars().next())
+            == Some('|');
+        if !prev_is_pipe && !next_is_pipe {
+            return raw.get(..index).zip(raw.get(index + ch.len_utf8()..));
         }
     }
     None
-}
-
-fn has_top_level_delimiter(raw: &str, delimiter: &str) -> bool {
-    let mut depth = 0usize;
-    let mut in_quote: Option<char> = None;
-    let mut escaped = false;
-
-    for (index, ch) in raw.char_indices() {
-        if let Some(quote) = in_quote {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == quote {
-                in_quote = None;
-            }
-            continue;
-        }
-
-        match ch {
-            '"' | '\'' => in_quote = Some(ch),
-            '(' => depth = depth.saturating_add(1),
-            ')' => depth = depth.saturating_sub(1),
-            _ if depth == 0
-                && raw
-                    .get(index..)
-                    .is_some_and(|rest| rest.starts_with(delimiter)) =>
-            {
-                return true;
-            }
-            _ => {}
-        }
-    }
-    false
-}
-
-fn expression_keys<'a>(raw: &'a str, prefix: &str) -> Vec<&'a str> {
-    let mut out = Vec::new();
-    let mut cursor = 0;
-    let bytes = raw.as_bytes();
-    let mut in_quote: Option<u8> = None;
-    while cursor < bytes.len() {
-        let Some(&byte) = bytes.get(cursor) else {
-            break;
-        };
-        if let Some(quote) = in_quote {
-            if byte == b'\\' {
-                cursor = cursor.saturating_add(2);
-                continue;
-            }
-            if byte == quote {
-                in_quote = None;
-            }
-            cursor += 1;
-            continue;
-        }
-        if byte == b'\'' || byte == b'"' {
-            in_quote = Some(byte);
-            cursor += 1;
-            continue;
-        }
-        let rest = raw.get(cursor..).unwrap_or_default();
-        if reference_starts_at(raw, cursor, prefix)
-            && let Some(after_prefix) = rest.strip_prefix(prefix)
-        {
-            let key_len = after_prefix
-                .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
-                .unwrap_or(after_prefix.len());
-            if key_len > 0
-                && let Some(key) = after_prefix.get(..key_len)
-            {
-                out.push(key);
-            }
-            cursor += prefix.len() + key_len;
-            continue;
-        }
-        cursor += 1;
-    }
-    out
-}
-
-fn reference_starts_at(raw: &str, cursor: usize, prefix: &str) -> bool {
-    if !raw
-        .get(cursor..)
-        .is_some_and(|rest| rest.starts_with(prefix))
-    {
-        return false;
-    }
-    raw.get(..cursor)
-        .and_then(|prefix| prefix.chars().next_back())
-        .is_none_or(|ch| !(ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')))
 }
 
 #[cfg(test)]
@@ -454,42 +304,10 @@ mod tests {
     }
 
     #[test]
-    fn token_reports_expression_input_keys() {
-        let template =
-            ParsedTemplate::parse(r#"{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
-                .expect("template");
-        let token = template.tokens().next().expect("token");
-        assert!(token.is_expression());
-        assert_eq!(token.input_keys(), vec!["API_KEY", "OAUTH_TOKEN"]);
-    }
-
-    #[test]
-    fn token_reports_expression_filter_and_state_keys() {
-        let template = ParsedTemplate::parse(r#"{{concat(filter.team, "-", state.cursor)}}"#)
-            .expect("template");
-        let token = template.tokens().next().expect("token");
-        assert!(token.is_expression());
-        assert_eq!(token.filter_keys(), vec!["team"]);
-        assert_eq!(token.state_keys(), vec!["cursor"]);
-    }
-
-    #[test]
-    fn token_reports_expression_arg_keys() {
-        let template =
-            ParsedTemplate::parse(r#"{{arg.query || concat("Bearer ", input.OAUTH_TOKEN)}}"#)
-                .expect("template");
-        let token = template.tokens().next().expect("token");
-        assert!(token.is_expression());
-        assert_eq!(token.arg_keys(), vec!["query"]);
-        assert_eq!(token.input_keys(), vec!["OAUTH_TOKEN"]);
-    }
-
-    #[test]
     fn default_values_can_contain_fallback_operator() {
         let template = ParsedTemplate::parse("{{input.API_KEY|foo||bar}}").expect("template");
         let token = template.tokens().next().expect("token");
 
-        assert!(!token.is_expression());
         assert_eq!(token.namespace(), &TemplateNamespace::Input);
         assert_eq!(token.key(), "API_KEY");
         assert_eq!(token.default_value(), Some("foo||bar"));
@@ -497,13 +315,13 @@ mod tests {
     }
 
     #[test]
-    fn expression_references_require_namespace_boundary() {
-        let template = ParsedTemplate::parse(r"{{filter.input.API_KEY || input.OAUTH_TOKEN}}")
-            .expect("template");
+    fn fallback_operator_is_not_a_template_default_separator() {
+        let template =
+            ParsedTemplate::parse("{{input.API_KEY || input.OAUTH_TOKEN}}").expect("template");
         let token = template.tokens().next().expect("token");
 
-        assert!(token.is_expression());
-        assert_eq!(token.filter_keys(), vec!["input.API_KEY"]);
-        assert_eq!(token.input_keys(), vec!["OAUTH_TOKEN"]);
+        assert_eq!(token.namespace(), &TemplateNamespace::Input);
+        assert_eq!(token.key(), "API_KEY || input.OAUTH_TOKEN");
+        assert_eq!(token.default_value(), None);
     }
 }

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -684,6 +684,22 @@ fn validate_arg_template(
     context: &str,
 ) -> Result<()> {
     for token in template.tokens() {
+        if token.is_expression() {
+            for key in token.arg_keys() {
+                if !request_arg_names.contains(key) {
+                    return Err(ManifestError::validation(format!(
+                        "{context} references unknown request arg '{key}' in template '{}'",
+                        template.raw()
+                    )));
+                }
+            }
+            if let Some(key) = token.filter_keys().into_iter().next() {
+                return Err(ManifestError::validation(format!(
+                    "{context} uses unsupported function request template token 'filter.{key}'"
+                )));
+            }
+            continue;
+        }
         match token.namespace() {
             TemplateNamespace::Arg => {
                 if !request_arg_names.contains(token.key()) {
@@ -838,6 +854,11 @@ pub(crate) fn validate_template(
                         template.raw()
                     )));
                 }
+            }
+            if let Some(key) = token.arg_keys().into_iter().next() {
+                return Err(ManifestError::validation(format!(
+                    "{context} uses function argument token 'arg.{key}' outside a function request"
+                )));
             }
             continue;
         }
@@ -1283,6 +1304,61 @@ mod tests {
     }
 
     #[test]
+    fn validate_http_table_rejects_function_arg_expression_tokens() {
+        let request = RequestSpec {
+            path: ParsedTemplate::parse(r"/search/{{arg.q || input.API_KEY}}").expect("template"),
+            ..RequestSpec::default()
+        };
+
+        let error = validate_http_table(
+            "demo",
+            "messages",
+            &test_filters(),
+            &[test_column()],
+            &request,
+            &[],
+            &PaginationSpec::default(),
+            None,
+            &[],
+        )
+        .expect_err("table request expression templates should reject function arguments");
+
+        assert!(
+            error
+                .to_string()
+                .contains("uses function argument token 'arg.q' outside a function request")
+        );
+    }
+
+    #[test]
+    fn validate_http_table_rejects_unknown_filter_expression_tokens() {
+        let request = RequestSpec {
+            path: ParsedTemplate::parse(r"/search/{{filter.missing || input.API_KEY}}")
+                .expect("template"),
+            ..RequestSpec::default()
+        };
+
+        let error = validate_http_table(
+            "demo",
+            "messages",
+            &test_filters(),
+            &[test_column()],
+            &request,
+            &[],
+            &PaginationSpec::default(),
+            None,
+            &[],
+        )
+        .expect_err("table request expression templates should reject unknown filters");
+
+        assert!(
+            error
+                .to_string()
+                .contains("references unknown filter 'missing'")
+        );
+    }
+
+    #[test]
     fn validate_http_function_rejects_table_filter_value_sources() {
         let cases = [
             ValueSourceSpec::Filter {
@@ -1346,6 +1422,32 @@ mod tests {
                 "unexpected error: {error}"
             );
         }
+    }
+
+    #[test]
+    fn validate_http_function_accepts_arg_expression_tokens() {
+        let function = function_with_request_value(ValueSourceSpec::Template {
+            template: ParsedTemplate::parse(r"{{arg.q || input.API_KEY}}").expect("template"),
+        });
+
+        validate_http_function("demo", &function)
+            .expect("function request expression should accept declared args");
+    }
+
+    #[test]
+    fn validate_http_function_rejects_unknown_arg_expression_tokens() {
+        let function = function_with_request_value(ValueSourceSpec::Template {
+            template: ParsedTemplate::parse(r"{{arg.missing || input.API_KEY}}").expect("template"),
+        });
+
+        let error = validate_http_function("demo", &function)
+            .expect_err("function request expression should reject unknown args");
+
+        assert!(
+            error
+                .to_string()
+                .contains("references unknown request arg 'missing'")
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -536,6 +536,20 @@ fn validate_value_source(
         ValueSourceSpec::Template { template } => {
             validate_template(template, known_filters, context)?;
         }
+        ValueSourceSpec::OneOf { values } => {
+            if values.is_empty() {
+                return Err(ManifestError::validation(format!(
+                    "{context} one_of values must not be empty"
+                )));
+            }
+            for (index, value) in values.iter().enumerate() {
+                validate_value_source(
+                    value,
+                    known_filters,
+                    &format!("{context} one_of values[{index}]"),
+                )?;
+            }
+        }
         ValueSourceSpec::Arg { key, .. }
         | ValueSourceSpec::ArgInt { key, .. }
         | ValueSourceSpec::ArgBool { key, .. }
@@ -673,6 +687,20 @@ fn validate_arg_value_source(
         ValueSourceSpec::Template { template } => {
             validate_arg_template(template, request_arg_names, context)?;
         }
+        ValueSourceSpec::OneOf { values } => {
+            if values.is_empty() {
+                return Err(ManifestError::validation(format!(
+                    "{context} one_of values must not be empty"
+                )));
+            }
+            for (index, value) in values.iter().enumerate() {
+                validate_arg_value_source(
+                    value,
+                    request_arg_names,
+                    &format!("{context} one_of values[{index}]"),
+                )?;
+            }
+        }
         _ => {}
     }
     Ok(())
@@ -684,22 +712,6 @@ fn validate_arg_template(
     context: &str,
 ) -> Result<()> {
     for token in template.tokens() {
-        if token.is_expression() {
-            for key in token.arg_keys() {
-                if !request_arg_names.contains(key) {
-                    return Err(ManifestError::validation(format!(
-                        "{context} references unknown request arg '{key}' in template '{}'",
-                        template.raw()
-                    )));
-                }
-            }
-            if let Some(key) = token.filter_keys().into_iter().next() {
-                return Err(ManifestError::validation(format!(
-                    "{context} uses unsupported function request template token 'filter.{key}'"
-                )));
-            }
-            continue;
-        }
         match token.namespace() {
             TemplateNamespace::Arg => {
                 if !request_arg_names.contains(token.key()) {
@@ -846,22 +858,6 @@ pub(crate) fn validate_template(
     context: &str,
 ) -> Result<()> {
     for token in template.tokens() {
-        if token.is_expression() {
-            for key in token.filter_keys() {
-                if !known_filters.contains(key) {
-                    return Err(ManifestError::validation(format!(
-                        "{context} references unknown filter '{key}' in template '{}'",
-                        template.raw()
-                    )));
-                }
-            }
-            if let Some(key) = token.arg_keys().into_iter().next() {
-                return Err(ManifestError::validation(format!(
-                    "{context} uses function argument token 'arg.{key}' outside a function request"
-                )));
-            }
-            continue;
-        }
         match token.namespace() {
             TemplateNamespace::Filter => {
                 if !known_filters.contains(token.key()) {
@@ -1280,7 +1276,7 @@ mod tests {
     fn validate_http_table_rejects_function_arg_template_tokens() {
         let request = RequestSpec {
             path: ParsedTemplate::parse("/search/{{arg.q}}").expect("template"),
-            ..RequestSpec::default()
+            ..base_request()
         };
 
         let error = validate_http_table(
@@ -1304,10 +1300,23 @@ mod tests {
     }
 
     #[test]
-    fn validate_http_table_rejects_function_arg_expression_tokens() {
+    fn validate_http_table_rejects_function_arg_one_of_value_sources() {
         let request = RequestSpec {
-            path: ParsedTemplate::parse(r"/search/{{arg.q || input.API_KEY}}").expect("template"),
-            ..RequestSpec::default()
+            query: vec![QueryParamSpec {
+                name: "value".to_string(),
+                value: ValueSourceSpec::OneOf {
+                    values: vec![
+                        ValueSourceSpec::Input {
+                            key: "API_KEY".to_string(),
+                        },
+                        ValueSourceSpec::Arg {
+                            key: "q".to_string(),
+                            default: None,
+                        },
+                    ],
+                },
+            }],
+            ..base_request()
         };
 
         let error = validate_http_table(
@@ -1321,21 +1330,33 @@ mod tests {
             None,
             &[],
         )
-        .expect_err("table request expression templates should reject function arguments");
+        .expect_err("table request one_of values should reject function arguments");
 
         assert!(
             error
                 .to_string()
-                .contains("uses function argument token 'arg.q' outside a function request")
+                .contains("uses function argument 'q' outside a function request")
         );
     }
 
     #[test]
-    fn validate_http_table_rejects_unknown_filter_expression_tokens() {
+    fn validate_http_table_rejects_unknown_filter_one_of_value_sources() {
         let request = RequestSpec {
-            path: ParsedTemplate::parse(r"/search/{{filter.missing || input.API_KEY}}")
-                .expect("template"),
-            ..RequestSpec::default()
+            query: vec![QueryParamSpec {
+                name: "value".to_string(),
+                value: ValueSourceSpec::OneOf {
+                    values: vec![
+                        ValueSourceSpec::Input {
+                            key: "API_KEY".to_string(),
+                        },
+                        ValueSourceSpec::Filter {
+                            key: "missing".to_string(),
+                            default: None,
+                        },
+                    ],
+                },
+            }],
+            ..base_request()
         };
 
         let error = validate_http_table(
@@ -1349,7 +1370,7 @@ mod tests {
             None,
             &[],
         )
-        .expect_err("table request expression templates should reject unknown filters");
+        .expect_err("table request one_of values should reject unknown filters");
 
         assert!(
             error
@@ -1425,23 +1446,39 @@ mod tests {
     }
 
     #[test]
-    fn validate_http_function_accepts_arg_expression_tokens() {
-        let function = function_with_request_value(ValueSourceSpec::Template {
-            template: ParsedTemplate::parse(r"{{arg.q || input.API_KEY}}").expect("template"),
+    fn validate_http_function_accepts_arg_one_of_value_sources() {
+        let function = function_with_request_value(ValueSourceSpec::OneOf {
+            values: vec![
+                ValueSourceSpec::Arg {
+                    key: "q".to_string(),
+                    default: None,
+                },
+                ValueSourceSpec::Input {
+                    key: "API_KEY".to_string(),
+                },
+            ],
         });
 
         validate_http_function("demo", &function)
-            .expect("function request expression should accept declared args");
+            .expect("function request one_of should accept declared args");
     }
 
     #[test]
-    fn validate_http_function_rejects_unknown_arg_expression_tokens() {
-        let function = function_with_request_value(ValueSourceSpec::Template {
-            template: ParsedTemplate::parse(r"{{arg.missing || input.API_KEY}}").expect("template"),
+    fn validate_http_function_rejects_unknown_arg_one_of_value_sources() {
+        let function = function_with_request_value(ValueSourceSpec::OneOf {
+            values: vec![
+                ValueSourceSpec::Arg {
+                    key: "missing".to_string(),
+                    default: None,
+                },
+                ValueSourceSpec::Input {
+                    key: "API_KEY".to_string(),
+                },
+            ],
         });
 
         let error = validate_http_function("demo", &function)
-            .expect_err("function request expression should reject unknown args");
+            .expect_err("function request one_of should reject unknown args");
 
         assert!(
             error

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -830,6 +830,17 @@ pub(crate) fn validate_template(
     context: &str,
 ) -> Result<()> {
     for token in template.tokens() {
+        if token.is_expression() {
+            for key in token.filter_keys() {
+                if !known_filters.contains(key) {
+                    return Err(ManifestError::validation(format!(
+                        "{context} references unknown filter '{key}' in template '{}'",
+                        template.raw()
+                    )));
+                }
+            }
+            continue;
+        }
         match token.namespace() {
             TemplateNamespace::Filter => {
                 if !known_filters.contains(token.key()) {

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -188,8 +188,8 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
+      from: bearer
+      key: API_TOKEN
 tables:
   - name: messages
     description: Messages from the API
@@ -251,9 +251,13 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: Bearer {{input.DEMO_API_TOKEN}}
+      from: bearer
+      key: DEMO_API_TOKEN
 ```
+
+When an API supports either a complete pasted API-key header or an OAuth access
+token, use `from: one_of` and put the pasted header first, then a `from: bearer`
+fallback for the raw OAuth token.
 
 ### OAuth client and redirect options
 

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -256,8 +256,19 @@ auth:
 ```
 
 When an API supports either a complete pasted API-key header or an OAuth access
-token, use `from: one_of` and put the pasted header first, then a `from: bearer`
+token, declare both credential inputs as optional secrets, then use
+`from: one_of` and put the pasted header first, followed by a `from: bearer`
 fallback for the raw OAuth token.
+
+```yaml
+inputs:
+  DEMO_API_KEY:
+    kind: secret
+    required: false
+  DEMO_OAUTH_ACCESS_TOKEN:
+    kind: secret
+    required: false
+```
 
 ### OAuth client and redirect options
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -145,6 +145,11 @@ Run the guided source setup flow.
 coral onboard
 ```
 
+When a secret input declares credential methods, onboarding asks which method
+to use before consuming a matching environment variable. Choosing a
+`source_config` method still uses the normal environment-variable or prompt
+path.
+
 ## `coral features`
 
 Coral ships with experimental runtime features that can be enabled on demand.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -571,6 +571,14 @@ Use `from: one_of` when a source supports multiple credential shapes. Coral
 uses the first value that is present and non-empty:
 
 ```yaml
+inputs:
+  API_KEY:
+    kind: secret
+    required: false
+  OAUTH_ACCESS_TOKEN:
+    kind: secret
+    required: false
+
 auth:
   type: HeaderAuth
   headers:

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -562,6 +562,9 @@ auth:
 ```
 
 `headers` entries share the same shape as request/table headers, but only `from: literal`, `from: template`, and `from: input` are meaningful here — filter and state tokens have no value at auth time.
+Auth and request templates can use `||` to choose the first available value
+and `concat(...)` to join string literals and template values, for example
+`{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}`.
 
 #### `BasicAuth`
 
@@ -967,6 +970,10 @@ callback, Coral exchanges the code, stores the access token as the source
 secret, and stores any refresh token as internal credential metadata.
 
 ### Inspecting configured inputs
+
+OAuth stores the token response `access_token` as the source secret value. If a
+runtime auth template needs a bearer header value, compose it in the template,
+for example `{{concat("Bearer ", input.OAUTH_TOKEN)}}`.
 
 At runtime, installed source inputs are also surfaced through `coral.inputs`.
 This is useful when agents or scripts need to inspect non-secret source config

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -413,8 +413,8 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
+      from: bearer
+      key: API_TOKEN
 tables:
   - name: messages
     description: Messages from the demo API
@@ -557,17 +557,31 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
+      from: bearer
+      key: API_TOKEN
 ```
 
-`headers` entries share the same shape as request/table headers, but only `from: literal`, `from: template`, and `from: input` are meaningful here — filter and state tokens have no value at auth time.
-Auth and request templates can use `||` to choose the first available value
-and `concat(...)` to join string literals and template values, for example
-`{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}`.
-This is useful when a source supports both pasted API-key headers and OAuth:
-OAuth stores the raw `access_token`, so templates should compose any required
-`Bearer ` prefix.
+`headers` entries share the same value-source shape as request/table headers,
+but auth is source-scoped: `from: literal`, `from: template`, `from: input`,
+`from: bearer`, and `from: one_of` are meaningful here. Filter, argument, and
+state values have no value at auth time. Use `from: bearer` when Coral stores a
+raw token but the API expects an `Authorization: Bearer <token>` header.
+
+Use `from: one_of` when a source supports multiple credential shapes. Coral
+uses the first value that is present and non-empty:
+
+```yaml
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: one_of
+      values:
+        - from: input
+          key: API_KEY
+        - from: bearer
+          key: OAUTH_ACCESS_TOKEN
+```
 
 #### `BasicAuth`
 
@@ -696,6 +710,8 @@ Request query params, body fields, and headers support these `from` values:
 | `arg_split` | Split a source function argument string and serialize one part as a string |
 | `arg_split_int` | Split a source function argument string and serialize one part as a JSON integer |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
+| `bearer` | Read a manifest-declared source input by key and serialize it as `Bearer <value>` |
+| `one_of` | Resolve nested value sources in order and use the first present, non-empty value |
 | `state` | Read pagination/runtime state |
 | `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |
 
@@ -863,8 +879,8 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: Bearer {{input.API_TOKEN}}
+      from: bearer
+      key: API_TOKEN
 ```
 
 ### Input rules
@@ -873,7 +889,7 @@ auth:
 - `kind: secret` values are stored with source secrets
 - `default` is allowed only for variables
 - `hint` is optional and shown alongside the input during `coral source add --interactive`
-- references elsewhere in the manifest use `{{input.KEY}}` templates or `from: input`
+- references elsewhere in the manifest use `{{input.KEY}}` templates, `from: input`, or wrappers such as `from: bearer`
 - credential-like inputs such as API keys, tokens, passwords, secrets, private keys, and bearer or authorization values must be `kind: secret`; Coral rejects those names as variables because variable values are visible through source APIs and `coral.inputs`
 - input keys must not start with Coral's reserved internal prefix `__coral`
 - declaring an input does not add it to any request by itself; reference it from `auth`, headers, query params, body fields, or other runtime request configuration where it should be used
@@ -975,8 +991,9 @@ secret, and stores any refresh token as internal credential metadata.
 ### Inspecting configured inputs
 
 OAuth stores the token response `access_token` as the source secret value. If a
-runtime auth template needs a bearer header value, compose it in the template,
-for example `{{concat("Bearer ", input.OAUTH_TOKEN)}}`.
+runtime auth header needs a bearer value, use `from: bearer` with that input
+key. If the source also accepts a full pasted API-key header, wrap the API-key
+input and OAuth bearer input in `from: one_of`.
 
 At runtime, installed source inputs are also surfaced through `coral.inputs`.
 This is useful when agents or scripts need to inspect non-secret source config

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -565,6 +565,9 @@ auth:
 Auth and request templates can use `||` to choose the first available value
 and `concat(...)` to join string literals and template values, for example
 `{{input.API_KEY || concat("Bearer ", input.OAUTH_TOKEN)}}`.
+This is useful when a source supports both pasted API-key headers and OAuth:
+OAuth stores the raw `access_token`, so templates should compose any required
+`Bearer ` prefix.
 
 #### `BasicAuth`
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -7,7 +7,10 @@ Coral is extensible through source specs. These are YAML files that describe how
 
 <Tip>
   For a guided walkthrough, see [Write a custom
-  source](/guides/write-a-custom-source).
+  source](/guides/write-a-custom-source). If you are adding OAuth credential
+  setup, start with [OAuth credential
+  setup](/guides/write-a-custom-source#oauth-credential-setup), then use this
+  page for field-level details.
 </Tip>
 
 ## Top-level fields

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -721,7 +721,7 @@ Request query params, body fields, and headers support these `from` values:
 | `arg_split` | Split a source function argument string and serialize one part as a string |
 | `arg_split_int` | Split a source function argument string and serialize one part as a JSON integer |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
-| `bearer` | Read a manifest-declared source input by key and serialize it as `Bearer <value>` |
+| `bearer` | Read a manifest-declared secret input by key and serialize it as `Bearer <value>` |
 | `one_of` | Resolve nested value sources in order and use the first present, non-empty value |
 | `state` | Read pagination/runtime state |
 | `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -190,7 +190,7 @@ For HTTP-backed sources:
 
 Read `references/http-source-checklist.md` when you need table-shape and pagination guidance.
 
-If your HTTP source uses an Authorization header with a prefix (e.g. `Authorization: Bearer <token>`), you can use a secret input for the token and define the header as a template:
+If your HTTP source uses an Authorization header with a prefix (e.g. `Authorization: Bearer <token>`), use a secret input for the raw token and define the header with `from: bearer`:
 
 ```yaml
 inputs:
@@ -201,8 +201,8 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: Bearer {{input.FOOBAR_API_TOKEN}}
+      from: bearer
+      key: FOOBAR_API_TOKEN
 ```
 
 For an OAuth-backed HTTP source, add the retrieval method to that same secret input:
@@ -240,8 +240,23 @@ auth:
   type: HeaderAuth
   headers:
     - name: Authorization
-      from: template
-      template: Bearer {{input.FOOBAR_API_TOKEN}}
+      from: bearer
+      key: FOOBAR_API_TOKEN
+```
+
+When a provider accepts either a full pasted API-key header or an OAuth access token, use `from: one_of` and put the complete header value first, then a `from: bearer` OAuth fallback:
+
+```yaml
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: one_of
+      values:
+        - from: input
+          key: FOOBAR_API_KEY
+        - from: bearer
+          key: FOOBAR_OAUTH_ACCESS_TOKEN
 ```
 
 ## Local Data Sources

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -84,8 +84,8 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
 - Use the source manifest schema as both inspiration for authoring and validation of structure: https://github.com/withcoral/coral/blob/main/crates/coral-spec/src/schema/source_manifest.schema.json
 - Use source variables for non-secret configuration.
 - Use source secrets for credentials.
-- For OAuth-backed services, model browser-based setup with `inputs.<TOKEN>.credential.methods[]` using `type: oauth`; keep the runtime `auth` or request header pointing at the same secret input.
-- OAuth credential methods currently mean authorization-code flow with a loopback `http://127.0.0.1` or `http://localhost` redirect URI. Set `flow.pkce` explicitly to `required` or `disabled`, choose `redirect_uri_port_mode: random` for provider apps that allow variable localhost ports, and choose `fixed` only when users can register the exact non-zero redirect URI.
+- For OAuth-backed services, model setup with `inputs.<TOKEN>.credential.methods[]` using `type: oauth`; keep the runtime `auth` or request header pointing at the same secret input.
+- OAuth credential methods can use device-code flow or authorization-code flow. For device-code flow, declare `flow.type: device_code`, `endpoints.device_authorization_url`, `endpoints.token_url`, and a public client ID. For authorization-code flow, set `flow.type: authorization_code`, set `flow.pkce` explicitly to `required` or `disabled`, use a loopback `http://127.0.0.1` or `http://localhost` redirect URI, choose `redirect_uri_port_mode: random` for provider apps that allow variable localhost ports, and choose `fixed` only when users can register the exact non-zero redirect URI.
 - If a provider also supports manually pasted tokens, include a `type: source_config` fallback after the OAuth method. When the provider's token endpoint requires client authentication with a client secret, prompt for both OAuth client values: declare `client.id.input`, `client.secret.input`, and `client.secret.transport` (`basic_auth` or `request_body`).
 - Do not add top-level source inputs solely for OAuth client credentials; `client.id.input` and `client.secret.input` are collected during OAuth setup.
 - Do not assume automatic token refresh. If the provider returns short-lived access tokens, call that out as a limitation unless the source has another supported long-lived credential path.
@@ -244,9 +244,16 @@ auth:
       key: FOOBAR_API_TOKEN
 ```
 
-When a provider accepts either a full pasted API-key header or an OAuth access token, use `from: one_of` and put the complete header value first, then a `from: bearer` OAuth fallback:
+When a provider accepts either a full pasted API-key header or an OAuth access token, declare both credential inputs as optional secrets, then use `from: one_of` and put the complete header value first, followed by a `from: bearer` OAuth fallback:
 
 ```yaml
+inputs:
+  FOOBAR_API_KEY:
+    kind: secret
+    required: false
+  FOOBAR_OAUTH_ACCESS_TOKEN:
+    kind: secret
+    required: false
 auth:
   type: HeaderAuth
   headers:

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -28,6 +28,7 @@ Use:
 ## Authentication Setup
 
 - Keep credential collection separate from runtime auth. `inputs` stores values; `auth`, request headers, query params, or body fields decide where values are sent.
+- Use `from: bearer` for raw access tokens that must be sent as `Authorization: Bearer <token>`. Use `from: one_of` when runtime auth should choose the first present credential, such as a pasted API-key header before an OAuth bearer token.
 - Use `type: source_config` when the user should provide a stored secret directly through an environment variable or prompt.
 - Use `type: oauth` when the provider should issue the source secret through an OAuth authorization-code flow during `coral source add --interactive`.
 - OAuth methods require `flow.type: authorization_code` and an explicit `flow.pkce` of `required` or `disabled`.

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -30,8 +30,8 @@ Use:
 - Keep credential collection separate from runtime auth. `inputs` stores values; `auth`, request headers, query params, or body fields decide where values are sent.
 - Use `from: bearer` for raw access tokens that must be sent as `Authorization: Bearer <token>`. Use `from: one_of` when runtime auth should choose the first present credential, such as a pasted API-key header before an OAuth bearer token.
 - Use `type: source_config` when the user should provide a stored secret directly through an environment variable or prompt.
-- Use `type: oauth` when the provider should issue the source secret through an OAuth authorization-code flow during `coral source add --interactive`.
-- OAuth methods require `flow.type: authorization_code` and an explicit `flow.pkce` of `required` or `disabled`.
+- Use `type: oauth` when the provider should issue the source secret through an OAuth device-code or authorization-code flow during `coral source add --interactive`.
+- Device-code OAuth methods require `flow.type: device_code`, `endpoints.device_authorization_url`, `endpoints.token_url`, and a public client ID. Authorization-code OAuth methods require `flow.type: authorization_code` and an explicit `flow.pkce` of `required` or `disabled`.
 - OAuth redirect URIs must use `http://127.0.0.1` or `http://localhost`. Use `redirect_uri_port_mode: random` with no port or port `0` when the provider accepts variable loopback ports. Use `fixed` with a non-zero port when the OAuth app must pre-register the exact URI.
 - For public clients, declare `client.id.default`, `client.id.input`, or both. When the provider's token endpoint requires client authentication with a client secret, prompt for both OAuth client values: declare `client.id.input`, `client.secret.input`, and `client.secret.transport` (`basic_auth` or `request_body`).
 - Do not add top-level source inputs solely for OAuth client credentials; `client.id.input` and `client.secret.input` are collected during OAuth setup.

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -29,6 +29,7 @@ Use:
 
 - Keep credential collection separate from runtime auth. `inputs` stores values; `auth`, request headers, query params, or body fields decide where values are sent.
 - Use `from: bearer` for raw access tokens that must be sent as `Authorization: Bearer <token>`. Use `from: one_of` when runtime auth should choose the first present credential, such as a pasted API-key header before an OAuth bearer token.
+- When `from: one_of` models alternate stored credentials, mark each branch's secret input `required: false` so either credential can satisfy auth.
 - Use `type: source_config` when the user should provide a stored secret directly through an environment variable or prompt.
 - Use `type: oauth` when the provider should issue the source secret through an OAuth device-code or authorization-code flow during `coral source add --interactive`.
 - Device-code OAuth methods require `flow.type: device_code`, `endpoints.device_authorization_url`, `endpoints.token_url`, and a public client ID. Authorization-code OAuth methods require `flow.type: authorization_code` and an explicit `flow.pkce` of `required` or `disabled`.


### PR DESCRIPTION
## Intent

Add first-class source-spec auth fallback so sources can support multiple credential shapes without embedding a mini expression language in templates, while keeping optional fallback credentials available at runtime.

## What it enables

- Adds `from: one_of` to resolve the first present, non-empty value source.
- Adds `from: bearer` to turn a raw secret input token into `Bearer <token>` and validates that bearer sources reference `kind: secret` inputs.
- Removes `||` and `concat(...)` expression templating from request/auth templates.
- Distinguishes required secrets from declared runtime secrets so optional OAuth fallback material is not dropped during query execution.
- Keeps HTTP, file, and MCP required-secret semantics consistent.
- Keeps input-reference validation, schema validation, runtime registration checks, source-spec docs, and maintained source-authoring skills aligned with the new auth model, including device-code OAuth guidance.

## Usage examples

A source can accept either a complete API-key authorization header or a raw OAuth access token:

```yaml
inputs:
  LINEAR_API_KEY:
    kind: secret
    required: false
  LINEAR_OAUTH_ACCESS_TOKEN:
    kind: secret
    required: false

auth:
  type: HeaderAuth
  headers:
    - name: Authorization
      from: one_of
      values:
        - from: input
          key: LINEAR_API_KEY
        - from: bearer
          key: LINEAR_OAUTH_ACCESS_TOKEN
```

If `LINEAR_API_KEY` is configured, Coral uses it as the header value. If only `LINEAR_OAUTH_ACCESS_TOKEN` is configured, Coral sends `Bearer <token>`.

## Validation

- `cargo test -p coral-spec bearer`
- `cargo test -p coral-spec parses_mcp_manifest_with_secret_input`
- `cargo test -p coral-app load_query_source_passes_present_optional_secrets_to_runtime`
- `env RUSTC_WRAPPER= make docs-check`
- `env RUSTC_WRAPPER= make rust-checks`
