### PR TITLE
feat(sources/core/slack): add OAuth credential method

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -78,6 +78,7 @@
         "group": "Guides",
         "pages": [
           "guides/use-coral-over-mcp",
+          "guides/connect-slack",
           "guides/write-a-custom-source",
           "guides/observe-with-opentelemetry"
         ]

--- a/docs/guides/connect-slack.mdx
+++ b/docs/guides/connect-slack.mdx
@@ -1,0 +1,130 @@
+---
+title: "Connect Slack"
+description: "Create a Slack app and connect the Slack source with OAuth."
+---
+
+The Slack source queries channels, messages, thread replies, and users from
+your workspace. Slack has no general-purpose API for reading messages, so
+Coral authenticates with a token issued by a Slack app.
+
+## Why you create your own Slack app
+
+Coral does not ship a shared Slack app. A Slack app can only authorize users
+outside its home workspace once it is **publicly distributed**, and Slack
+requires public-distribution apps to use **HTTPS** redirect URLs. Coral's
+OAuth flow completes on a local loopback redirect
+(`http://localhost:53682/oauth/callback`), which Slack does not accept for
+public distribution.
+
+A non-distributed app authorized only within its own workspace *is* allowed
+to use a loopback redirect. So each person creates a personal Slack app once
+and reuses it. It takes about a minute.
+
+<Note>
+Already have a User OAuth Token with the required scopes? Skip to
+[Use an existing token](#use-an-existing-token).
+</Note>
+
+## Create the Slack app
+
+<Steps>
+<Step title="Open the app creator">
+Open the [pre-filled app creation link](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Ahistory%22%2C%22groups%3Aread%22%2C%22channels%3Aread%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%2C%22pkce_enabled%22%3Atrue%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Afalse%7D%7D).
+It opens Slack's app creator with Coral's manifest pre-loaded — the app name,
+required user scopes, loopback redirect URL, and PKCE are all filled in.
+
+Prefer to create the app manually? Choose **Create an app → From a manifest**
+in Slack and paste the [app manifest](#app-manifest) below.
+</Step>
+<Step title="Pick a workspace and create">
+Select the workspace you want to query, review the configuration, and click
+**Create**.
+</Step>
+<Step title="Copy the Client ID">
+Open the app's **Basic Information** page and copy its **Client ID** from the
+**App Credentials** section. You do not need the Client Secret — Coral uses
+the public-client PKCE flow.
+</Step>
+</Steps>
+
+## Connect the source
+
+<Steps>
+<Step title="Start the interactive flow">
+Run:
+
+```bash
+coral source add --interactive slack
+```
+</Step>
+<Step title="Choose OAuth">
+Select **Connect with Slack**, then paste the **Client ID** from your app
+when prompted.
+</Step>
+<Step title="Authorize in the browser">
+Coral opens Slack in your browser. Approve the requested scopes. Slack
+redirects back to Coral on `http://localhost:53682/oauth/callback`, and Coral
+stores the resulting User OAuth Token.
+</Step>
+</Steps>
+
+The token is tied to the Slack user who authorized Coral, so channel access
+follows that user's visibility and workspace policy.
+
+## Use an existing token
+
+If you already have a Slack app, open its **OAuth & Permissions** page, copy
+a token, and run `coral source add --interactive slack`, choosing **Paste
+Slack OAuth Token** instead of the OAuth flow.
+
+Either token type works:
+
+- A **User OAuth Token** (`xoxp-`) reads the channels the authorizing user
+  belongs to.
+- A **Bot Token** (`xoxb-`) reads the channels the bot has been added to.
+
+The token must carry these scopes:
+
+| Scope               | Used for                              |
+| ------------------- | ------------------------------------- |
+| `channels:read`     | List public channels                  |
+| `channels:history`  | Read messages and thread replies      |
+| `groups:read`       | List private channels                 |
+| `groups:history`    | Read private channel messages         |
+| `users:read`        | List workspace users                  |
+| `users:read.email`  | Include user email addresses          |
+
+## App manifest
+
+To create the app manually, paste this manifest into Slack's
+**Create an app → From a manifest** flow:
+
+```json
+{
+  "display_information": {
+    "name": "Coral"
+  },
+  "oauth_config": {
+    "redirect_urls": [
+      "http://localhost:53682/oauth/callback"
+    ],
+    "scopes": {
+      "user": [
+        "channels:history",
+        "groups:read",
+        "channels:read",
+        "groups:history",
+        "users:read",
+        "users:read.email"
+      ]
+    },
+    "pkce_enabled": true
+  },
+  "settings": {
+    "org_deploy_enabled": false,
+    "socket_mode_enabled": false,
+    "token_rotation_enabled": false,
+    "is_mcp_enabled": false
+  }
+}
+```

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -333,15 +333,24 @@ See [Sentry auth token docs](https://docs.sentry.io/api/guides/create-auth-token
 `SLACK_TOKEN` (required)
 
 Slack doesn't provide a general-purpose API for reading messages.
-Instead, you need a Slack app with a Bot User OAuth Token.
+Instead, you need a Slack app with a User OAuth Token. Run
+`coral source add --interactive slack` to connect through OAuth as your
+Slack user, or paste an existing token.
+
+For OAuth, create a Slack app with the required user scopes, add
+`http://localhost:53682/oauth/callback` as a Redirect URL under OAuth &
+Permissions, and enable PKCE. Coral uses Slack's public-client PKCE user
+token flow. The OAuth token is tied to the Slack user who authorizes
+Coral, so channel access follows that user's visibility and workspace
+policy.
 
 If you already have a Slack app with the required scopes, you can
-find your Bot User OAuth Token on its OAuth & Permissions page. The
+find your User OAuth Token on its OAuth & Permissions page. The
 required scopes are: channels:read, channels:history, groups:read,
 groups:history, users:read, users:read.email.
 
 If you don't have a Slack app, you can
-[create one with the required scopes pre-filled](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22bot%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%2C%22features%22%3A%7B%22bot_user%22%3A%7B%22display_name%22%3A%22Coral%22%2C%22always_online%22%3Afalse%7D%7D%7D).
+[create one with the required user scopes and redirect URL pre-filled](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%7D).
 
 For more details, see the [Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
 

--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -332,27 +332,35 @@ See [Sentry auth token docs](https://docs.sentry.io/api/guides/create-auth-token
 
 `SLACK_TOKEN` (required)
 
-Slack doesn't provide a general-purpose API for reading messages.
-Instead, you need a Slack app with a User OAuth Token. Run
-`coral source add --interactive slack` to connect through OAuth as your
-Slack user, or paste an existing token.
+Slack has no general-purpose API for reading messages, so Coral
+connects with a token from a Slack app.
 
-For OAuth, create a Slack app with the required user scopes, add
-`http://localhost:53682/oauth/callback` as a Redirect URL under OAuth &
-Permissions, and enable PKCE. Coral uses Slack's public-client PKCE user
-token flow. The OAuth token is tied to the Slack user who authorizes
-Coral, so channel access follows that user's visibility and workspace
-policy.
+Coral ships no shared Slack app. Slack only lets an app authorize
+users outside its home workspace when it is publicly distributed
+over HTTPS, which is incompatible with Coral's local
+`http://localhost` OAuth redirect. You create your own Slack app
+once and reuse it.
 
-If you already have a Slack app with the required scopes, you can
-find your User OAuth Token on its OAuth & Permissions page. The
-required scopes are: channels:read, channels:history, groups:read,
-groups:history, users:read, users:read.email.
+To connect with OAuth:
+1. [Create a Slack app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Ahistory%22%2C%22groups%3Aread%22%2C%22channels%3Aread%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%2C%22pkce_enabled%22%3Atrue%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Afalse%7D%7D)
+   — the link pre-fills the app name, required user scopes,
+   redirect URL, and PKCE.
+2. Open the new app's Basic Information page and copy its Client ID.
+3. Run `coral source add --interactive slack`, choose "Connect
+   with Slack", and paste the Client ID when prompted.
 
-If you don't have a Slack app, you can
-[create one with the required user scopes and redirect URL pre-filled](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%7D).
+Coral uses Slack's public-client PKCE user token flow. The token
+is tied to the Slack user who authorizes Coral, so channel access
+follows that user's visibility and workspace policy.
 
-For more details, see the [Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
+Alternatively, paste an existing token from a Slack app's OAuth &
+Permissions page. A user token and a bot token both work: a user
+token reads the channels that user belongs to, a bot token reads
+the channels the bot has been added to. Required scopes:
+channels:read, channels:history, groups:read, groups:history,
+users:read, users:read.email.
+
+Full walkthrough: https://withcoral.com/docs/guides/connect-slack
 
 ### `statusgator`
 

--- a/sources/core/slack/manifest.yaml
+++ b/sources/core/slack/manifest.yaml
@@ -17,7 +17,7 @@ inputs:
               type: authorization_code
               pkce: required
             redirect_uri: http://localhost:53682/oauth/callback
-            redirect_uri_port: fixed
+            redirect_uri_port_mode: fixed
             endpoints:
               authorization_url: https://slack.com/oauth/v2_user/authorize
               token_url: https://slack.com/api/oauth.v2.user.access

--- a/sources/core/slack/manifest.yaml
+++ b/sources/core/slack/manifest.yaml
@@ -7,17 +7,57 @@ description: >-
 inputs:
   SLACK_TOKEN:
     kind: secret
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with Slack
+          description: Authorize Slack with OAuth and store a user token.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://localhost:53682/oauth/callback
+            redirect_uri_port: fixed
+            endpoints:
+              authorization_url: https://slack.com/oauth/v2_user/authorize
+              token_url: https://slack.com/api/oauth.v2.user.access
+            client:
+              id:
+                default: "6057250636981.11141166742192"
+                input: SLACK_OAUTH_CLIENT_ID
+            scopes:
+              scope:
+                delimiter: comma
+                values:
+                  - channels:read
+                  - groups:read
+                  - channels:history
+                  - groups:history
+                  - users:read
+                  - users:read.email
+        - type: source_config
+          label: Paste Slack OAuth Token
+          description: Paste an existing Slack OAuth token with the required scopes.
     hint: |
       Slack doesn't provide a general-purpose API for reading messages.
-      Instead, you need a Slack app with a Bot User OAuth Token.
+      Instead, you need a Slack app with a User OAuth Token. Run
+      `coral source add --interactive slack` to connect through OAuth as your
+      Slack user, or paste an existing token.
+
+      For OAuth, create a Slack app with the required user scopes, add
+      `http://localhost:53682/oauth/callback` as a Redirect URL under OAuth &
+      Permissions, and enable PKCE. Coral uses Slack's public-client PKCE user
+      token flow. The OAuth token is tied to the Slack user who authorizes
+      Coral, so channel access follows that user's visibility and workspace
+      policy.
 
       If you already have a Slack app with the required scopes, you can
-      find your Bot User OAuth Token on its OAuth & Permissions page. The
+      find your User OAuth Token on its OAuth & Permissions page. The
       required scopes are: channels:read, channels:history, groups:read,
       groups:history, users:read, users:read.email.
 
       If you don't have a Slack app, you can
-      [create one with the required scopes pre-filled](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22scopes%22%3A%7B%22bot%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%2C%22features%22%3A%7B%22bot_user%22%3A%7B%22display_name%22%3A%22Coral%22%2C%22always_online%22%3Afalse%7D%7D%7D).
+      [create one with the required user scopes and redirect URL pre-filled](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%7D).
 
       For more details, see the [Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
 base_url: https://slack.com

--- a/sources/core/slack/manifest.yaml
+++ b/sources/core/slack/manifest.yaml
@@ -23,7 +23,6 @@ inputs:
               token_url: https://slack.com/api/oauth.v2.user.access
             client:
               id:
-                default: "6057250636981.11141166742192"
                 input: SLACK_OAUTH_CLIENT_ID
             scopes:
               scope:
@@ -39,27 +38,35 @@ inputs:
           label: Paste Slack OAuth Token
           description: Paste an existing Slack OAuth token with the required scopes.
     hint: |
-      Slack doesn't provide a general-purpose API for reading messages.
-      Instead, you need a Slack app with a User OAuth Token. Run
-      `coral source add --interactive slack` to connect through OAuth as your
-      Slack user, or paste an existing token.
+      Slack has no general-purpose API for reading messages, so Coral
+      connects with a token from a Slack app.
 
-      For OAuth, create a Slack app with the required user scopes, add
-      `http://localhost:53682/oauth/callback` as a Redirect URL under OAuth &
-      Permissions, and enable PKCE. Coral uses Slack's public-client PKCE user
-      token flow. The OAuth token is tied to the Slack user who authorizes
-      Coral, so channel access follows that user's visibility and workspace
-      policy.
+      Coral ships no shared Slack app. Slack only lets an app authorize
+      users outside its home workspace when it is publicly distributed
+      over HTTPS, which is incompatible with Coral's local
+      `http://localhost` OAuth redirect. You create your own Slack app
+      once and reuse it.
 
-      If you already have a Slack app with the required scopes, you can
-      find your User OAuth Token on its OAuth & Permissions page. The
-      required scopes are: channels:read, channels:history, groups:read,
-      groups:history, users:read, users:read.email.
+      To connect with OAuth:
+      1. [Create a Slack app](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Ahistory%22%2C%22groups%3Aread%22%2C%22channels%3Aread%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%2C%22pkce_enabled%22%3Atrue%7D%2C%22settings%22%3A%7B%22org_deploy_enabled%22%3Afalse%2C%22socket_mode_enabled%22%3Afalse%2C%22token_rotation_enabled%22%3Afalse%2C%22is_mcp_enabled%22%3Afalse%7D%7D)
+         — the link pre-fills the app name, required user scopes,
+         redirect URL, and PKCE.
+      2. Open the new app's Basic Information page and copy its Client ID.
+      3. Run `coral source add --interactive slack`, choose "Connect
+         with Slack", and paste the Client ID when prompted.
 
-      If you don't have a Slack app, you can
-      [create one with the required user scopes and redirect URL pre-filled](https://api.slack.com/apps?new_app=1&manifest_json=%7B%22display_information%22%3A%7B%22name%22%3A%22Coral%22%2C%22description%22%3A%22Coral+data+access%22%7D%2C%22oauth_config%22%3A%7B%22redirect_urls%22%3A%5B%22http%3A%2F%2Flocalhost%3A53682%2Foauth%2Fcallback%22%5D%2C%22scopes%22%3A%7B%22user%22%3A%5B%22channels%3Aread%22%2C%22groups%3Aread%22%2C%22channels%3Ahistory%22%2C%22groups%3Ahistory%22%2C%22users%3Aread%22%2C%22users%3Aread.email%22%5D%7D%7D%7D).
+      Coral uses Slack's public-client PKCE user token flow. The token
+      is tied to the Slack user who authorizes Coral, so channel access
+      follows that user's visibility and workspace policy.
 
-      For more details, see the [Slack app setup guide](https://docs.slack.dev/app-management/quickstart-app-settings).
+      Alternatively, paste an existing token from a Slack app's OAuth &
+      Permissions page. A user token and a bot token both work: a user
+      token reads the channels that user belongs to, a bot token reads
+      the channels the bot has been added to. Required scopes:
+      channels:read, channels:history, groups:read, groups:history,
+      users:read, users:read.email.
+
+      Full walkthrough: https://withcoral.com/docs/guides/connect-slack
 base_url: https://slack.com
 auth:
   type: HeaderAuth


### PR DESCRIPTION
## Intent

Add OAuth credential metadata to the bundled Slack source so users can connect Slack through Coral's OAuth install flow instead of only pasting an existing token.

## What it enables

- `coral source add --interactive slack` can offer a "Connect with Slack" OAuth option.
- Slack installs request a PKCE authorization-code user token through Slack's `oauth.v2.user.access` endpoint.
- Manual token entry remains available through the existing source-config fallback.

## Usage examples

1. In the Slack app OAuth settings, add this Redirect URL: `http://localhost:53682/oauth/callback`.
2. Enable PKCE for the app.
3. Request these User Token Scopes: `channels:read`, `groups:read`, `channels:history`, `groups:history`, `users:read`, `users:read.email`.
4. Run `coral source add --interactive slack` and choose "Connect with Slack".

## Validation

- `make lint-sources`
- `make docs-check`
- `cargo fmt --all -- --check`
- `git diff --check`
