### PR TITLE
feat(sources/core): add codex source

### DIFF
--- a/docs/reference/bundled-sources.mdx
+++ b/docs/reference/bundled-sources.mdx
@@ -20,6 +20,7 @@ If the source you need is not available, you can extend Coral by [writing a cust
 | [clickup](#clickup) | `http` | Query tasks, spaces, folders, lists, goals, time entries, comments, views, tags, custom fields, teams, and users from ClickUp. |
 | [cloudwatch_logs](#cloudwatch_logs) | `http` | Query Amazon CloudWatch Logs groups, streams, and events. |
 | [cloudwatch_metrics](#cloudwatch_metrics) | `http` | Query Amazon CloudWatch metrics and monitoring metadata. |
+| [codex](#codex) | `file` | Query local Codex session event logs from ~/.codex/sessions. |
 | [confluence](#confluence) | `http` | Query spaces, pages, blog posts, comments, attachments, labels, and related metadata from Confluence Cloud. |
 | [datadog](#datadog) | `http` | Query monitors, events, incidents, dashboards, hosts, services, APM dependencies, downtimes, SLOs, synthetic tests, users, logs, spans, and metrics from Datadog. |
 | [github](#github) | `http` | Query repositories, issues, pull requests, workflows, organizations, users, teams, and API metadata from GitHub (Cloud or Enterprise). |
@@ -114,6 +115,10 @@ AWS access key ID with the CloudWatch read permissions.
 AWS secret access key.
 Coral does not read your AWS CLI profile, AWS SSO cache, or
 `AWS_PROFILE` at query time for this bundled source.
+
+### `codex`
+
+No configuration required.
 
 ### `confluence`
 

--- a/sources/core/codex/manifest.yaml
+++ b/sources/core/codex/manifest.yaml
@@ -1,0 +1,48 @@
+name: codex
+version: 0.1.0
+dsl_version: 3
+backend: file
+description: >-
+  Query local Codex session event logs from ~/.codex/sessions.
+test_queries:
+  - SELECT * FROM codex.events LIMIT 1
+tables:
+  - name: events
+    description: Codex session JSONL events partitioned by session date.
+    format: jsonl
+    guide: |
+      Reads current Codex session JSONL files under
+      `~/.codex/sessions/<year>/<month>/<day>/`.
+
+      Filter on `year`, `month`, and `day` to prune files before scanning.
+      Use JSON functions such as `json_get_str(payload, 'cwd')` and
+      `json_get_str(payload, 'model_provider')` for nested event payloads.
+    source:
+      location: file://~/.codex/sessions/
+      glob: "20??/**/*.jsonl"
+      partitions:
+        - name: year
+          type: Int64
+          path:
+            kind: segment
+            index: 0
+        - name: month
+          type: Int64
+          path:
+            kind: segment
+            index: 1
+        - name: day
+          type: Int64
+          path:
+            kind: segment
+            index: 2
+    columns:
+      - name: timestamp
+        type: Utf8
+        description: Event timestamp as recorded in the session log.
+      - name: type
+        type: Utf8
+        description: Codex event type.
+      - name: payload
+        type: Json
+        description: Event-specific JSON payload.


### PR DESCRIPTION
## Intent
Provide a zero-config local source for querying Codex session logs and exercise segment partitioning on the real directory shape that motivated it.

## Summary
- Add a bundled `codex` file source for local Codex session JSONL logs under `~/.codex/sessions`.
- Expose date path segments as partition columns so queries can prune by `year`, `month`, and `day`.
- Preserve event payloads as JSON text for `json_get_*` SQL functions.

## Validation
- `make rust-checks`
