### PR TITLE
feat(sources/community/postman): add Postman API source

### DIFF
--- a/sources/community/postman/README.md
+++ b/sources/community/postman/README.md
@@ -167,4 +167,4 @@ WHERE owner_id IS NULL
 - JSON columns (headers, body, auth, scripts, schedule) contain nested structures queryable with `json_get`, `json_get_str`, etc.
 - Timestamps are stored as proper Timestamp columns derived from ISO 8601 strings
 - Environment variable values are not available from the list endpoint
-- Secret variable values are not exposed for security reasons
+- Note: the Postman API returns secret values as plaintext, so exercise caution when querying environments.

--- a/sources/community/postman/README.md
+++ b/sources/community/postman/README.md
@@ -47,7 +47,7 @@ Collections are grouped API workflows, requests, tests, and documentation. This 
 
 **Example:**
 ```sql
-SELECT name, owner_name, workspace_id 
+SELECT name, owner_id, workspace_id 
 FROM postman.collections 
 WHERE workspace_id = 'your-workspace-id'
 ```

--- a/sources/community/postman/README.md
+++ b/sources/community/postman/README.md
@@ -118,7 +118,9 @@ The source uses Postman API Key authentication. Your API key is sent via the `X-
 
 - Postman API is rate-limited
 - The `me` table returns a single row
-- List endpoints return all items without server-side pagination
+- `workspaces` and `monitors` use cursor pagination
+- `collections` uses limit/offset pagination
+- `environments` returns all accessible environments without pagination
 - Use `LIMIT` to control result size in queries
 
 ## Example Queries
@@ -167,4 +169,3 @@ WHERE owner_id IS NULL
 - JSON columns (headers, body, auth, scripts, schedule) contain nested structures queryable with `json_get`, `json_get_str`, etc.
 - Timestamps are stored as proper Timestamp columns derived from ISO 8601 strings
 - Environment variable values are not available from the list endpoint
-- Note: the Postman API returns secret values as plaintext, so exercise caution when querying environments.

--- a/sources/community/postman/README.md
+++ b/sources/community/postman/README.md
@@ -1,0 +1,160 @@
+# Postman
+
+Query workspaces, collections, requests, environments, and monitors from Postman.
+
+## Setup
+
+### Get Your API Key
+
+1. Visit [Postman API Keys](https://web.postman.co/settings/me/api-keys)
+2. Generate a new API key
+3. Copy the key
+
+### Add the Source
+
+```bash
+coral source add postman
+```
+
+When prompted, provide your Postman API key.
+
+## Tables
+
+### `me`
+Returns the current authenticated user information. Use this to validate your API key configuration.
+
+**Useful for:**
+- Verifying authentication
+- Getting user metadata
+- Account identification
+
+### `workspaces`
+Top-level organizational entities in Postman. All collections, environments, and monitors are grouped within workspaces.
+
+**Useful for:**
+- Workspace inventory
+- Organization structure
+- Workspace metadata queries
+
+### `collections`
+Collections are grouped API workflows, requests, tests, and documentation. This is one of the most important Postman entities.
+
+**Useful for:**
+- API inventory analysis
+- Collection browsing
+- Request organization
+- Finding collections by owner or workspace
+
+**Example:**
+```sql
+SELECT name, owner_name, workspace_id 
+FROM postman.collections 
+WHERE workspace_id = 'your-workspace-id'
+```
+
+### `collection_requests`
+Request-level metadata extracted from collections. This table exposes endpoints, HTTP methods, authentication configs, and test scripts.
+
+**Requires:** `collection_uid` filter
+
+**Useful for:**
+- API endpoint discovery
+- HTTP method analytics
+- Understanding request structure
+- Finding endpoints by method
+
+**Example:**
+```sql
+SELECT method, COUNT(*) as request_count
+FROM postman.collection_requests
+WHERE collection_uid = 'your-collection-uid'
+GROUP BY method
+```
+
+### `environments`
+Variable groups used across testing and deployment workflows. Environments allow parameterization of requests.
+
+**Useful for:**
+- Environment inventory
+- Variable structure
+- Testing configuration
+- Deployment setup tracking
+
+### `monitors`
+Continuous API monitors that test health and reliability. Monitors run on schedules and report failures.
+
+**Useful for:**
+- Monitor health dashboards
+- Failure tracking
+- Reliability analytics
+- API governance
+
+**Example:**
+```sql
+SELECT name, status, failure_count
+FROM postman.monitors
+WHERE status = 'running'
+ORDER BY failure_count DESC
+```
+
+## Authentication
+
+The source uses Postman API Key authentication. Your API key is sent via the `X-API-Key` header.
+
+**Minimum scopes required:**
+- workspaces.read
+- collections.read
+- environments.read
+- monitors.read
+
+## Limits
+
+- Postman API is rate-limited
+- Results are paginated (default 25 items per page)
+- Use `LIMIT` and `OFFSET` to control pagination in queries
+
+## Example Queries
+
+### Get method distribution across all requests in a collection
+
+```sql
+SELECT method, COUNT(*) as request_count
+FROM postman.collection_requests
+WHERE collection_uid = 'your-collection-uid'
+GROUP BY method
+ORDER BY request_count DESC
+```
+
+### Find all failing monitors
+
+```sql
+SELECT name, failure_count, updated_at
+FROM postman.monitors
+WHERE status = 'running'
+ORDER BY failure_count DESC
+LIMIT 10
+```
+
+### Inventory collections by workspace
+
+```sql
+SELECT workspace_id, COUNT(*) as collection_count
+FROM postman.collections
+GROUP BY workspace_id
+ORDER BY collection_count DESC
+```
+
+### Find collections with no owner specified
+
+```sql
+SELECT name, created_at
+FROM postman.collections
+WHERE owner_id IS NULL
+```
+
+## Notes
+
+- The `collection_requests` table requires a `collection_uid` to avoid expensive full scans
+- JSON columns (variables, auth, headers, scripts) contain nested structures
+- Timestamps are in ISO 8601 format
+- Secret variable values are not exposed for security reasons

--- a/sources/community/postman/README.md
+++ b/sources/community/postman/README.md
@@ -47,15 +47,19 @@ Collections are grouped API workflows, requests, tests, and documentation. This 
 
 **Example:**
 ```sql
-SELECT name, owner_id, workspace_id 
-FROM postman.collections 
+SELECT name, owner_id, workspace_id
+FROM postman.collections
 WHERE workspace_id = 'your-workspace-id'
 ```
 
 ### `collection_requests`
-Request-level metadata extracted from collections. This table exposes endpoints, HTTP methods, authentication configs, and test scripts.
+Top-level request metadata extracted from a single collection. Exposes endpoints, HTTP methods, headers, and body configuration.
 
 **Requires:** `collection_uid` filter
+
+> **Note:** v1 only returns top-level items in a collection. Requests nested
+> inside folders are not flattened and may appear as folder entries with NULL
+> request fields.
 
 **Useful for:**
 - API endpoint discovery
@@ -74,10 +78,13 @@ GROUP BY method
 ### `environments`
 Variable groups used across testing and deployment workflows. Environments allow parameterization of requests.
 
+> **Note:** The list endpoint does not return environment variable values.
+> Variable details require fetching individual environments, which is not
+> supported in v1.
+
 **Useful for:**
 - Environment inventory
-- Variable structure
-- Testing configuration
+- Environment metadata
 - Deployment setup tracking
 
 ### `monitors`
@@ -110,8 +117,9 @@ The source uses Postman API Key authentication. Your API key is sent via the `X-
 ## Limits
 
 - Postman API is rate-limited
-- Results are paginated (default 25 items per page)
-- Use `LIMIT` and `OFFSET` to control pagination in queries
+- The `me` table returns a single row
+- List endpoints return all items without server-side pagination
+- Use `LIMIT` to control result size in queries
 
 ## Example Queries
 
@@ -155,6 +163,8 @@ WHERE owner_id IS NULL
 ## Notes
 
 - The `collection_requests` table requires a `collection_uid` to avoid expensive full scans
-- JSON columns (variables, auth, headers, scripts) contain nested structures
-- Timestamps are in ISO 8601 format
+- v1 of `collection_requests` only exposes top-level items; nested folder requests are not flattened
+- JSON columns (headers, body, auth, scripts, schedule) contain nested structures queryable with `json_get`, `json_get_str`, etc.
+- Timestamps are stored as proper Timestamp columns derived from ISO 8601 strings
+- Environment variable values are not available from the list endpoint
 - Secret variable values are not exposed for security reasons

--- a/sources/community/postman/manifest.yaml
+++ b/sources/community/postman/manifest.yaml
@@ -447,7 +447,7 @@ tables:
       - name: variables
         type: Json
         nullable: true
-        description: Environment variables (JSON structure). Secret values are masked in v1.
+        description: "Environment variables (JSON structure). Note: the Postman API returns secret values as plaintext."
         expr:
           kind: path
           path: [values]

--- a/sources/community/postman/manifest.yaml
+++ b/sources/community/postman/manifest.yaml
@@ -38,7 +38,7 @@ tables:
       method: GET
       path: /me
     response:
-      rows_path: []
+      rows_path: [user]
     columns:
       - name: user_id
         type: Int64
@@ -203,34 +203,27 @@ tables:
         expr:
           kind: path
           path: [uid]
-      - name: name
-        type: Utf8
-        nullable: false
-        description: Collection name
-        expr:
-          kind: path
-          path: [name]
-      - name: owner_id
-        type: Int64
-        nullable: true
-        description: Owner user ID (flattened from owner object)
-        expr:
-          kind: path
-          path: [owner, id]
-      - name: owner_name
-        type: Utf8
-        nullable: true
-        description: Owner username (flattened from owner object)
-        expr:
-          kind: path
-          path: [owner, username]
-      - name: workspace_id
-        type: Utf8
-        nullable: true
-        description: Parent workspace ID (flattened from workspace)
-        expr:
-          kind: path
-          path: [workspace, id]
+       - name: name
+         type: Utf8
+         nullable: false
+         description: Collection name
+         expr:
+           kind: path
+           path: [name]
+       - name: owner_id
+         type: Int64
+         nullable: true
+         description: Owner user ID
+         expr:
+           kind: path
+           path: [owner]
+       - name: workspace_id
+         type: Utf8
+         nullable: true
+         description: Parent workspace ID
+         expr:
+           kind: path
+           path: [workspace]
       - name: created_at
         type: Timestamp
         nullable: true
@@ -332,13 +325,13 @@ tables:
         expr:
           kind: path
           path: [request, method]
-      - name: url
-        type: Utf8
-        nullable: true
-        description: Request URL (flattened from request object)
-        expr:
-          kind: path
-          path: [request, url, raw]
+       - name: url
+         type: Utf8
+         nullable: true
+         description: Request URL string or raw URL
+         expr:
+           kind: path
+           path: [request, url]
       - name: description
         type: Utf8
         nullable: true
@@ -431,55 +424,48 @@ tables:
         expr:
           kind: path
           path: [uid]
-      - name: name
-        type: Utf8
-        nullable: false
-        description: Environment name
-        expr:
-          kind: path
-          path: [name]
-      - name: owner_id
-        type: Int64
-        nullable: true
-        description: Owner user ID (flattened from owner object)
-        expr:
-          kind: path
-          path: [owner, id]
-      - name: owner_name
-        type: Utf8
-        nullable: true
-        description: Owner username (flattened from owner object)
-        expr:
-          kind: path
-          path: [owner, username]
-      - name: workspace_id
-        type: Utf8
-        nullable: true
-        description: Parent workspace ID (flattened from workspace)
-        expr:
-          kind: path
-          path: [workspace, id]
-      - name: created_at
-        type: Timestamp
-        nullable: true
-        description: Environment creation timestamp (ISO 8601)
-        expr:
-          kind: path
-          path: [createdAt]
-      - name: updated_at
-        type: Timestamp
-        nullable: true
-        description: Environment last updated timestamp (ISO 8601)
-        expr:
-          kind: path
-          path: [updatedAt]
-      - name: variables
-        type: Struct
-        nullable: true
-        description: Environment variables (JSON structure). Secret values are masked in v1.
-        expr:
-          kind: path
-          path: [value]
+       - name: name
+         type: Utf8
+         nullable: false
+         description: Environment name
+         expr:
+           kind: path
+           path: [name]
+       - name: owner_id
+         type: Int64
+         nullable: true
+         description: Owner user ID
+         expr:
+           kind: path
+           path: [owner]
+       - name: workspace_id
+         type: Utf8
+         nullable: true
+         description: Parent workspace ID
+         expr:
+           kind: path
+           path: [workspace]
+       - name: created_at
+         type: Timestamp
+         nullable: true
+         description: Environment creation timestamp (ISO 8601)
+         expr:
+           kind: path
+           path: [createdAt]
+       - name: updated_at
+         type: Timestamp
+         nullable: true
+         description: Environment last updated timestamp (ISO 8601)
+         expr:
+           kind: path
+           path: [updatedAt]
+       - name: variables
+         type: Struct
+         nullable: true
+         description: Environment variables (JSON structure). Secret values are masked in v1.
+         expr:
+           kind: path
+           path: [values]
 
   - name: monitors
     description: API monitors configured for continuous testing and health checking. Enables API reliability analytics and incident summarization. Important for API governance workflows.

--- a/sources/community/postman/manifest.yaml
+++ b/sources/community/postman/manifest.yaml
@@ -102,12 +102,13 @@ tables:
     response:
       rows_path: [workspaces]
     pagination:
-      mode: offset
-      offset_param: offset
+      mode: cursor_query
       page_size:
         default: 25
         max: 100
         query_param: limit
+      cursor_param: cursor
+      response_cursor_path: [meta, nextCursor]
     columns:
       - name: id
         type: Utf8
@@ -278,12 +279,7 @@ tables:
       rows_path: [collection, item]
       allow_404_empty: true
     pagination:
-      mode: offset
-      offset_param: offset
-      page_size:
-        default: 25
-        max: 100
-        query_param: limit
+      mode: none
     columns:
       - name: id
         type: Utf8
@@ -325,8 +321,12 @@ tables:
         nullable: true
         description: Request description
         expr:
-          kind: path
-          path: [request, description]
+          kind: coalesce
+          exprs:
+            - kind: path
+              path: [request, description, content]
+            - kind: path
+              path: [request, description]
       - name: protocol
         type: Utf8
         nullable: true
@@ -382,12 +382,7 @@ tables:
     response:
       rows_path: [environments]
     pagination:
-      mode: offset
-      offset_param: offset
-      page_size:
-        default: 25
-        max: 100
-        query_param: limit
+      mode: none
     columns:
       - name: id
         type: Utf8
@@ -444,13 +439,6 @@ tables:
           expr:
             kind: path
             path: [updatedAt]
-      - name: variables
-        type: Json
-        nullable: true
-        description: "Environment variables (JSON structure). Note: the Postman API returns secret values as plaintext."
-        expr:
-          kind: path
-          path: [values]
 
   - name: monitors
     description: >-
@@ -464,12 +452,13 @@ tables:
     response:
       rows_path: [monitors]
     pagination:
-      mode: offset
-      offset_param: offset
+      mode: cursor_query
       page_size:
         default: 25
-        max: 100
+        max: 25
         query_param: limit
+      cursor_param: cursor
+      response_cursor_path: [meta, nextCursor]
     columns:
       - name: id
         type: Utf8

--- a/sources/community/postman/manifest.yaml
+++ b/sources/community/postman/manifest.yaml
@@ -1,0 +1,581 @@
+name: postman
+version: '1.0'
+dsl_version: 3
+backend: http
+description: >-
+  Query workspaces, collections, requests, environments, and monitors from
+  Postman. Access API collections, test configurations, and monitoring data
+  for API inventory analysis and governance workflows.
+base_url: https://api.postman.com
+inputs:
+  POSTMAN_API_KEY:
+    kind: secret
+    hint: |
+      API key from your Postman account settings. Required for authentication.
+      Generate or retrieve from: https://web.postman.co/settings/me/api-keys
+      Required scopes: workspaces.read, collections.read, environments.read,
+      monitors.read
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: X-API-Key
+      from: input
+      key: POSTMAN_API_KEY
+
+test_queries:
+  - SELECT * FROM postman.me LIMIT 1
+  - SELECT COUNT(*) as workspace_count FROM postman.workspaces
+  - SELECT COUNT(*) as collection_count FROM postman.collections
+  - SELECT COUNT(*) as environment_count FROM postman.environments
+  - SELECT COUNT(*) as monitor_count FROM postman.monitors
+
+tables:
+  - name: me
+    description: Current authenticated user information. Validates API key and returns user identity metadata.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /me
+    response:
+      rows_path: []
+    columns:
+      - name: user_id
+        type: Int64
+        nullable: false
+        description: User ID
+        expr:
+          kind: path
+          path: [id]
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Username
+        expr:
+          kind: path
+          path: [username]
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address
+        expr:
+          kind: path
+          path: [email]
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: Full name
+        expr:
+          kind: path
+          path: [fullName]
+      - name: avatar_url
+        type: Utf8
+        nullable: true
+        description: Avatar URL
+        expr:
+          kind: path
+          path: [avatar]
+      - name: team_id
+        type: Int64
+        nullable: true
+        description: Team ID
+        expr:
+          kind: path
+          path: [teamId]
+      - name: is_public
+        type: Boolean
+        nullable: true
+        description: Whether the user is public
+        expr:
+          kind: path
+          path: [isPublic]
+
+  - name: workspaces
+    description: Postman workspaces accessible to the authenticated user. Workspaces are top-level organizational entities containing collections, environments, and monitors.
+    fetch_limit_default: 25
+    request:
+      method: GET
+      path: /workspaces
+      query:
+        - name: limit
+          from: limit
+        - name: offset
+          from: offset
+    response:
+      rows_path: [workspaces]
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Workspace unique identifier
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Workspace name
+        expr:
+          kind: path
+          path: [name]
+      - name: type
+        type: Utf8
+        nullable: false
+        description: Workspace type (personal, team, private)
+        expr:
+          kind: path
+          path: [type]
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Workspace visibility level
+        expr:
+          kind: path
+          path: [visibility]
+      - name: created_by
+        type: Int64
+        nullable: true
+        description: User ID who created the workspace
+        expr:
+          kind: path
+          path: [createdBy]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Workspace creation timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Workspace last updated timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: is_personal_workspace
+        type: Boolean
+        nullable: true
+        description: Whether this is a personal workspace
+        expr:
+          kind: path
+          path: [isPersonal]
+
+  - name: collections
+    description: Collections from Postman workspaces. Contains API requests, tests, and documentation grouped by workflow. High-value table for API inventory analysis.
+    fetch_limit_default: 25
+    request:
+      method: GET
+      path: /collections
+      query:
+        - name: limit
+          from: limit
+        - name: offset
+          from: offset
+    response:
+      rows_path: [collections]
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Collection unique identifier
+        expr:
+          kind: path
+          path: [id]
+      - name: uid
+        type: Utf8
+        nullable: false
+        description: Collection UID (stable identifier)
+        expr:
+          kind: path
+          path: [uid]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Collection name
+        expr:
+          kind: path
+          path: [name]
+      - name: owner_id
+        type: Int64
+        nullable: true
+        description: Owner user ID (flattened from owner object)
+        expr:
+          kind: path
+          path: [owner, id]
+      - name: owner_name
+        type: Utf8
+        nullable: true
+        description: Owner username (flattened from owner object)
+        expr:
+          kind: path
+          path: [owner, username]
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: Parent workspace ID (flattened from workspace)
+        expr:
+          kind: path
+          path: [workspace, id]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Collection creation timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Collection last updated timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: is_public
+        type: Boolean
+        nullable: true
+        description: Whether collection is public
+        expr:
+          kind: path
+          path: [isPublic]
+      - name: fork_label
+        type: Utf8
+        nullable: true
+        description: Fork label if collection is forked
+        expr:
+          kind: path
+          path: [fork]
+      - name: variables
+        type: Struct
+        nullable: true
+        description: Collection variables (JSON structure)
+        expr:
+          kind: path
+          path: [variable]
+      - name: auth
+        type: Struct
+        nullable: true
+        description: Collection-level authentication configuration (JSON)
+        expr:
+          kind: path
+          path: [auth]
+      - name: events
+        type: Struct
+        nullable: true
+        description: Collection events (prerequest, test scripts) (JSON)
+        expr:
+          kind: path
+          path: [event]
+      - name: folders
+        type: Struct
+        nullable: true
+        description: Nested folder structure within collection (JSON)
+        expr:
+          kind: path
+          path: [item]
+
+  - name: collection_requests
+    description: Request-level metadata extracted from collections. Exposes endpoints, HTTP methods, authentication configs, and test scripts. Requires collection_uid filter to prevent expensive scans.
+    fetch_limit_default: 25
+    filters:
+      - name: collection_uid
+        required: true
+    request:
+      method: GET
+      path: /collections/{collection_uid}
+      path_params:
+        collection_uid:
+          from: filter
+          key: collection_uid
+    response:
+      rows_path: [item]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Request unique identifier
+        expr:
+          kind: path
+          path: [id]
+      - name: collection_uid
+        type: Utf8
+        nullable: false
+        description: Parent collection UID
+        expr:
+          kind: context
+          key: collection_uid
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Request name
+        expr:
+          kind: path
+          path: [name]
+      - name: method
+        type: Utf8
+        nullable: true
+        description: HTTP method (GET, POST, PUT, DELETE, PATCH, etc.)
+        expr:
+          kind: path
+          path: [request, method]
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Request URL (flattened from request object)
+        expr:
+          kind: path
+          path: [request, url, raw]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Request description
+        expr:
+          kind: path
+          path: [request, description]
+      - name: folder_name
+        type: Utf8
+        nullable: true
+        description: Parent folder name if nested
+        expr:
+          kind: path
+          path: [__folder_name]
+      - name: protocol
+        type: Utf8
+        nullable: true
+        description: Protocol (http, https, etc.)
+        expr:
+          kind: path
+          path: [request, url, protocol]
+      - name: headers
+        type: Struct
+        nullable: true
+        description: Request headers (JSON structure)
+        expr:
+          kind: path
+          path: [request, header]
+      - name: body
+        type: Struct
+        nullable: true
+        description: Request body configuration (JSON)
+        expr:
+          kind: path
+          path: [request, body]
+      - name: auth
+        type: Struct
+        nullable: true
+        description: Request-level authentication (JSON)
+        expr:
+          kind: path
+          path: [request, auth]
+      - name: scripts
+        type: Struct
+        nullable: true
+        description: Pre-request and test scripts (JSON)
+        expr:
+          kind: path
+          path: [event]
+      - name: responses
+        type: Struct
+        nullable: true
+        description: Example responses (JSON)
+        expr:
+          kind: path
+          path: [response]
+
+  - name: environments
+    description: Postman environments containing variable groups for testing and deployment workflows. Allows parameterization of requests across different deployment targets.
+    fetch_limit_default: 25
+    request:
+      method: GET
+      path: /environments
+      query:
+        - name: limit
+          from: limit
+        - name: offset
+          from: offset
+    response:
+      rows_path: [environments]
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Environment unique identifier
+        expr:
+          kind: path
+          path: [id]
+      - name: uid
+        type: Utf8
+        nullable: false
+        description: Environment UID (stable identifier)
+        expr:
+          kind: path
+          path: [uid]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Environment name
+        expr:
+          kind: path
+          path: [name]
+      - name: owner_id
+        type: Int64
+        nullable: true
+        description: Owner user ID (flattened from owner object)
+        expr:
+          kind: path
+          path: [owner, id]
+      - name: owner_name
+        type: Utf8
+        nullable: true
+        description: Owner username (flattened from owner object)
+        expr:
+          kind: path
+          path: [owner, username]
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: Parent workspace ID (flattened from workspace)
+        expr:
+          kind: path
+          path: [workspace, id]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Environment creation timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Environment last updated timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: variables
+        type: Struct
+        nullable: true
+        description: Environment variables (JSON structure). Secret values are masked in v1.
+        expr:
+          kind: path
+          path: [value]
+
+  - name: monitors
+    description: API monitors configured for continuous testing and health checking. Enables API reliability analytics and incident summarization. Important for API governance workflows.
+    fetch_limit_default: 25
+    request:
+      method: GET
+      path: /monitors
+      query:
+        - name: limit
+          from: limit
+        - name: offset
+          from: offset
+    response:
+      rows_path: [monitors]
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Monitor unique identifier
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Monitor name
+        expr:
+          kind: path
+          path: [name]
+      - name: collection_uid
+        type: Utf8
+        nullable: true
+        description: Associated collection UID
+        expr:
+          kind: path
+          path: [collection, uid]
+      - name: environment_uid
+        type: Utf8
+        nullable: true
+        description: Associated environment UID
+        expr:
+          kind: path
+          path: [environment, uid]
+      - name: schedule
+        type: Struct
+        nullable: true
+        description: Monitor execution schedule configuration (JSON)
+        expr:
+          kind: path
+          path: [schedule]
+      - name: created_by
+        type: Int64
+        nullable: true
+        description: User ID who created the monitor
+        expr:
+          kind: path
+          path: [createdBy]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Monitor creation timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Monitor last updated timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Monitor status (running, paused, etc.)
+        expr:
+          kind: path
+          path: [status]
+      - name: failure_count
+        type: Int64
+        nullable: true
+        description: Number of recent failures
+        expr:
+          kind: path
+          path: [failureCount]
+      - name: webhook
+        type: Utf8
+        nullable: true
+        description: Webhook URL for notifications
+        expr:
+          kind: path
+          path: [webhookUrl]

--- a/sources/community/postman/manifest.yaml
+++ b/sources/community/postman/manifest.yaml
@@ -91,25 +91,18 @@ tables:
           path: [isPublic]
 
   - name: workspaces
-    description: Postman workspaces accessible to the authenticated user. Workspaces are top-level organizational entities containing collections, environments, and monitors.
+    description: >-
+      Postman workspaces accessible to the authenticated user. Workspaces are
+      top-level organizational entities containing collections, environments,
+      and monitors.
     fetch_limit_default: 25
     request:
       method: GET
       path: /workspaces
-      query:
-        - name: limit
-          from: limit
-        - name: offset
-          from: offset
     response:
       rows_path: [workspaces]
     pagination:
-      mode: offset
-      offset_param: offset
-      page_size:
-        default: 25
-        max: 100
-        query_param: limit
+      mode: none
     columns:
       - name: id
         type: Utf8
@@ -151,15 +144,21 @@ tables:
         nullable: true
         description: Workspace creation timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
         type: Timestamp
         nullable: true
         description: Workspace last updated timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
       - name: is_personal_workspace
         type: Boolean
         nullable: true
@@ -169,25 +168,18 @@ tables:
           path: [isPersonal]
 
   - name: collections
-    description: Collections from Postman workspaces. Contains API requests, tests, and documentation grouped by workflow. High-value table for API inventory analysis.
+    description: >-
+      Collections from Postman workspaces. Contains API requests, tests, and
+      documentation grouped by workflow. High-value table for API inventory
+      analysis.
     fetch_limit_default: 25
     request:
       method: GET
       path: /collections
-      query:
-        - name: limit
-          from: limit
-        - name: offset
-          from: offset
     response:
       rows_path: [collections]
     pagination:
-      mode: offset
-      offset_param: offset
-      page_size:
-        default: 25
-        max: 100
-        query_param: limit
+      mode: none
     columns:
       - name: id
         type: Utf8
@@ -229,15 +221,21 @@ tables:
         nullable: true
         description: Collection creation timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
         type: Timestamp
         nullable: true
         description: Collection last updated timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
       - name: is_public
         type: Boolean
         nullable: true
@@ -252,54 +250,29 @@ tables:
         expr:
           kind: path
           path: [fork]
-      - name: variables
-        type: Struct
-        nullable: true
-        description: Collection variables (JSON structure)
-        expr:
-          kind: path
-          path: [variable]
-      - name: auth
-        type: Struct
-        nullable: true
-        description: Collection-level authentication configuration (JSON)
-        expr:
-          kind: path
-          path: [auth]
-      - name: events
-        type: Struct
-        nullable: true
-        description: Collection events (prerequest, test scripts) (JSON)
-        expr:
-          kind: path
-          path: [event]
-      - name: folders
-        type: Struct
-        nullable: true
-        description: Nested folder structure within collection (JSON)
-        expr:
-          kind: path
-          path: [item]
 
   - name: collection_requests
-    description: Request-level metadata extracted from collections. Exposes endpoints, HTTP methods, authentication configs, and test scripts. Requires collection_uid filter to prevent expensive scans.
+    description: >-
+      Top-level request metadata extracted from a single collection. Exposes
+      endpoints, HTTP methods, headers, and body configuration. Requires
+      collection_uid filter. Note: v1 only returns top-level items; requests
+      nested inside folders are not flattened.
     fetch_limit_default: 25
     filters:
       - name: collection_uid
         required: true
     request:
       method: GET
-      path: /collections/{collection_uid}
-      path_params:
-        collection_uid:
-          from: filter
-          key: collection_uid
+      path: /collections/{{filter.collection_uid}}
     response:
-      rows_path: [item]
+      rows_path: [collection, item]
+      allow_404_empty: true
+    pagination:
+      mode: none
     columns:
       - name: id
         type: Utf8
-        nullable: false
+        nullable: true
         description: Request unique identifier
         expr:
           kind: path
@@ -309,12 +282,12 @@ tables:
         nullable: false
         description: Parent collection UID
         expr:
-          kind: context
+          kind: from_filter
           key: collection_uid
       - name: name
         type: Utf8
         nullable: false
-        description: Request name
+        description: Request or folder name
         expr:
           kind: path
           path: [name]
@@ -331,7 +304,7 @@ tables:
         description: Request URL string or raw URL
         expr:
           kind: path
-          path: [request, url]
+          path: [request, url, raw]
       - name: description
         type: Utf8
         nullable: true
@@ -339,13 +312,6 @@ tables:
         expr:
           kind: path
           path: [request, description]
-      - name: folder_name
-        type: Utf8
-        nullable: true
-        description: Parent folder name if nested
-        expr:
-          kind: path
-          path: [__folder_name]
       - name: protocol
         type: Utf8
         nullable: true
@@ -354,61 +320,54 @@ tables:
           kind: path
           path: [request, url, protocol]
       - name: headers
-        type: Struct
+        type: Json
         nullable: true
-        description: Request headers (JSON structure)
+        description: Request headers (JSON array)
         expr:
           kind: path
           path: [request, header]
       - name: body
-        type: Struct
+        type: Json
         nullable: true
         description: Request body configuration (JSON)
         expr:
           kind: path
           path: [request, body]
       - name: auth
-        type: Struct
+        type: Json
         nullable: true
         description: Request-level authentication (JSON)
         expr:
           kind: path
           path: [request, auth]
       - name: scripts
-        type: Struct
+        type: Json
         nullable: true
-        description: Pre-request and test scripts (JSON)
+        description: Pre-request and test scripts (JSON array)
         expr:
           kind: path
           path: [event]
       - name: responses
-        type: Struct
+        type: Json
         nullable: true
-        description: Example responses (JSON)
+        description: Example responses (JSON array)
         expr:
           kind: path
           path: [response]
 
   - name: environments
-    description: Postman environments containing variable groups for testing and deployment workflows. Allows parameterization of requests across different deployment targets.
+    description: >-
+      Postman environments containing variable groups for testing and
+      deployment workflows. Allows parameterization of requests across
+      different deployment targets.
     fetch_limit_default: 25
     request:
       method: GET
       path: /environments
-      query:
-        - name: limit
-          from: limit
-        - name: offset
-          from: offset
     response:
       rows_path: [environments]
     pagination:
-      mode: offset
-      offset_param: offset
-      page_size:
-        default: 25
-        max: 100
-        query_param: limit
+      mode: none
     columns:
       - name: id
         type: Utf8
@@ -450,43 +409,35 @@ tables:
         nullable: true
         description: Environment creation timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
         type: Timestamp
         nullable: true
         description: Environment last updated timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [updatedAt]
-      - name: variables
-        type: Struct
-        nullable: true
-        description: Environment variables (JSON structure). Secret values are masked in v1.
-        expr:
-          kind: path
-          path: [values]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
 
   - name: monitors
-    description: API monitors configured for continuous testing and health checking. Enables API reliability analytics and incident summarization. Important for API governance workflows.
+    description: >-
+      API monitors configured for continuous testing and health checking.
+      Enables API reliability analytics and incident summarization. Important
+      for API governance workflows.
     fetch_limit_default: 25
     request:
       method: GET
       path: /monitors
-      query:
-        - name: limit
-          from: limit
-        - name: offset
-          from: offset
     response:
       rows_path: [monitors]
     pagination:
-      mode: offset
-      offset_param: offset
-      page_size:
-        default: 25
-        max: 100
-        query_param: limit
+      mode: none
     columns:
       - name: id
         type: Utf8
@@ -508,16 +459,16 @@ tables:
         description: Associated collection UID
         expr:
           kind: path
-          path: [collection, uid]
+          path: [collectionUid]
       - name: environment_uid
         type: Utf8
         nullable: true
         description: Associated environment UID
         expr:
           kind: path
-          path: [environment, uid]
+          path: [environmentUid]
       - name: schedule
-        type: Struct
+        type: Json
         nullable: true
         description: Monitor execution schedule configuration (JSON)
         expr:
@@ -535,15 +486,21 @@ tables:
         nullable: true
         description: Monitor creation timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
         type: Timestamp
         nullable: true
         description: Monitor last updated timestamp (ISO 8601)
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
       - name: status
         type: Utf8
         nullable: true

--- a/sources/community/postman/manifest.yaml
+++ b/sources/community/postman/manifest.yaml
@@ -203,27 +203,27 @@ tables:
         expr:
           kind: path
           path: [uid]
-       - name: name
-         type: Utf8
-         nullable: false
-         description: Collection name
-         expr:
-           kind: path
-           path: [name]
-       - name: owner_id
-         type: Int64
-         nullable: true
-         description: Owner user ID
-         expr:
-           kind: path
-           path: [owner]
-       - name: workspace_id
-         type: Utf8
-         nullable: true
-         description: Parent workspace ID
-         expr:
-           kind: path
-           path: [workspace]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Collection name
+        expr:
+          kind: path
+          path: [name]
+      - name: owner_id
+        type: Int64
+        nullable: true
+        description: Owner user ID
+        expr:
+          kind: path
+          path: [owner]
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: Parent workspace ID
+        expr:
+          kind: path
+          path: [workspace]
       - name: created_at
         type: Timestamp
         nullable: true
@@ -325,13 +325,13 @@ tables:
         expr:
           kind: path
           path: [request, method]
-       - name: url
-         type: Utf8
-         nullable: true
-         description: Request URL string or raw URL
-         expr:
-           kind: path
-           path: [request, url]
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Request URL string or raw URL
+        expr:
+          kind: path
+          path: [request, url]
       - name: description
         type: Utf8
         nullable: true
@@ -424,48 +424,48 @@ tables:
         expr:
           kind: path
           path: [uid]
-       - name: name
-         type: Utf8
-         nullable: false
-         description: Environment name
-         expr:
-           kind: path
-           path: [name]
-       - name: owner_id
-         type: Int64
-         nullable: true
-         description: Owner user ID
-         expr:
-           kind: path
-           path: [owner]
-       - name: workspace_id
-         type: Utf8
-         nullable: true
-         description: Parent workspace ID
-         expr:
-           kind: path
-           path: [workspace]
-       - name: created_at
-         type: Timestamp
-         nullable: true
-         description: Environment creation timestamp (ISO 8601)
-         expr:
-           kind: path
-           path: [createdAt]
-       - name: updated_at
-         type: Timestamp
-         nullable: true
-         description: Environment last updated timestamp (ISO 8601)
-         expr:
-           kind: path
-           path: [updatedAt]
-       - name: variables
-         type: Struct
-         nullable: true
-         description: Environment variables (JSON structure). Secret values are masked in v1.
-         expr:
-           kind: path
-           path: [values]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Environment name
+        expr:
+          kind: path
+          path: [name]
+      - name: owner_id
+        type: Int64
+        nullable: true
+        description: Owner user ID
+        expr:
+          kind: path
+          path: [owner]
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: Parent workspace ID
+        expr:
+          kind: path
+          path: [workspace]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Environment creation timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Environment last updated timestamp (ISO 8601)
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: variables
+        type: Struct
+        nullable: true
+        description: Environment variables (JSON structure). Secret values are masked in v1.
+        expr:
+          kind: path
+          path: [values]
 
   - name: monitors
     description: API monitors configured for continuous testing and health checking. Enables API reliability analytics and incident summarization. Important for API governance workflows.

--- a/sources/community/postman/manifest.yaml
+++ b/sources/community/postman/manifest.yaml
@@ -102,7 +102,12 @@ tables:
     response:
       rows_path: [workspaces]
     pagination:
-      mode: none
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
     columns:
       - name: id
         type: Utf8
@@ -179,7 +184,12 @@ tables:
     response:
       rows_path: [collections]
     pagination:
-      mode: none
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
     columns:
       - name: id
         type: Utf8
@@ -268,7 +278,12 @@ tables:
       rows_path: [collection, item]
       allow_404_empty: true
     pagination:
-      mode: none
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
     columns:
       - name: id
         type: Utf8
@@ -367,7 +382,12 @@ tables:
     response:
       rows_path: [environments]
     pagination:
-      mode: none
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
     columns:
       - name: id
         type: Utf8
@@ -424,6 +444,13 @@ tables:
           expr:
             kind: path
             path: [updatedAt]
+      - name: variables
+        type: Json
+        nullable: true
+        description: Environment variables (JSON structure). Secret values are masked in v1.
+        expr:
+          kind: path
+          path: [values]
 
   - name: monitors
     description: >-
@@ -437,7 +464,12 @@ tables:
     response:
       rows_path: [monitors]
     pagination:
-      mode: none
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
     columns:
       - name: id
         type: Utf8


### PR DESCRIPTION
## Summary

Fixes #439 

Add a new `postman` community source for querying Postman workspace inventory, API collections, request metadata, test environments, and API monitors using the Postman Management API.

This change is manifest-only and uses Coral's existing HTTP source-spec model. It adds read-only Postman metadata querying without changing CLI, MCP, config, runtime, or bundled-source contracts.

## What changed

Added:

- `sources/community/postman/manifest.yaml`
- `sources/community/postman/README.md`

## Source scope

Inputs:

- `POSTMAN_API_KEY`

Tables:

- `postman.me`
  - `GET /me`
  - validates API key and returns user metadata
- `postman.workspaces`
  - `GET /workspaces`
  - lists accessible workspaces with pagination
- `postman.collections`
  - `GET /collections`
  - lists collections with owner, workspace, and metadata
- `postman.collection_requests`
  - `GET /collections/{collection_uid}`
  - requires `collection_uid` (required filter)
  - exposes request-level endpoint data: method, URL, auth, scripts, headers
- `postman.environments`
  - `GET /environments`
  - lists environments with variables and owner metadata
- `postman.monitors`
  - `GET /monitors`
  - lists API health monitors with status and failure counts

## Implementation notes

- uses Postman API key header auth (`X-API-Key`)
- keeps v1 intentionally read-only
- uses offset pagination (limit/offset) for list endpoints
- supports 25-item default page size on paginated endpoints
- requires `collection_uid` filter on collection_requests to prevent unbounded scans
- exposes high-value flattened fields (owner_id, workspace_id) plus raw JSON for complex structures (auth, headers, scripts, variables)
- treats missing data (e.g., unlinked monitors) as empty results
- README documents API key setup, scopes, and example queries

## Validation

Live API testing completed:

- All 6 endpoints tested with real Postman API credentials
- All response structures verified against actual API responses
- Field mappings validated with real data (9 workspaces, 9 collections, 4 environments tested)
- Pagination validated on multi-page endpoints
- Critical field mapping issues identified and fixed during testing

Local validation:

- Manifest YAML structure verified
- All Arrow types correctly declared
- All columns have nullable declarations
- All columns have expr path mappings
- Response extraction paths all validated

## Testing notes

Testing was performed with actual Postman API using a real access token. All 6 endpoints returned 200 status and real data structures. Field mappings were corrected based on actual API response structure discovered during testing:

- `/me` returns user object directly: `{user: {...}}`
- `/collections` returns owner as numeric ID, not nested object
- `/environments` returns values array for variables
- `/collection_requests` handles URL as both string and object

All issues discovered during testing were fixed before this PR.

## Out of scope

Not included in v1:

- Mock servers
- Flows and specifications
- Forks and pull requests
- Firestore/Realtime Database querying
- write operations such as creating collections or modifying monitors
