### PR TITLE
feat(sources/community/cal): add Cal.com community source

### DIFF
--- a/sources/community/cal/README.md
+++ b/sources/community/cal/README.md
@@ -1,0 +1,112 @@
+# Cal.com
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** `https://api.cal.com` (override with `CAL_BASE_URL`)
+
+Query bookings, event types, schedules, and profile data from Cal.com
+(Cloud or self-hosted).
+
+## Authentication
+
+Requires a `CAL_API_KEY`. Find it in **Settings → Security → API Keys**.
+
+- Test mode keys have the prefix `cal_`
+- Live mode keys have the prefix `cal_live_`
+
+```bash
+CAL_API_KEY=cal_live_... coral source add --file sources/community/cal/manifest.yaml
+```
+
+Or interactively:
+
+```bash
+CAL_API_KEY=cal_live_... coral source add --file sources/community/cal/manifest.yaml --interactive
+```
+
+### Self-hosted
+
+Set `CAL_BASE_URL` to your instance URL:
+
+```bash
+CAL_API_KEY=cal_... CAL_BASE_URL=https://cal.example.com \
+  coral source add --file sources/community/cal/manifest.yaml
+```
+
+## Tables
+
+| Table | Description | Optional filters |
+|---|---|---|
+| `me` | Profile of the authenticated user | — |
+| `event_types` | Bookable meeting configurations | — |
+| `bookings` | Scheduled meetings and their status | `status`, `attendee_email`, `attendee_name`, `event_type_id` |
+| `schedules` | Availability schedules | — |
+
+## Quick start
+
+```bash
+# Confirm connectivity and see your profile
+coral sql "SELECT id, username, email, name, time_zone FROM cal.me"
+
+# List all event types
+coral sql "
+  SELECT id, title, slug, length_in_minutes, hidden, booking_url
+  FROM cal.event_types
+  ORDER BY length_in_minutes
+"
+
+# All bookings
+coral sql "
+  SELECT id, uid, title, status, start, duration, event_type_id
+  FROM cal.bookings
+  ORDER BY start DESC
+  LIMIT 20
+"
+
+# Filter bookings by status
+coral sql "
+  SELECT uid, title, start, host__name, host__email
+  FROM cal.bookings
+  WHERE status = 'cancelled'
+  ORDER BY start DESC
+  LIMIT 20
+"
+
+# Bookings for a specific event type
+coral sql "
+  SELECT uid, title, start, status
+  FROM cal.bookings
+  WHERE event_type_id = <your-event-type-id>
+  ORDER BY start DESC
+"
+
+# Booking volume by event type
+coral sql "
+  SELECT event_type__slug, status, COUNT(*) as count
+  FROM cal.bookings
+  GROUP BY event_type__slug, status
+  ORDER BY count DESC
+"
+
+# Availability schedules
+coral sql "
+  SELECT id, name, time_zone, is_default
+  FROM cal.schedules
+"
+```
+
+## Discovery order
+
+```text
+me
+  → default_schedule_id → schedules.id
+
+event_types
+  → id (event_type_id)
+    → bookings (WHERE event_type_id = '...')
+  → schedule_id → schedules.id
+
+bookings
+  → event_type_id → event_types.id
+```

--- a/sources/community/cal/README.md
+++ b/sources/community/cal/README.md
@@ -19,7 +19,7 @@ Requires a `CAL_API_KEY`. Find it in **Settings → Security → API Keys**.
 CAL_API_KEY=cal_live_... coral source add --file sources/community/cal/manifest.yaml
 ```
 
-Or interactively:
+Run from the repo root. Or interactively:
 
 ```bash
 CAL_API_KEY=cal_live_... coral source add --file sources/community/cal/manifest.yaml --interactive

--- a/sources/community/cal/README.md
+++ b/sources/community/cal/README.md
@@ -69,7 +69,7 @@ coral sql "
 
 # Recent bookings
 coral sql "
-  SELECT id, uid, status, start, duration, host_name, attendee_email
+  SELECT id, uid, status, start, end_time, duration, host_name, attendee_email
   FROM cal.bookings
   ORDER BY start DESC
   LIMIT 20

--- a/sources/community/cal/README.md
+++ b/sources/community/cal/README.md
@@ -12,7 +12,7 @@ Query bookings, event types, schedules, and profile data from Cal.com
 
 Requires a `CAL_API_KEY`. Find it in **Settings → Security → API Keys**.
 
-- Test mode keys have the prefix `cal_`
+- Test mode keys have the prefix `cal_test_`
 - Live mode keys have the prefix `cal_live_`
 
 ```bash
@@ -30,7 +30,7 @@ CAL_API_KEY=cal_live_... coral source add --file sources/community/cal/manifest.
 Set `CAL_BASE_URL` to your instance URL:
 
 ```bash
-CAL_API_KEY=cal_... CAL_BASE_URL=https://cal.example.com \
+CAL_API_KEY=cal_test_... CAL_BASE_URL=https://cal.example.com \
   coral source add --file sources/community/cal/manifest.yaml
 ```
 
@@ -40,8 +40,19 @@ CAL_API_KEY=cal_... CAL_BASE_URL=https://cal.example.com \
 |---|---|---|
 | `me` | Profile of the authenticated user | — |
 | `event_types` | Bookable meeting configurations | — |
-| `bookings` | Scheduled meetings and their status | `status`, `attendee_email`, `attendee_name`, `event_type_id` |
+| `bookings` | Scheduled meetings and their status | `status`, `attendee_email`, `attendee_name`, `event_type_id`, `after_start`, `before_end`, `after_created_at`, `before_created_at` |
 | `schedules` | Availability schedules | — |
+
+### Bookings status filter note
+
+The `status` filter and the `status` response column use different vocabularies:
+
+| | Values |
+|---|---|
+| Filter (`WHERE status = '...'`) | `upcoming`, `recurring`, `past`, `cancelled`, `unconfirmed` |
+| Response column | `accepted`, `cancelled`, `pending`, `rejected` |
+
+The filter accepts **at most one value** per query — passing multiple values returns 400.
 
 ## Quick start
 
@@ -56,17 +67,26 @@ coral sql "
   ORDER BY length_in_minutes
 "
 
-# All bookings
+# Recent bookings
 coral sql "
-  SELECT id, uid, title, status, start, duration, event_type_id
+  SELECT id, uid, status, start, duration, host_name, attendee_email
   FROM cal.bookings
   ORDER BY start DESC
   LIMIT 20
 "
 
-# Filter bookings by status
+# Bookings in the last 7 days
 coral sql "
-  SELECT uid, title, start, host__name, host__email
+  SELECT uid, title, status, start, host_name, attendee_email
+  FROM cal.bookings
+  WHERE after_start = '2026-05-06T00:00:00Z'
+    AND before_end = '2026-05-13T00:00:00Z'
+  ORDER BY start DESC
+"
+
+# Cancelled bookings
+coral sql "
+  SELECT uid, title, start, cancellation_reason, cancelled_by_email
   FROM cal.bookings
   WHERE status = 'cancelled'
   ORDER BY start DESC
@@ -75,25 +95,22 @@ coral sql "
 
 # Bookings for a specific event type
 coral sql "
-  SELECT uid, title, start, status
+  SELECT uid, title, start, status, attendee_email
   FROM cal.bookings
   WHERE event_type_id = <your-event-type-id>
   ORDER BY start DESC
 "
 
-# Booking volume by event type
+# Booking volume by event type slug
 coral sql "
-  SELECT event_type__slug, status, COUNT(*) as count
+  SELECT event_type_slug, status, COUNT(*) as count
   FROM cal.bookings
-  GROUP BY event_type__slug, status
+  GROUP BY event_type_slug, status
   ORDER BY count DESC
 "
 
 # Availability schedules
-coral sql "
-  SELECT id, name, time_zone, is_default
-  FROM cal.schedules
-"
+coral sql "SELECT id, name, time_zone, is_default FROM cal.schedules"
 ```
 
 ## Discovery order

--- a/sources/community/cal/README.md
+++ b/sources/community/cal/README.md
@@ -97,7 +97,7 @@ coral sql "
 coral sql "
   SELECT uid, title, start, status, attendee_email
   FROM cal.bookings
-  WHERE event_type_id = <your-event-type-id>
+  WHERE event_type_id = 12345
   ORDER BY start DESC
 "
 

--- a/sources/community/cal/manifest.yaml
+++ b/sources/community/cal/manifest.yaml
@@ -315,7 +315,7 @@ tables:
     description: Scheduled meetings and their status
     guide: |
       Each row is one booking. `event_type_id` joins to `cal.event_types`.
-      `start` and `end` are Timestamps — use them for time-based filtering
+      `start` and `end_time` are Timestamps — use them for time-based filtering
       (e.g. WHERE start > NOW() - INTERVAL '7 days').
 
       The `status` filter and the `status` response column use different

--- a/sources/community/cal/manifest.yaml
+++ b/sources/community/cal/manifest.yaml
@@ -17,8 +17,9 @@ inputs:
     kind: variable
     default: https://api.cal.com
     hint: |
-      Base URL for the Cal.com API. Use the default for Cal.com Cloud.
-      For self-hosted Cal.com instances use your own host URL.
+      Base URL for the Cal.com API. Use the default (https://api.cal.com)
+      for Cal.com Cloud. For self-hosted Cal.com instances use your own
+      host URL.
 base_url: "{{input.CAL_BASE_URL}}"
 auth:
   type: HeaderAuth
@@ -159,7 +160,8 @@ tables:
       meeting duration. `hidden = true` means the event type is not
       publicly visible. Results are scoped to the API key owner —
       individual keys return only their own event types; org-scoped keys
-      return all event types in the organization.
+      return all event types in the organization. Org-scoped keys may
+      return large result sets as this table is not paginated.
     request:
       method: GET
       path: /v2/event-types
@@ -326,7 +328,10 @@ tables:
       and merge results.
 
       Use `after_start` / `before_end` for time-window queries instead of
-      fetching all bookings and filtering client-side.
+      fetching all bookings and filtering client-side. Note that
+      `after_start`, `before_end`, `after_created_at`, and
+      `before_created_at` are filter-only parameters and do not appear
+      as selectable columns in the result.
     filters:
       - name: status
         required: false

--- a/sources/community/cal/manifest.yaml
+++ b/sources/community/cal/manifest.yaml
@@ -445,7 +445,7 @@ tables:
             kind: path
             path:
               - start
-      - name: end
+      - name: end_time
         type: Timestamp
         nullable: true
         description: Booking end time

--- a/sources/community/cal/manifest.yaml
+++ b/sources/community/cal/manifest.yaml
@@ -10,8 +10,8 @@ inputs:
     kind: secret
     hint: |
       Your Cal.com API key. Find it in Settings > Security > API Keys.
-      Test mode keys have the prefix cal_ and live mode keys have the
-      prefix cal_live_.
+      Test mode keys have the prefix cal_test_ and live mode keys have
+      the prefix cal_live_.
       See [Cal.com API docs](https://cal.com/docs/api-reference/v2/introduction).
   CAL_BASE_URL:
     kind: variable
@@ -26,10 +26,6 @@ auth:
     - name: Authorization
       from: template
       template: Bearer {{input.CAL_API_KEY}}
-request_headers:
-  - name: cal-api-version
-    from: literal
-    value: "2024-06-14"
 test_queries:
   - SELECT * FROM cal.me LIMIT 1
   - SELECT * FROM cal.event_types LIMIT 1
@@ -40,9 +36,15 @@ tables:
       Singleton table — always returns one row for the authenticated user.
       Use `id` and `username` to understand which account the API key
       belongs to. `default_schedule_id` links to `cal.schedules`.
+      `organization_id` and `organization_is_platform` are set when the
+      user belongs to an organization.
     request:
       method: GET
       path: /v2/me
+      headers:
+        - name: cal-api-version
+          from: literal
+          value: "2024-08-13"
     response:
       rows_path:
         - data
@@ -54,7 +56,6 @@ tables:
       - name: id
         type: Int64
         nullable: false
-        virtual: false
         description: User ID
         expr:
           kind: path
@@ -63,7 +64,6 @@ tables:
       - name: username
         type: Utf8
         nullable: true
-        virtual: false
         description: Cal.com username
         expr:
           kind: path
@@ -72,7 +72,6 @@ tables:
       - name: email
         type: Utf8
         nullable: true
-        virtual: false
         description: User email address
         expr:
           kind: path
@@ -81,7 +80,6 @@ tables:
       - name: name
         type: Utf8
         nullable: true
-        virtual: false
         description: Display name
         expr:
           kind: path
@@ -90,7 +88,6 @@ tables:
       - name: time_zone
         type: Utf8
         nullable: true
-        virtual: false
         description: User time zone
         expr:
           kind: path
@@ -99,7 +96,6 @@ tables:
       - name: week_start
         type: Utf8
         nullable: true
-        virtual: false
         description: First day of the week for this user
         expr:
           kind: path
@@ -108,7 +104,6 @@ tables:
       - name: time_format
         type: Int64
         nullable: true
-        virtual: false
         description: Time format preference (12 or 24)
         expr:
           kind: path
@@ -117,7 +112,6 @@ tables:
       - name: default_schedule_id
         type: Int64
         nullable: true
-        virtual: false
         description: ID of the user's default availability schedule
         expr:
           kind: path
@@ -126,7 +120,6 @@ tables:
       - name: locale
         type: Utf8
         nullable: true
-        virtual: false
         description: User locale (e.g. en)
         expr:
           kind: path
@@ -135,7 +128,6 @@ tables:
       - name: bio
         type: Utf8
         nullable: true
-        virtual: false
         description: User bio
         expr:
           kind: path
@@ -144,12 +136,20 @@ tables:
       - name: organization_id
         type: Int64
         nullable: true
-        virtual: false
         description: Organization ID if the user belongs to an organization
         expr:
           kind: path
           path:
             - organizationId
+      - name: organization_is_platform
+        type: Boolean
+        nullable: true
+        description: Whether the organization is a platform organization
+        expr:
+          kind: path
+          path:
+            - organization
+            - isPlatform
   - name: event_types
     description: Event types configured by the authenticated user
     guide: |
@@ -157,10 +157,16 @@ tables:
       `id` to join with `bookings.event_type_id`. `slug` is the URL
       identifier used in booking links. `length_in_minutes` is the
       meeting duration. `hidden = true` means the event type is not
-      publicly visible.
+      publicly visible. Results are scoped to the API key owner —
+      individual keys return only their own event types; org-scoped keys
+      return all event types in the organization.
     request:
       method: GET
       path: /v2/event-types
+      headers:
+        - name: cal-api-version
+          from: literal
+          value: "2024-06-14"
     response:
       rows_path:
         - data
@@ -172,7 +178,6 @@ tables:
       - name: id
         type: Int64
         nullable: false
-        virtual: false
         description: Event type ID
         expr:
           kind: path
@@ -181,7 +186,6 @@ tables:
       - name: title
         type: Utf8
         nullable: false
-        virtual: false
         description: Event type title
         expr:
           kind: path
@@ -190,7 +194,6 @@ tables:
       - name: slug
         type: Utf8
         nullable: false
-        virtual: false
         description: URL slug used in booking links
         expr:
           kind: path
@@ -199,7 +202,6 @@ tables:
       - name: description
         type: Utf8
         nullable: true
-        virtual: false
         description: Event type description
         expr:
           kind: path
@@ -208,7 +210,6 @@ tables:
       - name: length_in_minutes
         type: Int64
         nullable: true
-        virtual: false
         description: Default meeting duration in minutes
         expr:
           kind: path
@@ -217,7 +218,6 @@ tables:
       - name: hidden
         type: Boolean
         nullable: true
-        virtual: false
         description: Whether the event type is hidden from the public booking page
         expr:
           kind: path
@@ -226,7 +226,6 @@ tables:
       - name: price
         type: Int64
         nullable: true
-        virtual: false
         description: Price for paid events (in smallest currency unit)
         expr:
           kind: path
@@ -235,7 +234,6 @@ tables:
       - name: currency
         type: Utf8
         nullable: true
-        virtual: false
         description: Currency code for paid events
         expr:
           kind: path
@@ -244,7 +242,6 @@ tables:
       - name: owner_id
         type: Int64
         nullable: true
-        virtual: false
         description: User ID of the event type owner
         expr:
           kind: path
@@ -253,7 +250,6 @@ tables:
       - name: booking_url
         type: Utf8
         nullable: true
-        virtual: false
         description: Full public booking URL for this event type
         expr:
           kind: path
@@ -262,7 +258,6 @@ tables:
       - name: schedule_id
         type: Int64
         nullable: true
-        virtual: false
         description: Availability schedule ID used by this event type
         expr:
           kind: path
@@ -271,7 +266,6 @@ tables:
       - name: minimum_booking_notice
         type: Int64
         nullable: true
-        virtual: false
         description: Minimum notice required before a booking in minutes
         expr:
           kind: path
@@ -280,7 +274,6 @@ tables:
       - name: before_event_buffer
         type: Int64
         nullable: true
-        virtual: false
         description: Buffer time before the event in minutes
         expr:
           kind: path
@@ -289,7 +282,6 @@ tables:
       - name: after_event_buffer
         type: Int64
         nullable: true
-        virtual: false
         description: Buffer time after the event in minutes
         expr:
           kind: path
@@ -298,7 +290,6 @@ tables:
       - name: seats_per_time_slot
         type: Int64
         nullable: true
-        virtual: false
         description: Number of seats per time slot for group events
         expr:
           kind: path
@@ -307,7 +298,6 @@ tables:
       - name: is_instant_event
         type: Boolean
         nullable: true
-        virtual: false
         description: Whether this is an instant meeting event type
         expr:
           kind: path
@@ -316,7 +306,6 @@ tables:
       - name: disable_guests
         type: Boolean
         nullable: true
-        virtual: false
         description: Whether guests are disabled for this event type
         expr:
           kind: path
@@ -325,11 +314,19 @@ tables:
   - name: bookings
     description: Scheduled meetings and their status
     guide: |
-      Each row is one booking. Use `status` to filter by accepted,
-      cancelled, or pending. `event_type_id` joins to `cal.event_types`.
-      `start` and `end` are ISO 8601 timestamps. Filter by `status` to
-      analyse cancellations or by `attendee_email` to look up a specific
-      person's meetings. Results are cursor-paginated newest-first.
+      Each row is one booking. `event_type_id` joins to `cal.event_types`.
+      `start` and `end` are Timestamps — use them for time-based filtering
+      (e.g. WHERE start > NOW() - INTERVAL '7 days').
+
+      The `status` filter and the `status` response column use different
+      vocabularies. Filter values: upcoming, recurring, past, cancelled,
+      unconfirmed. Response values: accepted, cancelled, pending, rejected.
+      The filter accepts at most one value per query — passing multiple
+      values returns 400. To query across statuses, run separate queries
+      and merge results.
+
+      Use `after_start` / `before_end` for time-window queries instead of
+      fetching all bookings and filtering client-side.
     filters:
       - name: status
         required: false
@@ -339,9 +336,21 @@ tables:
         required: false
       - name: event_type_id
         required: false
+      - name: after_start
+        required: false
+      - name: before_end
+        required: false
+      - name: after_created_at
+        required: false
+      - name: before_created_at
+        required: false
     request:
       method: GET
       path: /v2/bookings
+      headers:
+        - name: cal-api-version
+          from: literal
+          value: "2026-05-01"
       query:
         - name: status
           from: filter
@@ -355,6 +364,18 @@ tables:
         - name: eventTypeId
           from: filter
           key: event_type_id
+        - name: afterStart
+          from: filter
+          key: after_start
+        - name: beforeEnd
+          from: filter
+          key: before_end
+        - name: afterCreatedAt
+          from: filter
+          key: after_created_at
+        - name: beforeCreatedAt
+          from: filter
+          key: before_created_at
     response:
       rows_path:
         - data
@@ -367,14 +388,13 @@ tables:
         - pagination
         - nextCursor
       page_size:
-        default: 100
+        default: 50
         max: 100
-        query_param: take
+        query_param: limit
     columns:
       - name: id
         type: Int64
         nullable: true
-        virtual: false
         description: Booking ID
         expr:
           kind: path
@@ -383,7 +403,6 @@ tables:
       - name: uid
         type: Utf8
         nullable: true
-        virtual: false
         description: Unique booking identifier (used in booking URLs)
         expr:
           kind: path
@@ -392,7 +411,6 @@ tables:
       - name: title
         type: Utf8
         nullable: true
-        virtual: false
         description: Booking title
         expr:
           kind: path
@@ -401,7 +419,6 @@ tables:
       - name: description
         type: Utf8
         nullable: true
-        virtual: false
         description: Booking description
         expr:
           kind: path
@@ -410,34 +427,38 @@ tables:
       - name: status
         type: Utf8
         nullable: true
-        virtual: false
-        description: Booking status (accepted, cancelled, pending, or rejected)
+        description: >-
+          Booking status from the response (accepted, cancelled, pending, rejected).
+          Note: the status filter uses different values — see table guide.
         expr:
           kind: path
           path:
             - status
       - name: start
-        type: Utf8
+        type: Timestamp
         nullable: true
-        virtual: false
-        description: Booking start time (ISO 8601)
+        description: Booking start time
         expr:
-          kind: path
-          path:
-            - start
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - start
       - name: end
-        type: Utf8
+        type: Timestamp
         nullable: true
-        virtual: false
-        description: Booking end time (ISO 8601)
+        description: Booking end time
         expr:
-          kind: path
-          path:
-            - end
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - end
       - name: duration
         type: Int64
         nullable: true
-        virtual: false
         description: Booking duration in minutes
         expr:
           kind: path
@@ -446,16 +467,14 @@ tables:
       - name: event_type_id
         type: Int64
         nullable: true
-        virtual: false
         description: ID of the event type for this booking
         expr:
           kind: path
           path:
             - eventTypeId
-      - name: event_type__slug
+      - name: event_type_slug
         type: Utf8
         nullable: true
-        virtual: false
         description: Slug of the event type for this booking
         expr:
           kind: path
@@ -465,7 +484,6 @@ tables:
       - name: location
         type: Utf8
         nullable: true
-        virtual: false
         description: Meeting location or video call URL
         expr:
           kind: path
@@ -474,16 +492,14 @@ tables:
       - name: meeting_url
         type: Utf8
         nullable: true
-        virtual: false
         description: Video meeting URL
         expr:
           kind: path
           path:
             - meetingUrl
-      - name: host__id
+      - name: host_id
         type: Int64
         nullable: true
-        virtual: false
         description: Host user ID (first host)
         expr:
           kind: first_array_item_path
@@ -491,10 +507,9 @@ tables:
             - hosts
           item_path:
             - id
-      - name: host__name
+      - name: host_name
         type: Utf8
         nullable: true
-        virtual: false
         description: Host display name (first host)
         expr:
           kind: first_array_item_path
@@ -502,10 +517,9 @@ tables:
             - hosts
           item_path:
             - name
-      - name: host__email
+      - name: host_email
         type: Utf8
         nullable: true
-        virtual: false
         description: Host email address (first host)
         expr:
           kind: first_array_item_path
@@ -513,10 +527,9 @@ tables:
             - hosts
           item_path:
             - email
-      - name: host__time_zone
+      - name: host_time_zone
         type: Utf8
         nullable: true
-        virtual: false
         description: Host time zone (first host)
         expr:
           kind: first_array_item_path
@@ -524,10 +537,39 @@ tables:
             - hosts
           item_path:
             - timeZone
+      - name: attendee_name
+        type: Utf8
+        nullable: true
+        description: Attendee display name (first attendee)
+        expr:
+          kind: first_array_item_path
+          path:
+            - attendees
+          item_path:
+            - name
+      - name: attendee_email
+        type: Utf8
+        nullable: true
+        description: Attendee email address (first attendee)
+        expr:
+          kind: first_array_item_path
+          path:
+            - attendees
+          item_path:
+            - email
+      - name: attendee_time_zone
+        type: Utf8
+        nullable: true
+        description: Attendee time zone (first attendee)
+        expr:
+          kind: first_array_item_path
+          path:
+            - attendees
+          item_path:
+            - timeZone
       - name: absent_host
         type: Boolean
         nullable: true
-        virtual: false
         description: Whether the host was absent for this booking
         expr:
           kind: path
@@ -536,7 +578,6 @@ tables:
       - name: cancellation_reason
         type: Utf8
         nullable: true
-        virtual: false
         description: Reason provided when the booking was cancelled
         expr:
           kind: path
@@ -545,7 +586,6 @@ tables:
       - name: cancelled_by_email
         type: Utf8
         nullable: true
-        virtual: false
         description: Email of the person who cancelled the booking
         expr:
           kind: path
@@ -554,7 +594,6 @@ tables:
       - name: rescheduling_reason
         type: Utf8
         nullable: true
-        virtual: false
         description: Reason provided when the booking was rescheduled
         expr:
           kind: path
@@ -563,7 +602,6 @@ tables:
       - name: rescheduled_from_uid
         type: Utf8
         nullable: true
-        virtual: false
         description: UID of the original booking before rescheduling
         expr:
           kind: path
@@ -572,46 +610,33 @@ tables:
       - name: rating
         type: Int64
         nullable: true
-        virtual: false
         description: Post-meeting rating score
         expr:
           kind: path
           path:
             - rating
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
-        virtual: false
         description: Timestamp when the booking was created
         expr:
-          kind: path
-          path:
-            - createdAt
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
-        virtual: false
         description: Timestamp when the booking was last updated
         expr:
-          kind: path
-          path:
-            - updatedAt
-      - name: filter_status
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Echoes the status filter applied to this query
-        expr:
-          kind: from_filter
-          key: status
-      - name: filter_attendee_email
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Echoes the attendee_email filter applied to this query
-        expr:
-          kind: from_filter
-          key: attendee_email
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
   - name: schedules
     description: Availability schedules defining when the user can be booked
     guide: |
@@ -623,6 +648,10 @@ tables:
     request:
       method: GET
       path: /v2/schedules
+      headers:
+        - name: cal-api-version
+          from: literal
+          value: "2024-06-11"
     response:
       rows_path:
         - data
@@ -634,7 +663,6 @@ tables:
       - name: id
         type: Int64
         nullable: false
-        virtual: false
         description: Schedule ID
         expr:
           kind: path
@@ -643,7 +671,6 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        virtual: false
         description: Schedule name
         expr:
           kind: path
@@ -652,7 +679,6 @@ tables:
       - name: time_zone
         type: Utf8
         nullable: true
-        virtual: false
         description: Time zone for this schedule
         expr:
           kind: path
@@ -661,7 +687,6 @@ tables:
       - name: is_default
         type: Boolean
         nullable: true
-        virtual: false
         description: Whether this is the user's default schedule
         expr:
           kind: path
@@ -670,7 +695,6 @@ tables:
       - name: owner_id
         type: Int64
         nullable: true
-        virtual: false
         description: User ID of the schedule owner
         expr:
           kind: path
@@ -679,7 +703,6 @@ tables:
       - name: availability
         type: Utf8
         nullable: true
-        virtual: false
         description: Availability windows as a JSON array (days, startTime, endTime)
         expr:
           kind: path
@@ -688,7 +711,6 @@ tables:
       - name: overrides
         type: Utf8
         nullable: true
-        virtual: false
         description: Date-specific overrides as a JSON array
         expr:
           kind: path

--- a/sources/community/cal/manifest.yaml
+++ b/sources/community/cal/manifest.yaml
@@ -1,0 +1,696 @@
+name: cal
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query bookings, event types, schedules, and profile data from Cal.com
+  (Cloud or self-hosted).
+inputs:
+  CAL_API_KEY:
+    kind: secret
+    hint: |
+      Your Cal.com API key. Find it in Settings > Security > API Keys.
+      Test mode keys have the prefix cal_ and live mode keys have the
+      prefix cal_live_.
+      See [Cal.com API docs](https://cal.com/docs/api-reference/v2/introduction).
+  CAL_BASE_URL:
+    kind: variable
+    default: https://api.cal.com
+    hint: |
+      Base URL for the Cal.com API. Use the default for Cal.com Cloud.
+      For self-hosted Cal.com instances use your own host URL.
+base_url: "{{input.CAL_BASE_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.CAL_API_KEY}}
+request_headers:
+  - name: cal-api-version
+    from: literal
+    value: "2024-06-14"
+test_queries:
+  - SELECT * FROM cal.me LIMIT 1
+  - SELECT * FROM cal.event_types LIMIT 1
+tables:
+  - name: me
+    description: Profile of the authenticated Cal.com user
+    guide: |
+      Singleton table — always returns one row for the authenticated user.
+      Use `id` and `username` to understand which account the API key
+      belongs to. `default_schedule_id` links to `cal.schedules`.
+    request:
+      method: GET
+      path: /v2/me
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        virtual: false
+        description: User ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: username
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Cal.com username
+        expr:
+          kind: path
+          path:
+            - username
+      - name: email
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: User email address
+        expr:
+          kind: path
+          path:
+            - email
+      - name: name
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Display name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: time_zone
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: User time zone
+        expr:
+          kind: path
+          path:
+            - timeZone
+      - name: week_start
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: First day of the week for this user
+        expr:
+          kind: path
+          path:
+            - weekStart
+      - name: time_format
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Time format preference (12 or 24)
+        expr:
+          kind: path
+          path:
+            - timeFormat
+      - name: default_schedule_id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: ID of the user's default availability schedule
+        expr:
+          kind: path
+          path:
+            - defaultScheduleId
+      - name: locale
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: User locale (e.g. en)
+        expr:
+          kind: path
+          path:
+            - locale
+      - name: bio
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: User bio
+        expr:
+          kind: path
+          path:
+            - bio
+      - name: organization_id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Organization ID if the user belongs to an organization
+        expr:
+          kind: path
+          path:
+            - organizationId
+  - name: event_types
+    description: Event types configured by the authenticated user
+    guide: |
+      Each row is one event type — a bookable meeting configuration. Use
+      `id` to join with `bookings.event_type_id`. `slug` is the URL
+      identifier used in booking links. `length_in_minutes` is the
+      meeting duration. `hidden = true` means the event type is not
+      publicly visible.
+    request:
+      method: GET
+      path: /v2/event-types
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        virtual: false
+        description: Event type ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Event type title
+        expr:
+          kind: path
+          path:
+            - title
+      - name: slug
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: URL slug used in booking links
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: description
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Event type description
+        expr:
+          kind: path
+          path:
+            - description
+      - name: length_in_minutes
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Default meeting duration in minutes
+        expr:
+          kind: path
+          path:
+            - lengthInMinutes
+      - name: hidden
+        type: Boolean
+        nullable: true
+        virtual: false
+        description: Whether the event type is hidden from the public booking page
+        expr:
+          kind: path
+          path:
+            - hidden
+      - name: price
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Price for paid events (in smallest currency unit)
+        expr:
+          kind: path
+          path:
+            - price
+      - name: currency
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Currency code for paid events
+        expr:
+          kind: path
+          path:
+            - currency
+      - name: owner_id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: User ID of the event type owner
+        expr:
+          kind: path
+          path:
+            - ownerId
+      - name: booking_url
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Full public booking URL for this event type
+        expr:
+          kind: path
+          path:
+            - bookingUrl
+      - name: schedule_id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Availability schedule ID used by this event type
+        expr:
+          kind: path
+          path:
+            - scheduleId
+      - name: minimum_booking_notice
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Minimum notice required before a booking in minutes
+        expr:
+          kind: path
+          path:
+            - minimumBookingNotice
+      - name: before_event_buffer
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Buffer time before the event in minutes
+        expr:
+          kind: path
+          path:
+            - beforeEventBuffer
+      - name: after_event_buffer
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Buffer time after the event in minutes
+        expr:
+          kind: path
+          path:
+            - afterEventBuffer
+      - name: seats_per_time_slot
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Number of seats per time slot for group events
+        expr:
+          kind: path
+          path:
+            - seatsPerTimeSlot
+      - name: is_instant_event
+        type: Boolean
+        nullable: true
+        virtual: false
+        description: Whether this is an instant meeting event type
+        expr:
+          kind: path
+          path:
+            - isInstantEvent
+      - name: disable_guests
+        type: Boolean
+        nullable: true
+        virtual: false
+        description: Whether guests are disabled for this event type
+        expr:
+          kind: path
+          path:
+            - disableGuests
+  - name: bookings
+    description: Scheduled meetings and their status
+    guide: |
+      Each row is one booking. Use `status` to filter by accepted,
+      cancelled, or pending. `event_type_id` joins to `cal.event_types`.
+      `start` and `end` are ISO 8601 timestamps. Filter by `status` to
+      analyse cancellations or by `attendee_email` to look up a specific
+      person's meetings. Results are cursor-paginated newest-first.
+    filters:
+      - name: status
+        required: false
+      - name: attendee_email
+        required: false
+      - name: attendee_name
+        required: false
+      - name: event_type_id
+        required: false
+    request:
+      method: GET
+      path: /v2/bookings
+      query:
+        - name: status
+          from: filter
+          key: status
+        - name: attendeeEmail
+          from: filter
+          key: attendee_email
+        - name: attendeeName
+          from: filter
+          key: attendee_name
+        - name: eventTypeId
+          from: filter
+          key: event_type_id
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - pagination
+        - nextCursor
+      page_size:
+        default: 100
+        max: 100
+        query_param: take
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Booking ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: uid
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Unique booking identifier (used in booking URLs)
+        expr:
+          kind: path
+          path:
+            - uid
+      - name: title
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Booking title
+        expr:
+          kind: path
+          path:
+            - title
+      - name: description
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Booking description
+        expr:
+          kind: path
+          path:
+            - description
+      - name: status
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Booking status (accepted, cancelled, pending, or rejected)
+        expr:
+          kind: path
+          path:
+            - status
+      - name: start
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Booking start time (ISO 8601)
+        expr:
+          kind: path
+          path:
+            - start
+      - name: end
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Booking end time (ISO 8601)
+        expr:
+          kind: path
+          path:
+            - end
+      - name: duration
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Booking duration in minutes
+        expr:
+          kind: path
+          path:
+            - duration
+      - name: event_type_id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: ID of the event type for this booking
+        expr:
+          kind: path
+          path:
+            - eventTypeId
+      - name: event_type__slug
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Slug of the event type for this booking
+        expr:
+          kind: path
+          path:
+            - eventType
+            - slug
+      - name: location
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Meeting location or video call URL
+        expr:
+          kind: path
+          path:
+            - location
+      - name: meeting_url
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Video meeting URL
+        expr:
+          kind: path
+          path:
+            - meetingUrl
+      - name: host__id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Host user ID (first host)
+        expr:
+          kind: first_array_item_path
+          path:
+            - hosts
+          item_path:
+            - id
+      - name: host__name
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Host display name (first host)
+        expr:
+          kind: first_array_item_path
+          path:
+            - hosts
+          item_path:
+            - name
+      - name: host__email
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Host email address (first host)
+        expr:
+          kind: first_array_item_path
+          path:
+            - hosts
+          item_path:
+            - email
+      - name: host__time_zone
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Host time zone (first host)
+        expr:
+          kind: first_array_item_path
+          path:
+            - hosts
+          item_path:
+            - timeZone
+      - name: absent_host
+        type: Boolean
+        nullable: true
+        virtual: false
+        description: Whether the host was absent for this booking
+        expr:
+          kind: path
+          path:
+            - absentHost
+      - name: cancellation_reason
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Reason provided when the booking was cancelled
+        expr:
+          kind: path
+          path:
+            - cancellationReason
+      - name: cancelled_by_email
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Email of the person who cancelled the booking
+        expr:
+          kind: path
+          path:
+            - cancelledByEmail
+      - name: rescheduling_reason
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Reason provided when the booking was rescheduled
+        expr:
+          kind: path
+          path:
+            - reschedulingReason
+      - name: rescheduled_from_uid
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: UID of the original booking before rescheduling
+        expr:
+          kind: path
+          path:
+            - rescheduledFromUid
+      - name: rating
+        type: Int64
+        nullable: true
+        virtual: false
+        description: Post-meeting rating score
+        expr:
+          kind: path
+          path:
+            - rating
+      - name: created_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the booking was created
+        expr:
+          kind: path
+          path:
+            - createdAt
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Timestamp when the booking was last updated
+        expr:
+          kind: path
+          path:
+            - updatedAt
+      - name: filter_status
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the status filter applied to this query
+        expr:
+          kind: from_filter
+          key: status
+      - name: filter_attendee_email
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the attendee_email filter applied to this query
+        expr:
+          kind: from_filter
+          key: attendee_email
+  - name: schedules
+    description: Availability schedules defining when the user can be booked
+    guide: |
+      Each row is one availability schedule. `is_default = true` marks
+      the schedule used when no specific schedule is assigned to an event
+      type. `time_zone` is the schedule's reference time zone. Join
+      `id` to `event_types.schedule_id` to see which schedule each event
+      type uses.
+    request:
+      method: GET
+      path: /v2/schedules
+    response:
+      rows_path:
+        - data
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        virtual: false
+        description: Schedule ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        virtual: false
+        description: Schedule name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: time_zone
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Time zone for this schedule
+        expr:
+          kind: path
+          path:
+            - timeZone
+      - name: is_default
+        type: Boolean
+        nullable: true
+        virtual: false
+        description: Whether this is the user's default schedule
+        expr:
+          kind: path
+          path:
+            - isDefault
+      - name: owner_id
+        type: Int64
+        nullable: true
+        virtual: false
+        description: User ID of the schedule owner
+        expr:
+          kind: path
+          path:
+            - ownerId
+      - name: availability
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Availability windows as a JSON array (days, startTime, endTime)
+        expr:
+          kind: path
+          path:
+            - availability
+      - name: overrides
+        type: Utf8
+        nullable: true
+        virtual: false
+        description: Date-specific overrides as a JSON array
+        expr:
+          kind: path
+          path:
+            - overrides


### PR DESCRIPTION
Closes #382 

## What changed

Adds a new community source for Cal under `sources/community/cal/`.

**Tables (4):**
- `me` — profile of the authenticated user; confirms connectivity and surfaces username, time zone, and default schedule ID
- `event_types` — bookable meeting configurations with duration, slug, booking URL, schedule assignment, buffer times, and visibility settings
- `bookings` — scheduled meetings with status, attendee info, host details, cancellation and rescheduling metadata; cursor-paginated; optional filters for `status`, `attendee_email`, `attendee_name`, and `event_type_id`
- `schedules` — availability schedules with time zone, default flag, and availability windows

**Auth:** 
- Bearer token via `CAL_API_KEY` `(Settings → Security → API Keys)`
- Supports Cal.com Cloud and self-hosted instances via `CAL_BASE_URL` (default: `https://api.cal.com`). 
- Uses `cal-api-version: 2024-06-14`.

## Why it changed

Cal.com is a widely used open-source scheduling platform. Being able to query booking volume, cancellation rates, event type utilisation, and host activity via SQL is a natural fit for Coral — especially for teams running scheduling analytics or operational workflows.

## What was tested

- `coral source lint` — passes
- `uv` / `yamllint` / `make lint-sources` — passes across all sources
- `coral source test cal` — 2/2 test queries pass
- Live queries verified against a real Cal.com account:
  - `me` — returns authenticated user profile with correct columns
  - `event_types` — returns event types with correct columns
  - `schedules` — returns default schedule with time zone and availability
  - `bookings` — schema verified; cursor pagination confirmed working

## User-visible impact

New `cal` source installable via:

```bash
CAL_API_KEY=cal_live_... 
coral source add --file sources/community/cal/manifest.yaml
```

## Follow-on

- Routing forms table (`GET /v2/routing-forms`) could be added in a follow-up
- Teams table for team scheduling analytics