### PR TITLE
feat(sources/community/mongodb): add MongoDB Atlas API source

### DIFF
--- a/sources/community/mongodb/README.md
+++ b/sources/community/mongodb/README.md
@@ -1,0 +1,232 @@
+# MongoDB Atlas
+
+Query MongoDB Atlas infrastructure and observability metadata from the Atlas Administration API.
+
+This source treats Atlas as a cloud database infrastructure platform, not as a generic MongoDB document query engine.
+
+## Setup
+
+### Create an Atlas Service Account Token
+
+Create a MongoDB Atlas service account with the least-privilege roles needed for the tables you want to query. For most inventory and observability tables, use Organization Member plus Project Read Only on the relevant projects.
+
+Add your current IP address or CIDR range to the service account API access list. Atlas rejects Admin API requests from IPs that are not on this list.
+
+Generate an OAuth access token from the service account client ID and secret:
+
+```bash
+ACCESS_TOKEN=$(curl -fsS --request POST https://cloud.mongodb.com/api/oauth/token \
+  --header "Authorization: Basic $(printf '%s' "${MONGODB_ATLAS_CLIENT_ID}:${MONGODB_ATLAS_CLIENT_SECRET}" | base64 | tr -d '\n')" \
+  --header "Content-Type: application/x-www-form-urlencoded" \
+  --header "Accept: application/json" \
+  --data "grant_type=client_credentials" | jq -r '.access_token')
+```
+
+Atlas access tokens are valid for 1 hour.
+
+### Add the Source
+
+```bash
+MONGODB_ATLAS_ACCESS_TOKEN="$ACCESS_TOKEN" coral source add mongodb
+```
+
+When prompted interactively, provide the token as `MONGODB_ATLAS_ACCESS_TOKEN`.
+
+## Tables
+
+### `organizations`
+
+Atlas organizations visible to the service account.
+
+**Useful for:**
+- Validating credentials
+- Discovering `org_id` values
+- Understanding which organizations the service account can inspect
+
+### `projects`
+
+Atlas projects visible to the service account. Atlas API paths also call projects "groups".
+
+**Useful for:**
+- Project inventory
+- Finding `project_id` values for project-scoped tables
+- Mapping projects to organizations
+
+### `clusters`
+
+Cluster inventory for a single Atlas project.
+
+**Requires:** `project_id`
+
+**Useful for:**
+- Database infrastructure inventory
+- Region and cloud provider review
+- MongoDB version and cluster state inspection
+- Detecting stale, paused, or unexpectedly large clusters
+
+This table does not connect to MongoDB clusters or query collection documents.
+
+### `database_users`
+
+Database user metadata for a single Atlas project.
+
+**Requires:** `project_id`
+
+**Security note:** This table intentionally does not expose passwords, generated credentials, connection strings, tokens, or secrets.
+
+**Useful for:**
+- Database user inventory
+- Role and scope review
+- Authentication mode inspection
+
+### `alerts`
+
+Atlas alerts for a single project.
+
+**Requires:** `project_id`
+
+Optional filters:
+- `status`
+- `event_type`
+
+**Useful for:**
+- Incident summaries
+- Noisy cluster detection
+- Operational analysis
+- Outage and alert timeline review
+
+### `project_events`
+
+Atlas project activity events.
+
+**Requires:** `project_id`
+
+Optional filters:
+- `event_type`
+- `min_date`
+- `max_date`
+
+**Useful for:**
+- Infrastructure change history
+- Security and governance timelines
+- Correlating alerts with project activity
+
+This table exposes event metadata. It does not fetch raw audit log files.
+
+### `audit_config`
+
+Database auditing configuration for a single Atlas project.
+
+**Requires:** `project_id`
+
+**Permission note:** Atlas requires Project Owner for this endpoint. The endpoint is not available for M0, M2, M5, or serverless clusters.
+
+**Useful for:**
+- Checking whether auditing is enabled
+- Reviewing audit filter configuration
+- Governance posture summaries
+
+This table does not fetch raw audit log streams.
+
+### `processes`
+
+Atlas process inventory for a single project.
+
+**Requires:** `project_id`
+
+**Useful for:**
+- Monitoring host inventory
+- Replica set and shard topology review
+- Finding process IDs for future metrics queries
+
+## Authentication
+
+This source uses Atlas Administration API OAuth bearer authentication:
+
+```text
+Authorization: Bearer <MONGODB_ATLAS_ACCESS_TOKEN>
+Accept: application/vnd.atlas.2025-03-12+json
+```
+
+MongoDB recommends service accounts for Atlas Administration API authentication. Legacy public/private API keys use HTTP Digest authentication; Coral's built-in source spec auth does not currently implement Digest auth or OAuth token refresh, so v1 expects a pre-minted bearer token.
+
+Do not put the service account client secret in the manifest or README. Use it only to mint a short-lived access token, then pass that token to Coral as `MONGODB_ATLAS_ACCESS_TOKEN`.
+
+## Limits
+
+- This source exposes read-only Atlas Administration API endpoints only.
+- Atlas OAuth access tokens expire after 1 hour and must be refreshed outside Coral for now.
+- Project-scoped tables require `project_id` to avoid broad, expensive scans.
+- Raw MongoDB document querying is out of scope.
+- Collection scans are out of scope.
+- Cluster mutations, provisioning, pause/resume, and configuration updates are out of scope.
+- Raw logs and compressed audit log streams are out of scope.
+- Backups, restores, private networking, access lists, and network configuration are out of scope for v1.
+- App Services, Data API, stream processing, and Atlas Search index management are separate product surfaces and are out of scope for v1.
+
+## Example Queries
+
+### List clusters by cloud provider and region
+
+```sql
+SELECT provider_name, region_name, COUNT(*) AS cluster_count
+FROM mongodb.clusters
+WHERE project_id = 'your-project-id'
+GROUP BY provider_name, region_name
+ORDER BY cluster_count DESC
+```
+
+### Find paused or unhealthy clusters
+
+```sql
+SELECT cluster_name, state_name, paused, mongo_version, disk_size_gb
+FROM mongodb.clusters
+WHERE project_id = 'your-project-id'
+  AND (paused = true OR state_name <> 'IDLE')
+ORDER BY cluster_name
+```
+
+### Review active alerts
+
+```sql
+SELECT alert_id, event_type, status, cluster_name, created_at, updated_at
+FROM mongodb.alerts
+WHERE project_id = 'your-project-id'
+  AND status = 'OPEN'
+ORDER BY created_at DESC
+LIMIT 50
+```
+
+### Summarize recent project activity
+
+```sql
+SELECT event_type, username, target_type, target_name, created_at
+FROM mongodb.project_events
+WHERE project_id = 'your-project-id'
+ORDER BY created_at DESC
+LIMIT 100
+```
+
+### Check database users and roles
+
+```sql
+SELECT username, auth_database, roles, scopes
+FROM mongodb.database_users
+WHERE project_id = 'your-project-id'
+ORDER BY username
+```
+
+### Inspect audit posture
+
+```sql
+SELECT auditing_enabled, configuration_type, audit_authorization_success, audit_filter
+FROM mongodb.audit_config
+WHERE project_id = 'your-project-id'
+```
+
+## Notes
+
+- Use `mongodb.projects` first to find project IDs.
+- Use `mongodb.organizations` first to confirm the service account can access the expected organization.
+- JSON columns preserve nested Atlas metadata without flattening every provider-specific field.
+- Timestamps are stored as proper Timestamp columns derived from Atlas ISO 8601 strings.

--- a/sources/community/mongodb/manifest.yaml
+++ b/sources/community/mongodb/manifest.yaml
@@ -1,0 +1,698 @@
+name: mongodb
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query MongoDB Atlas organizations, projects, clusters, database users,
+  alerts, project events, audit configuration, and process inventory.
+base_url: https://cloud.mongodb.com/api/atlas/v2
+inputs:
+  MONGODB_ATLAS_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      MongoDB Atlas Administration API OAuth access token. Create it from an
+      Atlas service account client ID and secret using the OAuth client
+      credentials flow at https://cloud.mongodb.com/api/oauth/token. The token
+      is sent as `Authorization: Bearer <MONGODB_ATLAS_ACCESS_TOKEN>` and is
+      valid for 1 hour. Grant the service account least-privilege read roles,
+      such as Organization Member and Project Read Only for inventory tables;
+      `audit_config` requires Project Owner in Atlas. The calling IP must also
+      be allowed by the service account API access list.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.MONGODB_ATLAS_ACCESS_TOKEN}}
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/vnd.atlas.2025-03-12+json
+rate_limit:
+  remaining_header: RateLimit-Remaining
+test_queries:
+  - SELECT * FROM mongodb.organizations LIMIT 1
+  - SELECT * FROM mongodb.projects LIMIT 1
+tables:
+  - name: organizations
+    description: MongoDB Atlas organizations visible to the service account.
+    guide: |
+      Use this table to validate credentials and find `org_id` values. Atlas
+      service-account tokens identify an application rather than an interactive
+      user, so this source uses organizations and projects for context
+      discovery instead of exposing a current-user profile.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /orgs
+    response:
+      rows_path: [results]
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 500
+        query_param: itemsPerPage
+      page_param: pageNum
+      page_start: 1
+      page_step: 1
+      max_pages: 20
+    columns:
+      - name: org_id
+        type: Utf8
+        nullable: false
+        description: Atlas organization ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: org_name
+        type: Utf8
+        nullable: false
+        description: Atlas organization name.
+        expr:
+          kind: path
+          path: [name]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Organization creation timestamp, when returned by Atlas.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created]
+
+  - name: projects
+    description: MongoDB Atlas projects visible to the service account.
+    guide: |
+      Projects are also called groups in Atlas API paths. Use `project_id`
+      from this table when querying project-scoped tables such as `clusters`,
+      `database_users`, `alerts`, `project_events`, `audit_config`, and
+      `processes`.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /groups
+    response:
+      rows_path: [results]
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 500
+        query_param: itemsPerPage
+      page_param: pageNum
+      page_start: 1
+      page_step: 1
+      max_pages: 50
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Atlas project ID. This is the groupId used in Atlas API paths.
+        expr:
+          kind: path
+          path: [id]
+      - name: project_name
+        type: Utf8
+        nullable: false
+        description: Atlas project name.
+        expr:
+          kind: path
+          path: [name]
+      - name: org_id
+        type: Utf8
+        nullable: true
+        description: Parent Atlas organization ID.
+        expr:
+          kind: path
+          path: [orgId]
+      - name: cluster_count
+        type: Int64
+        nullable: true
+        description: Number of clusters reported for this project.
+        expr:
+          kind: path
+          path: [clusterCount]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Project creation timestamp, when returned by Atlas.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created]
+
+  - name: clusters
+    description: MongoDB Atlas cluster inventory for one project.
+    guide: |
+      Requires `project_id` from `mongodb.projects`. This table exposes
+      infrastructure metadata only; it does not connect to MongoDB clusters or
+      read collection documents.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+    request:
+      method: GET
+      path: /groups/{{filter.project_id}}/clusters
+    response:
+      rows_path: [results]
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 500
+        query_param: itemsPerPage
+      page_param: pageNum
+      page_start: 1
+      page_step: 1
+      max_pages: 20
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent Atlas project ID.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: cluster_id
+        type: Utf8
+        nullable: true
+        description: Atlas cluster ID, when returned by Atlas.
+        expr:
+          kind: path
+          path: [id]
+      - name: cluster_name
+        type: Utf8
+        nullable: false
+        description: Atlas cluster name.
+        expr:
+          kind: path
+          path: [name]
+      - name: cluster_type
+        type: Utf8
+        nullable: true
+        description: Cluster topology type.
+        expr:
+          kind: path
+          path: [clusterType]
+      - name: mongo_version
+        type: Utf8
+        nullable: true
+        description: MongoDB server version configured for the cluster.
+        expr:
+          kind: path
+          path: [mongoDBVersion]
+      - name: state_name
+        type: Utf8
+        nullable: true
+        description: Current Atlas cluster state.
+        expr:
+          kind: path
+          path: [stateName]
+      - name: provider_name
+        type: Utf8
+        nullable: true
+        description: Cloud provider for the cluster.
+        expr:
+          kind: path
+          path: [providerSettings, providerName]
+      - name: region_name
+        type: Utf8
+        nullable: true
+        description: Primary provider region for the cluster.
+        expr:
+          kind: path
+          path: [providerSettings, regionName]
+      - name: disk_size_gb
+        type: Float64
+        nullable: true
+        description: Cluster disk size in gigabytes.
+        expr:
+          kind: path
+          path: [diskSizeGB]
+      - name: paused
+        type: Boolean
+        nullable: true
+        description: Whether the cluster is paused.
+        expr:
+          kind: path
+          path: [paused]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Cluster creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createDate]
+
+  - name: database_users
+    description: MongoDB Atlas database user metadata for one project.
+    guide: |
+      Requires `project_id` from `mongodb.projects`. This table intentionally
+      exposes database user metadata only. It does not expose passwords,
+      generated credentials, connection strings, tokens, or cluster data.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+    request:
+      method: GET
+      path: /groups/{{filter.project_id}}/databaseUsers
+    response:
+      rows_path: [results]
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 500
+        query_param: itemsPerPage
+      page_param: pageNum
+      page_start: 1
+      page_step: 1
+      max_pages: 20
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent Atlas project ID.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Database username.
+        expr:
+          kind: path
+          path: [username]
+      - name: auth_database
+        type: Utf8
+        nullable: true
+        description: Authentication database for the database user.
+        expr:
+          kind: path
+          path: [databaseName]
+      - name: ldap_auth_type
+        type: Utf8
+        nullable: true
+        description: LDAP authentication type, when configured.
+        expr:
+          kind: path
+          path: [ldapAuthType]
+      - name: x509_type
+        type: Utf8
+        nullable: true
+        description: X.509 authentication type, when configured.
+        expr:
+          kind: path
+          path: [x509Type]
+      - name: roles
+        type: Json
+        nullable: true
+        description: Database roles assigned to the user.
+        expr:
+          kind: path
+          path: [roles]
+      - name: scopes
+        type: Json
+        nullable: true
+        description: Atlas scopes limiting where this database user applies.
+        expr:
+          kind: path
+          path: [scopes]
+
+  - name: alerts
+    description: MongoDB Atlas alerts for one project.
+    guide: |
+      Requires `project_id` from `mongodb.projects`. Use this table for
+      incident summaries, noisy cluster analysis, and operational timelines.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+      - name: status
+      - name: event_type
+    request:
+      method: GET
+      path: /groups/{{filter.project_id}}/alerts
+      query:
+        - name: status
+          from: filter
+          key: status
+        - name: eventTypeName
+          from: filter
+          key: event_type
+    response:
+      rows_path: [results]
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 500
+        query_param: itemsPerPage
+      page_param: pageNum
+      page_start: 1
+      page_step: 1
+      max_pages: 50
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent Atlas project ID.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: alert_id
+        type: Utf8
+        nullable: false
+        description: Atlas alert ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: event_type
+        type: Utf8
+        nullable: true
+        description: Atlas alert event type.
+        expr:
+          kind: path
+          path: [eventTypeName]
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Current alert status.
+        expr:
+          kind: path
+          path: [status]
+      - name: cluster_name
+        type: Utf8
+        nullable: true
+        description: Cluster associated with the alert, when present.
+        expr:
+          kind: path
+          path: [clusterName]
+      - name: replica_set_name
+        type: Utf8
+        nullable: true
+        description: Replica set associated with the alert, when present.
+        expr:
+          kind: path
+          path: [replicaSetName]
+      - name: hostname_and_port
+        type: Utf8
+        nullable: true
+        description: Host associated with the alert, when present.
+        expr:
+          kind: path
+          path: [hostnameAndPort]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Alert creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Alert update timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updated]
+
+  - name: project_events
+    description: MongoDB Atlas project activity events for one project.
+    guide: |
+      Requires `project_id` from `mongodb.projects`. This table provides an
+      infrastructure and governance timeline. It exposes event metadata, not
+      raw audit log files or database documents.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+      - name: event_type
+      - name: min_date
+      - name: max_date
+    request:
+      method: GET
+      path: /groups/{{filter.project_id}}/events
+      query:
+        - name: eventType
+          from: filter
+          key: event_type
+        - name: minDate
+          from: filter
+          key: min_date
+        - name: maxDate
+          from: filter
+          key: max_date
+    response:
+      rows_path: [results]
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 500
+        query_param: itemsPerPage
+      page_param: pageNum
+      page_start: 1
+      page_step: 1
+      max_pages: 50
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent Atlas project ID.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: event_id
+        type: Utf8
+        nullable: false
+        description: Atlas event ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: event_type
+        type: Utf8
+        nullable: true
+        description: Atlas event type.
+        expr:
+          kind: path
+          path: [eventTypeName]
+      - name: username
+        type: Utf8
+        nullable: true
+        description: Atlas user or service account associated with the event.
+        expr:
+          kind: path
+          path: [username]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Event creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created]
+      - name: target_type
+        type: Utf8
+        nullable: true
+        description: Atlas target resource type, when returned by Atlas.
+        expr:
+          kind: path
+          path: [targetType]
+      - name: target_name
+        type: Utf8
+        nullable: true
+        description: Atlas target resource name, when returned by Atlas.
+        expr:
+          kind: path
+          path: [targetName]
+      - name: raw
+        type: Json
+        nullable: true
+        description: Event metadata returned by Atlas for fields not flattened in v1.
+        expr:
+          kind: current_row
+
+  - name: audit_config
+    description: MongoDB Atlas database auditing configuration for one project.
+    guide: |
+      Requires `project_id` from `mongodb.projects`. Atlas requires Project
+      Owner for this endpoint, and the endpoint is not available for M0, M2,
+      M5, or serverless clusters. This table exposes audit configuration only;
+      it does not fetch compressed audit log streams.
+    fetch_limit_default: 1
+    filters:
+      - name: project_id
+        required: true
+    request:
+      method: GET
+      path: /groups/{{filter.project_id}}/auditLog
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent Atlas project ID.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: auditing_enabled
+        type: Boolean
+        nullable: true
+        description: Whether database auditing is enabled for the project.
+        expr:
+          kind: path
+          path: [enabled]
+      - name: audit_authorization_success
+        type: Boolean
+        nullable: true
+        description: Whether successful authorization events are audited.
+        expr:
+          kind: path
+          path: [auditAuthorizationSuccess]
+      - name: configuration_type
+        type: Utf8
+        nullable: true
+        description: Audit filter configuration type.
+        expr:
+          kind: path
+          path: [configurationType]
+      - name: audit_filter
+        type: Utf8
+        nullable: true
+        description: Atlas audit filter JSON string.
+        expr:
+          kind: path
+          path: [auditFilter]
+
+  - name: processes
+    description: MongoDB Atlas process inventory for one project.
+    guide: |
+      Requires `project_id` from `mongodb.projects`. Processes are Atlas
+      monitoring resources such as mongod and mongos hosts. This table provides
+      observability metadata and IDs for future metrics tables without pulling
+      high-volume measurements by default.
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+    request:
+      method: GET
+      path: /groups/{{filter.project_id}}/processes
+    response:
+      rows_path: [results]
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 500
+        query_param: itemsPerPage
+      page_param: pageNum
+      page_start: 1
+      page_step: 1
+      max_pages: 20
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Parent Atlas project ID.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: process_id
+        type: Utf8
+        nullable: false
+        description: Atlas process ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: hostname
+        type: Utf8
+        nullable: true
+        description: Process hostname.
+        expr:
+          kind: path
+          path: [hostname]
+      - name: port
+        type: Int64
+        nullable: true
+        description: Process port.
+        expr:
+          kind: path
+          path: [port]
+      - name: type_name
+        type: Utf8
+        nullable: true
+        description: Process role or type, such as REPLICA_PRIMARY.
+        expr:
+          kind: path
+          path: [typeName]
+      - name: version
+        type: Utf8
+        nullable: true
+        description: MongoDB version running on the process.
+        expr:
+          kind: path
+          path: [version]
+      - name: replica_set_name
+        type: Utf8
+        nullable: true
+        description: Replica set name, when present.
+        expr:
+          kind: path
+          path: [replicaSetName]
+      - name: shard_name
+        type: Utf8
+        nullable: true
+        description: Shard name, when present.
+        expr:
+          kind: path
+          path: [shardName]
+      - name: user_alias
+        type: Utf8
+        nullable: true
+        description: Atlas user alias for the process, when present.
+        expr:
+          kind: path
+          path: [userAlias]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Process creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [created]
+      - name: last_ping_at
+        type: Timestamp
+        nullable: true
+        description: Last Atlas monitoring ping timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [lastPing]


### PR DESCRIPTION
## Summary

Fixes #485 

Add a new `mongodb` community source for querying MongoDB Atlas organizations, projects, clusters, database users, alerts, project events, audit configuration, and process inventory using the MongoDB Atlas Administration API.

This change is manifest-only and uses Coral's existing HTTP source-spec model. It adds read-only MongoDB Atlas infrastructure and observability visibility without changing CLI, MCP, config, runtime, or bundled-source contracts.

## What Changed

Added:

- `sources/community/mongodb/manifest.yaml`
- `sources/community/mongodb/README.md`

## Source Scope

Inputs:

- `MONGODB_ATLAS_ACCESS_TOKEN`

Tables:

- `mongodb.organizations`
  - `GET /orgs`
  - lists Atlas organizations visible to the service account
  - validates token access and helps discover organization context

- `mongodb.projects`
  - `GET /groups`
  - lists Atlas projects visible to the service account
  - exposes project IDs used by project-scoped tables

- `mongodb.clusters`
  - `GET /groups/{project_id}/clusters`
  - requires `project_id`
  - exposes cluster inventory, provider, region, MongoDB version, disk size, pause state, and cluster state

- `mongodb.database_users`
  - `GET /groups/{project_id}/databaseUsers`
  - requires `project_id`
  - exposes database user metadata, roles, scopes, and auth metadata only

- `mongodb.alerts`
  - `GET /groups/{project_id}/alerts`
  - requires `project_id`
  - supports optional `status` and `event_type` filters
  - exposes alert state and cluster/process context

- `mongodb.project_events`
  - `GET /groups/{project_id}/events`
  - requires `project_id`
  - supports optional `event_type`, `min_date`, and `max_date` filters
  - exposes project activity and infrastructure event metadata

- `mongodb.audit_config`
  - `GET /groups/{project_id}/auditLog`
  - requires `project_id`
  - exposes audit configuration only, not raw audit logs

- `mongodb.processes`
  - `GET /groups/{project_id}/processes`
  - requires `project_id`
  - exposes Atlas monitoring process inventory and topology metadata

## Implementation Notes

- uses MongoDB Atlas Administration API bearer auth
- expects a short-lived OAuth access token from an Atlas service account
- sends `Authorization: Bearer <token>`
- sends `Accept: application/vnd.atlas.2025-03-12+json`
- keeps v1 intentionally read-only
- requires `project_id` filters on project-scoped tables
- uses Atlas page pagination with `pageNum` and `itemsPerPage`
- includes `organizations` and `projects` as discovery tables
- exposes high-value flattened infrastructure and observability fields
- preserves nested roles, scopes, and event metadata as JSON where useful
- documents Atlas API access-list requirements for service accounts
- intentionally omits MongoDB document querying, raw logs, audit log streams, mutations, backups, restores, and network configuration

## Validation

Live API testing completed:

- Source installed successfully with real MongoDB Atlas service account credentials
- OAuth access token minted successfully from Atlas service account client ID and client secret
- Declared source tests passed:
  - `SELECT * FROM mongodb.organizations LIMIT 1`
  - `SELECT * FROM mongodb.projects LIMIT 1`
- Source registered all 8 tables:
  - `organizations`
  - `projects`
  - `clusters`
  - `database_users`
  - `alerts`
  - `project_events`
  - `audit_config`
  - `processes`
- Live read-only endpoint smoke checks passed for:
  - `clusters`
  - `database_users`
  - `alerts`
  - `project_events`
  - `audit_config`
  - `processes`

Local validation:

- `cargo run -p coral-cli -- source lint sources/community/mongodb/manifest.yaml`

## Testing Notes

Testing was performed with the MongoDB Atlas Administration API using a real service account. During testing:

- service account OAuth token minting was verified
- Atlas API access-list requirements were confirmed and documented
- organization and project discovery were validated through source test queries
- project-scoped endpoints were checked using a live `project_id`
- alert and process endpoints were verified to return valid empty result sets when no rows were present
- audit configuration endpoint was verified separately because it may require elevated Atlas project permissions

All issues discovered during testing were fixed before this PR.

## Out of Scope

Not included in v1:

- MongoDB collection document querying
- collection scans
- arbitrary BSON schema inspection
- cluster provisioning
- cluster pause, resume, or configuration updates
- database user creation or mutation
- raw MongoDB logs
- compressed audit log streams
- backups and restores
- private networking and access-list management
- App Services APIs
- Data API
- Atlas Search index management
- stream processing APIs
