### PR TITLE
feat(sources/sentry): convert drilldown tables to functions

### DIFF
--- a/sources/core/sentry/manifest.yaml
+++ b/sources/core/sentry/manifest.yaml
@@ -25,6 +25,404 @@ auth:
       template: Bearer {{input.SENTRY_TOKEN}}
 test_queries:
   - SELECT * FROM sentry.projects LIMIT 1
+functions:
+  - name: events
+    description: Individual events for a specific issue
+    request:
+      method: GET
+      path: /api/0/organizations/{{input.SENTRY_ORG}}/issues/{{arg.issue_id}}/events/
+      query: []
+    response: {}
+    pagination:
+      mode: link_header
+      link_header_require_results: true
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Event ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: event_id
+        type: Utf8
+        nullable: true
+        description: Event UUID
+        expr:
+          kind: path
+          path:
+            - eventID
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Event title
+        expr:
+          kind: path
+          path:
+            - title
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Event message
+        expr:
+          kind: path
+          path:
+            - message
+      - name: timestamp
+        type: Utf8
+        nullable: true
+        description: Event timestamp
+        expr:
+          kind: path
+          path:
+            - dateCreated
+      - name: platform
+        type: Utf8
+        nullable: true
+        description: Platform
+        expr:
+          kind: path
+          path:
+            - platform
+      - name: environment
+        type: Utf8
+        nullable: true
+        description: Environment
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: tag_value
+              path:
+                - tags
+              key: environment
+            - kind: path
+              path:
+                - environment
+      - name: release
+        type: Utf8
+        nullable: true
+        description: Release
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: tag_value
+              path:
+                - tags
+              key: release
+            - kind: path
+              path:
+                - release
+    args:
+      - name: issue_id
+        required: true
+        bind:
+          arg: issue_id
+  - name: issue_tags
+    description: Tags for a specific issue
+    request:
+      method: GET
+      path: /api/0/issues/{{arg.issue_id}}/tags/
+      query: []
+    response: {}
+    pagination:
+      mode: link_header
+      link_header_require_results: true
+    columns:
+      - name: key
+        type: Utf8
+        nullable: true
+        description: Tag key
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - key
+            - kind: path
+              path:
+                - name
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Tag name
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - name
+            - kind: path
+              path:
+                - key
+    args:
+      - name: issue_id
+        required: true
+        bind:
+          arg: issue_id
+  - name: issue_participants
+    description: Participants for a specific issue
+    request:
+      method: GET
+      path: /api/0/issues/{{arg.issue_id}}/participants/
+      query: []
+    response: {}
+    pagination:
+      mode: link_header
+      link_header_require_results: true
+    columns:
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Participant ID
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - id
+            - kind: path
+              path:
+                - user
+                - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Participant name
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - name
+            - kind: path
+              path:
+                - user
+                - name
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Participant email
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - email
+            - kind: path
+              path:
+                - user
+                - email
+    args:
+      - name: issue_id
+        required: true
+        bind:
+          arg: issue_id
+  - name: deployments
+    description: Deployments for a release version
+    request:
+      method: GET
+      path: /api/0/organizations/{{input.SENTRY_ORG}}/releases/{{arg.version}}/deploys/
+      query: []
+    response: {}
+    pagination:
+      mode: link_header
+      link_header_require_results: true
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Deployment ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: environment
+        type: Utf8
+        nullable: true
+        description: Environment
+        expr:
+          kind: path
+          path:
+            - environment
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Deployment name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: date_started
+        type: Utf8
+        nullable: true
+        description: Start timestamp
+        expr:
+          kind: path
+          path:
+            - dateStarted
+      - name: date_finished
+        type: Utf8
+        nullable: true
+        description: End timestamp
+        expr:
+          kind: path
+          path:
+            - dateFinished
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Deployment URL
+        expr:
+          kind: path
+          path:
+            - url
+    args:
+      - name: version
+        required: true
+        bind:
+          arg: version
+  - name: release_files
+    description: Files for a release version
+    request:
+      method: GET
+      path: /api/0/organizations/{{input.SENTRY_ORG}}/releases/{{arg.version}}/files/
+      query: []
+    response: {}
+    pagination:
+      mode: link_header
+      link_header_require_results: true
+    columns:
+      - name: id
+        type: Utf8
+        nullable: true
+        description: File ID
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - id
+            - kind: path
+              path:
+                - ident
+      - name: name
+        type: Utf8
+        nullable: true
+        description: File name
+        expr:
+          kind: coalesce
+          exprs:
+            - kind: path
+              path:
+                - name
+            - kind: path
+              path:
+                - fileName
+            - kind: path
+              path:
+                - filename
+    args:
+      - name: version
+        required: true
+        bind:
+          arg: version
+  - name: project_events
+    description: Recent events for a specific project
+    request:
+      method: GET
+      path: /api/0/projects/{{input.SENTRY_ORG}}/{{arg.project}}/events/
+      query: []
+    response: {}
+    pagination:
+      mode: link_header
+      link_header_require_results: true
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Event ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: event_id
+        type: Utf8
+        nullable: true
+        description: Event UUID
+        expr:
+          kind: path
+          path:
+            - eventID
+      - name: project_id
+        type: Utf8
+        nullable: true
+        description: Project ID
+        expr:
+          kind: path
+          path:
+            - projectID
+      - name: group_id
+        type: Utf8
+        nullable: true
+        description: Group ID
+        expr:
+          kind: path
+          path:
+            - groupID
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Title
+        expr:
+          kind: path
+          path:
+            - title
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Message
+        expr:
+          kind: path
+          path:
+            - message
+      - name: timestamp
+        type: Utf8
+        nullable: true
+        description: Timestamp
+        expr:
+          kind: path
+          path:
+            - dateCreated
+      - name: platform
+        type: Utf8
+        nullable: true
+        description: Platform
+        expr:
+          kind: path
+          path:
+            - platform
+      - name: location
+        type: Utf8
+        nullable: true
+        description: Location
+        expr:
+          kind: path
+          path:
+            - location
+      - name: culprit
+        type: Utf8
+        nullable: true
+        description: Culprit
+        expr:
+          kind: path
+          path:
+            - culprit
+    args:
+      - name: project
+        required: true
+        bind:
+          arg: project
 tables:
   - name: projects
     description: Sentry projects in the organization
@@ -205,224 +603,6 @@ tables:
     filters:
       - name: project
       - name: query
-  - name: events
-    description: Individual events for a specific issue
-    guide: |
-      Use this table for Individual events for a specific issue.
-      Requires `issue_id` from `sentry.issues`. Best used after
-      inventory tables identify the entity or time range you want to
-      investigate.
-    request:
-      method: GET
-      path: /api/0/organizations/{{input.SENTRY_ORG}}/issues/{{filter.issue_id}}/events/
-      query: []
-    response: {}
-    pagination:
-      mode: link_header
-      link_header_require_results: true
-    columns:
-      - name: id
-        type: Utf8
-        nullable: false
-        description: Event ID
-        expr:
-          kind: path
-          path:
-            - id
-      - name: event_id
-        type: Utf8
-        nullable: true
-        description: Event UUID
-        expr:
-          kind: path
-          path:
-            - eventID
-      - name: title
-        type: Utf8
-        nullable: true
-        description: Event title
-        expr:
-          kind: path
-          path:
-            - title
-      - name: message
-        type: Utf8
-        nullable: true
-        description: Event message
-        expr:
-          kind: path
-          path:
-            - message
-      - name: timestamp
-        type: Utf8
-        nullable: true
-        description: Event timestamp
-        expr:
-          kind: path
-          path:
-            - dateCreated
-      - name: platform
-        type: Utf8
-        nullable: true
-        description: Platform
-        expr:
-          kind: path
-          path:
-            - platform
-      - name: environment
-        type: Utf8
-        nullable: true
-        description: Environment
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: tag_value
-              path:
-                - tags
-              key: environment
-            - kind: path
-              path:
-                - environment
-      - name: release
-        type: Utf8
-        nullable: true
-        description: Release
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: tag_value
-              path:
-                - tags
-              key: release
-            - kind: path
-              path:
-                - release
-      - name: issue_id
-        type: Utf8
-        nullable: true
-        description: Required issue filter
-        expr:
-          kind: 'null'
-        virtual: true
-    filters:
-      - name: issue_id
-        required: true
-  - name: issue_tags
-    description: Tags for a specific issue
-    guide: |
-      Use this table for Tags for a specific issue. Requires `issue_id`
-      from `sentry.issues`.
-    request:
-      method: GET
-      path: /api/0/issues/{{filter.issue_id}}/tags/
-      query: []
-    response: {}
-    pagination:
-      mode: link_header
-      link_header_require_results: true
-    columns:
-      - name: key
-        type: Utf8
-        nullable: true
-        description: Tag key
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: path
-              path:
-                - key
-            - kind: path
-              path:
-                - name
-      - name: name
-        type: Utf8
-        nullable: true
-        description: Tag name
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: path
-              path:
-                - name
-            - kind: path
-              path:
-                - key
-      - name: issue_id
-        type: Utf8
-        nullable: true
-        description: Required issue filter
-        expr:
-          kind: from_filter
-          key: issue_id
-    filters:
-      - name: issue_id
-        required: true
-  - name: issue_participants
-    description: Participants for a specific issue
-    guide: |
-      Use this table for Participants for a specific issue. Requires
-      `issue_id` from `sentry.issues`.
-    request:
-      method: GET
-      path: /api/0/issues/{{filter.issue_id}}/participants/
-      query: []
-    response: {}
-    pagination:
-      mode: link_header
-      link_header_require_results: true
-    columns:
-      - name: id
-        type: Utf8
-        nullable: true
-        description: Participant ID
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: path
-              path:
-                - id
-            - kind: path
-              path:
-                - user
-                - id
-      - name: name
-        type: Utf8
-        nullable: true
-        description: Participant name
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: path
-              path:
-                - name
-            - kind: path
-              path:
-                - user
-                - name
-      - name: email
-        type: Utf8
-        nullable: true
-        description: Participant email
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: path
-              path:
-                - email
-            - kind: path
-              path:
-                - user
-                - email
-      - name: issue_id
-        type: Utf8
-        nullable: true
-        description: Required issue filter
-        expr:
-          kind: from_filter
-          key: issue_id
-    filters:
-      - name: issue_id
-        required: true
   - name: teams
     description: Teams in the organization
     guide: |
@@ -669,238 +849,6 @@ tables:
           kind: path
           path:
             - lastEvent
-  - name: deployments
-    description: Deployments for a release version
-    guide: |
-      Use this table for Deployments for a release version. Requires
-      `version` from `sentry.releases`. Use it after inventory tables
-      identify the entities worth investigating in detail.
-    request:
-      method: GET
-      path: /api/0/organizations/{{input.SENTRY_ORG}}/releases/{{filter.version}}/deploys/
-      query: []
-    response: {}
-    pagination:
-      mode: link_header
-      link_header_require_results: true
-    columns:
-      - name: id
-        type: Utf8
-        nullable: false
-        description: Deployment ID
-        expr:
-          kind: path
-          path:
-            - id
-      - name: version
-        type: Utf8
-        nullable: true
-        description: Required release version filter
-        expr:
-          kind: from_filter
-          key: version
-      - name: environment
-        type: Utf8
-        nullable: true
-        description: Environment
-        expr:
-          kind: path
-          path:
-            - environment
-      - name: name
-        type: Utf8
-        nullable: true
-        description: Deployment name
-        expr:
-          kind: path
-          path:
-            - name
-      - name: date_started
-        type: Utf8
-        nullable: true
-        description: Start timestamp
-        expr:
-          kind: path
-          path:
-            - dateStarted
-      - name: date_finished
-        type: Utf8
-        nullable: true
-        description: End timestamp
-        expr:
-          kind: path
-          path:
-            - dateFinished
-      - name: url
-        type: Utf8
-        nullable: true
-        description: Deployment URL
-        expr:
-          kind: path
-          path:
-            - url
-    filters:
-      - name: version
-        required: true
-  - name: release_files
-    description: Files for a release version
-    guide: |
-      Use this table for Files for a release version. Requires `version`
-      from `sentry.releases`.
-    request:
-      method: GET
-      path: /api/0/organizations/{{input.SENTRY_ORG}}/releases/{{filter.version}}/files/
-      query: []
-    response: {}
-    pagination:
-      mode: link_header
-      link_header_require_results: true
-    columns:
-      - name: id
-        type: Utf8
-        nullable: true
-        description: File ID
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: path
-              path:
-                - id
-            - kind: path
-              path:
-                - ident
-      - name: version
-        type: Utf8
-        nullable: true
-        description: Required release version filter
-        expr:
-          kind: from_filter
-          key: version
-      - name: name
-        type: Utf8
-        nullable: true
-        description: File name
-        expr:
-          kind: coalesce
-          exprs:
-            - kind: path
-              path:
-                - name
-            - kind: path
-              path:
-                - fileName
-            - kind: path
-              path:
-                - filename
-    filters:
-      - name: version
-        required: true
-  - name: project_events
-    description: Recent events for a specific project
-    guide: |
-      Use this table for Recent events for a specific project. Use
-      `project` with a slug from `sentry.projects` to scope results to
-      one project. Best used after inventory tables identify the entity
-      or time range you want to investigate.
-    request:
-      method: GET
-      path: /api/0/projects/{{input.SENTRY_ORG}}/{{filter.project}}/events/
-      query: []
-    response: {}
-    pagination:
-      mode: link_header
-      link_header_require_results: true
-    columns:
-      - name: id
-        type: Utf8
-        nullable: false
-        description: Event ID
-        expr:
-          kind: path
-          path:
-            - id
-      - name: event_id
-        type: Utf8
-        nullable: true
-        description: Event UUID
-        expr:
-          kind: path
-          path:
-            - eventID
-      - name: project_id
-        type: Utf8
-        nullable: true
-        description: Project ID
-        expr:
-          kind: path
-          path:
-            - projectID
-      - name: group_id
-        type: Utf8
-        nullable: true
-        description: Group ID
-        expr:
-          kind: path
-          path:
-            - groupID
-      - name: title
-        type: Utf8
-        nullable: true
-        description: Title
-        expr:
-          kind: path
-          path:
-            - title
-      - name: message
-        type: Utf8
-        nullable: true
-        description: Message
-        expr:
-          kind: path
-          path:
-            - message
-      - name: timestamp
-        type: Utf8
-        nullable: true
-        description: Timestamp
-        expr:
-          kind: path
-          path:
-            - dateCreated
-      - name: platform
-        type: Utf8
-        nullable: true
-        description: Platform
-        expr:
-          kind: path
-          path:
-            - platform
-      - name: location
-        type: Utf8
-        nullable: true
-        description: Location
-        expr:
-          kind: path
-          path:
-            - location
-      - name: culprit
-        type: Utf8
-        nullable: true
-        description: Culprit
-        expr:
-          kind: path
-          path:
-            - culprit
-      - name: project
-        type: Utf8
-        nullable: true
-        description: Required project filter
-        expr:
-          kind: from_filter
-          key: project
-    filters:
-      - name: project
-        required: true
   - name: discover
     description: Sentry discover query interface
     guide: |


### PR DESCRIPTION
## Summary
- convert six Sentry drill-down tables with required filters into table functions
- expose calls for issue, release, and project scoped endpoints:
  - `sentry.events(issue_id => ...)`
  - `sentry.issue_tags(issue_id => ...)`
  - `sentry.issue_participants(issue_id => ...)`
  - `sentry.deployments(version => ...)`
  - `sentry.release_files(version => ...)`
  - `sentry.project_events(project => ...)`
- drop virtual input echo columns from the function result shapes

## Verification
- `cargo run -p coral-cli -- source lint sources/core/sentry/manifest.yaml`
- `make lint-sources`
- temp-config install with local Sentry config confirmed the converted entries are discoverable in `coral.table_functions` and absent from `coral.tables`

## Live smoke note
The local Sentry token appears invalid/expired: inventory seed queries returned `401 Invalid token` or timed out, so I could not complete row-returning live smoke queries for this source in this environment.