### PR TITLE
feat(sources/community/jenkins): add jenkins community source

### DIFF
--- a/sources/community/jenkins/README.md
+++ b/sources/community/jenkins/README.md
@@ -1,8 +1,8 @@
 # Jenkins Connector (Community)
 
-**Version:** 0.1.0
+**Version:** 0.1.1
 **Backend:** HTTP (Jenkins REST JSON API)
-**Tables:** 5
+**Tables:** 4
 **Default base URL:** `http://127.0.0.1:8081` (override with `JENKINS_BASE_URL`)
 
 Query Jenkins jobs, last-build results, and Git revision metadata from Jenkins
@@ -38,7 +38,7 @@ coral source add --file sources/community/jenkins/manifest.yaml
 ```
 
 Create an API token under **User** → **Configure** → **API Token**. Use a user
-that can read jobs (and queue builds if you use `trigger_build`).
+that can read jobs and builds.
 
 On macOS, build the header with `base64 | tr -d '\n'` instead of `base64 -w0`.
 
@@ -68,12 +68,6 @@ Register one Coral source per Jenkins instance (for example `jenkins_ci`,
 | `builds` | Last build number, result, URL, and `commit_hash` when present |
 | `job_last_revision` | Git `SHA1` rows from job `actions` |
 | `job_git_sha_by_action_index` | Git SHA via indexed `actions` path |
-
-### Mutating
-
-| Table | Description |
-|---|---|
-| `trigger_build` | Queue a build via `POST /job/{job_name}/build` |
 
 ## Filters and pagination
 
@@ -134,14 +128,6 @@ FROM jenkins.job_last_revision
 WHERE job_name = 'my-pipeline';
 ```
 
-### Trigger a build
-
-```sql
-SELECT action
-FROM jenkins.trigger_build
-WHERE job_name = 'my-pipeline';
-```
-
 ## Validation
 
 ```bash
@@ -158,11 +144,10 @@ coral source test jenkins
 
 ## Limitations
 
+- Read-only v1 (no build triggers).
 - v1 focuses on last build per job, not full build history.
 - `JENKINS_AUTHORIZATION` must be the full `Basic ...` header; a bare token returns `403`.
-- `trigger_build` may fail with `403` when Jenkins CSRF protection is enabled.
 - `commit_hash` and Git SHA columns depend on job type and installed plugins.
-- `trigger_build` responses may be empty or non-JSON.
 - Community sources are maintained separately from bundled core sources.
 
 ## Contributing

--- a/sources/community/jenkins/README.md
+++ b/sources/community/jenkins/README.md
@@ -1,0 +1,172 @@
+# Jenkins Connector (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Jenkins REST JSON API)
+**Tables:** 5
+**Default base URL:** `http://127.0.0.1:8081` (override with `JENKINS_BASE_URL`)
+
+Query Jenkins jobs, last-build results, and Git revision metadata from Jenkins
+(self-hosted). Designed for CI triage and build auditing without custom Jenkins
+API scripts.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Import the manifest from
+this directory:
+
+```bash
+coral source import sources/community/Jenkins/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and import the local path.
+
+Reference the linked GitHub issue in your PR so maintainers can connect the
+contribution to the prior discussion.
+
+## Authentication and setup
+
+### Local development (recommended for contributors)
+
+Jenkins uses **HTTP Basic** for the JSON API, not a bare Bearer token. Export the
+full `Authorization` header before import:
+
+```bash
+export JENKINS_BASE_URL=http://127.0.0.1:8081
+export JENKINS_AUTHORIZATION="Basic $(echo -n 'admin:YOUR_API_TOKEN' | base64 -w0)"
+coral source import sources/community/Jenkins/manifest.yaml
+```
+
+Create an API token under **User** → **Configure** → **API Token**. Use a user
+that can read jobs (and queue builds if you use `trigger_build`).
+
+On macOS, build the header with `base64 | tr -d '\n'` instead of `base64 -w0`.
+
+### Remote or shared Jenkins
+
+Point `JENKINS_BASE_URL` at your controller root URL with no trailing slash (for
+example `https://jenkins.example.com`). Ensure the Jenkins user has permission to
+read jobs and builds for the tables you query.
+
+### Multiple controllers
+
+Register one Coral source per Jenkins instance (for example `jenkins_ci`,
+`jenkins_prod`), each with its own `JENKINS_BASE_URL` and `JENKINS_AUTHORIZATION`.
+
+## Table categories
+
+### Job inventory
+
+| Table | Description |
+|---|---|
+| `jobs` | Top-level jobs (`name`, `url`, `color`) |
+
+### Per-job metadata
+
+| Table | Description |
+|---|---|
+| `builds` | Last build number, result, URL, and `commit_hash` when present |
+| `job_last_revision` | Git `SHA1` rows from job `actions` |
+| `job_git_sha_by_action_index` | Git SHA via indexed `actions` path |
+
+### Mutating
+
+| Table | Description |
+|---|---|
+| `trigger_build` | Queue a build via `POST /job/{job_name}/build` |
+
+## Filters and pagination
+
+Per-job tables require a `job_name` filter. The `jobs` table has no required
+filter.
+
+Example:
+
+```sql
+SELECT job_name, build_number, result, commit_hash
+FROM jenkins.builds
+WHERE job_name = 'my-pipeline';
+```
+
+Responses use Jenkins `tree` query parameters for bounded JSON payloads. Tables
+use `pagination.mode: none` because each request returns a small, scoped result.
+Prefer `LIMIT` when listing jobs on large controllers.
+
+## Example relationships
+
+| From | To | Join hint |
+|---|---|---|
+| `jenkins.jobs.name` | `jenkins.builds.job_name` | Job to last build |
+| `jenkins.builds.commit_hash` | `k8s.pods.annotation_commit_hash` | When CI injects the same commit into cluster metadata |
+
+## Example queries
+
+### List jobs
+
+```sql
+SELECT name, color, url
+FROM jenkins.jobs
+LIMIT 50;
+```
+
+### Last build for a job
+
+```sql
+SELECT job_name, build_number, result, commit_hash, build_url
+FROM jenkins.builds
+WHERE job_name = 'my-pipeline';
+```
+
+### Unsuccessful last build
+
+```sql
+SELECT job_name, build_number, result
+FROM jenkins.builds
+WHERE job_name = 'api-deploy'
+  AND result != 'SUCCESS';
+```
+
+### Git SHA from job actions
+
+```sql
+SELECT sha1, plugin_class
+FROM jenkins.job_last_revision
+WHERE job_name = 'my-pipeline';
+```
+
+### Trigger a build
+
+```sql
+SELECT action
+FROM jenkins.trigger_build
+WHERE job_name = 'my-pipeline';
+```
+
+## Validation
+
+```bash
+# YAML style (requires: cargo install ryl --locked)
+make lint-sources
+
+# Manifest structure and smoke queries (requires Coral CLI)
+coral source lint sources/community/Jenkins/manifest.yaml
+export JENKINS_BASE_URL=http://127.0.0.1:8081
+export JENKINS_AUTHORIZATION="Basic $(echo -n 'admin:YOUR_API_TOKEN' | base64 -w0)"
+coral source import sources/community/Jenkins/manifest.yaml
+coral source test jenkins
+```
+
+## Limitations
+
+- v1 focuses on last build per job, not full build history.
+- `JENKINS_AUTHORIZATION` must be the full `Basic ...` header; a bare token returns `403`.
+- `trigger_build` may fail with `403` when Jenkins CSRF protection is enabled.
+- `commit_hash` and Git SHA columns depend on job type and installed plugins.
+- `trigger_build` responses may be empty or non-JSON.
+- Rename the directory to `sources/community/jenkins` (lowercase) before upstream PR.
+- Community sources are maintained separately from bundled core sources.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the issue first,
+sign the CLA if this is your first contribution, run `make lint-sources`, and
+open a focused PR titled `feat(sources/community/jenkins): add jenkins community source`.

--- a/sources/community/jenkins/README.md
+++ b/sources/community/jenkins/README.md
@@ -11,14 +11,15 @@ API scripts.
 
 ## Install
 
-Community sources are not bundled with the Coral binary. Import the manifest from
+Community sources are not bundled with the Coral binary. Add the manifest from
 this directory:
 
 ```bash
-coral source import sources/community/Jenkins/manifest.yaml
+coral source add --file sources/community/jenkins/manifest.yaml
 ```
 
-Or copy `manifest.yaml` into your workspace and import the local path.
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
 
 Reference the linked GitHub issue in your PR so maintainers can connect the
 contribution to the prior discussion.
@@ -28,12 +29,12 @@ contribution to the prior discussion.
 ### Local development (recommended for contributors)
 
 Jenkins uses **HTTP Basic** for the JSON API, not a bare Bearer token. Export the
-full `Authorization` header before import:
+full `Authorization` header before adding the source:
 
 ```bash
 export JENKINS_BASE_URL=http://127.0.0.1:8081
 export JENKINS_AUTHORIZATION="Basic $(echo -n 'admin:YOUR_API_TOKEN' | base64 -w0)"
-coral source import sources/community/Jenkins/manifest.yaml
+coral source add --file sources/community/jenkins/manifest.yaml
 ```
 
 Create an API token under **User** → **Configure** → **API Token**. Use a user
@@ -148,10 +149,10 @@ WHERE job_name = 'my-pipeline';
 make lint-sources
 
 # Manifest structure and smoke queries (requires Coral CLI)
-coral source lint sources/community/Jenkins/manifest.yaml
+coral source lint sources/community/jenkins/manifest.yaml
 export JENKINS_BASE_URL=http://127.0.0.1:8081
 export JENKINS_AUTHORIZATION="Basic $(echo -n 'admin:YOUR_API_TOKEN' | base64 -w0)"
-coral source import sources/community/Jenkins/manifest.yaml
+coral source add --file sources/community/jenkins/manifest.yaml
 coral source test jenkins
 ```
 
@@ -162,7 +163,6 @@ coral source test jenkins
 - `trigger_build` may fail with `403` when Jenkins CSRF protection is enabled.
 - `commit_hash` and Git SHA columns depend on job type and installed plugins.
 - `trigger_build` responses may be empty or non-JSON.
-- Rename the directory to `sources/community/jenkins` (lowercase) before upstream PR.
 - Community sources are maintained separately from bundled core sources.
 
 ## Contributing

--- a/sources/community/jenkins/manifest.yaml
+++ b/sources/community/jenkins/manifest.yaml
@@ -1,10 +1,10 @@
 name: jenkins
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-
   Query Jenkins jobs, last-build results, and Git revision metadata from Jenkins
-  (self-hosted). Supports local controllers via the JSON REST API.
+  (self-hosted). Read-only; uses the JSON REST API.
 inputs:
   JENKINS_BASE_URL:
     kind: variable
@@ -192,26 +192,3 @@ tables:
             - "1"
             - lastBuiltRevision
             - SHA1
-
-  - name: trigger_build
-    description: Queue a build for a job via POST (mutating).
-    guide: |
-      Required filter: `job_name`. Needs build permission; may return 403 when CSRF is enabled.
-    filters:
-      - name: job_name
-        required: true
-    request:
-      method: POST
-      path: "/job/{{filter.job_name}}/build"
-    response:
-      row_strategy: direct
-      allow_404_empty: true
-    pagination:
-      mode: none
-    columns:
-      - name: action
-        type: Utf8
-        description: Static marker when the POST is accepted.
-        expr:
-          kind: literal
-          value: trigger_build_posted

--- a/sources/community/jenkins/manifest.yaml
+++ b/sources/community/jenkins/manifest.yaml
@@ -1,0 +1,217 @@
+name: jenkins
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Jenkins jobs, last-build results, and Git revision metadata from Jenkins
+  (self-hosted). Supports local controllers via the JSON REST API.
+inputs:
+  JENKINS_BASE_URL:
+    kind: variable
+    default: http://127.0.0.1:8081
+    hint: |
+      Jenkins root URL with no trailing slash. Use the default for a local controller
+      on port 8081; for shared controllers use your instance URL
+      (for example `https://jenkins.example.com`).
+  JENKINS_AUTHORIZATION:
+    kind: secret
+    required: true
+    hint: |
+      Full `Authorization` header value: `Basic` plus base64(`username:apiToken`).
+      Create an API token under User → Configure → API Token. Not a bare Bearer token.
+      Example: `export JENKINS_AUTHORIZATION="Basic $(echo -n 'user:token' | base64 -w0)"`
+      See [Jenkins scripted client auth](https://www.jenkins.io/doc/book/system-administration/authenticating-scripted-clients/).
+base_url: "{{input.JENKINS_BASE_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: input
+      key: JENKINS_AUTHORIZATION
+test_queries:
+  - SELECT name, color FROM jenkins.jobs LIMIT 10
+tables:
+  - name: jobs
+    description: Top-level Jenkins jobs with name, URL, and health color.
+    guide: |
+      No required filters. Use as the entry point, then pass `name` as `job_name` on
+      per-job tables.
+    request:
+      method: GET
+      path: /api/json
+      query:
+        - name: tree
+          from: literal
+          value: "jobs[name,url,color]"
+    response:
+      rows_path:
+        - jobs
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        expr:
+          kind: path
+          path:
+            - name
+      - name: url
+        type: Utf8
+        expr:
+          kind: path
+          path:
+            - url
+      - name: color
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - color
+
+  - name: builds
+    description: Last build for a job, including commit hash when changeSet is present.
+    guide: |
+      Required filter: `job_name` (Jenkins job name from `jenkins.jobs.name`).
+    filters:
+      - name: job_name
+        required: true
+    request:
+      method: GET
+      path: "/job/{{filter.job_name}}/lastBuild/api/json"
+      query:
+        - name: tree
+          from: literal
+          value: "number,result,url,changeSet[items[commitId]]"
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: job_name
+        type: Utf8
+        description: Echoes the job_name filter for SQL joins.
+        expr:
+          kind: from_filter
+          key: job_name
+      - name: build_number
+        type: Int64
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - number
+      - name: result
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - result
+      - name: build_url
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - url
+      - name: commit_hash
+        type: Utf8
+        nullable: true
+        description: From changeSet.items[0].commitId when present.
+        expr:
+          kind: path
+          path:
+            - changeSet
+            - items
+            - "0"
+            - commitId
+
+  - name: job_last_revision
+    description: Git lastBuiltRevision rows from job actions (plugin-dependent).
+    guide: |
+      Required filter: `job_name`. Returns one row per actions[] entry with SHA1 when present.
+    filters:
+      - name: job_name
+        required: true
+    request:
+      method: GET
+      path: "/job/{{filter.job_name}}/api/json"
+      query:
+        - name: tree
+          from: literal
+          value: "actions[lastBuiltRevision[SHA1]],name,url"
+    response:
+      rows_path:
+        - actions
+    pagination:
+      mode: none
+    columns:
+      - name: sha1
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - lastBuiltRevision
+            - SHA1
+      - name: plugin_class
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - _class
+
+  - name: job_git_sha_by_action_index
+    description: Git SHA from a fixed actions index path (plugin-dependent).
+    guide: |
+      Required filter: `job_name`. Fallback when job_last_revision layout differs by plugin.
+    filters:
+      - name: job_name
+        required: true
+    request:
+      method: GET
+      path: "/job/{{filter.job_name}}/api/json"
+      query:
+        - name: tree
+          from: literal
+          value: "actions[lastBuiltRevision[SHA1]]"
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: sha_from_indexed_action
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - actions
+            - "1"
+            - lastBuiltRevision
+            - SHA1
+
+  - name: trigger_build
+    description: Queue a build for a job via POST (mutating).
+    guide: |
+      Required filter: `job_name`. Needs build permission; may return 403 when CSRF is enabled.
+    filters:
+      - name: job_name
+        required: true
+    request:
+      method: POST
+      path: "/job/{{filter.job_name}}/build"
+    response:
+      row_strategy: direct
+      allow_404_empty: true
+    pagination:
+      mode: none
+    columns:
+      - name: action
+        type: Utf8
+        description: Static marker when the POST is accepted.
+        expr:
+          kind: literal
+          value: trigger_build_posted


### PR DESCRIPTION
# Closes #471

# Summary

Adds a new read-only community Jenkins source under:

```text
sources/community/jenkins/
```

This source enables querying Jenkins jobs, last-build metadata, and Git revision information through SQL using the Jenkins REST JSON API.

The source is designed for self-managed Jenkins environments while remaining compatible with:

* Containerized Jenkins deployments
* VM-based Jenkins installations
* Internal enterprise Jenkins deployments

---

# Tables

| Table                         | Description                                                                      |
| ----------------------------- | -------------------------------------------------------------------------------- |
| `jobs`                        | Top-level jobs including name, URL, and color                                    |
| `builds`                      | Last build metadata including result, build number, and commit hash when present |
| `job_last_revision`           | Git SHA1 rows extracted from Jenkins job actions                                 |
| `job_git_sha_by_action_index` | Git SHA extraction via indexed Jenkins actions path (plugin-dependent)           |

---

# Files

```text
sources/community/jenkins/manifest.yaml
sources/community/jenkins/README.md
```

---

# Setup

```bash
export JENKINS_AUTHORIZATION="Basic $(echo -n 'admin:YOUR_API_TOKEN' | base64 -w0)"
export JENKINS_BASE_URL=http://127.0.0.1:8081
```

The source communicates directly with the Jenkins REST JSON API.

---

# Auth

Full Authorization header using HTTP Basic authentication (`username:apiToken`), not a bare Bearer token.

Example:

```text
Authorization: Basic base64("username:apiToken")
```

---

# Permissions

Read access to jobs and builds for the tables above.

---

# Why it changed

Teams need SQL answers such as:

* Which Jenkins jobs are failing
* What the last build result was
* Which Git SHA Jenkins recorded

without relying on custom `/api/json` scripts.

This source makes Jenkins operational metadata queryable through SQL workflows.

---

# What was tested

* `coral source lint sources/community/jenkins/manifest.yaml`
* `make lint-sources`
* `coral source add --file + coral source test jenkins` (with live Jenkins)
* Verified job listing and build metadata retrieval
* Verified Git revision extraction from Jenkins job actions
* Verified required filters for job-scoped tables
* Verified Jenkins tree parameter payload limiting

---

# Example queries

## List jobs

```sql
SELECT name, color, url
FROM jenkins.jobs
LIMIT 50;
```

## Last build for a job

```sql
SELECT job_name, build_number, result, commit_hash, build_url
FROM jenkins.builds
WHERE job_name = 'my-pipeline';
```

## Git SHA from job actions

```sql
SELECT sha1, plugin_class
FROM jenkins.job_last_revision
WHERE job_name = 'my-pipeline';
```

---

# User-visible impact

```bash
export JENKINS_AUTHORIZATION="Basic $(echo -n 'admin:YOUR_API_TOKEN' | base64 -w0)"
export JENKINS_BASE_URL=http://127.0.0.1:8081

coral source add --file sources/community/jenkins/manifest.yaml
```

---

# Notes

* Read-only v1 source
* Uses Jenkins tree parameters for bounded JSON payloads
* Compatible with local, containerized, and enterprise Jenkins deployments
* `commit_hash` and Git SHA fields depend on job type and installed plugins
* Nested Jenkins action payloads are preserved where appropriate

---

# Follow-on

Potential future enhancements:

* Full build history pagination
* Pipeline stage visibility
* Jenkins queue metadata
* Multibranch pipeline metadata
* Artifact metadata
* Test result reporting
* Optional build trigger support as a separate non-read-only feature
