### PR TITLE
feat(sources/community/k8s): add kubernetes community source

### DIFF
--- a/sources/community/k8s/README.md
+++ b/sources/community/k8s/README.md
@@ -199,23 +199,30 @@ LIMIT 50;
 
 ### Recent warning events (uses new timing/count columns)
 
+`/api/v1/events` mixes core/v1 events (which set `last_timestamp`) and
+`events.k8s.io/v1`-style events (which set `event_time` instead). The
+`COALESCE(last_timestamp, event_time)` ordering picks whichever timestamp the
+event actually populated, so newly-emitted events.k8s.io-style events are not
+buried by `NULLS LAST`.
+
 ```sql
 SELECT namespace, object_kind, object_name, reason, message,
-       last_timestamp, count
+       COALESCE(last_timestamp, event_time) AS event_at, count
 FROM k8s.events
 WHERE type = 'Warning'
-ORDER BY last_timestamp DESC NULLS LAST
+ORDER BY COALESCE(last_timestamp, event_time) DESC NULLS LAST
 LIMIT 20;
 ```
 
 ### Pod events
 
 ```sql
-SELECT namespace, reason, message, object_name, last_timestamp, count
+SELECT namespace, reason, message, object_name,
+       COALESCE(last_timestamp, event_time) AS event_at, count
 FROM k8s.events
 WHERE object_kind = 'Pod'
   AND object_name = 'api-service'
-ORDER BY last_timestamp DESC NULLS LAST
+ORDER BY COALESCE(last_timestamp, event_time) DESC NULLS LAST
 LIMIT 20;
 ```
 

--- a/sources/community/k8s/README.md
+++ b/sources/community/k8s/README.md
@@ -1,13 +1,13 @@
 # Kubernetes Connector (Community)
 
-**Version:** 0.1.0
+**Version:** 0.1.1
 **Backend:** HTTP (Kubernetes REST API)
 **Tables:** 16
 **Default base URL:** `http://127.0.0.1:8080` (override with `K8S_BASE_URL`)
 
-Community source for querying live Kubernetes cluster state with SQL: workloads,
-networking, storage, events, and nodes. Designed for operational triage and
-Day-2 workflows without custom kubectl scripts.
+Query live Kubernetes cluster state with SQL: workloads, networking, storage,
+events, and nodes. Read-only v1 uses unauthenticated HTTP against a base URL
+that already handles auth (typically `kubectl proxy`).
 
 ## Install
 
@@ -43,11 +43,15 @@ export K8S_BASE_URL=http://127.0.0.1:8080
 coral source add --file sources/community/k8s/manifest.yaml
 ```
 
-### In-cluster or direct API access
+### Authenticated gateways (advanced)
 
-Point `K8S_BASE_URL` at the API server or in-cluster service URL
-(`https://kubernetes.default.svc`). Ensure the caller identity has Kubernetes
-list/get permissions for the resources you query.
+v1 does not send `Authorization` headers or client certificates. To reach a
+cluster without `kubectl proxy`, point `K8S_BASE_URL` at a reverse proxy or API
+gateway that authenticates on your behalf (for example an in-cluster OAuth proxy
+or a corporate API front door). A raw Kubernetes API server URL such as
+`https://kubernetes.default.svc` requires bearer-token auth and is not supported
+in v1; use `kubectl proxy` locally or add a follow-on auth input in a later
+release.
 
 ### Multi-cluster
 
@@ -177,6 +181,9 @@ coral source test k8s
 
 ## Limitations
 
+- Read-only v1; no mutating Kubernetes API calls.
+- No bearer-token or client-cert auth in the manifest; use `kubectl proxy` or a
+  pre-authenticated API base URL.
 - Large list responses can be heavy; use filters and `LIMIT`.
 - Nested Kubernetes fields are exposed as `Json` columns for downstream parsing.
 - Community sources are maintained separately from bundled core sources.

--- a/sources/community/k8s/README.md
+++ b/sources/community/k8s/README.md
@@ -76,7 +76,8 @@ The `nodes` table is cluster-scoped; it requires cluster-wide `list nodes` and
 has no namespace filter.
 
 Minimal read-only `ClusterRole` for the cluster-wide path (drop the namespaced
-resources you don't need):
+resources you don't need). The connector only performs paginated `GET` list
+requests, so `watch` is intentionally omitted:
 
 ```yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -86,16 +87,16 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: [pods, services, endpoints, events, configmaps, persistentvolumeclaims, serviceaccounts, nodes]
-    verbs: [get, list, watch]
+    verbs: [get, list]
   - apiGroups: [apps]
     resources: [deployments, daemonsets, statefulsets, replicasets]
-    verbs: [get, list, watch]
+    verbs: [get, list]
   - apiGroups: [batch]
     resources: [jobs, cronjobs]
-    verbs: [get, list, watch]
+    verbs: [get, list]
   - apiGroups: [networking.k8s.io]
     resources: [ingresses, networkpolicies]
-    verbs: [get, list, watch]
+    verbs: [get, list]
 ```
 
 Reference: <https://kubernetes.io/docs/reference/access-authn-authz/rbac/>.

--- a/sources/community/k8s/README.md
+++ b/sources/community/k8s/README.md
@@ -11,14 +11,15 @@ Day-2 workflows without custom kubectl scripts.
 
 ## Install
 
-Community sources are not bundled with the Coral binary. Import the manifest from
+Community sources are not bundled with the Coral binary. Add the manifest from
 this directory:
 
 ```bash
-coral source import sources/community/k8s/manifest.yaml
+coral source add --file sources/community/k8s/manifest.yaml
 ```
 
-Or copy `manifest.yaml` into your workspace and import the local path.
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
 
 Reference the linked GitHub issue in your PR so maintainers can connect the
 contribution to the prior discussion.
@@ -35,11 +36,11 @@ kubectl proxy --port=8080
 ```
 
 Keep the default `K8S_BASE_URL` (`http://127.0.0.1:8080`) or set it when
-importing:
+adding the source:
 
 ```bash
 export K8S_BASE_URL=http://127.0.0.1:8080
-coral source import sources/community/k8s/manifest.yaml
+coral source add --file sources/community/k8s/manifest.yaml
 ```
 
 ### In-cluster or direct API access
@@ -170,7 +171,7 @@ make lint-sources
 # Manifest structure and smoke queries (requires Coral CLI)
 coral source lint sources/community/k8s/manifest.yaml
 kubectl proxy --port=8080 &
-coral source import sources/community/k8s/manifest.yaml
+coral source add --file sources/community/k8s/manifest.yaml
 coral source test k8s
 ```
 

--- a/sources/community/k8s/README.md
+++ b/sources/community/k8s/README.md
@@ -1,0 +1,187 @@
+# Kubernetes Connector (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Kubernetes REST API)
+**Tables:** 16
+**Default base URL:** `http://127.0.0.1:8080` (override with `K8S_BASE_URL`)
+
+Community source for querying live Kubernetes cluster state with SQL: workloads,
+networking, storage, events, and nodes. Designed for operational triage and
+Day-2 workflows without custom kubectl scripts.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Import the manifest from
+this directory:
+
+```bash
+coral source import sources/community/k8s/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and import the local path.
+
+Reference the linked GitHub issue in your PR so maintainers can connect the
+contribution to the prior discussion.
+
+## Authentication and setup
+
+### Local development (recommended for contributors)
+
+`kubectl proxy` reuses your kubeconfig credentials and avoids extra Coral auth
+configuration:
+
+```bash
+kubectl proxy --port=8080
+```
+
+Keep the default `K8S_BASE_URL` (`http://127.0.0.1:8080`) or set it when
+importing:
+
+```bash
+export K8S_BASE_URL=http://127.0.0.1:8080
+coral source import sources/community/k8s/manifest.yaml
+```
+
+### In-cluster or direct API access
+
+Point `K8S_BASE_URL` at the API server or in-cluster service URL
+(`https://kubernetes.default.svc`). Ensure the caller identity has Kubernetes
+list/get permissions for the resources you query.
+
+### Multi-cluster
+
+Register one Coral source per cluster (for example `k8s_dev`, `k8s_prod`), each
+with its own `K8S_BASE_URL`.
+
+## Table categories
+
+### Workloads
+
+| Table | Description |
+|---|---|
+| `pods` | Pod phase, scheduling, labels, container statuses |
+| `deployments` | Replica counts and availability |
+| `daemonsets` | Node-level daemon workload health |
+| `statefulsets` | Stateful workload replica health |
+| `replicasets` | ReplicaSet replica counts |
+| `jobs` | Batch job success and failure counts |
+| `cronjobs` | Scheduled workloads |
+
+### Networking and storage
+
+| Table | Description |
+|---|---|
+| `services` | Service discovery metadata |
+| `endpoints` | Service endpoint subsets |
+| `ingresses` | Ingress routing configuration |
+| `networkpolicies` | Network policy selectors |
+| `persistentvolumeclaims` | PVC phase and storage class |
+
+### Cluster resources
+
+| Table | Description |
+|---|---|
+| `nodes` | Node kubelet version and labels |
+| `events` | Cluster events for triage |
+| `configmaps` | ConfigMap metadata (data may be omitted in list responses) |
+| `serviceaccounts` | ServiceAccount metadata |
+
+## Filters and pagination
+
+Most list tables support Kubernetes server-side pushdown filters:
+
+- `label_selector` maps to `labelSelector`
+- `field_selector` maps to `fieldSelector`
+
+Example:
+
+```sql
+SELECT namespace, name, status
+FROM k8s.pods
+WHERE label_selector = 'app=api'
+LIMIT 50;
+```
+
+Tables use Kubernetes `continue` token pagination (`cursor_query`) with a default
+page size of 200. Prefer `LIMIT` and filters on large clusters.
+
+## Example relationships
+
+| From | To | Join hint |
+|---|---|---|
+| `k8s.pods.node_name` | `k8s.nodes.name` | Node scheduling |
+| `k8s.events.object_name` | `k8s.pods.name` | When `object_kind = 'Pod'` |
+| `k8s.services.name` | `k8s.endpoints.name` | Same namespace |
+
+## Example queries
+
+### Failing pods
+
+```sql
+SELECT namespace, name, status, status_reason
+FROM k8s.pods
+WHERE status != 'Running'
+LIMIT 20;
+```
+
+### Deployment replica mismatch
+
+```sql
+SELECT namespace, name, replicas, available_replicas
+FROM k8s.deployments
+WHERE replicas != available_replicas
+LIMIT 50;
+```
+
+### Pod events
+
+```sql
+SELECT namespace, reason, message, object_name
+FROM k8s.events
+WHERE object_kind = 'Pod'
+  AND object_name = 'api-service'
+LIMIT 20;
+```
+
+### Pending PVCs
+
+```sql
+SELECT namespace, name, phase, storage_class
+FROM k8s.persistentvolumeclaims
+WHERE phase = 'Pending'
+LIMIT 20;
+```
+
+### Pods on a node
+
+```sql
+SELECT p.namespace, p.name, p.status, n.kubelet_version
+FROM k8s.pods p
+JOIN k8s.nodes n ON p.node_name = n.name
+LIMIT 20;
+```
+
+## Validation
+
+```bash
+# YAML style (requires: cargo install ryl --locked)
+make lint-sources
+
+# Manifest structure and smoke queries (requires Coral CLI)
+coral source lint sources/community/k8s/manifest.yaml
+kubectl proxy --port=8080 &
+coral source import sources/community/k8s/manifest.yaml
+coral source test k8s
+```
+
+## Limitations
+
+- Large list responses can be heavy; use filters and `LIMIT`.
+- Nested Kubernetes fields are exposed as `Json` columns for downstream parsing.
+- Community sources are maintained separately from bundled core sources.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the issue first,
+sign the CLA if this is your first contribution, run `make lint-sources`, and
+open a focused PR titled `feat(sources/community/k8s): add kubernetes community source`.

--- a/sources/community/k8s/README.md
+++ b/sources/community/k8s/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Connector (Community)
 
-**Version:** 0.1.1
+**Version:** 0.1.2
 **Backend:** HTTP (Kubernetes REST API)
 **Tables:** 16
 **Default base URL:** `http://127.0.0.1:8080` (override with `K8S_BASE_URL`)
@@ -115,7 +115,8 @@ page size of 200. Prefer `LIMIT` and filters on large clusters.
 | From | To | Join hint |
 |---|---|---|
 | `k8s.pods.node_name` | `k8s.nodes.name` | Node scheduling |
-| `k8s.events.object_name` | `k8s.pods.name` | When `object_kind = 'Pod'` |
+| `k8s.events.object_uid` | `k8s.pods.uid` | Preferred when `object_kind = 'Pod'` |
+| `k8s.events.object_name` | `k8s.pods.name` | Fallback; same namespace when kind matches |
 | `k8s.services.name` | `k8s.endpoints.name` | Same namespace |
 
 ## Example queries

--- a/sources/community/k8s/README.md
+++ b/sources/community/k8s/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Connector (Community)
 
-**Version:** 0.1.2
+**Version:** 0.1.3
 **Backend:** HTTP (Kubernetes REST API)
 **Tables:** 16
 **Default base URL:** `http://127.0.0.1:8080` (override with `K8S_BASE_URL`)
@@ -58,6 +58,48 @@ release.
 Register one Coral source per cluster (for example `k8s_dev`, `k8s_prod`), each
 with its own `K8S_BASE_URL`.
 
+## RBAC requirements
+
+The 15 namespace-scoped tables in this source have two request paths:
+
+| Query shape | API path | RBAC required |
+|---|---|---|
+| `SELECT … FROM k8s.pods` (no `namespace` filter) | `GET /api/v1/pods` (list across all namespaces) | Cluster-wide `list` on the resource (e.g. a `ClusterRoleBinding` to a `ClusterRole` with `list pods`) |
+| `SELECT … FROM k8s.pods WHERE namespace = 'foo'` | `GET /api/v1/namespaces/foo/pods` (list in one namespace) | Namespace-scoped `list` is sufficient (a `RoleBinding` in `foo` is enough) |
+
+The manifest exposes a `namespace` filter on every namespace-scoped table; when
+the filter is present Coral rewrites the request to the namespaced URL. This
+gives users with namespace-scoped kubeconfigs a working first-success path —
+they only need permission inside their namespace, not cluster-wide.
+
+The `nodes` table is cluster-scoped; it requires cluster-wide `list nodes` and
+has no namespace filter.
+
+Minimal read-only `ClusterRole` for the cluster-wide path (drop the namespaced
+resources you don't need):
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: coral-k8s-source-readonly
+rules:
+  - apiGroups: [""]
+    resources: [pods, services, endpoints, events, configmaps, persistentvolumeclaims, serviceaccounts, nodes]
+    verbs: [get, list, watch]
+  - apiGroups: [apps]
+    resources: [deployments, daemonsets, statefulsets, replicasets]
+    verbs: [get, list, watch]
+  - apiGroups: [batch]
+    resources: [jobs, cronjobs]
+    verbs: [get, list, watch]
+  - apiGroups: [networking.k8s.io]
+    resources: [ingresses, networkpolicies]
+    verbs: [get, list, watch]
+```
+
+Reference: <https://kubernetes.io/docs/reference/access-authn-authz/rbac/>.
+
 ## Table categories
 
 ### Workloads
@@ -87,7 +129,7 @@ with its own `K8S_BASE_URL`.
 | Table | Description |
 |---|---|
 | `nodes` | Node kubelet version and labels |
-| `events` | Cluster events for triage |
+| `events` | Cluster events for triage (event_time / first_timestamp / last_timestamp / count / action / reason / type) |
 | `configmaps` | ConfigMap metadata (data may be omitted in list responses) |
 | `serviceaccounts` | ServiceAccount metadata |
 
@@ -95,20 +137,35 @@ with its own `K8S_BASE_URL`.
 
 Most list tables support Kubernetes server-side pushdown filters:
 
-- `label_selector` maps to `labelSelector`
-- `field_selector` maps to `fieldSelector`
+- `label_selector` maps to the Kubernetes `labelSelector` query parameter
+- `field_selector` maps to the Kubernetes `fieldSelector` query parameter
+- `namespace` rewrites the request to the namespaced list path
+  (`/api/v1/namespaces/<ns>/<resource>`), which is cheaper for the API server
+  and works for users without cluster-wide RBAC
 
 Example:
 
 ```sql
 SELECT namespace, name, status
 FROM k8s.pods
-WHERE label_selector = 'app=api'
+WHERE namespace = 'kube-system'
+  AND label_selector = 'k8s-app=kube-dns'
 LIMIT 50;
 ```
 
-Tables use Kubernetes `continue` token pagination (`cursor_query`) with a default
-page size of 200. Prefer `LIMIT` and filters on large clusters.
+### Total-row safety cap (`fetch_limit_default`) vs Kubernetes `limit`
+
+- The Kubernetes `limit` parameter is a **page size**, not a result cap. The API
+  server may return a `metadata.continue` token, and Coral paginates through
+  the chunks automatically. See
+  <https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks>.
+- This manifest sets `fetch_limit_default: 500` on every table, which caps the
+  total rows Coral materializes per query unless the SQL itself sets `LIMIT`.
+  This prevents accidental full-cluster scans of high-cardinality tables
+  (`pods`, `events`, `configmaps`, etc.) when a user forgets `LIMIT`.
+- For very large clusters, set an explicit SQL `LIMIT` and add
+  `label_selector` / `field_selector` / `namespace` filters; do not rely on the
+  default cap alone, because it deterministically truncates results.
 
 ## Example relationships
 
@@ -121,12 +178,13 @@ page size of 200. Prefer `LIMIT` and filters on large clusters.
 
 ## Example queries
 
-### Failing pods
+### Failing pods (namespace-scoped, namespace-RBAC friendly)
 
 ```sql
 SELECT namespace, name, status, status_reason
 FROM k8s.pods
-WHERE status != 'Running'
+WHERE namespace = 'production'
+  AND status != 'Running'
 LIMIT 20;
 ```
 
@@ -139,13 +197,25 @@ WHERE replicas != available_replicas
 LIMIT 50;
 ```
 
+### Recent warning events (uses new timing/count columns)
+
+```sql
+SELECT namespace, object_kind, object_name, reason, message,
+       last_timestamp, count
+FROM k8s.events
+WHERE type = 'Warning'
+ORDER BY last_timestamp DESC NULLS LAST
+LIMIT 20;
+```
+
 ### Pod events
 
 ```sql
-SELECT namespace, reason, message, object_name
+SELECT namespace, reason, message, object_name, last_timestamp, count
 FROM k8s.events
 WHERE object_kind = 'Pod'
   AND object_name = 'api-service'
+ORDER BY last_timestamp DESC NULLS LAST
 LIMIT 20;
 ```
 
@@ -185,9 +255,37 @@ coral source test k8s
 - Read-only v1; no mutating Kubernetes API calls.
 - No bearer-token or client-cert auth in the manifest; use `kubectl proxy` or a
   pre-authenticated API base URL.
-- Large list responses can be heavy; use filters and `LIMIT`.
+- Large list responses can be heavy; `fetch_limit_default: 500` is a safety cap
+  per query — for large clusters, add SQL `LIMIT` and pushdown filters
+  (`namespace`, `label_selector`, `field_selector`).
 - Nested Kubernetes fields are exposed as `Json` columns for downstream parsing.
+- Event timing columns map to core/v1 `Event` fields
+  (`firstTimestamp` / `lastTimestamp` / `count`). Some controllers now emit
+  events via `events.k8s.io/v1` only; for those, `event_time` and `action` are
+  populated and the core/v1 timestamps may be `null`. The `/api/v1/events`
+  endpoint surfaces both styles on most clusters.
 - Community sources are maintained separately from bundled core sources.
+
+## References
+
+- Kubernetes API reference: <https://kubernetes.io/docs/reference/kubernetes-api/>
+- API resource URIs and listing semantics:
+  <https://kubernetes.io/docs/reference/using-api/api-concepts/#resource-uris>
+- Listing pods in one namespace vs all namespaces:
+  <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#get-list>,
+  <https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#get-list-all-namespaces>
+- Chunked list pagination (`limit` / `continue`):
+  <https://kubernetes.io/docs/reference/using-api/api-concepts/#retrieving-large-results-sets-in-chunks>
+- Label selectors:
+  <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors>
+- Field selectors:
+  <https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/>
+- Event resource (`event_time`, `first_timestamp`, `last_timestamp`, `count`, `action`):
+  <https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/event-v1/>
+- `kubectl proxy`:
+  <https://kubernetes.io/docs/reference/kubectl/generated/kubectl_proxy/>
+- RBAC:
+  <https://kubernetes.io/docs/reference/access-authn-authz/rbac/>
 
 ## Contributing
 

--- a/sources/community/k8s/manifest.yaml
+++ b/sources/community/k8s/manifest.yaml
@@ -1,5 +1,5 @@
 name: k8s
-version: 0.1.2
+version: 0.1.3
 dsl_version: 3
 backend: http
 description: >-
@@ -21,7 +21,8 @@ base_url: "{{input.K8S_BASE_URL}}"
 test_queries:
   - SELECT namespace, name, status FROM k8s.pods LIMIT 20
   - SELECT namespace, name, replicas, available_replicas FROM k8s.deployments LIMIT 10
-  - SELECT namespace, object_name, reason, message FROM k8s.events WHERE object_kind = 'Pod' LIMIT 20
+  - SELECT namespace, object_name, reason, message, last_timestamp, count FROM k8s.events WHERE object_kind = 'Pod' ORDER BY last_timestamp DESC NULLS LAST LIMIT 20
+  - SELECT name, status FROM k8s.pods WHERE namespace = 'kube-system' LIMIT 10
 tables:
   - name: pods
     description: Pods across all namespaces with phase, scheduling, and container status metadata.
@@ -32,6 +33,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/pods
@@ -44,6 +47,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /api/v1/namespaces/{{filter.namespace}}/pods
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -85,9 +100,14 @@ tables:
           path: [status, hostIP]
       - name: start_time
         type: Timestamp
+        nullable: true
+        description: status.startTime (RFC3339); parsed via format_timestamp(iso8601).
         expr:
-          kind: path
-          path: [status, startTime]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [status, startTime]
       - name: status
         type: Utf8
         expr:
@@ -151,6 +171,7 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/nodes
@@ -207,6 +228,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/services
@@ -219,6 +242,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /api/v1/namespaces/{{filter.namespace}}/services
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -269,6 +304,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/apps/v1/deployments
@@ -281,6 +318,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/apps/v1/namespaces/{{filter.namespace}}/deployments
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -326,6 +375,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/apps/v1/daemonsets
@@ -338,6 +389,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/apps/v1/namespaces/{{filter.namespace}}/daemonsets
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -383,6 +446,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/apps/v1/statefulsets
@@ -395,6 +460,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/apps/v1/namespaces/{{filter.namespace}}/statefulsets
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -440,6 +517,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/apps/v1/replicasets
@@ -452,6 +531,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/apps/v1/namespaces/{{filter.namespace}}/replicasets
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -497,6 +588,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/batch/v1/jobs
@@ -509,6 +602,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/batch/v1/namespaces/{{filter.namespace}}/jobs
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -554,6 +659,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/batch/v1/cronjobs
@@ -566,6 +673,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/batch/v1/namespaces/{{filter.namespace}}/cronjobs
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -611,6 +730,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/networking.k8s.io/v1/ingresses
@@ -623,6 +744,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/networking.k8s.io/v1/namespaces/{{filter.namespace}}/ingresses
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -663,6 +796,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/endpoints
@@ -675,6 +810,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /api/v1/namespaces/{{filter.namespace}}/endpoints
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -715,6 +862,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /apis/networking.k8s.io/v1/networkpolicies
@@ -727,6 +876,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /apis/networking.k8s.io/v1/namespaces/{{filter.namespace}}/networkpolicies
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -776,6 +937,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/events
@@ -788,6 +951,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /api/v1/namespaces/{{filter.namespace}}/events
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -827,6 +1002,48 @@ tables:
         expr:
           kind: path
           path: [message]
+      - name: event_time
+        type: Timestamp
+        nullable: true
+        description: events.k8s.io-style eventTime when present (single-occurrence events); RFC3339.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [eventTime]
+      - name: first_timestamp
+        type: Timestamp
+        nullable: true
+        description: core/v1 firstTimestamp; first observation of a repeated event (RFC3339).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [firstTimestamp]
+      - name: last_timestamp
+        type: Timestamp
+        nullable: true
+        description: core/v1 lastTimestamp; most recent observation of a repeated event (RFC3339).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [lastTimestamp]
+      - name: count
+        type: Int64
+        description: Number of times this event has been observed.
+        expr:
+          kind: path
+          path: [count]
+      - name: action
+        type: Utf8
+        description: events.k8s.io-style action when present.
+        expr:
+          kind: path
+          path: [action]
       - name: object_kind
         type: Utf8
         description: involvedObject.kind (Pod, Service, etc.) for joins.
@@ -862,6 +1079,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/persistentvolumeclaims
@@ -874,6 +1093,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /api/v1/namespaces/{{filter.namespace}}/persistentvolumeclaims
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -934,6 +1165,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/configmaps
@@ -946,6 +1179,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /api/v1/namespaces/{{filter.namespace}}/configmaps
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue
@@ -993,6 +1238,8 @@ tables:
     filters:
       - name: label_selector
       - name: field_selector
+      - name: namespace
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/serviceaccounts
@@ -1005,6 +1252,18 @@ tables:
           key: field_selector
     response:
       rows_path: [items]
+    requests:
+      - when_filters:
+          - namespace
+        method: GET
+        path: /api/v1/namespaces/{{filter.namespace}}/serviceaccounts
+        query:
+          - name: labelSelector
+            from: filter
+            key: label_selector
+          - name: fieldSelector
+            from: filter
+            key: field_selector
     pagination:
       mode: cursor_query
       cursor_param: continue

--- a/sources/community/k8s/manifest.yaml
+++ b/sources/community/k8s/manifest.yaml
@@ -1,0 +1,868 @@
+name: k8s
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Kubernetes workloads, networking, storage, events, and cluster nodes
+  through the Kubernetes REST API. Supports kubectl-proxy local dev and
+  configurable API base URLs for in-cluster or remote access.
+inputs:
+  K8S_BASE_URL:
+    kind: variable
+    default: http://127.0.0.1:8080
+    hint: |
+      Kubernetes API base URL. For local development, run
+      `kubectl proxy --port=8080` and keep the default. For in-cluster access,
+      use `https://kubernetes.default.svc`. For remote clusters, point at your API
+      gateway or load-balanced control-plane endpoint.
+base_url: "{{input.K8S_BASE_URL}}"
+test_queries:
+  - SELECT namespace, name, status FROM k8s.pods LIMIT 20
+  - SELECT namespace, name, replicas, available_replicas FROM k8s.deployments LIMIT 10
+  - SELECT namespace, object_name, reason, message FROM k8s.events WHERE object_kind = 'Pod' LIMIT 20
+tables:
+  - name: pods
+    description: Pods across all namespaces with phase, scheduling, and container status metadata.
+    guide: |
+      Pushdown filters (faster and lighter on the API server):
+      - label_selector: Kubernetes labelSelector
+      - field_selector: Kubernetes fieldSelector
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/pods
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, uid]
+      - name: name
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, name]
+      - name: namespace
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, namespace]
+      - name: node_name
+        type: Utf8
+        expr:
+          kind: path
+          path: [spec, nodeName]
+      - name: pod_ip
+        type: Utf8
+        expr:
+          kind: path
+          path: [status, podIP]
+      - name: host_ip
+        type: Utf8
+        expr:
+          kind: path
+          path: [status, hostIP]
+      - name: start_time
+        type: Timestamp
+        expr:
+          kind: path
+          path: [status, startTime]
+      - name: status
+        type: Utf8
+        expr:
+          kind: path
+          path: [status, phase]
+      - name: status_reason
+        type: Utf8
+        expr:
+          kind: path
+          path: [status, reason]
+      - name: status_message
+        type: Utf8
+        expr:
+          kind: path
+          path: [status, message]
+      - name: labels
+        type: Json
+        expr:
+          kind: path
+          path: [metadata, labels]
+      - name: annotations
+        type: Json
+        expr:
+          kind: path
+          path: [metadata, annotations]
+      - name: annotation_commit_hash
+        type: Utf8
+        nullable: true
+        description: metadata.annotations.commit_hash when your CD pipeline injects it.
+        expr:
+          kind: path
+          path: [metadata, annotations, commit_hash]
+      - name: conditions
+        type: Json
+        expr:
+          kind: path
+          path: [status, conditions]
+      - name: container_statuses
+        type: Json
+        expr:
+          kind: path
+          path: [status, containerStatuses]
+      - name: init_container_statuses
+        type: Json
+        expr:
+          kind: path
+          path: [status, initContainerStatuses]
+      - name: volumes
+        type: Json
+        description: Pod spec.volumes; join claim names to k8s.persistentvolumeclaims.name.
+        expr:
+          kind: path
+          path: [spec, volumes]
+
+  - name: nodes
+    description: Cluster nodes with kubelet version and OS metadata.
+    guide: |
+      Pushdown filters:
+      - label_selector: Kubernetes labelSelector
+      - field_selector: Kubernetes fieldSelector
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/nodes
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, uid]
+      - name: name
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, name]
+      - name: kubelet_version
+        type: Utf8
+        expr:
+          kind: path
+          path: [status, nodeInfo, kubeletVersion]
+      - name: os_image
+        type: Utf8
+        expr:
+          kind: path
+          path: [status, nodeInfo, osImage]
+      - name: labels
+        type: Json
+        expr:
+          kind: path
+          path: [metadata, labels]
+
+  - name: services
+    description: Services across all namespaces.
+    guide: |
+      Pushdown filters:
+      - label_selector: Kubernetes labelSelector
+      - field_selector: Kubernetes fieldSelector
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/services
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, uid]
+      - name: name
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, name]
+      - name: namespace
+        type: Utf8
+        expr:
+          kind: path
+          path: [metadata, namespace]
+      - name: type
+        type: Utf8
+        expr:
+          kind: path
+          path: [spec, type]
+      - name: cluster_ip
+        type: Utf8
+        expr:
+          kind: path
+          path: [spec, clusterIP]
+      - name: selector
+        type: Json
+        expr:
+          kind: path
+          path: [spec, selector]
+      - name: labels
+        type: Json
+        expr:
+          kind: path
+          path: [metadata, labels]
+
+  - name: deployments
+    description: Deployments across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/apps/v1/deployments
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: replicas
+        type: Int64
+        expr: { kind: path, path: [spec, replicas] }
+      - name: available_replicas
+        type: Int64
+        expr: { kind: path, path: [status, availableReplicas] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: daemonsets
+    description: DaemonSets across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/apps/v1/daemonsets
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: desired_number_scheduled
+        type: Int64
+        expr: { kind: path, path: [status, desiredNumberScheduled] }
+      - name: number_ready
+        type: Int64
+        expr: { kind: path, path: [status, numberReady] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: statefulsets
+    description: StatefulSets across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/apps/v1/statefulsets
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: replicas
+        type: Int64
+        expr: { kind: path, path: [spec, replicas] }
+      - name: ready_replicas
+        type: Int64
+        expr: { kind: path, path: [status, readyReplicas] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: replicasets
+    description: ReplicaSets across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/apps/v1/replicasets
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: replicas
+        type: Int64
+        expr: { kind: path, path: [spec, replicas] }
+      - name: ready_replicas
+        type: Int64
+        expr: { kind: path, path: [status, readyReplicas] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: jobs
+    description: Jobs across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/batch/v1/jobs
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: succeeded
+        type: Int64
+        expr: { kind: path, path: [status, succeeded] }
+      - name: failed
+        type: Int64
+        expr: { kind: path, path: [status, failed] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: cronjobs
+    description: CronJobs across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/batch/v1/cronjobs
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: schedule
+        type: Utf8
+        expr: { kind: path, path: [spec, schedule] }
+      - name: suspend
+        type: Boolean
+        expr: { kind: path, path: [spec, suspend] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: ingresses
+    description: Ingresses across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/networking.k8s.io/v1/ingresses
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: ingress_class_name
+        type: Utf8
+        expr: { kind: path, path: [spec, ingressClassName] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: endpoints
+    description: Endpoints across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/endpoints
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: subsets
+        type: Json
+        expr: { kind: path, path: [subsets] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: networkpolicies
+    description: NetworkPolicies across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /apis/networking.k8s.io/v1/networkpolicies
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: policy_types
+        type: Json
+        expr: { kind: path, path: [spec, policyTypes] }
+      - name: pod_selector
+        type: Json
+        expr: { kind: path, path: [spec, podSelector] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: events
+    description: Events across all namespaces for operational debugging and audit trails.
+    guide: |
+      Join to pods: object_kind = 'Pod' and match object_namespace + object_name to k8s.pods.
+      Join to services: object_kind = 'Service' and match namespace + object_name.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/events
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: reason
+        type: Utf8
+        expr: { kind: path, path: [reason] }
+      - name: type
+        type: Utf8
+        expr: { kind: path, path: [type] }
+      - name: message
+        type: Utf8
+        expr: { kind: path, path: [message] }
+      - name: object_kind
+        type: Utf8
+        description: involvedObject.kind (Pod, Service, etc.) for joins.
+        expr: { kind: path, path: [involvedObject, kind] }
+      - name: object_name
+        type: Utf8
+        description: involvedObject.name; join to pods.name or services.name when kind matches.
+        expr: { kind: path, path: [involvedObject, name] }
+      - name: object_namespace
+        type: Utf8
+        description: involvedObject.namespace (empty for cluster-scoped kinds).
+        expr: { kind: path, path: [involvedObject, namespace] }
+      - name: involved_object
+        type: Json
+        expr: { kind: path, path: [involvedObject] }
+
+  - name: persistentvolumeclaims
+    description: PersistentVolumeClaims with phase and storage class metadata.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/persistentvolumeclaims
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: phase
+        type: Utf8
+        expr: { kind: path, path: [status, phase] }
+      - name: storage_class
+        type: Utf8
+        expr: { kind: path, path: [spec, storageClassName] }
+      - name: volume_name
+        type: Utf8
+        expr: { kind: path, path: [spec, volumeName] }
+      - name: capacity
+        type: Json
+        expr: { kind: path, path: [status, capacity] }
+      - name: access_modes
+        type: Json
+        expr: { kind: path, path: [spec, accessModes] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+
+  - name: configmaps
+    description: ConfigMaps; list responses may omit large data payloads depending on cluster settings.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/configmaps
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: resource_version
+        type: Utf8
+        description: Bump indicates the object changed.
+        expr: { kind: path, path: [metadata, resourceVersion] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }
+      - name: data
+        type: Json
+        description: Present when the API returns keys in list responses.
+        expr: { kind: path, path: [data] }
+
+  - name: serviceaccounts
+    description: ServiceAccounts across all namespaces.
+    filters:
+      - name: label_selector
+      - name: field_selector
+    request:
+      method: GET
+      path: /api/v1/serviceaccounts
+      query:
+        - name: labelSelector
+          from: filter
+          key: label_selector
+        - name: fieldSelector
+          from: filter
+          key: field_selector
+    response:
+      rows_path: [items]
+    pagination:
+      mode: cursor_query
+      cursor_param: continue
+      response_cursor_path: [metadata, continue]
+      page_size:
+        default: 200
+        max: 500
+        query_param: limit
+    columns:
+      - name: uid
+        type: Utf8
+        expr: { kind: path, path: [metadata, uid] }
+      - name: namespace
+        type: Utf8
+        expr: { kind: path, path: [metadata, namespace] }
+      - name: name
+        type: Utf8
+        expr: { kind: path, path: [metadata, name] }
+      - name: secrets
+        type: Json
+        expr: { kind: path, path: [secrets] }
+      - name: labels
+        type: Json
+        expr: { kind: path, path: [metadata, labels] }

--- a/sources/community/k8s/manifest.yaml
+++ b/sources/community/k8s/manifest.yaml
@@ -22,9 +22,10 @@ test_queries:
   - SELECT namespace, name, status FROM k8s.pods LIMIT 20
   - SELECT namespace, name, replicas, available_replicas FROM k8s.deployments LIMIT 10
   - >-
-    SELECT namespace, object_name, reason, message, last_timestamp, count
+    SELECT namespace, object_name, reason, message,
+    COALESCE(last_timestamp, event_time) AS event_at, count
     FROM k8s.events WHERE object_kind = 'Pod'
-    ORDER BY last_timestamp DESC NULLS LAST LIMIT 20
+    ORDER BY COALESCE(last_timestamp, event_time) DESC NULLS LAST LIMIT 20
   - SELECT name, status FROM k8s.pods WHERE namespace = 'kube-system' LIMIT 10
 tables:
   - name: pods

--- a/sources/community/k8s/manifest.yaml
+++ b/sources/community/k8s/manifest.yaml
@@ -1,5 +1,5 @@
 name: k8s
-version: 0.1.1
+version: 0.1.2
 dsl_version: 3
 backend: http
 description: >-
@@ -770,8 +770,9 @@ tables:
   - name: events
     description: Events across all namespaces for operational debugging and audit trails.
     guide: |
-      Join to pods: object_kind = 'Pod' and match object_namespace + object_name to k8s.pods.
-      Join to services: object_kind = 'Service' and match namespace + object_name.
+      Prefer joining on object_uid (involvedObject.uid) when correlating to pods or other
+      resources; names can be reused after deletion. Fallback: object_kind + object_namespace
+      + object_name (for example object_kind = 'Pod' and match k8s.pods.namespace + name).
     filters:
       - name: label_selector
       - name: field_selector
@@ -844,6 +845,12 @@ tables:
         expr:
           kind: path
           path: [involvedObject, namespace]
+      - name: object_uid
+        type: Utf8
+        description: involvedObject.uid; stable join key to resource metadata.uid.
+        expr:
+          kind: path
+          path: [involvedObject, uid]
       - name: involved_object
         type: Json
         expr:

--- a/sources/community/k8s/manifest.yaml
+++ b/sources/community/k8s/manifest.yaml
@@ -1,20 +1,22 @@
 name: k8s
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-
   Query Kubernetes workloads, networking, storage, events, and cluster nodes
-  through the Kubernetes REST API. Supports kubectl-proxy local dev and
-  configurable API base URLs for in-cluster or remote access.
+  through the Kubernetes REST API. Read-only v1; use kubectl proxy locally or an
+  API base URL that already injects authentication.
 inputs:
   K8S_BASE_URL:
     kind: variable
     default: http://127.0.0.1:8080
     hint: |
-      Kubernetes API base URL. For local development, run
-      `kubectl proxy --port=8080` and keep the default. For in-cluster access,
-      use `https://kubernetes.default.svc`. For remote clusters, point at your API
-      gateway or load-balanced control-plane endpoint.
+      Kubernetes API base URL that Coral can call without extra auth headers.
+      Recommended: run `kubectl proxy --port=8080` and keep the default
+      `http://127.0.0.1:8080`. You may also point at an authenticating reverse
+      proxy or gateway in front of the API server. Do not set this to a raw API
+      server URL (for example `https://kubernetes.default.svc`) unless that
+      endpoint is already authenticated for anonymous or proxy access.
 base_url: "{{input.K8S_BASE_URL}}"
 test_queries:
   - SELECT namespace, name, status FROM k8s.pods LIMIT 20

--- a/sources/community/k8s/manifest.yaml
+++ b/sources/community/k8s/manifest.yaml
@@ -21,7 +21,10 @@ base_url: "{{input.K8S_BASE_URL}}"
 test_queries:
   - SELECT namespace, name, status FROM k8s.pods LIMIT 20
   - SELECT namespace, name, replicas, available_replicas FROM k8s.deployments LIMIT 10
-  - SELECT namespace, object_name, reason, message, last_timestamp, count FROM k8s.events WHERE object_kind = 'Pod' ORDER BY last_timestamp DESC NULLS LAST LIMIT 20
+  - >-
+    SELECT namespace, object_name, reason, message, last_timestamp, count
+    FROM k8s.events WHERE object_kind = 'Pod'
+    ORDER BY last_timestamp DESC NULLS LAST LIMIT 20
   - SELECT name, status FROM k8s.pods WHERE namespace = 'kube-system' LIMIT 10
 tables:
   - name: pods

--- a/sources/community/k8s/manifest.yaml
+++ b/sources/community/k8s/manifest.yaml
@@ -290,22 +290,34 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: replicas
         type: Int64
-        expr: { kind: path, path: [spec, replicas] }
+        expr:
+          kind: path
+          path: [spec, replicas]
       - name: available_replicas
         type: Int64
-        expr: { kind: path, path: [status, availableReplicas] }
+        expr:
+          kind: path
+          path: [status, availableReplicas]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: daemonsets
     description: DaemonSets across all namespaces.
@@ -335,22 +347,34 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: desired_number_scheduled
         type: Int64
-        expr: { kind: path, path: [status, desiredNumberScheduled] }
+        expr:
+          kind: path
+          path: [status, desiredNumberScheduled]
       - name: number_ready
         type: Int64
-        expr: { kind: path, path: [status, numberReady] }
+        expr:
+          kind: path
+          path: [status, numberReady]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: statefulsets
     description: StatefulSets across all namespaces.
@@ -380,22 +404,34 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: replicas
         type: Int64
-        expr: { kind: path, path: [spec, replicas] }
+        expr:
+          kind: path
+          path: [spec, replicas]
       - name: ready_replicas
         type: Int64
-        expr: { kind: path, path: [status, readyReplicas] }
+        expr:
+          kind: path
+          path: [status, readyReplicas]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: replicasets
     description: ReplicaSets across all namespaces.
@@ -425,22 +461,34 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: replicas
         type: Int64
-        expr: { kind: path, path: [spec, replicas] }
+        expr:
+          kind: path
+          path: [spec, replicas]
       - name: ready_replicas
         type: Int64
-        expr: { kind: path, path: [status, readyReplicas] }
+        expr:
+          kind: path
+          path: [status, readyReplicas]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: jobs
     description: Jobs across all namespaces.
@@ -470,22 +518,34 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: succeeded
         type: Int64
-        expr: { kind: path, path: [status, succeeded] }
+        expr:
+          kind: path
+          path: [status, succeeded]
       - name: failed
         type: Int64
-        expr: { kind: path, path: [status, failed] }
+        expr:
+          kind: path
+          path: [status, failed]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: cronjobs
     description: CronJobs across all namespaces.
@@ -515,22 +575,34 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: schedule
         type: Utf8
-        expr: { kind: path, path: [spec, schedule] }
+        expr:
+          kind: path
+          path: [spec, schedule]
       - name: suspend
         type: Boolean
-        expr: { kind: path, path: [spec, suspend] }
+        expr:
+          kind: path
+          path: [spec, suspend]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: ingresses
     description: Ingresses across all namespaces.
@@ -560,19 +632,29 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: ingress_class_name
         type: Utf8
-        expr: { kind: path, path: [spec, ingressClassName] }
+        expr:
+          kind: path
+          path: [spec, ingressClassName]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: endpoints
     description: Endpoints across all namespaces.
@@ -602,19 +684,29 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: subsets
         type: Json
-        expr: { kind: path, path: [subsets] }
+        expr:
+          kind: path
+          path: [subsets]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: networkpolicies
     description: NetworkPolicies across all namespaces.
@@ -644,22 +736,34 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: policy_types
         type: Json
-        expr: { kind: path, path: [spec, policyTypes] }
+        expr:
+          kind: path
+          path: [spec, policyTypes]
       - name: pod_selector
         type: Json
-        expr: { kind: path, path: [spec, podSelector] }
+        expr:
+          kind: path
+          path: [spec, podSelector]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: events
     description: Events across all namespaces for operational debugging and audit trails.
@@ -692,37 +796,57 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: reason
         type: Utf8
-        expr: { kind: path, path: [reason] }
+        expr:
+          kind: path
+          path: [reason]
       - name: type
         type: Utf8
-        expr: { kind: path, path: [type] }
+        expr:
+          kind: path
+          path: [type]
       - name: message
         type: Utf8
-        expr: { kind: path, path: [message] }
+        expr:
+          kind: path
+          path: [message]
       - name: object_kind
         type: Utf8
         description: involvedObject.kind (Pod, Service, etc.) for joins.
-        expr: { kind: path, path: [involvedObject, kind] }
+        expr:
+          kind: path
+          path: [involvedObject, kind]
       - name: object_name
         type: Utf8
         description: involvedObject.name; join to pods.name or services.name when kind matches.
-        expr: { kind: path, path: [involvedObject, name] }
+        expr:
+          kind: path
+          path: [involvedObject, name]
       - name: object_namespace
         type: Utf8
         description: involvedObject.namespace (empty for cluster-scoped kinds).
-        expr: { kind: path, path: [involvedObject, namespace] }
+        expr:
+          kind: path
+          path: [involvedObject, namespace]
       - name: involved_object
         type: Json
-        expr: { kind: path, path: [involvedObject] }
+        expr:
+          kind: path
+          path: [involvedObject]
 
   - name: persistentvolumeclaims
     description: PersistentVolumeClaims with phase and storage class metadata.
@@ -752,31 +876,49 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: phase
         type: Utf8
-        expr: { kind: path, path: [status, phase] }
+        expr:
+          kind: path
+          path: [status, phase]
       - name: storage_class
         type: Utf8
-        expr: { kind: path, path: [spec, storageClassName] }
+        expr:
+          kind: path
+          path: [spec, storageClassName]
       - name: volume_name
         type: Utf8
-        expr: { kind: path, path: [spec, volumeName] }
+        expr:
+          kind: path
+          path: [spec, volumeName]
       - name: capacity
         type: Json
-        expr: { kind: path, path: [status, capacity] }
+        expr:
+          kind: path
+          path: [status, capacity]
       - name: access_modes
         type: Json
-        expr: { kind: path, path: [spec, accessModes] }
+        expr:
+          kind: path
+          path: [spec, accessModes]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
 
   - name: configmaps
     description: ConfigMaps; list responses may omit large data payloads depending on cluster settings.
@@ -806,24 +948,36 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: resource_version
         type: Utf8
         description: Bump indicates the object changed.
-        expr: { kind: path, path: [metadata, resourceVersion] }
+        expr:
+          kind: path
+          path: [metadata, resourceVersion]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]
       - name: data
         type: Json
         description: Present when the API returns keys in list responses.
-        expr: { kind: path, path: [data] }
+        expr:
+          kind: path
+          path: [data]
 
   - name: serviceaccounts
     description: ServiceAccounts across all namespaces.
@@ -853,16 +1007,26 @@ tables:
     columns:
       - name: uid
         type: Utf8
-        expr: { kind: path, path: [metadata, uid] }
+        expr:
+          kind: path
+          path: [metadata, uid]
       - name: namespace
         type: Utf8
-        expr: { kind: path, path: [metadata, namespace] }
+        expr:
+          kind: path
+          path: [metadata, namespace]
       - name: name
         type: Utf8
-        expr: { kind: path, path: [metadata, name] }
+        expr:
+          kind: path
+          path: [metadata, name]
       - name: secrets
         type: Json
-        expr: { kind: path, path: [secrets] }
+        expr:
+          kind: path
+          path: [secrets]
       - name: labels
         type: Json
-        expr: { kind: path, path: [metadata, labels] }
+        expr:
+          kind: path
+          path: [metadata, labels]


### PR DESCRIPTION
<html>
<body>
<p>Closes #414</p><h2>Summary</h2><p>Adds a new read-only community Kubernetes source under:</p><pre><code class="language-text">sources/community/k8s/</code></pre><p>This source enables querying Kubernetes cluster resources, workload metadata,
networking objects, storage entities, operational events, and cluster
infrastructure metadata through SQL using the Kubernetes API server.</p><p>The source is designed primarily for OSS/self-managed Kubernetes clusters. v1
targets local and shared development through <code>kubectl proxy</code>, with optional
support for API base URLs that already inject authentication through a reverse
proxy or gateway.</p><h2>Tables</h2>
Table | Description
-- | --
pods | Pod metadata, lifecycle state, scheduling, node placement, container status
deployments | Deployment metadata including replicas, availability, selectors, labels
replicasets | ReplicaSet ownership and scaling metadata
statefulsets | Stateful workload replica state
daemonsets | Node-level workload scheduling and rollout metadata
jobs | Batch job execution and completion state
cronjobs | Scheduled job configuration and execution scheduling
services | Cluster networking services, ports, selectors, exposure
ingresses | Ingress routing rules, host configuration, load-balancing
endpoints | Service endpoint subsets for service-to-backend mapping
networkpolicies | Network policy selectors and policy types
persistentvolumeclaims | Persistent storage claim metadata and binding state
events | Cluster events for debugging and lifecycle triage (with first_timestamp / last_timestamp / count / action)
configmaps | Configuration metadata
serviceaccounts | ServiceAccount metadata
nodes | Node-level infrastructure, kubelet version, labels

<p>The <code>nodes</code> table is cluster-scoped and always requires cluster-wide <code>list nodes</code>.</p><p>A minimal read-only <code>ClusterRole</code> is documented in
<code>sources/community/k8s/README.md</code> under "RBAC requirements".</p><h2>Pushdown filters</h2><p>All namespace-scoped tables support:</p><ul><li><p><code>label_selector</code> → Kubernetes <code>labelSelector</code></p></li><li><p><code>field_selector</code> → Kubernetes <code>fieldSelector</code></p></li><li><p><code>namespace</code> → rewrites the request to the namespaced list URL</p></li></ul><h2>Pagination and result safety</h2><ul><li><p>Kubernetes API pages are handled via <code>continue</code>-token chunking
(<code>cursor_query</code> pagination mode).</p></li><li><p>Every table sets <code>fetch_limit_default: 500</code> as a total-row safety cap so a
naive <code>SELECT * FROM k8s.pods</code> cannot accidentally scan an entire large
cluster. SQL <code>LIMIT</code> and pushdown filters are still important for large
clusters; the README explains this in the "Total-row safety cap
(fetch_limit_default) vs Kubernetes limit" section.</p></li></ul><h2>Why it changed</h2><p>Kubernetes clusters generate large amounts of operational metadata across
workloads, scheduling, networking, storage, infrastructure, orchestration
state, and operational events.</p><p>Teams frequently need answers to operational questions such as:</p><ul><li><p>Which pods are not running?</p></li><li><p>Which deployments are unhealthy?</p></li><li><p>Which PVCs are pending?</p></li><li><p>Which recent warning events explain a failure?</p></li></ul><p>Without a Coral source, users typically need to inspect cluster state with
<code>kubectl</code>, write custom scripts, or aggregate metadata externally. This source
makes Kubernetes operational metadata directly queryable through SQL for
operational analytics, debugging workflows, infrastructure visibility, and
automation systems.</p><h2>What was tested</h2><ul><li><p><code>coral source lint sources/community/k8s/manifest.yaml</code> — manifest validation
passed</p></li><li><p><code>make lint-sources</code> — validation passed</p></li><li><p><code>coral source add --file …</code> + <code>coral source test k8s</code> — validated against a
live <code>kind</code> cluster via <code>kubectl proxy</code></p></li><li><p>All 16 tables queried successfully with expected schema mapping</p></li><li><p>Cluster-wide and namespace-scoped request variants both exercised</p></li><li><p>Kubernetes <code>continue</code>-token pagination handling verified</p></li><li><p>Event timing (<code>first_timestamp</code> / <code>last_timestamp</code>) and <code>count</code> columns
verified parsing as <code>Timestamp</code> / <code>Int64</code> from real <code>/api/v1/events</code> payload</p></li></ul><h3>Declared test queries (all pass)</h3><pre><code class="language-text">✓ SELECT namespace, name, status FROM k8s.pods LIMIT 20
✓ SELECT namespace, name, replicas, available_replicas FROM k8s.deployments LIMIT 10
✓ SELECT namespace, object_name, reason, message, last_timestamp, count
    FROM k8s.events WHERE object_kind = 'Pod'
    ORDER BY last_timestamp DESC NULLS LAST LIMIT 20
✓ SELECT name, status FROM k8s.pods WHERE namespace = 'kube-system' LIMIT 10</code></pre><p>The fourth test exercises the namespaced request variant
(<code>/api/v1/namespaces/kube-system/pods</code>); the third exercises the new event
timing/count columns.</p><h2>Example queries</h2><h3>Failing pods (namespace-scoped, namespace-RBAC friendly)</h3><pre><code class="language-sql">SELECT namespace, name, status, status_reason
FROM k8s.pods
WHERE namespace = 'production'
  AND status != 'Running'
LIMIT 20;</code></pre><h3>Recent warning events</h3><pre><code class="language-sql">SELECT namespace, object_kind, object_name, reason, message,
       last_timestamp, count
FROM k8s.events
WHERE type = 'Warning'
ORDER BY last_timestamp DESC NULLS LAST
LIMIT 20;</code></pre><h3>Unhealthy deployments</h3><pre><code class="language-sql">SELECT namespace, name, replicas, available_replicas
FROM k8s.deployments
WHERE replicas != available_replicas
LIMIT 50;</code></pre><h3>Pending PVCs</h3><pre><code class="language-sql">SELECT namespace, name, phase, storage_class
FROM k8s.persistentvolumeclaims
WHERE phase = 'Pending'
LIMIT 20;</code></pre><h2>User-visible impact</h2><p>New <code>k8s</code> source installable via:</p><pre><code class="language-bash">kubectl proxy --port=8080
export K8S_BASE_URL=http://127.0.0.1:8080
coral source add --file sources/community/k8s/manifest.yaml</code></pre><h2>Notes</h2><ul><li><p>Read-only v1 (no mutating Kubernetes API calls)</p></li><li><p>Uses the standard Kubernetes API surface exposed through <code>kubectl proxy</code> or a
pre-authenticated base URL</p></li><li><p>Supports <code>label_selector</code>, <code>field_selector</code>, and <code>namespace</code> pushdown on list
tables</p></li><li><p>Nested Kubernetes resource payloads are preserved as <code>Json</code> where
appropriate</p></li><li><p>ISO 8601 timestamp fields (pod <code>startTime</code>, event timestamps) are parsed via
<code>format_timestamp(iso8601)</code> so they're true Coral <code>Timestamp</code> columns</p></li></ul><h2>Follow-on</h2><p>Potential future additions:</p><ul><li><p>Bearer-token or client-certificate authentication for direct API server
access</p></li><li><p><code>namespaces</code> and <code>persistentvolumes</code> tables</p></li><li><p><code>secrets</code> support with careful redaction</p></li><li><p><code>horizontalpodautoscalers</code>, <code>resourcequotas</code>, <code>limitranges</code>,
<code>ingressclasses</code></p></li><li><p>Cluster usage metrics integration</p></li><li><p>Workload relationship mapping</p></li><li><p>Helm release metadata</p></li></ul><p></p><!--EndFragment-->
</body>
</html>