### PR TITLE
feat(mcp): include table functions in catalog

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -262,7 +262,7 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .description
             .as_deref()
             .expect("list_catalog description")
-            .contains("3 table(s) are currently visible")
+            .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
         tools[3]
@@ -434,10 +434,20 @@ async fn assert_list_catalog_tool(
     assert_eq!(paginated["next_offset"], 2);
     assert_eq!(paginated["items"].as_array().expect("items").len(), 2);
 
+    let functions = structured_tool_content(
+        client,
+        CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+            "kind": "table_function"
+        }))),
+    )
+    .await?;
+    assert_eq!(functions["total"], 0);
+    assert!(functions["items"].as_array().expect("items").is_empty());
+
     client
         .call_tool(
             CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "kind": "table_function"
+                "kind": "function"
             }))),
         )
         .await

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -57,13 +57,13 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 
 ## Query Guidance
 
-- Use each table's `sql_reference` from `list_tables` or `coral://tables` in `FROM` and `JOIN` clauses, for example `slack.messages`.
+- Use each catalog item's `sql_reference` from `list_catalog` in `FROM` and `JOIN` clauses, for example `slack.messages` or `github.search_repositories(q => 'coral')`.
 - Do not quote the whole `schema.table` string. Write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Check `coral.tables.required_filters` and `coral.columns.is_required_filter` before querying tables that depend on filter-only inputs.
 - Cross-source joins work with standard SQL after source scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_catalog` shows queryable catalog items in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs.
+- `list_catalog` shows queryable tables and source-scoped table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs.
 - `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs.
 - `search_tables` searches table names, descriptions, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the table name or required filters.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -3,9 +3,9 @@
 use std::collections::BTreeSet;
 
 use coral_api::v1::{
-    ExecuteSqlRequest, ListSourcesRequest, ListTablesRequest, ListTablesResponse,
-    PaginationRequest, Source, SubmitFeedbackRequest, Table as ProtoTable,
-    TableSummary as ProtoTableSummary,
+    ExecuteSqlRequest, ListSourcesRequest, ListTableFunctionsRequest, ListTableFunctionsResponse,
+    ListTablesRequest, ListTablesResponse, PaginationRequest, Source, SubmitFeedbackRequest,
+    Table as ProtoTable, TableSummary as ProtoTableSummary,
 };
 use coral_client::{
     AppClient, FeedbackClient, QueryClient, SourceClient, batches_to_json_rows,
@@ -40,12 +40,20 @@ use crate::{
 
 const LIST_TABLES_COUNT_LIMIT: u32 = 1;
 const LIST_TABLES_UNBOUNDED_LIMIT: u32 = 0;
+const LIST_TABLE_FUNCTIONS_COUNT_LIMIT: u32 = 1;
+const LIST_TABLE_FUNCTIONS_UNBOUNDED_LIMIT: u32 = 0;
 
 struct LoadTablesParams<'a> {
     schema_name: Option<&'a str>,
     table_name: Option<&'a str>,
     pagination: PaginationRequest,
     omit_columns: bool,
+}
+
+struct LoadTableFunctionsParams<'a> {
+    schema_name: Option<&'a str>,
+    function_name: Option<&'a str>,
+    pagination: PaginationRequest,
 }
 
 enum ToolCallOutcome {
@@ -111,6 +119,22 @@ impl CoralMcpServer {
             .into_inner())
     }
 
+    async fn load_table_functions(
+        &self,
+        params: LoadTableFunctionsParams<'_>,
+    ) -> Result<ListTableFunctionsResponse, tonic::Status> {
+        let mut query_client = self.query.clone();
+        Ok(query_client
+            .list_table_functions(Request::new(ListTableFunctionsRequest {
+                workspace: Some(default_workspace()),
+                schema_name: params.schema_name.unwrap_or_default().to_string(),
+                function_name: params.function_name.unwrap_or_default().to_string(),
+                pagination: Some(params.pagination),
+            }))
+            .await?
+            .into_inner())
+    }
+
     async fn load_all_table_summaries(&self) -> Result<Vec<ProtoTableSummary>, tonic::Status> {
         self.load_table_summaries(None).await
     }
@@ -170,6 +194,31 @@ impl CoralMcpServer {
                 .pagination
                 .map_or(0, |pagination| pagination.total_count as usize)
         })
+    }
+
+    async fn load_table_function_count(&self) -> Result<usize, tonic::Status> {
+        self.load_table_functions(LoadTableFunctionsParams {
+            schema_name: None,
+            function_name: None,
+            pagination: PaginationRequest {
+                limit: LIST_TABLE_FUNCTIONS_COUNT_LIMIT,
+                offset: 0,
+            },
+        })
+        .await
+        .map(|response| {
+            response
+                .pagination
+                .map_or(0, |pagination| pagination.total_count as usize)
+        })
+    }
+
+    async fn load_sources_and_counts(&self) -> Result<(Vec<Source>, usize, usize), tonic::Status> {
+        tokio::try_join!(
+            self.load_sources(),
+            self.load_table_count(),
+            self.load_table_function_count()
+        )
     }
 
     async fn load_sources_and_table_count(&self) -> Result<(Vec<Source>, usize), tonic::Status> {
@@ -281,9 +330,25 @@ impl CoralMcpServer {
         kind: Option<&str>,
         pagination: crate::surface::Pagination,
     ) -> Result<Value, tonic::Status> {
-        debug_assert!(matches!(kind, None | Some("table")));
-        let tables = self.load_table_summaries(schema_name).await?;
-        let items = tables.iter().map(CatalogItem::from_table).collect();
+        let mut items = Vec::new();
+        if kind != Some("table_function") {
+            let tables = self.load_table_summaries(schema_name).await?;
+            items.extend(tables.iter().map(CatalogItem::from_table));
+        }
+        if kind != Some("table") {
+            let functions = self
+                .load_table_functions(LoadTableFunctionsParams {
+                    schema_name,
+                    function_name: None,
+                    pagination: PaginationRequest {
+                        limit: LIST_TABLE_FUNCTIONS_UNBOUNDED_LIMIT,
+                        offset: 0,
+                    },
+                })
+                .await?
+                .table_functions;
+            items.extend(functions.iter().map(CatalogItem::from_table_function));
+        }
         catalog_value(items, pagination).map_err(|error| tonic::Status::internal(error.to_string()))
     }
 
@@ -561,14 +626,14 @@ impl ServerHandler for CoralMcpServer {
     ) -> Result<ListToolsResult, ErrorData> {
         let span = telemetry::list_tools_span(self.options.trace_parent.as_deref());
         telemetry::instrument_protocol(span, async {
-            let (sources, visible_table_count) = self
-                .load_sources_and_table_count()
+            let (sources, visible_table_count, visible_function_count) = self
+                .load_sources_and_counts()
                 .await
                 .map_err(|status| status_to_error_data(&status))?;
             let mut tools = vec![
                 sql_tool(&sources, visible_table_count),
                 list_tables_tool(visible_table_count),
-                list_catalog_tool(visible_table_count),
+                list_catalog_tool(visible_table_count, visible_function_count),
                 search_tables_tool(visible_table_count),
                 describe_table_tool(),
                 list_columns_tool(),

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use coral_api::v1::TableSummary as ProtoTableSummary;
+use coral_api::v1::{TableFunction as ProtoTableFunction, TableSummary as ProtoTableSummary};
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
@@ -19,6 +19,13 @@ pub(crate) enum CatalogItem {
         description: String,
         table: CatalogTableDetails,
     },
+    TableFunction {
+        schema_name: String,
+        name: String,
+        sql_reference: String,
+        description: String,
+        table_function: CatalogTableFunctionDetails,
+    },
 }
 
 impl CatalogItem {
@@ -36,12 +43,47 @@ impl CatalogItem {
         }
     }
 
+    pub(crate) fn from_table_function(function: &ProtoTableFunction) -> Self {
+        Self::TableFunction {
+            schema_name: function.schema_name.clone(),
+            name: format!("{}.{}", function.schema_name, function.name),
+            sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
+            description: function.description.clone(),
+            table_function: CatalogTableFunctionDetails {
+                function_name: function.name.clone(),
+                arguments: function
+                    .arguments
+                    .iter()
+                    .map(|argument| CatalogTableFunctionArgument {
+                        name: argument.name.clone(),
+                        required: argument.required,
+                        values: argument.values.clone(),
+                    })
+                    .collect(),
+                result_columns: function
+                    .result_columns
+                    .iter()
+                    .map(|column| CatalogTableFunctionResultColumn {
+                        column_name: column.name.clone(),
+                        data_type: column.data_type.clone(),
+                        is_nullable: column.nullable,
+                        description: column.description.clone(),
+                    })
+                    .collect(),
+            },
+        }
+    }
+
     fn sort_key(&self) -> String {
-        match self {
+        let (schema_name, name, kind) = match self {
             Self::Table {
                 schema_name, name, ..
-            } => format!("{schema_name}\0{name}\0table"),
-        }
+            } => (schema_name, name, "table"),
+            Self::TableFunction {
+                schema_name, name, ..
+            } => (schema_name, name, "table_function"),
+        };
+        format!("{schema_name}\0{name}\0{kind}")
     }
 }
 
@@ -50,6 +92,28 @@ pub(crate) struct CatalogTableDetails {
     table_name: String,
     guide: String,
     required_filters: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CatalogTableFunctionDetails {
+    function_name: String,
+    arguments: Vec<CatalogTableFunctionArgument>,
+    result_columns: Vec<CatalogTableFunctionResultColumn>,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogTableFunctionArgument {
+    name: String,
+    required: bool,
+    values: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CatalogTableFunctionResultColumn {
+    column_name: String,
+    data_type: String,
+    is_nullable: bool,
+    description: String,
 }
 
 pub(crate) fn catalog_value(
@@ -68,7 +132,12 @@ pub(crate) fn catalog_output_schema() -> Arc<Map<String, Value>> {
         "properties": {
             "items": {
                 "type": "array",
-                "items": catalog_table_item_output_schema()
+                "items": {
+                    "oneOf": [
+                        catalog_table_item_output_schema(),
+                        catalog_table_function_item_output_schema()
+                    ]
+                }
             },
             "total": {
                 "type": "integer",
@@ -119,6 +188,66 @@ fn catalog_table_item_output_schema() -> Value {
     })
 }
 
+fn catalog_table_function_item_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": [
+            "kind",
+            "schema_name",
+            "name",
+            "sql_reference",
+            "description",
+            "table_function"
+        ],
+        "additionalProperties": false,
+        "properties": {
+            "kind": { "enum": ["table_function"] },
+            "schema_name": { "type": "string" },
+            "name": { "type": "string" },
+            "sql_reference": { "type": "string" },
+            "description": { "type": "string" },
+            "table_function": {
+                "type": "object",
+                "required": ["function_name", "arguments", "result_columns"],
+                "additionalProperties": false,
+                "properties": {
+                    "function_name": { "type": "string" },
+                    "arguments": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["name", "required", "values"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "name": { "type": "string" },
+                                "required": { "type": "boolean" },
+                                "values": {
+                                    "type": "array",
+                                    "items": { "type": "string" }
+                                }
+                            }
+                        }
+                    },
+                    "result_columns": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["column_name", "data_type", "is_nullable", "description"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "column_name": { "type": "string" },
+                                "data_type": { "type": "string" },
+                                "is_nullable": { "type": "boolean" },
+                                "description": { "type": "string" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     #![expect(
@@ -126,9 +255,11 @@ mod tests {
         reason = "JSON shape assertions intentionally fail loudly in tests"
     )]
 
-    use coral_api::v1::{TableSummary, Workspace};
+    use coral_api::v1::{
+        TableFunction, TableFunctionArgument, TableFunctionResultColumn, TableSummary, Workspace,
+    };
     use jsonschema::JSONSchema;
-    use serde_json::Value;
+    use serde_json::{Value, json};
 
     use super::{CatalogItem, catalog_output_schema, catalog_value};
     use crate::surface::Pagination;
@@ -136,7 +267,10 @@ mod tests {
     #[test]
     fn catalog_value_matches_advertised_schema() {
         let value = catalog_value(
-            vec![CatalogItem::from_table(&table("github", "pulls"))],
+            vec![
+                CatalogItem::from_table(&table("github", "pulls")),
+                CatalogItem::from_table_function(&table_function("github", "search_issues")),
+            ],
             Pagination {
                 limit: 10,
                 offset: 0,
@@ -155,22 +289,55 @@ mod tests {
             );
         }
 
-        assert_eq!(value["total"], 1);
+        assert_eq!(value["total"], 2);
         assert_eq!(value["items"][0]["kind"], "table");
         assert_eq!(value["items"][0]["name"], "github.pulls");
         assert_eq!(value["items"][0]["table"]["table_name"], "pulls");
+        assert_eq!(value["items"][1]["kind"], "table_function");
+        assert_eq!(
+            value["items"][1]["table_function"]["arguments"][0]["values"],
+            json!(["open", "closed"])
+        );
+        assert_eq!(
+            value["items"][1]["table_function"]["result_columns"][0]["column_name"],
+            "title"
+        );
     }
 
     fn table(schema_name: &str, name: &str) -> TableSummary {
         TableSummary {
-            workspace: Some(Workspace {
-                name: "default".to_string(),
-            }),
+            workspace: Some(workspace()),
             schema_name: schema_name.to_string(),
             name: name.to_string(),
             description: format!("{name} description"),
             required_filters: vec!["repo".to_string()],
             guide: format!("Query {name}."),
+        }
+    }
+
+    fn table_function(schema_name: &str, name: &str) -> TableFunction {
+        TableFunction {
+            workspace: Some(workspace()),
+            schema_name: schema_name.to_string(),
+            name: name.to_string(),
+            description: format!("{name} description"),
+            arguments: vec![TableFunctionArgument {
+                name: "state".to_string(),
+                required: true,
+                values: vec!["open".to_string(), "closed".to_string()],
+            }],
+            result_columns: vec![TableFunctionResultColumn {
+                name: "title".to_string(),
+                data_type: "Utf8".to_string(),
+                nullable: false,
+                description: "Issue title.".to_string(),
+            }],
+        }
+    }
+
+    fn workspace() -> Workspace {
+        Workspace {
+            name: "default".to_string(),
         }
     }
 }

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -5,7 +5,7 @@ use coral_api::v1::{ListTablesResponse, Source, Table, TableSummary};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_catalog`, `list_tables`, `search_tables`, `describe_table`, and `list_columns` to inspect queryable tables, and use `sql` for final queries.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_catalog` to inspect queryable tables and table functions, use `list_tables`, `search_tables`, `describe_table`, and `list_columns` for table-specific discovery, and use `sql` for final queries.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {
@@ -241,9 +241,7 @@ mod tests {
         assert!(content.contains("Visible source schemas:"));
         assert!(content.contains("- slack"));
         assert!(
-            content.contains(
-                "Use each table's `sql_reference` from `list_tables` or `coral://tables`"
-            )
+            content.contains("Use each catalog item's `sql_reference` from `list_catalog`")
         );
     }
 

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -107,10 +107,12 @@ pub(crate) fn list_tables_tool(visible_table_count: usize) -> Tool {
     )
 }
 
-pub(crate) fn list_catalog_tool(visible_table_count: usize) -> Tool {
+pub(crate) fn list_catalog_tool(visible_table_count: usize, visible_function_count: usize) -> Tool {
     Tool::new(
         "list_catalog",
-        format!("List queryable catalog items. {visible_table_count} table(s) are currently visible."),
+        format!(
+            "List queryable catalog items, including tables and source-scoped table functions. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
+        ),
         json_object_schema(&json!({
             "type": "object",
             "properties": {
@@ -123,7 +125,7 @@ pub(crate) fn list_catalog_tool(visible_table_count: usize) -> Tool {
                     "anyOf": [
                         {
                             "type": "string",
-                            "enum": ["table"]
+                            "enum": ["table", "table_function"]
                         },
                         {
                             "type": "null"
@@ -350,10 +352,10 @@ pub(crate) fn list_catalog_arguments(
 ) -> Result<ListCatalogArguments, ErrorData> {
     let kind = optional_string_argument(arguments, "kind")?;
     match kind.as_deref() {
-        None | Some("table") => {}
+        None | Some("table" | "table_function") => {}
         Some(_) => {
             return Err(ErrorData::invalid_params(
-                "argument 'kind' must be 'table'",
+                "argument 'kind' must be 'table' or 'table_function'",
                 None,
             ));
         }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -92,6 +92,53 @@ tables:
     manifest_path
 }
 
+fn table_function_manifest_yaml() -> String {
+    r"
+name: searchy
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: placeholder
+    description: Placeholder table
+    request:
+      method: GET
+      path: /placeholder
+    columns:
+      - name: id
+        type: Utf8
+functions:
+  - name: search_issues
+    description: Search issues
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: mode
+        values: [lexical, semantic, hybrid]
+        bind:
+          arg: search_type
+    request:
+      method: GET
+      path: /search/issues
+      query:
+        - name: q
+          from: arg
+          key: q
+    response:
+      rows_path: [items]
+    columns:
+      - name: title
+        type: Utf8
+        description: Issue title
+      - name: score
+        type: Float64
+"
+    .to_string()
+}
+
 fn json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
 }
@@ -300,7 +347,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .description
             .as_deref()
             .expect("catalog description")
-            .contains("3 table(s) are currently visible")
+            .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
         updated_tools[3]
@@ -494,7 +541,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     client
         .call_tool(
             CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "kind": "table_function"
+                "kind": "function"
             }))),
         )
         .await
@@ -758,6 +805,106 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         )
         .await
         .expect_err("empty column regex should fail");
+
+    session.shutdown().await;
+}
+
+#[tokio::test]
+async fn mcp_list_catalog_returns_tables_and_table_functions() {
+    let temp = TempDir::new().expect("temp dir");
+    let mut session = start_session(&temp).await;
+    let client = &session.client;
+
+    add_demo_source(&mut session.source_client, table_function_manifest_yaml()).await;
+
+    let tools = client.list_all_tools().await.expect("tools");
+    assert!(tool_by_name(&tools, "list_tables").name.as_ref() == "list_tables");
+    let list_catalog_tool = tool_by_name(&tools, "list_catalog");
+    assert!(
+        list_catalog_tool
+            .description
+            .as_deref()
+            .expect("catalog description")
+            .contains("1 table(s) and 1 table function(s) are currently visible")
+    );
+
+    let catalog = client
+        .call_tool(CallToolRequestParams::new("list_catalog"))
+        .await
+        .expect("list catalog");
+    let catalog = catalog.structured_content.expect("structured catalog");
+    assert_eq!(catalog["total"], 2);
+    assert_eq!(catalog["items"][0]["kind"], "table");
+    assert_eq!(catalog["items"][0]["name"], "searchy.placeholder");
+    assert_eq!(catalog["items"][1]["kind"], "table_function");
+    assert_eq!(catalog["items"][1]["name"], "searchy.search_issues");
+    assert_eq!(
+        catalog["items"][1]["sql_reference"],
+        "searchy.search_issues"
+    );
+    assert_eq!(
+        catalog["items"][1]["table_function"]["function_name"],
+        "search_issues"
+    );
+    assert_eq!(
+        catalog["items"][1]["table_function"]["arguments"][1]["values"],
+        json!(["lexical", "semantic", "hybrid"])
+    );
+    assert_eq!(
+        catalog["items"][1]["table_function"]["result_columns"][0]["column_name"],
+        "title"
+    );
+    assert_matches_output_schema(list_catalog_tool, &catalog);
+
+    let explicit_all_kinds = client
+        .call_tool(
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+                "schema": "searchy",
+                "kind": null,
+            }))),
+        )
+        .await
+        .expect("list catalog with null kind");
+    let explicit_all_kinds = explicit_all_kinds
+        .structured_content
+        .expect("structured catalog");
+    assert_eq!(explicit_all_kinds["total"], 2);
+    assert_matches_output_schema(list_catalog_tool, &explicit_all_kinds);
+
+    let functions = client
+        .call_tool(
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+                "schema": "searchy",
+                "kind": "table_function",
+                "limit": 10,
+                "offset": 0
+            }))),
+        )
+        .await
+        .expect("list table functions through catalog");
+    let functions = functions.structured_content.expect("structured catalog");
+    assert_eq!(functions["total"], 1);
+    assert_eq!(functions["items"][0]["kind"], "table_function");
+    assert_eq!(functions["items"][0]["name"], "searchy.search_issues");
+    assert_matches_output_schema(list_catalog_tool, &functions);
+
+    let page = client
+        .call_tool(
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+                "schema": "searchy",
+                "limit": 1,
+                "offset": 1
+            }))),
+        )
+        .await
+        .expect("list paginated catalog");
+    let page = page.structured_content.expect("structured catalog");
+    assert_eq!(page["total"], 2);
+    assert_eq!(page["limit"], 1);
+    assert_eq!(page["offset"], 1);
+    assert_eq!(page["has_more"], false);
+    assert_eq!(page["items"][0]["kind"], "table_function");
+    assert_matches_output_schema(list_catalog_tool, &page);
 
     session.shutdown().await;
 }

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -15,7 +15,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
-| Tool     | `list_catalog`   | List queryable catalog items with pagination            |
+| Tool     | `list_catalog`   | List queryable tables and table functions with pagination |
 | Tool     | `list_tables`    | List queryable fully qualified tables with pagination   |
 | Tool     | `search_tables`  | Search table metadata with a Rust regex                 |
 | Tool     | `describe_table` | Show compact metadata for one table                     |
@@ -25,7 +25,7 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-`list_catalog` returns queryable catalog items in pages and accepts optional `schema`, `kind`, `limit`, and `offset` arguments. In this version, catalog items are ordinary tables.
+`list_catalog` returns queryable catalog items in pages and accepts optional `schema`, `kind`, `limit`, and `offset` arguments. Omit `kind` or pass `null` to list both ordinary tables and source-scoped table functions; pass `table` or `table_function` to narrow the result.
 `list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. Use each table's `sql_reference` value in `FROM` and `JOIN` clauses. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 `search_tables` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table names, descriptions, guides, and required filters.
 `describe_table` accepts exact `schema` and `table` arguments and returns guide text, required filters, and a column count without dumping full columns.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -151,7 +151,7 @@ This server exposes:
 | Type     | Name             | Description                      |
 | -------- | ---------------- | -------------------------------- |
 | Tool     | `sql`            | Run a SQL query                  |
-| Tool     | `list_catalog`   | List queryable catalog items     |
+| Tool     | `list_catalog`   | List queryable catalog items, including table functions |
 | Tool     | `list_tables`    | List available tables by page    |
 | Tool     | `search_tables`  | Search table metadata by regex   |
 | Tool     | `describe_table` | Show compact table metadata      |


### PR DESCRIPTION
## Intent

Make `list_catalog` cover all queryable source capabilities by including source-scoped table functions alongside ordinary tables.

## What Changed

- Loads table-function metadata through the existing `ListTableFunctions` API.
- Adds `kind: "table_function"` catalog items with argument and result-column metadata.
- Allows `kind: null`, `kind: "table"`, and `kind: "table_function"` filters.
- Extends MCP/CLI tests to cover mixed catalog output and pagination.

## Ownership / Boundaries

`coral-mcp` owns the MCP response shape. The typed table-function metadata and transport contract stay in earlier engine/API PRs; this PR only consumes that metadata for catalog discovery.

## Not in This PR

- No separate `list_table_functions` or `search_table_functions` MCP tool.
- No `list_tables` removal; compatibility remains for one more PR.

## Validation

- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --features cli-test-server --test mcp`
- `cargo clippy -p coral-mcp --all-targets --locked -- -D warnings`
- `make docs-check`
- Full top-of-stack check: `make rust-checks`