### PR TITLE
docs(mcp): frame Coral as a SQL database for agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,9 +199,9 @@ coral sql "
 
 ## Use Coral with an agent
 
-Coral ships with a built-in MCP server so your agent can run SQL queries and
-discover schemas across your installed sources. Once you've added at least one
-source, wire Coral into your agent:
+Coral ships with a built-in MCP server that presents Coral to your agent as a
+read-only SQL database. Once you've added at least one source, wire Coral into
+your agent:
 
 ```bash
 claude mcp add --scope user coral -- coral mcp-stdio   # Claude Code
@@ -220,9 +220,10 @@ npx skills add withcoral/skills
 ```
 
 Once connected, ask your agent to "list the tables available in Coral" or to
-run a small query — it'll call `list_catalog`, `search_catalog`, or the
-`coral.tables` / `coral.table_functions` metadata tables and see your installed
-sources.
+run a small query. It should use `list_catalog`, `search_catalog`, or the
+`coral.tables` / `coral.table_functions` metadata tables as database catalog
+discovery, then answer with SQL over your visible schemas, tables, and table
+functions.
 
 ## Local state
 

--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -1,25 +1,27 @@
-# Coral Query Guide
+# Coral Database Guide
 
 {{SOURCES_SECTION}}
 
 ## Discovery Workflow
 
-Always inspect queryable tables, source-scoped table functions, and table metadata before writing queries. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
+Treat Coral like a read-only SQL database. The MCP discovery tools are catalog helpers, not replacement APIs. Inspect tables, parameterized table functions, and columns first, then answer with set-based SQL.
+
+Prefer one SQL statement with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over fetching rows and combining them in the agent. Use `CROSS JOIN` explicitly when the query needs every combination of rows from two relations. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
 
 ```sql
 -- List visible tables, descriptions, and required filters
 SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
 
--- List source-scoped table functions, such as provider-native search
+-- List parameterized table functions
 SELECT schema_name, function_name, description, arguments_json, result_columns_json FROM coral.table_functions ORDER BY schema_name, function_name;
 
 -- Inspect columns for one visible table, including nullability and filter-only virtual columns
 {{COLUMNS_EXAMPLE}}
 ```
 
-## Per-Source Configuration
+## Catalog Metadata
 
-Per-source config values (e.g. Datadog site, Sentry org slug, GitHub API base URL) are exposed via `coral.inputs`. Use it to compose absolute URLs or account-scoped identifiers from source variables. Secret values are never exposed — secret rows always have `value IS NULL`, but `is_set` tells you whether the secret is configured.
+Configured input metadata is exposed through `coral.inputs`. Use it to compose absolute URLs or account-scoped identifiers when a database row needs them. Secret values are never exposed: secret rows always have `value IS NULL`, but `is_set` tells you whether the secret is configured.
 
 ```sql
 -- Look up a variable value
@@ -33,7 +35,7 @@ WHERE kind = 'secret' AND is_set;
 
 ## JSON Columns
 
-Some source tables expose JSON payloads as `Utf8` columns. Extract fields with the `json_*` functions — path segments are variadic, e.g. `json_get(payload, 'user', 'id')`.
+Some tables expose JSON payloads as `Utf8` columns. Extract fields with the `json_*` functions: path segments are variadic, e.g. `json_get(payload, 'user', 'id')`.
 
 - `json_get(json, path…)` returns a union. Casting to `Boolean`, `Int32/64`, `Float32/64`, or `Utf8` is rewritten to the matching typed function; casts to `Decimal*` stay on the normal cast path and preserve the requested precision/scale.
 - Typed shortcuts: `json_get_bool`, `json_get_int`, `json_get_float`, `json_get_str` return the named type directly and yield NULL when the path is missing or the shape doesn't match.
@@ -45,7 +47,7 @@ Some source tables expose JSON payloads as `Utf8` columns. Extract fields with t
 SELECT json_get_str(payload, 'event')              AS event,
        json_get(payload, 'user', 'id')::bigint     AS user_id,
        json_get(payload, 'amount')::decimal(18, 2) AS amount
-FROM source.events;
+FROM app.events;
 ```
 
 ```sql
@@ -61,11 +63,11 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Use each table function's `sql_call_example` from `list_catalog` or `search_catalog`, filling in the required arguments before querying it.
 - Do not quote the whole `schema.table` string. Write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Check `coral.tables.required_filters` and `coral.columns.is_required_filter` before querying tables that depend on filter-only inputs.
-- Cross-source joins work with standard SQL after source scans complete.
+- Joins across schemas work with standard SQL after table scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_catalog` shows queryable tables and source-scoped table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
+- `list_catalog` shows queryable tables and parameterized table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
 - `search_catalog` searches table and table-function names, descriptions, arguments, result columns, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the catalog item you need.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
 - `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively. Existing tables return paginated `columns` plus `total`, `has_more`, and optional `next_offset`; regex matches add `matched_fields` per column. Missing tables return `found: false` with suggested recovery calls instead of an empty page.
-- `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, and `coral.inputs` provide richer SQL metadata.
+- `coral://tables` shows database table summaries; `coral.tables`, `coral.columns`, `coral.table_functions`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/surface/errors.rs
+++ b/crates/coral-mcp/src/surface/errors.rs
@@ -98,12 +98,12 @@ fn plain_fallback(operation: &str, code: tonic::Code) -> (String, Option<String>
         tonic::Code::NotFound => (
             format!("{operation} target was not found"),
             Some(
-                "Confirm the visible source, schema, and table names before retrying.".to_string(),
+                "Confirm the visible SQL schema and table names before retrying.".to_string(),
             ),
         ),
         tonic::Code::FailedPrecondition => (
             format!("{operation} prerequisites are not satisfied"),
-            Some("Check source configuration and required filters, then retry.".to_string()),
+            Some("Check database catalog metadata, configured inputs, and required filters, then retry.".to_string()),
         ),
         tonic::Code::Unavailable => (
             format!("{operation} is unavailable"),

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use super::values::queryable_table_summary_values;
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral. Read `coral://guide` for query patterns, use `list_catalog` and `search_catalog` to inspect queryable tables and source-scoped table functions, use `describe_table` and `list_columns` for table-specific metadata, and use `sql` for final queries.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral, a read-only SQL database. Treat exposed data as database schemas, tables, and table functions. Use `list_catalog` and `search_catalog` as catalog helpers, use `describe_table` and `list_columns` for table-specific metadata, then answer with set-based SQL through `sql`. Prefer one SQL statement with joins, CROSS JOIN, CTEs, subqueries, and aggregates over row-by-row tool calls.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {
@@ -44,7 +44,7 @@ pub(crate) fn guide_resource_content(
 ) -> String {
     let mut sources_section = String::from("## Available Schemas\n\n");
     sources_section.push_str(
-        "- coral: System metadata schema. Use `coral.tables`, `coral.columns`, and `coral.table_functions` to discover queryable tables, source-scoped table functions, columns, descriptions, and required filters.\n",
+        "- coral: System catalog schema. Query `coral.tables`, `coral.columns`, `coral.table_functions`, and `coral.inputs` like database catalog tables.\n",
     );
     let mut schemas = tables
         .iter()
@@ -53,13 +53,12 @@ pub(crate) fn guide_resource_content(
     schemas.extend(table_function_schema_names.iter().map(String::as_str));
     if schemas.is_empty() {
         if sources.is_empty() {
-            sources_section.push_str("\nNo source schemas are currently configured.\n");
+            sources_section.push_str("\nNo user schemas are currently configured.\n");
         } else {
-            sources_section
-                .push_str("\nNo query-visible source schemas are currently available.\n");
+            sources_section.push_str("\nNo user-visible schemas are currently available.\n");
         }
     } else {
-        sources_section.push_str("\nVisible source schemas:\n");
+        sources_section.push_str("\nVisible schemas:\n");
         for schema in schemas {
             writeln!(sources_section, "- {schema}").expect("writing to String is infallible");
         }
@@ -103,7 +102,7 @@ fn guide_resource_description(
     visible_function_count: usize,
 ) -> String {
     format!(
-        "Query workflow and schema discovery guidance for {} configured source(s), {} visible table(s), and {} visible table function(s).",
+        "Database workflow and catalog discovery guidance for {} configured connection(s), {} visible table(s), and {} visible table function(s).",
         sources.len(),
         visible_table_count,
         visible_function_count
@@ -111,7 +110,7 @@ fn guide_resource_description(
 }
 
 fn tables_resource_description(visible_table_count: usize) -> String {
-    format!("Queryable fully qualified Coral tables ({visible_table_count} table(s)).")
+    format!("Fully qualified database tables in Coral ({visible_table_count} table(s)).")
 }
 
 fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
@@ -127,7 +126,7 @@ fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
 mod tests {
     use coral_api::v1::{Source, TableSummary, Workspace};
 
-    use super::guide_resource_content;
+    use super::{guide_resource_content, initial_instructions};
     use crate::surface::values::format_schema_table_equivalent;
 
     fn source(name: &str) -> Source {
@@ -157,11 +156,20 @@ mod tests {
     }
 
     #[test]
+    fn initial_instructions_frame_coral_as_sql_database() {
+        let instructions = initial_instructions();
+        assert!(instructions.contains("read-only SQL database"));
+        assert!(instructions.contains("catalog helpers"));
+        assert!(instructions.contains("CROSS JOIN"));
+        assert!(instructions.contains("row-by-row tool calls"));
+    }
+
+    #[test]
     fn guide_content_renders_placeholder_when_no_schemas_exist() {
         let content = guide_resource_content(&[source("demo")], &[], &[]);
         assert!(content.contains("## Available Schemas"));
-        assert!(content.contains("- coral: System metadata schema."));
-        assert!(content.contains("No query-visible source schemas are currently available."));
+        assert!(content.contains("- coral: System catalog schema."));
+        assert!(content.contains("No user-visible schemas are currently available."));
         assert!(content.contains("schema_name = '<schema>'"));
     }
 
@@ -173,8 +181,8 @@ mod tests {
             &[],
         );
         assert!(content.contains("## Available Schemas"));
-        assert!(content.contains("- coral: System metadata schema."));
-        assert!(content.contains("Visible source schemas:"));
+        assert!(content.contains("- coral: System catalog schema."));
+        assert!(content.contains("Visible schemas:"));
         assert!(content.contains("- slack"));
         assert!(
             content.contains(
@@ -189,9 +197,9 @@ mod tests {
 
         let content = guide_resource_content(&[source("searchy")], &[], &function_schemas);
 
-        assert!(content.contains("Visible source schemas:"));
+        assert!(content.contains("Visible schemas:"));
         assert!(content.contains("- searchy"));
-        assert!(!content.contains("No query-visible source schemas are currently available."));
+        assert!(!content.contains("No user-visible schemas are currently available."));
     }
 
     #[test]

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -53,7 +53,7 @@ pub(crate) fn sql_tool(sources: &[Source], visible_table_count: usize) -> Tool {
             "properties": {
                 "sql": {
                     "type": "string",
-                    "description": "A single SQL statement to execute."
+                    "description": "One read-only SQL statement to execute against the Coral database."
                 }
             }
         })),
@@ -71,14 +71,14 @@ pub(crate) fn list_catalog_tool(visible_table_count: usize, visible_function_cou
     Tool::new(
         "list_catalog",
         format!(
-            "List queryable catalog items. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
+            "List database catalog items. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
         ),
         json_object_schema(&json!({
             "type": "object",
             "properties": {
                 "schema": {
                     "type": "string",
-                    "description": "Optional exact schema/source name to list."
+                    "description": "Optional exact SQL schema name to list."
                 },
                 "kind": {
                     "description": "Optional item kind to list. Omit or pass null to list all catalog items.",
@@ -132,11 +132,11 @@ pub(crate) fn search_catalog_tool(
             "properties": {
                 "pattern": {
                     "type": "string",
-                    "description": "Rust regex pattern to match catalog metadata."
+                    "description": "Rust regex pattern to match database catalog metadata."
                 },
                 "schema": {
                     "type": "string",
-                    "description": "Optional exact schema/source name to search."
+                    "description": "Optional exact SQL schema name to search."
                 },
                 "kind": {
                     "description": "Optional item kind to search. Omit or pass null to search all catalog items.",
@@ -184,18 +184,18 @@ pub(crate) fn search_catalog_tool(
 pub(crate) fn describe_table_tool() -> Tool {
     Tool::new(
         "describe_table",
-        "Describe one queryable table without returning full column definitions.",
+        "Describe one database table without returning full column definitions.",
         json_object_schema(&json!({
             "type": "object",
             "required": ["schema", "table"],
             "properties": {
                 "schema": {
                     "type": "string",
-                    "description": "Exact schema/source name."
+                    "description": "Exact SQL schema name."
                 },
                 "table": {
                     "type": "string",
-                    "description": "Exact table name within the schema."
+                    "description": "Exact table name within the SQL schema."
                 }
             }
         })),
@@ -212,18 +212,18 @@ pub(crate) fn describe_table_tool() -> Tool {
 pub(crate) fn list_columns_tool() -> Tool {
     Tool::new(
         "list_columns",
-        "List columns for one table with optional regex and required-filter narrowing.",
+        "List columns for one database table with optional regex and required-filter narrowing.",
         json_object_schema(&json!({
             "type": "object",
             "required": ["schema", "table"],
             "properties": {
                 "schema": {
                     "type": "string",
-                    "description": "Exact schema/source name."
+                    "description": "Exact SQL schema name."
                 },
                 "table": {
                     "type": "string",
-                    "description": "Exact table name within the schema."
+                    "description": "Exact table name within the SQL schema."
                 },
                 "pattern": {
                     "type": "string",
@@ -379,22 +379,20 @@ pub(crate) fn build_tool_result(value: Value) -> Result<CallToolResult, ErrorDat
     Ok(result)
 }
 
-fn sql_tool_description(sources: &[Source], visible_table_count: usize) -> String {
+fn sql_tool_description(_sources: &[Source], visible_table_count: usize) -> String {
     if visible_table_count == 0 {
-        format!(
-            "Run a SQL query against local Coral sources. {} configured source(s), but no visible SQL tables are currently available.",
-            sources.len()
-        )
+        "Execute read-only SQL against the Coral database. No user tables are currently visible."
+            .to_string()
     } else {
         format!(
-            "Run a SQL query against local Coral sources. {visible_table_count} table(s) are currently visible."
+            "Execute read-only SQL against the Coral database. {visible_table_count} table(s) are currently visible. Use JOIN, CROSS JOIN, CTEs, subqueries, and aggregates to combine tables in one statement."
         )
     }
 }
 
 fn search_catalog_description(visible_table_count: usize, visible_function_count: usize) -> String {
     format!(
-        "Search queryable catalog metadata with a Rust regex. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
+        "Search database catalog metadata with a Rust regex. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
     )
 }
 

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -299,7 +299,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .description
             .as_deref()
             .expect("sql description")
-            .contains("0 configured source")
+            .contains("No user tables are currently visible")
     );
     for tool in &initial_tools {
         let Some(output_schema) = &tool.output_schema else {
@@ -328,7 +328,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .description
             .as_deref()
             .expect("guide description")
-            .contains("0 configured source")
+            .contains("0 visible table")
     );
 
     let initial_guide = client
@@ -337,8 +337,10 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .expect("initial guide");
     let initial_guide_text = text_content(&initial_guide);
     assert!(initial_guide_text.contains("## Available Schemas"));
-    assert!(initial_guide_text.contains("- coral: System metadata schema."));
-    assert!(initial_guide_text.contains("No source schemas are currently configured."));
+    assert!(initial_guide_text.contains("- coral: System catalog schema."));
+    assert!(initial_guide_text.contains("No user schemas are currently configured."));
+    assert!(initial_guide_text.contains("read-only SQL database"));
+    assert!(initial_guide_text.contains("CROSS JOIN"));
     assert!(initial_guide_text.contains("schema_name = '<schema>'"));
 
     add_demo_source(&mut session.source_client, manifest_yaml).await;
@@ -378,7 +380,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
             .description
             .as_deref()
             .expect("guide description")
-            .contains("1 configured source")
+            .contains("1 configured connection")
     );
 
     let tables_resource = client
@@ -400,8 +402,9 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         .expect("updated guide");
     let updated_guide_text = text_content(&updated_guide);
     assert!(updated_guide_text.contains("## Available Schemas"));
-    assert!(updated_guide_text.contains("- coral: System metadata schema."));
+    assert!(updated_guide_text.contains("- coral: System catalog schema."));
     assert!(updated_guide_text.contains("- local_messages"));
+    assert!(updated_guide_text.contains("Prefer one SQL statement with `JOIN`, `CROSS JOIN`"));
     assert!(!updated_guide_text.contains("## Visible SQL Schemas"));
     assert!(updated_guide_text.contains(
         "FROM coral.columns WHERE schema_name = 'local_messages' AND table_name = 'events'"

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -3,7 +3,7 @@ title: "Use Coral over MCP"
 description: "Set up MCP for Claude Code, Cursor, and other agents."
 ---
 
-Coral ships with a built-in MCP server, giving agents access to SQL queries and schema discovery across all your installed sources.
+Coral ships with a built-in MCP server that presents Coral to agents as a read-only SQL database with catalog discovery.
 
 <Note>
 Before setting up a client, make sure you have [connected at least one source](/getting-started/quickstart).
@@ -14,18 +14,19 @@ Before setting up a client, make sure you have [connected at least one source](/
 
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
-| Tool     | `sql`            | Run a SQL query                                         |
-| Tool     | `list_catalog`   | List queryable tables and table functions with pagination |
-| Tool     | `search_catalog` | Search catalog metadata with a Rust regex               |
-| Tool     | `describe_table` | Show compact metadata for one table                     |
-| Tool     | `list_columns`   | List columns for one table with pagination              |
+| Tool     | `sql`            | Execute read-only SQL against the Coral database        |
+| Tool     | `list_catalog`   | List database tables and table functions with pagination |
+| Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
+| Tool     | `describe_table` | Show compact metadata for one database table            |
+| Tool     | `list_columns`   | List columns for one database table with pagination     |
 | Tool     | `feedback`       | Store a local blocked-agent feedback report and upload an anonymous copy to Coral when enabled |
-| Resource | `coral://guide`  | Usage guide for agents                                  |
-| Resource | `coral://tables` | JSON summaries of queryable tables and required filters |
+| Resource | `coral://guide`  | Database workflow guide for agents                     |
+| Resource | `coral://tables` | JSON summaries of database tables and required filters  |
 
-Clients see the same installed sources and query results as `coral sql`. You set up sources with the CLI, then agents query them over MCP.
-`list_catalog` returns queryable tables and source-scoped table functions in pages and accepts optional `schema`, `kind`, `limit`, and `offset` arguments. Omit `kind` or pass `null` to include both `"table"` and `"table_function"` items. For tables, use `sql_reference` in `FROM` and `JOIN` clauses. For table functions, use `sql_call_example` and fill in the required arguments. Do not quote the whole `schema.item` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
-`search_catalog` accepts a required `pattern` plus optional `schema`, `kind`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over table and table-function metadata.
+Clients see the same database catalog and query results as `coral sql`. You set up sources with the CLI, then agents query Coral over MCP as SQL schemas and tables.
+Agents should use the discovery tools as catalog helpers, not as replacement provider APIs. For data questions, prefer one `sql` call with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over multiple tool calls that fetch rows and combine them in the agent.
+`list_catalog` returns database tables and parameterized table functions in pages and accepts optional `schema`, `kind`, `limit`, and `offset` arguments. Omit `kind` or pass `null` to include both `"table"` and `"table_function"` items. For tables, use `sql_reference` in `FROM` and `JOIN` clauses. For table functions, use `sql_call_example` and fill in the required arguments. Do not quote the whole `schema.item` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+`search_catalog` accepts a required `pattern` plus optional `schema`, `kind`, `ignore_case`, `limit`, and `offset` arguments for deterministic regex matching over database catalog metadata.
 `describe_table` accepts exact `schema` and `table` arguments and returns guide text, required filters, and a column count without dumping full columns.
 `list_columns` accepts exact `schema` and `table` arguments plus optional `pattern`, `ignore_case`, `required_only`, `limit`, and `offset` arguments. For existing tables it returns a paginated `columns` page with `total`, `has_more`, and optional `next_offset`; when `pattern` is set, matching rows include `matched_fields` so clients can explain why a column matched. When the requested table does not exist, `list_columns` returns `found: false` with recovery hints instead of an empty page, so clients should branch to `search_catalog` or `list_catalog` rather than pretending the table has zero columns.
 For richer metadata, have the agent query `coral.tables`, `coral.columns`, `coral.table_functions`, and `coral.inputs` over the `sql` tool instead of relying only on `list_catalog` or `coral://tables`.
@@ -191,13 +192,13 @@ Coral uses stdio transport. If a client supports a command-based install flow, p
 
 ## Verify the connection
 
-Once your client is connected, ask the agent to list available tables or run a simple query. Examples:
+Once your client is connected, ask the agent to list available tables or run a simple database query. Examples:
 
 > "List the tables available in Coral."
 
 > "Run a small Coral query against `coral.tables`."
 
-The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` and `coral.table_functions` to return schemas from your installed sources, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
+The agent should call `list_catalog`, `search_catalog`, or query `coral.tables` and `coral.table_functions` to return SQL schemas and catalog items, and use `describe_table` or `list_columns` for table-specific metadata. Large catalogs should be paged with `limit` and `offset`.
 
 ## Troubleshooting
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -150,13 +150,13 @@ This server exposes:
 
 | Type     | Name             | Description                      |
 | -------- | ---------------- | -------------------------------- |
-| Tool     | `sql`            | Run a SQL query                  |
-| Tool     | `list_catalog`   | List queryable tables and table functions |
-| Tool     | `search_catalog` | Search catalog metadata by regex |
-| Tool     | `describe_table` | Show compact table metadata      |
-| Tool     | `list_columns`   | List columns for one table       |
-| Resource | `coral://guide`  | Usage guide for agents           |
-| Resource | `coral://tables` | Table summaries for all sources  |
+| Tool     | `sql`            | Execute read-only SQL against the Coral database |
+| Tool     | `list_catalog`   | List database tables and table functions |
+| Tool     | `search_catalog` | Search database catalog metadata by regex |
+| Tool     | `describe_table` | Show compact database table metadata |
+| Tool     | `list_columns`   | List columns for one database table |
+| Resource | `coral://guide`  | Database workflow guide for agents |
+| Resource | `coral://tables` | Database table summaries         |
 
 ## `coral completion <SHELL>`
 


### PR DESCRIPTION
## Intent

Agents were still getting nudged toward source/API-shaped behavior when using Coral over MCP. This changes the MCP-facing language to present the exposed read surface as a read-only SQL database with catalog helpers, so agents are more likely to answer with set-based SQL instead of stitching provider-shaped calls together.

## Changes

- Reframe MCP server instructions, tool descriptions, guide resource, and fallback hints around database catalog discovery and SQL execution.
- Explicitly guide agents toward JOIN, CROSS JOIN, CTEs, subqueries, aggregates, and window functions for data questions.
- Keep protocol/tool names and structured response shapes unchanged.
- Align README and MCP reference docs with the database-shaped agent workflow.

## Verification

- cargo fmt --check
- cargo test -p coral-mcp surface::resources
- cargo test -p coral-mcp mcp_surface_refreshes_and_renders_dynamic_guide
- cargo test -p coral-cli --features cli-test-server --test mcp mcp_stdio_lists_tools_and_resources
- make rust-checks
- neutral on CRAG, and promising behavioural improvements wrt. use of JOINs

http://mlflow-bench/#/experiments/19/runs/fcebce14517d47c18e9a18512af45e8c/evaluations?compareToRunUuid=e323ac1c01a44a629afbe8f6e28ad070&selectedEvaluationId=tr-4a7efa5c8387aa4aca7849e04f91e7df
