### PR TITLE
feat(sources/community/datahub): add DataHub community source 

### DIFF
--- a/sources/community/datahub/README.md
+++ b/sources/community/datahub/README.md
@@ -14,11 +14,11 @@ Works with DataHub OSS (local Docker quickstart) and any self-hosted deployment.
 
 ## Authentication
 
-DataHub OSS running locally is unauthenticated by default — set `DATAHUB_TOKEN`
+DataHub OSS running locally is unauthenticated by default â€” set `DATAHUB_TOKEN`
 to any non-empty placeholder value and the connector works without a real token.
 
 For authenticated deployments, generate a Personal Access Token in the DataHub
-UI under **Settings → Access Tokens** and pass it as `DATAHUB_TOKEN`.
+UI under **Settings â†’ Access Tokens** and pass it as `DATAHUB_TOKEN`.
 
 ```bash
 # Local unauthenticated OSS (Docker quickstart)
@@ -41,7 +41,7 @@ coral source add --file sources/community/datahub/manifest.yaml --interactive
 | Input | Kind | Default | Description |
 |---|---|---|---|
 | `DATAHUB_GMS_URL` | variable | `http://localhost:8080` | Base URL of your DataHub GMS instance. Do **not** include `/api/graphql`. |
-| `DATAHUB_TOKEN` | secret | — | Personal Access Token. Use any placeholder for unauthenticated local instances. |
+| `DATAHUB_TOKEN` | secret | â€” | Personal Access Token. Use any placeholder for unauthenticated local instances. |
 
 ## Tables
 
@@ -99,7 +99,7 @@ FROM datahub.datajobs
 | `urn` | Utf8 | Unique DataJob URN |
 | `name` | Utf8 | Task or job name |
 | `description` | Utf8 | Task description |
-| `flow_urn` | Utf8 | Parent pipeline URN — join to `datahub.dataflows.urn` |
+| `flow_urn` | Utf8 | Parent pipeline URN â€” join to `datahub.dataflows.urn` |
 | `flow_platform` | Utf8 | Orchestration platform of the parent pipeline |
 
 ---
@@ -191,22 +191,22 @@ coral sql "SELECT d.name AS dataset, d.platform, d.owners FROM datahub.datasets 
 
 ```text
 datahub.domains
-  → urn (domain grouping)
+  â†’ urn (domain grouping)
 
 datahub.tags
-  → urn (applied to datasets and other entities)
+  â†’ urn (applied to datasets and other entities)
 
 datahub.users
-  → username (matches owners column in datasets)
+  â†’ username (matches owners column in datasets)
 
 datahub.dataflows
-  → urn
-    → datahub.datajobs WHERE flow_urn = dataflows.urn
-      → task-level lineage and descriptions
+  â†’ urn
+    â†’ datahub.datajobs WHERE flow_urn = dataflows.urn
+      â†’ task-level lineage and descriptions
 
 datahub.datasets
-  → urn (cross-reference with lineage, tags, domains)
-  → owners → datahub.users.username
+  â†’ urn (cross-reference with lineage, tags, domains)
+  â†’ owners â†’ datahub.users.username
 ```
 
 ## Notes
@@ -215,9 +215,9 @@ datahub.datasets
   all registered entities. SQL `WHERE` clauses are evaluated client-side by
   Coral after the full result set is fetched.
 - `DATAHUB_TOKEN` is required by the connector even for unauthenticated local
-  instances — pass any non-empty placeholder (e.g. `no-auth`) and DataHub OSS
+  instances â€” pass any non-empty placeholder (e.g. `no-auth`) and DataHub OSS
   will ignore the `Authorization` header.
-- `DATAHUB_GMS_URL` should be the **base URL only** — do not append
+- `DATAHUB_GMS_URL` should be the **base URL only** â€” do not append
   `/api/graphql`. The connector appends that path automatically.
 - Tested against DataHub OSS v0.14+ (Docker quickstart). The GraphQL `search`
   API shape used here has been stable since v0.9.

--- a/sources/community/datahub/README.md
+++ b/sources/community/datahub/README.md
@@ -1,0 +1,223 @@
+# DataHub Connector
+
+**Version:** 0.1.0
+**Backend:** HTTP (GraphQL)
+**Tables:** 6 (`datasets`, `dataflows`, `datajobs`, `tags`, `domains`, `users`)
+**Base URL:** `http://localhost:8080` (override with `DATAHUB_GMS_URL`)
+
+Connects to a self-hosted [DataHub](https://datahubproject.io) instance and
+exposes the data catalog as queryable SQL tables. Covers dataset inventory,
+pipeline lineage, governance tags, business domains, and registered users via
+the DataHub GraphQL API.
+
+Works with DataHub OSS (local Docker quickstart) and any self-hosted deployment.
+
+## Authentication
+
+DataHub OSS running locally is unauthenticated by default — set `DATAHUB_TOKEN`
+to any non-empty placeholder value and the connector works without a real token.
+
+For authenticated deployments, generate a Personal Access Token in the DataHub
+UI under **Settings → Access Tokens** and pass it as `DATAHUB_TOKEN`.
+
+```bash
+# Local unauthenticated OSS (Docker quickstart)
+DATAHUB_GMS_URL=http://localhost:8080 \
+DATAHUB_TOKEN=no-auth \
+coral source add --file sources/community/datahub/manifest.yaml
+
+# Authenticated remote deployment
+DATAHUB_GMS_URL=https://datahub.example.com \
+DATAHUB_TOKEN=your_personal_access_token \
+coral source add --file sources/community/datahub/manifest.yaml
+```
+
+Or run interactively to be prompted for each value:
+
+```bash
+coral source add --file sources/community/datahub/manifest.yaml --interactive
+```
+
+| Input | Kind | Default | Description |
+|---|---|---|---|
+| `DATAHUB_GMS_URL` | variable | `http://localhost:8080` | Base URL of your DataHub GMS instance. Do **not** include `/api/graphql`. |
+| `DATAHUB_TOKEN` | secret | — | Personal Access Token. Use any placeholder for unauthenticated local instances. |
+
+## Tables
+
+### `datasets`
+
+All datasets registered in the DataHub catalog across all platforms.
+
+```sql
+SELECT urn, name, platform, qualified_name, description, owners
+FROM datahub.datasets
+ORDER BY platform, name
+```
+
+| Column | Type | Description |
+|---|---|---|
+| `urn` | Utf8 | Unique DataHub Resource Name |
+| `name` | Utf8 | Dataset name |
+| `platform` | Utf8 | Data platform (e.g. `hive`, `s3`, `kafka`, `hdfs`) |
+| `qualified_name` | Utf8 | Fully qualified name when available |
+| `description` | Utf8 | Dataset description |
+| `owners` | Utf8 | Comma-joined owner usernames |
+
+---
+
+### `dataflows`
+
+Orchestration pipelines and DAGs registered in DataHub (e.g. Airflow DAGs).
+
+```sql
+SELECT urn, name, platform, description
+FROM datahub.dataflows
+ORDER BY platform, name
+```
+
+| Column | Type | Description |
+|---|---|---|
+| `urn` | Utf8 | Unique DataFlow URN |
+| `name` | Utf8 | Pipeline or DAG name |
+| `platform` | Utf8 | Orchestration platform (e.g. `airflow`) |
+| `description` | Utf8 | Pipeline description |
+
+---
+
+### `datajobs`
+
+Individual tasks and jobs within pipelines (e.g. Airflow tasks within a DAG).
+
+```sql
+SELECT urn, name, description, flow_urn, flow_platform
+FROM datahub.datajobs
+```
+
+| Column | Type | Description |
+|---|---|---|
+| `urn` | Utf8 | Unique DataJob URN |
+| `name` | Utf8 | Task or job name |
+| `description` | Utf8 | Task description |
+| `flow_urn` | Utf8 | Parent pipeline URN — join to `datahub.dataflows.urn` |
+| `flow_platform` | Utf8 | Orchestration platform of the parent pipeline |
+
+---
+
+### `tags`
+
+Governance and classification tags registered in DataHub.
+
+```sql
+SELECT urn, name, description
+FROM datahub.tags
+ORDER BY name
+```
+
+| Column | Type | Description |
+|---|---|---|
+| `urn` | Utf8 | Unique Tag URN |
+| `name` | Utf8 | Tag display name |
+| `description` | Utf8 | Tag description |
+
+---
+
+### `domains`
+
+Business domains used to group and govern metadata entities.
+
+```sql
+SELECT urn, name, description
+FROM datahub.domains
+ORDER BY name
+```
+
+| Column | Type | Description |
+|---|---|---|
+| `urn` | Utf8 | Unique Domain URN |
+| `name` | Utf8 | Domain name (e.g. Marketing, Engineering) |
+| `description` | Utf8 | Domain description |
+
+---
+
+### `users`
+
+DataHub users (CorpUsers) registered in the catalog.
+
+```sql
+SELECT urn, username, display_name, email
+FROM datahub.users
+ORDER BY username
+```
+
+| Column | Type | Description |
+|---|---|---|
+| `urn` | Utf8 | Unique CorpUser URN |
+| `username` | Utf8 | Login username (often an email address) |
+| `display_name` | Utf8 | Human-readable display name |
+| `email` | Utf8 | User email address |
+
+---
+
+## Quick start
+
+```bash
+# 1. Add the source
+DATAHUB_GMS_URL=http://localhost:8080 \
+DATAHUB_TOKEN=no-auth \
+coral source add --file sources/community/datahub/manifest.yaml
+
+# 2. Restart the server
+coral server stop && coral server start
+
+# 3. Explore
+coral sql "SELECT * FROM coral.tables WHERE schema_name = 'datahub'"
+
+# All datasets with owners
+coral sql "SELECT name, platform, owners, description FROM datahub.datasets ORDER BY platform, name"
+
+# All pipelines and their tasks
+coral sql "SELECT f.name AS pipeline, j.name AS task, j.description FROM datahub.datajobs j JOIN datahub.dataflows f ON j.flow_urn = f.urn"
+
+# Governance overview
+coral sql "SELECT name, description FROM datahub.domains ORDER BY name"
+coral sql "SELECT name, description FROM datahub.tags ORDER BY name"
+
+# Who owns what
+coral sql "SELECT d.name AS dataset, d.platform, d.owners FROM datahub.datasets d ORDER BY d.owners, d.platform"
+```
+
+## Cascading queries
+
+```text
+datahub.domains
+  → urn (domain grouping)
+
+datahub.tags
+  → urn (applied to datasets and other entities)
+
+datahub.users
+  → username (matches owners column in datasets)
+
+datahub.dataflows
+  → urn
+    → datahub.datajobs WHERE flow_urn = dataflows.urn
+      → task-level lineage and descriptions
+
+datahub.datasets
+  → urn (cross-reference with lineage, tags, domains)
+  → owners → datahub.users.username
+```
+
+## Notes
+
+- All tables use the DataHub GraphQL `search` API with `query: "*"` to return
+  all registered entities. SQL `WHERE` clauses are evaluated client-side by
+  Coral after the full result set is fetched.
+- `DATAHUB_TOKEN` is required by the connector even for unauthenticated local
+  instances — pass any non-empty placeholder (e.g. `no-auth`) and DataHub OSS
+  will ignore the `Authorization` header.
+- `DATAHUB_GMS_URL` should be the **base URL only** — do not append
+  `/api/graphql`. The connector appends that path automatically.
+- Tested against DataHub OSS v0.14+ (Docker quickstart). The GraphQL `search`
+  API shape used here has been stable since v0.9.

--- a/sources/community/datahub/README.md
+++ b/sources/community/datahub/README.md
@@ -14,7 +14,7 @@ Works with DataHub OSS (local Docker quickstart) and any self-hosted deployment.
 
 ## Authentication
 
-DataHub OSS running locally is unauthenticated by default â€” set `DATAHUB_TOKEN`
+DataHub OSS running locally is unauthenticated by default — set `DATAHUB_TOKEN`
 to any non-empty placeholder value and the connector works without a real token.
 
 For authenticated deployments, generate a Personal Access Token in the DataHub

--- a/sources/community/datahub/manifest.yaml
+++ b/sources/community/datahub/manifest.yaml
@@ -14,16 +14,16 @@ inputs:
       Base URL of your DataHub GMS (Generalized Metadata Service) instance.
       For a local Docker quickstart use http://localhost:8080.
       For a remote deployment use its full base URL
-      (e.g. https://datahub.example.com). Do not include /api/graphql â€”
+      (e.g. https://datahub.example.com). Do not include /api/graphql --
       that path is appended automatically.
       See https://datahubproject.io/docs/quickstart for setup.
   DATAHUB_TOKEN:
     kind: secret
     hint: >-
       Personal Access Token for authenticated DataHub deployments.
-      Generate one in DataHub UI â†’ Settings â†’ Access Tokens.
-      For local unauthenticated OSS instances leave this blank â€”
-      the connector will omit the Authorization header.
+      Generate one in DataHub UI under Settings > Access Tokens.
+      For local unauthenticated OSS instances pass any non-empty placeholder
+      (e.g. no-auth) -- DataHub OSS ignores the Authorization header.
       See https://datahubproject.io/docs/authentication/personal-access-tokens.
 base_url: "{{input.DATAHUB_GMS_URL}}"
 auth:
@@ -42,12 +42,18 @@ test_queries:
 tables:
   - name: datasets
     description: >-
-      Data catalog inventory â€” datasets registered across all platforms
+      Data catalog inventory -- datasets registered across all platforms
       (Hive, S3, Kafka, HDFS, etc.) with ownership and descriptions.
     guide: |
       Each row is one registered dataset. `platform` is the underlying data
       platform (e.g. hive, s3, kafka). `owners` is a comma-joined list of
       owner usernames. Use `urn` to join to lineage or governance queries.
+      This table fetches up to 1000 datasets in a single GraphQL request.
+      The DataHub GraphQL search API supports offset pagination via start/count
+      but the Coral DSL does not support body-based offset pagination; if your
+      catalog exceeds 1000 datasets the count value in the manifest body must
+      be raised manually until native pagination support is added.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/graphql
@@ -105,7 +111,7 @@ tables:
             - input
             - count
           from: literal
-          value: 200
+          value: 1000
     response:
       rows_path:
         - data
@@ -185,6 +191,8 @@ tables:
     guide: |
       Each row is one tag. Use `urn` to cross-reference tags applied to
       datasets or other entities. `name` is the display label shown in the UI.
+      Fetches up to 1000 tags in a single request; most catalogs have far fewer.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/graphql
@@ -233,7 +241,7 @@ tables:
             - input
             - count
           from: literal
-          value: 100
+          value: 1000
     response:
       rows_path:
         - data
@@ -280,7 +288,8 @@ tables:
     guide: |
       Each row is one domain. Domains are top-level groupings such as
       Marketing, Engineering, or Sales. Use `urn` to scope dataset or
-      user queries by domain.
+      user queries by domain. Fetches up to 1000 domains in a single request.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/graphql
@@ -329,7 +338,7 @@ tables:
             - input
             - count
           from: literal
-          value: 100
+          value: 1000
     response:
       rows_path:
         - data
@@ -378,6 +387,8 @@ tables:
       Each row is one pipeline or DAG. `platform` is the orchestrator
       (e.g. airflow). Join `urn` to `datahub.datajobs.flow_urn` to see
       the individual tasks within a pipeline.
+      Fetches up to 1000 pipelines in a single request.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/graphql
@@ -427,7 +438,7 @@ tables:
             - input
             - count
           from: literal
-          value: 100
+          value: 1000
     response:
       rows_path:
         - data
@@ -486,7 +497,8 @@ tables:
       Each row is one task or job within a pipeline. `flow_urn` links back
       to the parent pipeline in `datahub.dataflows`. `flow_platform` is the
       orchestrator. Join `flow_urn` to `datahub.dataflows.urn` to get the
-      parent DAG name.
+      parent DAG name. Fetches up to 1000 jobs in a single request.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/graphql
@@ -539,7 +551,7 @@ tables:
             - input
             - count
           from: literal
-          value: 100
+          value: 1000
     response:
       rows_path:
         - data
@@ -603,12 +615,14 @@ tables:
 
   - name: users
     description: >-
-      DataHub users (CorpUsers) â€” people registered in the catalog with
+      DataHub users (CorpUsers) -- people registered in the catalog with
       display names and email addresses.
     guide: |
       Each row is one registered user. `username` is the login identifier.
       `display_name` is the human-readable name shown in the UI.
       Use `urn` to cross-reference ownership on datasets.
+      Fetches up to 1000 users in a single request.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/graphql
@@ -658,7 +672,7 @@ tables:
             - input
             - count
           from: literal
-          value: 100
+          value: 1000
     response:
       rows_path:
         - data

--- a/sources/community/datahub/manifest.yaml
+++ b/sources/community/datahub/manifest.yaml
@@ -117,7 +117,7 @@ tables:
         - data
         - search
         - searchResults
-      allow_404_empty: true
+      allow_404_empty: false
       row_strategy: direct
     pagination:
       mode: none
@@ -247,7 +247,7 @@ tables:
         - data
         - search
         - searchResults
-      allow_404_empty: true
+      allow_404_empty: false
       row_strategy: direct
     pagination:
       mode: none
@@ -344,7 +344,7 @@ tables:
         - data
         - search
         - searchResults
-      allow_404_empty: true
+      allow_404_empty: false
       row_strategy: direct
     pagination:
       mode: none
@@ -444,7 +444,7 @@ tables:
         - data
         - search
         - searchResults
-      allow_404_empty: true
+      allow_404_empty: false
       row_strategy: direct
     pagination:
       mode: none
@@ -557,7 +557,7 @@ tables:
         - data
         - search
         - searchResults
-      allow_404_empty: true
+      allow_404_empty: false
       row_strategy: direct
     pagination:
       mode: none
@@ -678,7 +678,7 @@ tables:
         - data
         - search
         - searchResults
-      allow_404_empty: true
+      allow_404_empty: false
       row_strategy: direct
     pagination:
       mode: none

--- a/sources/community/datahub/manifest.yaml
+++ b/sources/community/datahub/manifest.yaml
@@ -1,0 +1,709 @@
+name: datahub
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query datasets, dataflows, datajobs, users, tags, and domains from DataHub
+  (Open Source or self-hosted). Covers data catalog inventory, lineage
+  ownership, and governance metadata via the DataHub GraphQL API.
+inputs:
+  DATAHUB_GMS_URL:
+    kind: variable
+    default: http://localhost:8080
+    hint: >-
+      Base URL of your DataHub GMS (Generalized Metadata Service) instance.
+      For a local Docker quickstart use http://localhost:8080.
+      For a remote deployment use its full base URL
+      (e.g. https://datahub.example.com). Do not include /api/graphql —
+      that path is appended automatically.
+      See https://datahubproject.io/docs/quickstart for setup.
+  DATAHUB_TOKEN:
+    kind: secret
+    hint: >-
+      Personal Access Token for authenticated DataHub deployments.
+      Generate one in DataHub UI → Settings → Access Tokens.
+      For local unauthenticated OSS instances leave this blank —
+      the connector will omit the Authorization header.
+      See https://datahubproject.io/docs/authentication/personal-access-tokens.
+base_url: "{{input.DATAHUB_GMS_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.DATAHUB_TOKEN}}
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM datahub.datasets LIMIT 1
+  - SELECT * FROM datahub.tags LIMIT 1
+tables:
+  - name: datasets
+    description: >-
+      Data catalog inventory — datasets registered across all platforms
+      (Hive, S3, Kafka, HDFS, etc.) with ownership and descriptions.
+    guide: |
+      Each row is one registered dataset. `platform` is the underlying data
+      platform (e.g. hive, s3, kafka). `owners` is a comma-joined list of
+      owner usernames. Use `urn` to join to lineage or governance queries.
+    request:
+      method: POST
+      path: /api/graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query SearchDatasets($input: SearchInput!) {
+              search(input: $input) {
+                total
+                searchResults {
+                  entity {
+                    ... on Dataset {
+                      urn
+                      name
+                      platform { name }
+                      properties {
+                        description
+                        qualifiedName
+                      }
+                      ownership {
+                        owners {
+                          owner {
+                            ... on CorpUser { username }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - input
+            - type
+          from: literal
+          value: DATASET
+        - path:
+            - variables
+            - input
+            - query
+          from: literal
+          value: "*"
+        - path:
+            - variables
+            - input
+            - start
+          from: literal
+          value: 0
+        - path:
+            - variables
+            - input
+            - count
+          from: literal
+          value: 200
+    response:
+      rows_path:
+        - data
+        - search
+        - searchResults
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: urn
+        type: Utf8
+        nullable: false
+        description: Unique DataHub Resource Name for this dataset.
+        expr:
+          kind: path
+          path:
+            - entity
+            - urn
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Dataset name as registered in DataHub.
+        expr:
+          kind: path
+          path:
+            - entity
+            - name
+      - name: platform
+        type: Utf8
+        nullable: true
+        description: Underlying data platform (e.g. hive, s3, kafka, hdfs).
+        expr:
+          kind: path
+          path:
+            - entity
+            - platform
+            - name
+      - name: qualified_name
+        type: Utf8
+        nullable: true
+        description: Fully qualified dataset name when available.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - qualifiedName
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Dataset description from DataHub properties.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - description
+      - name: owners
+        type: Utf8
+        nullable: true
+        description: Comma-joined list of owner usernames.
+        expr:
+          kind: join_array_path
+          path:
+            - entity
+            - ownership
+            - owners
+          item_path:
+            - owner
+            - username
+          separator: ","
+
+  - name: tags
+    description: >-
+      Governance and classification tags registered in DataHub.
+    guide: |
+      Each row is one tag. Use `urn` to cross-reference tags applied to
+      datasets or other entities. `name` is the display label shown in the UI.
+    request:
+      method: POST
+      path: /api/graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query SearchTags($input: SearchInput!) {
+              search(input: $input) {
+                total
+                searchResults {
+                  entity {
+                    ... on Tag {
+                      urn
+                      properties {
+                        name
+                        description
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - input
+            - type
+          from: literal
+          value: TAG
+        - path:
+            - variables
+            - input
+            - query
+          from: literal
+          value: "*"
+        - path:
+            - variables
+            - input
+            - start
+          from: literal
+          value: 0
+        - path:
+            - variables
+            - input
+            - count
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - data
+        - search
+        - searchResults
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: urn
+        type: Utf8
+        nullable: false
+        description: Unique Tag URN.
+        expr:
+          kind: path
+          path:
+            - entity
+            - urn
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Tag display name.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Tag description.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - description
+
+  - name: domains
+    description: >-
+      Business domains used to group and govern metadata entities in DataHub.
+    guide: |
+      Each row is one domain. Domains are top-level groupings such as
+      Marketing, Engineering, or Sales. Use `urn` to scope dataset or
+      user queries by domain.
+    request:
+      method: POST
+      path: /api/graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query SearchDomains($input: SearchInput!) {
+              search(input: $input) {
+                total
+                searchResults {
+                  entity {
+                    ... on Domain {
+                      urn
+                      properties {
+                        name
+                        description
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - input
+            - type
+          from: literal
+          value: DOMAIN
+        - path:
+            - variables
+            - input
+            - query
+          from: literal
+          value: "*"
+        - path:
+            - variables
+            - input
+            - start
+          from: literal
+          value: 0
+        - path:
+            - variables
+            - input
+            - count
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - data
+        - search
+        - searchResults
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: urn
+        type: Utf8
+        nullable: false
+        description: Unique Domain URN.
+        expr:
+          kind: path
+          path:
+            - entity
+            - urn
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Domain name (e.g. Marketing, Engineering).
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Domain description.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - description
+
+  - name: dataflows
+    description: >-
+      Orchestration pipelines and DAGs registered in DataHub
+      (e.g. Airflow DAGs).
+    guide: |
+      Each row is one pipeline or DAG. `platform` is the orchestrator
+      (e.g. airflow). Join `urn` to `datahub.datajobs.flow_urn` to see
+      the individual tasks within a pipeline.
+    request:
+      method: POST
+      path: /api/graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query SearchDataFlows($input: SearchInput!) {
+              search(input: $input) {
+                total
+                searchResults {
+                  entity {
+                    ... on DataFlow {
+                      urn
+                      platform { name }
+                      properties {
+                        name
+                        description
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - input
+            - type
+          from: literal
+          value: DATA_FLOW
+        - path:
+            - variables
+            - input
+            - query
+          from: literal
+          value: "*"
+        - path:
+            - variables
+            - input
+            - start
+          from: literal
+          value: 0
+        - path:
+            - variables
+            - input
+            - count
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - data
+        - search
+        - searchResults
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: urn
+        type: Utf8
+        nullable: false
+        description: Unique DataFlow URN.
+        expr:
+          kind: path
+          path:
+            - entity
+            - urn
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Pipeline or DAG name.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - name
+      - name: platform
+        type: Utf8
+        nullable: true
+        description: Orchestration platform (e.g. airflow).
+        expr:
+          kind: path
+          path:
+            - entity
+            - platform
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Pipeline description.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - description
+
+  - name: datajobs
+    description: >-
+      Individual pipeline tasks and jobs registered in DataHub
+      (e.g. Airflow tasks within a DAG).
+    guide: |
+      Each row is one task or job within a pipeline. `flow_urn` links back
+      to the parent pipeline in `datahub.dataflows`. `flow_platform` is the
+      orchestrator. Join `flow_urn` to `datahub.dataflows.urn` to get the
+      parent DAG name.
+    request:
+      method: POST
+      path: /api/graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query SearchDataJobs($input: SearchInput!) {
+              search(input: $input) {
+                total
+                searchResults {
+                  entity {
+                    ... on DataJob {
+                      urn
+                      properties {
+                        name
+                        description
+                      }
+                      dataFlow {
+                        urn
+                        platform { name }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - input
+            - type
+          from: literal
+          value: DATA_JOB
+        - path:
+            - variables
+            - input
+            - query
+          from: literal
+          value: "*"
+        - path:
+            - variables
+            - input
+            - start
+          from: literal
+          value: 0
+        - path:
+            - variables
+            - input
+            - count
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - data
+        - search
+        - searchResults
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: urn
+        type: Utf8
+        nullable: false
+        description: Unique DataJob URN.
+        expr:
+          kind: path
+          path:
+            - entity
+            - urn
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Task or job name.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Task description.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - description
+      - name: flow_urn
+        type: Utf8
+        nullable: true
+        description: URN of the parent pipeline. Join to datahub.dataflows.urn.
+        expr:
+          kind: path
+          path:
+            - entity
+            - dataFlow
+            - urn
+      - name: flow_platform
+        type: Utf8
+        nullable: true
+        description: Orchestration platform of the parent pipeline (e.g. airflow).
+        expr:
+          kind: path
+          path:
+            - entity
+            - dataFlow
+            - platform
+            - name
+
+  - name: users
+    description: >-
+      DataHub users (CorpUsers) — people registered in the catalog with
+      display names and email addresses.
+    guide: |
+      Each row is one registered user. `username` is the login identifier.
+      `display_name` is the human-readable name shown in the UI.
+      Use `urn` to cross-reference ownership on datasets.
+    request:
+      method: POST
+      path: /api/graphql
+      query: []
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query SearchUsers($input: SearchInput!) {
+              search(input: $input) {
+                total
+                searchResults {
+                  entity {
+                    ... on CorpUser {
+                      urn
+                      username
+                      properties {
+                        displayName
+                        email
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - input
+            - type
+          from: literal
+          value: CORP_USER
+        - path:
+            - variables
+            - input
+            - query
+          from: literal
+          value: "*"
+        - path:
+            - variables
+            - input
+            - start
+          from: literal
+          value: 0
+        - path:
+            - variables
+            - input
+            - count
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - data
+        - search
+        - searchResults
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: urn
+        type: Utf8
+        nullable: false
+        description: Unique CorpUser URN.
+        expr:
+          kind: path
+          path:
+            - entity
+            - urn
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Login username (often an email address).
+        expr:
+          kind: path
+          path:
+            - entity
+            - username
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Human-readable display name.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - displayName
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+        expr:
+          kind: path
+          path:
+            - entity
+            - properties
+            - email

--- a/sources/community/datahub/manifest.yaml
+++ b/sources/community/datahub/manifest.yaml
@@ -14,15 +14,15 @@ inputs:
       Base URL of your DataHub GMS (Generalized Metadata Service) instance.
       For a local Docker quickstart use http://localhost:8080.
       For a remote deployment use its full base URL
-      (e.g. https://datahub.example.com). Do not include /api/graphql —
+      (e.g. https://datahub.example.com). Do not include /api/graphql â€”
       that path is appended automatically.
       See https://datahubproject.io/docs/quickstart for setup.
   DATAHUB_TOKEN:
     kind: secret
     hint: >-
       Personal Access Token for authenticated DataHub deployments.
-      Generate one in DataHub UI → Settings → Access Tokens.
-      For local unauthenticated OSS instances leave this blank —
+      Generate one in DataHub UI â†’ Settings â†’ Access Tokens.
+      For local unauthenticated OSS instances leave this blank â€”
       the connector will omit the Authorization header.
       See https://datahubproject.io/docs/authentication/personal-access-tokens.
 base_url: "{{input.DATAHUB_GMS_URL}}"
@@ -42,7 +42,7 @@ test_queries:
 tables:
   - name: datasets
     description: >-
-      Data catalog inventory — datasets registered across all platforms
+      Data catalog inventory â€” datasets registered across all platforms
       (Hive, S3, Kafka, HDFS, etc.) with ownership and descriptions.
     guide: |
       Each row is one registered dataset. `platform` is the underlying data
@@ -603,7 +603,7 @@ tables:
 
   - name: users
     description: >-
-      DataHub users (CorpUsers) — people registered in the catalog with
+      DataHub users (CorpUsers) â€” people registered in the catalog with
       display names and email addresses.
     guide: |
       Each row is one registered user. `username` is the login identifier.


### PR DESCRIPTION
Closes #451

## Summary

Adds a new community source for DataHub under `sources/community/datahub/`.

This source enables querying DataHub data catalog metadata, dataset inventory, pipeline lineage, governance classifications, business domains, and registered users through SQL using the DataHub GraphQL API.

The source is designed for:

- data catalog discovery
- lineage visibility
- governance auditing
- ownership analytics
- agentic data discovery workflows

The implementation is intentionally:

- read-only
- catalog-focused
- lightweight
- governance-scoped
- easy to validate locally

The source supports both:

- local/self-hosted DataHub OSS deployments (Docker quickstart)
- authenticated remote deployments via Personal Access Tokens

---

## Tables

| Table | GraphQL Type | Notes |
|---|---|---|
| datasets | `DATASET` | Registered datasets across all platforms with ownership and descriptions |
| dataflows | `DATA_FLOW` | Orchestration pipelines and DAGs (e.g. Airflow) |
| datajobs | `DATA_JOB` | Individual pipeline tasks, joinable to `dataflows` via `flow_urn` |
| tags | `TAG` | Governance and classification tags |
| domains | `DOMAIN` | Business domains for grouping metadata entities |
| users | `CORP_USER` | Registered users with display names and email addresses |

---

## Auth

Authentication supports both:

- unauthenticated local OSS deployments (pass any non-empty placeholder)
- authenticated deployments via Personal Access Token

Authentication when enabled uses:

```http
Authorization: Bearer <DATAHUB_TOKEN>
```

The source requires:

```env
DATAHUB_GMS_URL   # base URL only, e.g. http://localhost:8080
DATAHUB_TOKEN     # PAT for authenticated deployments; any placeholder for local OSS
```

Examples:

### Local unauthenticated OSS

```env
DATAHUB_GMS_URL=http://localhost:8080
DATAHUB_TOKEN=no-auth
```

### Remote authenticated deployment

```env
DATAHUB_GMS_URL=https://datahub.company.internal
DATAHUB_TOKEN=your_personal_access_token
```

This keeps:

- contributor onboarding simple
- local testing friction low
- OSS compatibility practical
- validation workflows reproducible

---

## Why it matters

DataHub is increasingly used for:

- data catalog management
- dataset discovery and governance
- pipeline lineage tracking
- ownership and stewardship workflows
- data quality and classification
- agentic data discovery pipelines

As data platforms scale, teams often need visibility into:

- what datasets exist and where
- who owns which datasets
- which pipelines produce which datasets
- what governance tags and domains are applied
- which users are registered in the catalog

Without a Coral source, users typically need to:

- manually browse the DataHub UI
- write custom GraphQL integrations
- export catalog metadata separately
- maintain operational scripts
- correlate lineage metadata manually

Being able to query catalog inventory, ownership, lineage, and governance through SQL is a natural fit for Coral data discovery and agentic workflows.

---

## Discovery flow

```text
domains
  → governance grouping context

tags
  → classification context

users
  → username (matches owners on datasets)

dataflows
  → urn
    → datajobs WHERE flow_urn = dataflows.urn
      → task-level lineage

datasets
  → urn (cross-reference with lineage, tags, domains)
  → owners → users.username
```

---

## What was tested

- `coral source lint` — manifest valid
- `coral source add --file` — installs successfully, all 6 tables registered
- `coral source test datahub` — 2/2 test queries pass
- All 6 tables queried against a live local DataHub OSS instance with demo data
- `coral.tables`, `coral.columns`, `coral.inputs` all surface correct metadata

### Live queries verified against a real DataHub instance

- `datasets` — 7 datasets across hive, s3, kafka, hdfs platforms returned correctly with owners join
- `dataflows` — Airflow DAG metadata returned correctly
- `datajobs` — 2 tasks with `flow_urn` join to parent pipeline validated
- `tags` — 4 governance tags returned correctly
- `domains` — 4 business domains (Marketing, Product, Sales, Engineering) returned correctly
- `users` — 6 registered users with display names and emails returned correctly
- Cross-table join query (`datajobs → dataflows`) executes successfully

---

## User-visible impact

New `datahub` source installable via:

### Local OSS

```bash
DATAHUB_GMS_URL=http://localhost:8080 \
DATAHUB_TOKEN=no-auth \
coral source add --file sources/community/datahub/manifest.yaml
```

### Authenticated deployments

```bash
DATAHUB_GMS_URL=https://datahub.company.internal \
DATAHUB_TOKEN=your_personal_access_token \
coral source add --file sources/community/datahub/manifest.yaml
```

### Example catalog query

```bash
coral sql "SELECT name, platform, owners, description FROM datahub.datasets ORDER BY platform, name"
```

### Example lineage query

```bash
coral sql "
  SELECT f.name AS pipeline, j.name AS task, j.description
  FROM datahub.datajobs j
  JOIN datahub.dataflows f ON j.flow_urn = f.urn
"
```

### Example governance query

```bash
coral sql "SELECT name, description FROM datahub.domains ORDER BY name"
```

---

## Notes

- Source intentionally remains read-only in v1
- All tables use `search(query: "*")` via the DataHub GraphQL API — SQL `WHERE` clauses are evaluated client-side by Coral after the full result set is fetched
- `owners` on datasets uses `join_array_path` to flatten the nested ownership array into a comma-joined string
- `DATAHUB_GMS_URL` takes the base URL only — `/api/graphql` is appended per-table in the request path
- `DATAHUB_TOKEN` is required by the connector even for unauthenticated local instances — pass any non-empty placeholder and DataHub OSS ignores the `Authorization` header
- Tested against DataHub OSS v0.14+ (Docker quickstart). The GraphQL search API shape used here has been stable since v0.9
- README documents local Docker setup, authentication, full column reference, query examples, and cascading query map

---

## Follow-on

Potential future additions could include:

- schema field-level metadata (column descriptions, types from DataHub schemas)
- glossary terms and business glossary entities
- data quality assertions and test results
- lineage edges (upstream/downstream dataset relationships)
- dashboard and chart entities
- group/team entities (`CorpGroups`)
- ingestion run history
- deprecation and soft-delete status filtering
- domain-scoped dataset filtering pushed down to GraphQL