### PR TITLE
feat(sources): add arg split function value sources

### DIFF
--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -1705,6 +1705,26 @@ mod tests {
                 "key": key,
                 "default": default,
             }),
+            ValueSourceSpec::ArgSplit {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "arg_split",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
+            ValueSourceSpec::ArgSplitInt {
+                key,
+                separator,
+                part,
+            } => json!({
+                "from": "arg_split_int",
+                "key": key,
+                "separator": separator,
+                "part": part,
+            }),
             ValueSourceSpec::Input { key } => json!({
                 "from": "input",
                 "key": key,
@@ -1929,6 +1949,33 @@ mod tests {
     }
 
     #[test]
+    fn resolve_value_source_splits_function_argument_parts() {
+        let args = HashMap::from([("issue".to_string(), "SOURCE-496".to_string())]);
+
+        let team = resolve_value_source(
+            &ValueSourceSpec::ArgSplit {
+                key: "issue".to_string(),
+                separator: "-".to_string(),
+                part: 0,
+            },
+            &test_render_context(&HashMap::new(), &args, &BTreeMap::new()),
+        )
+        .expect("split function argument should resolve");
+        let number = resolve_value_source(
+            &ValueSourceSpec::ArgSplitInt {
+                key: "issue".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+            &test_render_context(&HashMap::new(), &args, &BTreeMap::new()),
+        )
+        .expect("split integer function argument should resolve");
+
+        assert_eq!(team, Some(json!("SOURCE")));
+        assert_eq!(number, Some(json!(496)));
+    }
+
+    #[test]
     fn resolve_value_source_rejects_missing_filter_split_part() {
         let filters = HashMap::from([("issue_identifier".to_string(), "SOURCE496".to_string())]);
 
@@ -1945,6 +1992,27 @@ mod tests {
         assert!(
             error.to_string().contains(
                 "filter 'issue_identifier' value 'SOURCE496' does not contain split part 1"
+            )
+        );
+    }
+
+    #[test]
+    fn resolve_value_source_rejects_missing_function_argument_split_part() {
+        let args = HashMap::from([("issue".to_string(), "SOURCE496".to_string())]);
+
+        let error = resolve_value_source(
+            &ValueSourceSpec::ArgSplit {
+                key: "issue".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+            &test_render_context(&HashMap::new(), &args, &BTreeMap::new()),
+        )
+        .expect_err("missing split function argument part should fail");
+
+        assert!(
+            error.to_string().contains(
+                "function argument 'issue' value 'SOURCE496' does not contain split part 1"
             )
         );
     }
@@ -1967,6 +2035,27 @@ mod tests {
             error.to_string().contains(
                 "filter 'issue_identifier' value 'SOURCE496' does not contain split part 1"
             )
+        );
+    }
+
+    #[test]
+    fn resolve_value_source_rejects_invalid_function_argument_split_int_part() {
+        let args = HashMap::from([("issue".to_string(), "SOURCE-abc".to_string())]);
+
+        let error = resolve_value_source(
+            &ValueSourceSpec::ArgSplitInt {
+                key: "issue".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+            &test_render_context(&HashMap::new(), &args, &BTreeMap::new()),
+        )
+        .expect_err("invalid split function argument int should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("function argument 'issue' split part 1 value 'abc' is not a valid i64")
         );
     }
 

--- a/crates/coral-engine/src/backends/shared/template.rs
+++ b/crates/coral-engine/src/backends/shared/template.rs
@@ -40,6 +40,28 @@ impl<'a> RenderContext<'a> {
     }
 }
 
+#[derive(Clone, Copy)]
+enum RuntimeValueNamespace {
+    Filter,
+    FunctionArgument,
+}
+
+impl RuntimeValueNamespace {
+    fn values<'a>(self, context: &'a RenderContext<'_>) -> &'a HashMap<String, String> {
+        match self {
+            Self::Filter => context.filters,
+            Self::FunctionArgument => context.args,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Filter => "filter",
+            Self::FunctionArgument => "function argument",
+        }
+    }
+}
+
 /// Resolve one declarative value source into an optional JSON value.
 pub(crate) fn resolve_value_source(
     value: &ValueSourceSpec,
@@ -51,70 +73,128 @@ pub(crate) fn resolve_value_source(
             Ok(Some(Value::String(rendered)))
         }
         ValueSourceSpec::Literal { value } => Ok(Some(value.clone())),
-        ValueSourceSpec::Filter { key, default } => Ok(context
-            .filters
-            .get(key)
-            .map(|v| Value::String(v.clone()))
-            .or_else(|| default.clone())),
-        ValueSourceSpec::Arg { key, default } => Ok(context
-            .args
-            .get(key)
-            .map(|v| Value::String(v.clone()))
-            .or_else(|| default.clone())),
+        ValueSourceSpec::Filter { key, default } => Ok(string_runtime_value(
+            context,
+            RuntimeValueNamespace::Filter,
+            key,
+            default.as_ref(),
+        )),
+        ValueSourceSpec::Arg { key, default } => Ok(string_runtime_value(
+            context,
+            RuntimeValueNamespace::FunctionArgument,
+            key,
+            default.as_ref(),
+        )),
         ValueSourceSpec::FilterInt { key, default } => {
-            parse_i64_value(context.filters, key, *default, "filter")
+            parse_i64_value(context, RuntimeValueNamespace::Filter, key, *default)
         }
-        ValueSourceSpec::ArgInt { key, default } => {
-            parse_i64_value(context.args, key, *default, "function argument")
-        }
+        ValueSourceSpec::ArgInt { key, default } => parse_i64_value(
+            context,
+            RuntimeValueNamespace::FunctionArgument,
+            key,
+            *default,
+        ),
         ValueSourceSpec::FilterBool { key, default } => {
-            parse_bool_value(context.filters, key, *default, "filter")
+            parse_bool_value(context, RuntimeValueNamespace::Filter, key, *default)
         }
         ValueSourceSpec::FilterSplit {
             key,
             separator,
             part,
-        } => split_filter_part(context.filters, key, separator, *part)
-            .map(|value| value.map(Value::String)),
+        } => split_value_part(
+            context,
+            RuntimeValueNamespace::Filter,
+            key,
+            separator,
+            *part,
+        )
+        .map(|value| value.map(Value::String)),
         ValueSourceSpec::FilterSplitInt {
             key,
             separator,
             part,
-        } => parse_split_i64_value(context.filters, key, separator, *part),
-        ValueSourceSpec::ArgBool { key, default } => {
-            parse_bool_value(context.args, key, *default, "function argument")
-        }
+        } => parse_split_i64_value(
+            context,
+            RuntimeValueNamespace::Filter,
+            key,
+            separator,
+            *part,
+        ),
+        ValueSourceSpec::ArgBool { key, default } => parse_bool_value(
+            context,
+            RuntimeValueNamespace::FunctionArgument,
+            key,
+            *default,
+        ),
+        ValueSourceSpec::ArgSplit {
+            key,
+            separator,
+            part,
+        } => split_value_part(
+            context,
+            RuntimeValueNamespace::FunctionArgument,
+            key,
+            separator,
+            *part,
+        )
+        .map(|value| value.map(Value::String)),
+        ValueSourceSpec::ArgSplitInt {
+            key,
+            separator,
+            part,
+        } => parse_split_i64_value(
+            context,
+            RuntimeValueNamespace::FunctionArgument,
+            key,
+            separator,
+            *part,
+        ),
         ValueSourceSpec::Input { key } => {
             Ok(context.resolved_inputs.get(key).cloned().map(Value::String))
         }
         ValueSourceSpec::State { key } => {
             Ok(context.state.get(key).map(|v| Value::String(v.clone())))
         }
-        ValueSourceSpec::NowEpochMinusSeconds { seconds } => {
-            #[expect(
-                clippy::cast_possible_wrap,
-                reason = "Current Unix epoch seconds fit within i64 for centuries"
-            )]
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_secs() as i64;
-            let value = now.saturating_sub(*seconds);
-            Ok(Some(json!(value)))
-        }
+        ValueSourceSpec::NowEpochMinusSeconds { seconds } => Ok(Some(now_minus_seconds(*seconds))),
     }
 }
 
+fn string_runtime_value(
+    context: &RenderContext<'_>,
+    namespace: RuntimeValueNamespace,
+    key: &str,
+    default: Option<&Value>,
+) -> Option<Value> {
+    namespace
+        .values(context)
+        .get(key)
+        .map(|value| Value::String(value.clone()))
+        .or_else(|| default.cloned())
+}
+
+fn now_minus_seconds(seconds: i64) -> Value {
+    #[expect(
+        clippy::cast_possible_wrap,
+        reason = "Current Unix epoch seconds fit within i64 for centuries"
+    )]
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    json!(now.saturating_sub(seconds))
+}
+
 fn parse_i64_value(
-    values: &HashMap<String, String>,
+    context: &RenderContext<'_>,
+    namespace: RuntimeValueNamespace,
     key: &str,
     default: Option<i64>,
-    label: &str,
 ) -> Result<Option<Value>> {
-    let Some(raw) = values.get(key) else {
+    let Some(raw) = namespace.values(context).get(key) else {
         return Ok(default.map(|value| json!(value)));
     };
     let parsed = raw.parse::<i64>().map_err(|error| {
+        let label = namespace.label();
         DataFusionError::Execution(format!(
             "{label} '{key}' value '{raw}' is not a valid i64: {error}"
         ))
@@ -123,15 +203,16 @@ fn parse_i64_value(
 }
 
 fn parse_bool_value(
-    values: &HashMap<String, String>,
+    context: &RenderContext<'_>,
+    namespace: RuntimeValueNamespace,
     key: &str,
     default: Option<bool>,
-    label: &str,
 ) -> Result<Option<Value>> {
-    let Some(raw) = values.get(key) else {
+    let Some(raw) = namespace.values(context).get(key) else {
         return Ok(default.map(|value| json!(value)));
     };
     let parsed = raw.parse::<bool>().map_err(|error| {
+        let label = namespace.label();
         DataFusionError::Execution(format!(
             "{label} '{key}' value '{raw}' is not a valid bool: {error}"
         ))
@@ -140,37 +221,41 @@ fn parse_bool_value(
 }
 
 fn parse_split_i64_value(
-    filters: &HashMap<String, String>,
+    context: &RenderContext<'_>,
+    namespace: RuntimeValueNamespace,
     key: &str,
     separator: &str,
     part: usize,
 ) -> Result<Option<Value>> {
-    let Some(raw) = split_filter_part(filters, key, separator, part)? else {
+    let Some(raw) = split_value_part(context, namespace, key, separator, part)? else {
         return Ok(None);
     };
     let parsed = raw.parse::<i64>().map_err(|error| {
+        let label = namespace.label();
         DataFusionError::Execution(format!(
-            "filter '{key}' split part {part} value '{raw}' is not a valid i64: {error}"
+            "{label} '{key}' split part {part} value '{raw}' is not a valid i64: {error}"
         ))
     })?;
     Ok(Some(json!(parsed)))
 }
 
-fn split_filter_part(
-    filters: &HashMap<String, String>,
+fn split_value_part(
+    context: &RenderContext<'_>,
+    namespace: RuntimeValueNamespace,
     key: &str,
     separator: &str,
     part: usize,
 ) -> Result<Option<String>> {
-    let Some(filter) = filters.get(key) else {
+    let Some(value) = namespace.values(context).get(key) else {
         return Ok(None);
     };
-    filter
+    value
         .split(separator)
         .nth(part)
         .map_or_else(|| {
+            let label = namespace.label();
             Err(DataFusionError::Execution(format!(
-                "filter '{key}' value '{filter}' does not contain split part {part} using separator '{separator}'"
+                "{label} '{key}' value '{value}' does not contain split part {part} using separator '{separator}'"
             )))
         }, |value| Ok(Some(value.to_string())))
 }
@@ -306,6 +391,8 @@ pub(crate) fn validate_value_source_inputs(
         | ValueSourceSpec::Arg { .. }
         | ValueSourceSpec::ArgInt { .. }
         | ValueSourceSpec::ArgBool { .. }
+        | ValueSourceSpec::ArgSplit { .. }
+        | ValueSourceSpec::ArgSplitInt { .. }
         | ValueSourceSpec::State { .. }
         | ValueSourceSpec::NowEpochMinusSeconds { .. } => Ok(()),
     }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -109,6 +109,51 @@ fn function_only_search_manifest(name: &str, base_url: &str) -> Value {
     manifest
 }
 
+fn split_function_manifest(name: &str, base_url: &str) -> Value {
+    json!({
+        "name": name,
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": base_url,
+        "functions": [{
+            "name": "issue_comments",
+            "description": "Issue comments",
+            "args": [{
+                "name": "issue",
+                "required": true,
+                "bind": { "arg": "issue" }
+            }],
+            "request": {
+                "method": "POST",
+                "path": "/graphql",
+                "body": [
+                    {
+                        "path": ["variables", "teamKey"],
+                        "from": "arg_split",
+                        "key": "issue",
+                        "separator": "-",
+                        "part": 0
+                    },
+                    {
+                        "path": ["variables", "issueNumber"],
+                        "from": "arg_split_int",
+                        "key": "issue",
+                        "separator": "-",
+                        "part": 1
+                    }
+                ]
+            },
+            "response": {
+                "rows_path": ["data", "comments"]
+            },
+            "columns": [
+                { "name": "body", "type": "Utf8" }
+            ]
+        }]
+    })
+}
+
 fn internal_table_function_name(schema: &str, function: &str) -> String {
     // PR #306 only registers DataFusion's flat internal UDTF. The public
     // source-scoped planner in the next stack PR owns this mapping for users.
@@ -376,6 +421,47 @@ async fn validate_source_accepts_function_only_http_source_and_runs_queries() {
     assert_eq!(report.query_tests.len(), 1);
     assert!(report.query_tests[0].passed());
     assert_eq!(report.query_tests[0].row_count(), Some(1));
+}
+
+#[tokio::test]
+async fn source_scoped_table_function_splits_argument_values() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .and(body_json(json!({
+            "variables": {
+                "teamKey": "SOURCE",
+                "issueNumber": 496
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": {
+                "comments": [{
+                    "body": "Looks good"
+                }]
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let source = build_source(split_function_manifest("linearish", &server.uri()));
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT body FROM linearish.issue_comments(issue => 'SOURCE-496')",
+        )
+        .await
+        .expect("function arg split query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![json!({
+            "body": "Looks good"
+        })]
+    );
 }
 
 #[tokio::test]

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -467,6 +467,16 @@ pub enum ValueSourceSpec {
         #[serde(default)]
         default: Option<bool>,
     },
+    ArgSplit {
+        key: String,
+        separator: String,
+        part: usize,
+    },
+    ArgSplitInt {
+        key: String,
+        separator: String,
+        part: usize,
+    },
     Input {
         key: String,
     },

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -595,6 +595,24 @@
         },
         {
           "properties": {
+            "from": { "const": "arg_split" },
+            "key": { "type": "string", "minLength": 1 },
+            "separator": { "type": "string", "minLength": 1 },
+            "part": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["key", "separator", "part"]
+        },
+        {
+          "properties": {
+            "from": { "const": "arg_split_int" },
+            "key": { "type": "string", "minLength": 1 },
+            "separator": { "type": "string", "minLength": 1 },
+            "part": { "type": "integer", "minimum": 0 }
+          },
+          "required": ["key", "separator", "part"]
+        },
+        {
+          "properties": {
             "from": { "const": "input" },
             "key": { "type": "string", "minLength": 1 }
           },

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -508,7 +508,9 @@ fn validate_value_source(
         }
         ValueSourceSpec::Arg { key, .. }
         | ValueSourceSpec::ArgInt { key, .. }
-        | ValueSourceSpec::ArgBool { key, .. } => {
+        | ValueSourceSpec::ArgBool { key, .. }
+        | ValueSourceSpec::ArgSplit { key, .. }
+        | ValueSourceSpec::ArgSplitInt { key, .. } => {
             return Err(ManifestError::validation(format!(
                 "{context} uses function argument '{key}' outside a function request"
             )));
@@ -612,6 +614,8 @@ fn validate_arg_value_source(
         ValueSourceSpec::Arg { key, .. }
         | ValueSourceSpec::ArgInt { key, .. }
         | ValueSourceSpec::ArgBool { key, .. }
+        | ValueSourceSpec::ArgSplit { key, .. }
+        | ValueSourceSpec::ArgSplitInt { key, .. }
             if !request_arg_names.contains(key.as_str()) =>
         {
             return Err(ManifestError::validation(format!(
@@ -1133,6 +1137,16 @@ mod tests {
                 key: "archived".to_string(),
                 default: None,
             },
+            ValueSourceSpec::ArgSplit {
+                key: "issue_key".to_string(),
+                separator: "-".to_string(),
+                part: 0,
+            },
+            ValueSourceSpec::ArgSplitInt {
+                key: "issue_key".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
         ];
 
         for value in cases {
@@ -1225,6 +1239,33 @@ mod tests {
 
             assert!(
                 error.to_string().contains("uses table filter"),
+                "unexpected error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_http_function_rejects_unknown_arg_split_bindings() {
+        for value in [
+            ValueSourceSpec::ArgSplit {
+                key: "missing".to_string(),
+                separator: "-".to_string(),
+                part: 0,
+            },
+            ValueSourceSpec::ArgSplitInt {
+                key: "missing".to_string(),
+                separator: "-".to_string(),
+                part: 1,
+            },
+        ] {
+            let function = function_with_request_value(value);
+            let error = validate_http_function("demo", &function)
+                .expect_err("function requests should reject unknown split args");
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("references unknown request arg 'missing'"),
                 "unexpected error: {error}"
             );
         }

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -525,15 +525,17 @@ Request query params, body fields, and headers support these `from` values:
 | `arg` | Read a source function argument captured from the function call and serialize it as a string |
 | `arg_int` | Read a source function argument captured from the function call and serialize it as a JSON integer |
 | `arg_bool` | Read a source function argument captured from the function call and serialize it as a JSON boolean |
+| `arg_split` | Split a source function argument string and serialize one part as a string |
+| `arg_split_int` | Split a source function argument string and serialize one part as a JSON integer |
 | `input` | Read a manifest-declared source input (variable/secret) by key |
 | `state` | Read pagination/runtime state |
 | `now_epoch_minus_seconds` | Emit the current Unix epoch seconds minus the configured offset |
 
-`filter*`, `filter_split`, and `filter_split_int` differ from `arg*` by where
-the value comes from. Table requests use filter value sources because their
-request values come from SQL predicates such as `WHERE id = 123`. Source
-function requests use arg value sources because their request values come from
-named function arguments such as `github.search_issues(q => 'flaky')`.
+`filter*` value sources differ from `arg*` value sources by where the value
+comes from. Table requests use filter value sources because their request values
+come from SQL predicates such as `WHERE id = 123`. Source function requests use
+arg value sources because their request values come from named function
+arguments such as `github.search_issues(q => 'flaky')`.
 
 The suffix controls the value type sent to the provider. Use the bare form for a
 string request value, `_int` for a JSON integer, and `_bool` for a JSON boolean.
@@ -557,6 +559,29 @@ request fields but users naturally have one compound identifier. For example,
   key: issue_identifier
   separator: "-"
   part: 1
+```
+
+Use `arg_split` and `arg_split_int` the same way for source-scoped table
+functions:
+
+```yaml
+args:
+  - name: issue
+    required: true
+    bind:
+      arg: issue
+request:
+  body:
+    - path: [variables, teamKey]
+      from: arg_split
+      key: issue
+      separator: "-"
+      part: 0
+    - path: [variables, issueNumber]
+      from: arg_split_int
+      key: issue
+      separator: "-"
+      part: 1
 ```
 
 ### HTTP response fields


### PR DESCRIPTION
## Summary

Adds table-function request value sources for splitting string arguments before sending provider requests. This lets source manifests bind a single ergonomic function argument such as an issue key into multiple upstream API parameters, including parsed integer parts.

## Reviewer explainer

- Display: https://withcoral.dsp.so/TKuydarF-coral-arg-split-table-functions-explainer

## Changes

- Add `arg_split` and `arg_split_int` value sources to the source spec model and JSON schema.
- Validate function-only split sources against declared function args, while keeping table requests restricted to filter split sources.
- Resolve function argument split values in the HTTP backend alongside the existing filter split behavior.
- Cover the source-scoped table-function path with a Linear-shaped fixture for `issue_comments(issue => 'SOURCE-496')`.
- Document the new request value sources in the source spec reference.

## Validation

- `make rust-checks`
- `make lint-sources`
- Live smoke outside the PR diff: temporarily exposed `linear.issue_comments(issue => 'SOURCE-496')` in the Linear manifest and confirmed it returned real Linear comment data using the live Coral Linear credential. The manifest conversion was reverted so this PR stays support machinery only.