### PR TITLE
feat(sources/slack): convert message tables to functions

### DIFF
--- a/sources/core/slack/manifest.yaml
+++ b/sources/core/slack/manifest.yaml
@@ -29,6 +29,216 @@ auth:
       template: Bearer {{input.SLACK_TOKEN}}
 test_queries:
   - SELECT * FROM slack.channels LIMIT 1
+functions:
+  - name: messages
+    description: Messages in a Slack channel.
+    args:
+      - name: channel
+        required: true
+        bind:
+          arg: channel
+      - name: oldest
+        bind:
+          arg: oldest
+      - name: latest
+        bind:
+          arg: latest
+    request:
+      method: GET
+      path: /api/conversations.history
+      query:
+        - name: channel
+          from: arg
+          key: channel
+        - name: oldest
+          from: arg
+          key: oldest
+        - name: latest
+          from: arg
+          key: latest
+    response:
+      ok_path:
+        - ok
+      error_path:
+        - error
+      rows_path:
+        - messages
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+      cursor_param: cursor
+      response_cursor_path:
+        - response_metadata
+        - next_cursor
+    columns:
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: User ID of the message author
+        expr:
+          kind: path
+          path:
+            - user
+      - name: text
+        type: Utf8
+        nullable: true
+        description: Message text content
+        expr:
+          kind: path
+          path:
+            - text
+      - name: ts
+        type: Timestamp
+        nullable: false
+        description: Message time from Slack `ts`, exposed as a UTC Timestamp
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - ts
+      - name: thread_ts
+        type: Utf8
+        nullable: true
+        description: Thread parent timestamp (null if not in a thread)
+        expr:
+          kind: path
+          path:
+            - thread_ts
+      - name: reply_count
+        type: Int64
+        nullable: true
+        description: Number of replies in thread
+        expr:
+          kind: path
+          path:
+            - reply_count
+      - name: subtype
+        type: Utf8
+        nullable: true
+        description: Message subtype
+        expr:
+          kind: path
+          path:
+            - subtype
+  - name: thread_replies
+    description: Slack thread replies for a specific channel and parent message.
+    args:
+      - name: channel
+        required: true
+        bind:
+          arg: channel
+      - name: thread_ts
+        required: true
+        bind:
+          arg: thread_ts
+      - name: oldest
+        bind:
+          arg: oldest
+      - name: latest
+        bind:
+          arg: latest
+      - name: inclusive
+        bind:
+          arg: inclusive
+      - name: include_all_metadata
+        bind:
+          arg: include_all_metadata
+    request:
+      method: GET
+      path: /api/conversations.replies
+      query:
+        - name: channel
+          from: arg
+          key: channel
+        - name: ts
+          from: arg
+          key: thread_ts
+        - name: oldest
+          from: arg
+          key: oldest
+        - name: latest
+          from: arg
+          key: latest
+        - name: inclusive
+          from: arg
+          key: inclusive
+        - name: include_all_metadata
+          from: arg
+          key: include_all_metadata
+    response:
+      ok_path:
+        - ok
+      error_path:
+        - error
+      rows_path:
+        - messages
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+      cursor_param: cursor
+      response_cursor_path:
+        - response_metadata
+        - next_cursor
+    columns:
+      - name: thread_ts
+        type: Utf8
+        nullable: true
+        description: Thread parent timestamp
+        expr:
+          kind: path
+          path:
+            - thread_ts
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: User ID of the reply author
+        expr:
+          kind: path
+          path:
+            - user
+      - name: text
+        type: Utf8
+        nullable: true
+        description: Reply text content
+        expr:
+          kind: path
+          path:
+            - text
+      - name: ts
+        type: Timestamp
+        nullable: false
+        description: Reply time from Slack `ts`, exposed as a UTC Timestamp
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - ts
+      - name: reply_count
+        type: Int64
+        nullable: true
+        description: Number of replies in thread (present on parent messages)
+        expr:
+          kind: path
+          path:
+            - reply_count
+      - name: subtype
+        type: Utf8
+        nullable: true
+        description: Message subtype
+        expr:
+          kind: path
+          path:
+            - subtype
 tables:
   - name: channels
     description: Slack channels with topic, purpose, and member count
@@ -118,310 +328,6 @@ tables:
           kind: path
           path:
             - created
-  - name: messages
-    description: Messages in a Slack channel (requires channel filter)
-    guide: |
-      Use this table for Messages in a Slack channel (requires channel
-      filter). Requires `channel` from `slack.channels`. `oldest` and
-      `latest` are Slack API timestamp filters: pass raw Slack timestamp
-      strings such as `1777593600.000000`, not ISO-8601 timestamps. The
-      returned `ts` column is a normal UTC `Timestamp`, so use SQL
-      predicates such as `ts >= CAST('2026-05-01T00:00:00Z' AS TIMESTAMP)`
-      when you want ISO-style filtering after the channel history is fetched.
-    request:
-      method: GET
-      path: /api/conversations.history
-      query:
-        - name: channel
-          from: filter
-          key: channel
-        - name: oldest
-          from: filter
-          key: oldest
-        - name: latest
-          from: filter
-          key: latest
-    response:
-      ok_path:
-        - ok
-      error_path:
-        - error
-      rows_path:
-        - messages
-    pagination:
-      mode: cursor_query
-      page_size:
-        default: 200
-        max: 200
-        query_param: limit
-      cursor_param: cursor
-      response_cursor_path:
-        - response_metadata
-        - next_cursor
-    columns:
-      - name: channel
-        type: Utf8
-        nullable: false
-        description: Channel ID (required filter to specify which channel)
-        expr:
-          kind: from_filter
-          key: channel
-      - name: user_id
-        type: Utf8
-        nullable: true
-        description: User ID of the message author
-        expr:
-          kind: path
-          path:
-            - user
-      - name: text
-        type: Utf8
-        nullable: true
-        description: Message text content
-        expr:
-          kind: path
-          path:
-            - text
-      - name: ts
-        type: Timestamp
-        nullable: false
-        description: Message time from Slack `ts`, exposed as a UTC Timestamp
-        expr:
-          kind: format_timestamp
-          input: seconds
-          expr:
-            kind: path
-            path:
-              - ts
-      - name: permalink
-        type: Utf8
-        nullable: false
-        description: Deep link to the message in Slack
-        expr:
-          kind: template
-          template: "https://slack.com/archives/{{filter.channel}}/p{{expr.ts_id}}"
-          values:
-            ts_id:
-              kind: replace
-              expr:
-                kind: path
-                path:
-                  - ts
-              from: "."
-              to: ""
-      - name: thread_ts
-        type: Utf8
-        nullable: true
-        description: Thread parent timestamp (null if not in a thread)
-        expr:
-          kind: path
-          path:
-            - thread_ts
-      - name: reply_count
-        type: Int64
-        nullable: true
-        description: Number of replies in thread
-        expr:
-          kind: path
-          path:
-            - reply_count
-      - name: subtype
-        type: Utf8
-        nullable: true
-        description: Message subtype
-        expr:
-          kind: path
-          path:
-            - subtype
-      - name: oldest
-        type: Utf8
-        nullable: true
-        description: Oldest Slack raw `ts` filter such as `1777593600.000000`; not ISO-8601 (virtual)
-        expr:
-          kind: "null"
-        virtual: true
-      - name: latest
-        type: Utf8
-        nullable: true
-        description: Latest Slack raw `ts` filter such as `1777593600.000000`; not ISO-8601 (virtual)
-        expr:
-          kind: "null"
-        virtual: true
-    filters:
-      - name: channel
-        required: true
-      - name: oldest
-      - name: latest
-  - name: thread_replies
-    description: Slack thread replies for a specific channel and parent message
-    guide: |
-      Requires both `channel` and raw `thread_ts`. Start from
-      `slack.messages` with a channel filter, find a parent message with
-      `reply_count > 0`, then pass that row's `thread_ts` when present or
-      its raw Slack message timestamp as `thread_ts`. The `oldest` and
-      `latest` filters also expect raw Slack timestamp strings such as
-      `1777593600.000000`, not ISO-8601 timestamps.
-    request:
-      method: GET
-      path: /api/conversations.replies
-      query:
-        - name: channel
-          from: filter
-          key: channel
-        - name: ts
-          from: filter
-          key: thread_ts
-        - name: oldest
-          from: filter
-          key: oldest
-        - name: latest
-          from: filter
-          key: latest
-        - name: inclusive
-          from: filter
-          key: inclusive
-        - name: include_all_metadata
-          from: filter
-          key: include_all_metadata
-    response:
-      ok_path:
-        - ok
-      error_path:
-        - error
-      rows_path:
-        - messages
-    pagination:
-      mode: cursor_query
-      page_size:
-        default: 200
-        max: 200
-        query_param: limit
-      cursor_param: cursor
-      response_cursor_path:
-        - response_metadata
-        - next_cursor
-    columns:
-      - name: channel
-        type: Utf8
-        nullable: false
-        description: Channel ID (required filter to specify which channel)
-        expr:
-          kind: from_filter
-          key: channel
-      - name: thread_ts
-        type: Utf8
-        nullable: false
-        description: Thread parent timestamp (required filter)
-        expr:
-          kind: from_filter
-          key: thread_ts
-      - name: user_id
-        type: Utf8
-        nullable: true
-        description: User ID of the reply author
-        expr:
-          kind: path
-          path:
-            - user
-      - name: text
-        type: Utf8
-        nullable: true
-        description: Reply text content
-        expr:
-          kind: path
-          path:
-            - text
-      - name: ts
-        type: Timestamp
-        nullable: false
-        description: Reply time from Slack `ts`, exposed as a UTC Timestamp
-        expr:
-          kind: format_timestamp
-          input: seconds
-          expr:
-            kind: path
-            path:
-              - ts
-      - name: permalink
-        type: Utf8
-        nullable: false
-        description: Deep link to the thread reply in Slack
-        expr:
-          kind: template
-          template: "https://slack.com/archives/{{filter.channel}}/p{{expr.ts_id}}?thread_ts={{expr.thread_ts}}&cid={{filter.channel}}"
-          values:
-            ts_id:
-              kind: replace
-              expr:
-                kind: path
-                path:
-                  - ts
-              from: "."
-              to: ""
-            thread_ts:
-              kind: coalesce
-              exprs:
-                - kind: path
-                  path:
-                    - thread_ts
-                - kind: path
-                  path:
-                    - ts
-      - name: reply_count
-        type: Int64
-        nullable: true
-        description: Number of replies in thread (present on parent messages)
-        expr:
-          kind: path
-          path:
-            - reply_count
-      - name: subtype
-        type: Utf8
-        nullable: true
-        description: Message subtype
-        expr:
-          kind: path
-          path:
-            - subtype
-      - name: oldest
-        type: Utf8
-        nullable: true
-        description: Oldest Slack raw `ts` filter such as `1777593600.000000`; not ISO-8601 (virtual)
-        expr:
-          kind: "null"
-        virtual: true
-      - name: latest
-        type: Utf8
-        nullable: true
-        description: Latest Slack raw `ts` filter such as `1777593600.000000`; not ISO-8601 (virtual)
-        expr:
-          kind: "null"
-        virtual: true
-      - name: inclusive
-        type: Utf8
-        nullable: true
-        description: Include messages matching oldest or latest timestamps, as true or false (virtual)
-        expr:
-          kind: from_filter
-          key: inclusive
-        virtual: true
-      - name: include_all_metadata
-        type: Utf8
-        nullable: true
-        description: Return all metadata associated with thread messages, as true or false (virtual)
-        expr:
-          kind: from_filter
-          key: include_all_metadata
-        virtual: true
-    filters:
-      - name: channel
-        required: true
-      - name: thread_ts
-        required: true
-      - name: oldest
-      - name: latest
-      - name: inclusive
-      - name: include_all_metadata
   - name: users
     description: Slack workspace users with profile info (email requires users:read.email scope)
     guide: |


### PR DESCRIPTION
## Summary
- convert `slack.messages` and `slack.thread_replies` from required-filter tables to table functions
- expose calls as `slack.messages(channel => ...)` and `slack.thread_replies(channel => ..., thread_ts => ...)`
- preserve optional Slack history/reply request args and drop virtual input/permalink columns that depended on table filters

## Verification
- `cargo run -p coral-cli -- source lint sources/core/slack/manifest.yaml`
- `make lint-sources`
- live smoke with Slack config:
  - installed `sources/core/slack/manifest.yaml` in a temp Coral config
  - confirmed only `channels` and `users` remain in `coral.tables`
  - confirmed `messages` and `thread_replies` appear in `coral.table_functions`
  - queried `slack.messages(channel => ...)` against an accessible channel and received rows
  - queried `slack.thread_replies(channel => ..., thread_ts => ...)` against a real thread and received rows