### PR TITLE
feat: predicate push down planner

### DIFF
--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -61,6 +61,14 @@ impl HttpSourceTableProvider {
             schema,
         })
     }
+
+    pub(crate) fn source_schema(&self) -> &str {
+        &self.source_schema
+    }
+
+    pub(crate) fn table_spec(&self) -> &Arc<HttpTableSpec> {
+        &self.table
+    }
 }
 
 #[derive(Debug)]

--- a/crates/coral-engine/src/runtime/dependent_join/logical.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/logical.rs
@@ -1,0 +1,66 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::common::{DFSchemaRef, Result, plan_err};
+use datafusion::logical_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+
+/// Logical extension node reserved for dependent predicate pushdown plans.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DependentJoinNode {
+    resolver: LogicalPlan,
+    schema: DFSchemaRef,
+}
+
+impl PartialOrd for DependentJoinNode {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        if self == other {
+            return Some(Ordering::Equal);
+        }
+
+        match self.resolver.partial_cmp(&other.resolver) {
+            Some(Ordering::Equal) => {}
+            ordering => return ordering,
+        }
+
+        let schema_ordering = format!("{:?}", self.schema).cmp(&format!("{:?}", other.schema));
+        if schema_ordering != Ordering::Equal {
+            return Some(schema_ordering);
+        }
+
+        Some((Arc::as_ptr(&self.schema) as usize).cmp(&(Arc::as_ptr(&other.schema) as usize)))
+    }
+}
+
+impl UserDefinedLogicalNodeCore for DependentJoinNode {
+    fn name(&self) -> &'static str {
+        "DependentJoinNode"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.resolver]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        Vec::new()
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "DependentJoinNode")
+    }
+
+    fn with_exprs_and_inputs(&self, _exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
+        if inputs.len() != 1 {
+            return plan_err!("DependentJoinNode expects exactly one input");
+        }
+
+        Ok(Self {
+            resolver: inputs.into_iter().next().expect("input length was checked"),
+            schema: self.schema.clone(),
+        })
+    }
+}

--- a/crates/coral-engine/src/runtime/dependent_join/mod.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/mod.rs
@@ -1,0 +1,5 @@
+//! Planner scaffolding for dependent predicate pushdown.
+
+pub(crate) mod logical;
+pub(crate) mod optimizer;
+pub(crate) mod planner;

--- a/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
@@ -1,9 +1,15 @@
 use std::fmt;
+use std::sync::Arc;
 
-use datafusion::common::Result;
+use arrow::datatypes::DataType;
+use coral_spec::backends::http::HttpTableSpec;
 use datafusion::common::tree_node::Transformed;
-use datafusion::logical_expr::LogicalPlan;
+use datafusion::common::{DFSchemaRef, ExprSchema, Result};
+use datafusion::datasource::source_as_provider;
+use datafusion::logical_expr::{Expr, Join, JoinType, LogicalPlan};
 use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
+
+use crate::backends::http::HttpSourceTableProvider;
 
 /// Optimizer rule shell for dependent predicate pushdown.
 ///
@@ -12,6 +18,55 @@ use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
 /// otherwise-valid fallback plans into runtime failures.
 #[derive(Default)]
 pub(crate) struct DependentJoinOptimizerRule;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(
+    dead_code,
+    reason = "fallback taxonomy mirrors the RFC; later optimizer slices construct the remaining reasons"
+)]
+pub(crate) enum DependentJoinFallbackReason {
+    NonInner,
+    NonEqui,
+    NonHttpProvider,
+    NonPeelableWrapper,
+    MixedBindable,
+    MissingRequired,
+    OverConstrained,
+    NonCoercible,
+    CostUnfavourable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum JoinSide {
+    Left,
+    Right,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DependentJoinCandidate {
+    pub(crate) dependent_side: JoinSide,
+    pub(crate) source_name: String,
+    pub(crate) table_name: String,
+    pub(crate) binding_filters: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DependentJoinAnalysis {
+    Candidate(DependentJoinCandidate),
+    Fallback(DependentJoinFallbackReason),
+}
+
+struct PeeledDependentScan {
+    source_name: String,
+    table_schema: DFSchemaRef,
+    table: Arc<HttpTableSpec>,
+}
+
+enum PeelOutcome {
+    Match(PeeledDependentScan),
+    NotHttp,
+    NonPeelableWrapper,
+}
 
 impl fmt::Debug for DependentJoinOptimizerRule {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -33,6 +88,10 @@ impl OptimizerRule for DependentJoinOptimizerRule {
         plan: LogicalPlan,
         _config: &dyn OptimizerConfig,
     ) -> Result<Transformed<LogicalPlan>> {
+        if let LogicalPlan::Join(join) = &plan {
+            let _analysis = analyze_join(join);
+        }
+
         Ok(Transformed::no(plan))
     }
 }
@@ -41,14 +100,359 @@ pub(crate) fn rule() -> DependentJoinOptimizerRule {
     DependentJoinOptimizerRule
 }
 
+fn analyze_join(join: &Join) -> DependentJoinAnalysis {
+    if join.join_type != JoinType::Inner {
+        return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonInner);
+    }
+
+    if join.on.is_empty() || join.filter.is_some() {
+        return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonEqui);
+    }
+
+    let left_dependent = peel_dependent_side(join.left.as_ref());
+    let right_dependent = peel_dependent_side(join.right.as_ref());
+
+    match (left_dependent, right_dependent) {
+        (PeelOutcome::NonPeelableWrapper, _) | (_, PeelOutcome::NonPeelableWrapper) => {
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonPeelableWrapper)
+        }
+        (PeelOutcome::Match(dependent), PeelOutcome::NotHttp) => {
+            analyze_dependent_bindings(JoinSide::Left, &dependent, join.right.schema(), &join.on)
+        }
+        (PeelOutcome::NotHttp, PeelOutcome::Match(dependent)) => {
+            analyze_dependent_bindings(JoinSide::Right, &dependent, join.left.schema(), &join.on)
+        }
+        (PeelOutcome::NotHttp, PeelOutcome::NotHttp) => {
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonHttpProvider)
+        }
+        (PeelOutcome::Match(_), PeelOutcome::Match(_)) => {
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::MixedBindable)
+        }
+    }
+}
+
+fn analyze_dependent_bindings(
+    dependent_side: JoinSide,
+    dependent: &PeeledDependentScan,
+    resolver_schema: &DFSchemaRef,
+    join_on: &[(Expr, Expr)],
+) -> DependentJoinAnalysis {
+    let mut binding_filters = Vec::with_capacity(join_on.len());
+
+    for (left_expr, right_expr) in join_on {
+        let (dependent_expr, resolver_expr) = match dependent_side {
+            JoinSide::Left => (left_expr, right_expr),
+            JoinSide::Right => (right_expr, left_expr),
+        };
+
+        let (Expr::Column(dependent_column), Expr::Column(resolver_column)) =
+            (dependent_expr, resolver_expr)
+        else {
+            return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonEqui);
+        };
+
+        if dependent
+            .table_schema
+            .field_from_column(dependent_column)
+            .is_err()
+        {
+            return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonEqui);
+        }
+
+        let Some(filter) = dependent
+            .table
+            .filters()
+            .iter()
+            .find(|filter| filter.name == dependent_column.name)
+        else {
+            return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::MixedBindable);
+        };
+
+        if !filter.bindable {
+            return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::MixedBindable);
+        }
+
+        let Ok(field) = resolver_schema.field_from_column(resolver_column) else {
+            return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonCoercible);
+        };
+
+        if !matches!(
+            field.data_type(),
+            DataType::Utf8 | DataType::Int64 | DataType::Boolean
+        ) {
+            return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonCoercible);
+        }
+
+        binding_filters.push(filter.name.clone());
+    }
+
+    let missing_required = dependent
+        .table
+        .filters()
+        .iter()
+        .filter(|filter| filter.required)
+        .any(|filter| !binding_filters.contains(&filter.name));
+
+    if missing_required {
+        return DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::MissingRequired);
+    }
+
+    DependentJoinAnalysis::Candidate(DependentJoinCandidate {
+        dependent_side,
+        source_name: dependent.source_name.clone(),
+        table_name: dependent.table.name().to_string(),
+        binding_filters,
+    })
+}
+
+fn peel_dependent_side(plan: &LogicalPlan) -> PeelOutcome {
+    match plan {
+        LogicalPlan::TableScan(scan) => {
+            let Ok(provider) = source_as_provider(&scan.source) else {
+                return PeelOutcome::NotHttp;
+            };
+            let Some(provider) = provider.as_any().downcast_ref::<HttpSourceTableProvider>() else {
+                return PeelOutcome::NotHttp;
+            };
+
+            PeelOutcome::Match(PeeledDependentScan {
+                source_name: provider.source_schema().to_string(),
+                table_schema: scan.projected_schema.clone(),
+                table: Arc::clone(provider.table_spec()),
+            })
+        }
+        LogicalPlan::Filter(filter) => match peel_dependent_side(filter.input.as_ref()) {
+            PeelOutcome::Match(_) | PeelOutcome::NonPeelableWrapper => {
+                PeelOutcome::NonPeelableWrapper
+            }
+            PeelOutcome::NotHttp => PeelOutcome::NotHttp,
+        },
+        LogicalPlan::Projection(projection) => match peel_dependent_side(projection.input.as_ref())
+        {
+            PeelOutcome::Match(_) | PeelOutcome::NonPeelableWrapper => {
+                PeelOutcome::NonPeelableWrapper
+            }
+            PeelOutcome::NotHttp => PeelOutcome::NotHttp,
+        },
+        _ => PeelOutcome::NotHttp,
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::DependentJoinOptimizerRule;
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
+
+    use arrow::datatypes::{DataType, Field, Schema};
+    use coral_spec::parse_source_manifest_value;
+    use datafusion::common::{Column, TableReference};
+    use datafusion::datasource::provider_as_source;
+    use datafusion::logical_expr::logical_plan::builder::LogicalTableSource;
+    use datafusion::logical_expr::{JoinType, LogicalPlan, LogicalPlanBuilder};
     use datafusion::optimizer::OptimizerRule;
+    use serde_json::json;
+
+    use super::{
+        DependentJoinAnalysis, DependentJoinFallbackReason, DependentJoinOptimizerRule, JoinSide,
+        analyze_join,
+    };
+    use crate::backends::http::{HttpSourceClient, HttpSourceTableProvider};
 
     #[test]
     fn rule_is_registered_under_stable_name() {
         let rule = DependentJoinOptimizerRule;
         assert_eq!(rule.name(), "dependent_join_pushdown");
+    }
+
+    #[test]
+    fn inner_equi_single_binding_is_candidate() {
+        let plan = resolver_plan()
+            .join(
+                dependent_http_plan(bindable_pr_table()),
+                JoinType::Inner,
+                (
+                    vec![column("i", "github_owner")],
+                    vec![column("github.pull_requests", "owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        let analysis = analyze_join(join(&plan));
+
+        assert_eq!(
+            analysis,
+            DependentJoinAnalysis::Candidate(super::DependentJoinCandidate {
+                dependent_side: JoinSide::Right,
+                source_name: "github".to_string(),
+                table_name: "pull_requests".to_string(),
+                binding_filters: vec!["owner".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn non_inner_join_falls_back() {
+        let plan = resolver_plan()
+            .join(
+                dependent_http_plan(bindable_pr_table()),
+                JoinType::Left,
+                (
+                    vec![column("i", "github_owner")],
+                    vec![column("github.pull_requests", "owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        assert_eq!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonInner)
+        );
+    }
+
+    #[test]
+    fn non_http_provider_falls_back() {
+        let plan = resolver_plan()
+            .join(
+                file_like_plan("right", &[("owner", DataType::Utf8)]),
+                JoinType::Inner,
+                (
+                    vec![column("i", "github_owner")],
+                    vec![column("right", "owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        assert_eq!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonHttpProvider)
+        );
+    }
+
+    #[test]
+    fn non_bindable_dependent_filter_falls_back() {
+        let plan = resolver_plan()
+            .join(
+                dependent_http_plan(non_bindable_pr_table()),
+                JoinType::Inner,
+                (
+                    vec![column("i", "github_owner")],
+                    vec![column("github.pull_requests", "owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        assert_eq!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::MixedBindable)
+        );
+    }
+
+    fn join(plan: &LogicalPlan) -> &datafusion::logical_expr::Join {
+        let LogicalPlan::Join(join) = plan else {
+            panic!("expected join plan");
+        };
+        join
+    }
+
+    fn resolver_plan() -> LogicalPlanBuilder {
+        LogicalPlanBuilder::new(file_like_plan(
+            "i",
+            &[
+                ("github_owner", DataType::Utf8),
+                ("github_repo", DataType::Utf8),
+                ("github_pr_number", DataType::Int64),
+                ("status", DataType::Utf8),
+            ],
+        ))
+    }
+
+    fn file_like_plan(table: &str, fields: &[(&str, DataType)]) -> LogicalPlan {
+        let schema = Arc::new(Schema::new(
+            fields
+                .iter()
+                .map(|(name, data_type)| Field::new(*name, data_type.clone(), true))
+                .collect::<Vec<_>>(),
+        ));
+        let source = Arc::new(LogicalTableSource::new(schema));
+        LogicalPlanBuilder::scan(TableReference::bare(table), source, None)
+            .expect("scan should build")
+            .build()
+            .expect("plan should build")
+    }
+
+    fn dependent_http_plan(bindable_owner: bool) -> LogicalPlan {
+        let manifest = parse_source_manifest_value(json!({
+            "name": "github",
+            "version": "0.1.0",
+            "dsl_version": 3,
+            "backend": "http",
+            "base_url": "https://example.invalid",
+            "tables": [{
+                "name": "pull_requests",
+                "description": "Pull requests",
+                "filters": [
+                    { "name": "owner", "bindable": bindable_owner },
+                    { "name": "repo" },
+                    { "name": "number" }
+                ],
+                "request": { "path": "/repos/{{filter.owner}}/{{filter.repo}}/pulls/{{filter.number}}" },
+                "columns": [
+                    { "name": "owner", "type": "Utf8" },
+                    { "name": "repo", "type": "Utf8" },
+                    { "name": "number", "type": "Int64" },
+                    { "name": "state", "type": "Utf8" }
+                ]
+            }]
+        }))
+        .expect("manifest should parse");
+        let manifest = manifest.as_http().expect("http manifest").clone();
+        let client = HttpSourceClient::from_manifest(
+            &manifest,
+            &BTreeMap::new(),
+            &BTreeMap::new(),
+            &HashMap::new(),
+        )
+        .expect("client should build");
+        let table = manifest
+            .tables
+            .first()
+            .expect("manifest has one table")
+            .clone();
+        let provider = Arc::new(
+            HttpSourceTableProvider::new(client, "github".to_string(), table)
+                .expect("provider should build"),
+        );
+        LogicalPlanBuilder::scan(
+            TableReference::partial("github", "pull_requests"),
+            provider_as_source(provider),
+            None,
+        )
+        .expect("scan should build")
+        .build()
+        .expect("plan should build")
+    }
+
+    fn bindable_pr_table() -> bool {
+        true
+    }
+
+    fn non_bindable_pr_table() -> bool {
+        false
+    }
+
+    fn column(relation: &str, name: &str) -> Column {
+        Column::new(Some(TableReference::parse_str(relation)), name)
     }
 }

--- a/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
@@ -248,9 +248,9 @@ mod tests {
     use datafusion::common::{Column, TableReference};
     use datafusion::datasource::provider_as_source;
     use datafusion::logical_expr::logical_plan::builder::LogicalTableSource;
-    use datafusion::logical_expr::{JoinType, LogicalPlan, LogicalPlanBuilder};
+    use datafusion::logical_expr::{Expr, JoinType, LogicalPlan, LogicalPlanBuilder, lit};
     use datafusion::optimizer::OptimizerRule;
-    use serde_json::json;
+    use serde_json::{Value, json};
 
     use super::{
         DependentJoinAnalysis, DependentJoinFallbackReason, DependentJoinOptimizerRule, JoinSide,
@@ -290,6 +290,216 @@ mod tests {
                 table_name: "pull_requests".to_string(),
                 binding_filters: vec!["owner".to_string()],
             })
+        );
+    }
+
+    #[test]
+    fn inner_equi_composite_binding_preserves_filter_order() {
+        let plan = resolver_plan()
+            .join(
+                dependent_http_plan_with_filters(&[
+                    json!({ "name": "owner", "bindable": true }),
+                    json!({ "name": "repo", "bindable": true }),
+                    json!({ "name": "number", "bindable": true }),
+                ]),
+                JoinType::Inner,
+                (
+                    vec![
+                        column("i", "github_owner"),
+                        column("i", "github_repo"),
+                        column("i", "github_pr_number"),
+                    ],
+                    vec![
+                        column("github.pull_requests", "owner"),
+                        column("github.pull_requests", "repo"),
+                        column("github.pull_requests", "number"),
+                    ],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        let analysis = analyze_join(join(&plan));
+
+        assert_eq!(
+            analysis,
+            DependentJoinAnalysis::Candidate(super::DependentJoinCandidate {
+                dependent_side: JoinSide::Right,
+                source_name: "github".to_string(),
+                table_name: "pull_requests".to_string(),
+                binding_filters: vec![
+                    "owner".to_string(),
+                    "repo".to_string(),
+                    "number".to_string()
+                ],
+            })
+        );
+    }
+
+    #[test]
+    fn swapped_dependent_side_is_candidate() {
+        let plan = LogicalPlanBuilder::new(dependent_http_plan(bindable_pr_table()))
+            .join(
+                resolver_plan().build().expect("resolver plan should build"),
+                JoinType::Inner,
+                (
+                    vec![column("github.pull_requests", "owner")],
+                    vec![column("i", "github_owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        let analysis = analyze_join(join(&plan));
+
+        assert_eq!(
+            analysis,
+            DependentJoinAnalysis::Candidate(super::DependentJoinCandidate {
+                dependent_side: JoinSide::Left,
+                source_name: "github".to_string(),
+                table_name: "pull_requests".to_string(),
+                binding_filters: vec!["owner".to_string()],
+            })
+        );
+    }
+
+    #[test]
+    fn required_filter_satisfied_by_join_is_candidate() {
+        let plan = resolver_plan()
+            .join(
+                dependent_http_plan_with_filters(&[
+                    json!({ "name": "owner", "bindable": true, "required": true }),
+                    json!({ "name": "repo" }),
+                    json!({ "name": "number" }),
+                ]),
+                JoinType::Inner,
+                (
+                    vec![column("i", "github_owner")],
+                    vec![column("github.pull_requests", "owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        assert!(matches!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Candidate(_)
+        ));
+    }
+
+    #[test]
+    fn missing_required_filter_falls_back() {
+        let plan = resolver_plan()
+            .join(
+                dependent_http_plan_with_filters(&[
+                    json!({ "name": "owner", "bindable": true }),
+                    json!({ "name": "repo", "bindable": true, "required": true }),
+                    json!({ "name": "number" }),
+                ]),
+                JoinType::Inner,
+                (
+                    vec![column("i", "github_owner")],
+                    vec![column("github.pull_requests", "owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        assert_eq!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::MissingRequired)
+        );
+    }
+
+    #[test]
+    fn utf8_int64_and_boolean_resolver_bindings_are_candidate() {
+        let plan = resolver_plan()
+            .join(
+                dependent_http_plan_with_filters(&[
+                    json!({ "name": "owner", "bindable": true }),
+                    json!({ "name": "number", "bindable": true }),
+                    json!({ "name": "draft", "bindable": true }),
+                ]),
+                JoinType::Inner,
+                (
+                    vec![
+                        column("i", "github_owner"),
+                        column("i", "github_pr_number"),
+                        column("i", "draft"),
+                    ],
+                    vec![
+                        column("github.pull_requests", "owner"),
+                        column("github.pull_requests", "number"),
+                        column("github.pull_requests", "draft"),
+                    ],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        assert!(matches!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Candidate(_)
+        ));
+    }
+
+    #[test]
+    fn unsupported_resolver_binding_type_falls_back() {
+        let plan =
+            LogicalPlanBuilder::new(file_like_plan("i", &[("github_owner", DataType::Float64)]))
+                .join(
+                    dependent_http_plan(bindable_pr_table()),
+                    JoinType::Inner,
+                    (
+                        vec![column("i", "github_owner")],
+                        vec![column("github.pull_requests", "owner")],
+                    ),
+                    None,
+                )
+                .expect("join should build")
+                .build()
+                .expect("plan should build");
+
+        assert_eq!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonCoercible)
+        );
+    }
+
+    #[test]
+    fn dependent_side_with_wrapper_falls_back_until_peeling_preserves_semantics() {
+        let dependent = LogicalPlanBuilder::new(dependent_http_plan(bindable_pr_table()))
+            .filter(Expr::Column(column("github.pull_requests", "state")).eq(lit("open")))
+            .expect("filter should build")
+            .build()
+            .expect("dependent plan should build");
+        let plan = resolver_plan()
+            .join(
+                dependent,
+                JoinType::Inner,
+                (
+                    vec![column("i", "github_owner")],
+                    vec![column("github.pull_requests", "owner")],
+                ),
+                None,
+            )
+            .expect("join should build")
+            .build()
+            .expect("plan should build");
+
+        assert_eq!(
+            analyze_join(join(&plan)),
+            DependentJoinAnalysis::Fallback(DependentJoinFallbackReason::NonPeelableWrapper)
         );
     }
 
@@ -373,6 +583,7 @@ mod tests {
                 ("github_owner", DataType::Utf8),
                 ("github_repo", DataType::Utf8),
                 ("github_pr_number", DataType::Int64),
+                ("draft", DataType::Boolean),
                 ("status", DataType::Utf8),
             ],
         ))
@@ -393,6 +604,14 @@ mod tests {
     }
 
     fn dependent_http_plan(bindable_owner: bool) -> LogicalPlan {
+        dependent_http_plan_with_filters(&[
+            json!({ "name": "owner", "bindable": bindable_owner }),
+            json!({ "name": "repo" }),
+            json!({ "name": "number" }),
+        ])
+    }
+
+    fn dependent_http_plan_with_filters(filters: &[Value]) -> LogicalPlan {
         let manifest = parse_source_manifest_value(json!({
             "name": "github",
             "version": "0.1.0",
@@ -402,16 +621,13 @@ mod tests {
             "tables": [{
                 "name": "pull_requests",
                 "description": "Pull requests",
-                "filters": [
-                    { "name": "owner", "bindable": bindable_owner },
-                    { "name": "repo" },
-                    { "name": "number" }
-                ],
-                "request": { "path": "/repos/{{filter.owner}}/{{filter.repo}}/pulls/{{filter.number}}" },
+                "filters": filters,
+                "request": { "path": "/pulls" },
                 "columns": [
                     { "name": "owner", "type": "Utf8" },
                     { "name": "repo", "type": "Utf8" },
                     { "name": "number", "type": "Int64" },
+                    { "name": "draft", "type": "Boolean" },
                     { "name": "state", "type": "Utf8" }
                 ]
             }]

--- a/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
@@ -1,0 +1,54 @@
+use std::fmt;
+
+use datafusion::common::Result;
+use datafusion::common::tree_node::Transformed;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::optimizer::{ApplyOrder, OptimizerConfig, OptimizerRule};
+
+/// Optimizer rule shell for dependent predicate pushdown.
+///
+/// This rule is intentionally inert until the physical dependent join executor
+/// exists. Rewriting supported joins before execution is available would turn
+/// otherwise-valid fallback plans into runtime failures.
+#[derive(Default)]
+pub(crate) struct DependentJoinOptimizerRule;
+
+impl fmt::Debug for DependentJoinOptimizerRule {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DependentJoinOptimizerRule").finish()
+    }
+}
+
+impl OptimizerRule for DependentJoinOptimizerRule {
+    fn name(&self) -> &'static str {
+        "dependent_join_pushdown"
+    }
+
+    fn apply_order(&self) -> Option<ApplyOrder> {
+        Some(ApplyOrder::BottomUp)
+    }
+
+    fn rewrite(
+        &self,
+        plan: LogicalPlan,
+        _config: &dyn OptimizerConfig,
+    ) -> Result<Transformed<LogicalPlan>> {
+        Ok(Transformed::no(plan))
+    }
+}
+
+pub(crate) fn rule() -> DependentJoinOptimizerRule {
+    DependentJoinOptimizerRule
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DependentJoinOptimizerRule;
+    use datafusion::optimizer::OptimizerRule;
+
+    #[test]
+    fn rule_is_registered_under_stable_name() {
+        let rule = DependentJoinOptimizerRule;
+        assert_eq!(rule.name(), "dependent_join_pushdown");
+    }
+}

--- a/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/optimizer.rs
@@ -639,6 +639,8 @@ mod tests {
             &BTreeMap::new(),
             &BTreeMap::new(),
             &HashMap::new(),
+            None,
+            reqwest::Client::new(),
         )
         .expect("client should build");
         let table = manifest

--- a/crates/coral-engine/src/runtime/dependent_join/planner.rs
+++ b/crates/coral-engine/src/runtime/dependent_join/planner.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::common::{Result, plan_err};
+use datafusion::execution::SessionState;
+use datafusion::logical_expr::{LogicalPlan, UserDefinedLogicalNode};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+
+use crate::runtime::dependent_join::logical::DependentJoinNode;
+
+#[derive(Debug, Default)]
+pub(crate) struct DependentJoinExtensionPlanner;
+
+#[async_trait]
+impl ExtensionPlanner for DependentJoinExtensionPlanner {
+    async fn plan_extension(
+        &self,
+        _planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        _logical_inputs: &[&LogicalPlan],
+        physical_inputs: &[Arc<dyn ExecutionPlan>],
+        _session_state: &SessionState,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        if node.as_any().downcast_ref::<DependentJoinNode>().is_none() {
+            return Ok(None);
+        }
+
+        if physical_inputs.len() != 1 {
+            return plan_err!("DependentJoinNode expected one physical resolver input");
+        }
+
+        plan_err!("DependentJoinNode physical execution is not implemented")
+    }
+}

--- a/crates/coral-engine/src/runtime/mod.rs
+++ b/crates/coral-engine/src/runtime/mod.rs
@@ -2,10 +2,12 @@
 //! tables, and schema plumbing.
 
 pub(crate) mod catalog;
+pub(crate) mod dependent_join;
 pub(crate) mod error;
 pub(crate) mod json;
 pub(crate) mod pattern_validator;
 pub(crate) mod query;
+pub(crate) mod query_planner;
 pub(crate) mod registry;
 pub(crate) mod schema_provider;
 pub(crate) mod source_functions;

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -11,11 +11,14 @@ use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 
 use crate::backends::compile_query_source;
 use crate::runtime::catalog;
+use crate::runtime::dependent_join::optimizer;
+use crate::runtime::dependent_join::planner::DependentJoinExtensionPlanner;
 use crate::runtime::error::{
     datafusion_to_core, datafusion_to_core_with_sql, query_result_observer_error_to_core,
 };
 use crate::runtime::json::register_json_support;
 use crate::runtime::pattern_validator::register_pattern_validator;
+use crate::runtime::query_planner::CoralQueryPlanner;
 use crate::runtime::registry::{
     CompiledQuerySource, SourceRegistrationCandidate, SourceRegistrationFailure, register_sources,
 };
@@ -58,6 +61,10 @@ pub(crate) async fn build_runtime(
         .with_config(session_config)
         .with_runtime_env(runtime_env)
         .with_default_features()
+        .with_optimizer_rule(Arc::new(optimizer::rule()))
+        .with_query_planner(Arc::new(CoralQueryPlanner::new(vec![Arc::new(
+            DependentJoinExtensionPlanner,
+        )])))
         .with_physical_optimizer_rule(instrument_rule)
         .build();
     let session_state = datafusion_tracing::instrument_rules_with_trace_spans!(

--- a/crates/coral-engine/src/runtime/query_planner.rs
+++ b/crates/coral-engine/src/runtime/query_planner.rs
@@ -1,0 +1,45 @@
+use std::fmt;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::common::Result;
+use datafusion::execution::SessionState;
+use datafusion::execution::context::QueryPlanner;
+use datafusion::logical_expr::LogicalPlan;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_planner::{DefaultPhysicalPlanner, ExtensionPlanner, PhysicalPlanner};
+
+/// Query planner that installs Coral-owned `DataFusion` extension planners while
+/// leaving ordinary physical planning delegated to `DataFusion`.
+pub(crate) struct CoralQueryPlanner {
+    extension_planners: Vec<Arc<dyn ExtensionPlanner + Send + Sync>>,
+}
+
+impl CoralQueryPlanner {
+    pub(crate) fn new(extension_planners: Vec<Arc<dyn ExtensionPlanner + Send + Sync>>) -> Self {
+        Self { extension_planners }
+    }
+}
+
+impl fmt::Debug for CoralQueryPlanner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CoralQueryPlanner")
+            .field("extension_planner_count", &self.extension_planners.len())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl QueryPlanner for CoralQueryPlanner {
+    async fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        session_state: &SessionState,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let planner =
+            DefaultPhysicalPlanner::with_extension_planners(self.extension_planners.clone());
+        planner
+            .create_physical_plan(logical_plan, session_state)
+            .await
+    }
+}


### PR DESCRIPTION
# Planner Slice

This PR is the second PR in the dependent predicate pushdown stack. The full stack overview is documented in #399.

Base: `iaptsiauri/predicate-push-down-spec`
Head: `iaptsiauri/predicate-push-down-planner`

## What This PR Adds

This PR adds the planner layer for dependent predicate pushdown:

- dependent join candidate analysis
- safe detection of one HTTP-backed dependent table side
- bindable filter matching from inner equi-join keys
- required-filter and over-constrained-filter checks
- safe wrapper peeling for dependent scans
- DataFusion logical extension node
- Coral extension planner wiring
- optimizer/planner coverage for supported and unsupported join shapes

This PR intentionally stops at planning. It does not execute dependent HTTP fetches. Physical execution is added later in #605.

## Stack Position

Review order:

1. #399 - source-spec capability contract
2. #409 - planner rewrite layer
3. #605 - physical execution core
4. #606 - execution hardening, fallback, tracing, HTTP completeness
5. #607 - pilot source manifests

## Reviewer Notes

For this PR, focus on whether the optimizer recognizes only safe V1 shapes and falls back cleanly for unsupported joins. Execution behavior belongs to the later PRs.