### PR TITLE
feat(sources/community/tailscale): add Tailscale source spec

### DIFF
--- a/sources/community/tailscale/README.md
+++ b/sources/community/tailscale/README.md
@@ -1,0 +1,209 @@
+# Tailscale Community Source
+
+Query Tailscale devices, users, keys, routes, and DNS settings through Coral SQL
+using the [Tailscale API](https://tailscale.com/api).
+
+## Setup
+
+### 1. Create a Tailscale API token
+
+Create an API access token from the Tailscale admin console under
+**Settings > Keys**.
+
+For longer-lived automation, use a Tailscale trust credential to mint scoped
+access tokens. Grant only the scopes needed for the tables you plan to query:
+
+- `devices:core:read` for `devices`
+- `users:read` for `users`
+- `auth_keys:read`, `api_access_tokens:read`, `oauth_keys:read`, or
+  `federated_keys:read` for `keys`
+- `devices:routes:read` for `device_routes`
+- `dns:read` for `dns_configuration`
+
+### 2. Add the source
+
+```bash
+export TAILSCALE_API_TOKEN="<your-token>"
+export TAILSCALE_TAILNET="-" # or your tailnet name/ID
+coral source add --file sources/community/tailscale/manifest.yaml
+```
+
+### 3. Verify
+
+```bash
+coral source test tailscale
+```
+
+The default test query reads `tailscale.devices`, so the token must be able to
+list devices in the configured tailnet.
+
+## Tables
+
+### `tailscale.devices`
+
+Lists devices in the configured tailnet.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Legacy device ID |
+| `node_id` | Utf8 | Preferred device ID for API calls |
+| `user` | Utf8 | User who registered the device |
+| `name` | Utf8 | MagicDNS name |
+| `hostname` | Utf8 | Machine name |
+| `client_version` | Utf8 | Tailscale client version |
+| `os` | Utf8 | Device operating system |
+| `addresses` | Json | Tailscale IPv4 and IPv6 addresses |
+| `tags` | Json | Device tags |
+| `created_at` | Timestamp | Time the device joined the tailnet |
+| `connected_to_control` | Boolean | Recent control-server connection status |
+| `last_seen_at` | Timestamp | Last control-server connection time |
+| `expires_at` | Timestamp | Device key expiration time |
+| `authorized` | Boolean | Whether the device is authorized |
+| `key_expiry_disabled` | Boolean | Whether key expiry is disabled |
+| `is_external` | Boolean | Whether the device is shared in |
+| `is_ephemeral` | Boolean | Whether the device is ephemeral |
+| `update_available` | Boolean | Whether a client update is available |
+| `blocks_incoming_connections` | Boolean | Whether incoming Tailscale connections are blocked |
+| `enabled_routes` | Json | Approved subnet routes |
+| `advertised_routes` | Json | Advertised subnet routes |
+| `client_connectivity` | Json | Physical network connectivity details |
+| `machine_key` | Utf8 | Machine key |
+| `node_key` | Utf8 | Node key |
+
+**Optional filters:** `hostname`, `name`, `user`, `os`, `tags`, `authorized`,
+`is_external`, `is_ephemeral`, `key_expiry_disabled`
+
+### `tailscale.users`
+
+Lists users in the configured tailnet.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | User ID |
+| `display_name` | Utf8 | Display name |
+| `login_name` | Utf8 | Login name |
+| `profile_pic_url` | Utf8 | Profile picture URL |
+| `tailnet_id` | Utf8 | Owning tailnet |
+| `created_at` | Timestamp | Join time |
+| `type` | Utf8 | User relation, such as `member` or `shared` |
+| `role` | Utf8 | User role |
+| `status` | Utf8 | User status |
+| `device_count` | Int64 | Number of devices owned by the user |
+| `last_seen_at` | Timestamp | Last authentication or owned-device connection time |
+| `currently_connected` | Boolean | Whether any owned device is connected |
+
+**Optional filters:** `type`, `role`
+
+### `tailscale.keys`
+
+Lists active auth keys, API access tokens, OAuth clients, and federated
+identities visible to the token.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Key ID |
+| `key_type` | Utf8 | `auth`, `client`, `api`, or `federated` |
+| `expiry_seconds` | Int64 | Duration until expiry |
+| `created_at` | Timestamp | Creation time |
+| `updated_at` | Timestamp | Update time |
+| `expires_at` | Timestamp | Expiration time |
+| `revoked_at` | Timestamp | Revocation time |
+| `scopes` | Json | Granted scopes |
+| `tags` | Json | Trust credential tags |
+| `capabilities` | Json | Auth key capabilities |
+| `description` | Utf8 | Key description |
+| `invalid` | Boolean | Whether the key is revoked or expired |
+| `user_id` | Utf8 | User who created the key |
+| `audience` | Utf8 | Federated identity audience |
+| `issuer` | Utf8 | Federated identity issuer |
+
+**Optional filter:** `all`
+
+### `tailscale.device_routes`
+
+Lists advertised and enabled subnet routes for a single device.
+
+| Column | Type | Description |
+|---|---|---|
+| `device_id` | Utf8 | Device ID used for the request |
+| `advertised_routes` | Json | Subnets this device requests to expose |
+| `enabled_routes` | Json | Approved subnet routes |
+
+**Required filter:** `device_id`
+
+### `tailscale.dns_configuration`
+
+Returns the full DNS configuration for the configured tailnet.
+
+| Column | Type | Description |
+|---|---|---|
+| `nameservers` | Json | Global DNS resolvers |
+| `split_dns` | Json | Split DNS suffix mappings |
+| `search_paths` | Json | DNS search domains |
+| `preferences__override_local_dns` | Boolean | Whether resolvers override local OS DNS |
+| `preferences__magic_dns` | Boolean | Whether MagicDNS is enabled |
+
+## Example queries
+
+```sql
+-- Find Linux devices that have not checked in recently
+SELECT hostname, user, last_seen_at, client_version
+FROM tailscale.devices
+WHERE os = 'linux'
+ORDER BY last_seen_at ASC
+LIMIT 20;
+
+-- Inventory tagged production devices
+SELECT hostname, user, addresses, tags
+FROM tailscale.devices
+WHERE tags = 'tag:prod';
+
+-- Review suspended or idle users
+SELECT display_name, login_name, status, device_count, last_seen_at
+FROM tailscale.users
+WHERE role = 'member'
+ORDER BY last_seen_at ASC;
+
+-- Inspect route approvals for a device
+SELECT advertised_routes, enabled_routes
+FROM tailscale.device_routes
+WHERE device_id = 'n292kg92CNTRL';
+
+-- Check MagicDNS status
+SELECT preferences__magic_dns, preferences__override_local_dns, nameservers
+FROM tailscale.dns_configuration;
+```
+
+## Validation
+
+```bash
+export TAILSCALE_API_TOKEN="<your-token>"
+export TAILSCALE_TAILNET="-"
+coral source lint sources/community/tailscale/manifest.yaml
+coral source add --file sources/community/tailscale/manifest.yaml
+coral source test tailscale
+coral sql "SELECT * FROM coral.tables WHERE schema_name = 'tailscale'"
+coral sql "SELECT * FROM coral.columns WHERE schema_name = 'tailscale'"
+coral sql "SELECT hostname, os FROM tailscale.devices LIMIT 5"
+```
+
+## Limitations
+
+- **Read-only.** This source does not authorize, rename, delete, tag, invite, or
+  otherwise mutate Tailscale resources.
+- **No pagination.** The Tailscale API returns all results for these endpoints
+  at once.
+- **Token visibility.** The rows returned by `tailscale.keys` depend on the
+  access token type and scopes used for the request.
+- **Dynamic device filters.** Tailscale supports server-side filtering by
+  top-level device fields. This source exposes common filters in the manifest;
+  less common API fields may require extending the source.
+
+## Out of scope for v1
+
+- Policy file and ACL inspection
+- Configuration and network logs
+- Webhook management
+- User and device invite management
+- Tailscale Services
+- Any write operation

--- a/sources/community/tailscale/manifest.yaml
+++ b/sources/community/tailscale/manifest.yaml
@@ -1,0 +1,483 @@
+name: tailscale
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Tailscale devices, users, keys, device routes, and DNS configuration
+  from a tailnet.
+base_url: "{{input.TAILSCALE_API_BASE}}"
+
+inputs:
+  TAILSCALE_API_BASE:
+    kind: variable
+    default: https://api.tailscale.com/api/v2
+    hint: |
+      Base URL for the Tailscale API. Keep the default for Tailscale Cloud.
+  TAILSCALE_TAILNET:
+    kind: variable
+    default: "-"
+    hint: |
+      Tailnet identifier to query. Use "-" for the default tailnet associated
+      with the token, or provide the tailnet name/ID shown in Tailscale.
+  TAILSCALE_API_TOKEN:
+    kind: secret
+    hint: |
+      Tailscale API access token or trust-credential access token. Create one
+      from the Tailscale admin console under Settings > Keys, or use a scoped
+      trust credential token. Read-only queries require scopes such as
+      devices:core:read, users:read, auth_keys:read, api_access_tokens:read,
+      oauth_keys:read, federated_keys:read, devices:routes:read, and dns:read
+      depending on the tables you query.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.TAILSCALE_API_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT node_id, hostname, os FROM tailscale.devices LIMIT 1
+
+tables:
+  - name: devices
+    description: |
+      Devices in the configured tailnet. Optional filters map to common
+      top-level Tailscale device fields supported by the API.
+    filters:
+      - name: hostname
+      - name: name
+      - name: user
+      - name: os
+      - name: tags
+      - name: authorized
+      - name: is_external
+      - name: is_ephemeral
+      - name: key_expiry_disabled
+    request:
+      method: GET
+      path: /tailnet/{{input.TAILSCALE_TAILNET}}/devices
+      query:
+        - name: hostname
+          from: filter
+          key: hostname
+        - name: name
+          from: filter
+          key: name
+        - name: user
+          from: filter
+          key: user
+        - name: os
+          from: filter
+          key: os
+        - name: tags
+          from: filter
+          key: tags
+        - name: authorized
+          from: filter_bool
+          key: authorized
+        - name: isExternal
+          from: filter_bool
+          key: is_external
+        - name: isEphemeral
+          from: filter_bool
+          key: is_ephemeral
+        - name: keyExpiryDisabled
+          from: filter_bool
+          key: key_expiry_disabled
+    response:
+      rows_path: [devices]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Legacy device identifier.
+        expr: {kind: path, path: [id]}
+      - name: node_id
+        type: Utf8
+        nullable: false
+        description: Preferred device identifier for device-scoped API calls.
+        expr: {kind: path, path: [nodeId]}
+      - name: user
+        type: Utf8
+        nullable: true
+        description: User who registered the device, or device owner for untagged devices.
+        expr: {kind: path, path: [user]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: MagicDNS name for the device.
+        expr: {kind: path, path: [name]}
+      - name: hostname
+        type: Utf8
+        nullable: true
+        description: Machine name in the Tailscale admin console.
+        expr: {kind: path, path: [hostname]}
+      - name: client_version
+        type: Utf8
+        nullable: true
+        description: Tailscale client version.
+        expr: {kind: path, path: [clientVersion]}
+      - name: os
+        type: Utf8
+        nullable: true
+        description: Device operating system.
+        expr: {kind: path, path: [os]}
+      - name: addresses
+        type: Json
+        nullable: true
+        description: Tailscale IPv4 and IPv6 addresses assigned to the device.
+        expr: {kind: path, path: [addresses]}
+      - name: tags
+        type: Json
+        nullable: true
+        description: Tags applied to the device.
+        expr: {kind: path, path: [tags]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Time the device was added to the tailnet.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: connected_to_control
+        type: Boolean
+        nullable: true
+        description: Whether the device recently maintained a connection to the control server.
+        expr: {kind: path, path: [connectedToControl]}
+      - name: last_seen_at
+        type: Timestamp
+        nullable: true
+        description: Last time the device was connected to the control server.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [lastSeen]}
+      - name: expires_at
+        type: Timestamp
+        nullable: true
+        description: Device key expiration time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [expires]}
+      - name: authorized
+        type: Boolean
+        nullable: true
+        description: Whether the device is authorized to join the tailnet.
+        expr: {kind: path, path: [authorized]}
+      - name: key_expiry_disabled
+        type: Boolean
+        nullable: true
+        description: Whether device key expiry is disabled.
+        expr: {kind: path, path: [keyExpiryDisabled]}
+      - name: is_external
+        type: Boolean
+        nullable: true
+        description: Whether the device is shared in from another tailnet.
+        expr: {kind: path, path: [isExternal]}
+      - name: is_ephemeral
+        type: Boolean
+        nullable: true
+        description: Whether the device is ephemeral.
+        expr: {kind: path, path: [isEphemeral]}
+      - name: update_available
+        type: Boolean
+        nullable: true
+        description: Whether a Tailscale client update is available.
+        expr: {kind: path, path: [updateAvailable]}
+      - name: blocks_incoming_connections
+        type: Boolean
+        nullable: true
+        description: Whether the device blocks incoming Tailscale connections.
+        expr: {kind: path, path: [blocksIncomingConnections]}
+      - name: enabled_routes
+        type: Json
+        nullable: true
+        description: Approved subnet routes for the device.
+        expr: {kind: path, path: [enabledRoutes]}
+      - name: advertised_routes
+        type: Json
+        nullable: true
+        description: Subnet routes advertised by the device.
+        expr: {kind: path, path: [advertisedRoutes]}
+      - name: client_connectivity
+        type: Json
+        nullable: true
+        description: Current physical network connectivity details for the device.
+        expr: {kind: path, path: [clientConnectivity]}
+      - name: machine_key
+        type: Utf8
+        nullable: true
+        description: Device machine key.
+        expr: {kind: path, path: [machineKey]}
+      - name: node_key
+        type: Utf8
+        nullable: true
+        description: Device node key.
+        expr: {kind: path, path: [nodeKey]}
+
+  - name: users
+    description: Users in the configured tailnet.
+    filters:
+      - name: type
+      - name: role
+    request:
+      method: GET
+      path: /tailnet/{{input.TAILSCALE_TAILNET}}/users
+      query:
+        - name: type
+          from: filter
+          key: type
+        - name: role
+          from: filter
+          key: role
+    response:
+      rows_path: [users]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique Tailscale user identifier.
+        expr: {kind: path, path: [id]}
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: User display name.
+        expr: {kind: path, path: [displayName]}
+      - name: login_name
+        type: Utf8
+        nullable: true
+        description: User login name.
+        expr: {kind: path, path: [loginName]}
+      - name: profile_pic_url
+        type: Utf8
+        nullable: true
+        description: User profile picture URL.
+        expr: {kind: path, path: [profilePicUrl]}
+      - name: tailnet_id
+        type: Utf8
+        nullable: true
+        description: Tailnet that owns the user.
+        expr: {kind: path, path: [tailnetId]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Time the user joined the tailnet.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: User relation to the tailnet, such as member or shared.
+        expr: {kind: path, path: [type]}
+      - name: role
+        type: Utf8
+        nullable: true
+        description: User role in the tailnet.
+        expr: {kind: path, path: [role]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: User status.
+        expr: {kind: path, path: [status]}
+      - name: device_count
+        type: Int64
+        nullable: true
+        description: Number of devices owned by the user.
+        expr: {kind: path, path: [deviceCount]}
+      - name: last_seen_at
+        type: Timestamp
+        nullable: true
+        description: Most recent user authentication or owned-device connection time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [lastSeen]}
+      - name: currently_connected
+        type: Boolean
+        nullable: true
+        description: Whether the user currently has a device connected to the control server.
+        expr: {kind: path, path: [currentlyConnected]}
+
+  - name: keys
+    description: Active auth keys, API access tokens, OAuth clients, and federated identities.
+    filters:
+      - name: all
+    request:
+      method: GET
+      path: /tailnet/{{input.TAILSCALE_TAILNET}}/keys
+      query:
+        - name: all
+          from: filter_bool
+          key: all
+    response:
+      rows_path: [keys]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Key identifier.
+        expr: {kind: path, path: [id]}
+      - name: key_type
+        type: Utf8
+        nullable: true
+        description: "Key type: auth, client, api, or federated."
+        expr: {kind: path, path: [keyType]}
+      - name: expiry_seconds
+        type: Int64
+        nullable: true
+        description: Duration in seconds until the key expires.
+        expr: {kind: path, path: [expirySeconds]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Key creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Key update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated]}
+      - name: expires_at
+        type: Timestamp
+        nullable: true
+        description: Key expiration time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [expires]}
+      - name: revoked_at
+        type: Timestamp
+        nullable: true
+        description: Key revocation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [revoked]}
+      - name: scopes
+        type: Json
+        nullable: true
+        description: Scopes granted to the key.
+        expr: {kind: path, path: [scopes]}
+      - name: tags
+        type: Json
+        nullable: true
+        description: Tags associated with a trust credential.
+        expr: {kind: path, path: [tags]}
+      - name: capabilities
+        type: Json
+        nullable: true
+        description: Auth-key capabilities.
+        expr: {kind: path, path: [capabilities]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Key description.
+        expr: {kind: path, path: [description]}
+      - name: invalid
+        type: Boolean
+        nullable: true
+        description: Whether the key is revoked or expired.
+        expr: {kind: path, path: [invalid]}
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: User who created the key, empty for trust credentials.
+        expr: {kind: path, path: [userId]}
+      - name: audience
+        type: Utf8
+        nullable: true
+        description: OIDC audience for federated identities.
+        expr: {kind: path, path: [audience]}
+      - name: issuer
+        type: Utf8
+        nullable: true
+        description: OIDC issuer for federated identities.
+        expr: {kind: path, path: [issuer]}
+
+  - name: device_routes
+    description: Advertised and enabled subnet routes for a device.
+    filters:
+      - name: device_id
+        required: true
+    request:
+      method: GET
+      path: /device/{{filter.device_id}}/routes
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: device_id
+        type: Utf8
+        nullable: false
+        description: Device identifier used for the request.
+        expr:
+          kind: from_filter
+          key: device_id
+      - name: advertised_routes
+        type: Json
+        nullable: true
+        description: Subnets this device requests to expose.
+        expr: {kind: path, path: [advertisedRoutes]}
+      - name: enabled_routes
+        type: Json
+        nullable: true
+        description: Approved subnet routes for this device.
+        expr: {kind: path, path: [enabledRoutes]}
+
+  - name: dns_configuration
+    description: Full DNS configuration for the configured tailnet.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /tailnet/{{input.TAILSCALE_TAILNET}}/dns/configuration
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: nameservers
+        type: Json
+        nullable: true
+        description: Global DNS resolvers configured for the tailnet.
+        expr: {kind: path, path: [nameservers]}
+      - name: split_dns
+        type: Json
+        nullable: true
+        description: Split DNS suffix-to-resolver mappings.
+        expr: {kind: path, path: [splitDNS]}
+      - name: search_paths
+        type: Json
+        nullable: true
+        description: DNS search domains applied to the tailnet.
+        expr: {kind: path, path: [searchPaths]}
+      - name: preferences__override_local_dns
+        type: Boolean
+        nullable: true
+        description: Whether configured resolvers override local OS DNS.
+        expr: {kind: path, path: [preferences, overrideLocalDNS]}
+      - name: preferences__magic_dns
+        type: Boolean
+        nullable: true
+        description: Whether MagicDNS is enabled for the tailnet.
+        expr: {kind: path, path: [preferences, magicDNS]}


### PR DESCRIPTION
## Summary
- add a community Tailscale HTTP source spec for devices, users, keys, device routes, and DNS configuration
- document setup, required scopes, table columns, example queries, validation, and v1 limitations
- confirmed repo source audit: existing core/community sources include ClickUp, CloudWatch, Confluence, Datadog, GitHub, GitLab, Grafana, incident.io, Intercom, Jira, LaunchDarkly, Linear, Notion, OpenObserve, PagerDuty, PostHog, Sentry, Slack, StatusGator, Stripe, W&B, Cal, ClickHouse, crates.io, Fly.io, HN, Neon, and Postman; Tailscale was not present and fits the documented custom-source criteria

## Validation
- Ruby YAML parse: passed
- git diff --check: passed
- make lint-sources: not run successfully because ryl is not installed in this environment
- coral source lint / make rust-checks: not run because cargo is not installed in this environment

## Contributor behavior
- No agent/contributor operating guidance changed.