### PR TITLE
feat(mcp): hint at table functions during table discovery

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -32,6 +32,17 @@ fn json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
 }
 
+fn assert_has_table_function_hint(value: &Value) {
+    let hints = value["hints"].as_array().expect("hints array");
+    assert!(hints.iter().any(|hint| {
+        hint["suggested_tools"]
+            .as_array()
+            .expect("suggested tools")
+            .iter()
+            .any(|tool| tool == "search_table_functions")
+    }));
+}
+
 async fn start_mcp_client(
     server: &MockServer,
 ) -> Result<RunningService<RoleClient, ()>, Box<dyn std::error::Error>> {
@@ -350,6 +361,7 @@ async fn assert_list_tables_tool(
     assert_eq!(structured_tables["limit"], 50);
     assert_eq!(structured_tables["offset"], 0);
     assert_eq!(structured_tables["has_more"], false);
+    assert_has_table_function_hint(&structured_tables);
     assert_eq!(
         structured_tables["tables"][0]["name"],
         "local_messages.events"
@@ -393,6 +405,7 @@ async fn assert_search_tables_tool(
     .await?;
     assert_eq!(search["total"], 1);
     assert_eq!(search["tables"][0]["name"], "local_messages.messages");
+    assert_has_table_function_hint(&search);
     assert_eq!(
         search["tables"][0]["sql_reference"],
         "local_messages.messages"

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -63,8 +63,8 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Cross-source joins work with standard SQL after source scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs.
-- `search_tables` searches table names, descriptions, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the table name or required filters.
+- `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs. It does not include table functions; if the table you need is missing, inspect table functions too.
+- `search_tables` searches table names, descriptions, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the table name or required filters. It does not search table functions; if it misses a provider-native search, lookup, or range capability, call `search_table_functions`.
 - `list_table_functions` shows queryable source-scoped table functions in pages; pass `schema`, `function`, `limit`, and `offset` to narrow large catalogs.
 - `search_table_functions` searches table function names, descriptions, arguments, and result columns with a Rust regex; use it when you know part of a provider-native search or lookup capability.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -26,9 +26,9 @@ use tonic::Request;
 use crate::{
     McpOptions,
     surface::{
-        ColumnSummary, TableFunctionSummary, TableSummary, build_tool_result,
-        compile_metadata_regex, describe_table_arguments, describe_table_tool, feedback_tool,
-        format_schema_table_equivalent, guide_resource, guide_resource_content,
+        ColumnSummary, TABLE_FUNCTIONS_ARE_SEPARATE, TableFunctionSummary, TableSummary, add_hints,
+        build_tool_result, compile_metadata_regex, describe_table_arguments, describe_table_tool,
+        feedback_tool, format_schema_table_equivalent, guide_resource, guide_resource_content,
         initial_instructions, internal_status, list_columns_arguments, list_columns_tool,
         list_table_functions_arguments, list_table_functions_tool, list_tables_arguments,
         list_tables_tool, list_tables_value, page_items, paged_value, required_string_argument,
@@ -312,10 +312,9 @@ impl CoralMcpServer {
                         matches.push(summary.search_result_value(&matched_fields));
                     }
                 }
-                Ok(ToolCallOutcome::Success(paged_value(
-                    "tables",
-                    page_items(matches, arguments.pagination),
-                )))
+                let mut value = paged_value("tables", page_items(matches, arguments.pagination));
+                add_hints(&mut value, &[TABLE_FUNCTIONS_ARE_SEPARATE]);
+                Ok(ToolCallOutcome::Success(value))
             }
             Err(status) => Ok(ToolCallOutcome::ToolError {
                 operation: "Table search",

--- a/crates/coral-mcp/src/surface/hints.rs
+++ b/crates/coral-mcp/src/surface/hints.rs
@@ -1,0 +1,50 @@
+use serde_json::{Value, json};
+
+pub(crate) struct DiscoveryHint {
+    pub(crate) message: &'static str,
+    pub(crate) suggested_tools: &'static [&'static str],
+}
+
+pub(crate) const TABLE_FUNCTIONS_ARE_SEPARATE: DiscoveryHint = DiscoveryHint {
+    message: "Table discovery only returns ordinary tables. If you do not find the capability you need, also use list_table_functions or search_table_functions; provider-native search, lookup, and range capabilities may exist only as table functions.",
+    suggested_tools: &["list_table_functions", "search_table_functions"],
+};
+
+pub(crate) fn add_hints(value: &mut Value, hints: &[DiscoveryHint]) {
+    if hints.is_empty() {
+        return;
+    }
+    let object = value
+        .as_object_mut()
+        .expect("hinted MCP result should be a JSON object");
+    let existing_hints = object.entry("hints").or_insert_with(|| json!([]));
+    existing_hints
+        .as_array_mut()
+        .expect("hints should be a JSON array")
+        .extend(hints.iter().map(hint_value));
+}
+
+pub(crate) fn hints_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "required": ["message", "suggested_tools"],
+            "additionalProperties": false,
+            "properties": {
+                "message": { "type": "string" },
+                "suggested_tools": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                }
+            }
+        }
+    })
+}
+
+fn hint_value(hint: &DiscoveryHint) -> Value {
+    json!({
+        "message": hint.message,
+        "suggested_tools": hint.suggested_tools,
+    })
+}

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -2,6 +2,7 @@
 
 mod discovery;
 mod errors;
+mod hints;
 mod resources;
 mod tools;
 
@@ -12,6 +13,7 @@ pub(crate) use discovery::{
 pub(crate) use errors::{
     internal_status, status_to_error_data, tool_error_from_status, tool_error_result,
 };
+pub(crate) use hints::{TABLE_FUNCTIONS_ARE_SEPARATE, add_hints, hints_schema};
 pub(crate) use resources::{
     format_schema_table_equivalent, guide_resource, guide_resource_content, initial_instructions,
     list_tables_value, tables_resource, tables_resource_content,

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,6 +5,8 @@ use coral_api::v1::{ListTablesResponse, Source, Table, TableSummary};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
+use super::{TABLE_FUNCTIONS_ARE_SEPARATE, add_hints};
+
 static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_tables`, `search_tables`, `list_table_functions`, `search_table_functions`, `describe_table`, and `list_columns` to inspect queryable tables and source-scoped table functions, and use `sql` for final queries.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
@@ -90,6 +92,7 @@ pub(crate) fn list_tables_value(response: &ListTablesResponse) -> Value {
             .expect("list tables value is initialized as a JSON object")
             .insert("next_offset".to_string(), json!(pagination.next_offset));
     }
+    add_hints(&mut value, &[TABLE_FUNCTIONS_ARE_SEPARATE]);
     value
 }
 
@@ -279,6 +282,17 @@ mod tests {
         assert_eq!(value["limit"], 50);
         assert_eq!(value["offset"], 0);
         assert_eq!(value["has_more"], false);
+        assert!(
+            value["hints"]
+                .as_array()
+                .expect("hints array")
+                .iter()
+                .any(|hint| hint["suggested_tools"]
+                    .as_array()
+                    .expect("suggested tools")
+                    .iter()
+                    .any(|tool| tool == "search_table_functions"))
+        );
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -7,7 +7,7 @@ use rmcp::{
 };
 use serde_json::{Map, Value, json};
 
-use super::{Pagination, parse_pagination, parse_pagination_with_limits};
+use super::{Pagination, hints_schema, parse_pagination, parse_pagination_with_limits};
 
 pub(crate) struct ListTablesArguments {
     pub(crate) schema: Option<String>,
@@ -470,13 +470,13 @@ fn sql_tool_description(sources: &[Source], visible_table_count: usize) -> Strin
 
 fn list_tables_description(visible_table_count: usize) -> String {
     format!(
-        "List queryable fully qualified tables. {visible_table_count} table(s) are currently visible."
+        "List queryable fully qualified tables. {visible_table_count} table(s) are currently visible. Table functions are separate; use list_table_functions or search_table_functions when a table is missing."
     )
 }
 
 fn search_tables_description(visible_table_count: usize) -> String {
     format!(
-        "Search queryable table metadata with a Rust regex. {visible_table_count} table(s) are currently visible."
+        "Search queryable table metadata with a Rust regex. {visible_table_count} table(s) are currently visible. This does not search table functions; use search_table_functions for provider-native search, lookup, and range capabilities."
     )
 }
 
@@ -840,6 +840,7 @@ fn paginated_table_output_schema(table_item_schema: &Value) -> Arc<Map<String, V
                 "minimum": 0
             },
             "has_more": { "type": "boolean" },
+            "hints": hints_schema(),
             "next_offset": {
                 "type": "integer",
                 "minimum": 0

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -152,6 +152,17 @@ fn json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
 }
 
+fn assert_has_table_function_hint(value: &Value) {
+    let hints = value["hints"].as_array().expect("hints array");
+    assert!(hints.iter().any(|hint| {
+        hint["suggested_tools"]
+            .as_array()
+            .expect("suggested tools")
+            .iter()
+            .any(|tool| tool == "search_table_functions")
+    }));
+}
+
 async fn add_demo_source(source_client: &mut SourceClient, manifest_yaml: String) {
     source_client
         .import_source(Request::new(ImportSourceRequest {
@@ -433,6 +444,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(page["limit"], 2);
     assert_eq!(page["has_more"], true);
     assert_eq!(page["next_offset"], 2);
+    assert_has_table_function_hint(&page);
     assert_eq!(page["tables"].as_array().expect("tables").len(), 2);
     assert_matches_output_schema(list_tables_tool, &page);
 
@@ -799,6 +811,33 @@ async fn mcp_list_table_functions_returns_metadata() {
         "searchy.search_issues"
     );
     assert_matches_output_schema(list_tool, &listed);
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_search_tables_hints_at_table_functions() {
+    let temp = TempDir::new().expect("temp dir");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
+
+    add_table_function_demo_sources(&mut session.source_client).await;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    let search_tables_tool = tool_by_name(&tools, "search_tables");
+    let table_search = client
+        .call_tool(
+            CallToolRequestParams::new("search_tables").with_arguments(json_object(&json!({
+                "pattern": "search_issues",
+                "schema": "searchy"
+            }))),
+        )
+        .await
+        .expect("search tables should not find table functions");
+    let table_search = table_search.structured_content.expect("structured content");
+    assert_eq!(table_search["total"], 0);
+    assert_has_table_function_hint(&table_search);
+    assert_matches_output_schema(search_tables_tool, &table_search);
 
     session.shutdown().await;
 }

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -26,8 +26,8 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-`list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. Use each table's `sql_reference` value in `FROM` and `JOIN` clauses. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
-`search_tables` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table names, descriptions, guides, and required filters.
+`list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. Use each table's `sql_reference` value in `FROM` and `JOIN` clauses. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`. Table functions are separate, so a missing table result can still mean a source-scoped function exists.
+`search_tables` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table names, descriptions, guides, and required filters. It does not search table functions; use `search_table_functions` when looking for provider-native search, lookup, or range capabilities.
 `list_table_functions` returns source-scoped table function metadata in pages and accepts optional `schema`, `function`, `limit`, and `offset` arguments.
 `search_table_functions` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table function names, descriptions, arguments, and result columns.
 `describe_table` accepts exact `schema` and `table` arguments and returns guide text, required filters, and a column count without dumping full columns.


### PR DESCRIPTION
## Summary
- Add a reusable MCP `hints` result shape with `message` and `suggested_tools`.
- Attach a table-function discovery hint to `list_tables` and `search_tables` results.
- Make table discovery tool descriptions explicit that table functions are separate from tables.
- Add a regression for the important miss path: `search_tables` does not find a function-only capability, and the response points agents to `search_table_functions`.

## Boundaries
- MCP guidance and result-shaping only, stacked on the table-function search PR.
- No engine, API, app, source-spec, or SQL behavior changes.
- `hints` is optional in output schemas; these table-discovery tools currently emit the table-function hint consistently.

## Validation
- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --features cli-test-server --test mcp`
- `make docs-check`
- `make rust-checks`
- `git diff --check`