### PR TITLE
chore: rename review-coral-source

### DIFF
--- a/.agents/skills/coral-review-source-spec/SKILL.md
+++ b/.agents/skills/coral-review-source-spec/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: review-coral-source
+name: coral-review-source-spec
 description: Review new or updated Coral source manifests and source PRs for content, style, product fit, query ergonomics, documentation quality, and consistency with existing Coral sources. Use when Codex is asked to review a sources/core/name or sources/community/name source directory, a manifest.yaml, or a GitHub PR that adds or changes a Coral source.
 ---
 
-# Review Coral Source
+# Review Source Spec
 
 ## Review Goal
 

--- a/.agents/skills/coral-review-source-spec/agents/openai.yaml
+++ b/.agents/skills/coral-review-source-spec/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Source Spec"
+  short_description: "Review Coral source PRs for content and style"
+  default_prompt: "Use $coral-review-source-spec to review sources/community/foo for Coral source quality."

--- a/.agents/skills/review-coral-source/agents/openai.yaml
+++ b/.agents/skills/review-coral-source/agents/openai.yaml
@@ -1,4 +1,0 @@
-interface:
-  display_name: "Review Coral Source"
-  short_description: "Review Coral source PRs for content and style"
-  default_prompt: "Use $review-coral-source to review sources/community/foo for Coral source quality."


### PR DESCRIPTION
Follow the naming convention established in withcoral/skills for coral-create-source-spec