### PR TITLE
feat(cli): show table functions in source info

### DIFF
--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -76,6 +76,28 @@ message SourceInputSpec {
   string hint = 5;
 }
 
+// One argument accepted by a source table function.
+message SourceTableFunctionArgument {
+  // Function argument name.
+  string name = 1;
+  // Whether callers must provide this argument.
+  bool required = 2;
+  // Optional manifest-declared accepted values.
+  repeated string values = 3;
+}
+
+// One source-scoped table-valued function declared by a source manifest.
+message SourceTableFunction {
+  // Function name within the source schema.
+  string name = 1;
+  // Human-readable function description.
+  string description = 2;
+  // Arguments accepted by this function in stable manifest order.
+  repeated SourceTableFunctionArgument arguments = 3;
+  // Columns returned by this function in result order.
+  repeated Column result_columns = 4;
+}
+
 // One bundled or imported source metadata record.
 message SourceInfo {
   // Canonical source name.
@@ -90,6 +112,8 @@ message SourceInfo {
   bool installed = 5;
   // Where this source came from.
   SourceOrigin origin = 6;
+  // Table functions declared by this source manifest.
+  repeated SourceTableFunction table_functions = 7;
 }
 
 // Lists all bundled sources available for one workspace.

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -2,11 +2,16 @@
 
 use std::collections::BTreeSet;
 
-use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
+use coral_spec::{
+    ColumnSpec, SourceTableFunctionSpec, ValidatedSourceManifest, parse_source_manifest_yaml,
+};
 
 use crate::bootstrap::AppError;
 use crate::sources::SourceName;
-use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+use crate::sources::model::{
+    CandidateColumn, CandidateSource, CandidateTableFunction, CandidateTableFunctionArgument,
+    InstalledSource, SourceOrigin,
+};
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
@@ -106,9 +111,58 @@ fn candidate_from_manifest(
         description: manifest.description().to_string(),
         version: manifest.source_version().to_string(),
         inputs: manifest.declared_inputs().to_vec(),
+        table_functions: candidate_table_functions_from_manifest(manifest),
         installed,
         origin,
     })
+}
+
+fn candidate_table_functions_from_manifest(
+    manifest: &ValidatedSourceManifest,
+) -> Vec<CandidateTableFunction> {
+    manifest
+        .as_http()
+        .map(|http| {
+            http.functions
+                .iter()
+                .map(candidate_table_function_from_spec)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn candidate_table_function_from_spec(
+    function: &SourceTableFunctionSpec,
+) -> CandidateTableFunction {
+    CandidateTableFunction {
+        name: function.name.clone(),
+        description: function.description.clone(),
+        arguments: function
+            .args
+            .iter()
+            .map(|arg| CandidateTableFunctionArgument {
+                name: arg.name.clone(),
+                required: arg.required,
+                values: arg.values.clone(),
+            })
+            .collect(),
+        result_columns: function
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(index, column)| candidate_column_from_spec(index, column))
+            .collect(),
+    }
+}
+
+fn candidate_column_from_spec(index: usize, column: &ColumnSpec) -> CandidateColumn {
+    CandidateColumn {
+        name: column.name.clone(),
+        data_type: column.data_type.clone(),
+        nullable: column.nullable,
+        description: column.description.clone(),
+        ordinal_position: u32::try_from(index).expect("column ordinal fits u32"),
+    }
 }
 
 #[cfg(test)]
@@ -181,6 +235,23 @@ tables:
     columns:
       - name: id
         type: Utf8
+functions:
+  - name: message_comments
+    description: Comments for one message
+    args:
+      - name: message_id
+        required: true
+        values: [pinned]
+        bind:
+          arg: message_id
+    request:
+      method: GET
+      path: /messages/{{arg.message_id}}/comments
+    columns:
+      - name: body
+        type: Utf8
+        nullable: false
+        description: Comment body
 "#,
             SourceOrigin::Imported,
             false,
@@ -191,6 +262,18 @@ tables:
         assert_eq!(source.inputs[0].kind, ManifestInputKind::Variable);
         assert_eq!(source.inputs[1].key, "API_TOKEN");
         assert_eq!(source.inputs[1].kind, ManifestInputKind::Secret);
+        assert_eq!(source.table_functions.len(), 1);
+        let function = &source.table_functions[0];
+        assert_eq!(function.name, "message_comments");
+        assert_eq!(function.description, "Comments for one message");
+        assert_eq!(function.arguments[0].name, "message_id");
+        assert!(function.arguments[0].required);
+        assert_eq!(function.arguments[0].values, ["pinned"]);
+        assert_eq!(function.result_columns[0].name, "body");
+        assert_eq!(function.result_columns[0].data_type, "Utf8");
+        assert!(!function.result_columns[0].nullable);
+        assert_eq!(function.result_columns[0].description, "Comment body");
+        assert_eq!(function.result_columns[0].ordinal_position, 0);
     }
 
     #[test]

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -14,8 +14,33 @@ pub(crate) struct CandidateSource {
     pub(crate) description: String,
     pub(crate) version: String,
     pub(crate) inputs: Vec<ManifestInputSpec>,
+    pub(crate) table_functions: Vec<CandidateTableFunction>,
     pub(crate) installed: bool,
     pub(crate) origin: SourceOrigin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CandidateTableFunction {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) arguments: Vec<CandidateTableFunctionArgument>,
+    pub(crate) result_columns: Vec<CandidateColumn>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CandidateTableFunctionArgument {
+    pub(crate) name: String,
+    pub(crate) required: bool,
+    pub(crate) values: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CandidateColumn {
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) nullable: bool,
+    pub(crate) description: String,
+    pub(crate) ordinal_position: u32,
 }
 
 /// App-owned model for one source installed in a workspace.

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -2,12 +2,13 @@
 
 use coral_api::v1::source_service_server::SourceService as SourceServiceApi;
 use coral_api::v1::{
-    CreateBundledSourceRequest, CreateBundledSourceResponse, DeleteSourceRequest,
+    Column, CreateBundledSourceRequest, CreateBundledSourceResponse, DeleteSourceRequest,
     DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
     GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
     ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, Source, SourceInfo,
     SourceInputKind, SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret,
-    SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+    SourceTableFunction, SourceTableFunctionArgument, SourceVariable, ValidateSourceRequest,
+    ValidateSourceResponse,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use tonic::{Request, Response, Status};
@@ -18,7 +19,10 @@ use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, ImportSourceCommand, SourceBinding, SourceBindings, SourceManager,
 };
-use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
+use crate::sources::model::{
+    CandidateColumn, CandidateSource, CandidateTableFunction, CandidateTableFunctionArgument,
+    InstalledSource, SourceOrigin,
+};
 use crate::transport::{
     grpc_span, instrument_grpc, query_status, validate_source_response_to_proto,
     workspace_name_from_proto, workspace_to_proto,
@@ -55,7 +59,7 @@ impl SourceServiceApi for SourceService {
                 .discover_sources(&workspace_name)
                 .map_err(app_status)?
                 .into_iter()
-                .map(candidate_source_to_proto)
+                .map(candidate_source_summary_to_proto)
                 .collect();
             Ok(Response::new(DiscoverSourcesResponse { sources }))
         })
@@ -116,7 +120,7 @@ impl SourceServiceApi for SourceService {
                 .get_source_info(&workspace_name, &source_name)
                 .map_err(app_status)?;
             Ok(Response::new(GetSourceInfoResponse {
-                source_info: Some(candidate_source_to_proto(source)),
+                source_info: Some(candidate_source_info_to_proto(source)),
             }))
         })
         .await
@@ -269,7 +273,15 @@ fn proto_source_origin(origin: SourceOrigin) -> ProtoSourceOrigin {
     }
 }
 
-fn candidate_source_to_proto(source: CandidateSource) -> SourceInfo {
+fn candidate_source_summary_to_proto(source: CandidateSource) -> SourceInfo {
+    candidate_source_to_proto(source, false)
+}
+
+fn candidate_source_info_to_proto(source: CandidateSource) -> SourceInfo {
+    candidate_source_to_proto(source, true)
+}
+
+fn candidate_source_to_proto(source: CandidateSource, include_table_functions: bool) -> SourceInfo {
     SourceInfo {
         name: source.name.as_str().to_string(),
         description: source.description,
@@ -279,6 +291,15 @@ fn candidate_source_to_proto(source: CandidateSource) -> SourceInfo {
             .into_iter()
             .map(candidate_source_input_to_proto)
             .collect(),
+        table_functions: if include_table_functions {
+            source
+                .table_functions
+                .into_iter()
+                .map(candidate_table_function_to_proto)
+                .collect()
+        } else {
+            Vec::new()
+        },
         installed: source.installed,
         origin: proto_source_origin(source.origin) as i32,
     }
@@ -298,5 +319,44 @@ fn proto_candidate_input_kind(kind: ManifestInputKind) -> SourceInputKind {
     match kind {
         ManifestInputKind::Variable => SourceInputKind::Variable,
         ManifestInputKind::Secret => SourceInputKind::Secret,
+    }
+}
+
+fn candidate_table_function_to_proto(function: CandidateTableFunction) -> SourceTableFunction {
+    SourceTableFunction {
+        name: function.name,
+        description: function.description,
+        arguments: function
+            .arguments
+            .into_iter()
+            .map(candidate_table_function_argument_to_proto)
+            .collect(),
+        result_columns: function
+            .result_columns
+            .into_iter()
+            .map(candidate_column_to_proto)
+            .collect(),
+    }
+}
+
+fn candidate_table_function_argument_to_proto(
+    argument: CandidateTableFunctionArgument,
+) -> SourceTableFunctionArgument {
+    SourceTableFunctionArgument {
+        name: argument.name,
+        required: argument.required,
+        values: argument.values,
+    }
+}
+
+fn candidate_column_to_proto(column: CandidateColumn) -> Column {
+    Column {
+        name: column.name,
+        data_type: column.data_type,
+        nullable: column.nullable,
+        is_virtual: false,
+        is_required_filter: false,
+        description: column.description,
+        ordinal_position: column.ordinal_position,
     }
 }

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -724,6 +724,12 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
         .into_inner()
         .sources;
     assert!(!discovered.is_empty());
+    assert!(
+        discovered
+            .iter()
+            .all(|source| source.table_functions.is_empty()),
+        "discover_sources should return summary metadata without table function details"
+    );
     let github = discovered
         .iter()
         .find(|source| source.name == "github")
@@ -756,6 +762,12 @@ async fn discover_bundled_sources_returns_catalog_and_marks_installed_sources() 
         .expect("rediscover sources")
         .into_inner()
         .sources;
+    assert!(
+        rediscovered
+            .iter()
+            .all(|source| source.table_functions.is_empty()),
+        "discover_sources should keep table function details out of installed-source summaries"
+    );
     let github = rediscovered
         .iter()
         .find(|source| source.name == "github")
@@ -828,6 +840,74 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
     assert_eq!(info.inputs[0].key, "API_BASE");
     assert_eq!(info.inputs[0].default_value, "https://example.com");
     assert_eq!(info.inputs[1].key, "API_TOKEN");
+}
+
+#[tokio::test]
+async fn get_source_info_returns_table_function_metadata() {
+    let harness = GrpcHarness::new().await;
+
+    harness
+        .import_source(
+            r"
+name: function_demo
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+functions:
+  - name: issue_comments
+    description: Comments for one issue
+    args:
+      - name: issue
+        required: true
+        values: [SOURCE-496]
+        bind:
+          arg: issue
+    request:
+      method: GET
+      path: /issues/{{arg.issue}}/comments
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Comment id
+      - name: body
+        type: Utf8
+"
+            .to_string(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let info = harness
+        .source_client()
+        .get_source_info(Request::new(GetSourceInfoRequest {
+            workspace: Some(default_workspace()),
+            name: "function_demo".to_string(),
+        }))
+        .await
+        .expect("get source info")
+        .into_inner()
+        .source_info
+        .expect("get source info response");
+
+    assert_eq!(info.table_functions.len(), 1);
+    let function = &info.table_functions[0];
+    assert_eq!(function.name, "issue_comments");
+    assert_eq!(function.description, "Comments for one issue");
+    assert_eq!(function.arguments[0].name, "issue");
+    assert!(function.arguments[0].required);
+    assert_eq!(function.arguments[0].values, ["SOURCE-496"]);
+    assert_eq!(function.result_columns[0].name, "id");
+    assert_eq!(function.result_columns[0].data_type, "Utf8");
+    assert!(!function.result_columns[0].nullable);
+    assert!(!function.result_columns[0].is_virtual);
+    assert!(!function.result_columns[0].is_required_filter);
+    assert_eq!(function.result_columns[0].description, "Comment id");
+    assert_eq!(function.result_columns[0].ordinal_position, 0);
+    assert_eq!(function.result_columns[1].name, "body");
+    assert_eq!(function.result_columns[1].ordinal_position, 1);
 }
 
 #[tokio::test]

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -359,6 +359,7 @@ mod tests {
             description: "Query repositories and issues".to_string(),
             version: "1.0.0".to_string(),
             inputs: Vec::new(),
+            table_functions: Vec::new(),
             installed: true,
             origin: 1,
         };
@@ -375,6 +376,7 @@ mod tests {
             description: "Send and receive messages".to_string(),
             version: "1.0.0".to_string(),
             inputs: Vec::new(),
+            table_functions: Vec::new(),
             installed: false,
             origin: 1,
         };
@@ -390,6 +392,7 @@ mod tests {
             description: "GitHub".to_string(),
             version: "1.0.0".to_string(),
             inputs: Vec::new(),
+            table_functions: Vec::new(),
             installed: false,
             origin: 1,
         };
@@ -398,6 +401,7 @@ mod tests {
             description: "Status pages".to_string(),
             version: "1.0.0".to_string(),
             inputs: Vec::new(),
+            table_functions: Vec::new(),
             installed: false,
             origin: 1,
         };

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -5,8 +5,9 @@ use std::path::Path;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, GetSourceInfoRequest,
     ImportSourceRequest, ListSourcesRequest, QueryTestFailure, QueryTestSuccess, Source,
-    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, SourceSecret, SourceVariable,
-    ValidateSourceRequest, ValidateSourceResponse, query_test_result,
+    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, SourceSecret,
+    SourceTableFunctionArgument, SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+    query_test_result,
 };
 use coral_client::{AppClient, default_workspace};
 use coral_spec::{
@@ -180,35 +181,96 @@ fn print_source_info_response(source: &SourceInfo, verbose: bool) {
         println!("  Description: {}", source.description);
     }
 
-    if source.inputs.is_empty() {
+    if !source.inputs.is_empty() {
+        println!();
+        println!("  {}", style("Inputs").bold());
+        for input in &source.inputs {
+            let kind_label = match SourceInputKind::try_from(input.kind) {
+                Ok(SourceInputKind::Variable) => "variable",
+                Ok(SourceInputKind::Secret) => "secret",
+                Ok(SourceInputKind::Unspecified) | Err(_) => "unknown",
+            };
+            let requirement = if input.required {
+                "required"
+            } else {
+                "optional"
+            };
+            println!(
+                "    {} {}",
+                style(&input.key).bold(),
+                style(format!("({kind_label}, {requirement})")).dim()
+            );
+            if !input.default_value.is_empty() {
+                println!("      default: {}", input.default_value);
+            }
+            if verbose && !input.hint.is_empty() {
+                println!("      {}", style(&input.hint).dim());
+            }
+        }
+    }
+
+    if source.table_functions.is_empty() {
         return;
     }
 
     println!();
-    println!("  {}", style("Inputs").bold());
-    for input in &source.inputs {
-        let kind_label = match SourceInputKind::try_from(input.kind) {
-            Ok(SourceInputKind::Variable) => "variable",
-            Ok(SourceInputKind::Secret) => "secret",
-            Ok(SourceInputKind::Unspecified) | Err(_) => "unknown",
-        };
-        let requirement = if input.required {
-            "required"
-        } else {
-            "optional"
-        };
+    println!("  {}", style("Table functions").bold());
+    for function in &source.table_functions {
         println!(
-            "    {} {}",
-            style(&input.key).bold(),
-            style(format!("({kind_label}, {requirement})")).dim()
+            "    {}{}",
+            style(&function.name).bold(),
+            format_function_arguments(&function.arguments)
         );
-        if !input.default_value.is_empty() {
-            println!("      default: {}", input.default_value);
+        if !function.description.is_empty() {
+            println!("      {}", function.description);
         }
-        if verbose && !input.hint.is_empty() {
-            println!("      {}", style(&input.hint).dim());
+        if verbose && !function.result_columns.is_empty() {
+            println!("      {}", style("Returns").bold());
+            for column in &function.result_columns {
+                let nullability = if column.nullable {
+                    "nullable"
+                } else {
+                    "required"
+                };
+                println!(
+                    "        {} {} {}",
+                    style(&column.name).bold(),
+                    column.data_type,
+                    style(format!("({nullability})")).dim()
+                );
+                if !column.description.is_empty() {
+                    println!("          {}", style(&column.description).dim());
+                }
+            }
         }
     }
+}
+
+fn format_function_arguments(arguments: &[SourceTableFunctionArgument]) -> String {
+    if arguments.is_empty() {
+        return "()".to_string();
+    }
+
+    let formatted = arguments
+        .iter()
+        .map(format_function_argument)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("({formatted})")
+}
+
+fn format_function_argument(argument: &SourceTableFunctionArgument) -> String {
+    let requirement = if argument.required {
+        "required"
+    } else {
+        "optional"
+    };
+    let mut formatted = format!("{} {requirement}", argument.name);
+    if !argument.values.is_empty() {
+        formatted.push_str("; values: ");
+        formatted.push_str(&argument.values.join(", "));
+    }
+    formatted
 }
 
 pub(crate) async fn delete_source(app: &AppClient, name: &str) -> Result<(), anyhow::Error> {

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -211,6 +211,14 @@ async fn source_info_renders_metadata_for_installed_source() {
         "expected input requirement: {stdout}"
     );
     assert!(
+        stdout.contains("issue_comments(issue required; values: SOURCE-496, ENG-42)"),
+        "expected table function signature: {stdout}"
+    );
+    assert!(
+        stdout.contains("Comments for one issue"),
+        "expected table function description: {stdout}"
+    );
+    assert!(
         !stdout.contains("github.com/settings/tokens"),
         "expected hint to be hidden without --verbose: {stdout}"
     );
@@ -237,6 +245,14 @@ async fn source_info_verbose_includes_input_hints() {
     assert!(
         stdout.contains("github.com/settings/tokens"),
         "expected hint with --verbose: {stdout}"
+    );
+    assert!(
+        stdout.contains("Returns"),
+        "expected table function return columns with --verbose: {stdout}"
+    );
+    assert!(
+        stdout.contains("Comment body"),
+        "expected result column description with --verbose: {stdout}"
     );
 
     server.shutdown().await;
@@ -780,6 +796,7 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
                     description: "A demo bundled source for testing".to_string(),
                     version: "1.0.0".to_string(),
                     inputs: Vec::new(),
+                    table_functions: Vec::new(),
                     installed: false,
                     origin: SourceOrigin::Bundled as i32,
                 }],

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -19,8 +19,9 @@ use coral_api::v1::{
     ExecuteSqlResponse, GetSourceInfoRequest, GetSourceInfoResponse, GetSourceRequest,
     GetSourceResponse, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
     ListSourcesResponse, ListTablesRequest, ListTablesResponse, PaginationResponse, Source,
-    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, Table, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace,
+    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, SourceTableFunction,
+    SourceTableFunctionArgument, Table, TableSummary, ValidateSourceRequest,
+    ValidateSourceResponse, Workspace,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -203,6 +204,7 @@ fn mock_discover_response() -> DiscoverSourcesResponse {
                     default_value: String::new(),
                     hint: "Create a token at github.com/settings/tokens".to_string(),
                 }],
+                table_functions: Vec::new(),
                 installed: true,
                 origin: SourceOrigin::Bundled as i32,
             },
@@ -211,6 +213,7 @@ fn mock_discover_response() -> DiscoverSourcesResponse {
                 description: "Slack data".to_string(),
                 version: "2.1.0".to_string(),
                 inputs: Vec::new(),
+                table_functions: Vec::new(),
                 installed: false,
                 origin: SourceOrigin::Bundled as i32,
             },
@@ -242,6 +245,7 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
                 default_value: String::new(),
                 hint: "Create a token at github.com/settings/tokens".to_string(),
             }],
+            table_functions: vec![mock_table_function()],
             installed: true,
             origin: SourceOrigin::Bundled as i32,
         }),
@@ -250,6 +254,7 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             description: "Slack data".to_string(),
             version: "2.1.0".to_string(),
             inputs: Vec::new(),
+            table_functions: Vec::new(),
             installed: false,
             origin: SourceOrigin::Bundled as i32,
         }),
@@ -258,10 +263,43 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             description: "Jira data".to_string(),
             version: "2.0.0".to_string(),
             inputs: Vec::new(),
+            table_functions: Vec::new(),
             installed: true,
             origin: SourceOrigin::Imported as i32,
         }),
         _ => Err(Status::not_found(format!("unknown source '{name}'"))),
+    }
+}
+
+fn mock_table_function() -> SourceTableFunction {
+    SourceTableFunction {
+        name: "issue_comments".to_string(),
+        description: "Comments for one issue".to_string(),
+        arguments: vec![SourceTableFunctionArgument {
+            name: "issue".to_string(),
+            required: true,
+            values: vec!["SOURCE-496".to_string(), "ENG-42".to_string()],
+        }],
+        result_columns: vec![
+            Column {
+                name: "id".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: false,
+                is_virtual: false,
+                is_required_filter: false,
+                description: "Comment id".to_string(),
+                ordinal_position: 0,
+            },
+            Column {
+                name: "body".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: true,
+                is_virtual: false,
+                is_required_filter: false,
+                description: "Comment body".to_string(),
+                ordinal_position: 1,
+            },
+        ],
     }
 }
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -43,13 +43,13 @@ coral source list
 
 ### `coral source info <NAME>`
 
-Show metadata for a source: whether it is installed, its origin, version, description, and inputs. Works for bundled sources and imported sources installed via `coral source add --file`.
+Show metadata for a source: whether it is installed, its origin, version, description, inputs, and table functions. Works for bundled sources and imported sources installed via `coral source add --file`.
 
 ```shellscript
 coral source info datadog
 ```
 
-Pass `-v/--verbose` for more detailed output.
+Pass `-v/--verbose` for more detailed output, including input hints and table function result columns.
 
 ```shellscript
 coral source info datadog --verbose


### PR DESCRIPTION
## Summary
- add table function metadata to `SourceInfo` so source manifests can describe function arguments, accepted values, and result columns
- keep `DiscoverSources` summary-shaped by omitting table-function detail from broad catalog discovery responses
- return full table-function metadata from `GetSourceInfo`, which powers `coral source info`
- render table function signatures in `coral source info`, including accepted argument values; render result columns under `--verbose`

## Explainer
- Display: https://withcoral.dsp.so/PMu2sOhE-coral-source-info-table-functions

## Verification
- `cargo test -p coral-app --test grpc source_info`
- `cargo test -p coral-app --test grpc discover_bundled_sources_returns_catalog_and_marks_installed_sources`
- `cargo test -p coral-cli --test cli_e2e source_info --features cli-test-server`
- `make rust-checks`