### PR TITLE
feat(sources/community/medium): add Medium community source

### DIFF
--- a/sources/community/medium/README.md
+++ b/sources/community/medium/README.md
@@ -1,16 +1,14 @@
 # Medium Community Source
 
-This community source exposes a small, read-only slice of Medium's API through
-Coral SQL: authenticated user profile info plus publication metadata.
+Query your Medium profile, publications, and publication contributors using
+authenticated access to Medium's API.
 
-Medium has archived its API documentation and states the API is no longer
-supported. This source is best-effort and may break if Medium changes or
-disables these endpoints.
+**Status:** Medium has archived its official API documentation. This source is
+best-effort and may break if Medium changes or disables these endpoints.
 
 ## Setup
 
-1. In your Medium account settings, create an Integration Token (Medium calls
-   these "integration tokens").
+1. In your Medium account settings, create an Integration Token.
 2. Export it as `MEDIUM_TOKEN` or provide it via `--interactive` when adding the
    source.
 
@@ -19,8 +17,9 @@ MEDIUM_TOKEN='...' coral source add --file ./sources/community/medium/manifest.y
 coral source test medium
 ```
 
-The token should include the `basicProfile` scope. To query publications, the
-token must include the `listPublications` scope.
+**Token Scopes:** The token must include the `basicProfile` scope to query your
+profile. Add the `listPublications` scope to also query publications and
+contributors.
 
 ## Example Queries
 

--- a/sources/community/medium/README.md
+++ b/sources/community/medium/README.md
@@ -1,0 +1,44 @@
+# Medium Community Source
+
+This community source exposes a small, read-only slice of Medium's API through
+Coral SQL: authenticated user profile info plus publication metadata.
+
+Medium has archived its API documentation and states the API is no longer
+supported. This source is best-effort and may break if Medium changes or
+disables these endpoints.
+
+## Setup
+
+1. In your Medium account settings, create an Integration Token (Medium calls
+   these "integration tokens").
+2. Export it as `MEDIUM_TOKEN` or provide it via `--interactive` when adding the
+   source.
+
+```bash
+MEDIUM_TOKEN='...' coral source add --file ./sources/community/medium/manifest.yaml
+coral source test medium
+```
+
+The token should include the `basicProfile` scope. To query publications, the
+token must include the `listPublications` scope.
+
+## Example Queries
+
+```sql
+SELECT id, username, name, url
+FROM medium.me;
+```
+
+```sql
+SELECT id, name, url
+FROM medium.publications
+WHERE user_id = (SELECT id FROM medium.me LIMIT 1)
+LIMIT 50;
+```
+
+```sql
+SELECT user_id, role
+FROM medium.publication_contributors
+WHERE publication_id = '<publication-id>'
+LIMIT 50;
+```

--- a/sources/community/medium/manifest.yaml
+++ b/sources/community/medium/manifest.yaml
@@ -1,0 +1,206 @@
+name: medium
+version: 0.1.0
+dsl_version: 3
+backend: http
+
+description: >-
+  Query authenticated Medium profile info and publication metadata through
+  Medium's API.
+
+inputs:
+  MEDIUM_TOKEN:
+    kind: secret
+    hint: |
+      Medium Integration Token.
+
+      Note: Medium has archived its API documentation and states the API is no
+      longer supported. This source is best-effort and may break if Medium
+      changes or disables these endpoints.
+
+test_queries:
+  - SELECT * FROM medium.me LIMIT 1
+
+base_url: https://api.medium.com/v1
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.MEDIUM_TOKEN}}
+
+tables:
+  - name: me
+    description: Authenticated Medium user profile
+    guide: |
+      Use this table first to confirm the token works and to discover the
+      authenticated user's `id`. Use that `id` as `user_id` for
+      `medium.publications`.
+    request:
+      method: GET
+      path: /me
+
+    response:
+      rows_path:
+        - data
+
+    pagination:
+      mode: none
+
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: User ID
+        expr:
+          kind: path
+          path:
+            - id
+
+      - name: username
+        type: Utf8
+        nullable: true
+        description: Medium username (for example majelbstoat)
+        expr:
+          kind: path
+          path:
+            - username
+
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Display name
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Profile URL
+        expr:
+          kind: path
+          path:
+            - url
+
+      - name: image_url
+        type: Utf8
+        nullable: true
+        description: Profile image URL
+        expr:
+          kind: path
+          path:
+            - imageUrl
+
+  - name: publications
+    description: Publications the authenticated user can access
+    guide: |
+      Requires `user_id` from `medium.me`. This endpoint returns publications
+      where the user is an editor or writer, plus a subset of publications the
+      user follows. The token must include the `listPublications` scope.
+    filters:
+      - name: user_id
+        required: true
+
+    request:
+      method: GET
+      path: /users/{{filter.user_id}}/publications
+
+    response:
+      rows_path:
+        - data
+
+    pagination:
+      mode: none
+
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Publication ID
+        expr:
+          kind: path
+          path:
+            - id
+
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Publication name
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Publication description
+        expr:
+          kind: path
+          path:
+            - description
+
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Publication URL
+        expr:
+          kind: path
+          path:
+            - url
+
+      - name: image_url
+        type: Utf8
+        nullable: true
+        description: Publication image URL
+        expr:
+          kind: path
+          path:
+            - imageUrl
+
+  - name: publication_contributors
+    description: Contributors with publish access to a publication
+    guide: |
+      Requires `publication_id` from `medium.publications`. Returns contributors
+      and their roles (writer or editor).
+    filters:
+      - name: publication_id
+        required: true
+
+    request:
+      method: GET
+      path: /publications/{{filter.publication_id}}/contributors
+
+    response:
+      rows_path:
+        - data
+
+    pagination:
+      mode: none
+
+    columns:
+      - name: publication_id
+        type: Utf8
+        nullable: false
+        description: Publication ID filter
+        expr:
+          kind: from_filter
+          key: publication_id
+      - name: user_id
+        type: Utf8
+        nullable: false
+        description: Contributor user ID
+        expr:
+          kind: path
+          path:
+            - userId
+      - name: role
+        type: Utf8
+        nullable: true
+        description: Contributor role (writer or editor)
+        expr:
+          kind: path
+          path:
+            - role

--- a/sources/community/medium/manifest.yaml
+++ b/sources/community/medium/manifest.yaml
@@ -4,18 +4,17 @@ dsl_version: 3
 backend: http
 
 description: >-
-  Query authenticated Medium profile info and publication metadata through
-  Medium's API.
+  Query your Medium profile, publications, and publication contributors
+  using authenticated access to Medium's user-facing API.
 
 inputs:
   MEDIUM_TOKEN:
     kind: secret
     hint: |
-      Medium Integration Token.
+      Medium Integration Token from your account settings.
 
-      Note: Medium has archived its API documentation and states the API is no
-      longer supported. This source is best-effort and may break if Medium
-      changes or disables these endpoints.
+      Requires `basicProfile` scope; add `listPublications` scope to query
+      publications and contributors.
 
 test_queries:
   - SELECT * FROM medium.me LIMIT 1
@@ -60,7 +59,7 @@ tables:
       - name: username
         type: Utf8
         nullable: true
-        description: Medium username (for example majelbstoat)
+        description: Medium username handle
         expr:
           kind: path
           path:
@@ -98,9 +97,10 @@ tables:
     guide: |
       Requires `user_id` from `medium.me`. This endpoint returns publications
       where the user is an editor or writer, plus a subset of publications the
-      user follows. The token must include the `listPublications` scope.
+      user follows.
     filters:
       - name: user_id
+        description: Your Medium user ID (from the `me` table)
         required: true
 
     request:
@@ -167,6 +167,7 @@ tables:
       and their roles (writer or editor).
     filters:
       - name: publication_id
+        description: Publication ID (from the `publications` table)
         required: true
 
     request:
@@ -184,7 +185,7 @@ tables:
       - name: publication_id
         type: Utf8
         nullable: false
-        description: Publication ID filter
+        description: Publication ID (from filter)
         expr:
           kind: from_filter
           key: publication_id


### PR DESCRIPTION
## Summary

Fixes #386 

Add a new `medium` community source for querying authenticated Medium profile info and publication metadata using a Medium integration token.

This change is manifest-only and uses Coral’s existing HTTP source-spec model. It adds read-only access to the authenticated user, accessible publications, and publication contributors without changing CLI, MCP, config, or runtime contracts.

## What changed

Added:

- `sources/community/medium/manifest.yaml`
- `sources/community/medium/README.md`

## Source scope

Inputs:

- `MEDIUM_TOKEN`

Tables:

- `medium.me`
  - `GET /v1/me`
- `medium.publications`
  - `GET /v1/users/{userId}/publications`
  - requires `user_id`
- `medium.publication_contributors`
  - `GET /v1/publications/{publicationId}/contributors`
  - requires `publication_id`

## Implementation notes

- uses Medium Bearer token header auth
- keeps v1 intentionally read-only
- does not include RSS parsing (Coral HTTP source specs decode JSON only)
- README documents token setup, required scopes, and Medium API deprecation caveat

## Validation

Local checks passed:

- `cargo run --locked -p coral-cli -- source lint ./sources/community/medium/manifest.yaml`
- `ryl sources`
- `cargo run --locked -p xtask -- generate-docs --sources-dir sources/core --index docs/reference/bundled-sources.mdx --docs-json docs/docs.json --check`
- `git diff --check`

## Out of scope

Not included in v1:

- post publishing endpoints
- image upload endpoints
- OAuth token exchange flows
- article listing via RSS/web scraping
