### PR TITLE
feat(sources/community/sonarqube): add sonarqube source

### DIFF
--- a/sources/community/sonarqube/README.md
+++ b/sources/community/sonarqube/README.md
@@ -1,0 +1,168 @@
+# SonarQube source
+
+This community source lets Coral query projects, issues, quality gates, security hotspots,
+and code metrics from SonarQube Server or SonarQube Cloud.
+
+The v1 source is focused on engineering intelligence: projects, code quality metrics,
+security analysis, and release-readiness evaluation.
+
+## Authentication
+
+Create a bearer token in SonarQube under:
+
+- **SonarQube Server**: User > My Account > Security > Tokens
+- **SonarQube Cloud**: Organization > Members > Tokens
+
+Token must have:
+- 'Scan' scope for analysis-related data
+- 'Read on projects' scope for project metadata
+
+Then export:
+
+```sh
+export SONARQUBE_BASE_URL="https://sonarqube.company.com"  # or https://sonarcloud.io
+export SONARQUBE_TOKEN="your_bearer_token"
+```
+
+For self-hosted SonarQube, use your instance URL. For SonarCloud, keep `https://sonarcloud.io`.
+
+## Quick start
+
+```sh
+coral source add sonarqube
+coral source test sonarqube
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'sonarqube' ORDER BY table_name"
+```
+
+If you update the token later, run `coral source add sonarqube` again to refresh credentials.
+
+## Rate Limits
+
+SonarQube API rate limits vary based on plan and instance configuration:
+
+- **SonarQube Server**: Typically configurable; check your instance settings
+- **SonarQube Cloud**:
+  - Community: 10 requests/second
+  - Professional: 20 requests/second
+  - Enterprise: Contact SonarSource
+
+This source uses explicit pagination to respect limits. If you encounter rate limit errors,
+consider reducing query frequency or filtering by project scope.
+
+## Tables
+
+| Table | Notes |
+|---|---|
+| `current_user` | Validates token and returns authenticated user info |
+| `projects` | SonarQube projects accessible to the token |
+| `issues` | Code issues (requires project_key filter) |
+| `security_hotspots` | Security hotspots requiring review (requires project_key filter) |
+| `measures` | Project quality metrics (requires project_key and metric_keys filters) |
+| `quality_gates` | Configured quality gate definitions |
+| `project_quality_gate_status` | Quality gate evaluation results for projects (requires project_key filter) |
+
+## How to query it
+
+List all accessible projects:
+
+```sql
+SELECT project_key, project_name, last_analysis_date
+FROM sonarqube.projects
+ORDER BY last_analysis_date DESC
+LIMIT 20;
+```
+
+Find high-severity issues in a project:
+
+```sql
+SELECT issue_key, severity, type, message, component, line
+FROM sonarqube.issues
+WHERE project_key = 'my-backend-api'
+  AND severity IN ('BLOCKER', 'CRITICAL')
+ORDER BY severity DESC, creation_date DESC
+LIMIT 20;
+```
+
+List unreviewed security hotspots:
+
+```sql
+SELECT hotspot_key, component, vulnerability_probability, message
+FROM sonarqube.security_hotspots
+WHERE project_key = 'my-backend-api'
+  AND status = 'TO_REVIEW'
+ORDER BY creation_date DESC
+LIMIT 20;
+```
+
+Check project quality metrics:
+
+```sql
+SELECT metric_key, value
+FROM sonarqube.measures
+WHERE project_key = 'my-backend-api'
+  AND metric_keys = 'coverage,bugs,vulnerabilities,sqale_index';
+```
+
+Monitor quality gate status for release gating:
+
+```sql
+SELECT project_key, status, last_analysis_date
+FROM sonarqube.project_quality_gate_status
+WHERE project_key = 'my-backend-api'
+  AND status = 'ERROR';
+```
+
+## Common metrics
+
+Common metric keys for the `measures` table:
+
+- **Coverage**: `coverage` (overall), `line_coverage`, `branch_coverage`
+- **Quality**: `bugs`, `code_smells`, `vulnerabilities`, `reliability_issues`
+- **Ratings**: `reliability_rating`, `security_rating`, `maintainability_rating`
+- **Duplication**: `duplicated_lines_density`
+- **Debt**: `sqale_index` (technical debt), `security_hotspots`
+
+Comma-separate multiple metrics: `coverage,bugs,vulnerabilities`.
+
+See [SonarQube metrics documentation](https://docs.sonarsource.com/sonarqube/latest/user-guide/reports/metrics/)
+for the complete list and definitions.
+
+## Issue and hotspot statuses
+
+**Issue statuses**: OPEN, CONFIRMED, RESOLVED, REOPENED, CLOSED
+
+**Hotspot statuses**: TO_REVIEW, ACKNOWLEDGED, FIXED, SAFE
+
+**Hotspot probability**: HIGH, MEDIUM, LOW
+
+## Validation
+
+If you are developing this source in the Coral repo, run:
+
+```sh
+cargo run --locked -p coral-cli -- source lint ./sources/community/sonarqube/manifest.yaml
+```
+
+Then add and validate the source:
+
+```sh
+coral source add sonarqube
+coral source test sonarqube
+```
+
+Inspect the installed shape:
+
+```sh
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'sonarqube' ORDER BY table_name"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'sonarqube' ORDER BY table_name, ordinal_position"
+coral sql "SELECT key, kind, required, is_set FROM coral.inputs WHERE schema_name = 'sonarqube' ORDER BY key"
+```
+
+Then verify data flow with representative queries:
+
+```sh
+coral sql "SELECT * FROM sonarqube.current_user LIMIT 1"
+coral sql "SELECT * FROM sonarqube.projects LIMIT 1"
+coral sql "SELECT project_key FROM sonarqube.projects LIMIT 1" | xargs -I {} \
+  coral sql "SELECT * FROM sonarqube.issues WHERE project_key = '{}' LIMIT 1"
+```

--- a/sources/community/sonarqube/manifest.yaml
+++ b/sources/community/sonarqube/manifest.yaml
@@ -1,0 +1,685 @@
+dsl_version: 3
+name: sonarqube
+version: 0.1.0
+description: >-
+  Query projects, issues, quality gates, security hotspots, and code metrics from
+  SonarQube Server or SonarQube Cloud.
+backend: http
+inputs:
+  SONARQUBE_BASE_URL:
+    kind: variable
+    hint: |
+      Base URL of your SonarQube Server instance or Cloud organization.
+      Examples:
+      - Self-hosted: https://sonarqube.company.com
+      - Cloud: https://sonarcloud.io
+  SONARQUBE_TOKEN:
+    kind: secret
+    hint: |
+      Bearer token for SonarQube API access.
+      Create a token in SonarQube under User > My Account > Security > Tokens.
+      Token must have 'Scan' and 'Read on projects' scopes at minimum.
+      For Cloud, tokens are managed under Organization > Members > Tokens.
+base_url: "{{input.SONARQUBE_BASE_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.SONARQUBE_TOKEN}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM sonarqube.current_user LIMIT 1
+  - SELECT * FROM sonarqube.projects LIMIT 1
+tables:
+  - name: current_user
+    description: Authenticated user information and token validation
+    guide: |
+      Use this to validate SonarQube credentials and confirm token status.
+      This table should return exactly one row per query.
+    request:
+      method: GET
+      path: /api/authentication/validate
+    response:
+      rows_path: []
+      row_strategy: direct
+    columns:
+      - name: is_authenticated
+        type: Boolean
+        nullable: false
+        description: Whether the token is valid and authenticated
+        expr:
+          kind: path
+          path:
+            - valid
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full authentication response
+        expr:
+          kind: current_row
+
+  - name: projects
+    description: SonarQube projects accessible to the authenticated token
+    guide: |
+      Projects are the primary organizational unit in SonarQube.
+      Each project represents a repository or application being analyzed.
+      Use project_key to join with issues, measures, and quality gate status.
+    request:
+      method: GET
+      path: /api/components/search_projects
+    response:
+      rows_path:
+        - components
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: p
+      page_size:
+        default: 100
+        max: 500
+        query_param: ps
+    columns:
+      - name: project_key
+        type: Utf8
+        nullable: false
+        description: Unique project identifier
+        expr:
+          kind: path
+          path:
+            - key
+      - name: project_name
+        type: Utf8
+        nullable: true
+        description: Project display name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: qualifier
+        type: Utf8
+        nullable: true
+        description: Project qualifier (typically TRK for project)
+        expr:
+          kind: path
+          path:
+            - qualifier
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Project visibility (PUBLIC or PRIVATE)
+        expr:
+          kind: path
+          path:
+            - visibility
+      - name: last_analysis_date
+        type: Timestamp
+        nullable: true
+        description: Last analysis timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - lastAnalysisDate
+      - name: organization_key
+        type: Utf8
+        nullable: true
+        description: Organization key (SonarCloud only)
+        expr:
+          kind: path
+          path:
+            - organization
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw project object
+        expr:
+          kind: current_row
+
+  - name: issues
+    description: Code issues detected by SonarQube analysis (requires project filter)
+    guide: |
+      Issues include bugs, vulnerabilities, code smells, and maintainability concerns.
+      REQUIRED: Filter by project_key to scope queries to a specific project.
+      Optional: Further filter by severity, type, or status.
+
+      Types: BUG, VULNERABILITY, CODE_SMELL
+      Severities: BLOCKER, CRITICAL, MAJOR, MINOR, INFO
+      Statuses: OPEN, CONFIRMED, RESOLVED, REOPENED, CLOSED
+    filters:
+      - name: project_key
+        required: true
+      - name: severity
+        required: false
+      - name: type
+        required: false
+      - name: status
+        required: false
+    request:
+      method: GET
+      path: /api/issues/search
+      query:
+        - name: componentKeys
+          from: filter
+          key: project_key
+        - name: severities
+          from: filter
+          key: severity
+        - name: types
+          from: filter
+          key: type
+        - name: statuses
+          from: filter
+          key: status
+    response:
+      rows_path:
+        - issues
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: p
+      page_size:
+        default: 100
+        max: 500
+        query_param: ps
+    columns:
+      - name: issue_key
+        type: Utf8
+        nullable: false
+        description: Unique issue identifier
+        expr:
+          kind: path
+          path:
+            - key
+      - name: project_key
+        type: Utf8
+        nullable: false
+        description: Project identifier
+        expr:
+          kind: path
+          path:
+            - project
+      - name: rule
+        type: Utf8
+        nullable: true
+        description: SonarQube rule key that detected the issue
+        expr:
+          kind: path
+          path:
+            - rule
+      - name: severity
+        type: Utf8
+        nullable: true
+        description: Issue severity (BLOCKER, CRITICAL, MAJOR, MINOR, INFO)
+        expr:
+          kind: path
+          path:
+            - severity
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Issue type (BUG, VULNERABILITY, CODE_SMELL)
+        expr:
+          kind: path
+          path:
+            - type
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Issue status (OPEN, CONFIRMED, RESOLVED, REOPENED, CLOSED)
+        expr:
+          kind: path
+          path:
+            - status
+      - name: resolution
+        type: Utf8
+        nullable: true
+        description: Issue resolution (FIXED, REMOVED, WONTFIX, FALSE_POSITIVE, ACCEPTED)
+        expr:
+          kind: path
+          path:
+            - resolution
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Issue description or message
+        expr:
+          kind: path
+          path:
+            - message
+      - name: component
+        type: Utf8
+        nullable: true
+        description: File or component where issue was detected
+        expr:
+          kind: path
+          path:
+            - component
+      - name: line
+        type: Int64
+        nullable: true
+        description: Line number where issue starts
+        expr:
+          kind: path
+          path:
+            - line
+      - name: creation_date
+        type: Timestamp
+        nullable: true
+        description: When the issue was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - creationDate
+      - name: update_date
+        type: Timestamp
+        nullable: true
+        description: When the issue was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updateDate
+      - name: effort
+        type: Utf8
+        nullable: true
+        description: Estimated effort to fix (e.g., "5min", "1h")
+        expr:
+          kind: path
+          path:
+            - effort
+      - name: debt
+        type: Utf8
+        nullable: true
+        description: Technical debt (e.g., "5min", "1h")
+        expr:
+          kind: path
+          path:
+            - debt
+      - name: assignee_login
+        type: Utf8
+        nullable: true
+        description: Assigned user login
+        expr:
+          kind: path
+          path:
+            - assignee
+      - name: author_login
+        type: Utf8
+        nullable: true
+        description: User who created the issue
+        expr:
+          kind: path
+          path:
+            - author
+      - name: flows
+        type: Json
+        nullable: true
+        description: Issue flows (nested analysis paths)
+        expr:
+          kind: path
+          path:
+            - flows
+      - name: locations
+        type: Json
+        nullable: true
+        description: Issue locations (nested file/line references)
+        expr:
+          kind: path
+          path:
+            - locations
+      - name: impacts
+        type: Json
+        nullable: true
+        description: Issue impacts (nested impact definitions)
+        expr:
+          kind: path
+          path:
+            - impacts
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw issue object
+        expr:
+          kind: current_row
+
+  - name: security_hotspots
+    description: Security hotspots identified in SonarQube analysis (requires project filter)
+    guide: |
+      Security hotspots are security-sensitive code locations requiring manual review.
+      REQUIRED: Filter by project_key to scope queries to a specific project.
+      Optional: Filter by status to find hotspots at a specific review stage.
+
+      Statuses: TO_REVIEW, ACKNOWLEDGED, FIXED, SAFE
+    filters:
+      - name: project_key
+        required: true
+      - name: status
+        required: false
+    request:
+      method: GET
+      path: /api/hotspots/search
+      query:
+        - name: projectKey
+          from: filter
+          key: project_key
+        - name: status
+          from: filter
+          key: status
+    response:
+      rows_path:
+        - hotspots
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: p
+      page_size:
+        default: 100
+        max: 500
+        query_param: ps
+    columns:
+      - name: hotspot_key
+        type: Utf8
+        nullable: false
+        description: Unique hotspot identifier
+        expr:
+          kind: path
+          path:
+            - key
+      - name: project_key
+        type: Utf8
+        nullable: false
+        description: Project identifier
+        expr:
+          kind: path
+          path:
+            - project
+      - name: component
+        type: Utf8
+        nullable: true
+        description: File or component containing the hotspot
+        expr:
+          kind: path
+          path:
+            - component
+      - name: line
+        type: Int64
+        nullable: true
+        description: Line number where hotspot appears
+        expr:
+          kind: path
+          path:
+            - line
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Hotspot review status (TO_REVIEW, ACKNOWLEDGED, FIXED, SAFE)
+        expr:
+          kind: path
+          path:
+            - status
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Hotspot description
+        expr:
+          kind: path
+          path:
+            - message
+      - name: vulnerability_probability
+        type: Utf8
+        nullable: true
+        description: Probability of vulnerability (HIGH, MEDIUM, LOW)
+        expr:
+          kind: path
+          path:
+            - vulnerabilityProbability
+      - name: creation_date
+        type: Timestamp
+        nullable: true
+        description: When the hotspot was detected
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - creationDate
+      - name: update_date
+        type: Timestamp
+        nullable: true
+        description: When the hotspot was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updateDate
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw hotspot object
+        expr:
+          kind: current_row
+
+  - name: measures
+    description: Project quality metrics and code measures (requires project and metric keys)
+    guide: |
+      Measures expose project-level metrics including coverage, bugs, vulnerabilities,
+      duplications, and quality ratings.
+
+      REQUIRED: Filter by both project_key and metric_keys.
+      Common metrics: bugs, vulnerabilities, code_smells, coverage, duplicated_lines_density,
+      reliability_rating, security_rating, maintainability_rating, security_hotspots,
+      sqale_index
+
+      Metric keys can be comma-separated (e.g., coverage,bugs,vulnerabilities).
+    filters:
+      - name: project_key
+        required: true
+      - name: metric_keys
+        required: true
+    request:
+      method: GET
+      path: /api/measures/component
+      query:
+        - name: component
+          from: filter
+          key: project_key
+        - name: metricKeys
+          from: filter
+          key: metric_keys
+    response:
+      rows_path:
+        - component
+        - measures
+      row_strategy: direct
+    columns:
+      - name: project_key
+        type: Utf8
+        nullable: false
+        description: Project identifier
+        expr:
+          kind: from_filter
+          key: project_key
+      - name: metric_key
+        type: Utf8
+        nullable: false
+        description: Metric identifier (bugs, coverage, etc.)
+        expr:
+          kind: path
+          path:
+            - metric
+      - name: value
+        type: Utf8
+        nullable: true
+        description: Metric value (string to preserve format)
+        expr:
+          kind: path
+          path:
+            - value
+      - name: best_value
+        type: Boolean
+        nullable: true
+        description: Whether this metric represents the best possible value
+        expr:
+          kind: path
+          path:
+            - bestValue
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw measure object
+        expr:
+          kind: current_row
+
+  - name: quality_gates
+    description: SonarQube quality gate definitions
+    guide: |
+      Quality gates define pass/fail criteria for projects.
+      Use this table to understand configured quality gates.
+      Join with project_quality_gate_status to see how projects evaluate against each gate.
+    request:
+      method: GET
+      path: /api/qualitygates/list
+    response:
+      rows_path:
+        - qualitygates
+      row_strategy: direct
+    columns:
+      - name: quality_gate_id
+        type: Utf8
+        nullable: false
+        description: Unique quality gate identifier
+        expr:
+          kind: path
+          path:
+            - id
+      - name: quality_gate_name
+        type: Utf8
+        nullable: false
+        description: Quality gate display name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: is_default
+        type: Boolean
+        nullable: true
+        description: Whether this is the default quality gate
+        expr:
+          kind: path
+          path:
+            - isDefault
+      - name: is_built_in
+        type: Boolean
+        nullable: true
+        description: Whether this is a built-in quality gate
+        expr:
+          kind: path
+          path:
+            - isBuiltIn
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw quality gate object
+        expr:
+          kind: current_row
+
+  - name: project_quality_gate_status
+    description: Quality gate evaluation results for projects (requires project filter)
+    guide: |
+      Shows how each project evaluated against its assigned quality gate.
+      REQUIRED: Filter by project_key to retrieve quality gate status for a project.
+
+      Status values: OK (passed), ERROR (failed)
+    filters:
+      - name: project_key
+        required: true
+    request:
+      method: GET
+      path: /api/qualitygates/project_status
+      query:
+        - name: projectKey
+          from: filter
+          key: project_key
+    response:
+      rows_path:
+        - projectStatus
+      row_strategy: direct
+    columns:
+      - name: project_key
+        type: Utf8
+        nullable: false
+        description: Project identifier
+        expr:
+          kind: from_filter
+          key: project_key
+      - name: quality_gate_name
+        type: Utf8
+        nullable: true
+        description: Name of the quality gate
+        expr:
+          kind: path
+          path:
+            - qualityGate
+      - name: status
+        type: Utf8
+        nullable: false
+        description: Quality gate status (OK or ERROR)
+        expr:
+          kind: path
+          path:
+            - status
+      - name: is_quality_gate_passed
+        type: Boolean
+        nullable: false
+        description: Whether quality gate passed
+        expr:
+          kind: path
+          path:
+            - status
+      - name: last_analysis_date
+        type: Timestamp
+        nullable: true
+        description: Last analysis timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - analysisDate
+      - name: ignored_conditions
+        type: Json
+        nullable: true
+        description: Conditions that were ignored
+        expr:
+          kind: path
+          path:
+            - ignoredConditions
+      - name: failed_conditions
+        type: Json
+        nullable: true
+        description: Conditions that caused failure
+        expr:
+          kind: path
+          path:
+            - conditions
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw quality gate status
+        expr:
+          kind: current_row


### PR DESCRIPTION
## Summary

Fixes #436 

Add a new community SonarQube source for querying projects, issues, security hotspots, quality gates, and code metrics from SonarQube Server or SonarQube Cloud with a bearer token.
This change is manifest-only and uses Coral's existing HTTP source-spec model. It adds engineering intelligence and release-readiness data access without changing CLI, MCP, or runtime contracts.
## What changed
Added:
- `sources/community/sonarqube/manifest.yaml`
- `sources/community/sonarqube/README.md`
No generated docs updates needed for community sources.
## Source scope
**Inputs:**
- `SONARQUBE_BASE_URL` (variable): Base URL for SonarQube Server or Cloud instance
- `SONARQUBE_TOKEN` (secret): Bearer token for API access with 'Scan' and 'Read on projects' scopes
**Tables:**
- `sonarqube.current_user` - Token validation and authenticated user metadata
- `sonarqube.projects` - Accessible SonarQube projects
- `sonarqube.issues` - Code issues (bugs, vulnerabilities, code smells) with required `project_key` filter
- `sonarqube.security_hotspots` - Security-sensitive code locations with required `project_key` filter
- `sonarqube.measures` - Project quality metrics with required `project_key` and `metric_keys` filters
- `sonarqube.quality_gates` - Configured quality gate definitions
- `sonarqube.project_quality_gate_status` - Quality gate evaluation results with required `project_key` filter
## Implementation notes
- Uses SonarQube page-based pagination through Coral `page` mode with configurable page size (default 100, max 500)
- Keeps nested and account-specific data such as flows, locations, impacts, and conditions as Json
- Keeps lookup-style tables explicit: `security_hotspots` and `project_quality_gate_status` require filters to scope to specific projects
- Required filters prevent expensive instance-wide scans (e.g., `issues` requires `project_key`, `measures` requires both `project_key` and `metric_keys`)
- Keeps v1 intentionally narrow and read-only, focused on engineering intelligence and release-readiness workflows
## Validation
Local checks passed:
- `cargo run --locked -p coral-cli -- source lint ./sources/community/sonarqube/manifest.yaml` ✓
- Manifest validates successfully with no schema errors
Design validation against SonarQube API docs:
- Bearer token auth: Official SonarQube authentication model ✓
- Pagination: Page-based with `p` (page) and `ps` (page size) parameters ✓
- Response paths: Verified against SonarQube Web API v1 response structures ✓
- Filter mapping: Query parameters correctly mapped from Coral filters (componentKeys←project_key, metricKeys←metric_keys, etc.) ✓
- Rate limits: Cloud tiers documented (Community 10/sec, Professional 20/sec, Enterprise custom) ✓
## Out of scope
Not included in v1:
- Write APIs
- Search APIs
- Webhooks
- Portfolios
- Goals
- Admin-only or audit surfaces
- AI Code Assurance APIs (evolving rapidly)
## Reviewer notes
The README includes:
- Setup workflow for both SonarQube Server and Cloud
- Token creation and scope guidance
- Rate limit expectations by plan
- Quick start validation commands
- Seven representative SQL examples covering all major use cases (project discovery, issue analysis, hotspot review, metrics, quality gates)
- Common metric keys reference with links to official SonarQube docs
- Complete validation and testing instructions
The design follows Coral conventions:
- Capability-first description (engineering intelligence focused)
- Service-prefixed inputs (SONARQUBE_BASE_URL, SONARQUBE_TOKEN)
- Required filters prevent unsupported large scans
- Conservative field flattening (only assignee/author logins; complex nested structures remain as Json)
- Explicit lookup tables with documented filter requirements
- User-facing language throughout (no internal Coral jargon)
**Residual validation items for live testing:**
- Metrics response structure validation with actual metric keys
- Quality gate conditions format across Server/Cloud versions (safe fallback: kept as Json)
- Hotspot optional filter behavior confirmation