### PR TITLE
feat(sources/core/gitlab): add OAuth credential method

### DIFF
--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -216,8 +216,8 @@ Base URL of your GitLab instance. Keep the default for
 
 `GITLAB_TOKEN` (required)
 
-Create a personal access token (PAT) with the `read_api` scope;
-some admin tables require elevated scopes.
+Use GitLab OAuth or create a personal access token (PAT) with
+the `read_api` scope; some admin tables require elevated scopes.
 See [GitLab PAT docs](https://docs.gitlab.com/user/profile/personal_access_tokens/).
 
 ### `google_calendar`

--- a/sources/core/gitlab/README.md
+++ b/sources/core/gitlab/README.md
@@ -8,13 +8,49 @@
 
 ## Authentication
 
-Requires a `GITLAB_TOKEN` credential. Add the source and provide your token when prompted:
+Requires a `GITLAB_TOKEN` credential. You can connect with GitLab OAuth for
+GitLab.com, or paste a token.
+
+### OAuth
+
+Add the source interactively and choose `Connect with GitLab.com OAuth`:
 
 ```bash
-coral source add gitlab
+coral source add --interactive gitlab
 ```
 
-To rotate or update your token, run the same command again.
+Coral ships with a default GitLab.com OAuth client ID. If you need to use your
+own GitLab OAuth application instead, configure it with:
+
+- Redirect URI: `http://127.0.0.1:53682/oauth/callback`
+- Scopes: `read_api`
+- Leave `Confidential` unchecked
+
+Then enter its Application ID when prompted for `GITLAB_OAUTH_CLIENT_ID`;
+otherwise leave that prompt empty to use the default client.
+
+The bundled OAuth flow targets GitLab.com. For self-hosted GitLab instances,
+use a token with `GITLAB_API_BASE` set to your instance URL.
+
+GitLab OAuth access tokens expire after two hours. Until Coral supports
+automatic refresh, rerun `coral source add --interactive gitlab` to refresh the
+stored token. See the
+[GitLab OAuth provider docs](https://docs.gitlab.com/integration/oauth_provider/).
+
+### Token
+
+Add the source and provide your token when prompted:
+
+```bash
+coral source add --interactive gitlab
+```
+
+To rotate or update your token, run the same command again. Non-interactive
+setup still works with environment variables:
+
+```bash
+GITLAB_TOKEN=glpat-... coral source add gitlab
+```
 
 ### Token scopes
 

--- a/sources/core/gitlab/README.md
+++ b/sources/core/gitlab/README.md
@@ -19,15 +19,13 @@ Add the source interactively and choose `Connect with GitLab.com OAuth`:
 coral source add --interactive gitlab
 ```
 
-Coral ships with a default GitLab.com OAuth client ID. If you need to use your
-own GitLab OAuth application instead, configure it with:
+To use your own GitLab OAuth application, configure it with:
 
 - Redirect URI: `http://127.0.0.1:53682/oauth/callback`
 - Scopes: `read_api`
 - Leave `Confidential` unchecked
 
-Then enter its Application ID when prompted for `GITLAB_OAUTH_CLIENT_ID`;
-otherwise leave that prompt empty to use the default client.
+Then enter its Application ID when prompted for `GITLAB_OAUTH_CLIENT_ID`.
 
 The bundled OAuth flow targets GitLab.com. For self-hosted GitLab instances,
 use a token with `GITLAB_API_BASE` set to your instance URL.

--- a/sources/core/gitlab/manifest.yaml
+++ b/sources/core/gitlab/manifest.yaml
@@ -30,7 +30,7 @@ inputs:
               type: authorization_code
               pkce: required
             redirect_uri: http://127.0.0.1:53682/oauth/callback
-            redirect_uri_port: fixed
+            redirect_uri_port_mode: fixed
             endpoints:
               authorization_url: https://gitlab.com/oauth/authorize
               token_url: https://gitlab.com/oauth/token

--- a/sources/core/gitlab/manifest.yaml
+++ b/sources/core/gitlab/manifest.yaml
@@ -17,16 +17,41 @@ inputs:
   GITLAB_TOKEN:
     kind: secret
     hint: |
-      Create a personal access token (PAT) with the `read_api` scope;
-      some admin tables require elevated scopes.
+      Use GitLab OAuth or create a personal access token (PAT) with
+      the `read_api` scope; some admin tables require elevated scopes.
       See [GitLab PAT docs](https://docs.gitlab.com/user/profile/personal_access_tokens/).
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with GitLab.com OAuth
+          description: Use GitLab.com OAuth authorization code with PKCE.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            redirect_uri_port: fixed
+            endpoints:
+              authorization_url: https://gitlab.com/oauth/authorize
+              token_url: https://gitlab.com/oauth/token
+            client:
+              id:
+                default: b96d8711f4201c7c4ce86765e0c2a1a07db768c90a2934346859b64f066cc4f1
+                input: GITLAB_OAUTH_CLIENT_ID
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - read_api
+        - type: source_config
+          label: Paste token
 base_url: '{{input.GITLAB_API_BASE}}'
 auth:
   type: HeaderAuth
   headers:
-    - name: PRIVATE-TOKEN
+    - name: Authorization
       from: template
-      template: '{{input.GITLAB_TOKEN}}'
+      template: Bearer {{input.GITLAB_TOKEN}}
 test_queries:
   - SELECT * FROM gitlab.all_projects LIMIT 1
 tables:


### PR DESCRIPTION
Intent

Allow GitLab.com users to install the bundled GitLab source through OAuth instead of only pasting a personal access token.

What it enables

Adds an OAuth credential method with PKCE, a default GitLab.com OAuth client ID, and Bearer-token request auth that supports both OAuth tokens and existing PAT setup.

Usage examples

Run `coral source add --interactive gitlab`, choose `Connect with GitLab.com OAuth`, and leave `GITLAB_OAUTH_CLIENT_ID` empty to use the bundled client. Users can still set `GITLAB_TOKEN` non-interactively or paste a token through the interactive source-config path.