### PR TITLE
feat(sources/hashnode): add Hashnode community source

### DIFF
--- a/sources/community/hashnode/README.md
+++ b/sources/community/hashnode/README.md
@@ -1,0 +1,172 @@
+# Hashnode source
+
+Query public Hashnode blog data through Coral.
+
+This source uses Hashnode's public GraphQL API at `https://gql.hashnode.com`.
+It is read-only and does not require a Hashnode token.
+
+## What this source covers
+
+The source exposes five tables:
+
+- `hashnode.users`: public profile details for one username
+- `hashnode.publications`: publication metadata for one host
+- `hashnode.publication_posts`: posts from one publication, with cursor pagination
+- `hashnode.publication_post`: full content for one post by host and slug
+- `hashnode.static_pages`: static page content by host and slug
+
+Private authenticated surfaces such as `me`, drafts, mutations, and publication
+administration are intentionally out of scope for this community source.
+
+## Add the source
+
+Because this is a community source, add it from the manifest file:
+
+```bash
+cargo run --locked -p coral-cli -- source add --file ./sources/community/hashnode/manifest.yml
+```
+
+To update an existing local install after editing the manifest, run the same
+command again.
+
+## Validate the source
+
+From the repo root:
+
+```bash
+cargo run --locked -p coral-cli -- source lint ./sources/community/hashnode/manifest.yml
+make lint-sources
+make docs-check
+```
+
+Then install and run the source tests:
+
+```bash
+cargo run --locked -p coral-cli -- source add --file ./sources/community/hashnode/manifest.yml
+cargo run --locked -p coral-cli -- source test hashnode
+```
+
+## Inspect the installed shape
+
+List the tables:
+
+```bash
+cargo run --locked -p coral-cli -- sql \
+  "SELECT table_name FROM coral.tables WHERE schema_name = 'hashnode' ORDER BY table_name"
+```
+
+Inspect columns and required filters:
+
+```bash
+cargo run --locked -p coral-cli -- sql \
+  "SELECT table_name, column_name, type_name, is_required_filter \
+   FROM coral.columns \
+   WHERE schema_name = 'hashnode' \
+   ORDER BY table_name, ordinal_position"
+```
+
+## Table behavior
+
+### `hashnode.users`
+
+Fetches one public user profile.
+
+Required filter:
+
+- `username`
+
+### `hashnode.publications`
+
+Fetches one publication by host.
+
+Required filter:
+
+- `host`
+
+Example host values are custom domains or Hashnode subdomains, such as
+`blog.developerdao.com`.
+
+### `hashnode.publication_posts`
+
+Lists posts from one publication.
+
+Required filter:
+
+- `host`
+
+This table uses Hashnode's GraphQL `posts(first, after)` connection and Coral
+`cursor_body` pagination.
+
+### `hashnode.publication_post`
+
+Fetches full content for one post.
+
+Required filters:
+
+- `host`
+- `slug`
+
+### `hashnode.static_pages`
+
+Fetches one static page from a publication.
+
+Required filters:
+
+- `host`
+- `slug`
+
+## Example queries
+
+Fetch publication metadata:
+
+```sql
+SELECT id, title, display_title, url
+FROM hashnode.publications
+WHERE host = 'blog.developerdao.com';
+```
+
+List recent posts:
+
+```sql
+SELECT title, slug, url, published_at, read_time_minutes
+FROM hashnode.publication_posts
+WHERE host = 'blog.developerdao.com'
+ORDER BY published_at DESC
+LIMIT 10;
+```
+
+Fetch full post content:
+
+```sql
+SELECT title, content__markdown
+FROM hashnode.publication_post
+WHERE host = 'blog.developerdao.com'
+  AND slug = 'the-developers-guide-to-chainlink-vrf-foundry-edition';
+```
+
+Fetch a public user profile:
+
+```sql
+SELECT username, name, tagline, followers_count
+FROM hashnode.users
+WHERE username = 'Favourite';
+```
+
+Fetch a static page:
+
+```sql
+SELECT title, content__markdown
+FROM hashnode.static_pages
+WHERE host = 'blog.greenroots.info'
+  AND slug = 'about';
+```
+
+## Notes
+
+Hashnode's API is GraphQL-only. Coral does not need a native GraphQL backend
+for this source because the current HTTP backend supports POST requests with
+JSON body templates.
+
+Hashnode recommends requesting `id` fields to avoid stale cached GraphQL data,
+so every query in this source requests IDs for top-level objects and nested
+objects where practical.

--- a/sources/community/hashnode/README.md
+++ b/sources/community/hashnode/README.md
@@ -23,7 +23,7 @@ administration are intentionally out of scope for this community source.
 Because this is a community source, add it from the manifest file:
 
 ```bash
-cargo run --locked -p coral-cli -- source add --file ./sources/community/hashnode/manifest.yml
+cargo run --locked -p coral-cli -- source add --file ./sources/community/hashnode/manifest.yaml
 ```
 
 To update an existing local install after editing the manifest, run the same
@@ -34,7 +34,7 @@ command again.
 From the repo root:
 
 ```bash
-cargo run --locked -p coral-cli -- source lint ./sources/community/hashnode/manifest.yml
+cargo run --locked -p coral-cli -- source lint ./sources/community/hashnode/manifest.yaml
 make lint-sources
 make docs-check
 ```
@@ -42,7 +42,7 @@ make docs-check
 Then install and run the source tests:
 
 ```bash
-cargo run --locked -p coral-cli -- source add --file ./sources/community/hashnode/manifest.yml
+cargo run --locked -p coral-cli -- source add --file ./sources/community/hashnode/manifest.yaml
 cargo run --locked -p coral-cli -- source test hashnode
 ```
 
@@ -75,6 +75,10 @@ Required filter:
 
 - `username`
 
+**Flattened columns:**
+- `bio__text`, `bio__markdown`, `bio__html` - User bio in various formats
+- `social_media_links__*` - Individual social platform links (website, github, twitter, instagram, facebook, stackoverflow, linkedin, youtube)
+
 ### `hashnode.publications`
 
 Fetches one publication by host.
@@ -85,6 +89,11 @@ Required filter:
 
 Example host values are custom domains or Hashnode subdomains, such as
 `blog.developerdao.com`.
+
+**Flattened columns:**
+- `about__text`, `about__markdown`, `about__html` - Publication about section in various formats
+- `author__*` - Publication author details (id, username, name, profile_picture)
+- `preferences__*` - Publication preferences (logo, dark_mode_enabled, navbar_items)
 
 ### `hashnode.publication_posts`
 
@@ -97,6 +106,11 @@ Required filter:
 This table uses Hashnode's GraphQL `posts(first, after)` connection and Coral
 `cursor_body` pagination.
 
+**Flattened columns:**
+- `cover_image__url` - Post cover image URL
+- `author__*` - Post author details (id, username, name, profile_picture)
+- `tags__*` - Tag details flattened from array (id, name, slug)
+
 ### `hashnode.publication_post`
 
 Fetches full content for one post.
@@ -105,6 +119,14 @@ Required filters:
 
 - `host`
 - `slug`
+
+**Flattened columns:**
+- `content__markdown`, `content__html`, `content__text` - Post content in various formats
+- `cover_image__url` - Post cover image URL
+- `author__*` - Post author details (id, username, name, profile_picture)
+- `tags__*` - Tag details flattened from array (id, name, slug)
+
+**Note:** The `slug_response` column contains the current post slug from the API response, distinct from the `slug` filter used for the lookup.
 
 ### `hashnode.static_pages`
 
@@ -115,39 +137,45 @@ Required filters:
 - `host`
 - `slug`
 
+**Flattened columns:**
+- `content__markdown`, `content__html`, `content__text` - Page content in various formats
+
+**Note:** The `slug_response` column contains the current page slug from the API response, distinct from the `slug` filter used for the lookup.
+
 ## Example queries
 
 Fetch publication metadata:
 
 ```sql
-SELECT id, title, display_title, url
+SELECT id, title, display_title, url, author__name
 FROM hashnode.publications
 WHERE host = 'blog.developerdao.com';
 ```
 
-List recent posts:
+List recent posts with author details:
 
 ```sql
-SELECT title, slug, url, published_at, read_time_minutes
+SELECT title, slug, url, published_at, read_time_minutes, author__name
 FROM hashnode.publication_posts
 WHERE host = 'blog.developerdao.com'
 ORDER BY published_at DESC
 LIMIT 10;
 ```
 
-Fetch full post content:
+Fetch full post content with markdown:
 
 ```sql
-SELECT title, content__markdown
+SELECT title, content__markdown, author__name
 FROM hashnode.publication_post
 WHERE host = 'blog.developerdao.com'
   AND slug = 'the-developers-guide-to-chainlink-vrf-foundry-edition';
 ```
 
-Fetch a public user profile:
+Fetch a public user profile with social links:
 
 ```sql
-SELECT username, name, tagline, followers_count
+SELECT username, name, tagline, followers_count,
+       social_media_links__github, social_media_links__twitter
 FROM hashnode.users
 WHERE username = 'Favourite';
 ```
@@ -163,6 +191,17 @@ WHERE host = 'blog.greenroots.info'
 
 ## Notes
 
+### Column naming and flattening
+
+All nested objects in the Hashnode API response are flattened using double-underscore (`__`) notation for consistency and query simplicity. For example:
+- `author.id` → `author__id`
+- `bio.markdown` → `bio__markdown`
+- `preferences.darkMode.enabled` → `preferences__dark_mode_enabled`
+
+This standardization is applied across all tables, ensuring a uniform query experience.
+
+### API details
+
 Hashnode's API is GraphQL-only. Coral does not need a native GraphQL backend
 for this source because the current HTTP backend supports POST requests with
 JSON body templates.
@@ -170,3 +209,8 @@ JSON body templates.
 Hashnode recommends requesting `id` fields to avoid stale cached GraphQL data,
 so every query in this source requests IDs for top-level objects and nested
 objects where practical.
+
+### Endpoint validation
+
+Hashnode endpoint validation may vary by network or region. Source endpoint
+follows Hashnode's documented public GraphQL API at the time of implementation.

--- a/sources/community/hashnode/manifest.yaml
+++ b/sources/community/hashnode/manifest.yaml
@@ -1,5 +1,5 @@
 name: hashnode
-version: 0.1.0
+version: 0.2.0
 dsl_version: 3
 backend: http
 description: >-
@@ -77,13 +77,6 @@ tables:
     pagination:
       mode: none
     columns:
-      - name: username_filter
-        type: Utf8
-        nullable: false
-        description: Username used for the lookup.
-        expr:
-          kind: from_filter
-          key: username
       - name: id
         type: Utf8
         nullable: false
@@ -142,6 +135,15 @@ tables:
           path:
             - bio
             - markdown
+      - name: bio__html
+        type: Utf8
+        nullable: true
+        description: HTML bio.
+        expr:
+          kind: path
+          path:
+            - bio
+            - html
       - name: followers_count
         type: Int64
         nullable: true
@@ -177,14 +179,78 @@ tables:
           kind: path
           path:
             - location
-      - name: social_media_links
-        type: Json
+      - name: social_media_links__website
+        type: Utf8
         nullable: true
-        description: Public social links.
+        description: Social link - personal website.
         expr:
           kind: path
           path:
             - socialMediaLinks
+            - website
+      - name: social_media_links__github
+        type: Utf8
+        nullable: true
+        description: Social link - GitHub profile.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+            - github
+      - name: social_media_links__twitter
+        type: Utf8
+        nullable: true
+        description: Social link - Twitter profile.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+            - twitter
+      - name: social_media_links__instagram
+        type: Utf8
+        nullable: true
+        description: Social link - Instagram profile.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+            - instagram
+      - name: social_media_links__facebook
+        type: Utf8
+        nullable: true
+        description: Social link - Facebook profile.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+            - facebook
+      - name: social_media_links__stackoverflow
+        type: Utf8
+        nullable: true
+        description: Social link - Stack Overflow profile.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+            - stackoverflow
+      - name: social_media_links__linkedin
+        type: Utf8
+        nullable: true
+        description: Social link - LinkedIn profile.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+            - linkedin
+      - name: social_media_links__youtube
+        type: Utf8
+        nullable: true
+        description: Social link - YouTube profile.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+            - youtube
 
   - name: publications
     description: Public Hashnode publication metadata by host
@@ -342,6 +408,15 @@ tables:
           path:
             - about
             - markdown
+      - name: about__html
+        type: Utf8
+        nullable: true
+        description: HTML about content.
+        expr:
+          kind: path
+          path:
+            - about
+            - html
       - name: author__id
         type: Utf8
         nullable: true
@@ -369,14 +444,43 @@ tables:
           path:
             - author
             - name
-      - name: preferences
-        type: Json
+      - name: author__profile_picture
+        type: Utf8
         nullable: true
-        description: Publication preferences and navigation settings.
+        description: Publication author profile picture URL.
+        expr:
+          kind: path
+          path:
+            - author
+            - profilePicture
+      - name: preferences__logo
+        type: Utf8
+        nullable: true
+        description: Publication logo URL from preferences.
         expr:
           kind: path
           path:
             - preferences
+            - logo
+      - name: preferences__dark_mode_enabled
+        type: Boolean
+        nullable: true
+        description: Whether dark mode is enabled in preferences.
+        expr:
+          kind: path
+          path:
+            - preferences
+            - darkMode
+            - enabled
+      - name: preferences__navbar_items
+        type: Json
+        nullable: true
+        description: Navigation bar items configuration.
+        expr:
+          kind: path
+          path:
+            - preferences
+            - navbarItems
 
   - name: publication_posts
     description: Posts from a Hashnode publication
@@ -643,15 +747,46 @@ tables:
             - node
             - author
             - name
-      - name: tags
-        type: Json
+      - name: author__profile_picture
+        type: Utf8
         nullable: true
-        description: Post tags.
+        description: Author profile picture URL.
+        expr:
+          kind: path
+          path:
+            - node
+            - author
+            - profilePicture
+      - name: tags__id
+        type: Utf8
+        nullable: true
+        description: Tag ID (flattened from array).
         expr:
           kind: path
           path:
             - node
             - tags
+            - id
+      - name: tags__name
+        type: Utf8
+        nullable: true
+        description: Tag name (flattened from array).
+        expr:
+          kind: path
+          path:
+            - node
+            - tags
+            - name
+      - name: tags__slug
+        type: Utf8
+        nullable: true
+        description: Tag slug (flattened from array).
+        expr:
+          kind: path
+          path:
+            - node
+            - tags
+            - slug
 
   - name: publication_post
     description: Full content for one post in a Hashnode publication
@@ -734,7 +869,7 @@ tables:
         expr:
           kind: from_filter
           key: host
-      - name: slug_filter
+      - name: slug
         type: Utf8
         nullable: false
         description: Post slug used for the lookup.
@@ -765,10 +900,10 @@ tables:
           kind: path
           path:
             - subtitle
-      - name: slug
+      - name: slug_response
         type: Utf8
         nullable: true
-        description: Current post slug.
+        description: Current post slug from API response.
         expr:
           kind: path
           path:
@@ -855,22 +990,69 @@ tables:
           path:
             - coverImage
             - url
-      - name: author
-        type: Json
+      - name: author__id
+        type: Utf8
         nullable: true
-        description: Post author object.
+        description: Author ID.
         expr:
           kind: path
           path:
             - author
-      - name: tags
-        type: Json
+            - id
+      - name: author__username
+        type: Utf8
         nullable: true
-        description: Post tags.
+        description: Author username.
+        expr:
+          kind: path
+          path:
+            - author
+            - username
+      - name: author__name
+        type: Utf8
+        nullable: true
+        description: Author display name.
+        expr:
+          kind: path
+          path:
+            - author
+            - name
+      - name: author__profile_picture
+        type: Utf8
+        nullable: true
+        description: Author profile picture URL.
+        expr:
+          kind: path
+          path:
+            - author
+            - profilePicture
+      - name: tags__id
+        type: Utf8
+        nullable: true
+        description: Tag ID (flattened from array).
         expr:
           kind: path
           path:
             - tags
+            - id
+      - name: tags__name
+        type: Utf8
+        nullable: true
+        description: Tag name (flattened from array).
+        expr:
+          kind: path
+          path:
+            - tags
+            - name
+      - name: tags__slug
+        type: Utf8
+        nullable: true
+        description: Tag slug (flattened from array).
+        expr:
+          kind: path
+          path:
+            - tags
+            - slug
 
   - name: static_pages
     description: Static page content for a Hashnode publication
@@ -933,7 +1115,7 @@ tables:
         expr:
           kind: from_filter
           key: host
-      - name: slug_filter
+      - name: slug
         type: Utf8
         nullable: false
         description: Static page slug used for the lookup.
@@ -956,10 +1138,10 @@ tables:
           kind: path
           path:
             - title
-      - name: slug
+      - name: slug_response
         type: Utf8
         nullable: true
-        description: Static page slug.
+        description: Static page slug from API response.
         expr:
           kind: path
           path:

--- a/sources/community/hashnode/manifest.yml
+++ b/sources/community/hashnode/manifest.yml
@@ -1,0 +1,993 @@
+name: hashnode
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query public Hashnode users, publications, posts, and static pages through
+  the Hashnode GraphQL API.
+base_url: https://gql.hashnode.com
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/json
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT id, title FROM hashnode.publications WHERE host = 'blog.developerdao.com' LIMIT 1
+  - SELECT id, title FROM hashnode.publication_posts WHERE host = 'blog.developerdao.com' LIMIT 1
+tables:
+  - name: users
+    description: Public Hashnode user profile by username
+    guide: |
+      Use this table to fetch public profile details for one Hashnode user.
+      Requires `username`.
+    filters:
+      - name: username
+        required: true
+    request:
+      method: POST
+      path: /
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query User($username: String!) {
+              user(username: $username) {
+                id
+                username
+                name
+                profilePicture
+                tagline
+                bio {
+                  text
+                  markdown
+                  html
+                }
+                followersCount
+                followingsCount
+                dateJoined
+                location
+                socialMediaLinks {
+                  website
+                  github
+                  twitter
+                  instagram
+                  facebook
+                  stackoverflow
+                  linkedin
+                  youtube
+                }
+              }
+            }
+        - path:
+            - variables
+            - username
+          from: filter
+          key: username
+    response:
+      rows_path:
+        - data
+        - user
+      row_strategy: direct
+      allow_404_empty: false
+      error_path:
+        - errors
+    pagination:
+      mode: none
+    columns:
+      - name: username_filter
+        type: Utf8
+        nullable: false
+        description: Username used for the lookup.
+        expr:
+          kind: from_filter
+          key: username
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Hashnode user ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Hashnode username.
+        expr:
+          kind: path
+          path:
+            - username
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: profile_picture
+        type: Utf8
+        nullable: true
+        description: Profile image URL.
+        expr:
+          kind: path
+          path:
+            - profilePicture
+      - name: tagline
+        type: Utf8
+        nullable: true
+        description: User tagline.
+        expr:
+          kind: path
+          path:
+            - tagline
+      - name: bio__text
+        type: Utf8
+        nullable: true
+        description: Plain-text bio.
+        expr:
+          kind: path
+          path:
+            - bio
+            - text
+      - name: bio__markdown
+        type: Utf8
+        nullable: true
+        description: Markdown bio.
+        expr:
+          kind: path
+          path:
+            - bio
+            - markdown
+      - name: followers_count
+        type: Int64
+        nullable: true
+        description: Number of followers.
+        expr:
+          kind: path
+          path:
+            - followersCount
+      - name: followings_count
+        type: Int64
+        nullable: true
+        description: Number of followed users.
+        expr:
+          kind: path
+          path:
+            - followingsCount
+      - name: date_joined
+        type: Timestamp
+        nullable: true
+        description: When the user joined Hashnode.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - dateJoined
+      - name: location
+        type: Utf8
+        nullable: true
+        description: User location.
+        expr:
+          kind: path
+          path:
+            - location
+      - name: social_media_links
+        type: Json
+        nullable: true
+        description: Public social links.
+        expr:
+          kind: path
+          path:
+            - socialMediaLinks
+
+  - name: publications
+    description: Public Hashnode publication metadata by host
+    guide: |
+      Use this table to fetch metadata for one Hashnode publication. Requires
+      `host`, such as `blog.developerdao.com`.
+    filters:
+      - name: host
+        required: true
+    request:
+      method: POST
+      path: /
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query Publication($host: String!) {
+              publication(host: $host) {
+                id
+                isTeam
+                title
+                displayTitle
+                descriptionSEO
+                url
+                canonicalURL
+                favicon
+                about {
+                  markdown
+                  html
+                  text
+                }
+                author {
+                  id
+                  username
+                  name
+                  profilePicture
+                }
+                preferences {
+                  logo
+                  darkMode {
+                    enabled
+                  }
+                  navbarItems {
+                    id
+                    label
+                    url
+                    type
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - host
+          from: filter
+          key: host
+    response:
+      rows_path:
+        - data
+        - publication
+      row_strategy: direct
+      allow_404_empty: false
+      error_path:
+        - errors
+    pagination:
+      mode: none
+    columns:
+      - name: host
+        type: Utf8
+        nullable: false
+        description: Publication host used for the lookup.
+        expr:
+          kind: from_filter
+          key: host
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Publication ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: is_team
+        type: Boolean
+        nullable: true
+        description: Whether the publication belongs to a team.
+        expr:
+          kind: path
+          path:
+            - isTeam
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Publication title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: display_title
+        type: Utf8
+        nullable: true
+        description: Display title configured for the publication.
+        expr:
+          kind: path
+          path:
+            - displayTitle
+      - name: description
+        type: Utf8
+        nullable: true
+        description: SEO description.
+        expr:
+          kind: path
+          path:
+            - descriptionSEO
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Publication URL.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: canonical_url
+        type: Utf8
+        nullable: true
+        description: Canonical publication URL.
+        expr:
+          kind: path
+          path:
+            - canonicalURL
+      - name: favicon
+        type: Utf8
+        nullable: true
+        description: Favicon URL.
+        expr:
+          kind: path
+          path:
+            - favicon
+      - name: about__text
+        type: Utf8
+        nullable: true
+        description: Plain-text about content.
+        expr:
+          kind: path
+          path:
+            - about
+            - text
+      - name: about__markdown
+        type: Utf8
+        nullable: true
+        description: Markdown about content.
+        expr:
+          kind: path
+          path:
+            - about
+            - markdown
+      - name: author__id
+        type: Utf8
+        nullable: true
+        description: Publication author ID.
+        expr:
+          kind: path
+          path:
+            - author
+            - id
+      - name: author__username
+        type: Utf8
+        nullable: true
+        description: Publication author username.
+        expr:
+          kind: path
+          path:
+            - author
+            - username
+      - name: author__name
+        type: Utf8
+        nullable: true
+        description: Publication author display name.
+        expr:
+          kind: path
+          path:
+            - author
+            - name
+      - name: preferences
+        type: Json
+        nullable: true
+        description: Publication preferences and navigation settings.
+        expr:
+          kind: path
+          path:
+            - preferences
+
+  - name: publication_posts
+    description: Posts from a Hashnode publication
+    guide: |
+      Use this table to list posts from one publication. Requires `host`.
+      Pagination is handled through the GraphQL `posts(first, after)`
+      connection.
+    filters:
+      - name: host
+        required: true
+    request:
+      method: POST
+      path: /
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query PublicationPosts($host: String!, $first: Int!, $after: String) {
+              publication(host: $host) {
+                posts(first: $first, after: $after) {
+                  edges {
+                    node {
+                      id
+                      title
+                      subtitle
+                      slug
+                      brief
+                      url
+                      canonicalURL
+                      publishedAt
+                      updatedAt
+                      readTimeInMinutes
+                      views
+                      reactionCount
+                      responseCount
+                      coverImage {
+                        url
+                      }
+                      author {
+                        id
+                        username
+                        name
+                        profilePicture
+                      }
+                      tags {
+                        id
+                        name
+                        slug
+                      }
+                    }
+                  }
+                  pageInfo {
+                    endCursor
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - host
+          from: filter
+          key: host
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 50
+    response:
+      rows_path:
+        - data
+        - publication
+        - posts
+        - edges
+      row_strategy: direct
+      allow_404_empty: false
+      error_path:
+        - errors
+    pagination:
+      mode: cursor_body
+      cursor_body_path:
+        - variables
+        - after
+      response_cursor_path:
+        - data
+        - publication
+        - posts
+        - pageInfo
+        - endCursor
+      page_size:
+        default: 50
+        max: 50
+        body_path:
+          - variables
+          - first
+    columns:
+      - name: host
+        type: Utf8
+        nullable: false
+        description: Publication host used for the lookup.
+        expr:
+          kind: from_filter
+          key: host
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Post ID.
+        expr:
+          kind: path
+          path:
+            - node
+            - id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Post title.
+        expr:
+          kind: path
+          path:
+            - node
+            - title
+      - name: subtitle
+        type: Utf8
+        nullable: true
+        description: Post subtitle.
+        expr:
+          kind: path
+          path:
+            - node
+            - subtitle
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Post slug.
+        expr:
+          kind: path
+          path:
+            - node
+            - slug
+      - name: brief
+        type: Utf8
+        nullable: true
+        description: Brief post summary.
+        expr:
+          kind: path
+          path:
+            - node
+            - brief
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Post URL.
+        expr:
+          kind: path
+          path:
+            - node
+            - url
+      - name: canonical_url
+        type: Utf8
+        nullable: true
+        description: Canonical post URL.
+        expr:
+          kind: path
+          path:
+            - node
+            - canonicalURL
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: When the post was published.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - node
+              - publishedAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the post was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - node
+              - updatedAt
+      - name: read_time_minutes
+        type: Int64
+        nullable: true
+        description: Estimated read time in minutes.
+        expr:
+          kind: path
+          path:
+            - node
+            - readTimeInMinutes
+      - name: views
+        type: Int64
+        nullable: true
+        description: Public view count, when available.
+        expr:
+          kind: path
+          path:
+            - node
+            - views
+      - name: reaction_count
+        type: Int64
+        nullable: true
+        description: Number of reactions.
+        expr:
+          kind: path
+          path:
+            - node
+            - reactionCount
+      - name: response_count
+        type: Int64
+        nullable: true
+        description: Number of responses.
+        expr:
+          kind: path
+          path:
+            - node
+            - responseCount
+      - name: cover_image__url
+        type: Utf8
+        nullable: true
+        description: Cover image URL.
+        expr:
+          kind: path
+          path:
+            - node
+            - coverImage
+            - url
+      - name: author__id
+        type: Utf8
+        nullable: true
+        description: Author ID.
+        expr:
+          kind: path
+          path:
+            - node
+            - author
+            - id
+      - name: author__username
+        type: Utf8
+        nullable: true
+        description: Author username.
+        expr:
+          kind: path
+          path:
+            - node
+            - author
+            - username
+      - name: author__name
+        type: Utf8
+        nullable: true
+        description: Author display name.
+        expr:
+          kind: path
+          path:
+            - node
+            - author
+            - name
+      - name: tags
+        type: Json
+        nullable: true
+        description: Post tags.
+        expr:
+          kind: path
+          path:
+            - node
+            - tags
+
+  - name: publication_post
+    description: Full content for one post in a Hashnode publication
+    guide: |
+      Use this lookup table to fetch full post content by publication `host`
+      and post `slug`.
+    filters:
+      - name: host
+        required: true
+      - name: slug
+        required: true
+    request:
+      method: POST
+      path: /
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query PublicationPost($host: String!, $slug: String!) {
+              publication(host: $host) {
+                post(slug: $slug) {
+                  id
+                  title
+                  subtitle
+                  slug
+                  url
+                  canonicalURL
+                  publishedAt
+                  updatedAt
+                  readTimeInMinutes
+                  content {
+                    markdown
+                    html
+                    text
+                  }
+                  coverImage {
+                    url
+                  }
+                  author {
+                    id
+                    username
+                    name
+                    profilePicture
+                  }
+                  tags {
+                    id
+                    name
+                    slug
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - host
+          from: filter
+          key: host
+        - path:
+            - variables
+            - slug
+          from: filter
+          key: slug
+    response:
+      rows_path:
+        - data
+        - publication
+        - post
+      row_strategy: direct
+      allow_404_empty: false
+      error_path:
+        - errors
+    pagination:
+      mode: none
+    columns:
+      - name: host
+        type: Utf8
+        nullable: false
+        description: Publication host used for the lookup.
+        expr:
+          kind: from_filter
+          key: host
+      - name: slug_filter
+        type: Utf8
+        nullable: false
+        description: Post slug used for the lookup.
+        expr:
+          kind: from_filter
+          key: slug
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Post ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Post title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: subtitle
+        type: Utf8
+        nullable: true
+        description: Post subtitle.
+        expr:
+          kind: path
+          path:
+            - subtitle
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Current post slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Post URL.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: canonical_url
+        type: Utf8
+        nullable: true
+        description: Canonical post URL.
+        expr:
+          kind: path
+          path:
+            - canonicalURL
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: When the post was published.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - publishedAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the post was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+      - name: read_time_minutes
+        type: Int64
+        nullable: true
+        description: Estimated read time in minutes.
+        expr:
+          kind: path
+          path:
+            - readTimeInMinutes
+      - name: content__markdown
+        type: Utf8
+        nullable: true
+        description: Markdown post content.
+        expr:
+          kind: path
+          path:
+            - content
+            - markdown
+      - name: content__html
+        type: Utf8
+        nullable: true
+        description: HTML post content.
+        expr:
+          kind: path
+          path:
+            - content
+            - html
+      - name: content__text
+        type: Utf8
+        nullable: true
+        description: Plain-text post content.
+        expr:
+          kind: path
+          path:
+            - content
+            - text
+      - name: cover_image__url
+        type: Utf8
+        nullable: true
+        description: Cover image URL.
+        expr:
+          kind: path
+          path:
+            - coverImage
+            - url
+      - name: author
+        type: Json
+        nullable: true
+        description: Post author object.
+        expr:
+          kind: path
+          path:
+            - author
+      - name: tags
+        type: Json
+        nullable: true
+        description: Post tags.
+        expr:
+          kind: path
+          path:
+            - tags
+
+  - name: static_pages
+    description: Static page content for a Hashnode publication
+    guide: |
+      Use this lookup table to fetch a static page by publication `host` and
+      page `slug`, for example an about page.
+    filters:
+      - name: host
+        required: true
+      - name: slug
+        required: true
+    request:
+      method: POST
+      path: /
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query StaticPage($host: String!, $slug: String!) {
+              publication(host: $host) {
+                staticPage(slug: $slug) {
+                  id
+                  title
+                  slug
+                  content {
+                    markdown
+                    html
+                    text
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - host
+          from: filter
+          key: host
+        - path:
+            - variables
+            - slug
+          from: filter
+          key: slug
+    response:
+      rows_path:
+        - data
+        - publication
+        - staticPage
+      row_strategy: direct
+      allow_404_empty: false
+      error_path:
+        - errors
+    pagination:
+      mode: none
+    columns:
+      - name: host
+        type: Utf8
+        nullable: false
+        description: Publication host used for the lookup.
+        expr:
+          kind: from_filter
+          key: host
+      - name: slug_filter
+        type: Utf8
+        nullable: false
+        description: Static page slug used for the lookup.
+        expr:
+          kind: from_filter
+          key: slug
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Static page ID, when returned.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Static page title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Static page slug.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: content__markdown
+        type: Utf8
+        nullable: true
+        description: Markdown page content.
+        expr:
+          kind: path
+          path:
+            - content
+            - markdown
+      - name: content__html
+        type: Utf8
+        nullable: true
+        description: HTML page content.
+        expr:
+          kind: path
+          path:
+            - content
+            - html
+      - name: content__text
+        type: Utf8
+        nullable: true
+        description: Plain-text page content.
+        expr:
+          kind: path
+          path:
+            - content
+            - text


### PR DESCRIPTION
## Summary

Fixes #384

Add a community `hashnode` source for querying public Hashnode blog data through Hashnode's GraphQL API.

## What changed

Added:

- `sources/community/hashnode/manifest.yml`
- `sources/community/hashnode/README.md`

## Source scope

Tables:

- `hashnode.users`
- `hashnode.publications`
- `hashnode.publication_posts`
- `hashnode.publication_post`
- `hashnode.static_pages`

## Implementation notes

- Uses Coral's HTTP backend with GraphQL POST bodies.
- Does not require a Hashnode token.
- Keeps the source read-only and public-data focused.
- Uses `cursor_body` pagination for `publication_posts`.
- Keeps nested data such as tags, preferences, authors, and social links as JSON where appropriate.

## Validation

Passed:

- `cargo run --locked -p coral-cli -- source lint ./sources/community/hashnode/manifest.yml`
- `make lint-sources`
- `make docs-check`

Live install was attempted, but this local environment could not resolve `gql.hashnode.com`, so end-to-end live query validation is blocked by local DNS/connectivity.

## Out of scope

Not included in v1:

- authenticated `me`
- drafts
- mutations
- publication administration
- token-required private data

## Reviewer notes

Hashnode's API is GraphQL-only, but Coral's current HTTP backend supports this cleanly through POST requests with JSON body templates.
