### PR TITLE
fix: address backwards compatibility issue in #421

### DIFF
--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -153362,8 +153362,12 @@ tables:
         type: Utf8
         nullable: true
         virtual: false
+        description: >-
+          Deprecated: use the user field instead
         expr:
-          kind: current_row
+          kind: path
+          path:
+            - user
       - name: starred_at
         type: Utf8
         nullable: true
@@ -153373,26 +153377,15 @@ tables:
           kind: path
           path:
             - starred_at
-      - name: user_login
+      - name: user
         type: Utf8
         nullable: true
         virtual: false
-        description: GitHub login of the user who starred the repository.
+        description: User object for the Github user who starred the repo
         expr:
           kind: path
           path:
             - user
-            - login
-      - name: user_id
-        type: Int64
-        nullable: true
-        virtual: false
-        description: GitHub numeric user ID of the stargazer.
-        expr:
-          kind: path
-          path:
-            - user
-            - id
       - name: owner
         type: Utf8
         nullable: true


### PR DESCRIPTION
Addresses issues in #421:

1. The `json` column is retained, and keeps its existing shape, but is marked as deprecated (mostly because the name doesn't really mean anything)
2. Adds a new `user` column, which contains the same data as the `json` column (but has a more intuitive name)
3. Removes the columns extracting specific fields from the user object; callers can do this with JSON operators, as they could previously.

The net resule of this PR plus #421 is that `github.stargazers` gains two new columns:

1. `starred_at`: timestamp showing when the repo was starred
2. `user`: an alias for the existing `json` column, with a more intuitive name

## Test

```
$ cargo run -p coral-cli -- sql "select json_get_str(user, 'login') as login, starred_at from github.stargazers where owner = 'withcoral' and repo = 'coral' limit 3"
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.50s
     Running `target/debug/coral sql 'select json_get_str(user, '\''login'\'') as user, starred_at from github.stargazers where owner = '\''withcoral'\'' and repo = '\''coral'\'' limit 3'`
+----------------+----------------------+
| login          | starred_at           |
+----------------+----------------------+
| m3hen          | 2026-04-03T21:23:09Z |
| AlbertQM       | 2026-04-04T06:13:49Z |
| sauldhernandez | 2026-04-06T07:37:25Z |
+----------------+----------------------+
```