### PR TITLE
fix(mcp): advertise object-root output schema

### DIFF
--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -425,6 +425,7 @@ fn search_tables_output_schema() -> Arc<Map<String, Value>> {
 
 fn list_columns_output_schema() -> Arc<Map<String, Value>> {
     json_object_schema(&json!({
+        "type": "object",
         "oneOf": [
             list_columns_page_output_schema(),
             missing_table_output_schema()

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -233,6 +233,17 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .expect("sql description")
             .contains("0 configured source")
     );
+    for tool in &initial_tools {
+        let Some(output_schema) = &tool.output_schema else {
+            continue;
+        };
+        assert_eq!(
+            output_schema.get("type").and_then(Value::as_str),
+            Some("object"),
+            "tool '{}' output schema root type should be object",
+            tool.name
+        );
+    }
     let initial_resources = client
         .list_all_resources()
         .await


### PR DESCRIPTION
## Intent

Some MCP clients reject Coral's `tools/list` response when an advertised tool output schema does not declare a root object type. Coral's `list_columns` tool used a top-level `oneOf` without `type: object`, which made otherwise valid tool discovery fail before agents could call any Coral tools.

## Changes

- Add an explicit object root type to the `list_columns` output schema while preserving its existing `oneOf` response variants.
- Assert in the MCP surface test that advertised output schemas are object-rooted, matching the MCP contract strict clients enforce.

## Verification

- `cargo fmt --all --check`
- `cargo test -p coral-mcp mcp_surface_refreshes_and_renders_dynamic_guide`
- `cargo test -p coral-cli --features cli-test-server mcp_stdio_lists_tools_and_resources`
- `make rust-checks`
