### PR TITLE
feat(engine): expose table function metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "opentelemetry",
  "parquet",
  "reqwest",
+ "serde",
  "serde_json",
  "strsim",
  "tempfile",

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -25,6 +25,7 @@ object_store.workspace = true
 opentelemetry.workspace = true
 parquet.workspace = true
 reqwest.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 strsim.workspace = true
 thiserror.workspace = true

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -44,9 +44,24 @@ pub(crate) struct RegisteredTableFunction {
     pub(crate) function_name: String,
     pub(crate) internal_name: String,
     pub(crate) description: String,
-    pub(crate) arguments_json: String,
-    pub(crate) result_columns_json: String,
+    pub(crate) arguments: Vec<RegisteredTableFunctionArgument>,
+    pub(crate) result_columns: Vec<RegisteredTableFunctionResultColumn>,
     pub(crate) arg_names: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RegisteredTableFunctionArgument {
+    pub(crate) name: String,
+    pub(crate) required: bool,
+    pub(crate) values: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RegisteredTableFunctionResultColumn {
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) nullable: bool,
+    pub(crate) description: String,
 }
 
 #[derive(Debug, Clone)]
@@ -230,23 +245,19 @@ pub(crate) fn build_registered_table_function(
     let arguments = function
         .args
         .iter()
-        .map(|arg| {
-            serde_json::json!({
-                "name": arg.name,
-                "required": arg.required,
-                "values": arg.values,
-            })
+        .map(|arg| RegisteredTableFunctionArgument {
+            name: arg.name.clone(),
+            required: arg.required,
+            values: arg.values.clone(),
         })
         .collect::<Vec<_>>();
     let result_columns = registered_columns_from_specs(&function.columns, &[])
         .into_iter()
-        .map(|column| {
-            serde_json::json!({
-                "name": column.name,
-                "type": column.data_type,
-                "nullable": column.nullable,
-                "description": column.description,
-            })
+        .map(|column| RegisteredTableFunctionResultColumn {
+            name: column.name,
+            data_type: column.data_type,
+            nullable: column.nullable,
+            description: column.description,
         })
         .collect::<Vec<_>>();
 
@@ -255,8 +266,8 @@ pub(crate) fn build_registered_table_function(
         function_name: function.name.clone(),
         internal_name,
         description: function.description.clone(),
-        arguments_json: serde_json::to_string(&arguments).expect("arguments json"),
-        result_columns_json: serde_json::to_string(&result_columns).expect("result columns json"),
+        arguments,
+        result_columns,
         arg_names: function.args.iter().map(|arg| arg.name.clone()).collect(),
     }
 }

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -1,5 +1,7 @@
 //! Typed query-visible catalog metadata.
 
+use serde::Serialize;
+
 /// Describes one queryable column.
 #[derive(Debug, Clone)]
 pub struct ColumnInfo {
@@ -34,4 +36,44 @@ pub struct TableInfo {
     pub columns: Vec<ColumnInfo>,
     /// Required filter names for the table.
     pub required_filters: Vec<String>,
+}
+
+/// Describes one argument accepted by a source-scoped table function.
+#[derive(Debug, Clone, Serialize)]
+pub struct TableFunctionArgumentInfo {
+    /// Argument name as used in a named SQL function call.
+    pub name: String,
+    /// Whether callers must provide this argument.
+    pub required: bool,
+    /// Allowed values, if the source declares an enum-like value set.
+    pub values: Vec<String>,
+}
+
+/// Describes one result column returned by a source-scoped table function.
+#[derive(Debug, Clone, Serialize)]
+pub struct TableFunctionResultColumnInfo {
+    /// Column name returned by the table function.
+    pub name: String,
+    /// Data type rendered in `Arrow`/`DataFusion` string form.
+    #[serde(rename = "type")]
+    pub data_type: String,
+    /// Whether the column can contain null values.
+    pub nullable: bool,
+    /// User-facing column description.
+    pub description: String,
+}
+
+/// Describes one source-scoped table function.
+#[derive(Debug, Clone, Serialize)]
+pub struct TableFunctionInfo {
+    /// `SQL` schema name.
+    pub schema_name: String,
+    /// Function name within the schema.
+    pub function_name: String,
+    /// User-facing table function description.
+    pub description: String,
+    /// Accepted function arguments.
+    pub arguments: Vec<TableFunctionArgumentInfo>,
+    /// Columns returned by the function.
+    pub result_columns: Vec<TableFunctionResultColumnInfo>,
 }

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -5,7 +5,10 @@ mod error;
 mod query;
 mod query_error;
 
-pub use catalog::{ColumnInfo, TableInfo};
+pub use catalog::{
+    ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
+    TableInfo,
+};
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
     QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -68,7 +68,8 @@ pub use composition::{
 pub use contracts::{
     ColumnInfo, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
     QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport,
-    StatusCode, StructuredQueryError, TableInfo,
+    StatusCode, StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.
@@ -94,6 +95,28 @@ impl CoralQuery {
         Ok(runtime::query::build_runtime(sources, runtime)
             .await?
             .list_tables(schema_filter, table_filter))
+    }
+
+    /// Lists source-scoped table functions from the provided source set.
+    ///
+    /// When `schema_filter` is present, only functions for that visible `SQL`
+    /// schema are returned. When `function_filter` is present, only the exact
+    /// function name within the schema is returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CoreError`] if credential resolution fails, if any validated
+    /// source spec cannot be compiled, or if the underlying query runtime
+    /// cannot be built.
+    pub async fn list_table_functions(
+        sources: &[QuerySource],
+        runtime: QueryRuntimeConfig,
+        schema_filter: Option<&str>,
+        function_filter: Option<&str>,
+    ) -> Result<Vec<TableFunctionInfo>, CoreError> {
+        Ok(runtime::query::build_runtime(sources, runtime)
+            .await?
+            .list_table_functions(schema_filter, function_filter))
     }
 
     /// Executes one `SQL` statement over the provided source set.

--- a/crates/coral-engine/src/runtime/catalog.rs
+++ b/crates/coral-engine/src/runtime/catalog.rs
@@ -12,7 +12,10 @@ use datafusion::prelude::SessionContext;
 
 use crate::backends::RegisteredSource;
 use crate::runtime::schema_provider::StaticSchemaProvider;
-use crate::{ColumnInfo, TableInfo};
+use crate::{
+    ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
+    TableInfo,
+};
 
 /// Schema name for source metadata tables such as `coral.tables`.
 pub(crate) const SYSTEM_SCHEMA: &str = "coral";
@@ -59,13 +62,15 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
         Field::new("result_columns_json", DataType::Utf8, false),
     ]));
 
-    let mut rows = active_sources
+    let rows = collect_table_functions(active_sources);
+    let arguments_json = rows
         .iter()
-        .flat_map(|source| source.table_functions.iter())
-        .collect::<Vec<_>>();
-    rows.sort_by(|left, right| {
-        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
-    });
+        .map(table_function_arguments_json)
+        .collect::<Result<Vec<_>>>()?;
+    let result_columns_json = rows
+        .iter()
+        .map(table_function_result_columns_json)
+        .collect::<Result<Vec<_>>>()?;
 
     let batch = RecordBatch::try_new(
         schema.clone(),
@@ -73,16 +78,23 @@ fn build_table_functions_table(active_sources: &[RegisteredSource]) -> Result<Me
             utf8_column(rows.iter().map(|row| Some(row.schema_name.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.function_name.as_str()))),
             utf8_column(rows.iter().map(|row| Some(row.description.as_str()))),
-            utf8_column(rows.iter().map(|row| Some(row.arguments_json.as_str()))),
-            utf8_column(
-                rows.iter()
-                    .map(|row| Some(row.result_columns_json.as_str())),
-            ),
+            utf8_column(arguments_json.iter().map(|value| Some(value.as_str()))),
+            utf8_column(result_columns_json.iter().map(|value| Some(value.as_str()))),
         ],
     )
     .map_err(|error| DataFusionError::ArrowError(Box::new(error), None))?;
 
     MemTable::try_new(schema, vec![vec![batch]])
+}
+
+fn table_function_arguments_json(row: &TableFunctionInfo) -> Result<String> {
+    serde_json::to_string(&row.arguments)
+        .map_err(|error| DataFusionError::External(Box::new(error)))
+}
+
+fn table_function_result_columns_json(row: &TableFunctionInfo) -> Result<String> {
+    serde_json::to_string(&row.result_columns)
+        .map_err(|error| DataFusionError::External(Box::new(error)))
 }
 
 fn utf8_column<'a>(values: impl IntoIterator<Item = Option<&'a str>>) -> ArrayRef {
@@ -122,6 +134,49 @@ pub(crate) fn collect_tables(active_sources: &[RegisteredSource]) -> Vec<TableIn
         (&left.schema_name, &left.table_name).cmp(&(&right.schema_name, &right.table_name))
     });
     tables
+}
+
+/// Collect typed source-scoped table function metadata for the active source set.
+#[must_use]
+pub(crate) fn collect_table_functions(
+    active_sources: &[RegisteredSource],
+) -> Vec<TableFunctionInfo> {
+    let mut functions = active_sources
+        .iter()
+        .flat_map(|source| {
+            source
+                .table_functions
+                .iter()
+                .map(move |function| TableFunctionInfo {
+                    schema_name: source.schema_name.clone(),
+                    function_name: function.function_name.clone(),
+                    description: function.description.clone(),
+                    arguments: function
+                        .arguments
+                        .iter()
+                        .map(|argument| TableFunctionArgumentInfo {
+                            name: argument.name.clone(),
+                            required: argument.required,
+                            values: argument.values.clone(),
+                        })
+                        .collect(),
+                    result_columns: function
+                        .result_columns
+                        .iter()
+                        .map(|column| TableFunctionResultColumnInfo {
+                            name: column.name.clone(),
+                            data_type: column.data_type.clone(),
+                            nullable: column.nullable,
+                            description: column.description.clone(),
+                        })
+                        .collect(),
+                })
+        })
+        .collect::<Vec<_>>();
+    functions.sort_by(|left, right| {
+        (&left.schema_name, &left.function_name).cmp(&(&right.schema_name, &right.function_name))
+    });
+    functions
 }
 
 fn build_tables_table(active_sources: &[RegisteredSource]) -> Result<MemTable> {

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -22,12 +22,13 @@ use crate::runtime::registry::{
 use crate::runtime::source_functions::SourceFunctionRegistry;
 use crate::{
     CoreError, QueryExecution, QueryPlan, QueryResultObserver, QueryResultObserverError,
-    QueryRuntimeConfig, QuerySource, TableInfo,
+    QueryRuntimeConfig, QuerySource, TableFunctionInfo, TableInfo,
 };
 
 pub(crate) struct QueryRuntimeAdapter {
     ctx: Arc<SessionContext>,
     tables: Vec<TableInfo>,
+    table_functions: Vec<TableFunctionInfo>,
     failures: Vec<SourceRegistrationFailure>,
     query_result_observers: Vec<Arc<dyn QueryResultObserver>>,
 }
@@ -96,6 +97,7 @@ pub(crate) async fn build_runtime(
     catalog::register(&ctx, &registration.active_sources)
         .map_err(|err| datafusion_to_core(&err, &[]))?;
     let tables = catalog::collect_tables(&registration.active_sources);
+    let table_functions = catalog::collect_table_functions(&registration.active_sources);
     let source_functions = SourceFunctionRegistry::new(
         registration
             .active_sources
@@ -117,6 +119,7 @@ pub(crate) async fn build_runtime(
     Ok(QueryRuntimeAdapter {
         ctx,
         tables,
+        table_functions,
         failures: registration.failures,
         query_result_observers: extensions.query_result_observers,
     })
@@ -132,6 +135,19 @@ impl QueryRuntimeAdapter {
             .iter()
             .filter(|table| source_filter.is_none_or(|value| table.schema_name == value))
             .filter(|table| table_filter.is_none_or(|value| table.table_name == value))
+            .cloned()
+            .collect()
+    }
+
+    pub(crate) fn list_table_functions(
+        &self,
+        source_filter: Option<&str>,
+        function_filter: Option<&str>,
+    ) -> Vec<TableFunctionInfo> {
+        self.table_functions
+            .iter()
+            .filter(|function| source_filter.is_none_or(|value| function.schema_name == value))
+            .filter(|function| function_filter.is_none_or(|value| function.function_name == value))
             .cloned()
             .collect()
     }

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -436,6 +436,52 @@ async fn coral_table_functions_lists_source_functions() {
 }
 
 #[tokio::test]
+async fn list_table_functions_matches_catalog_metadata() {
+    let sources = vec![build_source(http_manifest_with_function())];
+
+    let functions =
+        CoralQuery::list_table_functions(&sources, test_runtime(), Some("searchy"), None)
+            .await
+            .expect("list_table_functions should succeed");
+
+    assert_eq!(functions.len(), 1);
+    let function = &functions[0];
+    assert_eq!(function.schema_name, "searchy");
+    assert_eq!(function.function_name, "search_issues");
+    assert_eq!(function.description, "Search issues");
+    assert_eq!(function.arguments.len(), 2);
+    assert_eq!(function.arguments[0].name, "q");
+    assert!(function.arguments[0].required);
+    assert_eq!(
+        function.arguments[1].values,
+        ["lexical", "semantic", "hybrid"]
+    );
+    assert_eq!(function.result_columns.len(), 2);
+    assert_eq!(function.result_columns[0].name, "title");
+    assert_eq!(function.result_columns[1].data_type, "Float64");
+
+    let exact = CoralQuery::list_table_functions(
+        &sources,
+        test_runtime(),
+        Some("searchy"),
+        Some("search_issues"),
+    )
+    .await
+    .expect("exact function filter should succeed");
+    assert_eq!(exact.len(), 1);
+
+    let missing = CoralQuery::list_table_functions(
+        &sources,
+        test_runtime(),
+        Some("searchy"),
+        Some("missing"),
+    )
+    .await
+    .expect("missing function filter should succeed");
+    assert!(missing.is_empty());
+}
+
+#[tokio::test]
 async fn coral_inputs_exposes_variable_values_and_defaults() {
     let sources = vec![build_demo_source(
         &[("ACCOUNT_ID", "123456")],


### PR DESCRIPTION
## Intent

Add typed engine discovery for source-scoped table functions, matching the existing `CoralQuery::list_tables` path while preserving the existing `coral.table_functions` SQL catalog table.

## What Changed

- Added `TableFunctionInfo`, argument metadata, and result-column metadata contracts in `coral-engine`.
- Added `CoralQuery::list_table_functions` with exact source/function filters.
- Collect table-function metadata during runtime build from registered sources.
- Replaced stored `arguments_json` / `result_columns_json` strings with typed registered metadata, then derive the existing `coral.table_functions` JSON columns from that typed data.
- Added engine tests covering the SQL catalog table and the new typed listing API.

## Boundaries

This PR is intentionally `coral-engine` only. It does not change `coral-api`, gRPC, app composition, MCP tools, CLI behavior, or docs surfaces.

## Validation

- `git diff --check`
- `cargo check -p coral-engine`
- `cargo test -p coral-engine table_functions`
- `make rust-checks`