### PR TITLE
feat(mcp)!: remove table-only listing tool

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -236,7 +236,6 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
             .collect::<Vec<_>>(),
         vec![
             "sql",
-            "list_tables",
             "list_catalog",
             "search_tables",
             "describe_table",
@@ -254,18 +253,11 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
         tools[1]
             .description
             .as_deref()
-            .expect("list_tables description")
-            .contains("3 table(s) are currently visible")
-    );
-    assert!(
-        tools[2]
-            .description
-            .as_deref()
             .expect("list_catalog description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
-        tools[3]
+        tools[2]
             .description
             .as_deref()
             .expect("search_tables description")
@@ -315,7 +307,6 @@ async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn s
             .collect::<Vec<_>>(),
         vec![
             "sql",
-            "list_tables",
             "list_catalog",
             "search_tables",
             "describe_table",
@@ -330,12 +321,11 @@ async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn s
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_sql_and_list_tables_return_structured_content()
+async fn mcp_stdio_sql_and_catalog_tools_return_structured_content()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client(&server).await?;
 
-    assert_list_tables_tool(&client, &server).await?;
     assert_list_catalog_tool(&client, &server).await?;
     assert_search_tables_tool(&client, &server).await?;
     assert_describe_table_tool(&client, &server).await?;
@@ -344,44 +334,6 @@ async fn mcp_stdio_sql_and_list_tables_return_structured_content()
 
     client.cancel().await?;
     server.shutdown().await;
-    Ok(())
-}
-
-async fn assert_list_tables_tool(
-    client: &RunningService<RoleClient, ()>,
-    server: &MockServer,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let structured_tables =
-        structured_tool_content(client, CallToolRequestParams::new("list_tables")).await?;
-    assert_eq!(structured_tables["total"], 3);
-    assert_eq!(structured_tables["limit"], 50);
-    assert_eq!(structured_tables["offset"], 0);
-    assert_eq!(structured_tables["has_more"], false);
-    assert_eq!(
-        structured_tables["tables"][0]["name"],
-        "local_messages.events"
-    );
-    assert!(structured_tables["tables"][0]["columns"].is_null());
-    let requests = server.list_tables_requests();
-    let request = requests.last().expect("list tables request");
-    assert_eq!(request.schema_name, "");
-    let request_pagination = request.pagination.as_ref().expect("request pagination");
-    assert_eq!(request_pagination.limit, 50);
-    assert_eq!(request_pagination.offset, 0);
-    assert!(request.omit_columns);
-
-    let paginated = structured_tool_content(
-        client,
-        CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
-            "schema": "local_messages",
-            "limit": 2,
-            "offset": 0
-        }))),
-    )
-    .await?;
-    assert_eq!(paginated["total"], 3);
-    assert_eq!(paginated["has_more"], true);
-    assert_eq!(paginated["next_offset"], 2);
     Ok(())
 }
 
@@ -433,25 +385,6 @@ async fn assert_list_catalog_tool(
     assert_eq!(paginated["has_more"], true);
     assert_eq!(paginated["next_offset"], 2);
     assert_eq!(paginated["items"].as_array().expect("items").len(), 2);
-
-    let functions = structured_tool_content(
-        client,
-        CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-            "kind": "table_function"
-        }))),
-    )
-    .await?;
-    assert_eq!(functions["total"], 0);
-    assert!(functions["items"].as_array().expect("items").is_empty());
-
-    client
-        .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "kind": "function"
-            }))),
-        )
-        .await
-        .expect_err("invalid catalog kind should fail");
     Ok(())
 }
 
@@ -607,12 +540,12 @@ async fn mcp_stdio_tool_errors_do_not_end_the_session() -> Result<(), Box<dyn st
         "Query request is invalid"
     );
 
-    let tables = client
-        .call_tool(CallToolRequestParams::new("list_tables"))
+    let catalog = client
+        .call_tool(CallToolRequestParams::new("list_catalog"))
         .await?;
-    assert_eq!(tables.is_error, Some(false));
+    assert_eq!(catalog.is_error, Some(false));
     assert_eq!(
-        tables.structured_content.expect("structured content")["tables"][0]["name"],
+        catalog.structured_content.expect("structured content")["items"][0]["name"],
         "local_messages.events"
     );
 

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -4,7 +4,7 @@
 
 ## Discovery Workflow
 
-Always inspect queryable tables, source-scoped table functions, and table metadata before writing queries. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
+Always inspect the queryable catalog and table metadata before writing queries. The catalog includes both ordinary tables and source-scoped table functions. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
 
 ```sql
 -- List visible tables, descriptions, and required filters
@@ -63,8 +63,7 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Cross-source joins work with standard SQL after source scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_catalog` shows queryable tables and source-scoped table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs.
-- `list_tables` shows queryable fully qualified tables in pages; pass `schema`, `limit`, and `offset` to narrow large catalogs.
+- `list_catalog` shows queryable tables and source-scoped table functions in one paginated catalog; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs.
 - `search_tables` searches table names, descriptions, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the table name or required filters.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
 - `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively.

--- a/crates/coral-mcp/src/lib.rs
+++ b/crates/coral-mcp/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! The exposed MCP surface is intentionally small:
 //!
-//! - tools: `sql`, paginated `list_catalog`, `list_tables`, `search_tables`, `describe_table`, `list_columns`, and optionally `feedback`
+//! - tools: `sql`, paginated `list_catalog`, `search_tables`, `describe_table`, `list_columns`, and optionally `feedback`
 //! - resources: `coral://guide`, `coral://tables`
 //!
 //! Protocol lifecycle, initialization, and stdio transport behavior should stay

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -30,10 +30,9 @@ use crate::{
         compile_metadata_regex, describe_table_arguments, describe_table_tool, feedback_tool,
         guide_resource, guide_resource_content, initial_instructions, internal_status,
         list_catalog_arguments, list_catalog_tool, list_columns_arguments, list_columns_tool,
-        list_tables_arguments, list_tables_tool, list_tables_value, page_items, paged_value,
-        required_string_argument, search_tables_arguments, search_tables_tool, sql_tool,
-        status_to_error_data, tables_resource, tables_resource_content, tool_error_from_status,
-        tool_error_result,
+        page_items, paged_value, required_string_argument, search_tables_arguments,
+        search_tables_tool, sql_tool, status_to_error_data, tables_resource,
+        tables_resource_content, tool_error_from_status, tool_error_result,
     },
     telemetry,
 };
@@ -398,22 +397,6 @@ impl CoralMcpServer {
                     self.execute_sql_value(&sql).await,
                 ))
             }
-            "list_tables" => {
-                let arguments = list_tables_arguments(request.arguments.as_ref())?;
-                let result = self
-                    .load_tables(LoadTablesParams {
-                        schema_name: arguments.schema.as_deref(),
-                        table_name: None,
-                        pagination: PaginationRequest {
-                            limit: arguments.limit,
-                            offset: arguments.offset,
-                        },
-                        omit_columns: true,
-                    })
-                    .await
-                    .map(|response| list_tables_value(&response));
-                Ok(ToolCallOutcome::from_value_result("Table listing", result))
-            }
             "list_catalog" => {
                 self.list_catalog_tool_result(request.arguments.as_ref())
                     .await
@@ -546,9 +529,10 @@ fn describe_missing_table_value(schema: &str, table: &str, summaries: &[TableSum
     })];
     if !same_schema_tables.is_empty() {
         suggested_calls.push(serde_json::json!({
-            "tool": "list_tables",
+            "tool": "list_catalog",
             "arguments": {
                 "schema": schema,
+                "kind": "table",
                 "limit": 10,
             }
         }));
@@ -632,7 +616,6 @@ impl ServerHandler for CoralMcpServer {
                 .map_err(|status| status_to_error_data(&status))?;
             let mut tools = vec![
                 sql_tool(&sources, visible_table_count),
-                list_tables_tool(visible_table_count),
                 list_catalog_tool(visible_table_count, visible_function_count),
                 search_tables_tool(visible_table_count),
                 describe_table_tool(),

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -292,7 +292,6 @@ mod tests {
         assert_eq!(value["total"], 2);
         assert_eq!(value["items"][0]["kind"], "table");
         assert_eq!(value["items"][0]["name"], "github.pulls");
-        assert_eq!(value["items"][0]["table"]["table_name"], "pulls");
         assert_eq!(value["items"][1]["kind"], "table_function");
         assert_eq!(
             value["items"][1]["table_function"]["arguments"][0]["values"],

--- a/crates/coral-mcp/src/surface/mod.rs
+++ b/crates/coral-mcp/src/surface/mod.rs
@@ -20,13 +20,12 @@ pub(crate) use errors::{
 };
 pub(crate) use resources::{
     format_schema_table_equivalent, guide_resource, guide_resource_content, initial_instructions,
-    list_tables_value, tables_resource, tables_resource_content,
+    tables_resource, tables_resource_content,
 };
 pub(crate) use tools::{
     build_tool_result, describe_table_arguments, describe_table_tool, feedback_tool,
     list_catalog_arguments, list_catalog_tool, list_columns_arguments, list_columns_tool,
-    list_tables_arguments, list_tables_tool, required_string_argument, search_tables_arguments,
-    search_tables_tool, sql_tool,
+    required_string_argument, search_tables_arguments, search_tables_tool, sql_tool,
 };
 
 fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeSet;
 use std::fmt::Write as _;
 
-use coral_api::v1::{ListTablesResponse, Source, Table, TableSummary};
+use coral_api::v1::{Source, TableSummary};
 use rmcp::model::{AnnotateAble, RawResource, Resource};
 use serde_json::{Value, json};
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_catalog` to inspect queryable tables and table functions, use `list_tables`, `search_tables`, `describe_table`, and `list_columns` for table-specific discovery, and use `sql` for final queries.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_catalog`, `search_tables`, `describe_table`, and `list_columns` to inspect queryable catalog items and tables, and use `sql` for final queries.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {
@@ -74,25 +74,6 @@ pub(crate) fn tables_resource_content(
     serde_json::to_string_pretty(&json!({ "tables": queryable_tables(tables) }))
 }
 
-pub(crate) fn list_tables_value(response: &ListTablesResponse) -> Value {
-    let pagination = response.pagination.unwrap_or_default();
-    let table_summaries = response_table_summaries(response);
-    let mut value = json!({
-        "tables": queryable_tables(&table_summaries),
-        "total": pagination.total_count,
-        "limit": pagination.limit,
-        "offset": pagination.offset,
-        "has_more": pagination.has_more,
-    });
-    if pagination.has_more {
-        value
-            .as_object_mut()
-            .expect("list tables value is initialized as a JSON object")
-            .insert("next_offset".to_string(), json!(pagination.next_offset));
-    }
-    value
-}
-
 fn guide_resource_description(sources: &[Source], visible_table_count: usize) -> String {
     format!(
         "Query workflow and schema discovery guidance for {} configured source(s) and {} visible table(s).",
@@ -126,25 +107,6 @@ fn queryable_tables(tables: &[TableSummary]) -> Vec<Value> {
             .cmp(&right.get("name").and_then(Value::as_str))
     });
     summaries
-}
-
-fn response_table_summaries(response: &ListTablesResponse) -> Vec<TableSummary> {
-    if response.table_summaries.is_empty() {
-        response.tables.iter().map(table_to_summary).collect()
-    } else {
-        response.table_summaries.clone()
-    }
-}
-
-fn table_to_summary(table: &Table) -> TableSummary {
-    TableSummary {
-        workspace: table.workspace.clone(),
-        schema_name: table.schema_name.clone(),
-        name: table.name.clone(),
-        description: table.description.clone(),
-        required_filters: table.required_filters.clone(),
-        guide: table.guide.clone(),
-    }
 }
 
 fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
@@ -190,10 +152,10 @@ mod tests {
         reason = "JSON shape assertions intentionally fail loudly in tests"
     )]
 
-    use coral_api::v1::{ListTablesResponse, PaginationResponse, Source, TableSummary, Workspace};
+    use coral_api::v1::{Source, TableSummary, Workspace};
     use serde_json::json;
 
-    use super::{format_schema_table_equivalent, guide_resource_content, list_tables_value};
+    use super::{format_schema_table_equivalent, guide_resource_content, tables_resource_content};
 
     fn source(name: &str) -> Source {
         Source {
@@ -240,24 +202,15 @@ mod tests {
         assert!(content.contains("- coral: System metadata schema."));
         assert!(content.contains("Visible source schemas:"));
         assert!(content.contains("- slack"));
-        assert!(
-            content.contains("Use each catalog item's `sql_reference` from `list_catalog`")
-        );
+        assert!(content.contains("Use each catalog item's `sql_reference` from `list_catalog`"));
     }
 
     #[test]
-    fn list_tables_value_includes_compatible_name_and_sql_reference() {
-        let value = list_tables_value(&ListTablesResponse {
-            tables: Vec::new(),
-            pagination: Some(PaginationResponse {
-                total_count: 1,
-                limit: 50,
-                offset: 0,
-                has_more: false,
-                next_offset: 0,
-            }),
-            table_summaries: vec![table("local_messages", "events")],
-        });
+    fn tables_resource_content_includes_compatible_name_and_sql_reference() {
+        let content = tables_resource_content(&[table("local_messages", "events")])
+            .expect("serialize tables resource");
+        let value: serde_json::Value =
+            serde_json::from_str(&content).expect("parse tables resource");
 
         assert_eq!(value["tables"][0]["name"], "local_messages.events");
         assert_eq!(value["tables"][0]["sql_reference"], "local_messages.events");
@@ -273,10 +226,6 @@ mod tests {
                 "required_filters": [],
             })
         );
-        assert_eq!(value["total"], 1);
-        assert_eq!(value["limit"], 50);
-        assert_eq!(value["offset"], 0);
-        assert_eq!(value["has_more"], false);
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -12,12 +12,6 @@ use super::{
     parse_pagination_with_limits,
 };
 
-pub(crate) struct ListTablesArguments {
-    pub(crate) schema: Option<String>,
-    pub(crate) limit: u32,
-    pub(crate) offset: u32,
-}
-
 pub(crate) struct ListCatalogArguments {
     pub(crate) schema: Option<String>,
     pub(crate) kind: Option<String>,
@@ -66,44 +60,6 @@ pub(crate) fn sql_tool(sources: &[Source], visible_table_count: usize) -> Tool {
             .destructive(false)
             .idempotent(true)
             .open_world(true),
-    )
-}
-
-pub(crate) fn list_tables_tool(visible_table_count: usize) -> Tool {
-    Tool::new(
-        "list_tables",
-        list_tables_description(visible_table_count),
-        json_object_schema(&json!({
-            "type": "object",
-            "properties": {
-                "schema": {
-                    "type": "string",
-                    "description": "Optional exact schema/source name to list."
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum tables to return, from 1 to 200. Defaults to 50.",
-                    "minimum": 1,
-                    "maximum": 200,
-                    "default": 50
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "Number of matching tables to skip. Defaults to 0.",
-                    "minimum": 0,
-                    "maximum": u32::MAX,
-                    "default": 0
-                }
-            }
-        })),
-    )
-    .with_raw_output_schema(list_tables_output_schema())
-    .with_annotations(
-        ToolAnnotations::with_title("List Tables")
-            .read_only(true)
-            .destructive(false)
-            .idempotent(true)
-            .open_world(false),
     )
 }
 
@@ -336,17 +292,6 @@ pub(crate) fn required_string_argument(
     Ok(value.to_string())
 }
 
-pub(crate) fn list_tables_arguments(
-    arguments: Option<&Map<String, Value>>,
-) -> Result<ListTablesArguments, ErrorData> {
-    let pagination = parse_pagination(arguments)?;
-    Ok(ListTablesArguments {
-        schema: optional_string_argument(arguments, "schema")?,
-        limit: pagination.limit,
-        offset: pagination.offset,
-    })
-}
-
 pub(crate) fn list_catalog_arguments(
     arguments: Option<&Map<String, Value>>,
 ) -> Result<ListCatalogArguments, ErrorData> {
@@ -421,44 +366,10 @@ fn sql_tool_description(sources: &[Source], visible_table_count: usize) -> Strin
     }
 }
 
-fn list_tables_description(visible_table_count: usize) -> String {
-    format!(
-        "List queryable fully qualified tables. {visible_table_count} table(s) are currently visible."
-    )
-}
-
 fn search_tables_description(visible_table_count: usize) -> String {
     format!(
         "Search queryable table metadata with a Rust regex. {visible_table_count} table(s) are currently visible."
     )
-}
-
-fn list_tables_output_schema() -> Arc<Map<String, Value>> {
-    paginated_table_output_schema(&json!({
-        "type": "object",
-        "required": [
-            "schema_name",
-            "table_name",
-            "name",
-            "sql_reference",
-            "description",
-            "guide",
-            "required_filters"
-        ],
-        "additionalProperties": false,
-        "properties": {
-            "schema_name": { "type": "string" },
-            "table_name": { "type": "string" },
-            "name": { "type": "string" },
-            "sql_reference": { "type": "string" },
-            "description": { "type": "string" },
-            "guide": { "type": "string" },
-            "required_filters": {
-                "type": "array",
-                "items": { "type": "string" }
-            }
-        }
-    }))
 }
 
 fn search_tables_output_schema() -> Arc<Map<String, Value>> {
@@ -612,7 +523,7 @@ fn missing_table_output_schema() -> Value {
                     "properties": {
                         "tool": {
                             "type": "string",
-                            "enum": ["search_tables", "list_tables"]
+                            "enum": ["search_tables", "list_catalog"]
                         },
                         "arguments": { "type": "object" }
                     }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -267,7 +267,6 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .collect::<Vec<_>>(),
         vec![
             "sql",
-            "list_tables",
             "list_catalog",
             "search_tables",
             "describe_table",
@@ -324,7 +323,6 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     add_demo_source(&mut session.source_client, manifest_yaml).await;
 
     let updated_tools = client.list_all_tools().await.expect("updated tools");
-    let list_tables_tool = tool_by_name(&updated_tools, "list_tables");
     let list_catalog_tool = tool_by_name(&updated_tools, "list_catalog");
     let search_tables_tool = tool_by_name(&updated_tools, "search_tables");
     let list_columns_tool = tool_by_name(&updated_tools, "list_columns");
@@ -339,18 +337,11 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         updated_tools[1]
             .description
             .as_deref()
-            .expect("tables description")
-            .contains("3 table(s) are currently visible")
-    );
-    assert!(
-        updated_tools[2]
-            .description
-            .as_deref()
             .expect("catalog description")
             .contains("3 table(s) and 0 table function(s) are currently visible")
     );
     assert!(
-        updated_tools[3]
+        updated_tools[2]
             .description
             .as_deref()
             .expect("table search description")
@@ -395,27 +386,6 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'events'"
     ));
 
-    let tables = client
-        .call_tool(CallToolRequestParams::new("list_tables"))
-        .await
-        .expect("list tables");
-    let structured_tables = tables.structured_content.expect("structured content");
-    assert_eq!(structured_tables["total"], 3);
-    assert_eq!(structured_tables["limit"], 50);
-    assert_eq!(structured_tables["offset"], 0);
-    assert_eq!(structured_tables["has_more"], false);
-    assert_eq!(
-        structured_tables["tables"][0]["name"],
-        "local_messages.events"
-    );
-    assert_eq!(
-        structured_tables["tables"][0]["sql_reference"],
-        "local_messages.events"
-    );
-    assert!(structured_tables["tables"][0]["columns"].is_null());
-    assert_eq!(tables.is_error, Some(false));
-    assert_matches_output_schema(list_tables_tool, &structured_tables);
-
     let catalog = client
         .call_tool(CallToolRequestParams::new("list_catalog"))
         .await
@@ -449,8 +419,9 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 
     let page = client
         .call_tool(
-            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
                 "schema": "local_messages",
+                "kind": "table",
                 "limit": 2,
                 "offset": 0
             }))),
@@ -462,32 +433,14 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(page["limit"], 2);
     assert_eq!(page["has_more"], true);
     assert_eq!(page["next_offset"], 2);
-    assert_eq!(page["tables"].as_array().expect("tables").len(), 2);
-    assert_matches_output_schema(list_tables_tool, &page);
-
-    let catalog_page = client
-        .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "local_messages",
-                "kind": "table",
-                "limit": 2,
-                "offset": 0
-            }))),
-        )
-        .await
-        .expect("list paginated catalog");
-    let catalog_page = catalog_page.structured_content.expect("structured content");
-    assert_eq!(catalog_page["total"], 3);
-    assert_eq!(catalog_page["limit"], 2);
-    assert_eq!(catalog_page["has_more"], true);
-    assert_eq!(catalog_page["next_offset"], 2);
-    assert_eq!(catalog_page["items"].as_array().expect("items").len(), 2);
-    assert_matches_output_schema(list_catalog_tool, &catalog_page);
+    assert_eq!(page["items"].as_array().expect("items").len(), 2);
+    assert_matches_output_schema(list_catalog_tool, &page);
 
     let unknown_schema = client
         .call_tool(
-            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
                 "schema": "missing",
+                "kind": "table",
                 "limit": 2,
                 "offset": 0
             }))),
@@ -499,53 +452,21 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .expect("structured content");
     assert_eq!(unknown_schema["total"], 0);
     assert!(
-        unknown_schema["tables"]
-            .as_array()
-            .expect("tables")
-            .is_empty()
-    );
-    assert_matches_output_schema(list_tables_tool, &unknown_schema);
-
-    let unknown_catalog_schema = client
-        .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "missing",
-                "kind": "table",
-                "limit": 2,
-                "offset": 0
-            }))),
-        )
-        .await
-        .expect("list unknown catalog schema");
-    let unknown_catalog_schema = unknown_catalog_schema
-        .structured_content
-        .expect("structured content");
-    assert_eq!(unknown_catalog_schema["total"], 0);
-    assert!(
-        unknown_catalog_schema["items"]
+        unknown_schema["items"]
             .as_array()
             .expect("items")
             .is_empty()
     );
-    assert_matches_output_schema(list_catalog_tool, &unknown_catalog_schema);
+    assert_matches_output_schema(list_catalog_tool, &unknown_schema);
 
     client
         .call_tool(
-            CallToolRequestParams::new("list_tables").with_arguments(json_object(&json!({
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
                 "limit": 0
             }))),
         )
         .await
         .expect_err("limit zero should be invalid");
-
-    client
-        .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "kind": "function"
-            }))),
-        )
-        .await
-        .expect_err("invalid catalog kind should fail");
 
     let search = client
         .call_tool(
@@ -818,7 +739,13 @@ async fn mcp_list_catalog_returns_tables_and_table_functions() {
     add_demo_source(&mut session.source_client, table_function_manifest_yaml()).await;
 
     let tools = client.list_all_tools().await.expect("tools");
-    assert!(tool_by_name(&tools, "list_tables").name.as_ref() == "list_tables");
+    assert!(
+        tools
+            .iter()
+            .all(|tool| tool.name.as_ref() != "list_table_functions"
+                && tool.name.as_ref() != "list_tables"),
+        "catalog discovery should go through list_catalog, not separate MCP list tools"
+    );
     let list_catalog_tool = tool_by_name(&tools, "list_catalog");
     assert!(
         list_catalog_tool
@@ -829,82 +756,67 @@ async fn mcp_list_catalog_returns_tables_and_table_functions() {
     );
 
     let catalog = client
-        .call_tool(CallToolRequestParams::new("list_catalog"))
+        .call_tool(
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+                "schema": "searchy"
+            }))),
+        )
         .await
         .expect("list catalog");
     let catalog = catalog.structured_content.expect("structured catalog");
     assert_eq!(catalog["total"], 2);
     assert_eq!(catalog["items"][0]["kind"], "table");
     assert_eq!(catalog["items"][0]["name"], "searchy.placeholder");
+    assert_eq!(catalog["items"][0]["table"]["required_filters"], json!([]));
     assert_eq!(catalog["items"][1]["kind"], "table_function");
     assert_eq!(catalog["items"][1]["name"], "searchy.search_issues");
-    assert_eq!(
-        catalog["items"][1]["sql_reference"],
-        "searchy.search_issues"
-    );
-    assert_eq!(
-        catalog["items"][1]["table_function"]["function_name"],
-        "search_issues"
-    );
     assert_eq!(
         catalog["items"][1]["table_function"]["arguments"][1]["values"],
         json!(["lexical", "semantic", "hybrid"])
     );
     assert_eq!(
-        catalog["items"][1]["table_function"]["result_columns"][0]["column_name"],
-        "title"
+        catalog["items"][1]["table_function"]["result_columns"][1]["data_type"],
+        "Float64"
     );
     assert_matches_output_schema(list_catalog_tool, &catalog);
 
-    let explicit_all_kinds = client
+    let functions_only = client
         .call_tool(
             CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "searchy",
-                "kind": null,
-            }))),
-        )
-        .await
-        .expect("list catalog with null kind");
-    let explicit_all_kinds = explicit_all_kinds
-        .structured_content
-        .expect("structured catalog");
-    assert_eq!(explicit_all_kinds["total"], 2);
-    assert_matches_output_schema(list_catalog_tool, &explicit_all_kinds);
-
-    let functions = client
-        .call_tool(
-            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "searchy",
-                "kind": "table_function",
-                "limit": 10,
-                "offset": 0
+                "kind": "table_function"
             }))),
         )
         .await
         .expect("list table functions through catalog");
-    let functions = functions.structured_content.expect("structured catalog");
-    assert_eq!(functions["total"], 1);
-    assert_eq!(functions["items"][0]["kind"], "table_function");
-    assert_eq!(functions["items"][0]["name"], "searchy.search_issues");
-    assert_matches_output_schema(list_catalog_tool, &functions);
+    let functions_only = functions_only
+        .structured_content
+        .expect("structured content");
+    assert_eq!(functions_only["total"], 1);
+    assert_eq!(functions_only["items"][0]["kind"], "table_function");
+    assert_matches_output_schema(list_catalog_tool, &functions_only);
 
-    let page = client
+    let first_page = client
         .call_tool(
             CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
-                "schema": "searchy",
-                "limit": 1,
-                "offset": 1
+                "limit": 1
             }))),
         )
         .await
-        .expect("list paginated catalog");
-    let page = page.structured_content.expect("structured catalog");
-    assert_eq!(page["total"], 2);
-    assert_eq!(page["limit"], 1);
-    assert_eq!(page["offset"], 1);
-    assert_eq!(page["has_more"], false);
-    assert_eq!(page["items"][0]["kind"], "table_function");
-    assert_matches_output_schema(list_catalog_tool, &page);
+        .expect("list catalog page");
+    let first_page = first_page.structured_content.expect("structured page");
+    assert_eq!(first_page["total"], 2);
+    assert_eq!(first_page["has_more"], true);
+    assert_eq!(first_page["next_offset"], 1);
+    assert_matches_output_schema(list_catalog_tool, &first_page);
+
+    client
+        .call_tool(
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+                "kind": "function"
+            }))),
+        )
+        .await
+        .expect_err("invalid catalog kind should fail");
 
     session.shutdown().await;
 }
@@ -930,7 +842,6 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             .collect::<Vec<_>>(),
         vec![
             "sql",
-            "list_tables",
             "list_catalog",
             "search_tables",
             "describe_table",
@@ -938,7 +849,7 @@ async fn mcp_feedback_tool_persists_blocked_agent_report() {
             "feedback"
         ]
     );
-    let feedback_annotations = tools[6].annotations.as_ref().expect("feedback annotations");
+    let feedback_annotations = tools[5].annotations.as_ref().expect("feedback annotations");
     assert_eq!(feedback_annotations.read_only_hint, Some(false));
     assert_eq!(feedback_annotations.destructive_hint, Some(false));
     assert_eq!(feedback_annotations.idempotent_hint, Some(false));
@@ -1088,18 +999,18 @@ async fn mcp_tool_error_does_not_end_session() {
     );
 
     let tables_after_error = client
-        .call_tool(CallToolRequestParams::new("list_tables"))
+        .call_tool(CallToolRequestParams::new("list_catalog"))
         .await
-        .expect("list tables after error");
+        .expect("list catalog after error");
     let structured_tables_after_error = tables_after_error
         .structured_content
         .expect("structured content");
     assert_eq!(
-        structured_tables_after_error["tables"][0]["name"],
+        structured_tables_after_error["items"][0]["name"],
         "local_messages.events"
     );
     assert_eq!(
-        structured_tables_after_error["tables"][0]["sql_reference"],
+        structured_tables_after_error["items"][0]["sql_reference"],
         "local_messages.events"
     );
     assert_eq!(tables_after_error.is_error, Some(false));

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -16,7 +16,6 @@ Before setting up a client, make sure you have [connected at least one source](/
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Run a SQL query                                         |
 | Tool     | `list_catalog`   | List queryable tables and table functions with pagination |
-| Tool     | `list_tables`    | List queryable fully qualified tables with pagination   |
 | Tool     | `search_tables`  | Search table metadata with a Rust regex                 |
 | Tool     | `describe_table` | Show compact metadata for one table                     |
 | Tool     | `list_columns`   | List columns for one table with pagination              |
@@ -25,12 +24,12 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
 
 Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-`list_catalog` returns queryable catalog items in pages and accepts optional `schema`, `kind`, `limit`, and `offset` arguments. Omit `kind` or pass `null` to list both ordinary tables and source-scoped table functions; pass `table` or `table_function` to narrow the result.
-`list_tables` returns table summaries in pages and accepts optional `schema`, `limit`, and `offset` arguments. Use each table's `sql_reference` value in `FROM` and `JOIN` clauses. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+`list_catalog` returns both ordinary tables and source-scoped table functions in one paginated catalog. Each item includes a `kind`, `sql_reference`, and either `table` or `table_function` details. Use the `sql_reference` value in `FROM` and `JOIN` clauses.
+To list only ordinary tables, call `list_catalog` with `kind: "table"`. Do not quote the whole `schema.table` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 `search_tables` accepts a required `pattern` plus optional `schema`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table names, descriptions, guides, and required filters.
 `describe_table` accepts exact `schema` and `table` arguments and returns guide text, required filters, and a column count without dumping full columns.
 `list_columns` accepts exact `schema` and `table` arguments plus optional `pattern`, `ignore_case`, `required_only`, `limit`, and `offset` arguments.
-For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_tables` or `coral://tables`.
+For richer metadata, have the agent query `coral.tables`, `coral.columns`, and `coral.inputs` over the `sql` tool instead of relying only on `list_catalog` or `coral://tables`.
 Start Coral as `coral mcp-stdio --enable-feedback` to expose the optional `feedback` tool. Agents can call `feedback` when they get blocked or repeat a pattern that is not working. Coral stores the report locally with what the agent was trying to do, what it tried, and where it got stuck, then uploads an anonymous copy to Coral's hosted feedback service in the background. Coral does not attach user identifiers to the hosted copy and uses these reports to improve Coral's performance. Only enable this tool if you are comfortable sending the feedback text to Coral. If hosted upload fails, the local report is still stored.
 
 ## Client setup
@@ -199,7 +198,7 @@ Once your client is connected, ask the agent to list available tables or run a s
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_tables`, `search_tables`, or query `coral.tables` to return schemas from your installed sources, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
+The agent should call `list_catalog`, `search_tables`, or query `coral.tables` to return schemas from your installed sources, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
 
 ## Troubleshooting
 

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -102,7 +102,7 @@ The MCP stdio server.
 | --------------- | ------------------------------------------------------------------- |
 | MCP protocol    | Tool and resource handlers via the `rmcp` SDK (`server.rs`)         |
 | Surface shaping | Tool/resource/error helpers split across `surface/{mod,tools,resources,errors}.rs` |
-| Tools           | `sql`, `list_catalog`, `list_tables`, `search_tables`, `describe_table`, `list_columns`, optional `feedback` |
+| Tools           | `sql`, `list_catalog`, `search_tables`, `describe_table`, `list_columns`, optional `feedback` |
 | Resources       | `coral://guide`, `coral://tables`                                   |
 
 Uses `coral-client` to reach `coral-app`, same transport as the CLI.

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -23,8 +23,8 @@ This release is intended for single-user local use:
   server binds to loopback, and the MCP server uses stdio transport.
 
 Coral reduces data exposure by keeping execution local and by exposing a narrow
-MCP surface: `sql`, `list_catalog`, `list_tables`, `search_tables`, `describe_table`,
-`list_columns`, `coral://guide`, and `coral://tables`.
+MCP surface: `sql`, `list_catalog`, `search_tables`,
+`describe_table`, `list_columns`, `coral://guide`, and `coral://tables`.
 Secret values are not returned through `coral.inputs`; secret rows show only
 whether a value is configured.
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -152,7 +152,6 @@ This server exposes:
 | -------- | ---------------- | -------------------------------- |
 | Tool     | `sql`            | Run a SQL query                  |
 | Tool     | `list_catalog`   | List queryable catalog items, including table functions |
-| Tool     | `list_tables`    | List available tables by page    |
 | Tool     | `search_tables`  | Search table metadata by regex   |
 | Tool     | `describe_table` | Show compact table metadata      |
 | Tool     | `list_columns`   | List columns for one table       |


### PR DESCRIPTION
## Intent

Finish the catalog migration by removing the legacy table-only MCP listing tool once `list_catalog` can represent both tables and table functions.

## What Changed

- Removes public MCP `list_tables` advertisement and dispatch.
- Keeps table metadata discovery available through `list_catalog`, `search_tables`, `describe_table`, `list_columns`, and `coral://tables`.
- Updates missing-table suggestions, docs, and MCP/CLI tests to point at `list_catalog`.

## Ownership / Boundaries

This is the only intentionally breaking MCP surface change in the split. Internal gRPC table listing remains in use where MCP needs table metadata behind the scenes.

## Not in This PR

- No changes to SQL execution or table-function execution.
- No search unification work.
- No removal of `coral://tables`.

## Validation

- `cargo test -p coral-mcp`
- `cargo test -p coral-cli --features cli-test-server --test mcp`
- `cargo clippy -p coral-mcp --all-targets --locked -- -D warnings`
- `make docs-check`
- `make rust-checks`
- Installed `/Users/brad/.cargo/bin/coral`; `coral --version` reports `coral 0.2.1+ebd26ba`
- Installed-binary MCP smoke: `tools/list` no longer advertises `list_tables`; `list_catalog` reports 395 tables and 12 table functions from the default config and paginates mixed catalog items.