### PR TITLE
feat(api): expose analytical plan evidence

### DIFF
--- a/crates/coral-api/build.rs
+++ b/crates/coral-api/build.rs
@@ -16,6 +16,7 @@ fn main() {
                 "proto/coral/v1/resources.proto",
                 "proto/coral/v1/feedback.proto",
                 "proto/coral/v1/sources.proto",
+                "proto/coral/v1/plan.proto",
                 "proto/coral/v1/query.proto",
                 "proto/coral/v1/traces.proto",
             ],

--- a/crates/coral-api/proto/coral/v1/plan.proto
+++ b/crates/coral-api/proto/coral/v1/plan.proto
@@ -1,0 +1,161 @@
+syntax = "proto3";
+
+package coral.v1;
+
+// Minimal analytical plan attached to query execution.
+message AnalyticalPlan {
+  // Stable identifier for this planned query execution.
+  string plan_id = 1;
+  // Workspace that scoped planning and execution.
+  string workspace = 2;
+  // User or caller intent captured before execution.
+  PlanIntent intent = 3;
+  // Source names that were successfully loaded into the query runtime.
+  repeated string workspace_sources_loaded = 4;
+  // Tables referenced by planning when that metadata is available.
+  repeated ReferencedTable referenced_tables = 5;
+  // Executable steps in the plan.
+  repeated PlanStep steps = 6;
+  // Policy checks considered by planning.
+  repeated PolicyCheck policy_checks = 7;
+  // Cost estimate for this plan.
+  CostEstimate cost_estimate = 8;
+  // Execution evidence recorded for this plan.
+  PlanExecution execution = 9;
+  // Memory integration status for this plan.
+  MemoryStatus memory_status = 10;
+}
+
+// Captures the original plan intent.
+message PlanIntent {
+  // Concrete intent payload.
+  oneof intent {
+    // SQL intent.
+    SqlIntent sql = 1;
+  }
+}
+
+// SQL statement provided as the original intent.
+message SqlIntent {
+  // Original SQL statement.
+  string sql = 1;
+}
+
+// One table referenced by a plan.
+message ReferencedTable {
+  // Table schema or source name.
+  string schema = 1;
+  // Table name.
+  string table = 2;
+}
+
+// One executable plan step.
+message PlanStep {
+  // Concrete step payload.
+  oneof step {
+    // Step that executes SQL in the relational engine.
+    RelationalSqlStep relational_sql = 1;
+  }
+}
+
+// SQL step for the relational query engine.
+message RelationalSqlStep {
+  // SQL statement executed by this step.
+  string sql = 1;
+}
+
+// One policy check considered for a plan.
+message PolicyCheck {
+  // Concrete policy check payload.
+  oneof check {
+    // Local default policy check.
+    LocalDefaultPolicyCheck local_default = 1;
+  }
+}
+
+// Local default policy check.
+message LocalDefaultPolicyCheck {
+  // Policy check status.
+  PolicyCheckStatus status = 1;
+}
+
+// Status of a policy check.
+enum PolicyCheckStatus {
+  // Policy check status was not specified.
+  POLICY_CHECK_STATUS_UNSPECIFIED = 0;
+  // Policy check was not evaluated.
+  POLICY_CHECK_STATUS_NOT_EVALUATED = 1;
+}
+
+// Cost estimate for a plan.
+message CostEstimate {
+  // Cost estimate status.
+  CostEstimateStatus status = 1;
+}
+
+// Status of a plan cost estimate.
+enum CostEstimateStatus {
+  // Cost estimate status was not specified.
+  COST_ESTIMATE_STATUS_UNSPECIFIED = 0;
+  // Cost estimate is unknown.
+  COST_ESTIMATE_STATUS_UNKNOWN = 1;
+}
+
+// Execution evidence recorded while running a plan.
+message PlanExecution {
+  // Execution status.
+  PlanExecutionStatus status = 1;
+  // Trace id linked to the query span when tracing is configured.
+  string trace_id = 2;
+  // Row count is meaningful only when row_count_recorded is true.
+  uint64 row_count = 3;
+  // Distinguishes an unknown row count from a recorded zero-row result.
+  bool row_count_recorded = 4;
+  // Stable error type for failed executions when available.
+  string error_type = 5;
+  // Non-fatal warnings observed during source loading or execution.
+  repeated PlanWarning warnings = 6;
+  // RFC 3339 timestamp for execution start, if recorded.
+  string started_at = 7;
+  // RFC 3339 timestamp for execution completion, if recorded.
+  string completed_at = 8;
+}
+
+// Status of plan execution.
+enum PlanExecutionStatus {
+  // Execution status was not specified.
+  PLAN_EXECUTION_STATUS_UNSPECIFIED = 0;
+  // Execution has not started.
+  PLAN_EXECUTION_STATUS_NOT_STARTED = 1;
+  // Execution is currently running.
+  PLAN_EXECUTION_STATUS_RUNNING = 2;
+  // Execution completed successfully.
+  PLAN_EXECUTION_STATUS_OK = 3;
+  // Execution failed.
+  PLAN_EXECUTION_STATUS_ERROR = 4;
+}
+
+// Non-fatal plan warning.
+message PlanWarning {
+  // Concrete warning payload.
+  oneof warning {
+    // Source loading was skipped but planning continued.
+    SourceSkippedWarning source_skipped = 1;
+  }
+}
+
+// Warning emitted when a source load was skipped.
+message SourceSkippedWarning {
+  // Source associated with the warning.
+  string source = 1;
+  // Human-readable warning message.
+  string message = 2;
+}
+
+// Memory integration status for a plan.
+enum MemoryStatus {
+  // Memory status was not specified.
+  MEMORY_STATUS_UNSPECIFIED = 0;
+  // Memory integration does not apply to this plan.
+  MEMORY_STATUS_NOT_APPLICABLE = 1;
+}

--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package coral.v1;
 
 import "coral/v1/catalog.proto";
+import "coral/v1/plan.proto";
 import "coral/v1/resources.proto";
 
 // Executes one SQL statement against the sources registered in one workspace.
@@ -19,6 +20,8 @@ message ExecuteSqlResponse {
   bytes arrow_ipc_stream = 1;
   // Total row count returned by the query.
   int64 row_count = 2;
+  // Analytical plan and execution evidence for this query.
+  AnalyticalPlan plan = 3;
 }
 
 // Explains one SQL statement by producing query-engine plan renderings without

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -34,6 +34,7 @@
 pub mod bootstrap;
 mod feedback;
 mod identity;
+mod plan;
 mod query;
 mod sources;
 mod state;

--- a/crates/coral-app/src/plan/mod.rs
+++ b/crates/coral-app/src/plan/mod.rs
@@ -1,0 +1,290 @@
+//! Minimal analytical plan model owned by app-level query orchestration.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::sources::SourceName;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct PlanId(String);
+
+impl PlanId {
+    #[must_use]
+    pub(crate) fn new() -> Self {
+        Self(format!("plan_{}", Uuid::new_v4().simple()))
+    }
+
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Default for PlanId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for PlanId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AnalyticalPlan {
+    pub(crate) plan_id: PlanId,
+    pub(crate) workspace: WorkspaceName,
+    pub(crate) query: PlannedQuery,
+    pub(crate) workspace_sources_loaded: Vec<SourceName>,
+    pub(crate) execution: PlanExecution,
+}
+
+impl AnalyticalPlan {
+    #[must_use]
+    pub(crate) fn from_sql(workspace_name: &WorkspaceName, sql: impl Into<String>) -> Self {
+        Self {
+            plan_id: PlanId::new(),
+            workspace: workspace_name.clone(),
+            query: PlannedQuery::Sql(sql.into()),
+            workspace_sources_loaded: Vec::new(),
+            execution: PlanExecution::default(),
+        }
+    }
+
+    pub(crate) fn record_source_load(
+        &mut self,
+        workspace_sources_loaded: Vec<SourceName>,
+        warnings: Vec<PlanWarning>,
+    ) {
+        self.workspace_sources_loaded = workspace_sources_loaded;
+        self.execution.warnings.extend(warnings);
+    }
+
+    pub(crate) fn mark_execution_started(&mut self, started_at: DateTime<Utc>) {
+        self.execution.status = PlanExecutionStatus::Running;
+        self.execution.started_at = Some(started_at);
+    }
+
+    pub(crate) fn record_success(
+        &mut self,
+        row_count: u64,
+        trace_id: Option<String>,
+        completed_at: DateTime<Utc>,
+    ) {
+        self.execution.status = PlanExecutionStatus::Ok;
+        self.execution.row_count = Some(row_count);
+        self.execution.trace_id = trace_id;
+        self.execution.completed_at = Some(completed_at);
+    }
+
+    pub(crate) fn record_error(
+        &mut self,
+        error_type: PlanError,
+        trace_id: Option<String>,
+        completed_at: DateTime<Utc>,
+    ) {
+        self.execution.status = PlanExecutionStatus::Error;
+        self.execution.error_type = Some(error_type);
+        self.execution.trace_id = trace_id;
+        self.execution.completed_at = Some(completed_at);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "text", rename_all = "snake_case")]
+pub(crate) enum PlannedQuery {
+    Sql(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PlanExecution {
+    pub(crate) status: PlanExecutionStatus,
+    pub(crate) trace_id: Option<String>,
+    pub(crate) row_count: Option<u64>,
+    pub(crate) error_type: Option<PlanError>,
+    pub(crate) warnings: Vec<PlanWarning>,
+    pub(crate) started_at: Option<DateTime<Utc>>,
+    pub(crate) completed_at: Option<DateTime<Utc>>,
+}
+
+impl Default for PlanExecution {
+    fn default() -> Self {
+        Self {
+            status: PlanExecutionStatus::NotStarted,
+            trace_id: None,
+            row_count: None,
+            error_type: None,
+            warnings: Vec::new(),
+            started_at: None,
+            completed_at: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PlanExecutionStatus {
+    NotStarted,
+    Running,
+    Ok,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub(crate) enum PlanError {
+    Code(PlanErrorCode),
+    QueryFailure(String),
+}
+
+impl PlanError {
+    #[must_use]
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Self::Code(error) => error.as_str(),
+            Self::QueryFailure(reason) => reason.as_str(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PlanErrorCode {
+    InvalidArgument,
+    NotFound,
+    FailedPrecondition,
+    Unavailable,
+    Unimplemented,
+    Internal,
+}
+
+impl PlanErrorCode {
+    #[must_use]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidArgument => "INVALID_ARGUMENT",
+            Self::NotFound => "NOT_FOUND",
+            Self::FailedPrecondition => "FAILED_PRECONDITION",
+            Self::Unavailable => "UNAVAILABLE",
+            Self::Unimplemented => "UNIMPLEMENTED",
+            Self::Internal => "INTERNAL",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum PlanWarning {
+    SourceSkipped { source: SourceName, message: String },
+}
+
+impl PlanWarning {
+    #[must_use]
+    pub(crate) fn source_skipped(source: SourceName, message: impl Into<String>) -> Self {
+        Self::SourceSkipped {
+            source,
+            message: message.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone as _;
+    use serde_json::json;
+
+    use super::{
+        AnalyticalPlan, PlanError, PlanErrorCode, PlanExecutionStatus, PlanWarning, PlannedQuery,
+    };
+    use crate::sources::SourceName;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn sql_plan_stores_only_app_owned_facts() {
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let plan = AnalyticalPlan::from_sql(&workspace, "SELECT * FROM github.issues LIMIT 5");
+
+        assert!(plan.plan_id.as_str().starts_with("plan_"));
+        assert_eq!(plan.workspace, workspace);
+        assert!(matches!(
+            &plan.query,
+            PlannedQuery::Sql(sql) if sql == "SELECT * FROM github.issues LIMIT 5"
+        ));
+        assert!(plan.workspace_sources_loaded.is_empty());
+        assert_eq!(plan.execution.status, PlanExecutionStatus::NotStarted);
+    }
+
+    #[test]
+    fn zero_row_success_preserves_zero_as_known_count() {
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let mut plan = AnalyticalPlan::from_sql(&workspace, "SELECT * FROM local.messages");
+        let completed_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 14, 12, 0, 0)
+            .single()
+            .expect("timestamp");
+
+        plan.record_success(0, Some("trace-1".to_string()), completed_at);
+
+        assert_eq!(plan.execution.status, PlanExecutionStatus::Ok);
+        assert_eq!(plan.execution.row_count, Some(0));
+        assert_eq!(plan.execution.trace_id.as_deref(), Some("trace-1"));
+    }
+
+    #[test]
+    fn error_evidence_records_error_type_without_row_count() {
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let mut plan = AnalyticalPlan::from_sql(&workspace, "SELECT * FROM missing.table");
+        let completed_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 14, 12, 0, 0)
+            .single()
+            .expect("timestamp");
+
+        plan.record_error(
+            PlanError::Code(PlanErrorCode::NotFound),
+            Some("trace-error".to_string()),
+            completed_at,
+        );
+
+        assert_eq!(plan.execution.status, PlanExecutionStatus::Error);
+        assert_eq!(plan.execution.row_count, None);
+        assert!(matches!(
+            plan.execution.error_type,
+            Some(PlanError::Code(PlanErrorCode::NotFound))
+        ));
+        assert_eq!(plan.execution.trace_id.as_deref(), Some("trace-error"));
+    }
+
+    #[test]
+    fn source_load_warnings_serialize_as_plan_evidence() {
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let mut plan = AnalyticalPlan::from_sql(&workspace, "SELECT * FROM secured.messages");
+        plan.record_source_load(
+            vec![SourceName::parse("github").expect("source name")],
+            vec![PlanWarning::source_skipped(
+                SourceName::parse("secured").expect("source name"),
+                "source 'secured' is missing secret 'API_TOKEN'",
+            )],
+        );
+
+        assert_eq!(
+            plan.workspace_sources_loaded,
+            vec![SourceName::parse("github").expect("source name")]
+        );
+        let warning = plan.execution.warnings.first().expect("warning");
+        let PlanWarning::SourceSkipped { source, message } = warning;
+        assert_eq!(source.as_str(), "secured");
+        assert!(message.contains("API_TOKEN"));
+
+        let value = serde_json::to_value(&plan).expect("serialize plan");
+        assert_eq!(value.pointer("/query/kind"), Some(&json!("sql")));
+        assert_eq!(
+            value.pointer("/execution/warnings/0/kind"),
+            Some(&json!("source_skipped"))
+        );
+    }
+}

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -5,16 +5,21 @@ use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
+use chrono::Utc;
 use coral_engine::{
     CoralQuery, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
     QuerySource, SourceValidationReport, StatusCode, TableInfo,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
-use opentelemetry::{KeyValue, trace::Status as OtelStatus};
+use opentelemetry::{
+    KeyValue,
+    trace::{Status as OtelStatus, TraceContextExt as _},
+};
 use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
+use crate::plan::{AnalyticalPlan, PlanError, PlanErrorCode, PlanId, PlanWarning};
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
@@ -31,6 +36,17 @@ pub(crate) enum QueryManagerError {
 pub(crate) struct ValidatedSource {
     pub(crate) source: InstalledSource,
     pub(crate) report: SourceValidationReport,
+}
+
+pub(crate) struct PlannedQueryExecution {
+    pub(crate) plan: AnalyticalPlan,
+    pub(crate) result: Result<QueryExecution, QueryManagerError>,
+}
+
+struct LoadedQuerySources {
+    sources: Vec<QuerySource>,
+    source_names: Vec<SourceName>,
+    warnings: Vec<PlanWarning>,
 }
 
 #[derive(Clone)]
@@ -74,19 +90,28 @@ impl QueryManager {
             .map_err(QueryManagerError::Core)
     }
 
-    pub(crate) async fn execute_sql(
+    pub(crate) async fn execute_sql_plan(
         &self,
         workspace_name: &WorkspaceName,
         sql: &str,
-    ) -> Result<QueryExecution, QueryManagerError> {
-        run_query_operation(
+    ) -> PlannedQueryExecution {
+        let mut plan = AnalyticalPlan::from_sql(workspace_name, sql);
+        plan.mark_execution_started(Utc::now());
+        let plan_id = plan.plan_id.clone();
+        let operation = run_query_operation(
             QueryOperation::ExecuteSql,
             workspace_name,
             sql,
+            Some(&plan_id),
             async {
-                let sources = self
-                    .load_query_sources(workspace_name)
+                let LoadedQuerySources {
+                    sources,
+                    source_names,
+                    warnings,
+                } = self
+                    .load_query_sources_with_report(workspace_name)
                     .map_err(QueryManagerError::App)?;
+                plan.record_source_load(source_names, warnings);
                 let runtime = self.runtime_config(&sources);
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
@@ -94,7 +119,27 @@ impl QueryManager {
             },
             |execution| Some(u64::try_from(execution.row_count()).unwrap_or(u64::MAX)),
         )
-        .await
+        .await;
+
+        match &operation.result {
+            Ok(execution) => plan.record_success(
+                u64::try_from(execution.row_count()).unwrap_or(u64::MAX),
+                operation.trace_id.clone(),
+                Utc::now(),
+            ),
+            Err(error) => {
+                plan.record_error(
+                    query_error_type(error),
+                    operation.trace_id.clone(),
+                    Utc::now(),
+                );
+            }
+        }
+
+        PlannedQueryExecution {
+            plan,
+            result: operation.result,
+        }
     }
 
     pub(crate) async fn explain_sql(
@@ -106,6 +151,7 @@ impl QueryManager {
             QueryOperation::ExplainSql,
             workspace_name,
             sql,
+            None,
             async {
                 let sources = self
                     .load_query_sources(workspace_name)
@@ -118,6 +164,7 @@ impl QueryManager {
             |_| None,
         )
         .await
+        .result
     }
 
     pub(crate) async fn validate_source(
@@ -150,21 +197,42 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<QuerySource>, AppError> {
+        self.load_query_sources_with_report(workspace_name)
+            .map(|loaded| loaded.sources)
+    }
+
+    fn load_query_sources_with_report(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<LoadedQuerySources, AppError> {
         let catalog = self.config_store.load_catalog()?;
-        let mut query_sources = Vec::new();
+        let mut sources = Vec::new();
+        let mut source_names = Vec::new();
+        let mut warnings = Vec::new();
         for source in catalog.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
-                Ok((query_source, _version)) => query_sources.push(query_source),
+                Ok((query_source, _version)) => {
+                    source_names.push(source.name.clone());
+                    sources.push(query_source);
+                }
                 Err(error) => {
                     tracing::warn!(
                         source = %source.name,
                         detail = %error,
                         "skipping source during query-source load"
                     );
+                    warnings.push(PlanWarning::source_skipped(
+                        source.name.clone(),
+                        error.to_string(),
+                    ));
                 }
             }
         }
-        Ok(query_sources)
+        Ok(LoadedQuerySources {
+            sources,
+            source_names,
+            warnings,
+        })
     }
 
     fn load_query_source(
@@ -233,19 +301,25 @@ impl QueryOperation {
     }
 }
 
+struct QueryOperationResult<T> {
+    result: Result<T, QueryManagerError>,
+    trace_id: Option<String>,
+}
+
 async fn run_query_operation<T, Fut, RowCount>(
     operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
+    plan_id: Option<&PlanId>,
     query: Fut,
     row_count: RowCount,
-) -> Result<T, QueryManagerError>
+) -> QueryOperationResult<T>
 where
     Fut: Future<Output = Result<T, QueryManagerError>>,
     RowCount: FnOnce(&T) -> Option<u64>,
 {
     let started_at = Instant::now();
-    let query_span = create_query_span(operation, workspace_name, sql);
+    let query_span = create_query_span(operation, workspace_name, sql, plan_id);
     let result = query.instrument(query_span.clone()).await;
 
     let metrics = crate::telemetry::metrics::metrics();
@@ -274,27 +348,45 @@ where
         query_span.set_status(OtelStatus::error(error_message));
     }
 
-    result
+    QueryOperationResult {
+        result,
+        trace_id: span_trace_id(&query_span),
+    }
 }
 
 fn create_query_span(
     operation: QueryOperation,
     workspace_name: &WorkspaceName,
     sql: &str,
+    plan_id: Option<&PlanId>,
 ) -> tracing::Span {
     let operation = operation.as_str();
-    tracing::info_span!(
+    let span = tracing::info_span!(
         "coral.query",
         otel.name = "coral.query",
         operation = operation,
         workspace = %workspace_name.as_str(),
         sql = %sql,
+        plan_id = tracing::field::Empty,
         row_count = tracing::field::Empty,
         status = tracing::field::Empty,
         error.kind = tracing::field::Empty,
         error.type = tracing::field::Empty,
         exception.message = tracing::field::Empty,
-    )
+    );
+    if let Some(plan_id) = plan_id {
+        span.record("plan_id", plan_id.as_str());
+    }
+    span
+}
+
+fn span_trace_id(span: &tracing::Span) -> Option<String> {
+    let context = span.context();
+    let otel_span = context.span();
+    let span_context = otel_span.span_context();
+    span_context
+        .is_valid()
+        .then(|| span_context.trace_id().to_string())
 }
 
 fn query_error_kind(error: &QueryManagerError) -> &'static str {
@@ -304,9 +396,9 @@ fn query_error_kind(error: &QueryManagerError) -> &'static str {
     }
 }
 
-fn query_error_type(error: &QueryManagerError) -> String {
+fn query_error_type(error: &QueryManagerError) -> PlanError {
     match error {
-        QueryManagerError::App(error) => app_error_type(error).to_string(),
+        QueryManagerError::App(error) => PlanError::Code(app_error_type(error)),
         QueryManagerError::Core(error) => core_error_type(error),
     }
 }
@@ -319,38 +411,38 @@ fn query_error_message(error: &QueryManagerError) -> String {
     }
 }
 
-fn app_error_type(error: &AppError) -> &'static str {
+fn app_error_type(error: &AppError) -> PlanErrorCode {
     match error {
-        AppError::SourceNotFound(_) => "SOURCE_NOT_FOUND",
-        AppError::InvalidInput(_) => "INVALID_INPUT",
-        AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
-        AppError::Io(_) => "IO",
-        AppError::Yaml(_) => "YAML",
-        AppError::TomlDecode(_) => "TOML_DECODE",
-        AppError::TomlEncode(_) => "TOML_ENCODE",
-        AppError::Json(_) => "JSON",
-        AppError::Transport(_) => "TRANSPORT",
-        AppError::TaskJoin(_) => "TASK_JOIN",
-        AppError::Credentials(_) => "CREDENTIALS",
-        AppError::MissingConfigDir => "MISSING_CONFIG_DIR",
+        AppError::SourceNotFound(_) => PlanErrorCode::NotFound,
+        AppError::InvalidInput(_) => PlanErrorCode::InvalidArgument,
+        AppError::FailedPrecondition(_) | AppError::Credentials(_) | AppError::MissingConfigDir => {
+            PlanErrorCode::FailedPrecondition
+        }
+        AppError::Io(_)
+        | AppError::Yaml(_)
+        | AppError::TomlDecode(_)
+        | AppError::TomlEncode(_)
+        | AppError::Json(_)
+        | AppError::Transport(_)
+        | AppError::TaskJoin(_) => PlanErrorCode::Internal,
     }
 }
 
-fn core_error_type(error: &CoreError) -> String {
+fn core_error_type(error: &CoreError) -> PlanError {
     match error {
-        CoreError::QueryFailure(error) => error.reason().to_string(),
-        error => status_code_error_type(error.status_code()).to_string(),
+        CoreError::QueryFailure(error) => PlanError::QueryFailure(error.reason().to_string()),
+        error => PlanError::Code(status_code_error_type(error.status_code())),
     }
 }
 
-fn status_code_error_type(status: StatusCode) -> &'static str {
+fn status_code_error_type(status: StatusCode) -> PlanErrorCode {
     match status {
-        StatusCode::InvalidArgument => "INVALID_ARGUMENT",
-        StatusCode::NotFound => "NOT_FOUND",
-        StatusCode::FailedPrecondition => "FAILED_PRECONDITION",
-        StatusCode::Unavailable => "UNAVAILABLE",
-        StatusCode::Unimplemented => "UNIMPLEMENTED",
-        StatusCode::Internal => "INTERNAL",
+        StatusCode::InvalidArgument => PlanErrorCode::InvalidArgument,
+        StatusCode::NotFound => PlanErrorCode::NotFound,
+        StatusCode::FailedPrecondition => PlanErrorCode::FailedPrecondition,
+        StatusCode::Unavailable => PlanErrorCode::Unavailable,
+        StatusCode::Unimplemented => PlanErrorCode::Unimplemented,
+        StatusCode::Internal => PlanErrorCode::Internal,
     }
 }
 
@@ -378,4 +470,294 @@ fn validate_required_variables(
         )));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use super::{PlannedQueryExecution, QueryManager};
+    use crate::plan::{PlanError, PlanExecutionStatus, PlanId, PlanWarning};
+    use crate::query::extensions::EngineExtensionsProvider;
+    use crate::sources::SourceName;
+    use crate::sources::manager::{
+        ImportSourceCommand, SourceBinding, SourceBindings, SourceManager,
+    };
+    use crate::state::{AppStateLayout, ConfigStore, SecretStore};
+    use crate::workspaces::WorkspaceName;
+    use coral_engine::QueryRuntimeContext;
+
+    struct QueryManagerHarness {
+        _temp: TempDir,
+        layout: AppStateLayout,
+        workspace_name: WorkspaceName,
+        source_manager: SourceManager,
+        query_manager: QueryManager,
+    }
+
+    impl QueryManagerHarness {
+        fn new() -> Self {
+            let temp = TempDir::new().expect("temp dir");
+            let layout =
+                AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+            layout.ensure().expect("ensure layout");
+            let config_store = ConfigStore::new(layout.clone());
+            let secret_store = SecretStore::new(layout.clone());
+            let source_manager =
+                SourceManager::new(config_store.clone(), secret_store.clone(), layout.clone());
+            let query_manager = QueryManager::new(
+                config_store,
+                secret_store,
+                QueryRuntimeContext::default(),
+                layout.clone(),
+                Vec::<Arc<dyn EngineExtensionsProvider>>::new(),
+            );
+
+            Self {
+                _temp: temp,
+                layout,
+                workspace_name: WorkspaceName::default(),
+                source_manager,
+                query_manager,
+            }
+        }
+
+        fn import_local_messages_source(&self) {
+            self.source_manager
+                .import_source(
+                    &self.workspace_name,
+                    &ImportSourceCommand {
+                        manifest_yaml: local_messages_manifest(self.layout.config_file()),
+                        bindings: SourceBindings::default(),
+                    },
+                )
+                .expect("import local messages source");
+        }
+
+        fn import_secured_messages_source(&self) {
+            self.source_manager
+                .import_source(
+                    &self.workspace_name,
+                    &ImportSourceCommand {
+                        manifest_yaml: secured_messages_manifest(),
+                        bindings: SourceBindings {
+                            variables: Vec::new(),
+                            secrets: vec![SourceBinding {
+                                key: "API_TOKEN".to_string(),
+                                value: "secret-token".to_string(),
+                            }],
+                        },
+                    },
+                )
+                .expect("import secured messages source");
+        }
+
+        async fn execute_plan(&self, sql: &str) -> PlannedQueryExecution {
+            self.query_manager
+                .execute_sql_plan(&self.workspace_name, sql)
+                .await
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_sql_plan_records_zero_row_success_evidence() {
+        let harness = QueryManagerHarness::new();
+        harness.import_local_messages_source();
+
+        let sql = "SELECT * FROM local_messages.messages WHERE text = 'missing'";
+        let planned = harness.execute_plan(sql).await;
+        let execution = planned.result.as_ref().expect("query should succeed");
+
+        assert_eq!(execution.row_count(), 0);
+        assert!(planned.plan.plan_id.as_str().starts_with("plan_"));
+        assert_eq!(planned.plan.workspace.as_str(), "default");
+        assert_eq!(
+            planned.plan.workspace_sources_loaded,
+            vec![SourceName::parse("local_messages").expect("source name")]
+        );
+        assert_eq!(planned.plan.execution.status, PlanExecutionStatus::Ok);
+        assert_eq!(planned.plan.execution.row_count, Some(0));
+        assert!(planned.plan.execution.started_at.is_some());
+        assert!(planned.plan.execution.completed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn execute_sql_plan_records_sql_error_evidence() {
+        let harness = QueryManagerHarness::new();
+        harness.import_local_messages_source();
+
+        let planned = harness
+            .execute_plan("SELECT * FROM missing_schema.missing_table")
+            .await;
+
+        planned.result.expect_err("query should fail");
+        assert_eq!(planned.plan.execution.status, PlanExecutionStatus::Error);
+        assert!(planned.plan.execution.row_count.is_none());
+        assert!(
+            matches!(
+                planned.plan.execution.error_type,
+                Some(PlanError::QueryFailure(_))
+            ),
+            "SQL errors should carry a stable error type"
+        );
+        assert_eq!(
+            planned.plan.workspace_sources_loaded,
+            vec![SourceName::parse("local_messages").expect("source name")]
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_sql_plan_keeps_shell_when_source_load_is_skipped() {
+        let harness = QueryManagerHarness::new();
+        harness.import_secured_messages_source();
+        let source_name = SourceName::parse("secured_messages").expect("source name");
+        fs::remove_file(
+            harness
+                .layout
+                .secret_file(&harness.workspace_name, &source_name),
+        )
+        .expect("remove persisted secret");
+
+        let planned = harness
+            .execute_plan("SELECT * FROM secured_messages.messages")
+            .await;
+
+        planned
+            .result
+            .expect_err("query should fail without source");
+        assert_eq!(planned.plan.execution.status, PlanExecutionStatus::Error);
+        assert!(planned.plan.workspace_sources_loaded.is_empty());
+        let warning = planned
+            .plan
+            .execution
+            .warnings
+            .first()
+            .expect("source load warning");
+        let PlanWarning::SourceSkipped { source, message } = warning;
+        assert_eq!(source.as_str(), "secured_messages");
+        assert!(
+            message.contains("missing secret 'API_TOKEN'"),
+            "unexpected warning: {message}"
+        );
+    }
+
+    #[test]
+    fn query_span_records_plan_id_attribute() {
+        use opentelemetry::Value as OtelValue;
+        use opentelemetry::trace::TracerProvider as _;
+        use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider};
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        let memory = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(memory.clone())
+            .build();
+        let tracer = provider.tracer("query-manager-test");
+        let layer = tracing_opentelemetry::layer()
+            .with_tracer(tracer)
+            .with_level(true);
+        let subscriber = tracing_subscriber::Registry::default().with(layer);
+        let workspace_name = WorkspaceName::default();
+        let plan_id = PlanId::new();
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = super::create_query_span(
+                super::QueryOperation::ExecuteSql,
+                &workspace_name,
+                "SELECT 1",
+                Some(&plan_id),
+            );
+            let _guard = span.enter();
+        });
+        provider.force_flush().expect("flush spans");
+
+        let spans = memory.get_finished_spans().expect("finished spans");
+        let span = spans.first().expect("query span");
+        let plan_id_attribute = span
+            .attributes
+            .iter()
+            .find(|attribute| attribute.key.as_str() == "plan_id")
+            .expect("plan_id attribute");
+
+        match &plan_id_attribute.value {
+            OtelValue::String(value) => assert_eq!(value.as_ref(), plan_id.as_str()),
+            other => panic!("unexpected plan_id value: {other:?}"),
+        }
+
+        provider.shutdown().expect("provider shutdown");
+    }
+
+    fn local_messages_manifest(config_file: &std::path::Path) -> String {
+        let data_dir = config_file
+            .parent()
+            .expect("config parent")
+            .join("fixture-data");
+        fs::create_dir_all(&data_dir).expect("create fixture data dir");
+        fs::write(
+            data_dir.join("messages.jsonl"),
+            r#"{"type":"user","sessionId":"s1","text":"hello"}
+{"type":"assistant","sessionId":"s1","text":"world"}
+"#,
+        )
+        .expect("write fixture data");
+
+        format!(
+            r#"
+name: local_messages
+version: 0.1.0
+dsl_version: 3
+backend: jsonl
+tables:
+  - name: messages
+    description: Fixture messages
+    source:
+      location: "file://{}/"
+      glob: "**/*.jsonl"
+    columns:
+      - name: type
+        type: Utf8
+      - name: sessionId
+        type: Utf8
+      - name: text
+        type: Utf8
+"#,
+            data_dir.display()
+        )
+    }
+
+    fn secured_messages_manifest() -> String {
+        r#"
+name: secured_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+inputs:
+  API_BASE:
+    kind: variable
+    default: https://example.com
+  API_TOKEN:
+    kind: secret
+base_url: "{{input.API_BASE}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.API_TOKEN}}
+tables:
+  - name: messages
+    description: Secured messages
+    request:
+      method: GET
+      path: /messages
+    response: {}
+    columns:
+      - name: id
+        type: Utf8
+"#
+        .to_string()
+    }
 }

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -11,10 +11,10 @@ use coral_api::v1::{
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::core_status;
-use crate::query::manager::QueryManager;
+use crate::query::manager::{PlannedQueryExecution, QueryManager};
 use crate::transport::{
-    grpc_span, instrument_grpc, query_status, table_summary_to_proto, table_to_proto,
-    workspace_name_from_proto,
+    analytical_plan_to_proto, grpc_span, instrument_grpc, query_status, table_summary_to_proto,
+    table_to_proto, workspace_name_from_proto,
 };
 
 #[derive(Clone)]
@@ -107,10 +107,9 @@ impl QueryServiceApi for QueryService {
         instrument_grpc(span, async move {
             let inner = request.into_inner();
             let workspace_name = workspace_name_from_proto(inner.workspace.as_ref())?;
-            let execution = queries
-                .execute_sql(&workspace_name, &inner.sql)
-                .await
-                .map_err(query_status)?;
+            let PlannedQueryExecution { plan, result } =
+                Box::pin(queries.execute_sql_plan(&workspace_name, &inner.sql)).await;
+            let execution = result.map_err(query_status)?;
             let response = ExecuteSqlResponse {
                 arrow_ipc_stream: encode_arrow_ipc_stream(
                     execution.arrow_schema(),
@@ -119,6 +118,7 @@ impl QueryServiceApi for QueryService {
                 .map_err(coral_engine::CoreError::from)
                 .map_err(core_status)?,
                 row_count: i64::try_from(execution.row_count()).unwrap_or(i64::MAX),
+                plan: Some(analytical_plan_to_proto(&plan)),
             };
             Ok(Response::new(response))
         })

--- a/crates/coral-app/src/transport.rs
+++ b/crates/coral-app/src/transport.rs
@@ -5,8 +5,17 @@ use std::future::Future;
 use coral_api::{
     CORAL_ERROR_DOMAIN, grpc_response_status_code,
     v1::{
-        Column, QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, Table, TableSummary,
-        ValidateSourceResponse, Workspace, query_test_result,
+        AnalyticalPlan as AnalyticalPlanProto, Column, CostEstimate as CostEstimateProto,
+        CostEstimateStatus as CostEstimateStatusProto,
+        LocalDefaultPolicyCheck as LocalDefaultPolicyCheckProto, MemoryStatus as MemoryStatusProto,
+        PlanExecution as PlanExecutionProto, PlanExecutionStatus as PlanExecutionStatusProto,
+        PlanIntent as PlanIntentProto, PlanStep as PlanStepProto, PlanWarning as PlanWarningProto,
+        PolicyCheck as PolicyCheckProto, PolicyCheckStatus as PolicyCheckStatusProto,
+        QueryTestFailure, QueryTestResult, QueryTestSuccess,
+        RelationalSqlStep as RelationalSqlStepProto, Source,
+        SourceSkippedWarning as SourceSkippedWarningProto, SqlIntent as SqlIntentProto, Table,
+        TableSummary, ValidateSourceResponse, Workspace, plan_intent, plan_step, plan_warning,
+        policy_check, query_test_result,
     },
 };
 use opentelemetry::propagation::Extractor;
@@ -18,6 +27,7 @@ use tracing::{Instrument as _, field};
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::{AppError, app_status, core_status};
+use crate::plan as app_plan;
 use crate::query::manager::QueryManagerError;
 use crate::workspaces::WorkspaceName;
 
@@ -243,6 +253,111 @@ pub(crate) fn workspace_to_proto(workspace_name: &WorkspaceName) -> Workspace {
     }
 }
 
+pub(crate) fn analytical_plan_to_proto(plan: &app_plan::AnalyticalPlan) -> AnalyticalPlanProto {
+    AnalyticalPlanProto {
+        plan_id: plan.plan_id.as_str().to_string(),
+        workspace: plan.workspace.as_str().to_string(),
+        intent: Some(plan_intent_to_proto(&plan.query)),
+        workspace_sources_loaded: plan
+            .workspace_sources_loaded
+            .iter()
+            .map(|source| source.as_str().to_string())
+            .collect(),
+        referenced_tables: Vec::new(),
+        steps: vec![plan_step_to_proto(&plan.query)],
+        policy_checks: vec![local_default_policy_check_to_proto()],
+        cost_estimate: Some(unknown_cost_estimate_to_proto()),
+        execution: Some(plan_execution_to_proto(&plan.execution)),
+        memory_status: MemoryStatusProto::NotApplicable as i32,
+    }
+}
+
+fn plan_intent_to_proto(query: &app_plan::PlannedQuery) -> PlanIntentProto {
+    match query {
+        app_plan::PlannedQuery::Sql(sql) => PlanIntentProto {
+            intent: Some(plan_intent::Intent::Sql(SqlIntentProto {
+                sql: sql.clone(),
+            })),
+        },
+    }
+}
+
+fn plan_step_to_proto(query: &app_plan::PlannedQuery) -> PlanStepProto {
+    match query {
+        app_plan::PlannedQuery::Sql(sql) => PlanStepProto {
+            step: Some(plan_step::Step::RelationalSql(RelationalSqlStepProto {
+                sql: sql.clone(),
+            })),
+        },
+    }
+}
+
+fn local_default_policy_check_to_proto() -> PolicyCheckProto {
+    PolicyCheckProto {
+        check: Some(policy_check::Check::LocalDefault(
+            LocalDefaultPolicyCheckProto {
+                status: PolicyCheckStatusProto::NotEvaluated as i32,
+            },
+        )),
+    }
+}
+
+fn unknown_cost_estimate_to_proto() -> CostEstimateProto {
+    CostEstimateProto {
+        status: CostEstimateStatusProto::Unknown as i32,
+    }
+}
+
+fn plan_execution_to_proto(execution: &app_plan::PlanExecution) -> PlanExecutionProto {
+    PlanExecutionProto {
+        status: match execution.status {
+            app_plan::PlanExecutionStatus::NotStarted => PlanExecutionStatusProto::NotStarted,
+            app_plan::PlanExecutionStatus::Running => PlanExecutionStatusProto::Running,
+            app_plan::PlanExecutionStatus::Ok => PlanExecutionStatusProto::Ok,
+            app_plan::PlanExecutionStatus::Error => PlanExecutionStatusProto::Error,
+        } as i32,
+        trace_id: execution
+            .trace_id
+            .as_deref()
+            .unwrap_or_default()
+            .to_string(),
+        row_count: execution.row_count.unwrap_or_default(),
+        row_count_recorded: execution.row_count.is_some(),
+        error_type: execution
+            .error_type
+            .as_ref()
+            .map(app_plan::PlanError::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        warnings: execution
+            .warnings
+            .iter()
+            .map(plan_warning_to_proto)
+            .collect(),
+        started_at: execution
+            .started_at
+            .map(|timestamp| timestamp.to_rfc3339())
+            .unwrap_or_default(),
+        completed_at: execution
+            .completed_at
+            .map(|timestamp| timestamp.to_rfc3339())
+            .unwrap_or_default(),
+    }
+}
+
+fn plan_warning_to_proto(warning: &app_plan::PlanWarning) -> PlanWarningProto {
+    match warning {
+        app_plan::PlanWarning::SourceSkipped { source, message } => PlanWarningProto {
+            warning: Some(plan_warning::Warning::SourceSkipped(
+                SourceSkippedWarningProto {
+                    source: source.as_str().to_string(),
+                    message: message.clone(),
+                },
+            )),
+        },
+    }
+}
+
 pub(crate) fn table_to_proto(
     workspace_name: &WorkspaceName,
     table: coral_engine::TableInfo,
@@ -336,19 +451,26 @@ mod tests {
         reason = "proto shape assertions intentionally fail loudly in tests"
     )]
 
+    use chrono::TimeZone as _;
     use coral_api::{
         grpc_response_status_code,
-        v1::{QueryTestFailure, Workspace, query_test_result},
+        v1::{
+            CostEstimateStatus, MemoryStatus, PlanExecutionStatus, PolicyCheckStatus,
+            QueryTestFailure, Workspace, plan_intent, plan_step, plan_warning, policy_check,
+            query_test_result,
+        },
     };
     use tonic::{Code, Request};
 
     use super::{
-        GrpcMethodMetadata, GrpcServerMethod, grpc_method, query_status,
+        GrpcMethodMetadata, GrpcServerMethod, analytical_plan_to_proto, grpc_method, query_status,
         query_test_result_to_proto, table_summary_to_proto, table_to_proto,
         workspace_name_from_proto, workspace_to_proto,
     };
     use crate::bootstrap::AppError;
+    use crate::plan::{AnalyticalPlan, PlanWarning};
     use crate::query::manager::QueryManagerError;
+    use crate::sources::SourceName;
     use crate::workspaces::WorkspaceName;
     use coral_engine::{
         ColumnInfo, CoreError, QueryTestResult as EngineQueryTestResult, TableInfo,
@@ -431,6 +553,68 @@ mod tests {
             workspace_name_from_proto(Some(&workspace)).expect("workspace should parse");
 
         assert_eq!(workspace_name.as_str(), "default");
+    }
+
+    #[test]
+    fn analytical_plan_to_proto_preserves_execution_evidence() {
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let started_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 14, 10, 0, 0)
+            .single()
+            .expect("started at");
+        let completed_at = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 14, 10, 0, 1)
+            .single()
+            .expect("completed at");
+        let mut plan = AnalyticalPlan::from_sql(&workspace_name, "SELECT 1");
+        plan.record_source_load(
+            vec![SourceName::parse("local_messages").expect("source name")],
+            vec![PlanWarning::source_skipped(
+                SourceName::parse("secured_messages").expect("source name"),
+                "missing secret 'API_TOKEN'",
+            )],
+        );
+        plan.mark_execution_started(started_at);
+        plan.record_success(0, Some("trace-123".to_string()), completed_at);
+
+        let proto = analytical_plan_to_proto(&plan);
+
+        assert_eq!(proto.plan_id, plan.plan_id.as_str());
+        assert_eq!(proto.workspace, "default");
+        assert!(proto.referenced_tables.is_empty());
+        let intent = proto.intent.expect("intent");
+        assert!(matches!(
+            intent.intent,
+            Some(plan_intent::Intent::Sql(sql)) if sql.sql == "SELECT 1"
+        ));
+        assert_eq!(proto.workspace_sources_loaded, vec!["local_messages"]);
+        assert!(matches!(
+            proto.steps.first().expect("step").step.as_ref(),
+            Some(plan_step::Step::RelationalSql(sql)) if sql.sql == "SELECT 1"
+        ));
+        assert!(matches!(
+            proto.policy_checks.first().expect("policy").check.as_ref(),
+            Some(policy_check::Check::LocalDefault(check))
+                if check.status == PolicyCheckStatus::NotEvaluated as i32
+        ));
+        assert_eq!(
+            proto.cost_estimate.expect("cost estimate").status,
+            CostEstimateStatus::Unknown as i32
+        );
+        assert_eq!(proto.memory_status, MemoryStatus::NotApplicable as i32);
+        let execution = proto.execution.expect("execution");
+        assert_eq!(execution.status, PlanExecutionStatus::Ok as i32);
+        assert_eq!(execution.trace_id, "trace-123");
+        assert_eq!(execution.row_count, 0);
+        assert!(execution.row_count_recorded);
+        assert_eq!(execution.started_at, started_at.to_rfc3339());
+        assert_eq!(execution.completed_at, completed_at.to_rfc3339());
+        let warning = execution.warnings.first().expect("warning");
+        assert!(matches!(
+            warning.warning.as_ref(),
+            Some(plan_warning::Warning::SourceSkipped(warning))
+                if warning.source == "secured_messages" && warning.message.contains("API_TOKEN")
+        ));
     }
 
     #[test]

--- a/crates/coral-app/src/workspaces/name.rs
+++ b/crates/coral-app/src/workspaces/name.rs
@@ -1,4 +1,7 @@
 use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 pub use coral_api::DEFAULT_WORKSPACE_ID;
 
@@ -31,6 +34,33 @@ impl WorkspaceName {
 impl fmt::Display for WorkspaceName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl Serialize for WorkspaceName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkspaceName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::from_str(&value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl FromStr for WorkspaceName {
+    type Err = AppError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
     }
 }
 

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -9,8 +9,10 @@ use std::fs;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     ExplainSqlRequest, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
-    ListTablesRequest, PaginationRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin,
-    SourceSecret, SourceVariable, ValidateSourceRequest, Workspace, query_test_result,
+    ListTablesRequest, MemoryStatus, PaginationRequest, PlanExecutionStatus, PolicyCheckStatus,
+    QueryTestFailure, QueryTestSuccess, SourceOrigin, SourceSecret, SourceVariable,
+    ValidateSourceRequest, Workspace, plan_intent, plan_step, plan_warning, policy_check,
+    query_test_result,
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
@@ -218,6 +220,110 @@ async fn validate_source_returns_tables() {
         .await;
     assert_eq!(rows.len(), 2);
     assert_eq!(rows[0]["text"], "hello");
+}
+
+#[tokio::test]
+async fn execute_sql_response_includes_analytical_plan() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let sql = "SELECT * FROM local_messages.messages WHERE text = 'missing'";
+    let response = harness
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: sql.to_string(),
+        }))
+        .await
+        .expect("execute sql")
+        .into_inner();
+
+    assert_eq!(response.row_count, 0);
+    let plan = response.plan.expect("execute sql plan");
+    assert!(plan.plan_id.starts_with("plan_"));
+    assert_eq!(plan.workspace, "default");
+    assert_eq!(plan.workspace_sources_loaded, vec!["local_messages"]);
+    let intent = plan.intent.expect("intent");
+    assert!(matches!(
+        intent.intent,
+        Some(plan_intent::Intent::Sql(sql_intent)) if sql_intent.sql == sql
+    ));
+    let step = plan.steps.first().expect("plan step");
+    assert!(matches!(
+        step.step.as_ref(),
+        Some(plan_step::Step::RelationalSql(sql_step)) if sql_step.sql == sql
+    ));
+    assert!(matches!(
+        plan.policy_checks
+            .first()
+            .expect("policy check")
+            .check
+            .as_ref(),
+        Some(policy_check::Check::LocalDefault(check))
+            if check.status == PolicyCheckStatus::NotEvaluated as i32
+    ));
+    assert_eq!(plan.memory_status, MemoryStatus::NotApplicable as i32);
+    let execution = plan.execution.expect("plan execution");
+    assert_eq!(execution.status, PlanExecutionStatus::Ok as i32);
+    assert_eq!(execution.row_count, 0);
+    assert!(execution.row_count_recorded);
+    assert!(execution.error_type.is_empty());
+    assert!(execution.started_at.contains('T'));
+    assert!(execution.completed_at.contains('T'));
+}
+
+#[tokio::test]
+async fn execute_sql_response_plan_includes_source_load_warnings() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+    harness
+        .import_source(
+            fixture_manifest_with_inputs_yaml(),
+            vec![SourceVariable {
+                key: "API_BASE".to_string(),
+                value: "https://example.com".to_string(),
+            }],
+            vec![SourceSecret {
+                key: "API_TOKEN".to_string(),
+                value: "secret-token".to_string(),
+            }],
+        )
+        .await;
+    fs::remove_file(source_dir(harness.config_dir(), "secured_messages").join("secrets.env"))
+        .expect("remove persisted secret");
+
+    let response = harness
+        .query_client()
+        .execute_sql(Request::new(ExecuteSqlRequest {
+            workspace: Some(default_workspace()),
+            sql: "SELECT * FROM local_messages.messages LIMIT 1".to_string(),
+        }))
+        .await
+        .expect("execute sql")
+        .into_inner();
+
+    let plan = response.plan.expect("execute sql plan");
+    assert_eq!(plan.workspace_sources_loaded, vec!["local_messages"]);
+    let execution = plan.execution.expect("plan execution");
+    let warning = execution.warnings.first().expect("source load warning");
+    assert!(matches!(
+        warning.warning.as_ref(),
+        Some(plan_warning::Warning::SourceSkipped(warning))
+            if warning.source == "secured_messages"
+                && warning.message.contains("missing secret 'API_TOKEN'")
+    ));
 }
 
 #[tokio::test]

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -460,6 +460,7 @@ fn sql_response(schema: &Schema, batches: &[RecordBatch], row_count: i64) -> Exe
     ExecuteSqlResponse {
         arrow_ipc_stream: encode_arrow_ipc_stream(schema, batches).expect("encode arrow ipc"),
         row_count,
+        plan: None,
     }
 }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -149,6 +149,7 @@ fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
     ExecuteSqlResponse {
         arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
         row_count,
+        plan: None,
     }
 }
 
@@ -187,6 +188,7 @@ fn mock_coral_tables_response() -> ExecuteSqlResponse {
     ExecuteSqlResponse {
         arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode arrow ipc"),
         row_count: 3,
+        plan: None,
     }
 }
 

--- a/crates/coral-client/src/lib.rs
+++ b/crates/coral-client/src/lib.rs
@@ -188,6 +188,7 @@ mod tests {
         ExecuteSqlResponse {
             arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[batch]).expect("encode"),
             row_count: 2,
+            plan: None,
         }
     }
 
@@ -222,6 +223,7 @@ mod tests {
         let response = ExecuteSqlResponse {
             arrow_ipc_stream: encode_arrow_ipc_stream(&schema, &[]).expect("encode"),
             row_count: 0,
+            plan: None,
         };
         let decoded = decode_execute_sql_response(&response).expect("decode");
         assert_eq!(decoded.row_count(), 0);

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -25,9 +25,10 @@ A query follows this path:
 1. **Entry point:** a user runs `coral sql` or an agent calls the `sql` MCP tool
 2. **Bootstrap:** the caller decides whether to start a local `coral-app` server or dial an existing endpoint
 3. **`coral-client`:** connects to that endpoint and sends the request over gRPC
-4. **`coral-app`:** loads installed sources from local state, delegates spec validation to `coral-spec`, and hands validated specs to `coral-engine`
+4. **`coral-app`:** creates an app-local analytical plan, loads installed sources from local state, delegates spec validation to `coral-spec`, and hands validated specs to `coral-engine`
 5. **`coral-engine`:** compiles specs into DataFusion table providers, registers them in a session, and executes SQL
-6. **Result:** Arrow record batches flow back through gRPC to the client, which formats them as table or JSON output (CLI) or structured MCP tool results (MCP)
+6. **Evidence:** the plan records the original SQL intent, loaded source context, execution status, row count, warnings, and trace linkage
+7. **Result:** Arrow record batches and the analytical plan flow back through gRPC; clients decode the Arrow result for table or JSON output while the transport contract preserves plan evidence for API consumers
 
 ## Crates
 
@@ -66,7 +67,8 @@ The local server and core orchestrator.
 | Source management | Install, add from file, list, validate, remove (`sources/`) |
 | Workspace state | Config, secrets, and workspace layout (`state/`, `storage/`) |
 | Feedback persistence | Workspace-scoped blocked-agent feedback reports (`feedback/`) |
-| Query orchestration | Loads sources, builds the engine, executes SQL (`query/`) |
+| Analytical planning | App-local plan objects that wrap SQL intent, source-load context, execution evidence, and trace linkage (`plan/`) |
+| Query orchestration | Creates plans, loads sources, builds the engine, executes SQL (`query/`) |
 
 This is the largest crate. It ties `coral-spec` and `coral-engine` together and manages all persistent local state.
 
@@ -113,7 +115,7 @@ The shared gRPC contract.
 
 | Owns                 | Details                                                                                |
 | -------------------- | -------------------------------------------------------------------------------------- |
-| Protobuf definitions | `proto/coral/v1/` — `query.proto`, `sources.proto`, `catalog.proto`, `resources.proto` |
+| Protobuf definitions | `proto/coral/v1/` — `query.proto`, `plan.proto`, `sources.proto`, `catalog.proto`, `resources.proto` |
 | Generated bindings   | Tonic-generated Rust types and service traits                                          |
 
 All inter-crate communication between `coral-client` and `coral-app` goes through these generated types.
@@ -135,4 +137,5 @@ graph TD
 ## Key design choices
 
 - **Local gRPC server.** The CLI and MCP server don't embed the engine directly, they go through a local gRPC server managed by `coral-app`. This keeps the engine lifecycle in one place and makes the client/server boundary explicit.
+- **App-local analytical plans.** `coral-app` creates a minimal plan object above query execution and below user-facing Ask, UI, gateway, CLI, and MCP surfaces. V0 plans are ephemeral and trace-linked, and successful `ExecuteSqlResponse` messages expose the plan alongside Arrow bytes and row count.
 - **Spec vs engine separation.** `coral-spec` is pure validation (no I/O, no runtime). `coral-engine` is pure execution (no YAML parsing, no persistence). `coral-app` bridges the two.

--- a/docs/project/roadmap.mdx
+++ b/docs/project/roadmap.mdx
@@ -7,7 +7,7 @@ description: "What Coral supports today, what is coming next, and where the proj
 
 - One SQL interface across APIs, local files, and live systems
 - Use Coral from the CLI or over MCP
-- Data, credentials, and query history stay local
+- Data, credentials, plan evidence, and query history stay local
 - Bundled sources for GitHub, Slack, Datadog, Linear, Sentry, Stripe, and more
 - Bring your own sources with source specs
 
@@ -15,7 +15,7 @@ description: "What Coral supports today, what is coming next, and where the proj
 
 - Self-host Coral for shared team use
 - Share source definitions, credentials, history, and schemas across a workspace
-- Explore schemas, query traces, and source health in a local UI
+- Explore schemas, analytical plans with trace evidence, and source health in a local UI
 - Source actions as table functions
 - Table and column level access policies
 - Semantic search predicates that push down to source-native search


### PR DESCRIPTION
## Intent

Coral needs a minimal analytical plan object at the API boundary so SQL execution can expose intent and execution evidence without every future surface inventing its own partial model.

## Changes

- Adds `coral.v1.AnalyticalPlan` and attaches it to successful `ExecuteSqlResponse` messages.
- Creates an app-local plan model for SQL intent, loaded sources, execution status, row count, warnings, trace linkage, and typed error evidence.
- Records `plan_id` on query spans and derives V0 policy, cost, memory, intent, and step fields at the transport edge.
- Covers zero-row success, SQL failure evidence, skipped-source warnings, and gRPC response plan shape.
- Updates project architecture and roadmap docs for plan plus trace evidence.

## Verification

- `make rust-checks`
