### PR TITLE
feat(sources/community/neondb): add NeonDB API source

### DIFF
--- a/sources/community/neondb/README.md
+++ b/sources/community/neondb/README.md
@@ -42,7 +42,7 @@ Top-level Neon project inventory.
 
 Optional filters:
 - `org_id`
-- `search`
+- `search`: Substring match on project name or ID
 
 Organization-scoped API keys may require `org_id`. Query `neondb.organizations` first to find it.
 
@@ -55,6 +55,9 @@ Branch inventory for a single Neon project.
 - Preview and development environment discovery
 - Default and protected branch inspection
 - Branch topology through `parent_id`
+
+Optional filters:
+- `search`: Substring match on branch name or ID
 
 ### `databases`
 Database metadata for a single Neon branch.

--- a/sources/community/neondb/README.md
+++ b/sources/community/neondb/README.md
@@ -1,0 +1,171 @@
+# NeonDB
+
+Query Neon organizations, projects, branches, databases, roles, compute endpoints, operations, and user identity from the Neon Developer API.
+
+## Setup
+
+### Get Your API Key
+
+1. Open the Neon Console.
+2. Go to Account settings > API keys.
+3. Create a personal, organization, or project-scoped API key.
+4. Copy the token when it is shown.
+
+### Add the Source
+
+```bash
+coral source add neondb
+```
+
+When prompted, provide your Neon API key as `NEON_API_KEY`.
+
+## Tables
+
+### `current_user`
+Returns the authenticated Neon user. Use this table to validate credentials and identify which account the API key belongs to.
+
+### `organizations`
+Organizations available to the authenticated Neon user.
+
+**Useful for:**
+- Discovering `org_id` values
+- Understanding organization plan and MFA requirements
+- Supplying the `org_id` filter for organization-scoped project queries
+
+### `projects`
+Top-level Neon project inventory.
+
+**Useful for:**
+- Project inventory
+- Region and PostgreSQL version visibility
+- Finding `project_id` values for scoped tables
+
+Optional filters:
+- `org_id`
+- `search`
+
+Organization-scoped API keys may require `org_id`. Query `neondb.organizations` first to find it.
+
+### `branches`
+Branch inventory for a single Neon project.
+
+**Requires:** `project_id`
+
+**Useful for:**
+- Preview and development environment discovery
+- Default and protected branch inspection
+- Branch topology through `parent_id`
+
+### `databases`
+Database metadata for a single Neon branch.
+
+**Requires:** `project_id`, `branch_id`
+
+**Useful for:**
+- Database topology
+- Owner role inspection
+- Branch composition analysis
+
+### `roles`
+Postgres role metadata for a single Neon branch.
+
+**Requires:** `project_id`, `branch_id`
+
+> **Security note:** This table intentionally does not expose role passwords or generated credentials.
+
+**Useful for:**
+- Role inventory
+- Protected role inspection
+- Authentication method review
+
+### `compute_endpoints`
+Compute endpoint metadata for a single Neon branch.
+
+**Requires:** `project_id`, `branch_id`
+
+> **Security note:** This table intentionally does not expose connection URIs, passwords, or endpoint hostnames.
+
+**Useful for:**
+- Read-write and read-only compute inventory
+- Autoscaling limit inspection
+- Compute state and suspension analysis
+
+### `operations`
+Recent operation history for a single Neon project.
+
+**Requires:** `project_id`
+
+**Useful for:**
+- Infrastructure change history
+- Debugging failed operations
+- Summarizing recent branch, endpoint, and project activity
+
+Neon may remove operations older than six months.
+
+## Authentication
+
+The source uses the Neon Developer API with bearer authentication:
+
+```text
+Authorization: Bearer <NEON_API_KEY>
+```
+
+Use a key with read access to the projects you want to inspect. Organization-scoped keys may require the `org_id` filter when querying `projects`.
+
+## Limits
+
+- This source exposes read-only Neon API endpoints only.
+- Management operations such as creating branches, deleting endpoints, resetting passwords, and changing autoscaling are out of scope.
+- `branches` and `operations` use cursor pagination.
+- `projects` uses a single-page list request capped at 400 rows in v1 because Neon returns a terminal cursor even when the following page is empty.
+- `operations` caps cursor traversal defensively to avoid looping on empty terminal pages.
+- Branch child tables require filters to avoid cross-project scans.
+- Role passwords, connection strings, and endpoint hostnames are intentionally omitted.
+
+## Example Queries
+
+### List projects by region
+
+```sql
+SELECT region_id, COUNT(*) AS project_count
+FROM neondb.projects
+GROUP BY region_id
+ORDER BY project_count DESC
+```
+
+### Inspect branches in a project
+
+```sql
+SELECT branch_id, branch_name, default_branch, protected, current_state
+FROM neondb.branches
+WHERE project_id = 'your-project-id'
+ORDER BY updated_at DESC
+```
+
+### Find compute endpoints for a branch
+
+```sql
+SELECT endpoint_id, endpoint_type, current_state, autoscaling_limit_max_cu
+FROM neondb.compute_endpoints
+WHERE project_id = 'your-project-id'
+  AND branch_id = 'your-branch-id'
+```
+
+### Review recent failed operations
+
+```sql
+SELECT operation_id, action, status, error, created_at
+FROM neondb.operations
+WHERE project_id = 'your-project-id'
+  AND status IN ('failed', 'error')
+ORDER BY created_at DESC
+LIMIT 20
+```
+
+## Notes
+
+- Use `neondb.projects` first to find project IDs.
+- Use `neondb.organizations` first if Neon requires `org_id` for project listing.
+- Use `neondb.branches` next to find branch IDs for branch-scoped tables.
+- JSON columns preserve nested configuration without exposing credentials.
+- Timestamps are stored as proper Timestamp columns derived from ISO 8601 strings.

--- a/sources/community/neondb/manifest.yaml
+++ b/sources/community/neondb/manifest.yaml
@@ -1,0 +1,753 @@
+name: neondb
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Neon organizations, projects, branches, databases, roles, compute
+  endpoints, operations, and user identity.
+base_url: https://console.neon.tech/api/v2
+inputs:
+  NEON_API_KEY:
+    kind: secret
+    hint: |
+      Neon API key for the Developer API. Create one in the Neon Console
+      under Account settings > API keys. Use a personal, organization, or
+      project-scoped key with read access to the projects you want to inspect.
+      The token is sent as `Authorization: Bearer <NEON_API_KEY>`.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.NEON_API_KEY}}
+test_queries:
+  - SELECT * FROM neondb.current_user LIMIT 1
+  - SELECT * FROM neondb.organizations LIMIT 1
+tables:
+  - name: current_user
+    description: Current authenticated Neon user information for credential validation.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /users/me
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: user_id
+        type: Utf8
+        nullable: false
+        description: Neon user ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: email
+        type: Utf8
+        nullable: false
+        description: User email address.
+        expr:
+          kind: path
+          path: [email]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: User display name.
+        expr:
+          kind: path
+          path: [name]
+      - name: plan
+        type: Utf8
+        nullable: true
+        description: Neon plan name for the authenticated account.
+        expr:
+          kind: path
+          path: [plan]
+      - name: projects_limit
+        type: Int64
+        nullable: true
+        description: Maximum number of projects allowed for the account.
+        expr:
+          kind: path
+          path: [projects_limit]
+      - name: branches_limit
+        type: Int64
+        nullable: true
+        description: Maximum number of branches allowed for the account.
+        expr:
+          kind: path
+          path: [branches_limit]
+
+  - name: organizations
+    description: Neon organizations available to the authenticated user.
+    guide: |
+      Use `org_id` from this table when querying `projects` with an
+      organization-scoped API key. Personal API keys may not need this filter.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /users/me/organizations
+    response:
+      rows_path: [organizations]
+    pagination:
+      mode: none
+    columns:
+      - name: org_id
+        type: Utf8
+        nullable: false
+        description: Neon organization ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: org_name
+        type: Utf8
+        nullable: false
+        description: Organization name.
+        expr:
+          kind: path
+          path: [name]
+      - name: handle
+        type: Utf8
+        nullable: true
+        description: Organization handle.
+        expr:
+          kind: path
+          path: [handle]
+      - name: plan
+        type: Utf8
+        nullable: true
+        description: Organization plan.
+        expr:
+          kind: path
+          path: [plan]
+      - name: managed_by
+        type: Utf8
+        nullable: true
+        description: System that manages this organization.
+        expr:
+          kind: path
+          path: [managed_by]
+      - name: require_mfa
+        type: Boolean
+        nullable: true
+        description: Whether the organization requires multi-factor authentication.
+        expr:
+          kind: path
+          path: [require_mfa]
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: Organization creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created_at]
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: Organization last updated timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated_at]
+
+  - name: projects
+    description: Top-level Neon projects visible to the API key.
+    guide: |
+      Use `project_id` from this table to query `branches` and `operations`.
+      Organization API keys may require the optional `org_id` filter. Query
+      `organizations` first if Neon returns an org_id-required error.
+    fetch_limit_default: 100
+    filters:
+      - name: org_id
+      - name: search
+    request:
+      method: GET
+      path: /projects
+      query:
+        - name: limit
+          from: literal
+          value: "400"
+        - name: org_id
+          from: filter
+          key: org_id
+        - name: search
+          from: filter
+          key: search
+    response:
+      rows_path: [projects]
+    pagination:
+      mode: none
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Neon project ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: project_name
+        type: Utf8
+        nullable: false
+        description: Project name.
+        expr:
+          kind: path
+          path: [name]
+      - name: org_id
+        type: Utf8
+        nullable: true
+        description: Organization ID when the project belongs to an organization.
+        expr:
+          kind: path
+          path: [org_id]
+      - name: platform_id
+        type: Utf8
+        nullable: true
+        description: Cloud platform identifier.
+        expr:
+          kind: path
+          path: [platform_id]
+      - name: region_id
+        type: Utf8
+        nullable: false
+        description: Region identifier.
+        expr:
+          kind: path
+          path: [region_id]
+      - name: pg_version
+        type: Int64
+        nullable: false
+        description: PostgreSQL major version.
+        expr:
+          kind: path
+          path: [pg_version]
+      - name: creation_source
+        type: Utf8
+        nullable: true
+        description: Source that created the project.
+        expr:
+          kind: path
+          path: [creation_source]
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: Project creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created_at]
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: Project last updated timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated_at]
+
+  - name: branches
+    description: Branches within a Neon project.
+    guide: |
+      Requires `project_id`. Branches are Neon's isolated database timelines
+      for production, development, previews, testing, and agent workflows.
+      Use `branch_id` from this table to inspect databases, roles, and
+      compute endpoints.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+      - name: search
+    request:
+      method: GET
+      path: /projects/{{filter.project_id}}/branches
+      query:
+        - name: search
+          from: filter
+          key: search
+    response:
+      rows_path: [branches]
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 100
+        max: 10000
+        query_param: limit
+      cursor_param: cursor
+      response_cursor_path: [pagination, next]
+    columns:
+      - name: branch_id
+        type: Utf8
+        nullable: false
+        description: Branch ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent project ID.
+        expr:
+          kind: path
+          path: [project_id]
+      - name: branch_name
+        type: Utf8
+        nullable: false
+        description: Branch name.
+        expr:
+          kind: path
+          path: [name]
+      - name: parent_id
+        type: Utf8
+        nullable: true
+        description: Parent branch ID.
+        expr:
+          kind: path
+          path: [parent_id]
+      - name: default_branch
+        type: Boolean
+        nullable: false
+        description: Whether this is the project's default branch.
+        expr:
+          kind: path
+          path: [default]
+      - name: protected
+        type: Boolean
+        nullable: false
+        description: Whether this branch is protected.
+        expr:
+          kind: path
+          path: [protected]
+      - name: current_state
+        type: Utf8
+        nullable: true
+        description: Current branch state.
+        expr:
+          kind: path
+          path: [current_state]
+      - name: logical_size
+        type: Int64
+        nullable: true
+        description: Logical branch size in bytes.
+        expr:
+          kind: path
+          path: [logical_size]
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: Branch creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created_at]
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: Branch last updated timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated_at]
+
+  - name: databases
+    description: Databases within a Neon branch.
+    guide: |
+      Requires `project_id` and `branch_id`. This table exposes database
+      topology only; it does not connect to Postgres or inspect table data.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+      - name: branch_id
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_id}}/branches/{{filter.branch_id}}/databases
+    response:
+      rows_path: [databases]
+    pagination:
+      mode: none
+    columns:
+      - name: database_id
+        type: Int64
+        nullable: false
+        description: Neon database ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: database_name
+        type: Utf8
+        nullable: false
+        description: Database name.
+        expr:
+          kind: path
+          path: [name]
+      - name: owner_name
+        type: Utf8
+        nullable: false
+        description: Role that owns the database.
+        expr:
+          kind: path
+          path: [owner_name]
+      - name: branch_id
+        type: Utf8
+        nullable: false
+        description: Parent branch ID.
+        expr:
+          kind: path
+          path: [branch_id]
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent project ID from the required filter.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: Database creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created_at]
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: Database last updated timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated_at]
+
+  - name: roles
+    description: Postgres roles within a Neon branch, excluding passwords.
+    guide: |
+      Requires `project_id` and `branch_id`. Neon role responses may include a
+      password field in some contexts; this source intentionally does not
+      expose passwords, connection strings, or other credentials.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+      - name: branch_id
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_id}}/branches/{{filter.branch_id}}/roles
+    response:
+      rows_path: [roles]
+    pagination:
+      mode: none
+    columns:
+      - name: role_name
+        type: Utf8
+        nullable: false
+        description: Role name.
+        expr:
+          kind: path
+          path: [name]
+      - name: branch_id
+        type: Utf8
+        nullable: false
+        description: Parent branch ID.
+        expr:
+          kind: path
+          path: [branch_id]
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent project ID from the required filter.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: protected
+        type: Boolean
+        nullable: true
+        description: Whether this role is system-protected.
+        expr:
+          kind: path
+          path: [protected]
+      - name: authentication_method
+        type: Utf8
+        nullable: true
+        description: Authentication method configured for the role.
+        expr:
+          kind: path
+          path: [authentication_method]
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: Role creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created_at]
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: Role last updated timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated_at]
+
+  - name: compute_endpoints
+    description: Compute endpoints attached to a Neon branch.
+    guide: |
+      Requires `project_id` and `branch_id`. This table exposes compute
+      topology and state, not connection URIs or credentials. Use it to inspect
+      read-write/read-only endpoints, autoscaling limits, and suspension state.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+      - name: branch_id
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_id}}/branches/{{filter.branch_id}}/endpoints
+    response:
+      rows_path: [endpoints]
+    pagination:
+      mode: none
+    columns:
+      - name: endpoint_id
+        type: Utf8
+        nullable: false
+        description: Compute endpoint ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: endpoint_name
+        type: Utf8
+        nullable: true
+        description: Optional compute endpoint name.
+        expr:
+          kind: path
+          path: [name]
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent project ID.
+        expr:
+          kind: path
+          path: [project_id]
+      - name: branch_id
+        type: Utf8
+        nullable: false
+        description: Parent branch ID.
+        expr:
+          kind: path
+          path: [branch_id]
+      - name: endpoint_type
+        type: Utf8
+        nullable: false
+        description: Endpoint type, such as read_write or read_only.
+        expr:
+          kind: path
+          path: [type]
+      - name: current_state
+        type: Utf8
+        nullable: false
+        description: Current compute endpoint state.
+        expr:
+          kind: path
+          path: [current_state]
+      - name: region_id
+        type: Utf8
+        nullable: false
+        description: Region identifier.
+        expr:
+          kind: path
+          path: [region_id]
+      - name: autoscaling_limit_min_cu
+        type: Float64
+        nullable: true
+        description: Minimum autoscaling compute units.
+        expr:
+          kind: path
+          path: [autoscaling_limit_min_cu]
+      - name: autoscaling_limit_max_cu
+        type: Float64
+        nullable: true
+        description: Maximum autoscaling compute units.
+        expr:
+          kind: path
+          path: [autoscaling_limit_max_cu]
+      - name: disabled
+        type: Boolean
+        nullable: false
+        description: Whether connections to the compute endpoint are disabled.
+        expr:
+          kind: path
+          path: [disabled]
+      - name: pooler_enabled
+        type: Boolean
+        nullable: false
+        description: Whether connection pooling is enabled.
+        expr:
+          kind: path
+          path: [pooler_enabled]
+      - name: suspend_timeout_seconds
+        type: Int64
+        nullable: true
+        description: Idle timeout before the compute endpoint suspends.
+        expr:
+          kind: path
+          path: [suspend_timeout_seconds]
+      - name: settings
+        type: Json
+        nullable: true
+        description: Nested endpoint settings.
+        expr:
+          kind: path
+          path: [settings]
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: Endpoint creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created_at]
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: Endpoint last updated timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated_at]
+
+  - name: operations
+    description: Operation history for a Neon project.
+    guide: |
+      Requires `project_id`. Operations record infrastructure changes and
+      background work for a project. Neon may delete operations older than six
+      months, so this table is best for recent change history and debugging.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_id}}/operations
+    response:
+      rows_path: [operations]
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+      cursor_param: cursor
+      response_cursor_path: [pagination, cursor]
+      max_pages: 25
+    columns:
+      - name: operation_id
+        type: Utf8
+        nullable: false
+        description: Operation ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent project ID.
+        expr:
+          kind: path
+          path: [project_id]
+      - name: branch_id
+        type: Utf8
+        nullable: true
+        description: Branch ID associated with the operation, when present.
+        expr:
+          kind: path
+          path: [branch_id]
+      - name: endpoint_id
+        type: Utf8
+        nullable: true
+        description: Endpoint ID associated with the operation, when present.
+        expr:
+          kind: path
+          path: [endpoint_id]
+      - name: action
+        type: Utf8
+        nullable: false
+        description: Operation action.
+        expr:
+          kind: path
+          path: [action]
+      - name: status
+        type: Utf8
+        nullable: false
+        description: Operation status.
+        expr:
+          kind: path
+          path: [status]
+      - name: error
+        type: Utf8
+        nullable: true
+        description: Error message when the operation failed.
+        expr:
+          kind: path
+          path: [error]
+      - name: failures_count
+        type: Int64
+        nullable: true
+        description: Number of operation failures.
+        expr:
+          kind: path
+          path: [failures_count]
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: Operation creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created_at]
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: Operation last updated timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated_at]
+      - name: total_duration_ms
+        type: Int64
+        nullable: true
+        description: Total operation duration in milliseconds.
+        expr:
+          kind: path
+          path: [total_duration_ms]

--- a/sources/community/neondb/manifest.yaml
+++ b/sources/community/neondb/manifest.yaml
@@ -160,7 +160,8 @@ tables:
     guide: |
       Use `project_id` from this table to query `branches` and `operations`.
       Organization API keys may require the optional `org_id` filter. Query
-      `organizations` first if Neon returns an org_id-required error.
+      `organizations` first if Neon returns an org_id-required error. The optional
+      `search` filter performs a substring match on project name or ID.
     fetch_limit_default: 100
     filters:
       - name: org_id
@@ -259,7 +260,8 @@ tables:
       Requires `project_id`. Branches are Neon's isolated database timelines
       for production, development, previews, testing, and agent workflows.
       Use `branch_id` from this table to inspect databases, roles, and
-      compute endpoints.
+      compute endpoints. The optional `search` filter performs a substring match
+      on branch name or ID.
     fetch_limit_default: 100
     filters:
       - name: project_id


### PR DESCRIPTION
## Summary

Fixes #476 

Add a new `neondb` community source for querying Neon organizations, project inventory, branch topology, database metadata, role metadata, compute endpoint state, and operation history using the Neon Developer API.

This change is manifest-only and uses Coral's existing HTTP source-spec model. It adds read-only Neon infrastructure visibility without changing CLI, MCP, config, runtime, or bundled-source contracts.

## What changed

Added:

- `sources/community/neondb/manifest.yaml`
- `sources/community/neondb/README.md`

## Source scope

Inputs:

- `NEON_API_KEY`

Tables:

- `neondb.current_user`
  - `GET /users/me`
  - validates API key and returns user metadata
- `neondb.organizations`
  - `GET /users/me/organizations`
  - lists organizations available to the authenticated user
- `neondb.projects`
  - `GET /projects`
  - lists visible Neon projects
  - supports optional `org_id` and `search` filters
- `neondb.branches`
  - `GET /projects/{project_id}/branches`
  - requires `project_id`
  - exposes branch topology and state
- `neondb.databases`
  - `GET /projects/{project_id}/branches/{branch_id}/databases`
  - requires `project_id` and `branch_id`
  - exposes database metadata
- `neondb.roles`
  - `GET /projects/{project_id}/branches/{branch_id}/roles`
  - requires `project_id` and `branch_id`
  - exposes role metadata only
- `neondb.compute_endpoints`
  - `GET /projects/{project_id}/branches/{branch_id}/endpoints`
  - requires `project_id` and `branch_id`
  - exposes compute endpoint type, state, autoscaling limits, and settings
- `neondb.operations`
  - `GET /projects/{project_id}/operations`
  - requires `project_id`
  - exposes recent operation history

## Implementation notes

- uses Neon Developer API bearer auth (`Authorization: Bearer <token>`)
- keeps v1 intentionally read-only
- includes `organizations` so users can discover `org_id` for organization-scoped keys
- requires `project_id` and/or `branch_id` filters on scoped tables
- uses cursor pagination for `branches` and `operations`
- uses single-page `projects` listing with `limit=400` because Neon can return a terminal cursor even when the next page is empty
- caps operation pagination defensively
- exposes high-value flattened fields plus JSON for nested endpoint settings
- intentionally omits role passwords, connection URIs, endpoint hostnames, and proxy hosts

## Validation

Live API testing completed:

- Source installed successfully with real Neon API credentials
- Declared source tests passed:
  - `SELECT * FROM neondb.current_user LIMIT 1`
  - `SELECT * FROM neondb.organizations LIMIT 1`
- Live queries passed for all 8 tables:
  - `current_user`
  - `organizations`
  - `projects`
  - `branches`
  - `databases`
  - `roles`
  - `compute_endpoints`
  - `operations`
- Required filters verified through `coral.columns`
- Sensitive fields checked to ensure passwords, connection URIs, endpoint hostnames, and proxy hosts are not exposed

Local validation:

- `coral source lint sources/community/neondb/manifest.yaml`
- `ryl sources/community/neondb/manifest.yaml`
- `git diff --check -- sources/community/neondb/manifest.yaml sources/community/neondb/README.md`

## Testing notes

Testing was performed with the Neon Developer API using a real API key. During testing:

- organization-scoped project listing required `org_id`, so `neondb.organizations` was added
- `/projects` cursor behavior could repeat a terminal cursor after an empty page, so v1 uses a single-page request with `limit=400`
- project and branch IDs from live data were used to validate scoped tables
- role responses were checked without exposing passwords
- compute endpoint responses were checked without exposing endpoint hostnames

All issues discovered during testing were fixed before this PR.

## Out of scope

Not included in v1:

- creating branches
- creating databases
- creating or modifying roles
- resetting passwords
- deleting endpoints
- modifying autoscaling
- connection URI generation
- branch restore or other operational mutations
