### PR TITLE
feat(mcp): search table function metadata

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -239,6 +239,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             "list_tables",
             "search_tables",
             "list_table_functions",
+            "search_table_functions",
             "describe_table",
             "list_columns"
         ]
@@ -310,6 +311,7 @@ async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn s
             "list_tables",
             "search_tables",
             "list_table_functions",
+            "search_table_functions",
             "describe_table",
             "list_columns",
             "feedback"

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -66,6 +66,7 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs.
 - `search_tables` searches table names, descriptions, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the table name or required filters.
 - `list_table_functions` shows queryable source-scoped table functions in pages; pass `schema`, `function`, `limit`, and `offset` to narrow large catalogs.
+- `search_table_functions` searches table function names, descriptions, arguments, and result columns with a Rust regex; use it when you know part of a provider-native search or lookup capability.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
 - `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively.
 - `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, paginated `list_tables`, `search_tables`, `list_table_functions`, `describe_table`, `list_columns`, and optionally `feedback`
+//! - tools: `sql`, paginated `list_tables`, `search_tables`, `list_table_functions`, `search_table_functions`, `describe_table`, `list_columns`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -26,14 +26,15 @@ use tonic::Request;
 use crate::{
     McpOptions,
     surface::{
-        ColumnSummary, TableSummary, build_tool_result, compile_metadata_regex,
-        describe_table_arguments, describe_table_tool, feedback_tool,
+        ColumnSummary, TableFunctionSummary, TableSummary, build_tool_result,
+        compile_metadata_regex, describe_table_arguments, describe_table_tool, feedback_tool,
         format_schema_table_equivalent, guide_resource, guide_resource_content,
         initial_instructions, internal_status, list_columns_arguments, list_columns_tool,
         list_table_functions_arguments, list_table_functions_tool, list_tables_arguments,
         list_tables_tool, list_tables_value, page_items, paged_value, required_string_argument,
-        search_tables_arguments, search_tables_tool, sql_tool, status_to_error_data,
-        tables_resource, tables_resource_content, tool_error_from_status, tool_error_result,
+        search_table_functions_arguments, search_table_functions_tool, search_tables_arguments,
+        search_tables_tool, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
     },
     telemetry,
 };
@@ -41,6 +42,7 @@ use crate::{
 const LIST_TABLES_COUNT_LIMIT: u32 = 1;
 const LIST_TABLES_UNBOUNDED_LIMIT: u32 = 0;
 const LIST_TABLE_FUNCTIONS_COUNT_LIMIT: u32 = 1;
+const LIST_TABLE_FUNCTIONS_UNBOUNDED_LIMIT: u32 = 0;
 
 struct LoadTablesParams<'a> {
     schema_name: Option<&'a str>,
@@ -154,6 +156,23 @@ impl CoralMcpServer {
             })
             .await?
             .table_summaries)
+    }
+
+    async fn load_table_function_summaries(
+        &self,
+        schema_name: Option<&str>,
+    ) -> Result<Vec<ProtoTableFunction>, tonic::Status> {
+        Ok(self
+            .load_table_functions(LoadTableFunctionsParams {
+                schema_name,
+                function_name: None,
+                pagination: PaginationRequest {
+                    limit: LIST_TABLE_FUNCTIONS_UNBOUNDED_LIMIT,
+                    offset: 0,
+                },
+            })
+            .await?
+            .table_functions)
     }
 
     async fn load_exact_table(
@@ -305,6 +324,37 @@ impl CoralMcpServer {
         }
     }
 
+    async fn search_table_functions_tool_result(
+        &self,
+        request_arguments: Option<&Map<String, Value>>,
+    ) -> Result<ToolCallOutcome, ErrorData> {
+        let arguments = search_table_functions_arguments(request_arguments)?;
+        let regex = compile_metadata_regex(&arguments.pattern, arguments.ignore_case)?;
+        match self
+            .load_table_function_summaries(arguments.schema.as_deref())
+            .await
+        {
+            Ok(functions) => {
+                let mut matches = Vec::new();
+                for function in &functions {
+                    let summary = TableFunctionSummary::from_proto(function);
+                    let matched_fields = summary.matched_fields(&regex);
+                    if !matched_fields.is_empty() {
+                        matches.push(summary.search_result_value(&matched_fields));
+                    }
+                }
+                Ok(ToolCallOutcome::Success(paged_value(
+                    "table_functions",
+                    page_items(matches, arguments.pagination),
+                )))
+            }
+            Err(status) => Ok(ToolCallOutcome::ToolError {
+                operation: "Table function search",
+                status,
+            }),
+        }
+    }
+
     async fn describe_table_tool_result(
         &self,
         request_arguments: Option<&Map<String, Value>>,
@@ -387,6 +437,10 @@ impl CoralMcpServer {
             }
             "search_tables" => {
                 self.search_tables_tool_result(request.arguments.as_ref())
+                    .await
+            }
+            "search_table_functions" => {
+                self.search_table_functions_tool_result(request.arguments.as_ref())
                     .await
             }
             "describe_table" => {
@@ -652,6 +706,7 @@ impl ServerHandler for CoralMcpServer {
                 list_tables_tool(visible_table_count),
                 search_tables_tool(visible_table_count),
                 list_table_functions_tool(visible_function_count),
+                search_table_functions_tool(visible_function_count),
                 describe_table_tool(),
                 list_columns_tool(),
             ];

--- a/crates/coral-mcp/src/surface/discovery.rs
+++ b/crates/coral-mcp/src/surface/discovery.rs
@@ -1,5 +1,6 @@
 use coral_api::v1::{
-    Column as ProtoColumn, Table as ProtoTable, TableSummary as ProtoTableSummary,
+    Column as ProtoColumn, Table as ProtoTable, TableFunction as ProtoTableFunction,
+    TableSummary as ProtoTableSummary,
 };
 use regex::{Regex, RegexBuilder};
 use rmcp::ErrorData;
@@ -35,6 +36,30 @@ pub(crate) struct TableSummary {
     pub(crate) description: String,
     pub(crate) guide: String,
     pub(crate) required_filters: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TableFunctionSummary {
+    pub(crate) schema_name: String,
+    pub(crate) function_name: String,
+    pub(crate) description: String,
+    pub(crate) arguments: Vec<TableFunctionArgumentSummary>,
+    pub(crate) result_columns: Vec<TableFunctionResultColumnSummary>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TableFunctionArgumentSummary {
+    pub(crate) name: String,
+    pub(crate) required: bool,
+    pub(crate) values: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct TableFunctionResultColumnSummary {
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) nullable: bool,
+    pub(crate) description: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -151,6 +176,89 @@ impl TableSummary {
             "name": format!("{}.{}", self.schema_name, self.table_name),
             "description": self.description,
             "required_filters": self.required_filters,
+        })
+    }
+}
+
+impl TableFunctionSummary {
+    pub(crate) fn from_proto(function: &ProtoTableFunction) -> Self {
+        Self {
+            schema_name: function.schema_name.clone(),
+            function_name: function.name.clone(),
+            description: function.description.clone(),
+            arguments: function
+                .arguments
+                .iter()
+                .map(|argument| TableFunctionArgumentSummary {
+                    name: argument.name.clone(),
+                    required: argument.required,
+                    values: argument.values.clone(),
+                })
+                .collect(),
+            result_columns: function
+                .result_columns
+                .iter()
+                .map(|column| TableFunctionResultColumnSummary {
+                    name: column.name.clone(),
+                    data_type: column.data_type.clone(),
+                    nullable: column.nullable,
+                    description: column.description.clone(),
+                })
+                .collect(),
+        }
+    }
+
+    pub(crate) fn matched_fields(&self, regex: &Regex) -> Vec<&'static str> {
+        let name = format!("{}.{}", self.schema_name, self.function_name);
+        let candidates = [
+            ("schema_name", self.schema_name.as_str()),
+            ("function_name", self.function_name.as_str()),
+            ("name", name.as_str()),
+            ("description", self.description.as_str()),
+        ];
+        let mut matches = candidates
+            .into_iter()
+            .filter_map(|(field, value)| regex.is_match(value).then_some(field))
+            .collect::<Vec<_>>();
+        if self.arguments.iter().any(|argument| {
+            regex.is_match(&argument.name)
+                || argument.values.iter().any(|value| regex.is_match(value))
+        }) {
+            matches.push("arguments");
+        }
+        if self.result_columns.iter().any(|column| {
+            regex.is_match(&column.name)
+                || regex.is_match(&column.data_type)
+                || regex.is_match(&column.description)
+        }) {
+            matches.push("result_columns");
+        }
+        matches
+    }
+
+    pub(crate) fn search_result_value(&self, matched_fields: &[&'static str]) -> Value {
+        json!({
+            "schema_name": self.schema_name,
+            "function_name": self.function_name,
+            "name": format!("{}.{}", self.schema_name, self.function_name),
+            "sql_reference": format_schema_table_equivalent(&self.schema_name, &self.function_name),
+            "description": self.description,
+            "arguments": self.arguments.iter().map(|argument| {
+                json!({
+                    "name": argument.name,
+                    "required": argument.required,
+                    "values": argument.values,
+                })
+            }).collect::<Vec<_>>(),
+            "result_columns": self.result_columns.iter().map(|column| {
+                json!({
+                    "column_name": column.name,
+                    "data_type": column.data_type,
+                    "is_nullable": column.nullable,
+                    "description": column.description,
+                })
+            }).collect::<Vec<_>>(),
+            "matched_fields": matched_fields,
         })
     }
 }

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -6,8 +6,8 @@ mod resources;
 mod tools;
 
 pub(crate) use discovery::{
-    ColumnSummary, Pagination, TableSummary, compile_metadata_regex, page_items, paged_value,
-    parse_pagination, parse_pagination_with_limits,
+    ColumnSummary, Pagination, TableFunctionSummary, TableSummary, compile_metadata_regex,
+    page_items, paged_value, parse_pagination, parse_pagination_with_limits,
 };
 pub(crate) use errors::{
     internal_status, status_to_error_data, tool_error_from_status, tool_error_result,
@@ -20,5 +20,6 @@ pub(crate) use tools::{
     build_tool_result, describe_table_arguments, describe_table_tool, feedback_tool,
     list_columns_arguments, list_columns_tool, list_table_functions_arguments,
     list_table_functions_tool, list_tables_arguments, list_tables_tool, required_string_argument,
-    search_tables_arguments, search_tables_tool, sql_tool,
+    search_table_functions_arguments, search_table_functions_tool, search_tables_arguments,
+    search_tables_tool, sql_tool,
 };

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{ListTablesResponse, Source, Table, TableSummary};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables`, `search_tables`, `list_table_functions`, `describe_table`, and `list_columns` to inspect queryable tables and source-scoped table functions, and use `sql` for final queries.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables`, `search_tables`, `list_table_functions`, `search_table_functions`, `describe_table`, and `list_columns` to inspect queryable tables and source-scoped table functions, and use `sql` for final queries.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -29,6 +29,13 @@ pub(crate) struct SearchTablesArguments {
     pub(crate) pagination: Pagination,
 }
 
+pub(crate) struct SearchTableFunctionsArguments {
+    pub(crate) pattern: String,
+    pub(crate) schema: Option<String>,
+    pub(crate) ignore_case: bool,
+    pub(crate) pagination: Pagination,
+}
+
 pub(crate) struct DescribeTableArguments {
     pub(crate) schema: String,
     pub(crate) table: String,
@@ -189,6 +196,53 @@ pub(crate) fn list_table_functions_tool(visible_function_count: usize) -> Tool {
     .with_raw_output_schema(list_table_functions_output_schema())
     .with_annotations(
         ToolAnnotations::with_title("List Table Functions")
+            .read_only(true)
+            .destructive(false)
+            .idempotent(true)
+            .open_world(false),
+    )
+}
+
+pub(crate) fn search_table_functions_tool(visible_function_count: usize) -> Tool {
+    Tool::new(
+        "search_table_functions",
+        search_table_functions_description(visible_function_count),
+        json_object_schema(&json!({
+            "type": "object",
+            "required": ["pattern"],
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "description": "Rust regex pattern to match table function metadata."
+                },
+                "schema": {
+                    "type": "string",
+                    "description": "Optional exact schema/source name to search."
+                },
+                "ignore_case": {
+                    "type": "boolean",
+                    "description": "Whether regex matching is case-insensitive. Defaults to true."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum table functions to return, from 1 to 100. Defaults to 20.",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 20
+                },
+                "offset": {
+                    "type": "integer",
+                    "description": "Number of matching table functions to skip. Defaults to 0.",
+                    "minimum": 0,
+                    "maximum": u32::MAX,
+                    "default": 0
+                }
+            }
+        })),
+    )
+    .with_raw_output_schema(search_table_functions_output_schema())
+    .with_annotations(
+        ToolAnnotations::with_title("Search Table Functions")
             .read_only(true)
             .destructive(false)
             .idempotent(true)
@@ -360,6 +414,17 @@ pub(crate) fn search_tables_arguments(
     })
 }
 
+pub(crate) fn search_table_functions_arguments(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<SearchTableFunctionsArguments, ErrorData> {
+    Ok(SearchTableFunctionsArguments {
+        pattern: required_string_argument(arguments, "pattern")?,
+        schema: optional_string_argument(arguments, "schema")?,
+        ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
+        pagination: parse_pagination_with_limits(arguments, 20, 100)?,
+    })
+}
+
 pub(crate) fn describe_table_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<DescribeTableArguments, ErrorData> {
@@ -412,6 +477,12 @@ fn list_tables_description(visible_table_count: usize) -> String {
 fn search_tables_description(visible_table_count: usize) -> String {
     format!(
         "Search queryable table metadata with a Rust regex. {visible_table_count} table(s) are currently visible."
+    )
+}
+
+fn search_table_functions_description(visible_function_count: usize) -> String {
+    format!(
+        "Search queryable source-scoped table function metadata with a Rust regex. {visible_function_count} table function(s) are currently visible."
     )
 }
 
@@ -487,6 +558,99 @@ fn search_tables_output_schema() -> Arc<Map<String, Value>> {
 }
 
 fn list_table_functions_output_schema() -> Arc<Map<String, Value>> {
+    paginated_table_functions_output_schema(&table_function_output_schema(false))
+}
+
+fn search_table_functions_output_schema() -> Arc<Map<String, Value>> {
+    paginated_table_functions_output_schema(&table_function_output_schema(true))
+}
+
+fn table_function_output_schema(include_matched_fields: bool) -> Value {
+    let mut required = vec![
+        "schema_name",
+        "function_name",
+        "name",
+        "sql_reference",
+        "description",
+        "arguments",
+        "result_columns",
+    ];
+    if include_matched_fields {
+        required.push("matched_fields");
+    }
+    let mut properties = Map::from_iter([
+        ("schema_name".to_string(), json!({ "type": "string" })),
+        ("function_name".to_string(), json!({ "type": "string" })),
+        ("name".to_string(), json!({ "type": "string" })),
+        ("sql_reference".to_string(), json!({ "type": "string" })),
+        ("description".to_string(), json!({ "type": "string" })),
+        (
+            "arguments".to_string(),
+            json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["name", "required", "values"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": { "type": "string" },
+                        "required": { "type": "boolean" },
+                        "values": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        }
+                    }
+                }
+            }),
+        ),
+        (
+            "result_columns".to_string(),
+            json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["column_name", "data_type", "is_nullable", "description"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "column_name": { "type": "string" },
+                        "data_type": { "type": "string" },
+                        "is_nullable": { "type": "boolean" },
+                        "description": { "type": "string" }
+                    }
+                }
+            }),
+        ),
+    ]);
+    if include_matched_fields {
+        properties.insert(
+            "matched_fields".to_string(),
+            json!({
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "schema_name",
+                        "function_name",
+                        "name",
+                        "description",
+                        "arguments",
+                        "result_columns"
+                    ]
+                }
+            }),
+        );
+    }
+    json!({
+        "type": "object",
+        "required": required,
+        "additionalProperties": false,
+        "properties": properties,
+    })
+}
+
+fn paginated_table_functions_output_schema(
+    function_item_schema: &Value,
+) -> Arc<Map<String, Value>> {
     json_object_schema(&json!({
         "type": "object",
         "required": ["table_functions", "total", "limit", "offset", "has_more"],
@@ -494,56 +658,7 @@ fn list_table_functions_output_schema() -> Arc<Map<String, Value>> {
         "properties": {
             "table_functions": {
                 "type": "array",
-                "items": {
-                    "type": "object",
-                    "required": [
-                        "schema_name",
-                        "function_name",
-                        "name",
-                        "sql_reference",
-                        "description",
-                        "arguments",
-                        "result_columns"
-                    ],
-                    "additionalProperties": false,
-                    "properties": {
-                        "schema_name": { "type": "string" },
-                        "function_name": { "type": "string" },
-                        "name": { "type": "string" },
-                        "sql_reference": { "type": "string" },
-                        "description": { "type": "string" },
-                        "arguments": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "required": ["name", "required", "values"],
-                                "additionalProperties": false,
-                                "properties": {
-                                    "name": { "type": "string" },
-                                    "required": { "type": "boolean" },
-                                    "values": {
-                                        "type": "array",
-                                        "items": { "type": "string" }
-                                    }
-                                }
-                            }
-                        },
-                        "result_columns": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "required": ["column_name", "data_type", "is_nullable", "description"],
-                                "additionalProperties": false,
-                                "properties": {
-                                    "column_name": { "type": "string" },
-                                    "data_type": { "type": "string" },
-                                    "is_nullable": { "type": "boolean" },
-                                    "description": { "type": "string" }
-                                }
-                            }
-                        }
-                    }
-                }
+                "items": function_item_schema
             },
             "total": {
                 "type": "integer",

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -139,6 +139,15 @@ functions:
     .to_string()
 }
 
+async fn add_table_function_demo_sources(source_client: &mut SourceClient) {
+    add_demo_source(source_client, table_function_manifest_yaml()).await;
+    add_demo_source(
+        source_client,
+        table_function_manifest_yaml().replace("name: searchy", "name: searchable"),
+    )
+    .await;
+}
+
 fn json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
 }
@@ -270,6 +279,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             "list_tables",
             "search_tables",
             "list_table_functions",
+            "search_table_functions",
             "describe_table",
             "list_columns"
         ]
@@ -725,12 +735,7 @@ async fn mcp_list_table_functions_returns_metadata() {
     let mut session = start_session(&temp).await;
     let client = &session.client;
 
-    add_demo_source(&mut session.source_client, table_function_manifest_yaml()).await;
-    add_demo_source(
-        &mut session.source_client,
-        table_function_manifest_yaml().replace("name: searchy", "name: searchable"),
-    )
-    .await;
+    add_table_function_demo_sources(&mut session.source_client).await;
 
     let tools = client.list_all_tools().await.expect("tools");
     let list_tool = tool_by_name(&tools, "list_table_functions");
@@ -799,6 +804,113 @@ async fn mcp_list_table_functions_returns_metadata() {
 }
 
 #[tokio::test]
+async fn mcp_search_table_functions_returns_metadata() {
+    let temp = TempDir::new().expect("temp dir");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
+
+    add_table_function_demo_sources(&mut session.source_client).await;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    let search_tool = tool_by_name(&tools, "search_table_functions");
+    assert!(
+        search_tool
+            .description
+            .as_deref()
+            .expect("search function description")
+            .contains("2 table function(s) are currently visible")
+    );
+
+    let search = client
+        .call_tool(
+            CallToolRequestParams::new("search_table_functions").with_arguments(json_object(
+                &json!({
+                    "pattern": "^SEARCH_ISSUES$",
+                    "schema": "searchy",
+                    "ignore_case": true
+                }),
+            )),
+        )
+        .await
+        .expect("search exact table function");
+    let search = search.structured_content.expect("structured content");
+    assert_eq!(search["total"], 1);
+    assert_eq!(
+        search["table_functions"][0]["name"],
+        "searchy.search_issues"
+    );
+    assert!(
+        search["table_functions"][0]["matched_fields"]
+            .as_array()
+            .expect("matched fields")
+            .iter()
+            .any(|field| field == "function_name")
+    );
+    assert_matches_output_schema(search_tool, &search);
+
+    let search_page = client
+        .call_tool(
+            CallToolRequestParams::new("search_table_functions").with_arguments(json_object(
+                &json!({
+                    "pattern": "hybrid",
+                    "limit": 1
+                }),
+            )),
+        )
+        .await
+        .expect("search table function page");
+    let search_page = search_page.structured_content.expect("structured content");
+    assert_eq!(search_page["total"], 2);
+    assert_eq!(search_page["limit"], 1);
+    assert_eq!(search_page["has_more"], true);
+    assert_eq!(search_page["next_offset"], 1);
+    assert!(
+        search_page["table_functions"][0]["matched_fields"]
+            .as_array()
+            .expect("matched fields")
+            .iter()
+            .any(|field| field == "arguments")
+    );
+    assert_matches_output_schema(search_tool, &search_page);
+
+    let result_column_search = client
+        .call_tool(
+            CallToolRequestParams::new("search_table_functions").with_arguments(json_object(
+                &json!({
+                    "pattern": "issue title",
+                    "schema": "searchy"
+                }),
+            )),
+        )
+        .await
+        .expect("search table function result columns");
+    let result_column_search = result_column_search
+        .structured_content
+        .expect("structured content");
+    assert_eq!(result_column_search["total"], 1);
+    assert!(
+        result_column_search["table_functions"][0]["matched_fields"]
+            .as_array()
+            .expect("matched fields")
+            .iter()
+            .any(|field| field == "result_columns")
+    );
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("search_table_functions").with_arguments(json_object(
+                &json!({
+                    "pattern": "["
+                }),
+            )),
+        )
+        .await
+        .expect_err("invalid regex should fail");
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
 async fn mcp_feedback_tool_persists_blocked_agent_report() {
     let temp = TempDir::new().expect("temp dir");
     let session = start_session_with_options(
@@ -822,12 +934,13 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             "list_tables",
             "search_tables",
             "list_table_functions",
+            "search_table_functions",
             "describe_table",
             "list_columns",
             "feedback"
         ]
     );
-    let feedback_annotations = tools[6].annotations.as_ref().expect("feedback annotations");
+    let feedback_annotations = tools[7].annotations.as_ref().expect("feedback annotations");
     assert_eq!(feedback_annotations.read_only_hint, Some(false));
     assert_eq!(feedback_annotations.destructive_hint, Some(false));
     assert_eq!(feedback_annotations.idempotent_hint, Some(false));

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -18,6 +18,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Tool     | `list_tables`    | List queryable fully qualified tables with pagination   |
 | Tool     | `search_tables`  | Search table metadata with a Rust regex                 |
 | Tool     | `list_table_functions` | List source-scoped table functions with pagination |
+| Tool     | `search_table_functions` | Search table function metadata with a Rust regex |
 | Tool     | `describe_table` | Show compact metadata for one table                     |
 | Tool     | `list_columns`   | List columns for one table with pagination              |
 | Tool     | `feedback`       | Store a local blocked-agent feedback report and upload an anonymous copy to Coral when enabled |
@@ -28,6 +29,7 @@ Clients see the same installed sources and query results as `coral sql`. You set
 `list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. Use each table's `sql_reference` value in `FROM` and `JOIN` clauses. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 `search_tables` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table names, descriptions, guides, and required filters.
 `list_table_functions` returns source-scoped table function metadata in pages and accepts optional `schema`, `function`, `limit`, and `offset` arguments.
+`search_table_functions` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table function names, descriptions, arguments, and result columns.
 `describe_table` accepts exact `schema` and `table` arguments and returns guide text, required filters, and a column count without dumping full columns.
 `list_columns` accepts exact `schema` and `table` arguments plus optional `pattern`, `ignore_case`, `required_only`, `limit`, and `offset` arguments.
 For richer metadata, have the agent query `coral.tables`, `coral.columns`, `coral.table_functions`, and `coral.inputs` over the `sql` tool instead of relying only on discovery tools or `coral://tables`.

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -102,7 +102,7 @@ The MCP stdio server.
 | --------------- | ------------------------------------------------------------------- |
 | MCP protocol    | Tool and resource handlers via the `rmcp` SDK (`server.rs`)         |
 | Surface shaping | Tool/resource/error helpers split across `surface/{mod,tools,resources,errors}.rs` |
-| Tools           | `sql`, `list_tables`, `search_tables`, `list_table_functions`, `describe_table`, `list_columns`, optional `feedback` |
+| Tools           | `sql`, `list_tables`, `search_tables`, `list_table_functions`, `search_table_functions`, `describe_table`, `list_columns`, optional `feedback` |
 | Resources       | `coral://guide`, `coral://tables`                                   |
 
 Uses `coral-client` to reach `coral-app`, same transport as the CLI.

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -24,7 +24,8 @@ This release is intended for single-user local use:
 
 Coral reduces data exposure by keeping execution local and by exposing a narrow
 MCP surface: `sql`, `list_tables`, `search_tables`, `list_table_functions`,
-`describe_table`, `list_columns`, `coral://guide`, and `coral://tables`.
+`search_table_functions`, `describe_table`, `list_columns`, `coral://guide`,
+and `coral://tables`.
 Secret values are not returned through `coral.inputs`; secret rows show only
 whether a value is configured.
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -154,6 +154,7 @@ This server exposes:
 | Tool     | `list_tables`    | List available tables by page    |
 | Tool     | `search_tables`  | Search table metadata by regex   |
 | Tool     | `list_table_functions` | List available table functions by page |
+| Tool     | `search_table_functions` | Search table function metadata by regex |
 | Tool     | `describe_table` | Show compact table metadata      |
 | Tool     | `list_columns`   | List columns for one table       |
 | Resource | `coral://guide`  | Usage guide for agents           |


### PR DESCRIPTION
## Summary
- Add MCP `search_table_functions` alongside `search_tables`, using the same Rust regex, schema narrowing, and local pagination behavior.
- Match table function metadata across schema/function names, descriptions, arguments, and result columns, returning `matched_fields` in structured results.
- Update MCP tool lists, prompts, docs, and focused tests for pagination, case-insensitive matching, result-column matching, invalid regex handling, and output schema compatibility.

## Boundaries
- MCP-only slice stacked on the `list_table_functions` PR.
- No engine, API, app, source-spec, or CLI command changes.
- Keeps regex search semantics parallel to `search_tables`: load unbounded metadata through the API, filter in MCP, then page results.

## Validation
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --features cli-test-server --test mcp`
- `make docs-check`
- `make rust-checks`
- `git diff --check`