### PR TITLE
feat(sources/community/coralogix): add Coralogix source spec

### DIFF
--- a/sources/community/coralogix/README.md
+++ b/sources/community/coralogix/README.md
@@ -1,0 +1,228 @@
+# Coralogix Community Source
+
+Query Coralogix dashboards, alert definitions, service SLOs, team groups, and
+roles through Coral SQL using the
+[Coralogix OpenAPI management APIs](https://docs.coralogix.com/introduction-latest).
+
+## Setup
+
+### 1. Create a Coralogix API key
+
+Create an API key from **Data Flow > API Keys** in your Coralogix account.
+Grant only the read permissions needed for the tables you plan to query, for
+example:
+
+- `team-dashboards:Read` for dashboards and dashboard folders
+- `alerts:ReadConfig` for alert definitions
+- APM SLO read permissions for service SLOs
+- Team administration read permissions for team groups and roles
+
+### 2. Choose the API endpoint
+
+Use the management API endpoint for your Coralogix region. The default is:
+
+```bash
+export CORALOGIX_API_BASE="https://api.coralogix.com/mgmt/openapi/5"
+```
+
+If your account uses a regional endpoint, replace the host with the endpoint
+from your Coralogix documentation/account.
+
+### 3. Add the source
+
+```bash
+export CORALOGIX_API_KEY="<your-api-key>"
+coral source add --file sources/community/coralogix/manifest.yaml
+```
+
+### 4. Verify
+
+```bash
+coral source test coralogix
+```
+
+The default test query reads `coralogix.dashboards`, so the API key must have
+dashboard read access.
+
+## Tables
+
+### `coralogix.dashboards`
+
+Dashboard catalog items accessible to the API key.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Dashboard ID |
+| `name` | Utf8 | Dashboard name |
+| `slug_name` | Utf8 | Dashboard slug |
+| `description` | Utf8 | Dashboard description |
+| `author_id` | Utf8 | Author ID |
+| `folder__id` | Utf8 | Folder ID |
+| `folder__name` | Utf8 | Folder name |
+| `folder__parent_id` | Utf8 | Parent folder ID |
+| `create_time` | Timestamp | Creation time |
+| `update_time` | Timestamp | Update time |
+| `is_default` | Boolean | Whether this is a default dashboard |
+| `is_locked` | Boolean | Whether this dashboard is locked |
+| `is_pinned` | Boolean | Whether this dashboard is pinned |
+| `raw` | Json | Full dashboard catalog item |
+
+### `coralogix.dashboard_folders`
+
+Dashboard folders accessible to the API key.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Folder ID |
+| `name` | Utf8 | Folder name |
+| `parent_id` | Utf8 | Parent folder ID |
+
+### `coralogix.alerts`
+
+Alert definitions accessible to the API key.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Persistent alert definition ID |
+| `alert_version_id` | Utf8 | Alert version ID |
+| `name` | Utf8 | Alert name |
+| `description` | Utf8 | Alert description |
+| `status` | Utf8 | Alert status |
+| `priority` | Utf8 | Alert priority |
+| `created_time` | Timestamp | Creation time |
+| `updated_time` | Timestamp | Update time |
+| `last_triggered_time` | Timestamp | Last trigger time |
+| `properties` | Json | Alert definition properties |
+| `raw` | Json | Full alert definition payload |
+
+### `coralogix.service_slos`
+
+APM service-level objectives.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | SLO ID |
+| `name` | Utf8 | SLO name |
+| `service_name` | Utf8 | Service name |
+| `description` | Utf8 | SLO description |
+| `status` | Utf8 | SLO status |
+| `target_percentage` | Int64 | SLO target percentage |
+| `remaining_error_budget_percentage` | Int64 | Remaining error budget percentage |
+| `created_at` | Timestamp | Creation time |
+| `filters` | Json | SLO filters |
+| `period` | Json | Evaluation period |
+| `latency_sli` | Json | Latency SLI configuration |
+| `error_sli` | Json | Error SLI configuration |
+
+**Optional filter:** `service_name`
+
+### `coralogix.team_groups`
+
+Team groups with role and scope configuration.
+
+| Column | Type | Description |
+|---|---|---|
+| `group_id` | Int64 | Group ID |
+| `name` | Utf8 | Group name |
+| `description` | Utf8 | Group description |
+| `external_id` | Utf8 | External identity provider ID |
+| `group_origin` | Utf8 | Group origin |
+| `group_type` | Utf8 | Group type |
+| `team_id` | Int64 | Team ID |
+| `next_gen_scope_id` | Utf8 | Scope ID |
+| `created_at` | Timestamp | Creation time |
+| `updated_at` | Timestamp | Update time |
+| `roles` | Json | Assigned roles |
+| `scope` | Json | Assigned scope |
+
+### `coralogix.custom_roles`
+
+Custom team roles.
+
+| Column | Type | Description |
+|---|---|---|
+| `role_id` | Int64 | Role ID |
+| `name` | Utf8 | Role name |
+| `description` | Utf8 | Role description |
+| `team_id` | Int64 | Team ID |
+| `parent_role_id` | Int64 | Parent role ID |
+| `parent_role_name` | Utf8 | Parent role name |
+| `permissions` | Json | Role permissions |
+
+**Optional filter:** `team_id`
+
+### `coralogix.system_roles`
+
+Built-in Coralogix roles.
+
+| Column | Type | Description |
+|---|---|---|
+| `role_id` | Int64 | Role ID |
+| `name` | Utf8 | Role name |
+| `description` | Utf8 | Role description |
+| `permissions` | Json | Role permissions |
+
+## Example Queries
+
+```sql
+-- List dashboards by folder
+SELECT folder__name, name, update_time, is_locked
+FROM coralogix.dashboards
+ORDER BY folder__name, name;
+
+-- Review alert definitions and last trigger time
+SELECT name, status, priority, last_triggered_time
+FROM coralogix.alerts
+ORDER BY last_triggered_time DESC
+LIMIT 20;
+
+-- Check service SLO error budgets
+SELECT service_name, name, target_percentage, remaining_error_budget_percentage
+FROM coralogix.service_slos
+ORDER BY remaining_error_budget_percentage ASC
+LIMIT 20;
+
+-- Inspect group role assignments
+SELECT name, group_origin, team_id, roles
+FROM coralogix.team_groups
+ORDER BY name;
+
+-- Find roles with a specific permission
+SELECT name, permissions
+FROM coralogix.system_roles
+WHERE CAST(permissions AS VARCHAR) LIKE '%alerts%';
+```
+
+## Validation
+
+```bash
+export CORALOGIX_API_KEY="<your-api-key>"
+export CORALOGIX_API_BASE="https://api.coralogix.com/mgmt/openapi/5"
+coral source lint sources/community/coralogix/manifest.yaml
+coral source add --file sources/community/coralogix/manifest.yaml
+coral source test coralogix
+coral sql "SELECT * FROM coral.tables WHERE schema_name = 'coralogix'"
+coral sql "SELECT * FROM coral.columns WHERE schema_name = 'coralogix'"
+coral sql "SELECT name, folder__name FROM coralogix.dashboards LIMIT 5"
+```
+
+## Limitations
+
+- **Read-only.** This source does not create, update, delete, enable, or disable
+  Coralogix resources.
+- **Regional endpoints.** Coralogix uses regional API endpoints. Set
+  `CORALOGIX_API_BASE` to the endpoint for your account.
+- **Pagination.** This first pass maps endpoints that return compact inventory
+  payloads directly. Some Coralogix APIs expose advanced object-shaped
+  pagination/filter parameters that can be added in a future revision.
+- **Permissions.** Empty or unauthorized results usually mean the API key lacks
+  the corresponding read permission.
+
+## Out of scope for v1
+
+- Logs, metrics, and trace data queries
+- Incidents and cases
+- Alert event history
+- Parsing rules and data routing rules
+- Dashboard widget expansion
+- Write operations

--- a/sources/community/coralogix/manifest.yaml
+++ b/sources/community/coralogix/manifest.yaml
@@ -1,0 +1,465 @@
+name: coralogix
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Coralogix dashboards, alerts, SLOs, team groups, and roles.
+base_url: "{{input.CORALOGIX_API_BASE}}"
+
+inputs:
+  CORALOGIX_API_BASE:
+    kind: variable
+    default: https://api.coralogix.com/mgmt/openapi/5
+    hint: |
+      Base URL for Coralogix management APIs. Keep the default for the global
+      endpoint, or use the regional API endpoint from your Coralogix account.
+  CORALOGIX_API_KEY:
+    kind: secret
+    hint: |
+      Coralogix API key with read permissions for the resources you plan to
+      query, such as team-dashboards:Read, alerts:ReadConfig, and case/APM or
+      team administration read scopes as needed.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.CORALOGIX_API_KEY}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name FROM coralogix.dashboards LIMIT 1
+
+tables:
+  - name: dashboards
+    description: Dashboards accessible to the configured Coralogix API key.
+    request:
+      method: GET
+      path: /dashboards/dashboards/v1/catalog
+    response:
+      rows_path: [items]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Dashboard ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Dashboard name.
+        expr: {kind: path, path: [name]}
+      - name: slug_name
+        type: Utf8
+        nullable: true
+        description: Dashboard slug name.
+        expr: {kind: path, path: [slugName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Dashboard description.
+        expr: {kind: path, path: [description]}
+      - name: author_id
+        type: Utf8
+        nullable: true
+        description: Author ID.
+        expr: {kind: path, path: [authorId]}
+      - name: folder__id
+        type: Utf8
+        nullable: true
+        description: Folder ID containing the dashboard.
+        expr: {kind: path, path: [folder, id]}
+      - name: folder__name
+        type: Utf8
+        nullable: true
+        description: Folder name containing the dashboard.
+        expr: {kind: path, path: [folder, name]}
+      - name: folder__parent_id
+        type: Utf8
+        nullable: true
+        description: Parent folder ID.
+        expr: {kind: path, path: [folder, parentId]}
+      - name: create_time
+        type: Timestamp
+        nullable: true
+        description: Dashboard creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createTime]}
+      - name: update_time
+        type: Timestamp
+        nullable: true
+        description: Dashboard update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updateTime]}
+      - name: is_default
+        type: Boolean
+        nullable: true
+        description: Whether this is a default dashboard.
+        expr: {kind: path, path: [isDefault]}
+      - name: is_locked
+        type: Boolean
+        nullable: true
+        description: Whether this dashboard is locked.
+        expr: {kind: path, path: [isLocked]}
+      - name: is_pinned
+        type: Boolean
+        nullable: true
+        description: Whether this dashboard is pinned.
+        expr: {kind: path, path: [isPinned]}
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full dashboard catalog item.
+        expr: {kind: path, path: []}
+
+  - name: dashboard_folders
+    description: Dashboard folders accessible to the configured API key.
+    request:
+      method: GET
+      path: /dashboards/dashboards/v1/folders
+    response:
+      rows_path: [folder]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Folder ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Folder name.
+        expr: {kind: path, path: [name]}
+      - name: parent_id
+        type: Utf8
+        nullable: true
+        description: Parent folder ID.
+        expr: {kind: path, path: [parentId]}
+
+  - name: alerts
+    description: Alert definitions accessible to the configured API key.
+    request:
+      method: GET
+      path: /alerts/alerts-general/v3
+    response:
+      rows_path: [alertDefs]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Persistent alert definition ID.
+        expr: {kind: path, path: [id]}
+      - name: alert_version_id
+        type: Utf8
+        nullable: true
+        description: Alert version ID.
+        expr: {kind: path, path: [alertVersionId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Alert name.
+        expr: {kind: path, path: [alertDefProperties, name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Alert description.
+        expr: {kind: path, path: [alertDefProperties, description]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Alert status.
+        expr: {kind: path, path: [status]}
+      - name: priority
+        type: Utf8
+        nullable: true
+        description: Alert priority.
+        expr: {kind: path, path: [alertDefProperties, priority]}
+      - name: created_time
+        type: Timestamp
+        nullable: true
+        description: Alert creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdTime]}
+      - name: updated_time
+        type: Timestamp
+        nullable: true
+        description: Alert update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updatedTime]}
+      - name: last_triggered_time
+        type: Timestamp
+        nullable: true
+        description: Last time the alert triggered.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [lastTriggeredTime]}
+      - name: properties
+        type: Json
+        nullable: true
+        description: Full alert definition properties.
+        expr: {kind: path, path: [alertDefProperties]}
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full alert definition payload.
+        expr: {kind: path, path: []}
+
+  - name: service_slos
+    description: Coralogix APM service-level objectives.
+    filters:
+      - name: service_name
+    request:
+      method: GET
+      path: /apm/apm-slo/v1
+      query:
+        - name: service_names
+          from: filter
+          key: service_name
+    response:
+      rows_path: [slos]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Service SLO ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Service SLO name.
+        expr: {kind: path, path: [name]}
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: Service name.
+        expr: {kind: path, path: [serviceName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: SLO description.
+        expr: {kind: path, path: [description]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: SLO status.
+        expr: {kind: path, path: [status]}
+      - name: target_percentage
+        type: Int64
+        nullable: true
+        description: SLO target percentage.
+        expr: {kind: path, path: [targetPercentage]}
+      - name: remaining_error_budget_percentage
+        type: Int64
+        nullable: true
+        description: Remaining error budget percentage.
+        expr: {kind: path, path: [remainingErrorBudgetPercentage]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: SLO creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
+      - name: filters
+        type: Json
+        nullable: true
+        description: SLO filters.
+        expr: {kind: path, path: [filters]}
+      - name: period
+        type: Json
+        nullable: true
+        description: SLO evaluation period.
+        expr: {kind: path, path: [period]}
+      - name: latency_sli
+        type: Json
+        nullable: true
+        description: Latency SLI configuration.
+        expr: {kind: path, path: [latencySli]}
+      - name: error_sli
+        type: Json
+        nullable: true
+        description: Error SLI configuration.
+        expr: {kind: path, path: [errorSli]}
+
+  - name: team_groups
+    description: Coralogix team groups with roles and scope configuration.
+    request:
+      method: GET
+      path: /aaa/team-groups/v1
+    response:
+      rows_path: [groups]
+    pagination:
+      mode: none
+    columns:
+      - name: group_id
+        type: Int64
+        nullable: false
+        description: Team group ID.
+        expr: {kind: path, path: [groupId, id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Team group name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Team group description.
+        expr: {kind: path, path: [description]}
+      - name: external_id
+        type: Utf8
+        nullable: true
+        description: External identity provider ID.
+        expr: {kind: path, path: [externalId]}
+      - name: group_origin
+        type: Utf8
+        nullable: true
+        description: Group origin.
+        expr: {kind: path, path: [groupOrigin]}
+      - name: group_type
+        type: Utf8
+        nullable: true
+        description: Group type.
+        expr: {kind: path, path: [groupType]}
+      - name: team_id
+        type: Int64
+        nullable: true
+        description: Coralogix team ID.
+        expr: {kind: path, path: [teamId, id]}
+      - name: next_gen_scope_id
+        type: Utf8
+        nullable: true
+        description: Next-generation scope ID.
+        expr: {kind: path, path: [nextGenScopeId]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Group creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Group update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updatedAt]}
+      - name: roles
+        type: Json
+        nullable: true
+        description: Roles assigned to the group.
+        expr: {kind: path, path: [roles]}
+      - name: scope
+        type: Json
+        nullable: true
+        description: Scope assigned to the group.
+        expr: {kind: path, path: [scope]}
+
+  - name: custom_roles
+    description: Custom Coralogix team roles.
+    filters:
+      - name: team_id
+    request:
+      method: GET
+      path: /aaa/team-roles/v1/custom-roles
+      query:
+        - name: team_id
+          from: filter_int
+          key: team_id
+    response:
+      rows_path: [roles]
+    pagination:
+      mode: none
+    columns:
+      - name: role_id
+        type: Int64
+        nullable: false
+        description: Role ID.
+        expr: {kind: path, path: [roleId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Role name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Role description.
+        expr: {kind: path, path: [description]}
+      - name: team_id
+        type: Int64
+        nullable: true
+        description: Team ID.
+        expr: {kind: path, path: [teamId]}
+      - name: parent_role_id
+        type: Int64
+        nullable: true
+        description: Parent role ID.
+        expr: {kind: path, path: [parentRoleId]}
+      - name: parent_role_name
+        type: Utf8
+        nullable: true
+        description: Parent role name.
+        expr: {kind: path, path: [parentRoleName]}
+      - name: permissions
+        type: Json
+        nullable: true
+        description: Permissions granted by the role.
+        expr: {kind: path, path: [permissions]}
+
+  - name: system_roles
+    description: Built-in Coralogix system roles.
+    request:
+      method: GET
+      path: /aaa/team-roles/v1/system-roles
+    response:
+      rows_path: [roles]
+    pagination:
+      mode: none
+    columns:
+      - name: role_id
+        type: Int64
+        nullable: false
+        description: Role ID.
+        expr: {kind: path, path: [roleId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Role name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Role description.
+        expr: {kind: path, path: [description]}
+      - name: permissions
+        type: Json
+        nullable: true
+        description: Permissions granted by the role.
+        expr: {kind: path, path: [permissions]}


### PR DESCRIPTION
## Summary
- add a community Coralogix HTTP source spec for dashboards, dashboard folders, alert definitions, service SLOs, team groups, custom roles, and system roles
- document setup, regional API base configuration, table columns, example SQL, validation, and v1 limitations
- checked existing repo sources and open PRs before implementation; Coralogix was not present and no open Coralogix source PR was found

## Validation
- Ruby YAML parse: passed
- coral source lint sources/community/coralogix/manifest.yaml: passed
- git diff --check: passed
- live coral source test: not run because no Coralogix API key is available in this environment
- make rust-checks: not run because cargo is not installed in this environment

## Contributor behavior
- No agent/contributor operating guidance changed.