### PR TITLE
feat(sources/community/langfuse): add langfuse community source

### DIFF
--- a/sources/community/langfuse/README.md
+++ b/sources/community/langfuse/README.md
@@ -1,0 +1,145 @@
+# Langfuse
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 5
+**Base URL:** `https://cloud.langfuse.com` (override with `LANGFUSE_BASE_URL`)
+
+Query traces, observations, scores, sessions, and projects from Langfuse
+(Cloud or self-hosted).
+
+## Authentication
+
+Langfuse uses HTTP Basic Auth. The public key is the username and the secret
+key is the password. Both are available in your project settings under
+**Settings → API Keys**.
+
+```bash
+coral source add --interactive langfuse
+```
+
+Or pass credentials directly:
+
+```bash
+LANGFUSE_BASE_URL=https://cloud.langfuse.com \
+LANGFUSE_PUBLIC_KEY=pk-lf-... \
+LANGFUSE_SECRET_KEY=sk-lf-... \
+  coral source add langfuse
+```
+
+### Self-hosted
+
+Set `LANGFUSE_BASE_URL` to your instance URL:
+
+```bash
+LANGFUSE_BASE_URL=http://localhost:3000 \
+LANGFUSE_PUBLIC_KEY=pk-lf-... \
+LANGFUSE_SECRET_KEY=sk-lf-... \
+  coral source add langfuse
+```
+
+### Cloud regions
+
+| Region | Base URL |
+|---|---|
+| US Cloud (default) | `https://cloud.langfuse.com` |
+| EU Cloud | `https://eu.cloud.langfuse.com` |
+| Self-hosted | Your instance URL |
+
+## Tables
+
+| Table | Description | Optional filters |
+|---|---|---|
+| `projects` | Projects accessible with the API keys | — |
+| `traces` | LLM application traces | `name`, `user_id`, `session_id`, `tags`, `environment` |
+| `observations` | Spans, generations, and events within traces | `trace_id`, `type`, `name`, `user_id`, `environment` |
+| `scores` | Evaluation scores on traces or observations | `trace_id`, `observation_id`, `name`, `data_type`, `environment` |
+| `sessions` | Multi-turn conversation sessions | `environment` |
+
+## Quick start
+
+```bash
+# Confirm connectivity
+coral sql "SELECT id, name FROM langfuse.projects"
+
+# Recent traces with cost and latency
+coral sql "
+  SELECT id, name, user_id, latency, total_cost, total_tokens, timestamp
+  FROM langfuse.traces
+  ORDER BY timestamp DESC
+  LIMIT 20
+"
+
+# Filter traces by name (use case)
+coral sql "
+  SELECT id, user_id, latency, total_cost, timestamp
+  FROM langfuse.traces
+  WHERE name = 'my-pipeline'
+  ORDER BY timestamp DESC
+  LIMIT 20
+"
+
+# All LLM generations with token usage and cost
+coral sql "
+  SELECT id, trace_id, name, model, latency, input_tokens, output_tokens, total_cost
+  FROM langfuse.observations
+  WHERE type = 'GENERATION'
+  ORDER BY created_at DESC
+  LIMIT 20
+"
+
+# Observations for a specific trace
+coral sql "
+  SELECT id, type, name, model, latency, total_cost, level
+  FROM langfuse.observations
+  WHERE trace_id = '<your-trace-id>'
+  ORDER BY start_time
+"
+
+# Evaluation scores for a trace
+coral sql "
+  SELECT name, value, string_value, data_type, source, comment
+  FROM langfuse.scores
+  WHERE trace_id = '<your-trace-id>'
+"
+
+# Average score by name
+coral sql "
+  SELECT name, AVG(value) as avg_score, COUNT(*) as count
+  FROM langfuse.scores
+  WHERE data_type = 'NUMERIC'
+  GROUP BY name
+  ORDER BY avg_score DESC
+"
+
+# Cost breakdown by model
+coral sql "
+  SELECT model, COUNT(*) as calls,
+    SUM(input_tokens) as total_input,
+    SUM(output_tokens) as total_output,
+    SUM(total_cost) as total_cost_usd
+  FROM langfuse.observations
+  WHERE type = 'GENERATION'
+  GROUP BY model
+  ORDER BY total_cost_usd DESC
+"
+
+# Sessions with trace counts
+coral sql "SELECT id, created_at, project_id FROM langfuse.sessions ORDER BY created_at DESC LIMIT 10"
+```
+
+## Discovery order
+
+```text
+projects
+  → id (project context)
+
+traces
+  → id (trace_id)
+    → observations (WHERE trace_id = '...')
+    → scores (WHERE trace_id = '...')
+
+sessions
+  → id
+    → traces (WHERE session_id = '...')
+```

--- a/sources/community/langfuse/README.md
+++ b/sources/community/langfuse/README.md
@@ -15,16 +15,19 @@ key is the password. Both are available in your project settings under
 **Settings → API Keys**.
 
 ```bash
-coral source add --interactive langfuse
+LANGFUSE_BASE_URL=https://cloud.langfuse.com \
+LANGFUSE_PUBLIC_KEY=pk-lf-... \
+LANGFUSE_SECRET_KEY=sk-lf-... \
+  coral source add --file sources/community/langfuse/manifest.yaml
 ```
 
-Or pass credentials directly:
+Or interactively:
 
 ```bash
 LANGFUSE_BASE_URL=https://cloud.langfuse.com \
 LANGFUSE_PUBLIC_KEY=pk-lf-... \
 LANGFUSE_SECRET_KEY=sk-lf-... \
-  coral source add langfuse
+  coral source add --file sources/community/langfuse/manifest.yaml --interactive
 ```
 
 ### Self-hosted
@@ -35,15 +38,16 @@ Set `LANGFUSE_BASE_URL` to your instance URL:
 LANGFUSE_BASE_URL=http://localhost:3000 \
 LANGFUSE_PUBLIC_KEY=pk-lf-... \
 LANGFUSE_SECRET_KEY=sk-lf-... \
-  coral source add langfuse
+  coral source add --file sources/community/langfuse/manifest.yaml
 ```
 
 ### Cloud regions
 
 | Region | Base URL |
 |---|---|
-| US Cloud (default) | `https://cloud.langfuse.com` |
-| EU Cloud | `https://eu.cloud.langfuse.com` |
+| EU Cloud (default) | `https://cloud.langfuse.com` |
+| US Cloud | `https://us.cloud.langfuse.com` |
+| Japan Cloud | `https://jp.cloud.langfuse.com` |
 | Self-hosted | Your instance URL |
 
 ## Tables

--- a/sources/community/langfuse/README.md
+++ b/sources/community/langfuse/README.md
@@ -128,7 +128,7 @@ coral sql "
   ORDER BY total_cost_usd DESC
 "
 
-# Sessions with trace counts
+# Sessions ordered by creation time
 coral sql "SELECT id, created_at, project_id FROM langfuse.sessions ORDER BY created_at DESC LIMIT 10"
 ```
 

--- a/sources/community/langfuse/README.md
+++ b/sources/community/langfuse/README.md
@@ -68,7 +68,7 @@ coral sql "SELECT id, name FROM langfuse.projects"
 
 # Recent traces with cost and latency
 coral sql "
-  SELECT id, name, user_id, latency, total_cost, total_tokens, timestamp
+  SELECT id, name, user_id, latency, total_cost, timestamp
   FROM langfuse.traces
   ORDER BY timestamp DESC
   LIMIT 20

--- a/sources/community/langfuse/manifest.yaml
+++ b/sources/community/langfuse/manifest.yaml
@@ -1,0 +1,803 @@
+name: langfuse
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query traces, observations, scores, sessions, and projects from Langfuse
+  (Cloud or self-hosted).
+inputs:
+  LANGFUSE_BASE_URL:
+    kind: variable
+    default: https://cloud.langfuse.com
+    hint: |
+      Base URL of your Langfuse instance. Use `https://cloud.langfuse.com`
+      for Langfuse Cloud (US region), `https://eu.cloud.langfuse.com` for
+      EU Cloud, or your self-hosted URL (e.g. `http://localhost:3000`).
+  LANGFUSE_PUBLIC_KEY:
+    kind: secret
+    hint: |
+      Your Langfuse project public key. Find it in your project settings
+      under API Keys. Used as the HTTP Basic Auth username.
+      See [Langfuse API docs](https://langfuse.com/docs/api).
+  LANGFUSE_SECRET_KEY:
+    kind: secret
+    hint: |
+      Your Langfuse project secret key. Find it in your project settings
+      under API Keys. Used as the HTTP Basic Auth password.
+      See [Langfuse API docs](https://langfuse.com/docs/api).
+base_url: "{{input.LANGFUSE_BASE_URL}}"
+auth:
+  type: BasicAuth
+  username: "{{input.LANGFUSE_PUBLIC_KEY}}"
+  password: "{{input.LANGFUSE_SECRET_KEY}}"
+test_queries:
+  - SELECT * FROM langfuse.projects LIMIT 1
+  - SELECT * FROM langfuse.traces LIMIT 1
+tables:
+  - name: projects
+    description: Langfuse projects accessible with the API keys
+    guide: |
+      Start here to confirm connectivity and inspect project metadata.
+      Each row is one Langfuse project. The `id` field can be used to
+      scope downstream queries.
+    request:
+      method: GET
+      path: /api/public/projects
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Project ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Project name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the project was created
+        expr:
+          kind: path
+          path:
+            - createdAt
+  - name: traces
+    description: LLM application traces recorded in the project
+    guide: |
+      Each row is one trace — a top-level request through your LLM
+      application. Use `name` to filter by trace type, `user_id` to
+      scope to a specific user, and `session_id` to group multi-turn
+      conversations. Join `id` to `observations.trace_id` to drill into
+      individual spans and generations. Results are ordered newest-first.
+    filters:
+      - name: user_id
+        required: false
+      - name: name
+        required: false
+      - name: session_id
+        required: false
+      - name: tags
+        required: false
+      - name: environment
+        required: false
+    request:
+      method: GET
+      path: /api/public/traces
+      query:
+        - name: userId
+          from: filter
+          key: user_id
+        - name: name
+          from: filter
+          key: name
+        - name: sessionId
+          from: filter
+          key: session_id
+        - name: tags
+          from: filter
+          key: tags
+        - name: environment
+          from: filter
+          key: environment
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Trace ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Trace name (identifies the use case or feature)
+        expr:
+          kind: path
+          path:
+            - name
+      - name: user_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: User ID associated with this trace
+        expr:
+          kind: path
+          path:
+            - userId
+      - name: session_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Session ID for grouping multi-turn conversations
+        expr:
+          kind: path
+          path:
+            - sessionId
+      - name: environment
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Deployment environment (e.g. production, staging)
+        expr:
+          kind: path
+          path:
+            - environment
+      - name: release
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Application release version
+        expr:
+          kind: path
+          path:
+            - release
+      - name: version
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Application version
+        expr:
+          kind: path
+          path:
+            - version
+      - name: tags
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Tags attached to this trace (JSON array)
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: timestamp
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the trace was recorded
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: latency
+        type: Float64
+        nullable: true
+        virtual: false
+        description: End-to-end latency in seconds
+        expr:
+          kind: path
+          path:
+            - latency
+      - name: total_cost
+        type: Float64
+        nullable: true
+        virtual: false
+        description: Total cost in USD across all observations in this trace
+        expr:
+          kind: path
+          path:
+            - totalCost
+      - name: input_tokens
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Total input tokens across all observations
+        expr:
+          kind: path
+          path:
+            - usage
+            - input
+      - name: output_tokens
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Total output tokens across all observations
+        expr:
+          kind: path
+          path:
+            - usage
+            - output
+      - name: total_tokens
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Total tokens (input + output) across all observations
+        expr:
+          kind: path
+          path:
+            - usage
+            - total
+      - name: project_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Project ID this trace belongs to
+        expr:
+          kind: path
+          path:
+            - projectId
+      - name: created_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the trace record was created
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the trace record was last updated
+        expr:
+          kind: path
+          path:
+            - updatedAt
+      - name: filter_user_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the user_id filter applied to this query
+        expr:
+          kind: from_filter
+          key: user_id
+      - name: filter_name
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the name filter applied to this query
+        expr:
+          kind: from_filter
+          key: name
+      - name: filter_session_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the session_id filter applied to this query
+        expr:
+          kind: from_filter
+          key: session_id
+  - name: observations
+    description: Spans, generations, and events within traces
+    guide: |
+      Each row is one observation — a span, generation, or event inside a
+      trace. Use `type = 'GENERATION'` to focus on LLM calls with token
+      usage and cost. Filter by `trace_id` to get all observations for a
+      specific trace. `model` shows which LLM was called. `latency` and
+      `total_cost` are the most useful columns for performance analysis.
+    filters:
+      - name: trace_id
+        required: false
+      - name: type
+        required: false
+      - name: name
+        required: false
+      - name: user_id
+        required: false
+      - name: environment
+        required: false
+    request:
+      method: GET
+      path: /api/public/observations
+      query:
+        - name: traceId
+          from: filter
+          key: trace_id
+        - name: type
+          from: filter
+          key: type
+        - name: name
+          from: filter
+          key: name
+        - name: userId
+          from: filter
+          key: user_id
+        - name: environment
+          from: filter
+          key: environment
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Observation ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: trace_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Parent trace ID
+        expr:
+          kind: path
+          path:
+            - traceId
+      - name: type
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Observation type (SPAN, GENERATION, or EVENT)
+        expr:
+          kind: path
+          path:
+            - type
+      - name: name
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Observation name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: model
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Model name used for this generation
+        expr:
+          kind: path
+          path:
+            - model
+      - name: model_parameters
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Model parameters as a JSON object
+        expr:
+          kind: path
+          path:
+            - modelParameters
+      - name: start_time
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Observation start timestamp
+        expr:
+          kind: path
+          path:
+            - startTime
+      - name: end_time
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Observation end timestamp
+        expr:
+          kind: path
+          path:
+            - endTime
+      - name: latency
+        type: Float64
+        nullable: true
+        virtual: false
+        description: Observation latency in seconds
+        expr:
+          kind: path
+          path:
+            - latency
+      - name: input_tokens
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Number of input tokens
+        expr:
+          kind: path
+          path:
+            - usage
+            - input
+      - name: output_tokens
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Number of output tokens
+        expr:
+          kind: path
+          path:
+            - usage
+            - output
+      - name: total_tokens
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Total tokens (input + output)
+        expr:
+          kind: path
+          path:
+            - usage
+            - total
+      - name: input_cost
+        type: Float64
+        nullable: true
+        virtual: false
+        description: Input cost in USD
+        expr:
+          kind: path
+          path:
+            - inputCost
+      - name: output_cost
+        type: Float64
+        nullable: true
+        virtual: false
+        description: Output cost in USD
+        expr:
+          kind: path
+          path:
+            - outputCost
+      - name: total_cost
+        type: Float64
+        nullable: true
+        virtual: false
+        description: Total cost in USD
+        expr:
+          kind: path
+          path:
+            - totalCost
+      - name: level
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Log level (DEBUG, DEFAULT, WARNING, ERROR)
+        expr:
+          kind: path
+          path:
+            - level
+      - name: status_message
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Status message or error description
+        expr:
+          kind: path
+          path:
+            - statusMessage
+      - name: version
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Version tag on this observation
+        expr:
+          kind: path
+          path:
+            - version
+      - name: environment
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Deployment environment
+        expr:
+          kind: path
+          path:
+            - environment
+      - name: created_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the observation was created
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the observation was last updated
+        expr:
+          kind: path
+          path:
+            - updatedAt
+  - name: scores
+    description: Evaluation scores attached to traces or observations
+    guide: |
+      Each row is one score — a numeric or categorical evaluation attached
+      to a trace or observation. Scores come from human annotation, LLM
+      judges, or custom SDK calls. Use `data_type = 'NUMERIC'` for
+      numeric scores and `data_type = 'CATEGORICAL'` for label-based
+      scores. Filter by `trace_id` to see all scores for a specific trace.
+    filters:
+      - name: trace_id
+        required: false
+      - name: observation_id
+        required: false
+      - name: name
+        required: false
+      - name: data_type
+        required: false
+      - name: environment
+        required: false
+    request:
+      method: GET
+      path: /api/public/scores
+      query:
+        - name: traceId
+          from: filter
+          key: trace_id
+        - name: observationId
+          from: filter
+          key: observation_id
+        - name: name
+          from: filter
+          key: name
+        - name: dataType
+          from: filter
+          key: data_type
+        - name: environment
+          from: filter
+          key: environment
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Score ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: trace_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Trace ID this score is attached to
+        expr:
+          kind: path
+          path:
+            - traceId
+      - name: observation_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Observation ID this score is attached to (if observation-level)
+        expr:
+          kind: path
+          path:
+            - observationId
+      - name: name
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Score name (e.g. quality, relevance, hallucination)
+        expr:
+          kind: path
+          path:
+            - name
+      - name: value
+        type: Float64
+        nullable: true
+        virtual: false
+        description: Numeric score value (null for categorical scores)
+        expr:
+          kind: path
+          path:
+            - value
+      - name: string_value
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Categorical score label (null for numeric scores)
+        expr:
+          kind: path
+          path:
+            - stringValue
+      - name: data_type
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Score data type (NUMERIC, CATEGORICAL, or BOOLEAN)
+        expr:
+          kind: path
+          path:
+            - dataType
+      - name: source
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Score source (API, ANNOTATION, or EVAL)
+        expr:
+          kind: path
+          path:
+            - source
+      - name: comment
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Optional comment on the score
+        expr:
+          kind: path
+          path:
+            - comment
+      - name: environment
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Deployment environment
+        expr:
+          kind: path
+          path:
+            - environment
+      - name: created_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the score was created
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the score was last updated
+        expr:
+          kind: path
+          path:
+            - updatedAt
+  - name: sessions
+    description: Multi-turn conversation sessions grouping related traces
+    guide: |
+      Each row is one session — a group of traces that belong to the same
+      multi-turn conversation or workflow. Use `id` to filter traces by
+      session via `WHERE session_id = '<id>'` on the `traces` table.
+      `user_id` identifies the end user across sessions.
+    filters:
+      - name: environment
+        required: false
+    request:
+      method: GET
+      path: /api/public/sessions
+      query:
+        - name: environment
+          from: filter
+          key: environment
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Session ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: created_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the session was created
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the session was last updated
+        expr:
+          kind: path
+          path:
+            - updatedAt
+      - name: project_id
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Project ID this session belongs to
+        expr:
+          kind: path
+          path:
+            - projectId
+      - name: environment
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the environment filter applied to this query
+        expr:
+          kind: from_filter
+          key: environment

--- a/sources/community/langfuse/manifest.yaml
+++ b/sources/community/langfuse/manifest.yaml
@@ -57,7 +57,6 @@ tables:
       - name: id
         type: Utf8
         nullable: false
-        virtual: false
         description: Project ID
         expr:
           kind: path
@@ -66,7 +65,6 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        virtual: false
         description: Project name
         expr:
           kind: path
@@ -75,7 +73,6 @@ tables:
       - name: created_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the project was created
         expr:
           kind: path
@@ -139,7 +136,6 @@ tables:
       - name: id
         type: Utf8
         nullable: false
-        virtual: false
         description: Trace ID
         expr:
           kind: path
@@ -148,7 +144,6 @@ tables:
       - name: name
         type: Utf8
         nullable: true
-        virtual: false
         description: Trace name (identifies the use case or feature)
         expr:
           kind: path
@@ -157,7 +152,6 @@ tables:
       - name: user_id
         type: Utf8
         nullable: true
-        virtual: false
         description: User ID associated with this trace
         expr:
           kind: path
@@ -166,7 +160,6 @@ tables:
       - name: session_id
         type: Utf8
         nullable: true
-        virtual: false
         description: Session ID for grouping multi-turn conversations
         expr:
           kind: path
@@ -175,7 +168,6 @@ tables:
       - name: environment
         type: Utf8
         nullable: true
-        virtual: false
         description: Deployment environment (e.g. production, staging)
         expr:
           kind: path
@@ -184,7 +176,6 @@ tables:
       - name: release
         type: Utf8
         nullable: true
-        virtual: false
         description: Application release version
         expr:
           kind: path
@@ -193,7 +184,6 @@ tables:
       - name: version
         type: Utf8
         nullable: true
-        virtual: false
         description: Application version
         expr:
           kind: path
@@ -202,7 +192,6 @@ tables:
       - name: tags
         type: Utf8
         nullable: true
-        virtual: false
         description: Tags attached to this trace (JSON array)
         expr:
           kind: path
@@ -211,7 +200,6 @@ tables:
       - name: timestamp
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the trace was recorded
         expr:
           kind: path
@@ -220,7 +208,6 @@ tables:
       - name: latency
         type: Float64
         nullable: true
-        virtual: false
         description: End-to-end latency in seconds
         expr:
           kind: path
@@ -229,7 +216,6 @@ tables:
       - name: total_cost
         type: Float64
         nullable: true
-        virtual: false
         description: Total cost in USD across all observations in this trace
         expr:
           kind: path
@@ -238,7 +224,6 @@ tables:
       - name: project_id
         type: Utf8
         nullable: true
-        virtual: false
         description: Project ID this trace belongs to
         expr:
           kind: path
@@ -247,7 +232,6 @@ tables:
       - name: created_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the trace record was created
         expr:
           kind: path
@@ -256,36 +240,11 @@ tables:
       - name: updated_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the trace record was last updated
         expr:
           kind: path
           path:
             - updatedAt
-      - name: filter_user_id
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Echoes the user_id filter applied to this query
-        expr:
-          kind: from_filter
-          key: user_id
-      - name: filter_name
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Echoes the name filter applied to this query
-        expr:
-          kind: from_filter
-          key: name
-      - name: filter_session_id
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Echoes the session_id filter applied to this query
-        expr:
-          kind: from_filter
-          key: session_id
   - name: observations
     description: Spans, generations, and events within traces
     guide: |
@@ -344,7 +303,6 @@ tables:
       - name: id
         type: Utf8
         nullable: false
-        virtual: false
         description: Observation ID
         expr:
           kind: path
@@ -353,7 +311,6 @@ tables:
       - name: trace_id
         type: Utf8
         nullable: true
-        virtual: false
         description: Parent trace ID
         expr:
           kind: path
@@ -362,7 +319,6 @@ tables:
       - name: type
         type: Utf8
         nullable: true
-        virtual: false
         description: Observation type (SPAN, GENERATION, or EVENT)
         expr:
           kind: path
@@ -371,7 +327,6 @@ tables:
       - name: name
         type: Utf8
         nullable: true
-        virtual: false
         description: Observation name
         expr:
           kind: path
@@ -380,7 +335,6 @@ tables:
       - name: model
         type: Utf8
         nullable: true
-        virtual: false
         description: Model name used for this generation
         expr:
           kind: path
@@ -389,7 +343,6 @@ tables:
       - name: model_parameters
         type: Utf8
         nullable: true
-        virtual: false
         description: Model parameters as a JSON object
         expr:
           kind: path
@@ -398,7 +351,6 @@ tables:
       - name: start_time
         type: Utf8
         nullable: true
-        virtual: false
         description: Observation start timestamp
         expr:
           kind: path
@@ -407,7 +359,6 @@ tables:
       - name: end_time
         type: Utf8
         nullable: true
-        virtual: false
         description: Observation end timestamp
         expr:
           kind: path
@@ -416,7 +367,6 @@ tables:
       - name: latency
         type: Float64
         nullable: true
-        virtual: false
         description: Observation latency in seconds
         expr:
           kind: path
@@ -425,7 +375,6 @@ tables:
       - name: input_tokens
         type: Int64
         nullable: true
-        virtual: false
         description: Number of input tokens
         expr:
           kind: path
@@ -435,7 +384,6 @@ tables:
       - name: output_tokens
         type: Int64
         nullable: true
-        virtual: false
         description: Number of output tokens
         expr:
           kind: path
@@ -445,7 +393,6 @@ tables:
       - name: total_tokens
         type: Int64
         nullable: true
-        virtual: false
         description: Total tokens (input + output)
         expr:
           kind: path
@@ -455,7 +402,6 @@ tables:
       - name: input_cost
         type: Float64
         nullable: true
-        virtual: false
         description: Calculated input cost in USD
         expr:
           kind: path
@@ -464,7 +410,6 @@ tables:
       - name: output_cost
         type: Float64
         nullable: true
-        virtual: false
         description: Calculated output cost in USD
         expr:
           kind: path
@@ -473,7 +418,6 @@ tables:
       - name: total_cost
         type: Float64
         nullable: true
-        virtual: false
         description: Calculated total cost in USD
         expr:
           kind: path
@@ -482,7 +426,6 @@ tables:
       - name: level
         type: Utf8
         nullable: true
-        virtual: false
         description: Log level (DEBUG, DEFAULT, WARNING, ERROR)
         expr:
           kind: path
@@ -491,7 +434,6 @@ tables:
       - name: status_message
         type: Utf8
         nullable: true
-        virtual: false
         description: Status message or error description
         expr:
           kind: path
@@ -500,7 +442,6 @@ tables:
       - name: version
         type: Utf8
         nullable: true
-        virtual: false
         description: Version tag on this observation
         expr:
           kind: path
@@ -509,7 +450,6 @@ tables:
       - name: environment
         type: Utf8
         nullable: true
-        virtual: false
         description: Deployment environment
         expr:
           kind: path
@@ -518,7 +458,6 @@ tables:
       - name: created_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the observation was created
         expr:
           kind: path
@@ -527,7 +466,6 @@ tables:
       - name: updated_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the observation was last updated
         expr:
           kind: path
@@ -591,7 +529,6 @@ tables:
       - name: id
         type: Utf8
         nullable: false
-        virtual: false
         description: Score ID
         expr:
           kind: path
@@ -600,7 +537,6 @@ tables:
       - name: trace_id
         type: Utf8
         nullable: true
-        virtual: false
         description: Trace ID this score is attached to
         expr:
           kind: path
@@ -609,7 +545,6 @@ tables:
       - name: observation_id
         type: Utf8
         nullable: true
-        virtual: false
         description: Observation ID this score is attached to (if observation-level)
         expr:
           kind: path
@@ -618,7 +553,6 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        virtual: false
         description: Score name (e.g. quality, relevance, hallucination)
         expr:
           kind: path
@@ -627,7 +561,6 @@ tables:
       - name: value
         type: Float64
         nullable: true
-        virtual: false
         description: Numeric score value (null for categorical scores)
         expr:
           kind: path
@@ -636,7 +569,6 @@ tables:
       - name: string_value
         type: Utf8
         nullable: true
-        virtual: false
         description: Categorical score label (null for numeric scores)
         expr:
           kind: path
@@ -645,7 +577,6 @@ tables:
       - name: data_type
         type: Utf8
         nullable: true
-        virtual: false
         description: Score data type (NUMERIC, CATEGORICAL, or BOOLEAN)
         expr:
           kind: path
@@ -654,7 +585,6 @@ tables:
       - name: source
         type: Utf8
         nullable: true
-        virtual: false
         description: Score source (API, ANNOTATION, or EVAL)
         expr:
           kind: path
@@ -663,7 +593,6 @@ tables:
       - name: comment
         type: Utf8
         nullable: true
-        virtual: false
         description: Optional comment on the score
         expr:
           kind: path
@@ -672,7 +601,6 @@ tables:
       - name: environment
         type: Utf8
         nullable: true
-        virtual: false
         description: Deployment environment
         expr:
           kind: path
@@ -681,7 +609,6 @@ tables:
       - name: created_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the score was created
         expr:
           kind: path
@@ -690,7 +617,6 @@ tables:
       - name: updated_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the score was last updated
         expr:
           kind: path
@@ -732,7 +658,6 @@ tables:
       - name: id
         type: Utf8
         nullable: false
-        virtual: false
         description: Session ID
         expr:
           kind: path
@@ -741,7 +666,6 @@ tables:
       - name: created_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the session was created
         expr:
           kind: path
@@ -750,7 +674,6 @@ tables:
       - name: updated_at
         type: Utf8
         nullable: true
-        virtual: false
         description: Timestamp when the session was last updated
         expr:
           kind: path
@@ -759,7 +682,6 @@ tables:
       - name: project_id
         type: Utf8
         nullable: true
-        virtual: false
         description: Project ID this session belongs to
         expr:
           kind: path

--- a/sources/community/langfuse/manifest.yaml
+++ b/sources/community/langfuse/manifest.yaml
@@ -729,7 +729,6 @@ tables:
       Each row is one session — a group of traces that belong to the same
       multi-turn conversation or workflow. Use `id` to filter traces by
       session via `WHERE session_id = '<id>'` on the `traces` table.
-      `user_id` identifies the end user across sessions.
     filters:
       - name: environment
         required: false

--- a/sources/community/langfuse/manifest.yaml
+++ b/sources/community/langfuse/manifest.yaml
@@ -10,9 +10,12 @@ inputs:
     kind: variable
     default: https://cloud.langfuse.com
     hint: |
-      Base URL of your Langfuse instance. Use `https://cloud.langfuse.com`
-      for Langfuse Cloud (US region), `https://eu.cloud.langfuse.com` for
-      EU Cloud, or your self-hosted URL (e.g. `http://localhost:3000`).
+      Base URL of your Langfuse instance.
+      Cloud regions:
+        EU:    https://cloud.langfuse.com  (default)
+        US:    https://us.cloud.langfuse.com
+        Japan: https://jp.cloud.langfuse.com
+      For self-hosted instances use your own URL (e.g. http://localhost:3000).
   LANGFUSE_PUBLIC_KEY:
     kind: secret
     hint: |
@@ -232,36 +235,6 @@ tables:
           kind: path
           path:
             - totalCost
-      - name: input_tokens
-        type: Int64
-        nullable: true
-        virtual: false
-        description: Total input tokens across all observations
-        expr:
-          kind: path
-          path:
-            - usage
-            - input
-      - name: output_tokens
-        type: Int64
-        nullable: true
-        virtual: false
-        description: Total output tokens across all observations
-        expr:
-          kind: path
-          path:
-            - usage
-            - output
-      - name: total_tokens
-        type: Int64
-        nullable: true
-        virtual: false
-        description: Total tokens (input + output) across all observations
-        expr:
-          kind: path
-          path:
-            - usage
-            - total
       - name: project_id
         type: Utf8
         nullable: true
@@ -483,29 +456,29 @@ tables:
         type: Float64
         nullable: true
         virtual: false
-        description: Input cost in USD
+        description: Calculated input cost in USD
         expr:
           kind: path
           path:
-            - inputCost
+            - calculatedInputCost
       - name: output_cost
         type: Float64
         nullable: true
         virtual: false
-        description: Output cost in USD
+        description: Calculated output cost in USD
         expr:
           kind: path
           path:
-            - outputCost
+            - calculatedOutputCost
       - name: total_cost
         type: Float64
         nullable: true
         virtual: false
-        description: Total cost in USD
+        description: Calculated total cost in USD
         expr:
           kind: path
           path:
-            - totalCost
+            - calculatedTotalCost
       - name: level
         type: Utf8
         nullable: true
@@ -581,7 +554,7 @@ tables:
         required: false
     request:
       method: GET
-      path: /api/public/scores
+      path: /api/public/v2/scores
       query:
         - name: traceId
           from: filter


### PR DESCRIPTION
Closes #373 

## What changed

Adds a new community source for Langfuse under `sources/community/langfuse/`.

**Tables (5):**
- `projects` — Langfuse projects accessible with the API keys
- `traces` — LLM application traces with latency, cost, and token usage
- `observations` — Spans, generations, and events within traces; filter by `type = 'GENERATION'` for LLM calls with model and token data
- `scores` — Evaluation scores (numeric, categorical, boolean) attached to traces or observations from human annotation, LLM judges, or API
- `sessions` — Multi-turn conversation sessions grouping related traces

**Auth:** HTTP BasicAuth — public key as username, secret key as password. Supports Langfuse Cloud (US and EU) and self-hosted instances via the `LANGFUSE_BASE_URL` variable input (default: `https://cloud.langfuse.com`).

## Why it changed

Langfuse is a widely used open-source LLM observability platform. Being able to query traces, costs, latency, and evaluation scores via SQL is a natural fit for Coral — especially for teams running post-hoc analysis on their LLM pipelines.

## What was tested

- `coral source lint` — passes
- `uv` / `yamllint` / `make lint-sources` — passes across all sources
- `coral source test langfuse` — 2/2 test queries pass
- Live queries verified against a self-hosted Langfuse instance:
  - `projects` — returns project row with correct columns
  - `traces` — schema correct, returns empty on fresh instance
  - `observations` — schema correct, all columns mapped
  - `scores` — schema correct, all columns mapped
  - `sessions` — schema correct, all columns mapped

## User-visible impact

New `langfuse` source installable via:

```bash
coral source add --file sources/community/langfuse/manifest.yaml
```

## Follow-on

- Prompts table (`GET /api/public/prompts`) could be added in a follow-up
- Dataset and experiment tables could be added once the source is validated with more production data