### PR TITLE
docs: add meta change operating loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,29 @@
   `type!: summary` or `type(scope)!: summary`. Local WIP commit messages can
   stay pragmatic unless the user explicitly asks for polished commit history.
 
+## Meta Changes
+
+A meta change modifies how contributors or agents should work in this repo, not
+only runtime behavior. Examples include repo layout, crate ownership, source
+directory conventions, docs generation behavior, CLI/MCP surface rules, PR
+title/scope guidance, verification commands, and agent-facing review or
+source-authoring instructions.
+
+For meta changes:
+
+- Update the nearest relevant `AGENTS.md` in the same change.
+- Update `docs/`, generated docs, or docs tooling when the changed behavior is
+  user-facing or docs-authoring-facing.
+- Preserve provenance: keep observed repo facts, project direction, local
+  preferences, and generated context separate instead of merging them into one
+  untraceable rule.
+- Treat repeated human steering as a defect in the operating loop. Identify the
+  failure class, update durable context or tooling when that can prevent
+  recurrence, and verify the new rule before resuming unrelated work.
+- Include explicit validation showing the guidance matches the implemented
+  behavior.
+- Mention in the PR description what agent or contributor behavior changed.
+
 ## What Counts As a Breaking Change for a CLI?
 
 For a CLI, the user interface is the API.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,6 +21,14 @@
   flags, output contracts, tools, resources, prompts, or workflows change
   elsewhere in the repo, update the relevant docs in the same change
 
+## Maintaining these instructions
+- Keep docs-specific agent rules here; keep repo-wide agent and contributor
+  rules in the root `AGENTS.md`
+- If human feedback exposes a repeated docs workflow failure, update this file,
+  the nearest docs source, or docs tooling in the same change
+- Do not add public MDX pages for internal agent process unless the process is
+  itself useful to Coral docs readers
+
 ## Frontmatter requirements for pages
 - title: Clear, descriptive page title
 - description: Concise summary for SEO/navigation


### PR DESCRIPTION
## Intent

Repeated steering on agent and contributor process should become durable repository context, not one-off conversational correction. This change gives Coral a small meta-change gate so process failures are classified, written down in the right context file, and verified before unrelated work continues.

## Changes

- Add a root `AGENTS.md` definition and checklist for meta changes.
- Require provenance separation, recurrence handling, and explicit validation for agent/contributor behavior changes.
- Add docs-specific guidance in `docs/AGENTS.md` for maintaining documentation workflow instructions without pushing internal process into public MDX.

## Validation

- `git diff --check HEAD~1 HEAD`
- `make docs-check`
