### PR TITLE
feat(cli): collect OAuth source credentials

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -258,6 +258,19 @@ message CreateBundledSourceWithCredentialsRequest {
   repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
 }
 
+// Streaming event emitted while installing a bundled source with credentials.
+message CreateBundledSourceWithCredentialsResponse {
+  // Installation progress or completion event.
+  oneof event {
+    // Bundled source installation completed.
+    Source source = 1;
+    // OAuth authorization URL is ready.
+    OAuthCredentialAuthorization oauth_authorization = 2;
+    // OAuth credential retrieval completed.
+    OAuthCredentialCompleted oauth_completed = 3;
+  }
+}
+
 // Imports one user-supplied source manifest into Coral ownership.
 message ImportSourceRequest {
   // Owning workspace resource.
@@ -440,7 +453,7 @@ service SourceService {
   rpc CreateBundledSource(CreateBundledSourceRequest) returns (CreateBundledSourceResponse);
   // Installs one bundled source with app-owned credential retrieval.
   rpc CreateBundledSourceWithCredentials(CreateBundledSourceWithCredentialsRequest)
-      returns (stream ImportSourceResponse);
+      returns (stream CreateBundledSourceWithCredentialsResponse);
   // Imports one user-provided source manifest, streaming credential retrieval
   // progress before the final source event when credentials are app-owned.
   rpc ImportSource(ImportSourceRequest) returns (stream ImportSourceResponse);

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -244,6 +244,20 @@ message CreateBundledSourceResponse {
   Source source = 1;
 }
 
+// Installs one bundled source with app-owned credential retrieval.
+message CreateBundledSourceWithCredentialsRequest {
+  // Owning workspace resource.
+  Workspace workspace = 1;
+  // Canonical bundled source name.
+  string name = 2;
+  // Visible configured non-secret variables.
+  repeated SourceVariable variables = 3;
+  // Source-config secret bindings.
+  repeated SourceSecret secrets = 4;
+  // OAuth credential retrievals the app should run before validation and install.
+  repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
+}
+
 // Imports one user-supplied source manifest into Coral ownership.
 message ImportSourceRequest {
   // Owning workspace resource.
@@ -424,6 +438,9 @@ service SourceService {
   rpc GetSourceInfo(GetSourceInfoRequest) returns (GetSourceInfoResponse);
   // Installs one bundled source.
   rpc CreateBundledSource(CreateBundledSourceRequest) returns (CreateBundledSourceResponse);
+  // Installs one bundled source with app-owned credential retrieval.
+  rpc CreateBundledSourceWithCredentials(CreateBundledSourceWithCredentialsRequest)
+      returns (stream ImportSourceResponse);
   // Imports one user-provided source manifest, streaming credential retrieval
   // progress before the final source event when credentials are app-owned.
   rpc ImportSource(ImportSourceRequest) returns (stream ImportSourceResponse);

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -244,8 +244,8 @@ message CreateBundledSourceResponse {
   Source source = 1;
 }
 
-// Installs one bundled source with app-owned credential retrieval.
-message CreateBundledSourceWithCredentialsRequest {
+// Installs one bundled source with app-owned OAuth credential retrieval.
+message CreateBundledSourceWithOAuthRequest {
   // Owning workspace resource.
   Workspace workspace = 1;
   // Canonical bundled source name.
@@ -258,8 +258,8 @@ message CreateBundledSourceWithCredentialsRequest {
   repeated OAuthCredentialRetrieval oauth_credential_retrievals = 5;
 }
 
-// Streaming event emitted while installing a bundled source with credentials.
-message CreateBundledSourceWithCredentialsResponse {
+// Streaming event emitted while installing a bundled source with OAuth.
+message CreateBundledSourceWithOAuthResponse {
   // Installation progress or completion event.
   oneof event {
     // Bundled source installation completed.
@@ -451,9 +451,9 @@ service SourceService {
   rpc GetSourceInfo(GetSourceInfoRequest) returns (GetSourceInfoResponse);
   // Installs one bundled source.
   rpc CreateBundledSource(CreateBundledSourceRequest) returns (CreateBundledSourceResponse);
-  // Installs one bundled source with app-owned credential retrieval.
-  rpc CreateBundledSourceWithCredentials(CreateBundledSourceWithCredentialsRequest)
-      returns (stream CreateBundledSourceWithCredentialsResponse);
+  // Installs one bundled source with app-owned OAuth credential retrieval.
+  rpc CreateBundledSourceWithOAuth(CreateBundledSourceWithOAuthRequest)
+      returns (stream CreateBundledSourceWithOAuthResponse);
   // Imports one user-provided source manifest, streaming credential retrieval
   // progress before the final source event when credentials are app-owned.
   rpc ImportSource(ImportSourceRequest) returns (stream ImportSourceResponse);

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -36,7 +36,7 @@ pub(crate) struct CreateBundledSourceCommand {
     pub(crate) bindings: SourceBindings,
 }
 
-pub(crate) struct CreateBundledSourceWithCredentialsCommand {
+pub(crate) struct CreateBundledSourceWithOAuthCommand {
     pub(crate) name: SourceName,
     pub(crate) bindings: SourceBindings,
     pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
@@ -239,10 +239,10 @@ impl SourceManager {
         )
     }
 
-    pub(crate) async fn create_bundled_source_with_credentials(
+    pub(crate) async fn create_bundled_source_with_oauth(
         &self,
         workspace_name: &WorkspaceName,
-        command: CreateBundledSourceWithCredentialsCommand,
+        command: CreateBundledSourceWithOAuthCommand,
         events: ImportSourceEventSender,
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -36,6 +36,12 @@ pub(crate) struct CreateBundledSourceCommand {
     pub(crate) bindings: SourceBindings,
 }
 
+pub(crate) struct CreateBundledSourceWithCredentialsCommand {
+    pub(crate) name: SourceName,
+    pub(crate) bindings: SourceBindings,
+    pub(crate) oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+}
+
 pub(crate) struct ImportSourceCommand {
     pub(crate) manifest_yaml: String,
     pub(crate) bindings: SourceBindings,
@@ -233,6 +239,45 @@ impl SourceManager {
         )
     }
 
+    pub(crate) async fn create_bundled_source_with_credentials(
+        &self,
+        workspace_name: &WorkspaceName,
+        command: CreateBundledSourceWithCredentialsCommand,
+        events: ImportSourceEventSender,
+    ) -> Result<InstalledSource, AppError> {
+        let bundled = load_bundled_source(&command.name)?;
+        let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
+        let oauth_input_keys = command
+            .oauth_credential_retrievals
+            .iter()
+            .map(|credential| credential.input_key.clone())
+            .collect::<BTreeSet<_>>();
+        let stored_material = self.source_material_for_validation(
+            workspace_name,
+            &candidate,
+            &command.bindings,
+            &oauth_input_keys,
+        )?;
+        let bindings = self
+            .bindings_with_oauth_material(
+                &candidate,
+                &command.bindings,
+                stored_material,
+                command.oauth_credential_retrievals,
+                events,
+            )
+            .await?;
+        self.persist_source(
+            workspace_name,
+            PersistSourceRequest {
+                candidate: &candidate,
+                manifest_yaml: None,
+                bindings,
+                origin: SourceOrigin::Bundled,
+            },
+        )
+    }
+
     pub(crate) fn import_source(
         &self,
         workspace_name: &WorkspaceName,
@@ -279,21 +324,15 @@ impl SourceManager {
             &command.bindings,
             &oauth_input_keys,
         )?;
-        Self::validate_oauth_import_preflight(
-            &candidate,
-            &command.bindings,
-            &stored_material,
-            &command.oauth_credential_retrievals,
-        )?;
-        let oauth_material = self
-            .retrieve_oauth_material(&candidate, command.oauth_credential_retrievals, events)
+        let bindings = self
+            .bindings_with_oauth_material(
+                &candidate,
+                &command.bindings,
+                stored_material,
+                command.oauth_credential_retrievals,
+                events,
+            )
             .await?;
-        let mut validation_material = stored_material;
-        for material in &oauth_material {
-            validation_material.insert(material.input_key.clone(), material.access_token.clone());
-        }
-        let mut bindings = validate_bindings(&candidate, &command.bindings, &validation_material)?;
-        merge_oauth_material_into_bindings(&mut bindings, oauth_material)?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -580,6 +619,32 @@ impl SourceManager {
             materials.push(material);
         }
         Ok(materials)
+    }
+
+    async fn bindings_with_oauth_material(
+        &self,
+        candidate: &CandidateSource,
+        bindings: &SourceBindings,
+        stored_material: BTreeMap<String, String>,
+        oauth_credential_retrievals: Vec<SourceOAuthCredentialRetrieval>,
+        events: ImportSourceEventSender,
+    ) -> Result<ValidatedBindings, AppError> {
+        Self::validate_oauth_import_preflight(
+            candidate,
+            bindings,
+            &stored_material,
+            &oauth_credential_retrievals,
+        )?;
+        let oauth_material = self
+            .retrieve_oauth_material(candidate, oauth_credential_retrievals, events)
+            .await?;
+        let mut validation_material = stored_material;
+        for material in &oauth_material {
+            validation_material.insert(material.input_key.clone(), material.access_token.clone());
+        }
+        let mut bindings = validate_bindings(candidate, bindings, &validation_material)?;
+        merge_oauth_material_into_bindings(&mut bindings, oauth_material)?;
+        Ok(bindings)
     }
 
     fn load_source_rollback_state(

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -6,10 +6,11 @@ use std::task::{Context, Poll};
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceResponse, CredentialMetadata,
-    DeleteSourceRequest, DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
-    GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
-    ImportSourceRequest, ImportSourceResponse, ListSourcesRequest, ListSourcesResponse,
+    CreateBundledSourceRequest, CreateBundledSourceResponse,
+    CreateBundledSourceWithCredentialsRequest, CredentialMetadata, DeleteSourceRequest,
+    DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
+    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse,
     OAuthAuthorizationCodeCredentialMethod, OAuthCredentialAuthorization, OAuthCredentialClient,
     OAuthCredentialClientId, OAuthCredentialClientSecret, OAuthCredentialCompleted,
     OAuthCredentialEndpoints, OAuthCredentialInput, OAuthCredentialRetrieval, OAuthCredentialScope,
@@ -32,8 +33,8 @@ use crate::bootstrap::{AppError, app_status};
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::{
-    CreateBundledSourceCommand, ImportSourceCommand, ImportSourceEventSender,
-    ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
+    CreateBundledSourceCommand, CreateBundledSourceWithCredentialsCommand, ImportSourceCommand,
+    ImportSourceEventSender, ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
     PendingImportSourceWithCredentialsEvent, SourceBinding, SourceBindings, SourceManager,
     SourceOAuthCredentialRetrieval,
 };
@@ -63,6 +64,8 @@ impl SourceService {
 
 #[tonic::async_trait]
 impl SourceServiceApi for SourceService {
+    type CreateBundledSourceWithCredentialsStream =
+        Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
     type ImportSourceStream =
         Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 
@@ -166,6 +169,47 @@ impl SourceServiceApi for SourceService {
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(&workspace_name, installed)),
             }))
+        })
+        .await
+    }
+
+    async fn create_bundled_source_with_credentials(
+        &self,
+        request: Request<CreateBundledSourceWithCredentialsRequest>,
+    ) -> Result<Response<Self::CreateBundledSourceWithCredentialsStream>, Status> {
+        let span = grpc_span(&request);
+        let sources = self.sources.clone();
+        instrument_grpc(span.clone(), async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let response_workspace_name = workspace_name.clone();
+            let command = CreateBundledSourceWithCredentialsCommand {
+                name: SourceName::parse(&request.name).map_err(app_status)?,
+                bindings: source_bindings_from_proto(request.variables, request.secrets),
+                oauth_credential_retrievals: request
+                    .oauth_credential_retrievals
+                    .into_iter()
+                    .map(oauth_credential_retrieval_from_proto)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(app_status)?,
+            };
+            let (event_tx, event_rx) = mpsc::channel(8);
+            let import = Box::pin(instrument_grpc(span, async move {
+                sources
+                    .create_bundled_source_with_credentials(
+                        &workspace_name,
+                        command,
+                        ImportSourceEventSender::new(event_tx),
+                    )
+                    .await
+                    .map_err(app_status)
+            }));
+            Ok(Response::new(Box::pin(ImportSourceResponseStream::new(
+                event_rx,
+                import,
+                response_workspace_name,
+            ))
+                as Self::CreateBundledSourceWithCredentialsStream))
         })
         .await
     }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -64,10 +64,8 @@ impl SourceService {
 
 #[tonic::async_trait]
 impl SourceServiceApi for SourceService {
-    type CreateBundledSourceWithCredentialsStream =
-        Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
-    type ImportSourceStream =
-        Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
+    type CreateBundledSourceWithCredentialsStream = ImportSourceResponseStreamBox;
+    type ImportSourceStream = ImportSourceResponseStreamBox;
 
     async fn discover_sources(
         &self,
@@ -193,23 +191,20 @@ impl SourceServiceApi for SourceService {
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(app_status)?,
             };
-            let (event_tx, event_rx) = mpsc::channel(8);
-            let import = Box::pin(instrument_grpc(span, async move {
-                sources
-                    .create_bundled_source_with_credentials(
-                        &workspace_name,
-                        command,
-                        ImportSourceEventSender::new(event_tx),
-                    )
-                    .await
-                    .map_err(app_status)
-            }));
-            Ok(Response::new(Box::pin(ImportSourceResponseStream::new(
-                event_rx,
-                import,
-                response_workspace_name,
-            ))
-                as Self::CreateBundledSourceWithCredentialsStream))
+            let stream =
+                import_source_response_stream(response_workspace_name, move |event_sender| {
+                    instrument_grpc(span, async move {
+                        sources
+                            .create_bundled_source_with_credentials(
+                                &workspace_name,
+                                command,
+                                event_sender,
+                            )
+                            .await
+                            .map_err(app_status)
+                    })
+                });
+            Ok(Response::new(stream))
         })
         .await
     }
@@ -251,22 +246,16 @@ impl SourceServiceApi for SourceService {
                     .collect::<Result<Vec<_>, _>>()
                     .map_err(app_status)?,
             };
-            let (event_tx, event_rx) = mpsc::channel(8);
-            let import = Box::pin(instrument_grpc(span, async move {
-                sources
-                    .import_source_with_credentials(
-                        &workspace_name,
-                        command,
-                        ImportSourceEventSender::new(event_tx),
-                    )
-                    .await
-                    .map_err(app_status)
-            }));
-            Ok(Response::new(Box::pin(ImportSourceResponseStream::new(
-                event_rx,
-                import,
-                response_workspace_name,
-            )) as Self::ImportSourceStream))
+            let stream =
+                import_source_response_stream(response_workspace_name, move |event_sender| {
+                    instrument_grpc(span, async move {
+                        sources
+                            .import_source_with_credentials(&workspace_name, command, event_sender)
+                            .await
+                            .map_err(app_status)
+                    })
+                });
+            Ok(Response::new(stream))
         })
         .await
     }
@@ -315,7 +304,25 @@ impl SourceServiceApi for SourceService {
     }
 }
 
+type ImportSourceResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
+
+fn import_source_response_stream<F, Fut>(
+    response_workspace_name: WorkspaceName,
+    import: F,
+) -> ImportSourceResponseStreamBox
+where
+    F: FnOnce(ImportSourceEventSender) -> Fut,
+    Fut: Future<Output = Result<InstalledSource, Status>> + Send + 'static,
+{
+    let (event_tx, event_rx) = mpsc::channel(8);
+    Box::pin(ImportSourceResponseStream::new(
+        event_rx,
+        Box::pin(import(ImportSourceEventSender::new(event_tx))),
+        response_workspace_name,
+    ))
+}
 
 struct ImportSourceResponseStream {
     events: mpsc::Receiver<PendingImportSourceWithCredentialsEvent>,

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -6,20 +6,19 @@ use std::task::{Context, Poll};
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceResponse,
-    CreateBundledSourceWithCredentialsRequest, CreateBundledSourceWithCredentialsResponse,
-    CredentialMetadata, DeleteSourceRequest, DeleteSourceResponse, DiscoverSourcesRequest,
-    DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
-    ListSourcesResponse, OAuthAuthorizationCodeCredentialMethod, OAuthCredentialAuthorization,
-    OAuthCredentialClient, OAuthCredentialClientId, OAuthCredentialClientSecret,
-    OAuthCredentialCompleted, OAuthCredentialEndpoints, OAuthCredentialInput,
-    OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
-    OauthCredentialClientSecretTransport, OauthCredentialPkceMode, OauthCredentialScopeDelimiter,
-    Source, SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod, SourceInfo,
-    SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput,
-    SourceVariable, SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
-    create_bundled_source_with_credentials_response, import_source_response,
+    CreateBundledSourceRequest, CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, CredentialMetadata, DeleteSourceRequest,
+    DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
+    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse,
+    OAuthAuthorizationCodeCredentialMethod, OAuthCredentialAuthorization, OAuthCredentialClient,
+    OAuthCredentialClientId, OAuthCredentialClientSecret, OAuthCredentialCompleted,
+    OAuthCredentialEndpoints, OAuthCredentialInput, OAuthCredentialRetrieval, OAuthCredentialScope,
+    OAuthCredentialScopes, OauthCredentialClientSecretTransport, OauthCredentialPkceMode,
+    OauthCredentialScopeDelimiter, Source, SourceConfigCredentialMethod, SourceCredential,
+    SourceCredentialMethod, SourceInfo, SourceInputSpec, SourceOrigin as ProtoSourceOrigin,
+    SourceSecret, SourceSecretInput, SourceVariable, SourceVariableInput, ValidateSourceRequest,
+    ValidateSourceResponse, create_bundled_source_with_o_auth_response, import_source_response,
     source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
@@ -34,7 +33,7 @@ use crate::bootstrap::{AppError, app_status};
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::{
-    CreateBundledSourceCommand, CreateBundledSourceWithCredentialsCommand, ImportSourceCommand,
+    CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
     ImportSourceEventSender, ImportSourceWithCredentialsCommand, ImportSourceWithCredentialsEvent,
     PendingImportSourceWithCredentialsEvent, SourceBinding, SourceBindings, SourceManager,
     SourceOAuthCredentialRetrieval,
@@ -66,8 +65,7 @@ impl SourceService {
 
 #[tonic::async_trait]
 impl SourceServiceApi for SourceService {
-    type CreateBundledSourceWithCredentialsStream =
-        CreateBundledSourceWithCredentialsResponseStreamBox;
+    type CreateBundledSourceWithOAuthStream = CreateBundledSourceWithOAuthResponseStreamBox;
     type ImportSourceStream = ImportSourceResponseStreamBox;
 
     async fn discover_sources(
@@ -174,17 +172,17 @@ impl SourceServiceApi for SourceService {
         .await
     }
 
-    async fn create_bundled_source_with_credentials(
+    async fn create_bundled_source_with_o_auth(
         &self,
-        request: Request<CreateBundledSourceWithCredentialsRequest>,
-    ) -> Result<Response<Self::CreateBundledSourceWithCredentialsStream>, Status> {
+        request: Request<CreateBundledSourceWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
             let response_workspace_name = workspace_name.clone();
-            let command = CreateBundledSourceWithCredentialsCommand {
+            let command = CreateBundledSourceWithOAuthCommand {
                 name: SourceName::parse(&request.name).map_err(app_status)?,
                 bindings: source_bindings_from_proto(request.variables, request.secrets),
                 oauth_credential_retrievals: request
@@ -198,7 +196,7 @@ impl SourceServiceApi for SourceService {
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
                         sources
-                            .create_bundled_source_with_credentials(
+                            .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
@@ -208,9 +206,9 @@ impl SourceServiceApi for SourceService {
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {
-                response.map(create_bundled_source_with_credentials_response_from_import_response)
+                response.map(create_bundled_source_with_o_auth_response_from_import_response)
             }))
-                as Self::CreateBundledSourceWithCredentialsStream))
+                as Self::CreateBundledSourceWithOAuthStream))
         })
         .await
     }
@@ -310,8 +308,8 @@ impl SourceServiceApi for SourceService {
     }
 }
 
-type CreateBundledSourceWithCredentialsResponseStreamBox =
-    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithCredentialsResponse, Status>> + Send>>;
+type CreateBundledSourceWithOAuthResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
@@ -474,23 +472,21 @@ fn import_source_event_to_proto(event: ImportSourceWithCredentialsEvent) -> Impo
     ImportSourceResponse { event: Some(event) }
 }
 
-fn create_bundled_source_with_credentials_response_from_import_response(
+fn create_bundled_source_with_o_auth_response_from_import_response(
     response: ImportSourceResponse,
-) -> CreateBundledSourceWithCredentialsResponse {
+) -> CreateBundledSourceWithOAuthResponse {
     let event = response.event.map(|event| match event {
         import_source_response::Event::Source(source) => {
-            create_bundled_source_with_credentials_response::Event::Source(source)
+            create_bundled_source_with_o_auth_response::Event::Source(source)
         }
         import_source_response::Event::OauthAuthorization(authorization) => {
-            create_bundled_source_with_credentials_response::Event::OauthAuthorization(
-                authorization,
-            )
+            create_bundled_source_with_o_auth_response::Event::OauthAuthorization(authorization)
         }
         import_source_response::Event::OauthCompleted(completed) => {
-            create_bundled_source_with_credentials_response::Event::OauthCompleted(completed)
+            create_bundled_source_with_o_auth_response::Event::OauthCompleted(completed)
         }
     });
-    CreateBundledSourceWithCredentialsResponse { event }
+    CreateBundledSourceWithOAuthResponse { event }
 }
 
 fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSource) -> Source {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -7,18 +7,19 @@ use std::task::{Context, Poll};
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
     CreateBundledSourceRequest, CreateBundledSourceResponse,
-    CreateBundledSourceWithCredentialsRequest, CredentialMetadata, DeleteSourceRequest,
-    DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
-    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
-    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse,
-    OAuthAuthorizationCodeCredentialMethod, OAuthCredentialAuthorization, OAuthCredentialClient,
-    OAuthCredentialClientId, OAuthCredentialClientSecret, OAuthCredentialCompleted,
-    OAuthCredentialEndpoints, OAuthCredentialInput, OAuthCredentialRetrieval, OAuthCredentialScope,
-    OAuthCredentialScopes, OauthCredentialClientSecretTransport, OauthCredentialPkceMode,
-    OauthCredentialScopeDelimiter, Source, SourceConfigCredentialMethod, SourceCredential,
-    SourceCredentialMethod, SourceInfo, SourceInputSpec, SourceOrigin as ProtoSourceOrigin,
-    SourceSecret, SourceSecretInput, SourceVariable, SourceVariableInput, ValidateSourceRequest,
-    ValidateSourceResponse, import_source_response,
+    CreateBundledSourceWithCredentialsRequest, CreateBundledSourceWithCredentialsResponse,
+    CredentialMetadata, DeleteSourceRequest, DeleteSourceResponse, DiscoverSourcesRequest,
+    DiscoverSourcesResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
+    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
+    ListSourcesResponse, OAuthAuthorizationCodeCredentialMethod, OAuthCredentialAuthorization,
+    OAuthCredentialClient, OAuthCredentialClientId, OAuthCredentialClientSecret,
+    OAuthCredentialCompleted, OAuthCredentialEndpoints, OAuthCredentialInput,
+    OAuthCredentialRetrieval, OAuthCredentialScope, OAuthCredentialScopes,
+    OauthCredentialClientSecretTransport, OauthCredentialPkceMode, OauthCredentialScopeDelimiter,
+    Source, SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod, SourceInfo,
+    SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput,
+    SourceVariable, SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
+    create_bundled_source_with_credentials_response, import_source_response,
     source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
@@ -46,6 +47,7 @@ use crate::transport::{
 use crate::workspaces::WorkspaceName;
 use tokio::sync::mpsc;
 use tokio_stream::Stream;
+use tokio_stream::StreamExt as _;
 
 #[derive(Clone)]
 pub(crate) struct SourceService {
@@ -64,7 +66,8 @@ impl SourceService {
 
 #[tonic::async_trait]
 impl SourceServiceApi for SourceService {
-    type CreateBundledSourceWithCredentialsStream = ImportSourceResponseStreamBox;
+    type CreateBundledSourceWithCredentialsStream =
+        CreateBundledSourceWithCredentialsResponseStreamBox;
     type ImportSourceStream = ImportSourceResponseStreamBox;
 
     async fn discover_sources(
@@ -204,7 +207,10 @@ impl SourceServiceApi for SourceService {
                             .map_err(app_status)
                     })
                 });
-            Ok(Response::new(stream))
+            Ok(Response::new(Box::pin(stream.map(|response| {
+                response.map(create_bundled_source_with_credentials_response_from_import_response)
+            }))
+                as Self::CreateBundledSourceWithCredentialsStream))
         })
         .await
     }
@@ -304,6 +310,8 @@ impl SourceServiceApi for SourceService {
     }
 }
 
+type CreateBundledSourceWithCredentialsResponseStreamBox =
+    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithCredentialsResponse, Status>> + Send>>;
 type ImportSourceResponseStreamBox =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 type ImportSourceFuture = Pin<Box<dyn Future<Output = Result<InstalledSource, Status>> + Send>>;
@@ -464,6 +472,25 @@ fn import_source_event_to_proto(event: ImportSourceWithCredentialsEvent) -> Impo
         }),
     };
     ImportSourceResponse { event: Some(event) }
+}
+
+fn create_bundled_source_with_credentials_response_from_import_response(
+    response: ImportSourceResponse,
+) -> CreateBundledSourceWithCredentialsResponse {
+    let event = response.event.map(|event| match event {
+        import_source_response::Event::Source(source) => {
+            create_bundled_source_with_credentials_response::Event::Source(source)
+        }
+        import_source_response::Event::OauthAuthorization(authorization) => {
+            create_bundled_source_with_credentials_response::Event::OauthAuthorization(
+                authorization,
+            )
+        }
+        import_source_response::Event::OauthCompleted(completed) => {
+            create_bundled_source_with_credentials_response::Event::OauthCompleted(completed)
+        }
+    });
+    CreateBundledSourceWithCredentialsResponse { event }
 }
 
 fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSource) -> Source {

--- a/crates/coral-cli/src/browser.rs
+++ b/crates/coral-cli/src/browser.rs
@@ -3,6 +3,25 @@
 use std::io;
 use std::process::Command;
 
+#[derive(Debug, Clone, Copy)]
+enum BrowserOpener {
+    Macos,
+    Windows,
+    XdgOpen,
+}
+
+impl BrowserOpener {
+    fn current() -> Self {
+        if cfg!(target_os = "macos") {
+            Self::Macos
+        } else if cfg!(target_os = "windows") {
+            Self::Windows
+        } else {
+            Self::XdgOpen
+        }
+    }
+}
+
 /// Opens a URL in the user's default browser.
 ///
 /// # Errors
@@ -10,13 +29,7 @@ use std::process::Command;
 /// Returns an error if the platform opener cannot be launched or exits
 /// unsuccessfully.
 pub(crate) fn open_url(url: &str) -> Result<(), io::Error> {
-    let status = if cfg!(target_os = "macos") {
-        Command::new("open").arg(url).status()
-    } else if cfg!(target_os = "windows") {
-        Command::new("cmd").args(["/C", "start", "", url]).status()
-    } else {
-        Command::new("xdg-open").arg(url).status()
-    }?;
+    let status = browser_command(BrowserOpener::current(), url).status()?;
 
     if status.success() {
         Ok(())
@@ -24,5 +37,41 @@ pub(crate) fn open_url(url: &str) -> Result<(), io::Error> {
         Err(io::Error::other(format!(
             "browser opener exited with {status}"
         )))
+    }
+}
+
+fn browser_command(opener: BrowserOpener, url: &str) -> Command {
+    let mut command = match opener {
+        BrowserOpener::Macos => Command::new("open"),
+        BrowserOpener::Windows => Command::new("rundll32"),
+        BrowserOpener::XdgOpen => Command::new("xdg-open"),
+    };
+    match opener {
+        BrowserOpener::Macos | BrowserOpener::XdgOpen => {
+            command.arg(url);
+        }
+        BrowserOpener::Windows => {
+            command.args(["url.dll,FileProtocolHandler", url]);
+        }
+    }
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+
+    use super::{BrowserOpener, browser_command};
+
+    #[test]
+    fn windows_opener_passes_query_urls_without_cmd_shell_parsing() {
+        let url = "https://provider.example/oauth?response_type=code&client_id=abc&state=xyz";
+        let command = browser_command(BrowserOpener::Windows, url);
+
+        assert_eq!(command.get_program(), OsStr::new("rundll32"));
+        assert_eq!(
+            command.get_args().collect::<Vec<_>>(),
+            vec![OsStr::new("url.dll,FileProtocolHandler"), OsStr::new(url)]
+        );
     }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -627,13 +627,6 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
     if interactive {
         source_ops::require_interactive()?;
     }
-    let collect = |inputs: &[coral_spec::ManifestInputSpec]| {
-        if interactive {
-            source_ops::prompt_for_inputs(inputs)
-        } else {
-            source_ops::collect_inputs_from_env(inputs)
-        }
-    };
     let response = match (name, file) {
         (Some(name), None) => {
             let bundled_name = source_ops::source_name_arg(Some(&name))?;
@@ -648,13 +641,27 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
                 .map(manifest_input_from_proto)
                 .collect::<Result<Vec<_>, _>>()
                 .map_err(anyhow::Error::from)?;
-            let (variables, secrets) = collect(&inputs)?;
-            source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
+            if interactive {
+                let inputs = source_ops::prompt_for_inputs_with_credential_methods(&inputs)?;
+                source_ops::add_bundled_source_with_credentials(app, &available.name, inputs)
+                    .await?
+            } else {
+                let (variables, secrets) = source_ops::collect_inputs_from_env(&inputs)?;
+                source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
+            }
         }
         (None, Some(file)) => {
             let (manifest_yaml, manifest) = source_ops::load_validated_manifest_file(&file)?;
-            let (variables, secrets) = collect(manifest.declared_inputs())?;
-            source_ops::import_source(app, manifest_yaml, variables, secrets).await?
+            if interactive {
+                let inputs = source_ops::prompt_for_inputs_with_credential_methods(
+                    manifest.declared_inputs(),
+                )?;
+                source_ops::import_source_with_credentials(app, manifest_yaml, inputs).await?
+            } else {
+                let (variables, secrets) =
+                    source_ops::collect_inputs_from_env(manifest.declared_inputs())?;
+                source_ops::import_source(app, manifest_yaml, variables, secrets).await?
+            }
         }
         _ => unreachable!("clap enforces exactly one of name or file"),
     };

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceWithCredentialsRequest, DeleteSourceRequest,
-    DiscoverSourcesRequest, GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse,
-    ListSourcesRequest, OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure,
-    QueryTestSuccess, Source, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
-    ValidateSourceRequest,
-    ValidateSourceResponse, import_source_response, query_test_result,
-    source_input_spec::Input as ProtoSourceInput,
+    CreateBundledSourceRequest, CreateBundledSourceWithCredentialsRequest,
+    CreateBundledSourceWithCredentialsResponse, DeleteSourceRequest, DiscoverSourcesRequest,
+    GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
+    OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
+    SourceInfo, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
+    ValidateSourceResponse, create_bundled_source_with_credentials_response,
+    import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::{
@@ -164,7 +164,7 @@ pub(crate) async fn add_bundled_source_with_credentials(
             },
         ))
         .await?;
-    source_from_credential_stream(response.into_inner(), &inputs.oauth_labels).await
+    source_from_bundled_credential_stream(response.into_inner(), &inputs.oauth_labels).await
 }
 
 pub(crate) async fn import_source_with_credentials(
@@ -185,10 +185,29 @@ pub(crate) async fn import_source_with_credentials(
             oauth_credential_retrievals: inputs.oauth_credential_retrievals,
         }))
         .await?;
-    source_from_credential_stream(response.into_inner(), &inputs.oauth_labels).await
+    source_from_import_credential_stream(response.into_inner(), &inputs.oauth_labels).await
 }
 
-async fn source_from_credential_stream(
+async fn source_from_bundled_credential_stream(
+    mut stream: tonic::Streaming<CreateBundledSourceWithCredentialsResponse>,
+    oauth_labels: &BTreeMap<String, String>,
+) -> Result<Source, anyhow::Error> {
+    while let Some(response) = stream
+        .message()
+        .await
+        .map_err(|error| oauth_error("retrieve", &error))?
+    {
+        let event = response.event.map(CredentialStreamEvent::from);
+        if let Some(source) = handle_credential_stream_event(event, oauth_labels) {
+            return Ok(source);
+        }
+    }
+    Err(anyhow::anyhow!(
+        "source credential retrieval stream ended before source installation completed"
+    ))
+}
+
+async fn source_from_import_credential_stream(
     mut stream: tonic::Streaming<ImportSourceResponse>,
     oauth_labels: &BTreeMap<String, String>,
 ) -> Result<Source, anyhow::Error> {
@@ -197,26 +216,81 @@ async fn source_from_credential_stream(
         .await
         .map_err(|error| oauth_error("retrieve", &error))?
     {
-        match response.event {
-            Some(import_source_response::Event::OauthAuthorization(authorization)) => {
-                let label = oauth_labels
-                    .get(&authorization.input_key)
-                    .map_or(authorization.input_key.as_str(), String::as_str);
-                println!("Open this URL to connect {label}:");
-                println!("{}", authorization.authorization_url);
-                if let Err(err) = crate::browser::open_url(&authorization.authorization_url) {
-                    println!("{}", style(format!("Could not open browser: {err}")).dim());
-                }
-            }
-            Some(import_source_response::Event::Source(source)) => {
-                return Ok(source);
-            }
-            Some(import_source_response::Event::OauthCompleted(_)) | None => {}
+        let event = response.event.map(CredentialStreamEvent::from);
+        if let Some(source) = handle_credential_stream_event(event, oauth_labels) {
+            return Ok(source);
         }
     }
     Err(anyhow::anyhow!(
         "source credential retrieval stream ended before source import completed"
     ))
+}
+
+enum CredentialStreamEvent {
+    Source(Source),
+    OAuthAuthorization {
+        input_key: String,
+        authorization_url: String,
+    },
+    OAuthCompleted,
+}
+
+impl From<create_bundled_source_with_credentials_response::Event> for CredentialStreamEvent {
+    fn from(event: create_bundled_source_with_credentials_response::Event) -> Self {
+        match event {
+            create_bundled_source_with_credentials_response::Event::Source(source) => {
+                Self::Source(source)
+            }
+            create_bundled_source_with_credentials_response::Event::OauthAuthorization(
+                authorization,
+            ) => Self::OAuthAuthorization {
+                input_key: authorization.input_key,
+                authorization_url: authorization.authorization_url,
+            },
+            create_bundled_source_with_credentials_response::Event::OauthCompleted(_) => {
+                Self::OAuthCompleted
+            }
+        }
+    }
+}
+
+impl From<import_source_response::Event> for CredentialStreamEvent {
+    fn from(event: import_source_response::Event) -> Self {
+        match event {
+            import_source_response::Event::Source(source) => Self::Source(source),
+            import_source_response::Event::OauthAuthorization(authorization) => {
+                Self::OAuthAuthorization {
+                    input_key: authorization.input_key,
+                    authorization_url: authorization.authorization_url,
+                }
+            }
+            import_source_response::Event::OauthCompleted(_) => Self::OAuthCompleted,
+        }
+    }
+}
+
+fn handle_credential_stream_event(
+    event: Option<CredentialStreamEvent>,
+    oauth_labels: &BTreeMap<String, String>,
+) -> Option<Source> {
+    match event {
+        Some(CredentialStreamEvent::OAuthAuthorization {
+            input_key,
+            authorization_url,
+        }) => {
+            let label = oauth_labels
+                .get(&input_key)
+                .map_or(input_key.as_str(), String::as_str);
+            println!("Open this URL to connect {label}:");
+            println!("{authorization_url}");
+            if let Err(err) = crate::browser::open_url(&authorization_url) {
+                println!("{}", style(format!("Could not open browser: {err}")).dim());
+            }
+            None
+        }
+        Some(CredentialStreamEvent::Source(source)) => Some(source),
+        Some(CredentialStreamEvent::OAuthCompleted) | None => None,
+    }
 }
 
 pub(crate) async fn validate_source(

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -4,18 +4,22 @@ use std::path::Path;
 
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, GetSourceInfoRequest,
-    ImportSourceRequest, ListSourcesRequest, QueryTestFailure, QueryTestSuccess, Source,
-    SourceInfo, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
+    CreateBundledSourceRequest, CreateBundledSourceWithCredentialsRequest, DeleteSourceRequest,
+    DiscoverSourcesRequest, GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse,
+    ListSourcesRequest, OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure,
+    QueryTestSuccess, Source, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
+    ValidateSourceRequest,
     ValidateSourceResponse, import_source_response, query_test_result,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::{
-    ManifestInputKind, ManifestInputSpec, ValidatedSourceManifest, parse_source_manifest_yaml,
+    ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
+    ManifestInputKind, ManifestInputSpec, ManifestOAuthCredentialSpec, ValidatedSourceManifest,
+    parse_source_manifest_yaml,
 };
 use dialoguer::console::style;
-use dialoguer::{Input, Password, theme::ColorfulTheme};
+use dialoguer::{Input, Password, Select, theme::ColorfulTheme};
 use tonic::Request;
 
 const MAX_TABLES_PER_SCHEMA: usize = 9;
@@ -120,6 +124,97 @@ pub(crate) async fn import_source(
         }
     }
     Err(anyhow::anyhow!("import source stream ended without source"))
+}
+
+pub(crate) struct CollectedSourceInputs {
+    pub(crate) variables: Vec<SourceVariable>,
+    pub(crate) secrets: Vec<SourceSecret>,
+    oauth_credential_retrievals: Vec<OAuthCredentialRetrieval>,
+    oauth_labels: BTreeMap<String, String>,
+}
+
+impl CollectedSourceInputs {
+    fn new() -> Self {
+        Self {
+            variables: Vec::new(),
+            secrets: Vec::new(),
+            oauth_credential_retrievals: Vec::new(),
+            oauth_labels: BTreeMap::new(),
+        }
+    }
+}
+
+pub(crate) async fn add_bundled_source_with_credentials(
+    app: &AppClient,
+    name: &str,
+    inputs: CollectedSourceInputs,
+) -> Result<Source, anyhow::Error> {
+    if inputs.oauth_credential_retrievals.is_empty() {
+        return add_bundled_source(app, name, inputs.variables, inputs.secrets).await;
+    }
+    let response = app
+        .source_client()
+        .create_bundled_source_with_credentials(Request::new(
+            CreateBundledSourceWithCredentialsRequest {
+                workspace: Some(default_workspace()),
+                name: name.to_string(),
+                variables: inputs.variables,
+                secrets: inputs.secrets,
+                oauth_credential_retrievals: inputs.oauth_credential_retrievals,
+            },
+        ))
+        .await?;
+    source_from_credential_stream(response.into_inner(), &inputs.oauth_labels).await
+}
+
+pub(crate) async fn import_source_with_credentials(
+    app: &AppClient,
+    manifest_yaml: String,
+    inputs: CollectedSourceInputs,
+) -> Result<Source, anyhow::Error> {
+    if inputs.oauth_credential_retrievals.is_empty() {
+        return import_source(app, manifest_yaml, inputs.variables, inputs.secrets).await;
+    }
+    let response = app
+        .source_client()
+        .import_source(Request::new(ImportSourceRequest {
+            workspace: Some(default_workspace()),
+            manifest_yaml,
+            variables: inputs.variables,
+            secrets: inputs.secrets,
+            oauth_credential_retrievals: inputs.oauth_credential_retrievals,
+        }))
+        .await?;
+    source_from_credential_stream(response.into_inner(), &inputs.oauth_labels).await
+}
+
+async fn source_from_credential_stream(
+    mut stream: tonic::Streaming<ImportSourceResponse>,
+    oauth_labels: &BTreeMap<String, String>,
+) -> Result<Source, anyhow::Error> {
+    while let Some(response) = stream
+        .message()
+        .await
+        .map_err(|error| oauth_error("retrieve", &error))?
+    {
+        match response.event {
+            Some(import_source_response::Event::OauthAuthorization(authorization)) => {
+                let label = oauth_labels
+                    .get(&authorization.input_key)
+                    .map_or(authorization.input_key.as_str(), String::as_str);
+                println!("Open this URL to connect {label}:");
+                println!("{}", authorization.authorization_url);
+                open_url(&authorization.authorization_url);
+            }
+            Some(import_source_response::Event::Source(source)) => {
+                return Ok(source);
+            }
+            Some(import_source_response::Event::OauthCompleted(_)) | None => {}
+        }
+    }
+    Err(anyhow::anyhow!(
+        "source credential retrieval stream ended before source import completed"
+    ))
 }
 
 pub(crate) async fn validate_source(
@@ -277,6 +372,50 @@ pub(crate) fn prompt_for_inputs(
     }
 
     Ok((variables, secrets))
+}
+
+pub(crate) fn prompt_for_inputs_with_credential_methods(
+    inputs: &[ManifestInputSpec],
+) -> Result<CollectedSourceInputs, anyhow::Error> {
+    let mut collected = CollectedSourceInputs::new();
+
+    for input in inputs {
+        let env_value = read_source_input_env(&input.key).unwrap_or_default();
+        if !env_value.is_empty() {
+            match input.kind {
+                ManifestInputKind::Variable => collected.variables.push(SourceVariable {
+                    key: input.key.clone(),
+                    value: env_value,
+                }),
+                ManifestInputKind::Secret => collected.secrets.push(SourceSecret {
+                    key: input.key.clone(),
+                    value: env_value,
+                }),
+            }
+            continue;
+        }
+
+        match input.kind {
+            ManifestInputKind::Variable => {
+                if let Some(variable) = prompt_variable(input)? {
+                    collected.variables.push(variable);
+                }
+            }
+            ManifestInputKind::Secret => match prompt_secret_with_methods(input)? {
+                SecretInputOutcome::SourceConfig(secret) => {
+                    if let Some(secret) = secret {
+                        collected.secrets.push(secret);
+                    }
+                }
+                SecretInputOutcome::OAuth { credential, label } => {
+                    collected.oauth_labels.insert(input.key.clone(), label);
+                    collected.oauth_credential_retrievals.push(credential);
+                }
+            },
+        }
+    }
+
+    Ok(collected)
 }
 
 pub(crate) fn collect_inputs_from_env(
@@ -650,6 +789,166 @@ fn prompt_secret(input: &ManifestInputSpec) -> Result<Option<SourceSecret>, anyh
         key: input.key.clone(),
         value,
     }))
+}
+
+enum SecretInputOutcome {
+    SourceConfig(Option<SourceSecret>),
+    OAuth {
+        credential: OAuthCredentialRetrieval,
+        label: String,
+    },
+}
+
+fn prompt_secret_with_methods(
+    input: &ManifestInputSpec,
+) -> Result<SecretInputOutcome, anyhow::Error> {
+    let Some(credential) = input.credential.as_ref() else {
+        return Ok(SecretInputOutcome::SourceConfig(prompt_secret(input)?));
+    };
+    let selected = select_credential_method(input, credential)?;
+    let method = credential
+        .methods
+        .get(selected)
+        .ok_or_else(|| anyhow::anyhow!("credential method index {selected} is out of range"))?;
+    match method.kind {
+        ManifestCredentialMethodKind::SourceConfig => {
+            Ok(SecretInputOutcome::SourceConfig(prompt_secret(input)?))
+        }
+        ManifestCredentialMethodKind::OAuth => Ok(SecretInputOutcome::OAuth {
+            credential: collect_oauth_credential_method(input, selected, method)?,
+            label: credential_method_label(method),
+        }),
+    }
+}
+
+fn select_credential_method(
+    input: &ManifestInputSpec,
+    credential: &ManifestCredentialSpec,
+) -> Result<usize, anyhow::Error> {
+    if credential.methods.len() == 1 {
+        return Ok(0);
+    }
+    let theme = ColorfulTheme::default();
+    let items = credential
+        .methods
+        .iter()
+        .map(credential_method_label)
+        .collect::<Vec<_>>();
+    let selected = Select::with_theme(&theme)
+        .with_prompt(format!("{} credential", input.key))
+        .items(&items)
+        .default(0)
+        .interact()?;
+    Ok(selected)
+}
+
+fn credential_method_label(method: &ManifestCredentialMethod) -> String {
+    method.label.clone().unwrap_or_else(|| match method.kind {
+        ManifestCredentialMethodKind::SourceConfig => "Paste token".to_string(),
+        ManifestCredentialMethodKind::OAuth => "Connect with OAuth".to_string(),
+    })
+}
+
+fn collect_oauth_credential_method(
+    input: &ManifestInputSpec,
+    method_index: usize,
+    method: &ManifestCredentialMethod,
+) -> Result<OAuthCredentialRetrieval, anyhow::Error> {
+    let oauth = method
+        .oauth
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("oauth credential method is missing OAuth config"))?;
+    Ok(OAuthCredentialRetrieval {
+        input_key: input.key.clone(),
+        method_index: Some(u32::try_from(method_index)?),
+        credential_inputs: prompt_oauth_credential_inputs(oauth)?,
+    })
+}
+
+fn oauth_error(action: &str, error: &tonic::Status) -> anyhow::Error {
+    anyhow::anyhow!(
+        "OAuth credential retrieval failed during {action}: {error}. Rerun `coral source add` to try again."
+    )
+}
+
+fn prompt_oauth_credential_inputs(
+    oauth: &ManifestOAuthCredentialSpec,
+) -> Result<Vec<OAuthCredentialInput>, anyhow::Error> {
+    let mut values = Vec::new();
+    if let Some(input_key) = oauth.client.id.input.as_deref()
+        && let Some(value) = prompt_oauth_client_id(input_key, oauth.client.id.default.as_deref())?
+    {
+        values.push(OAuthCredentialInput {
+            key: input_key.to_string(),
+            value,
+        });
+    }
+    if let Some(secret) = oauth.client.secret.as_ref() {
+        let value = prompt_oauth_client_secret(&secret.input)?;
+        values.push(OAuthCredentialInput {
+            key: secret.input.clone(),
+            value,
+        });
+    }
+    Ok(values)
+}
+
+fn prompt_oauth_client_id(
+    input_key: &str,
+    default: Option<&str>,
+) -> Result<Option<String>, anyhow::Error> {
+    let theme = ColorfulTheme::default();
+    let prompt = if default.is_some_and(|value| !value.is_empty()) {
+        format!("{input_key} [source default]")
+    } else {
+        input_key.to_string()
+    };
+    let value = Input::<String>::with_theme(&theme)
+        .with_prompt(prompt)
+        .allow_empty(true)
+        .interact_text()?;
+    if !value.is_empty() {
+        return Ok(Some(value));
+    }
+    if default.is_some_and(|value| !value.is_empty()) {
+        return Ok(None);
+    }
+    Err(anyhow::anyhow!(
+        "missing required OAuth client ID '{input_key}'"
+    ))
+}
+
+fn prompt_oauth_client_secret(input_key: &str) -> Result<String, anyhow::Error> {
+    let theme = ColorfulTheme::default();
+    let value = Password::with_theme(&theme)
+        .with_prompt(input_key)
+        .allow_empty_password(false)
+        .interact()?;
+    if value.is_empty() {
+        return Err(anyhow::anyhow!(
+            "missing required OAuth client secret '{input_key}'"
+        ));
+    }
+    Ok(value)
+}
+
+fn open_url(url: &str) {
+    let result = if cfg!(target_os = "macos") {
+        std::process::Command::new("open").arg(url).status()
+    } else if cfg!(target_os = "linux") {
+        std::process::Command::new("xdg-open").arg(url).status()
+    } else if cfg!(target_os = "windows") {
+        std::process::Command::new("cmd")
+            .args(["/c", "start", url])
+            .status()
+    } else {
+        return;
+    };
+    match result {
+        Ok(status) if status.success() => {}
+        Ok(status) => println!("{}", style(format!("Browser exited with {status}")).dim()),
+        Err(err) => println!("{}", style(format!("Could not open browser: {err}")).dim()),
+    }
 }
 
 fn print_input_hint(input: &ManifestInputSpec) {

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -4,13 +4,13 @@ use std::path::Path;
 
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceWithCredentialsRequest,
-    CreateBundledSourceWithCredentialsResponse, DeleteSourceRequest, DiscoverSourcesRequest,
+    CreateBundledSourceRequest, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DiscoverSourcesRequest,
     GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
     OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
     SourceInfo, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
-    ValidateSourceResponse, create_bundled_source_with_credentials_response,
-    import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
+    ValidateSourceResponse, create_bundled_source_with_o_auth_response, import_source_response,
+    query_test_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::{
@@ -154,15 +154,13 @@ pub(crate) async fn add_bundled_source_with_credentials(
     }
     let response = app
         .source_client()
-        .create_bundled_source_with_credentials(Request::new(
-            CreateBundledSourceWithCredentialsRequest {
-                workspace: Some(default_workspace()),
-                name: name.to_string(),
-                variables: inputs.variables,
-                secrets: inputs.secrets,
-                oauth_credential_retrievals: inputs.oauth_credential_retrievals,
-            },
-        ))
+        .create_bundled_source_with_o_auth(Request::new(CreateBundledSourceWithOAuthRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+            variables: inputs.variables,
+            secrets: inputs.secrets,
+            oauth_credential_retrievals: inputs.oauth_credential_retrievals,
+        }))
         .await?;
     source_from_bundled_credential_stream(response.into_inner(), &inputs.oauth_labels).await
 }
@@ -189,7 +187,7 @@ pub(crate) async fn import_source_with_credentials(
 }
 
 async fn source_from_bundled_credential_stream(
-    mut stream: tonic::Streaming<CreateBundledSourceWithCredentialsResponse>,
+    mut stream: tonic::Streaming<CreateBundledSourceWithOAuthResponse>,
     oauth_labels: &BTreeMap<String, String>,
 ) -> Result<Source, anyhow::Error> {
     while let Some(response) = stream
@@ -235,19 +233,19 @@ enum CredentialStreamEvent {
     OAuthCompleted,
 }
 
-impl From<create_bundled_source_with_credentials_response::Event> for CredentialStreamEvent {
-    fn from(event: create_bundled_source_with_credentials_response::Event) -> Self {
+impl From<create_bundled_source_with_o_auth_response::Event> for CredentialStreamEvent {
+    fn from(event: create_bundled_source_with_o_auth_response::Event) -> Self {
         match event {
-            create_bundled_source_with_credentials_response::Event::Source(source) => {
+            create_bundled_source_with_o_auth_response::Event::Source(source) => {
                 Self::Source(source)
             }
-            create_bundled_source_with_credentials_response::Event::OauthAuthorization(
+            create_bundled_source_with_o_auth_response::Event::OauthAuthorization(
                 authorization,
             ) => Self::OAuthAuthorization {
                 input_key: authorization.input_key,
                 authorization_url: authorization.authorization_url,
             },
-            create_bundled_source_with_credentials_response::Event::OauthCompleted(_) => {
+            create_bundled_source_with_o_auth_response::Event::OauthCompleted(_) => {
                 Self::OAuthCompleted
             }
         }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -204,7 +204,9 @@ async fn source_from_credential_stream(
                     .map_or(authorization.input_key.as_str(), String::as_str);
                 println!("Open this URL to connect {label}:");
                 println!("{}", authorization.authorization_url);
-                open_url(&authorization.authorization_url);
+                if let Err(err) = crate::browser::open_url(&authorization.authorization_url) {
+                    println!("{}", style(format!("Could not open browser: {err}")).dim());
+                }
             }
             Some(import_source_response::Event::Source(source)) => {
                 return Ok(source);
@@ -930,25 +932,6 @@ fn prompt_oauth_client_secret(input_key: &str) -> Result<String, anyhow::Error> 
         ));
     }
     Ok(value)
-}
-
-fn open_url(url: &str) {
-    let result = if cfg!(target_os = "macos") {
-        std::process::Command::new("open").arg(url).status()
-    } else if cfg!(target_os = "linux") {
-        std::process::Command::new("xdg-open").arg(url).status()
-    } else if cfg!(target_os = "windows") {
-        std::process::Command::new("cmd")
-            .args(["/c", "start", url])
-            .status()
-    } else {
-        return;
-    };
-    match result {
-        Ok(status) if status.success() => {}
-        Ok(status) => println!("{}", style(format!("Browser exited with {status}")).dim()),
-        Err(err) => println!("{}", style(format!("Could not open browser: {err}")).dim()),
-    }
 }
 
 fn print_input_hint(input: &ManifestInputSpec) {

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -17,16 +17,16 @@ use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
     CatalogItem, CatalogSearchResult, Column, ColumnSearchResult, CreateBundledSourceRequest,
-    CreateBundledSourceResponse, DeleteSourceRequest, DeleteSourceResponse, DescribeTableRequest,
-    DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest,
-    ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest,
-    GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
-    ImportSourceResponse, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
-    ListColumnsResponse, ListSourcesRequest, ListSourcesResponse, PaginationRequest,
-    PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse, Source, SourceInfo,
-    SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace, catalog_item, import_source_response,
-    source_input_spec::Input as ProtoSourceInput,
+    CreateBundledSourceResponse, CreateBundledSourceWithCredentialsRequest, DeleteSourceRequest,
+    DeleteSourceResponse, DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest,
+    DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest,
+    ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
+    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
+    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListSourcesRequest,
+    ListSourcesResponse, PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest,
+    SearchCatalogResponse, Source, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
+    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    import_source_response, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
 use tokio::net::TcpListener;
@@ -555,6 +555,7 @@ struct Captured {
     get_source: Mutex<Vec<GetSourceRequest>>,
     get_source_info: Mutex<Vec<GetSourceInfoRequest>>,
     create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
+    create_bundled_source_with_credentials: Mutex<Vec<CreateBundledSourceWithCredentialsRequest>>,
     import_source: Mutex<Vec<ImportSourceRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
@@ -786,8 +787,20 @@ struct MockSourceService {
     captured: Arc<Captured>,
 }
 
+fn mock_source_stream() -> Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>
+{
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<ImportSourceResponse, Status>>(1);
+    tx.try_send(Ok(ImportSourceResponse {
+        event: Some(import_source_response::Event::Source(mock_source())),
+    }))
+    .expect("send mock import event");
+    Box::pin(ReceiverStream::new(rx))
+}
+
 #[tonic::async_trait]
 impl SourceService for MockSourceService {
+    type CreateBundledSourceWithCredentialsStream =
+        Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
     type ImportSourceStream =
         Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 
@@ -862,6 +875,18 @@ impl SourceService for MockSourceService {
         }))
     }
 
+    async fn create_bundled_source_with_credentials(
+        &self,
+        request: Request<CreateBundledSourceWithCredentialsRequest>,
+    ) -> Result<Response<Self::CreateBundledSourceWithCredentialsStream>, Status> {
+        self.captured
+            .create_bundled_source_with_credentials
+            .lock()
+            .expect("create_bundled_source_with_credentials capture")
+            .push(request.into_inner());
+        Ok(Response::new(mock_source_stream()))
+    }
+
     async fn import_source(
         &self,
         request: Request<ImportSourceRequest>,
@@ -871,13 +896,7 @@ impl SourceService for MockSourceService {
             .lock()
             .expect("import_source capture")
             .push(request.into_inner());
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<ImportSourceResponse, Status>>(1);
-        tx.send(Ok(ImportSourceResponse {
-            event: Some(import_source_response::Event::Source(mock_source())),
-        }))
-        .await
-        .expect("send import source response");
-        Ok(Response::new(Box::pin(ReceiverStream::new(rx))))
+        Ok(Response::new(mock_source_stream()))
     }
 
     async fn delete_source(

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -17,16 +17,18 @@ use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
     CatalogItem, CatalogSearchResult, Column, ColumnSearchResult, CreateBundledSourceRequest,
-    CreateBundledSourceResponse, CreateBundledSourceWithCredentialsRequest, DeleteSourceRequest,
-    DeleteSourceResponse, DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest,
-    DiscoverSourcesResponse, ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest,
-    ExplainSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
-    GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListCatalogRequest,
-    ListCatalogResponse, ListColumnsRequest, ListColumnsResponse, ListSourcesRequest,
-    ListSourcesResponse, PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest,
-    SearchCatalogResponse, Source, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
-    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
-    import_source_response, source_input_spec::Input as ProtoSourceInput,
+    CreateBundledSourceResponse, CreateBundledSourceWithCredentialsRequest,
+    CreateBundledSourceWithCredentialsResponse, DeleteSourceRequest, DeleteSourceResponse,
+    DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
+    ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
+    GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
+    ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
+    ListColumnsRequest, ListColumnsResponse, ListSourcesRequest, ListSourcesResponse,
+    PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
+    Source, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
+    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    create_bundled_source_with_credentials_response, import_source_response,
+    source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
 use tokio::net::TcpListener;
@@ -787,22 +789,34 @@ struct MockSourceService {
     captured: Arc<Captured>,
 }
 
-fn mock_source_stream() -> Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>
-{
+type MockBundledSourceStream =
+    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithCredentialsResponse, Status>> + Send>>;
+type MockImportSourceStream =
+    Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
+
+fn mock_bundled_source_stream() -> MockBundledSourceStream {
+    let (tx, rx) =
+        tokio::sync::mpsc::channel::<Result<CreateBundledSourceWithCredentialsResponse, Status>>(1);
+    tx.try_send(Ok(CreateBundledSourceWithCredentialsResponse {
+        event: Some(create_bundled_source_with_credentials_response::Event::Source(mock_source())),
+    }))
+    .expect("send mock bundled source credential event");
+    Box::pin(ReceiverStream::new(rx))
+}
+
+fn mock_import_source_stream() -> MockImportSourceStream {
     let (tx, rx) = tokio::sync::mpsc::channel::<Result<ImportSourceResponse, Status>>(1);
     tx.try_send(Ok(ImportSourceResponse {
         event: Some(import_source_response::Event::Source(mock_source())),
     }))
-    .expect("send mock import event");
+    .expect("send mock import source credential event");
     Box::pin(ReceiverStream::new(rx))
 }
 
 #[tonic::async_trait]
 impl SourceService for MockSourceService {
-    type CreateBundledSourceWithCredentialsStream =
-        Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
-    type ImportSourceStream =
-        Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
+    type CreateBundledSourceWithCredentialsStream = MockBundledSourceStream;
+    type ImportSourceStream = MockImportSourceStream;
 
     async fn discover_sources(
         &self,
@@ -884,7 +898,7 @@ impl SourceService for MockSourceService {
             .lock()
             .expect("create_bundled_source_with_credentials capture")
             .push(request.into_inner());
-        Ok(Response::new(mock_source_stream()))
+        Ok(Response::new(mock_bundled_source_stream()))
     }
 
     async fn import_source(
@@ -896,7 +910,7 @@ impl SourceService for MockSourceService {
             .lock()
             .expect("import_source capture")
             .push(request.into_inner());
-        Ok(Response::new(mock_source_stream()))
+        Ok(Response::new(mock_import_source_stream()))
     }
 
     async fn delete_source(

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -17,8 +17,8 @@ use coral_api::v1::query_service_server::{QueryService, QueryServiceServer};
 use coral_api::v1::source_service_server::{SourceService, SourceServiceServer};
 use coral_api::v1::{
     CatalogItem, CatalogSearchResult, Column, ColumnSearchResult, CreateBundledSourceRequest,
-    CreateBundledSourceResponse, CreateBundledSourceWithCredentialsRequest,
-    CreateBundledSourceWithCredentialsResponse, DeleteSourceRequest, DeleteSourceResponse,
+    CreateBundledSourceResponse, CreateBundledSourceWithOAuthRequest,
+    CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DeleteSourceResponse,
     DescribeTableRequest, DescribeTableResponse, DiscoverSourcesRequest, DiscoverSourcesResponse,
     ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
     GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest, GetSourceResponse,
@@ -27,7 +27,7 @@ use coral_api::v1::{
     PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
     Source, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
     ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
-    create_bundled_source_with_credentials_response, import_source_response,
+    create_bundled_source_with_o_auth_response, import_source_response,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
@@ -557,7 +557,7 @@ struct Captured {
     get_source: Mutex<Vec<GetSourceRequest>>,
     get_source_info: Mutex<Vec<GetSourceInfoRequest>>,
     create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
-    create_bundled_source_with_credentials: Mutex<Vec<CreateBundledSourceWithCredentialsRequest>>,
+    create_bundled_source_with_oauth: Mutex<Vec<CreateBundledSourceWithOAuthRequest>>,
     import_source: Mutex<Vec<ImportSourceRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
@@ -790,15 +790,17 @@ struct MockSourceService {
 }
 
 type MockBundledSourceStream =
-    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithCredentialsResponse, Status>> + Send>>;
+    Pin<Box<dyn Stream<Item = Result<CreateBundledSourceWithOAuthResponse, Status>> + Send>>;
 type MockImportSourceStream =
     Pin<Box<dyn Stream<Item = Result<ImportSourceResponse, Status>> + Send>>;
 
 fn mock_bundled_source_stream() -> MockBundledSourceStream {
     let (tx, rx) =
-        tokio::sync::mpsc::channel::<Result<CreateBundledSourceWithCredentialsResponse, Status>>(1);
-    tx.try_send(Ok(CreateBundledSourceWithCredentialsResponse {
-        event: Some(create_bundled_source_with_credentials_response::Event::Source(mock_source())),
+        tokio::sync::mpsc::channel::<Result<CreateBundledSourceWithOAuthResponse, Status>>(1);
+    tx.try_send(Ok(CreateBundledSourceWithOAuthResponse {
+        event: Some(create_bundled_source_with_o_auth_response::Event::Source(
+            mock_source(),
+        )),
     }))
     .expect("send mock bundled source credential event");
     Box::pin(ReceiverStream::new(rx))
@@ -815,7 +817,7 @@ fn mock_import_source_stream() -> MockImportSourceStream {
 
 #[tonic::async_trait]
 impl SourceService for MockSourceService {
-    type CreateBundledSourceWithCredentialsStream = MockBundledSourceStream;
+    type CreateBundledSourceWithOAuthStream = MockBundledSourceStream;
     type ImportSourceStream = MockImportSourceStream;
 
     async fn discover_sources(
@@ -889,14 +891,14 @@ impl SourceService for MockSourceService {
         }))
     }
 
-    async fn create_bundled_source_with_credentials(
+    async fn create_bundled_source_with_o_auth(
         &self,
-        request: Request<CreateBundledSourceWithCredentialsRequest>,
-    ) -> Result<Response<Self::CreateBundledSourceWithCredentialsStream>, Status> {
+        request: Request<CreateBundledSourceWithOAuthRequest>,
+    ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         self.captured
-            .create_bundled_source_with_credentials
+            .create_bundled_source_with_oauth
             .lock()
-            .expect("create_bundled_source_with_credentials capture")
+            .expect("create_bundled_source_with_oauth capture")
             .push(request.into_inner());
         Ok(Response::new(mock_bundled_source_stream()))
     }

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -65,7 +65,14 @@ By default, Coral reads each declared input from an environment variable of the 
 GITHUB_TOKEN=ghp_... coral source add github
 ```
 
-Pass `--interactive` to be prompted for variables and secrets instead:
+Pass `--interactive` to be prompted for variables and secrets instead. If a
+missing secret declares credential methods, Coral shows those choices in the
+source spec's authored order. `source_config` methods use the normal source
+input path and prompt for the secret value here; OAuth methods open or print an
+authorization URL, wait for the loopback callback, and store the
+resulting secret without printing token material.
+Environment variables still win, so a secret value already present in the
+environment bypasses the retrieval choice.
 
 ```shellscript
 coral source add --interactive github


### PR DESCRIPTION
## Summary
- let interactive source install choose among authored credential methods
- prompt for OAuth client inputs when required
- start and complete OAuth credential retrieval through the app RPCs
- update CLI docs for environment-variable precedence and OAuth retrieval

## Scope
Builds on the backend OAuth flow. This PR is the user-facing CLI collection layer.

## Verification
- make rust-checks
- make docs-check
