### PR TITLE
feat(spec): support random OAuth redirect ports

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -120,7 +120,7 @@ message OAuthAuthorizationCodeCredentialMethod {
   // PKCE mode.
   OauthCredentialPkceMode pkce = 5;
   // Loopback callback port binding mode.
-  OauthCredentialRedirectUriPortMode redirect_uri_port = 6;
+  OauthCredentialRedirectUriPortMode redirect_uri_port_mode = 6;
 }
 
 // Supported OAuth PKCE modes.

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -119,6 +119,8 @@ message OAuthAuthorizationCodeCredentialMethod {
   OAuthCredentialScopes scopes = 4;
   // PKCE mode.
   OauthCredentialPkceMode pkce = 5;
+  // Loopback callback port binding mode.
+  OauthCredentialRedirectUriPortMode redirect_uri_port = 6;
 }
 
 // Supported OAuth PKCE modes.
@@ -130,6 +132,16 @@ enum OauthCredentialPkceMode {
   OAUTH_CREDENTIAL_PKCE_MODE_REQUIRED = 1;
   // PKCE is not used for the OAuth flow.
   OAUTH_CREDENTIAL_PKCE_MODE_DISABLED = 2;
+}
+
+// Supported loopback redirect URI port binding modes.
+enum OauthCredentialRedirectUriPortMode {
+  // Port mode is unspecified.
+  OAUTH_CREDENTIAL_REDIRECT_URI_PORT_MODE_UNSPECIFIED = 0;
+  // Bind the exact port authored in redirect_uri.
+  OAUTH_CREDENTIAL_REDIRECT_URI_PORT_MODE_FIXED = 1;
+  // Bind a random free port and use it for authorization and token exchange.
+  OAUTH_CREDENTIAL_REDIRECT_URI_PORT_MODE_RANDOM = 2;
 }
 
 // OAuth provider endpoints.

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -60,8 +60,10 @@ struct OAuthSessionConfig {
     client_secret: Option<String>,
     state: String,
     code_verifier: Option<String>,
-    redirect_uri: Url,
-    redirect_uri_parameter: String,
+    // Request path accepted by the local callback listener.
+    callback_path: String,
+    // Exact redirect_uri value sent to the provider for authorization and token exchange.
+    provider_redirect_uri: String,
     listener: TcpListener,
     expires_at: Instant,
 }
@@ -112,13 +114,13 @@ impl OAuthCredentialManager {
         reject_unknown_credential_inputs(&oauth, &credential_inputs)?;
         let client_id = resolve_client_id(&oauth, &credential_inputs)?;
         let client_secret = resolve_client_secret(&oauth, &credential_inputs)?;
-        let (listener, redirect_uri, redirect_uri_parameter) =
+        let (listener, callback_path, provider_redirect_uri) =
             bind_redirect_listener(&oauth).await?;
         let state = random_token();
         let code_verifier = pkce_code_verifier(&oauth);
         let authorization_url = build_authorization_url(
             &oauth,
-            &redirect_uri_parameter,
+            &provider_redirect_uri,
             &client_id,
             &state,
             code_verifier.as_deref(),
@@ -131,8 +133,8 @@ impl OAuthCredentialManager {
             client_secret,
             state,
             code_verifier,
-            redirect_uri,
-            redirect_uri_parameter,
+            callback_path,
+            provider_redirect_uri,
             listener,
             expires_at,
         };
@@ -289,7 +291,7 @@ fn resolve_client_secret(
 
 async fn bind_redirect_listener(
     oauth: &ManifestOAuthCredentialSpec,
-) -> Result<(TcpListener, Url, String), AppError> {
+) -> Result<(TcpListener, String, String), AppError> {
     let redirect_uri = Url::parse(&oauth.redirect_uri)
         .map_err(|error| AppError::InvalidInput(format!("invalid OAuth redirect URI: {error}")))?;
     let host = redirect_uri
@@ -300,7 +302,7 @@ async fn bind_redirect_listener(
             "OAuth redirect URI must use a loopback host".to_string(),
         ));
     }
-    let port = match oauth.redirect_uri_port {
+    let port = match oauth.redirect_uri_port_mode {
         ManifestOAuthRedirectUriPortMode::Fixed => {
             let port = redirect_uri.port().ok_or_else(|| {
                 AppError::InvalidInput("OAuth redirect URI is missing explicit port".to_string())
@@ -312,7 +314,10 @@ async fn bind_redirect_listener(
             }
             port
         }
-        ManifestOAuthRedirectUriPortMode::Random => 0,
+        ManifestOAuthRedirectUriPortMode::Random => {
+            // Binding port 0 asks the OS to assign a free loopback port.
+            0
+        }
     };
     let listener = TcpListener::bind((host, port)).await.map_err(|error| {
         let port_label = if port == 0 {
@@ -325,7 +330,7 @@ async fn bind_redirect_listener(
         ))
     })?;
     let mut effective_redirect_uri = redirect_uri;
-    if oauth.redirect_uri_port == ManifestOAuthRedirectUriPortMode::Random {
+    if oauth.redirect_uri_port_mode == ManifestOAuthRedirectUriPortMode::Random {
         let assigned_port = listener.local_addr()?.port();
         effective_redirect_uri
             .set_port(Some(assigned_port))
@@ -333,16 +338,17 @@ async fn bind_redirect_listener(
                 AppError::InvalidInput("OAuth redirect URI port is invalid".to_string())
             })?;
     }
-    let redirect_uri_parameter = match oauth.redirect_uri_port {
+    let provider_redirect_uri = match oauth.redirect_uri_port_mode {
         ManifestOAuthRedirectUriPortMode::Fixed => oauth.redirect_uri.clone(),
         ManifestOAuthRedirectUriPortMode::Random => effective_redirect_uri.to_string(),
     };
-    Ok((listener, effective_redirect_uri, redirect_uri_parameter))
+    let callback_path = effective_redirect_uri.path().to_string();
+    Ok((listener, callback_path, provider_redirect_uri))
 }
 
 fn build_authorization_url(
     oauth: &ManifestOAuthCredentialSpec,
-    redirect_uri: &str,
+    provider_redirect_uri: &str,
     client_id: &str,
     state: &str,
     code_verifier: Option<&str>,
@@ -355,7 +361,7 @@ fn build_authorization_url(
         query
             .append_pair("response_type", "code")
             .append_pair("client_id", client_id)
-            .append_pair("redirect_uri", redirect_uri)
+            .append_pair("redirect_uri", provider_redirect_uri)
             .append_pair("state", state);
         if let Some(scopes) = oauth.scopes.as_ref() {
             query.append_pair(
@@ -410,7 +416,7 @@ async fn receive_callback(session: &OAuthSessionConfig) -> Result<Callback, AppE
             accepted = session.listener.accept() => {
                 let (mut stream, _peer): (_, SocketAddr) = accepted?;
                 let result_tx = result_tx.clone();
-                let expected_path = session.redirect_uri.path().to_string();
+                let expected_path = session.callback_path.clone();
                 let expected_state = session.state.clone();
                 tokio::spawn(async move {
                     let result = handle_callback_connection(
@@ -618,7 +624,7 @@ async fn exchange_authorization_code(
     let mut form = vec![
         ("grant_type", "authorization_code".to_string()),
         ("code", code.to_string()),
-        ("redirect_uri", session.redirect_uri_parameter.clone()),
+        ("redirect_uri", session.provider_redirect_uri.clone()),
     ];
     let mut request = http
         .post(&session.oauth.token_url)
@@ -1065,9 +1071,8 @@ mod tests {
             client_secret: None,
             state: "expected-state".to_string(),
             code_verifier: None,
-            redirect_uri: Url::parse(&format!("http://127.0.0.1:{redirect_port}/oauth/callback"))
-                .expect("redirect uri"),
-            redirect_uri_parameter: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
+            callback_path: "/oauth/callback".to_string(),
+            provider_redirect_uri: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
             listener,
             expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
         };
@@ -1126,9 +1131,8 @@ mod tests {
             client_secret: None,
             state: "expected-state".to_string(),
             code_verifier: None,
-            redirect_uri: Url::parse(&format!("http://127.0.0.1:{redirect_port}/oauth/callback"))
-                .expect("redirect uri"),
-            redirect_uri_parameter: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
+            callback_path: "/oauth/callback".to_string(),
+            provider_redirect_uri: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
             listener,
             expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
         };
@@ -1360,7 +1364,7 @@ mod tests {
     fn oauth_spec_with_redirect_uri(
         token_url: &str,
         redirect_uri: &str,
-        redirect_uri_port: ManifestOAuthRedirectUriPortMode,
+        redirect_uri_port_mode: ManifestOAuthRedirectUriPortMode,
         pkce: ManifestOAuthPkceMode,
         client: ManifestOAuthClientSpec,
     ) -> ManifestOAuthCredentialSpec {
@@ -1370,7 +1374,7 @@ mod tests {
                 pkce,
             },
             redirect_uri: redirect_uri.to_string(),
-            redirect_uri_port,
+            redirect_uri_port_mode,
             authorization_url: "https://provider.example.com/oauth/authorize".to_string(),
             token_url: token_url.to_string(),
             client,

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -12,7 +12,7 @@ use base64::engine::general_purpose::{
 use chrono::{DateTime, Utc};
 use coral_spec::{
     ManifestOAuthClientSecretTransport, ManifestOAuthCredentialSpec, ManifestOAuthPkceMode,
-    ManifestOAuthScopeDelimiter,
+    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter,
 };
 use reqwest::header::{ACCEPT, AUTHORIZATION};
 use serde_json::Value;
@@ -61,6 +61,7 @@ struct OAuthSessionConfig {
     state: String,
     code_verifier: Option<String>,
     redirect_uri: Url,
+    redirect_uri_parameter: String,
     listener: TcpListener,
     expires_at: Instant,
 }
@@ -111,15 +112,17 @@ impl OAuthCredentialManager {
         reject_unknown_credential_inputs(&oauth, &credential_inputs)?;
         let client_id = resolve_client_id(&oauth, &credential_inputs)?;
         let client_secret = resolve_client_secret(&oauth, &credential_inputs)?;
-        let redirect_uri = Url::parse(&oauth.redirect_uri).map_err(|error| {
-            AppError::InvalidInput(format!("invalid OAuth redirect URI: {error}"))
-        })?;
-        let listener = bind_redirect_listener(&redirect_uri).await?;
+        let (listener, redirect_uri, redirect_uri_parameter) =
+            bind_redirect_listener(&oauth).await?;
         let state = random_token();
-        let code_verifier =
-            (oauth.flow.pkce == ManifestOAuthPkceMode::Required).then(random_code_verifier);
-        let authorization_url =
-            build_authorization_url(&oauth, &client_id, &state, code_verifier.as_deref())?;
+        let code_verifier = pkce_code_verifier(&oauth);
+        let authorization_url = build_authorization_url(
+            &oauth,
+            &redirect_uri_parameter,
+            &client_id,
+            &state,
+            code_verifier.as_deref(),
+        )?;
         let expires_at = Instant::now() + SESSION_TTL;
         let session = OAuthSessionConfig {
             input_key: request.input_key.to_string(),
@@ -129,6 +132,7 @@ impl OAuthCredentialManager {
             state,
             code_verifier,
             redirect_uri,
+            redirect_uri_parameter,
             listener,
             expires_at,
         };
@@ -283,27 +287,62 @@ fn resolve_client_secret(
     Ok(Some(value.clone()))
 }
 
-async fn bind_redirect_listener(redirect_uri: &Url) -> Result<TcpListener, AppError> {
+async fn bind_redirect_listener(
+    oauth: &ManifestOAuthCredentialSpec,
+) -> Result<(TcpListener, Url, String), AppError> {
+    let redirect_uri = Url::parse(&oauth.redirect_uri)
+        .map_err(|error| AppError::InvalidInput(format!("invalid OAuth redirect URI: {error}")))?;
     let host = redirect_uri
         .host_str()
         .ok_or_else(|| AppError::InvalidInput("OAuth redirect URI is missing host".to_string()))?;
-    let port = redirect_uri.port().ok_or_else(|| {
-        AppError::InvalidInput("OAuth redirect URI is missing explicit port".to_string())
-    })?;
     if host != "127.0.0.1" && host != "localhost" {
         return Err(AppError::InvalidInput(
             "OAuth redirect URI must use a loopback host".to_string(),
         ));
     }
-    TcpListener::bind((host, port)).await.map_err(|error| {
+    let port = match oauth.redirect_uri_port {
+        ManifestOAuthRedirectUriPortMode::Fixed => {
+            let port = redirect_uri.port().ok_or_else(|| {
+                AppError::InvalidInput("OAuth redirect URI is missing explicit port".to_string())
+            })?;
+            if port == 0 {
+                return Err(AppError::InvalidInput(
+                    "OAuth redirect URI fixed port must be non-zero".to_string(),
+                ));
+            }
+            port
+        }
+        ManifestOAuthRedirectUriPortMode::Random => 0,
+    };
+    let listener = TcpListener::bind((host, port)).await.map_err(|error| {
+        let port_label = if port == 0 {
+            "a random port".to_string()
+        } else {
+            port.to_string()
+        };
         AppError::FailedPrecondition(format!(
-            "OAuth callback listener could not bind {host}:{port}: {error}"
+            "OAuth callback listener could not bind {host}:{port_label}: {error}"
         ))
-    })
+    })?;
+    let mut effective_redirect_uri = redirect_uri;
+    if oauth.redirect_uri_port == ManifestOAuthRedirectUriPortMode::Random {
+        let assigned_port = listener.local_addr()?.port();
+        effective_redirect_uri
+            .set_port(Some(assigned_port))
+            .map_err(|()| {
+                AppError::InvalidInput("OAuth redirect URI port is invalid".to_string())
+            })?;
+    }
+    let redirect_uri_parameter = match oauth.redirect_uri_port {
+        ManifestOAuthRedirectUriPortMode::Fixed => oauth.redirect_uri.clone(),
+        ManifestOAuthRedirectUriPortMode::Random => effective_redirect_uri.to_string(),
+    };
+    Ok((listener, effective_redirect_uri, redirect_uri_parameter))
 }
 
 fn build_authorization_url(
     oauth: &ManifestOAuthCredentialSpec,
+    redirect_uri: &str,
     client_id: &str,
     state: &str,
     code_verifier: Option<&str>,
@@ -316,7 +355,7 @@ fn build_authorization_url(
         query
             .append_pair("response_type", "code")
             .append_pair("client_id", client_id)
-            .append_pair("redirect_uri", &oauth.redirect_uri)
+            .append_pair("redirect_uri", redirect_uri)
             .append_pair("state", state);
         if let Some(scopes) = oauth.scopes.as_ref() {
             query.append_pair(
@@ -343,6 +382,10 @@ fn join_scope_values(delimiter: ManifestOAuthScopeDelimiter, values: &[String]) 
 
 fn random_token() -> String {
     format!("{}{}", Uuid::new_v4().simple(), Uuid::new_v4().simple())
+}
+
+fn pkce_code_verifier(oauth: &ManifestOAuthCredentialSpec) -> Option<String> {
+    (oauth.flow.pkce == ManifestOAuthPkceMode::Required).then(random_code_verifier)
 }
 
 fn random_code_verifier() -> String {
@@ -575,7 +618,7 @@ async fn exchange_authorization_code(
     let mut form = vec![
         ("grant_type", "authorization_code".to_string()),
         ("code", code.to_string()),
-        ("redirect_uri", session.oauth.redirect_uri.clone()),
+        ("redirect_uri", session.redirect_uri_parameter.clone()),
     ];
     let mut request = http
         .post(&session.oauth.token_url)
@@ -787,7 +830,8 @@ mod tests {
         ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
         ManifestOAuthClientSecretTransport, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
         ManifestOAuthFlowKind, ManifestOAuthFlowSpec, ManifestOAuthPkceMode,
-        ManifestOAuthScopeDelimiter, ManifestOAuthScopeSpec, ManifestOAuthScopesSpec,
+        ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, ManifestOAuthScopeSpec,
+        ManifestOAuthScopesSpec,
     };
     use tokio::sync::oneshot;
     use tokio::task::JoinHandle;
@@ -984,7 +1028,7 @@ mod tests {
             let authorization_url = authorization_rx.await.expect("authorization url");
             let parsed = Url::parse(&authorization_url).expect("authorization url");
             assert!(!query_pairs(&parsed).contains_key("client_secret"));
-            callback(&authorization_url, redirect_port).await;
+            callback(&authorization_url).await;
         };
 
         let (completed, ()) = tokio::join!(authorize, callback);
@@ -1023,6 +1067,7 @@ mod tests {
             code_verifier: None,
             redirect_uri: Url::parse(&format!("http://127.0.0.1:{redirect_port}/oauth/callback"))
                 .expect("redirect uri"),
+            redirect_uri_parameter: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
             listener,
             expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
         };
@@ -1083,6 +1128,7 @@ mod tests {
             code_verifier: None,
             redirect_uri: Url::parse(&format!("http://127.0.0.1:{redirect_port}/oauth/callback"))
                 .expect("redirect uri"),
+            redirect_uri_parameter: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
             listener,
             expires_at: std::time::Instant::now() + std::time::Duration::from_mins(1),
         };
@@ -1151,7 +1197,7 @@ mod tests {
         );
         let callback = async {
             let authorization_url = authorization_rx.await.expect("authorization url");
-            callback(&authorization_url, redirect_port).await;
+            callback(&authorization_url).await;
         };
 
         let (completed, ()) = tokio::join!(authorize, callback);
@@ -1164,13 +1210,131 @@ mod tests {
         );
     }
 
-    async fn callback(authorization_url: &str, redirect_port: u16) {
+    #[tokio::test]
+    async fn random_redirect_port_is_used_for_authorization_callback_and_token_exchange() {
+        let fixture = OAuthFixture::new(None);
+        let oauth = oauth_spec_with_redirect_uri(
+            &fixture.token_url,
+            "http://127.0.0.1/oauth/callback",
+            ManifestOAuthRedirectUriPortMode::Random,
+            ManifestOAuthPkceMode::Required,
+            ManifestOAuthClientSpec {
+                id: ManifestOAuthClientIdSpec {
+                    default: Some("default-client".to_string()),
+                    input: None,
+                },
+                secret: None,
+            },
+        );
+        let manager = OAuthCredentialManager::new();
+
+        let (authorization_tx, authorization_rx) = oneshot::channel();
+        let authorize = manager.authorize(
+            StartOAuthCredentialRequest {
+                input_key: "API_TOKEN",
+                oauth: &oauth,
+                credential_inputs: Vec::new(),
+            },
+            move |authorization| async move {
+                authorization_tx
+                    .send(authorization.authorization_url)
+                    .map_err(|_authorization_url| {
+                        crate::bootstrap::AppError::FailedPrecondition(
+                            "authorization receiver closed".to_string(),
+                        )
+                    })
+            },
+        );
+        let callback = async {
+            let authorization_url = authorization_rx.await.expect("authorization url");
+            let authorization_url = Url::parse(&authorization_url).expect("authorization url");
+            let query = query_pairs(&authorization_url);
+            let redirect_uri =
+                Url::parse(query.get("redirect_uri").expect("redirect uri")).expect("redirect uri");
+            let redirect_port = redirect_uri.port().expect("assigned redirect port");
+            assert_ne!(redirect_port, 0);
+
+            callback(authorization_url.as_str()).await;
+            redirect_uri
+        };
+        let (completed, redirect_uri) = tokio::join!(authorize, callback);
+        completed.expect("authorize oauth");
+
+        let captured = fixture.token_server.await.expect("token server");
+        assert_eq!(
+            captured.form.get("redirect_uri").map(String::as_str),
+            Some(redirect_uri.as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn fixed_redirect_uri_is_sent_exactly_as_authored() {
+        let fixture = OAuthFixture::new(None);
+        let redirect_port = free_loopback_port();
+        let redirect_uri = format!("http://127.0.0.1:{redirect_port}");
+        let oauth = oauth_spec_with_redirect_uri(
+            &fixture.token_url,
+            &redirect_uri,
+            ManifestOAuthRedirectUriPortMode::Fixed,
+            ManifestOAuthPkceMode::Required,
+            ManifestOAuthClientSpec {
+                id: ManifestOAuthClientIdSpec {
+                    default: Some("default-client".to_string()),
+                    input: None,
+                },
+                secret: None,
+            },
+        );
+        let manager = OAuthCredentialManager::new();
+
+        let (authorization_tx, authorization_rx) = oneshot::channel();
+        let authorize = manager.authorize(
+            StartOAuthCredentialRequest {
+                input_key: "API_TOKEN",
+                oauth: &oauth,
+                credential_inputs: Vec::new(),
+            },
+            move |authorization| async move {
+                authorization_tx
+                    .send(authorization.authorization_url)
+                    .map_err(|_authorization_url| {
+                        crate::bootstrap::AppError::FailedPrecondition(
+                            "authorization receiver closed".to_string(),
+                        )
+                    })
+            },
+        );
+        let callback = async {
+            let authorization_url = authorization_rx.await.expect("authorization url");
+            let authorization_url = Url::parse(&authorization_url).expect("authorization url");
+            let query = query_pairs(&authorization_url);
+            assert_eq!(
+                query.get("redirect_uri").map(String::as_str),
+                Some(redirect_uri.as_str())
+            );
+
+            callback(authorization_url.as_str()).await;
+        };
+        let (completed, ()) = tokio::join!(authorize, callback);
+        completed.expect("authorize oauth");
+
+        let captured = fixture.token_server.await.expect("token server");
+        assert_eq!(
+            captured.form.get("redirect_uri").map(String::as_str),
+            Some(redirect_uri.as_str())
+        );
+    }
+
+    async fn callback(authorization_url: &str) {
         let authorization_url = Url::parse(authorization_url).expect("authorization url");
-        let state = query_pairs(&authorization_url)
-            .remove("state")
-            .expect("state");
-        let callback_url =
-            format!("http://127.0.0.1:{redirect_port}/oauth/callback?state={state}&code=test-code");
+        let mut query = query_pairs(&authorization_url);
+        let state = query.remove("state").expect("state");
+        let mut callback_url =
+            Url::parse(query.get("redirect_uri").expect("redirect uri")).expect("redirect uri");
+        callback_url
+            .query_pairs_mut()
+            .append_pair("state", &state)
+            .append_pair("code", "test-code");
         reqwest::get(callback_url)
             .await
             .expect("callback response")
@@ -1184,12 +1348,29 @@ mod tests {
         pkce: ManifestOAuthPkceMode,
         client: ManifestOAuthClientSpec,
     ) -> ManifestOAuthCredentialSpec {
+        oauth_spec_with_redirect_uri(
+            token_url,
+            &format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
+            ManifestOAuthRedirectUriPortMode::Fixed,
+            pkce,
+            client,
+        )
+    }
+
+    fn oauth_spec_with_redirect_uri(
+        token_url: &str,
+        redirect_uri: &str,
+        redirect_uri_port: ManifestOAuthRedirectUriPortMode,
+        pkce: ManifestOAuthPkceMode,
+        client: ManifestOAuthClientSpec,
+    ) -> ManifestOAuthCredentialSpec {
         ManifestOAuthCredentialSpec {
             flow: ManifestOAuthFlowSpec {
                 kind: ManifestOAuthFlowKind::AuthorizationCode,
                 pkce,
             },
-            redirect_uri: format!("http://127.0.0.1:{redirect_port}/oauth/callback"),
+            redirect_uri: redirect_uri.to_string(),
+            redirect_uri_port,
             authorization_url: "https://provider.example.com/oauth/authorize".to_string(),
             token_url: token_url.to_string(),
             client,

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -12,7 +12,7 @@ use base64::engine::general_purpose::{
 use chrono::{DateTime, Utc};
 use coral_spec::{
     ManifestOAuthClientSecretTransport, ManifestOAuthCredentialSpec, ManifestOAuthPkceMode,
-    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter,
+    ManifestOAuthRedirectBindPort, ManifestOAuthScopeDelimiter,
 };
 use reqwest::header::{ACCEPT, AUTHORIZATION};
 use serde_json::Value;
@@ -154,9 +154,9 @@ impl OAuthCredentialManager {
         reject_unknown_credential_inputs(oauth, &credential_inputs)?;
         let _client_id = resolve_client_id(oauth, &credential_inputs)?;
         let _client_secret = resolve_client_secret(oauth, &credential_inputs)?;
-        Url::parse(&oauth.redirect_uri).map_err(|error| {
-            AppError::InvalidInput(format!("invalid OAuth redirect URI: {error}"))
-        })?;
+        oauth
+            .redirect_bind_port()
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         Ok(())
     }
 
@@ -292,21 +292,17 @@ fn resolve_client_secret(
 async fn bind_redirect_listener(
     oauth: &ManifestOAuthCredentialSpec,
 ) -> Result<(TcpListener, String, String), AppError> {
+    let bind_port = oauth
+        .redirect_bind_port()
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
     let redirect_uri = Url::parse(&oauth.redirect_uri)
         .map_err(|error| AppError::InvalidInput(format!("invalid OAuth redirect URI: {error}")))?;
     let host = redirect_uri
         .host_str()
         .ok_or_else(|| AppError::InvalidInput("OAuth redirect URI is missing host".to_string()))?;
-    if host != "127.0.0.1" && host != "localhost" {
-        return Err(AppError::InvalidInput(
-            "OAuth redirect URI must use a loopback host".to_string(),
-        ));
-    }
-    let port = match oauth.redirect_uri_port_mode {
-        ManifestOAuthRedirectUriPortMode::Fixed => {
-            fixed_redirect_port(&oauth.redirect_uri, &redirect_uri)?
-        }
-        ManifestOAuthRedirectUriPortMode::Random => {
+    let port = match bind_port {
+        ManifestOAuthRedirectBindPort::Fixed(port) => port,
+        ManifestOAuthRedirectBindPort::Random => {
             // Binding port 0 asks the OS to assign a free loopback port.
             0
         }
@@ -322,7 +318,7 @@ async fn bind_redirect_listener(
         ))
     })?;
     let mut effective_redirect_uri = redirect_uri;
-    if oauth.redirect_uri_port_mode == ManifestOAuthRedirectUriPortMode::Random {
+    if bind_port == ManifestOAuthRedirectBindPort::Random {
         let assigned_port = listener.local_addr()?.port();
         effective_redirect_uri
             .set_port(Some(assigned_port))
@@ -330,46 +326,12 @@ async fn bind_redirect_listener(
                 AppError::InvalidInput("OAuth redirect URI port is invalid".to_string())
             })?;
     }
-    let provider_redirect_uri = match oauth.redirect_uri_port_mode {
-        ManifestOAuthRedirectUriPortMode::Fixed => oauth.redirect_uri.clone(),
-        ManifestOAuthRedirectUriPortMode::Random => effective_redirect_uri.to_string(),
+    let provider_redirect_uri = match bind_port {
+        ManifestOAuthRedirectBindPort::Fixed(_) => oauth.redirect_uri.clone(),
+        ManifestOAuthRedirectBindPort::Random => effective_redirect_uri.to_string(),
     };
     let callback_path = effective_redirect_uri.path().to_string();
     Ok((listener, callback_path, provider_redirect_uri))
-}
-
-fn fixed_redirect_port(raw: &str, redirect_uri: &Url) -> Result<u16, AppError> {
-    if !redirect_uri_has_explicit_port(raw) {
-        return Err(AppError::InvalidInput(
-            "OAuth redirect URI is missing explicit port".to_string(),
-        ));
-    }
-    let port = redirect_uri.port_or_known_default().ok_or_else(|| {
-        AppError::InvalidInput("OAuth redirect URI is missing explicit port".to_string())
-    })?;
-    if port == 0 {
-        return Err(AppError::InvalidInput(
-            "OAuth redirect URI fixed port must be non-zero".to_string(),
-        ));
-    }
-    Ok(port)
-}
-
-fn redirect_uri_has_explicit_port(raw: &str) -> bool {
-    let Some((_, after_scheme)) = raw.split_once("://") else {
-        return false;
-    };
-    let authority = after_scheme
-        .split(['/', '?', '#'])
-        .next()
-        .unwrap_or_default();
-    let host_and_port = authority
-        .rsplit_once('@')
-        .map_or(authority, |(_, host_and_port)| host_and_port);
-    let Some((_, port)) = host_and_port.rsplit_once(':') else {
-        return false;
-    };
-    !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn build_authorization_url(
@@ -855,9 +817,8 @@ mod tests {
 
     use super::{
         OAuthCredentialManager, OAuthSessionConfig, StartOAuthCredentialRequest,
-        basic_client_authorization, fixed_redirect_port, join_scope_values,
-        material_key_belongs_to_input, oauth_metadata_prefix, parse_token_response, pkce_challenge,
-        receive_callback,
+        basic_client_authorization, join_scope_values, material_key_belongs_to_input,
+        oauth_metadata_prefix, parse_token_response, pkce_challenge, receive_callback,
     };
     use coral_spec::{
         ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
@@ -1354,32 +1315,6 @@ mod tests {
             captured.form.get("redirect_uri").map(String::as_str),
             Some(redirect_uri.as_str())
         );
-    }
-
-    #[test]
-    fn fixed_redirect_port_accepts_explicit_default_http_port() {
-        let raw = "http://127.0.0.1:80/oauth/callback";
-        let redirect_uri = Url::parse(raw).expect("redirect uri");
-
-        assert_eq!(fixed_redirect_port(raw, &redirect_uri).expect("port"), 80);
-    }
-
-    #[test]
-    fn fixed_redirect_port_rejects_portless_uri() {
-        let raw = "http://127.0.0.1/oauth/callback";
-        let redirect_uri = Url::parse(raw).expect("redirect uri");
-
-        let error = fixed_redirect_port(raw, &redirect_uri).expect_err("missing explicit port");
-        assert!(error.to_string().contains("missing explicit port"));
-    }
-
-    #[test]
-    fn fixed_redirect_port_rejects_zero_port() {
-        let raw = "http://127.0.0.1:0/oauth/callback";
-        let redirect_uri = Url::parse(raw).expect("redirect uri");
-
-        let error = fixed_redirect_port(raw, &redirect_uri).expect_err("zero fixed port");
-        assert!(error.to_string().contains("fixed port must be non-zero"));
     }
 
     async fn callback(authorization_url: &str) {

--- a/crates/coral-app/src/credentials/oauth.rs
+++ b/crates/coral-app/src/credentials/oauth.rs
@@ -304,15 +304,7 @@ async fn bind_redirect_listener(
     }
     let port = match oauth.redirect_uri_port_mode {
         ManifestOAuthRedirectUriPortMode::Fixed => {
-            let port = redirect_uri.port().ok_or_else(|| {
-                AppError::InvalidInput("OAuth redirect URI is missing explicit port".to_string())
-            })?;
-            if port == 0 {
-                return Err(AppError::InvalidInput(
-                    "OAuth redirect URI fixed port must be non-zero".to_string(),
-                ));
-            }
-            port
+            fixed_redirect_port(&oauth.redirect_uri, &redirect_uri)?
         }
         ManifestOAuthRedirectUriPortMode::Random => {
             // Binding port 0 asks the OS to assign a free loopback port.
@@ -344,6 +336,40 @@ async fn bind_redirect_listener(
     };
     let callback_path = effective_redirect_uri.path().to_string();
     Ok((listener, callback_path, provider_redirect_uri))
+}
+
+fn fixed_redirect_port(raw: &str, redirect_uri: &Url) -> Result<u16, AppError> {
+    if !redirect_uri_has_explicit_port(raw) {
+        return Err(AppError::InvalidInput(
+            "OAuth redirect URI is missing explicit port".to_string(),
+        ));
+    }
+    let port = redirect_uri.port_or_known_default().ok_or_else(|| {
+        AppError::InvalidInput("OAuth redirect URI is missing explicit port".to_string())
+    })?;
+    if port == 0 {
+        return Err(AppError::InvalidInput(
+            "OAuth redirect URI fixed port must be non-zero".to_string(),
+        ));
+    }
+    Ok(port)
+}
+
+fn redirect_uri_has_explicit_port(raw: &str) -> bool {
+    let Some((_, after_scheme)) = raw.split_once("://") else {
+        return false;
+    };
+    let authority = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or_default();
+    let host_and_port = authority
+        .rsplit_once('@')
+        .map_or(authority, |(_, host_and_port)| host_and_port);
+    let Some((_, port)) = host_and_port.rsplit_once(':') else {
+        return false;
+    };
+    !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit())
 }
 
 fn build_authorization_url(
@@ -829,8 +855,9 @@ mod tests {
 
     use super::{
         OAuthCredentialManager, OAuthSessionConfig, StartOAuthCredentialRequest,
-        basic_client_authorization, join_scope_values, material_key_belongs_to_input,
-        oauth_metadata_prefix, parse_token_response, pkce_challenge, receive_callback,
+        basic_client_authorization, fixed_redirect_port, join_scope_values,
+        material_key_belongs_to_input, oauth_metadata_prefix, parse_token_response, pkce_challenge,
+        receive_callback,
     };
     use coral_spec::{
         ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
@@ -1327,6 +1354,32 @@ mod tests {
             captured.form.get("redirect_uri").map(String::as_str),
             Some(redirect_uri.as_str())
         );
+    }
+
+    #[test]
+    fn fixed_redirect_port_accepts_explicit_default_http_port() {
+        let raw = "http://127.0.0.1:80/oauth/callback";
+        let redirect_uri = Url::parse(raw).expect("redirect uri");
+
+        assert_eq!(fixed_redirect_port(raw, &redirect_uri).expect("port"), 80);
+    }
+
+    #[test]
+    fn fixed_redirect_port_rejects_portless_uri() {
+        let raw = "http://127.0.0.1/oauth/callback";
+        let redirect_uri = Url::parse(raw).expect("redirect uri");
+
+        let error = fixed_redirect_port(raw, &redirect_uri).expect_err("missing explicit port");
+        assert!(error.to_string().contains("missing explicit port"));
+    }
+
+    #[test]
+    fn fixed_redirect_port_rejects_zero_port() {
+        let raw = "http://127.0.0.1:0/oauth/callback";
+        let redirect_uri = Url::parse(raw).expect("redirect uri");
+
+        let error = fixed_redirect_port(raw, &redirect_uri).expect_err("zero fixed port");
+        assert!(error.to_string().contains("fixed port must be non-zero"));
     }
 
     async fn callback(authorization_url: &str) {

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -599,7 +599,7 @@ fn oauth_to_proto(oauth: ManifestOAuthCredentialSpec) -> OAuthAuthorizationCodeC
                     transport: proto_oauth_client_secret_transport(secret.transport) as i32,
                 }),
         }),
-        redirect_uri_port: proto_redirect_uri_port_mode(oauth.redirect_uri_port) as i32,
+        redirect_uri_port_mode: proto_redirect_uri_port_mode(oauth.redirect_uri_port_mode) as i32,
         scopes: oauth.scopes.map(|scopes| OAuthCredentialScopes {
             scope: Some(OAuthCredentialScope {
                 delimiter: proto_oauth_scope_delimiter(scopes.scope.delimiter) as i32,
@@ -683,7 +683,7 @@ mod tests {
                                 pkce: ManifestOAuthPkceMode::Required,
                             },
                             redirect_uri: "http://127.0.0.1:53682/oauth/callback".to_string(),
-                            redirect_uri_port: ManifestOAuthRedirectUriPortMode::Fixed,
+                            redirect_uri_port_mode: ManifestOAuthRedirectUriPortMode::Fixed,
                             authorization_url: "https://provider.example.com/oauth/authorize"
                                 .to_string(),
                             token_url: "https://provider.example.com/oauth/token".to_string(),
@@ -719,7 +719,7 @@ mod tests {
             ProtoCredentialMethod::OauthAuthorizationCode(oauth) => {
                 assert_eq!(oauth.redirect_uri, "http://127.0.0.1:53682/oauth/callback");
                 assert_eq!(
-                    OauthCredentialRedirectUriPortMode::try_from(oauth.redirect_uri_port)
+                    OauthCredentialRedirectUriPortMode::try_from(oauth.redirect_uri_port_mode)
                         .expect("redirect uri port mode"),
                     OauthCredentialRedirectUriPortMode::Fixed
                 );

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -15,17 +15,18 @@ use coral_api::v1::{
     OAuthCredentialClientId, OAuthCredentialClientSecret, OAuthCredentialCompleted,
     OAuthCredentialEndpoints, OAuthCredentialInput, OAuthCredentialRetrieval, OAuthCredentialScope,
     OAuthCredentialScopes, OauthCredentialClientSecretTransport, OauthCredentialPkceMode,
-    OauthCredentialScopeDelimiter, Source, SourceConfigCredentialMethod, SourceCredential,
-    SourceCredentialMethod, SourceInfo, SourceInputSpec, SourceOrigin as ProtoSourceOrigin,
-    SourceSecret, SourceSecretInput, SourceVariable, SourceVariableInput, ValidateSourceRequest,
-    ValidateSourceResponse, create_bundled_source_with_o_auth_response, import_source_response,
+    OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter, Source,
+    SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod, SourceInfo,
+    SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput,
+    SourceVariable, SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
+    create_bundled_source_with_o_auth_response, import_source_response,
     source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_spec::{
     ManifestCredentialMethodKind, ManifestCredentialSpec, ManifestInputKind, ManifestInputSpec,
     ManifestOAuthClientSecretTransport, ManifestOAuthCredentialSpec, ManifestOAuthPkceMode,
-    ManifestOAuthScopeDelimiter,
+    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter,
 };
 use tonic::{Request, Response, Status};
 
@@ -598,6 +599,7 @@ fn oauth_to_proto(oauth: ManifestOAuthCredentialSpec) -> OAuthAuthorizationCodeC
                     transport: proto_oauth_client_secret_transport(secret.transport) as i32,
                 }),
         }),
+        redirect_uri_port: proto_redirect_uri_port_mode(oauth.redirect_uri_port) as i32,
         scopes: oauth.scopes.map(|scopes| OAuthCredentialScopes {
             scope: Some(OAuthCredentialScope {
                 delimiter: proto_oauth_scope_delimiter(scopes.scope.delimiter) as i32,
@@ -605,6 +607,15 @@ fn oauth_to_proto(oauth: ManifestOAuthCredentialSpec) -> OAuthAuthorizationCodeC
             }),
         }),
         pkce: proto_oauth_pkce_mode(oauth.flow.pkce) as i32,
+    }
+}
+
+fn proto_redirect_uri_port_mode(
+    mode: ManifestOAuthRedirectUriPortMode,
+) -> OauthCredentialRedirectUriPortMode {
+    match mode {
+        ManifestOAuthRedirectUriPortMode::Fixed => OauthCredentialRedirectUriPortMode::Fixed,
+        ManifestOAuthRedirectUriPortMode::Random => OauthCredentialRedirectUriPortMode::Random,
     }
 }
 
@@ -649,6 +660,7 @@ mod tests {
         ManifestCredentialMethod, ManifestCredentialMethodKind, ManifestCredentialSpec,
         ManifestOAuthClientIdSpec, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
         ManifestOAuthFlowKind, ManifestOAuthFlowSpec, ManifestOAuthPkceMode,
+        ManifestOAuthRedirectUriPortMode,
     };
 
     #[test]
@@ -671,6 +683,7 @@ mod tests {
                                 pkce: ManifestOAuthPkceMode::Required,
                             },
                             redirect_uri: "http://127.0.0.1:53682/oauth/callback".to_string(),
+                            redirect_uri_port: ManifestOAuthRedirectUriPortMode::Fixed,
                             authorization_url: "https://provider.example.com/oauth/authorize"
                                 .to_string(),
                             token_url: "https://provider.example.com/oauth/token".to_string(),
@@ -705,6 +718,11 @@ mod tests {
         match credential.methods[0].method.as_ref().expect("method") {
             ProtoCredentialMethod::OauthAuthorizationCode(oauth) => {
                 assert_eq!(oauth.redirect_uri, "http://127.0.0.1:53682/oauth/callback");
+                assert_eq!(
+                    OauthCredentialRedirectUriPortMode::try_from(oauth.redirect_uri_port)
+                        .expect("redirect uri port mode"),
+                    OauthCredentialRedirectUriPortMode::Fixed
+                );
                 assert_eq!(
                     OauthCredentialPkceMode::try_from(oauth.pkce).expect("pkce"),
                     OauthCredentialPkceMode::Required

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -646,7 +646,10 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
                 source_ops::add_bundled_source_with_credentials(app, &available.name, inputs)
                     .await?
             } else {
-                let (variables, secrets) = source_ops::collect_inputs_from_env(&inputs)?;
+                let (variables, secrets) = source_ops::collect_inputs_from_env(
+                    &inputs,
+                    format!("coral source add --interactive {}", available.name),
+                )?;
                 source_ops::add_bundled_source(app, &available.name, variables, secrets).await?
             }
         }
@@ -658,8 +661,13 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
                 )?;
                 source_ops::import_source_with_credentials(app, manifest_yaml, inputs).await?
             } else {
-                let (variables, secrets) =
-                    source_ops::collect_inputs_from_env(manifest.declared_inputs())?;
+                let (variables, secrets) = source_ops::collect_inputs_from_env(
+                    manifest.declared_inputs(),
+                    format!(
+                        "coral source add --interactive --file {}",
+                        source_ops::shell_quote_arg(&file.display().to_string())
+                    ),
+                )?;
                 source_ops::import_source(app, manifest_yaml, variables, secrets).await?
             }
         }

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -494,8 +494,23 @@ pub(crate) fn prompt_for_inputs_with_credential_methods(
 
 pub(crate) fn collect_inputs_from_env(
     inputs: &[ManifestInputSpec],
+    interactive_command: String,
 ) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
-    collect_inputs_with(inputs, |key| read_source_input_env(key).unwrap_or_default())
+    collect_inputs_with_hint(
+        inputs,
+        |key| read_source_input_env(key).unwrap_or_default(),
+        Some(interactive_command),
+    )
+}
+
+pub(crate) fn shell_quote_arg(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '_' | '-' | ':' | '='))
+    {
+        return value.to_string();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
 }
 
 #[expect(
@@ -506,9 +521,10 @@ fn read_source_input_env(key: &str) -> Option<String> {
     std::env::var(key).ok()
 }
 
-fn collect_inputs_with(
+fn collect_inputs_with_hint(
     inputs: &[ManifestInputSpec],
     mut lookup: impl FnMut(&str) -> String,
+    interactive_command: Option<String>,
 ) -> Result<(Vec<SourceVariable>, Vec<SourceSecret>), anyhow::Error> {
     let mut variables = Vec::new();
     let mut secrets = Vec::new();
@@ -540,8 +556,12 @@ fn collect_inputs_with(
     }
 
     if !missing.is_empty() {
+        let interactive_hint = interactive_command.map_or_else(
+            || "--interactive".to_string(),
+            |command| format!("`{command}`"),
+        );
         return Err(anyhow::anyhow!(
-            "missing required environment variable{}: {}. Set the variable{} or run with --interactive.",
+            "missing required environment variable{}: {}. Set the variable{} or run {interactive_hint}.",
             if missing.len() == 1 { "" } else { "s" },
             missing.join(", "),
             if missing.len() == 1 { "" } else { "s" },
@@ -1044,8 +1064,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{
-        ValidationFollowUp, ValidationSeverityMode, collect_inputs_with, finalize_input_value,
-        source_name_arg, validation_follow_up,
+        ValidationFollowUp, ValidationSeverityMode, collect_inputs_with_hint, finalize_input_value,
+        shell_quote_arg, source_name_arg, validation_follow_up,
     };
 
     #[test]
@@ -1069,9 +1089,11 @@ mod tests {
             },
         ];
         let env: HashMap<&str, &str> = [("LINEAR_API_KEY", "lin_token")].into_iter().collect();
-        let (variables, secrets) = collect_inputs_with(&inputs, |key| {
-            env.get(key).map(|v| (*v).to_string()).unwrap_or_default()
-        })
+        let (variables, secrets) = collect_inputs_with_hint(
+            &inputs,
+            |key| env.get(key).map(|v| (*v).to_string()).unwrap_or_default(),
+            None,
+        )
         .expect("should succeed");
         assert_eq!(variables.len(), 1);
         assert_eq!(variables[0].key, "LINEAR_API_BASE");
@@ -1091,8 +1113,9 @@ mod tests {
             hint: None,
             credential: None,
         }];
-        let (variables, _) = collect_inputs_with(&inputs, |_| "https://override.test".to_string())
-            .expect("env should override default");
+        let (variables, _) =
+            collect_inputs_with_hint(&inputs, |_| "https://override.test".to_string(), None)
+                .expect("env should override default");
         assert_eq!(variables.len(), 1);
         assert_eq!(variables[0].value, "https://override.test");
     }
@@ -1107,7 +1130,7 @@ mod tests {
             hint: None,
             credential: None,
         }];
-        let (variables, secrets) = collect_inputs_with(&inputs, |_| String::new())
+        let (variables, secrets) = collect_inputs_with_hint(&inputs, |_| String::new(), None)
             .expect("default should satisfy required");
         assert_eq!(secrets.len(), 0);
         assert_eq!(variables.len(), 1);
@@ -1134,7 +1157,7 @@ mod tests {
                 credential: None,
             },
         ];
-        let error = collect_inputs_with(&inputs, |_| String::new())
+        let error = collect_inputs_with_hint(&inputs, |_| String::new(), None)
             .expect_err("missing required inputs should fail");
         let message = error.to_string();
         assert!(message.contains("LINEAR_API_KEY"));
@@ -1161,8 +1184,8 @@ mod tests {
             hint: None,
             credential: None,
         }];
-        let (variables, secrets) =
-            collect_inputs_with(&inputs, |_| String::new()).expect("optional should be omitted");
+        let (variables, secrets) = collect_inputs_with_hint(&inputs, |_| String::new(), None)
+            .expect("optional should be omitted");
         assert!(variables.is_empty());
         assert!(secrets.is_empty());
     }
@@ -1197,6 +1220,16 @@ mod tests {
         let error = finalize_input_value(&input, String::new(), "source secret")
             .expect_err("required empty input should fail");
         assert!(error.to_string().contains("missing required source secret"));
+    }
+
+    #[test]
+    fn shell_quote_arg_quotes_copyable_commands() {
+        assert_eq!(shell_quote_arg("sources/demo.yaml"), "sources/demo.yaml");
+        assert_eq!(
+            shell_quote_arg("fixtures/my source.yaml"),
+            "'fixtures/my source.yaml'"
+        );
+        assert_eq!(shell_quote_arg("it'demo.yaml"), "'it'\\''demo.yaml'");
     }
 
     #[test]

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -747,6 +747,10 @@ async fn source_add_reports_missing_env_vars_without_interactive() {
         stderr.contains("GITHUB_TOKEN"),
         "expected missing env var to name GITHUB_TOKEN: {stderr}"
     );
+    assert!(
+        stderr.contains("coral source add --interactive github"),
+        "expected exact interactive recovery command: {stderr}"
+    );
 
     server.shutdown().await;
 }

--- a/crates/coral-client/src/sources.rs
+++ b/crates/coral-client/src/sources.rs
@@ -145,7 +145,7 @@ fn oauth_authorization_code_from_proto(
             pkce: oauth_pkce_from_proto(oauth.pkce)?,
         },
         redirect_uri: oauth.redirect_uri.clone(),
-        redirect_uri_port: redirect_uri_port_from_proto(oauth.redirect_uri_port)?,
+        redirect_uri_port_mode: redirect_uri_port_mode_from_proto(oauth.redirect_uri_port_mode)?,
         authorization_url: endpoints.authorization_url.clone(),
         token_url: endpoints.token_url.clone(),
         client,
@@ -168,7 +168,7 @@ fn oauth_pkce_from_proto(pkce: i32) -> Result<ManifestOAuthPkceMode, SourceInput
     Ok(pkce)
 }
 
-fn redirect_uri_port_from_proto(
+fn redirect_uri_port_mode_from_proto(
     mode: i32,
 ) -> Result<ManifestOAuthRedirectUriPortMode, SourceInputDecodeError> {
     match OauthCredentialRedirectUriPortMode::try_from(mode) {
@@ -292,8 +292,8 @@ mod tests {
                                         }),
                                         secret: None,
                                     }),
-                                    redirect_uri_port: OauthCredentialRedirectUriPortMode::Random
-                                        as i32,
+                                    redirect_uri_port_mode:
+                                        OauthCredentialRedirectUriPortMode::Random as i32,
                                     scopes: None,
                                 },
                             )),
@@ -323,7 +323,7 @@ mod tests {
                 .oauth
                 .as_ref()
                 .expect("oauth")
-                .redirect_uri_port,
+                .redirect_uri_port_mode,
             ManifestOAuthRedirectUriPortMode::Random
         );
         assert_eq!(
@@ -370,7 +370,8 @@ mod tests {
                                     }),
                                     secret: None,
                                 }),
-                                redirect_uri_port: OauthCredentialRedirectUriPortMode::Fixed as i32,
+                                redirect_uri_port_mode: OauthCredentialRedirectUriPortMode::Fixed
+                                    as i32,
                                 scopes: None,
                             },
                         )),

--- a/crates/coral-client/src/sources.rs
+++ b/crates/coral-client/src/sources.rs
@@ -2,8 +2,8 @@
 
 use coral_api::v1::{
     OAuthAuthorizationCodeCredentialMethod, OauthCredentialClientSecretTransport,
-    OauthCredentialPkceMode, OauthCredentialScopeDelimiter, SourceCredential,
-    SourceCredentialMethod, SourceInputSpec,
+    OauthCredentialPkceMode, OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter,
+    SourceCredential, SourceCredentialMethod, SourceInputSpec,
     source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
 };
@@ -12,7 +12,8 @@ use coral_spec::{
     ManifestInputKind, ManifestInputSpec, ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
     ManifestOAuthClientSecretTransport, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
     ManifestOAuthFlowKind, ManifestOAuthFlowSpec, ManifestOAuthPkceMode,
-    ManifestOAuthScopeDelimiter, ManifestOAuthScopeSpec, ManifestOAuthScopesSpec,
+    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, ManifestOAuthScopeSpec,
+    ManifestOAuthScopesSpec,
 };
 
 /// Errors returned while decoding source input metadata from the gRPC API.
@@ -30,6 +31,9 @@ pub enum SourceInputDecodeError {
     /// The OAuth PKCE mode was missing or unknown.
     #[error("unknown oauth pkce mode")]
     UnknownOAuthPkceMode,
+    /// The OAuth redirect URI port mode was missing or unknown.
+    #[error("unknown oauth redirect URI port mode")]
+    UnknownOAuthRedirectUriPortMode,
     /// The OAuth credential method did not include provider endpoints.
     #[error("oauth credential method is missing endpoints")]
     MissingOAuthEndpoints,
@@ -141,6 +145,7 @@ fn oauth_authorization_code_from_proto(
             pkce: oauth_pkce_from_proto(oauth.pkce)?,
         },
         redirect_uri: oauth.redirect_uri.clone(),
+        redirect_uri_port: redirect_uri_port_from_proto(oauth.redirect_uri_port)?,
         authorization_url: endpoints.authorization_url.clone(),
         token_url: endpoints.token_url.clone(),
         client,
@@ -161,6 +166,21 @@ fn oauth_pkce_from_proto(pkce: i32) -> Result<ManifestOAuthPkceMode, SourceInput
         }
     };
     Ok(pkce)
+}
+
+fn redirect_uri_port_from_proto(
+    mode: i32,
+) -> Result<ManifestOAuthRedirectUriPortMode, SourceInputDecodeError> {
+    match OauthCredentialRedirectUriPortMode::try_from(mode) {
+        Ok(
+            OauthCredentialRedirectUriPortMode::Fixed
+            | OauthCredentialRedirectUriPortMode::Unspecified,
+        ) => Ok(ManifestOAuthRedirectUriPortMode::Fixed),
+        Ok(OauthCredentialRedirectUriPortMode::Random) => {
+            Ok(ManifestOAuthRedirectUriPortMode::Random)
+        }
+        Err(_) => Err(SourceInputDecodeError::UnknownOAuthRedirectUriPortMode),
+    }
 }
 
 fn oauth_client_from_proto(
@@ -272,6 +292,8 @@ mod tests {
                                         }),
                                         secret: None,
                                     }),
+                                    redirect_uri_port: OauthCredentialRedirectUriPortMode::Random
+                                        as i32,
                                     scopes: None,
                                 },
                             )),
@@ -296,6 +318,14 @@ mod tests {
             ManifestCredentialMethodKind::OAuth
         );
         assert_eq!(credential.methods[0].label.as_deref(), Some("Connect"));
+        assert_eq!(
+            credential.methods[0]
+                .oauth
+                .as_ref()
+                .expect("oauth")
+                .redirect_uri_port,
+            ManifestOAuthRedirectUriPortMode::Random
+        );
         assert_eq!(
             credential.methods[0]
                 .oauth
@@ -340,6 +370,7 @@ mod tests {
                                     }),
                                     secret: None,
                                 }),
+                                redirect_uri_port: OauthCredentialRedirectUriPortMode::Fixed as i32,
                                 scopes: None,
                             },
                         )),

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -82,6 +82,8 @@ pub struct ManifestOAuthCredentialSpec {
     pub flow: ManifestOAuthFlowSpec,
     /// Loopback callback URI Coral binds during the OAuth session.
     pub redirect_uri: String,
+    /// Whether Coral binds the authored redirect URI port exactly or chooses a free port.
+    pub redirect_uri_port: ManifestOAuthRedirectUriPortMode,
     /// Provider authorization endpoint URL.
     pub authorization_url: String,
     /// Provider token endpoint URL.
@@ -90,6 +92,15 @@ pub struct ManifestOAuthCredentialSpec {
     pub client: ManifestOAuthClientSpec,
     /// Optional OAuth scope parameter configuration.
     pub scopes: Option<ManifestOAuthScopesSpec>,
+}
+
+/// Supported loopback redirect URI port binding modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestOAuthRedirectUriPortMode {
+    /// Bind the exact port authored in `redirect_uri`.
+    Fixed,
+    /// Bind a random free port and use it in OAuth authorization and token exchange.
+    Random,
 }
 
 /// Supported OAuth credential retrieval flow settings.
@@ -424,7 +435,12 @@ fn parse_oauth(
         })
         .and_then(|flow| parse_oauth_flow(input_key, flow))?;
     let redirect_uri = required_string(oauth, "redirect_uri", input_key, "oauth")?;
-    validate_loopback_redirect_uri(input_key, &redirect_uri)?;
+    let redirect_uri_port = oauth
+        .get("redirect_uri_port")
+        .map(|value| parse_redirect_uri_port(input_key, value))
+        .transpose()?
+        .unwrap_or(ManifestOAuthRedirectUriPortMode::Fixed);
+    validate_loopback_redirect_uri(input_key, &redirect_uri, redirect_uri_port)?;
     let endpoints = oauth
         .get("endpoints")
         .and_then(Value::as_object)
@@ -453,11 +469,28 @@ fn parse_oauth(
     Ok(ManifestOAuthCredentialSpec {
         flow,
         redirect_uri,
+        redirect_uri_port,
         authorization_url,
         token_url,
         client,
         scopes,
     })
+}
+
+fn parse_redirect_uri_port(
+    input_key: &str,
+    value: &Value,
+) -> Result<ManifestOAuthRedirectUriPortMode> {
+    match value.as_str() {
+        Some("fixed") => Ok(ManifestOAuthRedirectUriPortMode::Fixed),
+        Some("random") => Ok(ManifestOAuthRedirectUriPortMode::Random),
+        Some(other) => Err(ManifestError::validation(format!(
+            "manifest input '{input_key}' oauth.redirect_uri_port has unsupported value '{other}'"
+        ))),
+        None => Err(ManifestError::validation(format!(
+            "manifest input '{input_key}' oauth.redirect_uri_port must be a string"
+        ))),
+    }
 }
 
 fn parse_oauth_flow(input_key: &str, value: &Value) -> Result<ManifestOAuthFlowSpec> {
@@ -654,7 +687,11 @@ fn required_string(
         })
 }
 
-fn validate_loopback_redirect_uri(input_key: &str, raw: &str) -> Result<()> {
+fn validate_loopback_redirect_uri(
+    input_key: &str,
+    raw: &str,
+    port_mode: ManifestOAuthRedirectUriPortMode,
+) -> Result<()> {
     let url = Url::parse(raw).map_err(|error| {
         ManifestError::validation(format!(
             "manifest input '{input_key}' oauth.redirect_uri is invalid: {error}"
@@ -671,10 +708,21 @@ fn validate_loopback_redirect_uri(input_key: &str, raw: &str) -> Result<()> {
             "manifest input '{input_key}' oauth.redirect_uri must use a loopback host"
         )));
     }
-    if !redirect_uri_has_explicit_port(raw) {
-        return Err(ManifestError::validation(format!(
-            "manifest input '{input_key}' oauth.redirect_uri must include an explicit port"
-        )));
+    let has_explicit_port = redirect_uri_has_explicit_port(raw);
+    match port_mode {
+        ManifestOAuthRedirectUriPortMode::Fixed if has_explicit_port && url.port() != Some(0) => {}
+        ManifestOAuthRedirectUriPortMode::Fixed => {
+            return Err(ManifestError::validation(format!(
+                "manifest input '{input_key}' oauth.redirect_uri must include an explicit non-zero port when redirect_uri_port is fixed"
+            )));
+        }
+        ManifestOAuthRedirectUriPortMode::Random if !has_explicit_port || url.port() == Some(0) => {
+        }
+        ManifestOAuthRedirectUriPortMode::Random => {
+            return Err(ManifestError::validation(format!(
+                "manifest input '{input_key}' oauth.redirect_uri must omit the port or use port 0 when redirect_uri_port is random"
+            )));
+        }
     }
     Ok(())
 }
@@ -821,8 +869,8 @@ mod tests {
 
     use super::{
         ManifestCredentialMethodKind, ManifestInputKind, ManifestInputSpec,
-        ManifestOAuthClientSecretTransport, ManifestOAuthPkceMode, ManifestOAuthScopeDelimiter,
-        collect_source_inputs_value,
+        ManifestOAuthClientSecretTransport, ManifestOAuthPkceMode,
+        ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, collect_source_inputs_value,
     };
     use crate::{ManifestError, Result};
 
@@ -979,10 +1027,39 @@ tables: []
         assert_eq!(method.kind, ManifestCredentialMethodKind::OAuth);
         let oauth = method.oauth.as_ref().expect("oauth");
         assert_eq!(oauth.flow.pkce, ManifestOAuthPkceMode::Required);
+        assert_eq!(
+            oauth.redirect_uri_port,
+            ManifestOAuthRedirectUriPortMode::Fixed
+        );
         assert_eq!(oauth.client.id.default.as_deref(), Some("default-client"));
         assert_eq!(
             oauth.scopes.as_ref().expect("scopes").scope.delimiter,
             ManifestOAuthScopeDelimiter::Space
+        );
+    }
+
+    #[test]
+    fn parses_random_redirect_uri_port_without_explicit_port() {
+        let inputs = collect(
+            &oauth_input(
+                r"
+              id:
+                default: default-client
+",
+            )
+            .replace(
+                "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n",
+                "            redirect_uri: http://127.0.0.1/oauth/callback\n            redirect_uri_port: random\n",
+            ),
+        )
+        .expect("inputs");
+        let oauth = inputs[0].credential.as_ref().expect("credential").methods[0]
+            .oauth
+            .as_ref()
+            .expect("oauth");
+        assert_eq!(
+            oauth.redirect_uri_port,
+            ManifestOAuthRedirectUriPortMode::Random
         );
     }
 
@@ -1165,7 +1242,43 @@ tables: []
             ),
         )
         .expect_err("missing port should fail");
-        assert!(error.to_string().contains("explicit port"));
+        assert!(error.to_string().contains("explicit non-zero port"));
+    }
+
+    #[test]
+    fn rejects_random_redirect_uri_port_with_explicit_nonzero_port() {
+        let error = collect(
+            &oauth_input(
+                r"
+              id:
+                default: default-client
+",
+            )
+            .replace(
+                "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n",
+                "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n            redirect_uri_port: random\n",
+            ),
+        )
+        .expect_err("random port with explicit nonzero port should fail");
+        assert!(error.to_string().contains("must omit the port"));
+    }
+
+    #[test]
+    fn rejects_random_redirect_uri_port_with_explicit_default_http_port() {
+        let error = collect(
+            &oauth_input(
+                r"
+              id:
+                default: default-client
+",
+            )
+            .replace(
+                "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n",
+                "            redirect_uri: http://127.0.0.1:80/oauth/callback\n            redirect_uri_port: random\n",
+            ),
+        )
+        .expect_err("random port with explicit default port should fail");
+        assert!(error.to_string().contains("must omit the port"));
     }
 
     #[test]

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -83,7 +83,7 @@ pub struct ManifestOAuthCredentialSpec {
     /// Loopback callback URI Coral binds during the OAuth session.
     pub redirect_uri: String,
     /// Whether Coral binds the authored redirect URI port exactly or chooses a free port.
-    pub redirect_uri_port: ManifestOAuthRedirectUriPortMode,
+    pub redirect_uri_port_mode: ManifestOAuthRedirectUriPortMode,
     /// Provider authorization endpoint URL.
     pub authorization_url: String,
     /// Provider token endpoint URL.
@@ -435,12 +435,12 @@ fn parse_oauth(
         })
         .and_then(|flow| parse_oauth_flow(input_key, flow))?;
     let redirect_uri = required_string(oauth, "redirect_uri", input_key, "oauth")?;
-    let redirect_uri_port = oauth
-        .get("redirect_uri_port")
-        .map(|value| parse_redirect_uri_port(input_key, value))
+    let redirect_uri_port_mode = oauth
+        .get("redirect_uri_port_mode")
+        .map(|value| parse_redirect_uri_port_mode(input_key, value))
         .transpose()?
-        .unwrap_or(ManifestOAuthRedirectUriPortMode::Fixed);
-    validate_loopback_redirect_uri(input_key, &redirect_uri, redirect_uri_port)?;
+        .unwrap_or_else(|| default_redirect_uri_port_mode(&redirect_uri));
+    validate_loopback_redirect_uri(input_key, &redirect_uri, redirect_uri_port_mode)?;
     let endpoints = oauth
         .get("endpoints")
         .and_then(Value::as_object)
@@ -469,7 +469,7 @@ fn parse_oauth(
     Ok(ManifestOAuthCredentialSpec {
         flow,
         redirect_uri,
-        redirect_uri_port,
+        redirect_uri_port_mode,
         authorization_url,
         token_url,
         client,
@@ -477,7 +477,15 @@ fn parse_oauth(
     })
 }
 
-fn parse_redirect_uri_port(
+fn default_redirect_uri_port_mode(raw: &str) -> ManifestOAuthRedirectUriPortMode {
+    if Url::parse(raw).ok().and_then(|url| url.port()) == Some(0) {
+        ManifestOAuthRedirectUriPortMode::Random
+    } else {
+        ManifestOAuthRedirectUriPortMode::Fixed
+    }
+}
+
+fn parse_redirect_uri_port_mode(
     input_key: &str,
     value: &Value,
 ) -> Result<ManifestOAuthRedirectUriPortMode> {
@@ -485,10 +493,10 @@ fn parse_redirect_uri_port(
         Some("fixed") => Ok(ManifestOAuthRedirectUriPortMode::Fixed),
         Some("random") => Ok(ManifestOAuthRedirectUriPortMode::Random),
         Some(other) => Err(ManifestError::validation(format!(
-            "manifest input '{input_key}' oauth.redirect_uri_port has unsupported value '{other}'"
+            "manifest input '{input_key}' oauth.redirect_uri_port_mode has unsupported value '{other}'"
         ))),
         None => Err(ManifestError::validation(format!(
-            "manifest input '{input_key}' oauth.redirect_uri_port must be a string"
+            "manifest input '{input_key}' oauth.redirect_uri_port_mode must be a string"
         ))),
     }
 }
@@ -713,14 +721,14 @@ fn validate_loopback_redirect_uri(
         ManifestOAuthRedirectUriPortMode::Fixed if has_explicit_port && url.port() != Some(0) => {}
         ManifestOAuthRedirectUriPortMode::Fixed => {
             return Err(ManifestError::validation(format!(
-                "manifest input '{input_key}' oauth.redirect_uri must include an explicit non-zero port when redirect_uri_port is fixed"
+                "manifest input '{input_key}' oauth.redirect_uri must include an explicit non-zero port when redirect_uri_port_mode is fixed"
             )));
         }
         ManifestOAuthRedirectUriPortMode::Random if !has_explicit_port || url.port() == Some(0) => {
         }
         ManifestOAuthRedirectUriPortMode::Random => {
             return Err(ManifestError::validation(format!(
-                "manifest input '{input_key}' oauth.redirect_uri must omit the port or use port 0 when redirect_uri_port is random"
+                "manifest input '{input_key}' oauth.redirect_uri must omit the port or use port 0 when redirect_uri_port_mode is random"
             )));
         }
     }
@@ -1028,7 +1036,7 @@ tables: []
         let oauth = method.oauth.as_ref().expect("oauth");
         assert_eq!(oauth.flow.pkce, ManifestOAuthPkceMode::Required);
         assert_eq!(
-            oauth.redirect_uri_port,
+            oauth.redirect_uri_port_mode,
             ManifestOAuthRedirectUriPortMode::Fixed
         );
         assert_eq!(oauth.client.id.default.as_deref(), Some("default-client"));
@@ -1039,7 +1047,7 @@ tables: []
     }
 
     #[test]
-    fn parses_random_redirect_uri_port_without_explicit_port() {
+    fn parses_random_redirect_uri_port_mode_without_explicit_port() {
         let inputs = collect(
             &oauth_input(
                 r"
@@ -1049,7 +1057,7 @@ tables: []
             )
             .replace(
                 "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n",
-                "            redirect_uri: http://127.0.0.1/oauth/callback\n            redirect_uri_port: random\n",
+                "            redirect_uri: http://127.0.0.1/oauth/callback\n            redirect_uri_port_mode: random\n",
             ),
         )
         .expect("inputs");
@@ -1058,7 +1066,32 @@ tables: []
             .as_ref()
             .expect("oauth");
         assert_eq!(
-            oauth.redirect_uri_port,
+            oauth.redirect_uri_port_mode,
+            ManifestOAuthRedirectUriPortMode::Random
+        );
+    }
+
+    #[test]
+    fn infers_random_redirect_uri_port_mode_from_explicit_zero_port() {
+        let inputs = collect(
+            &oauth_input(
+                r"
+              id:
+                default: default-client
+",
+            )
+            .replace(
+                "http://127.0.0.1:53682/oauth/callback",
+                "http://127.0.0.1:0/oauth/callback",
+            ),
+        )
+        .expect("inputs");
+        let oauth = inputs[0].credential.as_ref().expect("credential").methods[0]
+            .oauth
+            .as_ref()
+            .expect("oauth");
+        assert_eq!(
+            oauth.redirect_uri_port_mode,
             ManifestOAuthRedirectUriPortMode::Random
         );
     }
@@ -1246,7 +1279,7 @@ tables: []
     }
 
     #[test]
-    fn rejects_random_redirect_uri_port_with_explicit_nonzero_port() {
+    fn rejects_random_redirect_uri_port_mode_with_explicit_nonzero_port() {
         let error = collect(
             &oauth_input(
                 r"
@@ -1256,7 +1289,7 @@ tables: []
             )
             .replace(
                 "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n",
-                "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n            redirect_uri_port: random\n",
+                "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n            redirect_uri_port_mode: random\n",
             ),
         )
         .expect_err("random port with explicit nonzero port should fail");
@@ -1264,7 +1297,7 @@ tables: []
     }
 
     #[test]
-    fn rejects_random_redirect_uri_port_with_explicit_default_http_port() {
+    fn rejects_random_redirect_uri_port_mode_with_explicit_default_http_port() {
         let error = collect(
             &oauth_input(
                 r"
@@ -1274,7 +1307,7 @@ tables: []
             )
             .replace(
                 "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n",
-                "            redirect_uri: http://127.0.0.1:80/oauth/callback\n            redirect_uri_port: random\n",
+                "            redirect_uri: http://127.0.0.1:80/oauth/callback\n            redirect_uri_port_mode: random\n",
             ),
         )
         .expect_err("random port with explicit default port should fail");

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -94,12 +94,32 @@ pub struct ManifestOAuthCredentialSpec {
     pub scopes: Option<ManifestOAuthScopesSpec>,
 }
 
+impl ManifestOAuthCredentialSpec {
+    /// Resolve the local listener port behavior for this OAuth redirect URI.
+    pub fn redirect_bind_port(&self) -> Result<ManifestOAuthRedirectBindPort> {
+        redirect_bind_port(
+            &self.redirect_uri,
+            self.redirect_uri_port_mode,
+            "OAuth redirect URI",
+        )
+    }
+}
+
 /// Supported loopback redirect URI port binding modes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManifestOAuthRedirectUriPortMode {
     /// Bind the exact port authored in `redirect_uri`.
     Fixed,
     /// Bind a random free port and use it in OAuth authorization and token exchange.
+    Random,
+}
+
+/// Resolved loopback listener port behavior for an OAuth redirect URI.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestOAuthRedirectBindPort {
+    /// Bind the exact fixed port authored in `redirect_uri`.
+    Fixed(u16),
+    /// Bind port 0 and let the OS choose a free port.
     Random,
 }
 
@@ -700,39 +720,53 @@ fn validate_loopback_redirect_uri(
     raw: &str,
     port_mode: ManifestOAuthRedirectUriPortMode,
 ) -> Result<()> {
-    let url = Url::parse(raw).map_err(|error| {
-        ManifestError::validation(format!(
-            "manifest input '{input_key}' oauth.redirect_uri is invalid: {error}"
-        ))
-    })?;
+    let context = format!("manifest input '{input_key}' oauth.redirect_uri");
+    redirect_bind_port(raw, port_mode, &context).map(|_| ())
+}
+
+fn redirect_bind_port(
+    raw: &str,
+    port_mode: ManifestOAuthRedirectUriPortMode,
+    context: &str,
+) -> Result<ManifestOAuthRedirectBindPort> {
+    let url = Url::parse(raw)
+        .map_err(|error| ManifestError::validation(format!("{context} is invalid: {error}")))?;
     if url.scheme() != "http" {
         return Err(ManifestError::validation(format!(
-            "manifest input '{input_key}' oauth.redirect_uri must use http"
+            "{context} must use http"
         )));
     }
     let host = url.host_str().unwrap_or_default();
     if host != "127.0.0.1" && host != "localhost" {
         return Err(ManifestError::validation(format!(
-            "manifest input '{input_key}' oauth.redirect_uri must use a loopback host"
+            "{context} must use a loopback host"
         )));
     }
     let has_explicit_port = redirect_uri_has_explicit_port(raw);
     match port_mode {
-        ManifestOAuthRedirectUriPortMode::Fixed if has_explicit_port && url.port() != Some(0) => {}
-        ManifestOAuthRedirectUriPortMode::Fixed => {
-            return Err(ManifestError::validation(format!(
-                "manifest input '{input_key}' oauth.redirect_uri must include an explicit non-zero port when redirect_uri_port_mode is fixed"
-            )));
+        ManifestOAuthRedirectUriPortMode::Fixed if has_explicit_port => {
+            let port = url.port_or_known_default().ok_or_else(|| {
+                ManifestError::validation(format!(
+                    "{context} must include an explicit non-zero port when redirect_uri_port_mode is fixed"
+                ))
+            })?;
+            if port == 0 {
+                return Err(ManifestError::validation(format!(
+                    "{context} must include an explicit non-zero port when redirect_uri_port_mode is fixed"
+                )));
+            }
+            Ok(ManifestOAuthRedirectBindPort::Fixed(port))
         }
+        ManifestOAuthRedirectUriPortMode::Fixed => Err(ManifestError::validation(format!(
+            "{context} must include an explicit non-zero port when redirect_uri_port_mode is fixed"
+        ))),
         ManifestOAuthRedirectUriPortMode::Random if !has_explicit_port || url.port() == Some(0) => {
+            Ok(ManifestOAuthRedirectBindPort::Random)
         }
-        ManifestOAuthRedirectUriPortMode::Random => {
-            return Err(ManifestError::validation(format!(
-                "manifest input '{input_key}' oauth.redirect_uri must omit the port or use port 0 when redirect_uri_port_mode is random"
-            )));
-        }
+        ManifestOAuthRedirectUriPortMode::Random => Err(ManifestError::validation(format!(
+            "{context} must omit the port or use port 0 when redirect_uri_port_mode is random"
+        ))),
     }
-    Ok(())
 }
 
 fn redirect_uri_has_explicit_port(raw: &str) -> bool {
@@ -877,7 +911,7 @@ mod tests {
 
     use super::{
         ManifestCredentialMethodKind, ManifestInputKind, ManifestInputSpec,
-        ManifestOAuthClientSecretTransport, ManifestOAuthPkceMode,
+        ManifestOAuthClientSecretTransport, ManifestOAuthPkceMode, ManifestOAuthRedirectBindPort,
         ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, collect_source_inputs_value,
     };
     use crate::{ManifestError, Result};
@@ -1039,6 +1073,10 @@ tables: []
             oauth.redirect_uri_port_mode,
             ManifestOAuthRedirectUriPortMode::Fixed
         );
+        assert_eq!(
+            oauth.redirect_bind_port().expect("bind port"),
+            ManifestOAuthRedirectBindPort::Fixed(53682)
+        );
         assert_eq!(oauth.client.id.default.as_deref(), Some("default-client"));
         assert_eq!(
             oauth.scopes.as_ref().expect("scopes").scope.delimiter,
@@ -1069,6 +1107,10 @@ tables: []
             oauth.redirect_uri_port_mode,
             ManifestOAuthRedirectUriPortMode::Random
         );
+        assert_eq!(
+            oauth.redirect_bind_port().expect("bind port"),
+            ManifestOAuthRedirectBindPort::Random
+        );
     }
 
     #[test]
@@ -1093,6 +1135,10 @@ tables: []
         assert_eq!(
             oauth.redirect_uri_port_mode,
             ManifestOAuthRedirectUriPortMode::Random
+        );
+        assert_eq!(
+            oauth.redirect_bind_port().expect("bind port"),
+            ManifestOAuthRedirectBindPort::Random
         );
     }
 
@@ -1258,6 +1304,10 @@ tables: []
             .as_ref()
             .expect("oauth");
         assert_eq!(oauth.redirect_uri, "http://127.0.0.1:80/oauth/callback");
+        assert_eq!(
+            oauth.redirect_bind_port().expect("bind port"),
+            ManifestOAuthRedirectBindPort::Fixed(80)
+        );
     }
 
     #[test]
@@ -1312,6 +1362,24 @@ tables: []
         )
         .expect_err("random port with explicit default port should fail");
         assert!(error.to_string().contains("must omit the port"));
+    }
+
+    #[test]
+    fn rejects_fixed_redirect_uri_port_mode_with_explicit_zero_port() {
+        let error = collect(
+            &oauth_input(
+                r"
+              id:
+                default: default-client
+",
+            )
+            .replace(
+                "            redirect_uri: http://127.0.0.1:53682/oauth/callback\n",
+                "            redirect_uri: http://127.0.0.1:0/oauth/callback\n            redirect_uri_port_mode: fixed\n",
+            ),
+        )
+        .expect_err("fixed port with explicit zero port should fail");
+        assert!(error.to_string().contains("explicit non-zero port"));
     }
 
     #[test]

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -101,7 +101,8 @@ pub use inputs::{
     ManifestInputKind, ManifestInputSpec, ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
     ManifestOAuthClientSecretTransport, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
     ManifestOAuthFlowKind, ManifestOAuthFlowSpec, ManifestOAuthPkceMode,
-    ManifestOAuthScopeDelimiter, ManifestOAuthScopeSpec, ManifestOAuthScopesSpec, resolve_inputs,
+    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, ManifestOAuthScopeSpec,
+    ManifestOAuthScopesSpec, resolve_inputs,
 };
 pub use loader::load_manifest_path;
 pub use parser::{

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -101,8 +101,8 @@ pub use inputs::{
     ManifestInputKind, ManifestInputSpec, ManifestOAuthClientIdSpec, ManifestOAuthClientSecretSpec,
     ManifestOAuthClientSecretTransport, ManifestOAuthClientSpec, ManifestOAuthCredentialSpec,
     ManifestOAuthFlowKind, ManifestOAuthFlowSpec, ManifestOAuthPkceMode,
-    ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter, ManifestOAuthScopeSpec,
-    ManifestOAuthScopesSpec, resolve_inputs,
+    ManifestOAuthRedirectBindPort, ManifestOAuthRedirectUriPortMode, ManifestOAuthScopeDelimiter,
+    ManifestOAuthScopeSpec, ManifestOAuthScopesSpec, resolve_inputs,
 };
 pub use loader::load_manifest_path;
 pub use parser::{

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -169,7 +169,7 @@
       "properties": {
         "flow": { "$ref": "#/$defs/oauth_flow" },
         "redirect_uri": { "type": "string", "minLength": 1 },
-        "redirect_uri_port": { "type": "string", "enum": ["fixed", "random"] },
+        "redirect_uri_port_mode": { "type": "string", "enum": ["fixed", "random"] },
         "endpoints": { "$ref": "#/$defs/oauth_endpoints" },
         "client": { "$ref": "#/$defs/oauth_client" },
         "scopes": { "$ref": "#/$defs/oauth_scopes" }

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -169,6 +169,7 @@
       "properties": {
         "flow": { "$ref": "#/$defs/oauth_flow" },
         "redirect_uri": { "type": "string", "minLength": 1 },
+        "redirect_uri_port": { "type": "string", "enum": ["fixed", "random"] },
         "endpoints": { "$ref": "#/$defs/oauth_endpoints" },
         "client": { "$ref": "#/$defs/oauth_client" },
         "scopes": { "$ref": "#/$defs/oauth_scopes" }

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -751,7 +751,7 @@ inputs:
               type: authorization_code
               pkce: required
             redirect_uri: http://127.0.0.1:53682/oauth/callback
-            redirect_uri_port: fixed
+            redirect_uri_port_mode: fixed
             endpoints:
               authorization_url: https://github.com/login/oauth/authorize
               token_url: https://github.com/login/oauth/access_token
@@ -776,10 +776,12 @@ used. OAuth currently supports authorization-code flow with a loopback HTTP
 callback URI: `http://127.0.0.1[:<port>]/<path>` or
 `http://localhost[:<port>]/<path>`.
 
-`redirect_uri_port` controls how Coral binds the loopback port:
+`redirect_uri_port_mode` controls how Coral binds the loopback port. When this
+field is omitted, Coral treats `redirect_uri` port `0` as `random`; otherwise it
+defaults to `fixed`.
 
-- `fixed` (default) binds the exact non-zero port authored in `redirect_uri`;
-  if that port is busy, install fails.
+- `fixed` binds the exact non-zero port authored in `redirect_uri`; if that port
+  is busy, install fails.
 - `random` binds a free port at install time. In this mode `redirect_uri` must
   omit the port or use port `0`; Coral sends the effective URI with the assigned
   port in both the authorization request and the token exchange.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -751,6 +751,7 @@ inputs:
               type: authorization_code
               pkce: required
             redirect_uri: http://127.0.0.1:53682/oauth/callback
+            redirect_uri_port: fixed
             endpoints:
               authorization_url: https://github.com/login/oauth/authorize
               token_url: https://github.com/login/oauth/access_token
@@ -771,15 +772,23 @@ inputs:
 Supported credential method types are `source_config` and `oauth`.
 `source_config` uses the normal source input path: an environment variable by
 default, or an interactive prompt when `coral source add --interactive` is
-used. OAuth method metadata currently supports authorization-code flow with a
-fixed loopback HTTP callback URI:
-`http://127.0.0.1:<port>/<path>` or
-`http://localhost:<port>/<path>`. Coral validates and exposes the declared
-`redirect_uri`. For OAuth methods, Coral starts the loopback flow and returns
-the provider authorization URL. After the callback, Coral exchanges the code,
-stores the access token as the source secret, and stores any refresh token as
-internal credential metadata. If users provide their own OAuth client ID, they
-must configure the declared redirect URI exactly in the OAuth app.
+used. OAuth currently supports authorization-code flow with a loopback HTTP
+callback URI: `http://127.0.0.1[:<port>]/<path>` or
+`http://localhost[:<port>]/<path>`.
+
+`redirect_uri_port` controls how Coral binds the loopback port:
+
+- `fixed` (default) binds the exact non-zero port authored in `redirect_uri`;
+  if that port is busy, install fails.
+- `random` binds a free port at install time. In this mode `redirect_uri` must
+  omit the port or use port `0`; Coral sends the effective URI with the assigned
+  port in both the authorization request and the token exchange.
+
+When users provide their own OAuth client ID, they must configure the matching
+loopback redirect behavior in the OAuth app. For OAuth methods, Coral starts
+the loopback flow and returns the provider authorization URL. After the
+callback, Coral exchanges the code, stores the access token as the source
+secret, and stores any refresh token as internal credential metadata.
 
 `flow.type` and `pkce` are required. Unspecified protobuf enum values are
 invalid and are rejected rather than treated as defaults. `pkce` is either
@@ -790,9 +799,9 @@ required `transport` of `basic_auth` or `request_body`. Client secrets are sent
 only to the token endpoint and are never included in the authorization URL.
 
 Scopes are declared under `scopes.scope`; `delimiter: space` represents
-`scope=a b`, and `delimiter: comma` represents `scope=a,b`. Automatic token
-refresh is not implemented yet; stored refresh tokens are preserved for a
-future refresh flow.
+`scope=a b`, and `delimiter: comma` represents `scope=a,b`. Coral may store
+refresh tokens and OAuth metadata alongside the source secret, but automatic
+token refresh is not implemented yet.
 
 At runtime, installed source inputs are also surfaced through `coral.inputs`.
 This is useful when agents or scripts need to inspect non-secret source config


### PR DESCRIPTION
## Summary
- add `redirect_uri_port: random` to OAuth credential specs
- bind an available loopback port for OAuth callback sessions
- propagate the selected port through authorization and token exchange
- document fixed vs random redirect-port behavior

## Scope
This is a follow-up extension to the fixed-port authorization-code flow from the previous PRs.

## Verification
- make rust-checks
- make docs-check
