### PR TITLE
feat(api): expose table function metadata

### DIFF
--- a/crates/coral-api/proto/coral/v1/catalog.proto
+++ b/crates/coral-api/proto/coral/v1/catalog.proto
@@ -55,3 +55,41 @@ message TableSummary {
   // User-facing query guidance.
   string guide = 6;
 }
+
+// An argument accepted by a source-scoped table function.
+message TableFunctionArgument {
+  // Argument name as used in a named SQL function call.
+  string name = 1;
+  // Whether callers must provide this argument.
+  bool required = 2;
+  // Allowed values, if the source declares an enum-like value set.
+  repeated string values = 3;
+}
+
+// A result column returned by a source-scoped table function.
+message TableFunctionResultColumn {
+  // Column name returned by the table function.
+  string name = 1;
+  // The DataFusion/Arrow data type rendered as text.
+  string data_type = 2;
+  // Whether the column can contain null values.
+  bool nullable = 3;
+  // Human-readable column description.
+  string description = 4;
+}
+
+// A source-scoped table function in one workspace.
+message TableFunction {
+  // Workspace whose source set makes this function visible.
+  Workspace workspace = 1;
+  // The schema name used for SQL qualification.
+  string schema_name = 2;
+  // The bare function name within the schema.
+  string name = 3;
+  // The user-facing function description.
+  string description = 4;
+  // Arguments accepted by the function.
+  repeated TableFunctionArgument arguments = 5;
+  // Columns returned by the function.
+  repeated TableFunctionResultColumn result_columns = 6;
+}

--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -92,10 +92,32 @@ message ListTablesResponse {
   repeated TableSummary table_summaries = 3;
 }
 
+// Lists all query-visible table functions in one workspace.
+message ListTableFunctionsRequest {
+  // Workspace whose current query-visible table functions should be listed.
+  Workspace workspace = 1;
+  // Optional exact schema/source name.
+  string schema_name = 2;
+  // Optional page request. Missing or zero limit keeps the unbounded behavior.
+  PaginationRequest pagination = 3;
+  // Optional exact function name. If set without `schema_name`, matches across all schemas.
+  string function_name = 4;
+}
+
+// Returns the query-visible table functions in one workspace.
+message ListTableFunctionsResponse {
+  // Query-visible table functions.
+  repeated TableFunction table_functions = 1;
+  // Page metadata for the table function list.
+  PaginationResponse pagination = 2;
+}
+
 // SQL query execution APIs.
 service QueryService {
   // Lists query-visible tables for one workspace.
   rpc ListTables(ListTablesRequest) returns (ListTablesResponse);
+  // Lists query-visible table functions for one workspace.
+  rpc ListTableFunctions(ListTableFunctionsRequest) returns (ListTableFunctionsResponse);
   // Executes one read-only SQL statement and returns the full result set.
   rpc ExecuteSql(ExecuteSqlRequest) returns (ExecuteSqlResponse);
   // Explains one read-only SQL statement without executing it.

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
-    QuerySource, SourceValidationReport, StatusCode, TableInfo,
+    QuerySource, SourceValidationReport, StatusCode, TableFunctionInfo, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::{KeyValue, trace::Status as OtelStatus};
@@ -70,6 +70,21 @@ impl QueryManager {
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_config(&sources);
         CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
+            .await
+            .map_err(QueryManagerError::Core)
+    }
+
+    pub(crate) async fn list_table_functions(
+        &self,
+        workspace_name: &WorkspaceName,
+        schema_filter: Option<&str>,
+        function_filter: Option<&str>,
+    ) -> Result<Vec<TableFunctionInfo>, QueryManagerError> {
+        let sources = self
+            .load_query_sources(workspace_name)
+            .map_err(QueryManagerError::App)?;
+        let runtime = self.runtime_config(&sources);
+        CoralQuery::list_table_functions(&sources, runtime, schema_filter, function_filter)
             .await
             .map_err(QueryManagerError::Core)
     }

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -6,15 +6,16 @@ use arrow::record_batch::RecordBatch;
 use coral_api::v1::query_service_server::QueryService as QueryServiceApi;
 use coral_api::v1::{
     ExecuteSqlRequest, ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse,
-    ListTablesRequest, ListTablesResponse, PaginationResponse, QueryPlan as QueryPlanProto,
+    ListTableFunctionsRequest, ListTableFunctionsResponse, ListTablesRequest, ListTablesResponse,
+    PaginationResponse, QueryPlan as QueryPlanProto,
 };
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::core_status;
 use crate::query::manager::QueryManager;
 use crate::transport::{
-    grpc_span, instrument_grpc, query_status, table_summary_to_proto, table_to_proto,
-    workspace_name_from_proto,
+    grpc_span, instrument_grpc, query_status, table_function_to_proto, table_summary_to_proto,
+    table_to_proto, workspace_name_from_proto,
 };
 
 #[derive(Clone)]
@@ -61,7 +62,7 @@ impl QueryServiceApi for QueryService {
             let total = tables.len();
             let offset = pagination.offset as usize;
             let limit = pagination.limit as usize;
-            let page = paginate_tables(tables, offset, limit);
+            let page = paginate_items(tables, offset, limit);
             let returned_count = page.len();
             let has_more = pagination.limit != 0 && offset.saturating_add(returned_count) < total;
             let (tables, table_summaries) = if request.omit_columns {
@@ -82,6 +83,59 @@ impl QueryServiceApi for QueryService {
             Ok(Response::new(ListTablesResponse {
                 tables,
                 table_summaries,
+                pagination: Some(PaginationResponse {
+                    total_count: count_to_u32(total),
+                    limit: pagination.limit,
+                    offset: pagination.offset,
+                    has_more,
+                    next_offset: if has_more {
+                        count_to_u32(offset.saturating_add(returned_count))
+                    } else {
+                        0
+                    },
+                }),
+            }))
+        })
+        .await
+    }
+
+    async fn list_table_functions(
+        &self,
+        request: Request<ListTableFunctionsRequest>,
+    ) -> Result<Response<ListTableFunctionsResponse>, Status> {
+        let span = grpc_span(&request);
+        let queries = self.queries.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let pagination = request.pagination.unwrap_or_default();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let schema_name = request.schema_name.trim();
+            let schema_name = if schema_name.is_empty() {
+                None
+            } else {
+                Some(schema_name)
+            };
+            let function_name = request.function_name.trim();
+            let function_name = if function_name.is_empty() {
+                None
+            } else {
+                Some(function_name)
+            };
+            let functions = queries
+                .list_table_functions(&workspace_name, schema_name, function_name)
+                .await
+                .map_err(query_status)?;
+            let total = functions.len();
+            let offset = pagination.offset as usize;
+            let limit = pagination.limit as usize;
+            let page = paginate_items(functions, offset, limit);
+            let returned_count = page.len();
+            let has_more = pagination.limit != 0 && offset.saturating_add(returned_count) < total;
+            Ok(Response::new(ListTableFunctionsResponse {
+                table_functions: page
+                    .into_iter()
+                    .map(|function| table_function_to_proto(&workspace_name, function))
+                    .collect(),
                 pagination: Some(PaginationResponse {
                     total_count: count_to_u32(total),
                     limit: pagination.limit,
@@ -146,12 +200,8 @@ impl QueryServiceApi for QueryService {
     }
 }
 
-fn paginate_tables(
-    tables: Vec<coral_engine::TableInfo>,
-    offset: usize,
-    limit: usize,
-) -> Vec<coral_engine::TableInfo> {
-    let iter = tables.into_iter().skip(offset);
+fn paginate_items<T>(items: Vec<T>, offset: usize, limit: usize) -> Vec<T> {
+    let iter = items.into_iter().skip(offset);
     if limit == 0 {
         iter.collect()
     } else {

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -5,8 +5,9 @@ use std::future::Future;
 use coral_api::{
     CORAL_ERROR_DOMAIN, grpc_response_status_code,
     v1::{
-        Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableSummary,
-        ValidateSourceResponse, Workspace, query_test_result,
+        Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableFunction,
+        TableFunctionArgument, TableFunctionResultColumn, TableSummary, ValidateSourceResponse,
+        Workspace, query_test_result,
     },
 };
 use opentelemetry::propagation::Extractor;
@@ -261,6 +262,37 @@ pub(crate) fn table_summary_to_proto(
         description: table.description,
         required_filters: table.required_filters,
         guide: table.guide,
+    }
+}
+
+pub(crate) fn table_function_to_proto(
+    workspace_name: &WorkspaceName,
+    function: coral_engine::TableFunctionInfo,
+) -> TableFunction {
+    TableFunction {
+        workspace: Some(workspace_to_proto(workspace_name)),
+        schema_name: function.schema_name,
+        name: function.function_name,
+        description: function.description,
+        arguments: function
+            .arguments
+            .into_iter()
+            .map(|argument| TableFunctionArgument {
+                name: argument.name,
+                required: argument.required,
+                values: argument.values,
+            })
+            .collect(),
+        result_columns: function
+            .result_columns
+            .into_iter()
+            .map(|column| TableFunctionResultColumn {
+                name: column.name,
+                data_type: column.data_type,
+                nullable: column.nullable,
+                description: column.description,
+            })
+            .collect(),
     }
 }
 

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -251,6 +251,79 @@ pub(crate) fn fixture_manifest_with_multiple_tables_yaml(root: &Path) -> String 
     }))
 }
 
+pub(crate) fn fixture_manifest_with_functions_yaml() -> String {
+    manifest_yaml(&json!({
+        "name": "searchy",
+        "version": "0.1.0",
+        "dsl_version": 3,
+        "backend": "http",
+        "base_url": "https://example.com",
+        "tables": [{
+            "name": "placeholder",
+            "description": "Placeholder table",
+            "request": {
+                "method": "GET",
+                "path": "/placeholder",
+            },
+            "columns": [
+                { "name": "id", "type": "Utf8" },
+            ],
+        }],
+        "functions": [
+            {
+                "name": "lookup_issue",
+                "description": "Lookup issue",
+                "args": [
+                    {
+                        "name": "number",
+                        "required": true,
+                        "bind": { "arg": "number" },
+                    },
+                ],
+                "request": {
+                    "method": "GET",
+                    "path": "/issues/{{arg.number}}",
+                },
+                "response": {},
+                "columns": [
+                    { "name": "title", "type": "Utf8", "description": "Issue title" },
+                ],
+            },
+            {
+                "name": "search_issues",
+                "description": "Search issues",
+                "args": [
+                    {
+                        "name": "q",
+                        "required": true,
+                        "bind": { "arg": "q" },
+                    },
+                    {
+                        "name": "mode",
+                        "values": ["lexical", "semantic", "hybrid"],
+                        "bind": { "arg": "search_type" },
+                    },
+                ],
+                "request": {
+                    "method": "GET",
+                    "path": "/search/issues",
+                    "query": [
+                        { "name": "q", "from": "arg", "key": "q" },
+                        { "name": "search_type", "from": "arg", "key": "search_type" },
+                    ],
+                },
+                "response": {
+                    "rows_path": ["items"],
+                },
+                "columns": [
+                    { "name": "title", "type": "Utf8", "description": "Issue title" },
+                    { "name": "score", "type": "Float64" },
+                ],
+            },
+        ],
+    }))
+}
+
 pub(crate) fn fixture_manifest_with_test_queries_yaml(
     root: &Path,
     test_queries: &[&str],

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -9,18 +9,19 @@ use std::fs;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     ExplainSqlRequest, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
-    ListTablesRequest, PaginationRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin,
-    SourceSecret, SourceVariable, ValidateSourceRequest, Workspace, query_test_result,
+    ListTableFunctionsRequest, ListTablesRequest, PaginationRequest, QueryTestFailure,
+    QueryTestSuccess, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest, Workspace,
+    query_test_result,
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
 use tonic::Request;
 
 use crate::harness::{
-    FailingHttpFixture, GrpcHarness, fixture_manifest_with_inputs_yaml,
-    fixture_manifest_with_multiple_tables_yaml, fixture_manifest_with_required_inputs_yaml,
-    fixture_manifest_with_test_queries_yaml, fixture_manifest_yaml, invalid_manifest_yaml,
-    source_dir,
+    FailingHttpFixture, GrpcHarness, fixture_manifest_with_functions_yaml,
+    fixture_manifest_with_inputs_yaml, fixture_manifest_with_multiple_tables_yaml,
+    fixture_manifest_with_required_inputs_yaml, fixture_manifest_with_test_queries_yaml,
+    fixture_manifest_yaml, invalid_manifest_yaml, source_dir,
 };
 
 #[tokio::test]
@@ -335,6 +336,89 @@ async fn assert_exact_table_filter(harness: &GrpcHarness) {
     assert_eq!(exact_table.tables[0].schema_name, "local_messages");
     assert_eq!(exact_table.tables[0].name, "messages");
     assert!(!exact_table.tables[0].columns.is_empty());
+}
+
+#[tokio::test]
+async fn list_table_functions_supports_filters_and_pagination() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_with_functions_yaml(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let page = harness
+        .query_client()
+        .list_table_functions(Request::new(ListTableFunctionsRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "searchy".to_string(),
+            function_name: String::new(),
+            pagination: Some(PaginationRequest {
+                limit: 1,
+                offset: 0,
+            }),
+        }))
+        .await
+        .expect("paginated list table functions")
+        .into_inner();
+    let page_pagination = page.pagination.as_ref().expect("page pagination");
+    assert_eq!(page_pagination.total_count, 2);
+    assert_eq!(page_pagination.limit, 1);
+    assert_eq!(page_pagination.offset, 0);
+    assert!(page_pagination.has_more);
+    assert_eq!(page_pagination.next_offset, 1);
+    assert_eq!(page.table_functions.len(), 1);
+    assert_eq!(page.table_functions[0].schema_name, "searchy");
+    assert_eq!(page.table_functions[0].name, "lookup_issue");
+    assert_eq!(page.table_functions[0].arguments[0].name, "number");
+    assert!(page.table_functions[0].arguments[0].required);
+    assert_eq!(page.table_functions[0].result_columns[0].name, "title");
+    assert_eq!(
+        page.table_functions[0].result_columns[0].description,
+        "Issue title"
+    );
+
+    let exact = harness
+        .query_client()
+        .list_table_functions(Request::new(ListTableFunctionsRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "searchy".to_string(),
+            function_name: "search_issues".to_string(),
+            pagination: None,
+        }))
+        .await
+        .expect("exact list table functions")
+        .into_inner();
+    let function = exact.table_functions.first().expect("exact table function");
+    assert_eq!(
+        exact.pagination.as_ref().expect("pagination").total_count,
+        1
+    );
+    assert_eq!(function.name, "search_issues");
+    assert_eq!(
+        function.arguments[1].values,
+        ["lexical", "semantic", "hybrid"]
+    );
+    assert_eq!(function.result_columns[1].data_type, "Float64");
+
+    let missing = harness
+        .query_client()
+        .list_table_functions(Request::new(ListTableFunctionsRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "searchy".to_string(),
+            function_name: "missing".to_string(),
+            pagination: None,
+        }))
+        .await
+        .expect("missing list table functions")
+        .into_inner();
+    assert_eq!(
+        missing.pagination.as_ref().expect("pagination").total_count,
+        0
+    );
+    assert!(missing.table_functions.is_empty());
 }
 
 #[tokio::test]

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -18,10 +18,10 @@ use coral_api::v1::{
     DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, ExecuteSqlRequest,
     ExecuteSqlResponse, ExplainSqlRequest, ExplainSqlResponse, GetSourceInfoRequest,
     GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
-    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, ListTablesRequest,
-    ListTablesResponse, PaginationResponse, QueryPlan, Source, SourceInfo, SourceInputKind,
-    SourceInputSpec, SourceOrigin, Table, TableSummary, ValidateSourceRequest,
-    ValidateSourceResponse, Workspace,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, ListTableFunctionsRequest,
+    ListTableFunctionsResponse, ListTablesRequest, ListTablesResponse, PaginationResponse,
+    QueryPlan, Source, SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, Table,
+    TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace,
 };
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -391,6 +391,7 @@ impl MockServerConfig {
 struct Captured {
     execute_sql: Mutex<Vec<ExecuteSqlRequest>>,
     list_tables: Mutex<Vec<ListTablesRequest>>,
+    list_table_functions: Mutex<Vec<ListTableFunctionsRequest>>,
     discover_sources: Mutex<Vec<DiscoverSourcesRequest>>,
     list_sources: Mutex<Vec<ListSourcesRequest>>,
     get_source: Mutex<Vec<GetSourceRequest>>,
@@ -480,6 +481,21 @@ impl QueryService for MockQueryService {
                 has_more,
                 next_offset,
             }),
+        }))
+    }
+
+    async fn list_table_functions(
+        &self,
+        request: Request<ListTableFunctionsRequest>,
+    ) -> Result<Response<ListTableFunctionsResponse>, Status> {
+        self.captured
+            .list_table_functions
+            .lock()
+            .expect("list_table_functions capture")
+            .push(request.into_inner());
+        Ok(Response::new(ListTableFunctionsResponse {
+            table_functions: Vec::new(),
+            pagination: Some(PaginationResponse::default()),
         }))
     }
 


### PR DESCRIPTION
## Intent

Expose PR1's typed table-function metadata through the local API/app transport path, mirroring the existing `ListTables` discovery shape without adding MCP tools yet.

## What Changed

- Added protobuf metadata messages for table functions, arguments, and result columns.
- Added `QueryService.ListTableFunctions` with exact schema/function filters and offset pagination.
- Added `QueryManager::list_table_functions` and gRPC service plumbing over the engine API.
- Added transport conversion from engine table-function metadata to protobuf messages.
- Updated the CLI test mock for the expanded generated `QueryService` trait.
- Added a gRPC regression test covering filtering, pagination, enum argument values, result columns, and descriptions.

## Boundaries

This PR intentionally stops at API/app transport. It does not add MCP `list_table_functions` or `search_table_functions`, CLI commands, docs, or new source behavior.

## Size

This is 353 additions / 23 deletions against PR1. The bulk is the gRPC fixture and regression test for the new transport contract.

## Validation

- `git diff --check`
- `cargo check -p coral-app`
- `cargo check -p coral-client`
- `cargo test -p coral-app list_table_functions_supports_filters_and_pagination`
- `make rust-checks`