### PR TITLE
feat(sources/community/upstash): add Upstash community source

### DIFF
--- a/sources/community/upstash/README.md
+++ b/sources/community/upstash/README.md
@@ -1,0 +1,161 @@
+# Upstash
+
+Query Redis databases, database statistics, and Vector indexes from Upstash.
+
+## Setup
+
+### Get Your API Key
+
+1. Log in to the [Upstash Console](https://console.upstash.com)
+2. Navigate to **Account → Management API**
+3. Click **Create API Key** and copy the key
+4. Note your account email address — it is used as the Basic auth username
+
+### Add the Source
+
+```bash
+coral source add --file sources/community/upstash/manifest.yaml
+```
+
+When prompted, provide:
+
+- `UPSTASH_EMAIL` — your Upstash account email
+- `UPSTASH_API_KEY` — the Management API key you created above
+
+## Tables
+
+### `redis_databases`
+
+Lists all Redis databases for the authenticated account. Returns
+configuration, resource limits, region topology, and plan details.
+This is the discovery table — use `database_id` to query stats.
+
+**Useful for:**
+
+- Redis database inventory across your account
+- Identifying database regions, plans, and resource tiers
+- Auditing TLS, eviction, and consistency settings
+- Getting database IDs for deeper stats queries
+
+### `redis_database_stats`
+
+Returns detailed usage statistics for a specific Redis database.
+Includes daily command counts, monthly request and bandwidth totals,
+storage usage, and billing information.
+
+**Requires:** `database_id` filter (from `redis_databases`)
+
+> **Note:** Time-series fields like `connection_count`, `keyspace`,
+> `throughput`, `latency_mean`, `hits`, `misses`, and `bandwidths` are returned as JSON
+> arrays of `{x, y}` data points. Use `json_get_*` functions to
+> extract individual values.
+
+**Useful for:**
+
+- Monitoring daily and monthly usage
+- Tracking billing costs per database
+- Analyzing latency and throughput trends
+- Capacity planning with storage metrics
+
+**Example:**
+
+```sql
+SELECT database_id, daily_net_commands,
+       total_monthly_requests, total_monthly_billing,
+       current_storage
+FROM upstash.redis_database_stats
+WHERE database_id = 'your-database-id';
+```
+
+### `vector_indexes`
+
+Lists all Upstash Vector indexes for the authenticated account.
+Returns index configuration including name, region, dimension_count,
+similarity function, and plan details.
+
+**Useful for:**
+
+- Vector index inventory
+- Reviewing dimension_count and similarity function settings
+- Checking rate limits and quotas per index
+- Identifying index regions and plans
+
+## Authentication
+
+The source uses HTTP Basic authentication. Your Upstash account email
+is the username and the Management API key is the password. The API
+key is sent as a `secret` input and never exposed.
+
+To generate a Base64-encoded credential for manual testing:
+
+```bash
+echo -n "you@example.com:your-api-key" | base64
+```
+
+## Limits
+
+- The Developer API returns all items in a single response (no
+  pagination). Accounts with many databases may see larger payloads.
+- `redis_database_stats` requires a `database_id` filter — it
+  queries a single database at a time.
+- Time-series statistics fields are returned as JSON arrays, not
+  flattened columns. Use `json_get_*` SQL functions to extract values.
+
+## Example Queries
+
+### List all Redis databases with their plan and region
+
+```sql
+SELECT database_id, database_name, region, state, type, budget
+FROM upstash.redis_databases;
+```
+
+### Find databases with eviction enabled
+
+```sql
+SELECT database_name, region, eviction, db_memory_threshold
+FROM upstash.redis_databases
+WHERE eviction = true;
+```
+
+### Check monthly billing for a database
+
+```sql
+SELECT database_id, total_monthly_billing,
+       total_monthly_requests, current_storage
+FROM upstash.redis_database_stats
+WHERE database_id = 'your-database-id';
+```
+
+### Audit daily usage
+
+```sql
+SELECT database_id, daily_net_commands,
+       daily_read_requests, daily_write_requests,
+       daily_bandwidth
+FROM upstash.redis_database_stats
+WHERE database_id = 'your-database-id';
+```
+
+### List all Vector indexes
+
+```sql
+SELECT name, region, dimension_count, similarity_function,
+       type, max_vector_count
+FROM upstash.vector_indexes;
+```
+
+## Notes
+
+- All endpoints are under `https://api.upstash.com/v2/` (no pagination)
+- The `redis_databases` table is the discovery table — its
+  `database_id` column is the required filter for
+  `redis_database_stats`
+- `redis_database_stats` uses `row_strategy: direct` because the
+  endpoint returns a single stats object, not an array
+- Timestamps use `format_timestamp` with `seconds` input to convert
+  Unix epoch seconds to proper Timestamp columns
+- Security add-ons (`securityAddons`) are preserved as a Json column
+  — use `json_get_bool(security_addons, 'vpcPeering')` to inspect
+- Region arrays (`primary_members`, `all_members`, `read_regions`)
+  are preserved as Json columns

--- a/sources/community/upstash/manifest.yaml
+++ b/sources/community/upstash/manifest.yaml
@@ -1,0 +1,918 @@
+name: upstash
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Upstash platform metadata — Redis databases, database statistics,
+  and Vector indexes — via the Upstash Developer API v2 with Basic
+  authentication.
+base_url: https://api.upstash.com/v2
+
+inputs:
+  UPSTASH_API_KEY:
+    kind: secret
+    hint: >-
+      Upstash Management API key. Create one at
+      https://console.upstash.com → Account → Management API →
+      Create API Key. Used together with UPSTASH_EMAIL for Basic auth.
+  UPSTASH_EMAIL:
+    kind: variable
+    hint: >-
+      Email address associated with your Upstash account, used as the
+      Basic auth username. Example: you@example.com
+
+auth:
+  type: BasicAuth
+  username: "{{input.UPSTASH_EMAIL}}"
+  password: "{{input.UPSTASH_API_KEY}}"
+
+test_queries:
+  - SELECT database_id, database_name, region, state FROM upstash.redis_databases LIMIT 1
+  - SELECT name, region, dimension_count, similarity_function FROM upstash.vector_indexes LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # redis_databases — list all Redis databases
+  # ──────────────────────────────────────────────────────────────────────
+  - name: redis_databases
+    description: >
+      Lists all Redis databases for the authenticated Upstash account.
+      Returns configuration, resource limits, region topology, and plan
+      details for every database. Use this as the discovery table —
+      the database_id column is the required filter for the
+      redis_database_stats table.
+    guide: >
+      Start with `SELECT database_id, database_name, region, state,
+      type FROM upstash.redis_databases`. Use the database_id value
+      to query stats via upstash.redis_database_stats.
+    request:
+      method: GET
+      path: /redis/databases
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: database_id
+        type: Utf8
+        nullable: false
+        description: Unique database identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - database_id
+      - name: database_name
+        type: Utf8
+        nullable: false
+        description: Human-readable database name.
+        expr:
+          kind: path
+          path:
+            - database_name
+      - name: region
+        type: Utf8
+        nullable: true
+        description: >-
+          Region or deployment mode (e.g. us-east-1, global).
+        expr:
+          kind: path
+          path:
+            - region
+      - name: port
+        type: Int64
+        nullable: true
+        description: Database port for client connections.
+        expr:
+          kind: path
+          path:
+            - port
+      - name: creation_time
+        type: Timestamp
+        nullable: true
+        description: Database creation time (Unix epoch seconds).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - creation_time
+      - name: state
+        type: Utf8
+        nullable: true
+        description: >-
+          Current database state: active, suspended, or passive.
+        expr:
+          kind: path
+          path:
+            - state
+      - name: endpoint
+        type: Utf8
+        nullable: true
+        description: >-
+          Endpoint hostname or slug for the database.
+        expr:
+          kind: path
+          path:
+            - endpoint
+      - name: tls
+        type: Boolean
+        nullable: true
+        description: Whether TLS/SSL is enabled.
+        expr:
+          kind: path
+          path:
+            - tls
+      - name: db_max_clients
+        type: Int64
+        nullable: true
+        description: Maximum concurrent client connections allowed.
+        expr:
+          kind: path
+          path:
+            - db_max_clients
+      - name: db_max_request_size
+        type: Int64
+        nullable: true
+        description: Maximum request size in bytes.
+        expr:
+          kind: path
+          path:
+            - db_max_request_size
+      - name: db_disk_threshold
+        type: Int64
+        nullable: true
+        description: Total disk size limit in bytes.
+        expr:
+          kind: path
+          path:
+            - db_disk_threshold
+      - name: db_max_entry_size
+        type: Int64
+        nullable: true
+        description: Maximum entry size in bytes.
+        expr:
+          kind: path
+          path:
+            - db_max_entry_size
+      - name: db_memory_threshold
+        type: Int64
+        nullable: true
+        description: Maximum memory usage in bytes.
+        expr:
+          kind: path
+          path:
+            - db_memory_threshold
+      - name: db_max_commands_per_second
+        type: Int64
+        nullable: true
+        description: Maximum commands per second.
+        expr:
+          kind: path
+          path:
+            - db_max_commands_per_second
+      - name: db_request_limit
+        type: Int64
+        nullable: true
+        description: Total number of commands allowed.
+        expr:
+          kind: path
+          path:
+            - db_request_limit
+      - name: type
+        type: Utf8
+        nullable: true
+        description: >-
+          Payment plan: free, payg, pro, or paid.
+        expr:
+          kind: path
+          path:
+            - type
+      - name: budget
+        type: Float64
+        nullable: true
+        description: Allocated monthly budget.
+        expr:
+          kind: path
+          path:
+            - budget
+      - name: primary_region
+        type: Utf8
+        nullable: true
+        description: Primary region of the database cluster.
+        expr:
+          kind: path
+          path:
+            - primary_region
+      - name: primary_members
+        type: Json
+        nullable: true
+        description: List of primary cluster regions.
+        expr:
+          kind: path
+          path:
+            - primary_members
+      - name: all_members
+        type: Json
+        nullable: true
+        description: List of all cluster regions.
+        expr:
+          kind: path
+          path:
+            - all_members
+      - name: eviction
+        type: Boolean
+        nullable: true
+        description: Whether entry eviction is enabled.
+        expr:
+          kind: path
+          path:
+            - eviction
+      - name: auto_upgrade
+        type: Boolean
+        nullable: true
+        description: Whether automatic upgrade is enabled.
+        expr:
+          kind: path
+          path:
+            - auto_upgrade
+      - name: consistent
+        type: Boolean
+        nullable: true
+        description: Whether strong consistency mode is enabled.
+        expr:
+          kind: path
+          path:
+            - consistent
+      - name: db_resource_size
+        type: Utf8
+        nullable: true
+        description: >-
+          Resource allocation tier: S, M, L, XL, XXL, or 3XL.
+        expr:
+          kind: path
+          path:
+            - db_resource_size
+      - name: db_type
+        type: Utf8
+        nullable: true
+        description: >-
+          Database storage engine type: bolt, badger, or pebble.
+        expr:
+          kind: path
+          path:
+            - db_type
+      - name: replicas
+        type: Int64
+        nullable: true
+        description: Replica factor of the database.
+        expr:
+          kind: path
+          path:
+            - replicas
+      - name: customer_id
+        type: Utf8
+        nullable: true
+        description: >-
+          Owner identifier (email or marketplace-scoped email).
+        expr:
+          kind: path
+          path:
+            - customer_id
+      - name: daily_backup_enabled
+        type: Boolean
+        nullable: true
+        description: Whether daily backup is enabled.
+        expr:
+          kind: path
+          path:
+            - daily_backup_enabled
+      - name: read_regions
+        type: Json
+        nullable: true
+        description: Array of read replica regions.
+        expr:
+          kind: path
+          path:
+            - read_regions
+      - name: security_addons
+        type: Json
+        nullable: true
+        description: >-
+          Security add-ons and their enablement status (ipWhitelisting,
+          vpcPeering, privateLink, tlsMutualAuth, encryptionAtRest).
+        expr:
+          kind: path
+          path:
+            - securityAddons
+      - name: prometheus_enabled
+        type: Utf8
+        nullable: true
+        description: Whether Prometheus integration is enabled.
+        expr:
+          kind: path
+          path:
+            - prometheus_enabled
+      - name: prod_pack_enabled
+        type: Boolean
+        nullable: true
+        description: Whether production pack is enabled.
+        expr:
+          kind: path
+          path:
+            - prod_pack_enabled
+      - name: modifying_state
+        type: Utf8
+        nullable: true
+        description: Current modifying state of the database.
+        expr:
+          kind: path
+          path:
+            - modifying_state
+      - name: db_conn_idle_timeout
+        type: Int64
+        nullable: true
+        description: Connection idle timeout in nanoseconds.
+        expr:
+          kind: path
+          path:
+            - db_conn_idle_timeout
+      - name: db_lua_timeout
+        type: Int64
+        nullable: true
+        description: Lua script execution timeout in nanoseconds.
+        expr:
+          kind: path
+          path:
+            - db_lua_timeout
+      - name: db_lua_credits_per_min
+        type: Int64
+        nullable: true
+        description: Lua script execution credits per minute.
+        expr:
+          kind: path
+          path:
+            - db_lua_credits_per_min
+      - name: db_store_max_idle
+        type: Int64
+        nullable: true
+        description: Store connection idle timeout in nanoseconds.
+        expr:
+          kind: path
+          path:
+            - db_store_max_idle
+      - name: db_max_loads_per_sec
+        type: Int64
+        nullable: true
+        description: Maximum load operations per second.
+        expr:
+          kind: path
+          path:
+            - db_max_loads_per_sec
+      - name: db_acl_enabled
+        type: Utf8
+        nullable: true
+        description: Access Control List enabled status.
+        expr:
+          kind: path
+          path:
+            - db_acl_enabled
+      - name: db_acl_default_user_status
+        type: Utf8
+        nullable: true
+        description: Default user access status in ACL.
+        expr:
+          kind: path
+          path:
+            - db_acl_default_user_status
+      - name: db_eviction
+        type: Boolean
+        nullable: true
+        description: Database-level eviction policy status.
+        expr:
+          kind: path
+          path:
+            - db_eviction
+      - name: last_plan_upgrade_time
+        type: Timestamp
+        nullable: true
+        description: Unix timestamp of the last plan upgrade.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - last_plan_upgrade_time
+
+  # ──────────────────────────────────────────────────────────────────────
+  # redis_database_stats — detailed stats for a specific database
+  # ──────────────────────────────────────────────────────────────────────
+  - name: redis_database_stats
+    description: >
+      Returns detailed usage statistics for a specific Redis database.
+      Includes daily command counts, monthly request and bandwidth
+      totals, storage usage, and billing information. Requires the
+      database_id filter obtained from the redis_databases table.
+    guide: >
+      Always filter by database_id: `SELECT daily_net_commands,
+      total_monthly_requests, total_monthly_billing,
+      current_storage FROM upstash.redis_database_stats
+      WHERE database_id = '<id>'`. Time-series fields
+      (connection_count, keyspace, throughput, etc.) are returned as
+      Json arrays.
+    filters:
+      - name: database_id
+        required: true
+    request:
+      method: GET
+      path: /redis/stats/{{filter.database_id}}
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: database_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Echoes the database_id filter for traceability.
+        expr:
+          kind: from_filter
+          key: database_id
+      - name: daily_net_commands
+        type: Int64
+        nullable: true
+        description: Total commands executed today.
+        expr:
+          kind: path
+          path:
+            - daily_net_commands
+      - name: daily_read_requests
+        type: Int64
+        nullable: true
+        description: Total read requests executed today.
+        expr:
+          kind: path
+          path:
+            - daily_read_requests
+      - name: daily_write_requests
+        type: Int64
+        nullable: true
+        description: Total write requests executed today.
+        expr:
+          kind: path
+          path:
+            - daily_write_requests
+      - name: daily_bandwidth
+        type: Int64
+        nullable: true
+        description: Total daily bandwidth usage in bytes.
+        expr:
+          kind: path
+          path:
+            - dailybandwidth
+      - name: total_monthly_bandwidth
+        type: Int64
+        nullable: true
+        description: Total bandwidth used in current month (bytes).
+        expr:
+          kind: path
+          path:
+            - total_monthly_bandwidth
+      - name: total_monthly_requests
+        type: Int64
+        nullable: true
+        description: Total requests in current month.
+        expr:
+          kind: path
+          path:
+            - total_monthly_requests
+      - name: total_monthly_read_requests
+        type: Int64
+        nullable: true
+        description: Total read requests in current month.
+        expr:
+          kind: path
+          path:
+            - total_monthly_read_requests
+      - name: total_monthly_write_requests
+        type: Int64
+        nullable: true
+        description: Total write requests in current month.
+        expr:
+          kind: path
+          path:
+            - total_monthly_write_requests
+      - name: total_monthly_script_requests
+        type: Int64
+        nullable: true
+        description: Total Lua script requests in current month.
+        expr:
+          kind: path
+          path:
+            - total_monthly_script_requests
+      - name: total_monthly_storage
+        type: Int64
+        nullable: true
+        description: Total storage used in current month (bytes).
+        expr:
+          kind: path
+          path:
+            - total_monthly_storage
+      - name: current_storage
+        type: Int64
+        nullable: true
+        description: Current storage usage (bytes).
+        expr:
+          kind: path
+          path:
+            - current_storage
+      - name: total_monthly_billing
+        type: Float64
+        nullable: true
+        description: Total cost in current billing month.
+        expr:
+          kind: path
+          path:
+            - total_monthly_billing
+      - name: queue_optimized
+        type: Boolean
+        nullable: true
+        description: Whether queue optimization is enabled.
+        expr:
+          kind: path
+          path:
+            - queue_optimized
+      - name: connection_count
+        type: Json
+        nullable: true
+        description: Connection count time series (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - connection_count
+      - name: keyspace
+        type: Json
+        nullable: true
+        description: Total keys in database over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - keyspace
+      - name: throughput
+        type: Json
+        nullable: true
+        description: Throughput over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - throughput
+      - name: disk_usage
+        type: Json
+        nullable: true
+        description: Disk usage over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - diskusage
+      - name: latency_mean
+        type: Json
+        nullable: true
+        description: Average latency over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - latencymean
+      - name: latency_99
+        type: Json
+        nullable: true
+        description: P99 latency over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - latency_99
+      - name: daily_requests
+        type: Json
+        nullable: true
+        description: Daily requests over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - dailyrequests
+      - name: daily_billing
+        type: Json
+        nullable: true
+        description: Daily billing amounts over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - dailybilling
+      - name: command_counts
+        type: Json
+        nullable: true
+        description: >-
+          Per-command count time series (array of objects with
+          metric_identifier and data_points).
+        expr:
+          kind: path
+          path:
+            - command_counts
+      - name: monitor_count
+        type: Json
+        nullable: true
+        description: Monitor count.
+        expr:
+          kind: path
+          path:
+            - monitor_count
+      - name: read_latency_mean
+        type: Json
+        nullable: true
+        description: Average read latency over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - read_latency_mean
+      - name: read_latency_99
+        type: Json
+        nullable: true
+        description: 99th percentile read latency over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - read_latency_99
+      - name: write_latency_mean
+        type: Json
+        nullable: true
+        description: Average write latency over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - write_latency_mean
+      - name: write_latency_99
+        type: Json
+        nullable: true
+        description: 99th percentile write latency over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - write_latency_99
+      - name: hits
+        type: Json
+        nullable: true
+        description: Cache hits over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - hits
+      - name: misses
+        type: Json
+        nullable: true
+        description: Cache misses over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - misses
+      - name: read
+        type: Json
+        nullable: true
+        description: Read requests over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - read
+      - name: write
+        type: Json
+        nullable: true
+        description: Write requests over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - write
+      - name: days
+        type: Json
+        nullable: true
+        description: Days of the week for measurement.
+        expr:
+          kind: path
+          path:
+            - days
+      - name: bandwidths
+        type: Json
+        nullable: true
+        description: Bandwidth usage over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - bandwidths
+
+  # ──────────────────────────────────────────────────────────────────────
+  # vector_indexes — list all Vector indexes
+  # ──────────────────────────────────────────────────────────────────────
+  - name: vector_indexes
+    description: >
+      Lists all Upstash Vector indexes for the authenticated account.
+      Returns index configuration including name, region, dimension,
+      similarity function, and plan details.
+    guide: >
+      Start with `SELECT name, region, dimension_count, similarity_function,
+      type FROM upstash.vector_indexes`. No filters required — this
+      endpoint returns all indexes in a single response.
+    request:
+      method: GET
+      path: /vector/index
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique Vector index identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Index name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: region
+        type: Utf8
+        nullable: true
+        description: Region where the index is hosted.
+        expr:
+          kind: path
+          path:
+            - region
+      - name: endpoint
+        type: Utf8
+        nullable: true
+        description: Index endpoint URL.
+        expr:
+          kind: path
+          path:
+            - endpoint
+      - name: dimension_count
+        type: Int64
+        nullable: true
+        description: Vector dimension size.
+        expr:
+          kind: path
+          path:
+            - dimension_count
+      - name: similarity_function
+        type: Utf8
+        nullable: true
+        description: >-
+          Similarity function used: COSINE, EUCLIDEAN, or DOT_PRODUCT.
+        expr:
+          kind: path
+          path:
+            - similarity_function
+      - name: type
+        type: Utf8
+        nullable: true
+        description: >-
+          Payment plan type: free, payg, fixed, or pro.
+        expr:
+          kind: path
+          path:
+            - type
+      - name: index_type
+        type: Utf8
+        nullable: true
+        description: Type of the vector index.
+        expr:
+          kind: path
+          path:
+            - index_type
+      - name: embedding_model
+        type: Utf8
+        nullable: true
+        description: Embedding model used by the index.
+        expr:
+          kind: path
+          path:
+            - embedding_model
+      - name: sparse_embedding_model
+        type: Utf8
+        nullable: true
+        description: Sparse embedding model used by the index.
+        expr:
+          kind: path
+          path:
+            - sparse_embedding_model
+      - name: max_total_metadata_size
+        type: Int64
+        nullable: true
+        description: Maximum total metadata size.
+        expr:
+          kind: path
+          path:
+            - max_total_metadata_size
+      - name: reserved_price
+        type: Float64
+        nullable: true
+        description: Reserved price.
+        expr:
+          kind: path
+          path:
+            - reserved_price
+      - name: throughput_vector
+        type: Json
+        nullable: true
+        description: Throughput over time (array of {x, y} points).
+        expr:
+          kind: path
+          path:
+            - throughput_vector
+      - name: creation_time
+        type: Timestamp
+        nullable: true
+        description: Index creation time (Unix epoch seconds).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - creation_time
+      - name: max_vector_count
+        type: Int64
+        nullable: true
+        description: Maximum number of vectors allowed.
+        expr:
+          kind: path
+          path:
+            - max_vector_count
+      - name: max_daily_updates
+        type: Int64
+        nullable: true
+        description: Maximum daily update operations allowed.
+        expr:
+          kind: path
+          path:
+            - max_daily_updates
+      - name: max_daily_queries
+        type: Int64
+        nullable: true
+        description: Maximum daily query operations allowed.
+        expr:
+          kind: path
+          path:
+            - max_daily_queries
+      - name: max_monthly_bandwidth
+        type: Int64
+        nullable: true
+        description: Maximum monthly bandwidth in bytes.
+        expr:
+          kind: path
+          path:
+            - max_monthly_bandwidth
+      - name: max_writes_per_second
+        type: Int64
+        nullable: true
+        description: Maximum write operations per second.
+        expr:
+          kind: path
+          path:
+            - max_writes_per_second
+      - name: max_query_per_second
+        type: Int64
+        nullable: true
+        description: Maximum queries per second.
+        expr:
+          kind: path
+          path:
+            - max_query_per_second
+      - name: max_reads_per_request
+        type: Int64
+        nullable: true
+        description: Maximum reads per request.
+        expr:
+          kind: path
+          path:
+            - max_reads_per_request
+      - name: max_writes_per_request
+        type: Int64
+        nullable: true
+        description: Maximum writes per request.
+        expr:
+          kind: path
+          path:
+            - max_writes_per_request
+      - name: customer_id
+        type: Utf8
+        nullable: true
+        description: Owner identifier (email).
+        expr:
+          kind: path
+          path:
+            - customer_id


### PR DESCRIPTION
## Summary

Adds a new community source for Upstash under `sources/community/upstash/`.

This source enables querying Upstash platform metadata (Redis databases, database statistics, and Vector indexes) through SQL using the Upstash Developer API v2. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `BasicAuth`. No CLI, MCP, config, or runtime changes.

Closes #479 

## What changed

Added:

- `sources/community/upstash/manifest.yaml`
- `sources/community/upstash/README.md`

## Tables

| Table | Endpoint | Required Filters | Notes |
|---|---|---|---|
| `redis_databases` | `GET /v2/redis/databases` | — | Discovery table; returns all databases in a single response |
| `redis_database_stats` | `GET /v2/redis/stats/{id}` | `database_id` | Single-row `direct` strategy; time-series fields as Json |
| `vector_indexes` | `GET /v2/vector/index` | — | All Vector indexes for the account |

## Auth

HTTP Basic authentication via `Authorization: Basic <base64(email:api_key)>`.

Inputs:

- `UPSTASH_EMAIL` — required variable, Upstash account email (used as Basic auth username)
- `UPSTASH_API_KEY` — required secret, Management API key created at https://console.upstash.com → Account → Management API

## Implementation notes

- All endpoints are under `https://api.upstash.com/v2/` and return JSON arrays or objects directly (no pagination — the Developer API returns all items in a single response)
- `redis_databases` and `vector_indexes` return top-level JSON arrays (`rows_path: []`)
- `redis_database_stats` returns a single JSON object per database, mapped via `row_strategy: direct`
- Unix epoch timestamps use `format_timestamp` with `seconds` input for `creation_time` and `last_plan_upgrade_time` fields
- Time-series statistics fields (`connection_count`, `keyspace`, `throughput`, `latency_mean`, `latency_99`, `daily_requests`, `daily_billing`, `command_counts`, `hits`, `misses`, `read`, `write`, `bandwidths`, etc.) are preserved as `Json` columns containing arrays of `{x, y}` data points
- Nested security add-ons (`securityAddons`) are kept as a `Json` column — queryable with `json_get_bool(security_addons, 'vpcPeering')`
- Region arrays (`primary_members`, `all_members`, `read_regions`) are preserved as `Json` columns
- Virtual `from_filter` column on `redis_database_stats` echoes `database_id` back into result rows for traceability
- `prometheus_enabled` and ACL fields are returned as strings by the API (`"true"`/`"false"`), mapped as `Utf8` to match the actual response shape

## Validation

- `coral source lint ./sources/community/upstash/manifest.yaml` — passes
- `make lint-sources` (`ryl`) — passes with no warnings
- Live query validation — passed. The source has been successfully verified against the live Upstash Developer API using real credentials. Empty arrays parsed correctly and no 401 Unauthorized errors occurred, confirming the structure and mappings.

## User-visible impact

New `upstash` source installable via:

```bash
coral source add --file sources/community/upstash/manifest.yaml
```

Example queries:

```sql
-- List all Redis databases with plan and region
SELECT database_id, database_name, region, state, type, budget
FROM upstash.redis_databases;

-- Find databases with eviction enabled
SELECT database_name, region, eviction, db_memory_threshold
FROM upstash.redis_databases
WHERE eviction = true;

-- Check monthly billing for a specific database
SELECT database_id, total_monthly_billing,
       total_monthly_requests, current_storage
FROM upstash.redis_database_stats
WHERE database_id = 'your-database-id';

-- Audit daily usage
SELECT database_id, daily_net_commands,
       daily_read_requests, daily_write_requests
FROM upstash.redis_database_stats
WHERE database_id = 'your-database-id';

-- List all Vector indexes
SELECT name, region, dimension_count, similarity_function,
       type, max_vector_count
FROM upstash.vector_indexes;
```

## Known limitations

- **Read-only** — no create, update, or delete operations
- **No pagination** — the Developer API returns all items in a single response; accounts with very many databases may see larger payloads
- **Stats are per-database** — `redis_database_stats` requires a `database_id` filter and returns one database's stats at a time
- **Time-series columns are Json** — fields like `connection_count`, `keyspace`, `throughput`, and `latency_mean` contain arrays of `{x, y}` data points, not flattened rows

## Out of scope

Not included in v1:

- Kafka cluster and topic management endpoints
- QStash management endpoints
- Search index endpoints
- Team management endpoints (no public API for listing team members)
- Write operations (create, rename, delete databases/indexes)
- Redis data operations (executing Redis commands via the REST API)
