### PR TITLE
feat(sources/community/mailgun): add Mailgun community source

### DIFF
--- a/sources/community/mailgun/README.md
+++ b/sources/community/mailgun/README.md
@@ -1,0 +1,230 @@
+# Mailgun
+
+Query sending domains, SMTP credentials, inbound routes, and email
+suppression lists (bounces, unsubscribes, complaints) from Mailgun.
+
+## Setup
+
+### Get Your API Key
+
+1. Log in to the [Mailgun Dashboard](https://app.mailgun.com)
+2. Navigate to **Account Settings → API Security**
+3. Copy your **Private API Key**
+
+### Add the Source
+
+```bash
+export MAILGUN_API_KEY="key-your-private-api-key"
+coral source add --file sources/community/mailgun/manifest.yaml
+```
+
+For EU-hosted domains, also set the base URL before adding the source:
+
+```bash
+export MAILGUN_BASE_URL="https://api.eu.mailgun.net"
+```
+
+## Tables
+
+### `domains`
+
+Lists all sending domains for the Mailgun account. Returns domain
+verification state, type, SMTP login, security, and tracking settings.
+
+**Useful for:**
+
+- Domain inventory and verification status
+- Reviewing automatic sender security and tracking settings
+- Checking TLS requirements and spam action policies
+
+### `credentials`
+
+Lists SMTP credentials for a specific sending domain. Returns login
+usernames and creation timestamps. Passwords are never returned by
+the API.
+
+**Requires:** `domain` filter (from `domains`)
+
+**Example:**
+
+```sql
+SELECT domain, login, mailbox, created_at
+FROM mailgun.credentials
+WHERE domain = 'example.com';
+```
+
+### `routes`
+
+Lists all inbound routing rules for the Mailgun account. Routes are
+global (not domain-specific) and define match expressions and actions
+for incoming messages.
+
+**Useful for:**
+
+- Auditing inbound email routing rules
+- Reviewing forwarding destinations and priorities
+- Checking for stale or unused routes
+
+### `bounces`
+
+Lists bounced email addresses for a specific sending domain. Bounces
+are addresses that have permanently failed delivery and are
+automatically suppressed from future sends.
+
+**Requires:** `domain` filter (from `domains`)
+
+**Useful for:**
+
+- Reviewing delivery failures and SMTP error codes
+- Auditing suppression lists for email deliverability
+- Identifying problematic recipient addresses
+
+**Example:**
+
+```sql
+SELECT address, code, error, created_at
+FROM mailgun.bounces
+WHERE domain = 'example.com';
+```
+
+### `unsubscribes`
+
+Lists email addresses that have unsubscribed from a specific sending
+domain. These addresses are automatically suppressed from future
+sends.
+
+**Requires:** `domain` filter (from `domains`)
+
+**Useful for:**
+
+- Monitoring unsubscribe rates
+- Auditing suppression lists
+- Reviewing tag-specific unsubscribes
+
+**Example:**
+
+```sql
+SELECT address, tags, created_at
+FROM mailgun.unsubscribes
+WHERE domain = 'example.com';
+```
+
+### `complaints`
+
+Lists email addresses that have filed spam complaints for a specific
+sending domain. These addresses are automatically suppressed from
+future sends.
+
+**Requires:** `domain` filter (from `domains`)
+
+**Example:**
+
+```sql
+SELECT address, created_at
+FROM mailgun.complaints
+WHERE domain = 'example.com';
+```
+
+## Authentication
+
+The source uses HTTP Basic Authentication with username `api` and
+your Private API Key as the password. The key is sent as a `secret`
+input and never exposed in query results.
+
+## Region Support
+
+Mailgun operates in two regions. Set the `MAILGUN_BASE_URL` input
+to match your domain's region:
+
+| Region | Base URL |
+|---|---|
+| US (default) | `https://api.mailgun.net` |
+| EU | `https://api.eu.mailgun.net` |
+
+## Limits
+
+- `domains`, `credentials`, and `routes` are account-wide; no domain filter required
+  (except `credentials` which is per-domain).
+- `bounces`, `unsubscribes`, `complaints`, and `credentials` require
+  a `domain` filter — they query one domain at a time.
+- All list endpoints use `skip`/`limit` offset pagination. The source
+  defaults to 100 per page with a max of 1000.
+- Timestamps are returned as strings in RFC 2822 format, not as
+  epoch milliseconds.
+
+## Example Queries
+
+### List all domains with their verification state
+
+```sql
+SELECT name, id, state, type, smtp_login,
+       require_tls, use_automatic_sender_security
+FROM mailgun.domains;
+```
+
+### Find unverified domains
+
+```sql
+SELECT name, state, created_at
+FROM mailgun.domains
+WHERE state != 'active';
+```
+
+### List all inbound routes sorted by priority
+
+```sql
+SELECT id, priority, expression,
+       actions, description
+FROM mailgun.routes
+ORDER BY priority;
+```
+
+### Review bounce errors for a domain
+
+```sql
+SELECT address, code, error, created_at
+FROM mailgun.bounces
+WHERE domain = 'example.com';
+```
+
+### Check unsubscribes for a domain
+
+```sql
+SELECT address, tags, created_at
+FROM mailgun.unsubscribes
+WHERE domain = 'example.com';
+```
+
+### List spam complaints
+
+```sql
+SELECT address, created_at
+FROM mailgun.complaints
+WHERE domain = 'example.com';
+```
+
+### Check SMTP credentials
+
+```sql
+SELECT login, mailbox, created_at
+FROM mailgun.credentials
+WHERE domain = 'example.com';
+```
+
+## Notes
+
+- All endpoints use the Mailgun v3 REST API with HTTP Basic
+  Authentication (`api:<private_key>`), except domains inventory which
+  uses Mailgun's current v4 domains endpoint
+- The `base_url` is configurable via the `MAILGUN_BASE_URL` input
+  to support both US and EU regions
+- Timestamps are returned as Utf8 strings in RFC 2822 format (e.g.
+  "Thu, 15 May 2025 12:00:00 UTC") because Mailgun does not use
+  Unix epoch timestamps
+- The Events API (email delivery, open, click tracking) uses
+  cursor-based pagination with full URL cursors, which is not yet
+  supported. It may be added in a future version
+- SMTP passwords are never exposed — the `credentials` table only
+  returns login usernames
+- The `domains` table does not expose `smtp_password` to prevent
+  credential leakage through SQL results

--- a/sources/community/mailgun/manifest.yaml
+++ b/sources/community/mailgun/manifest.yaml
@@ -1,0 +1,566 @@
+name: mailgun
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query sending domains, SMTP credentials, inbound routes, and email
+  suppression lists (bounces, unsubscribes, complaints) from Mailgun.
+base_url: "{{input.MAILGUN_BASE_URL}}"
+
+inputs:
+  MAILGUN_API_KEY:
+    kind: secret
+    hint: >-
+      Mailgun Private API Key. Find it in the Mailgun Dashboard at
+      https://app.mailgun.com/settings/api_security under API Keys.
+      Starts with "key-" for legacy keys or a long hex string for
+      newer keys.
+  MAILGUN_BASE_URL:
+    kind: variable
+    default: "https://api.mailgun.net"
+    hint: >-
+      Base URL for the Mailgun API. Defaults to the US region
+      (https://api.mailgun.net). For EU-hosted domains, use
+      https://api.eu.mailgun.net.
+
+auth:
+  type: BasicAuth
+  username: api
+  password: "{{input.MAILGUN_API_KEY}}"
+
+test_queries:
+  - SELECT name, state, type FROM mailgun.domains LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # domains — list all sending domains
+  # ──────────────────────────────────────────────────────────────────────
+  - name: domains
+    description: >
+      Lists all sending domains for the Mailgun account. Returns domain
+      verification state, type, SMTP login, security, and tracking settings.
+    guide: >
+      Start with `SELECT name, state, type, created_at
+      FROM mailgun.domains LIMIT 10`. Use the name value as the
+      domain filter for bounces, unsubscribes, complaints, and
+      credentials tables.
+    request:
+      method: GET
+      path: /v4/domains
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Fully qualified domain name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Unique domain identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: state
+        type: Utf8
+        nullable: true
+        description: >-
+          Domain verification state (e.g. active, unverified, disabled).
+        expr:
+          kind: path
+          path:
+            - state
+      - name: type
+        type: Utf8
+        nullable: true
+        description: >-
+          Domain type (e.g. custom, sandbox).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: subaccount_id
+        type: Utf8
+        nullable: true
+        description: Subaccount ID when the domain belongs to a subaccount.
+        expr:
+          kind: path
+          path:
+            - subaccount_id
+      - name: smtp_login
+        type: Utf8
+        nullable: true
+        description: SMTP login username for the domain.
+        expr:
+          kind: path
+          path:
+            - smtp_login
+      - name: archive_to
+        type: Utf8
+        nullable: true
+        description: URL where delivered message copies are posted.
+        expr:
+          kind: path
+          path:
+            - archive_to
+      - name: wildcard
+        type: Boolean
+        nullable: true
+        description: Whether wildcard matching is enabled for subdomains.
+        expr:
+          kind: path
+          path:
+            - wildcard
+      - name: spam_action
+        type: Utf8
+        nullable: true
+        description: >-
+          Action taken on spam (e.g. disabled, block, tag).
+        expr:
+          kind: path
+          path:
+            - spam_action
+      - name: web_scheme
+        type: Utf8
+        nullable: true
+        description: >-
+          URL scheme for tracking links (http or https).
+        expr:
+          kind: path
+          path:
+            - web_scheme
+      - name: web_prefix
+        type: Utf8
+        nullable: true
+        description: >-
+          Custom CNAME prefix used for tracking URLs.
+        expr:
+          kind: path
+          path:
+            - web_prefix
+      - name: tracking_host
+        type: Utf8
+        nullable: true
+        description: Custom host used for open and click tracking.
+        expr:
+          kind: path
+          path:
+            - tracking_host
+      - name: use_automatic_sender_security
+        type: Boolean
+        nullable: true
+        description: Whether Mailgun manages DKIM keys and DNS automatically.
+        expr:
+          kind: path
+          path:
+            - use_automatic_sender_security
+      - name: is_disabled
+        type: Boolean
+        nullable: true
+        description: Whether the domain is disabled.
+        expr:
+          kind: path
+          path:
+            - is_disabled
+      - name: disabled
+        type: Json
+        nullable: true
+        description: Additional details about disabled domain status.
+        expr:
+          kind: path
+          path:
+            - disabled
+      - name: require_tls
+        type: Boolean
+        nullable: true
+        description: Whether TLS is required for outbound messages.
+        expr:
+          kind: path
+          path:
+            - require_tls
+      - name: skip_verification
+        type: Boolean
+        nullable: true
+        description: Whether certificate verification is skipped.
+        expr:
+          kind: path
+          path:
+            - skip_verification
+      - name: encrypt_incoming_message
+        type: Boolean
+        nullable: true
+        description: Whether incoming messages to this domain are encrypted.
+        expr:
+          kind: path
+          path:
+            - encrypt_incoming_message
+      - name: message_ttl
+        type: Int64
+        nullable: true
+        description: Time-to-live in seconds for retrieving stored messages.
+        expr:
+          kind: path
+          path:
+            - message_ttl
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the domain was created (RFC 2822 format).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # credentials — SMTP credentials per domain
+  # ──────────────────────────────────────────────────────────────────────
+  - name: credentials
+    description: >
+      Lists SMTP credentials for a specific sending domain. Returns
+      login usernames and creation timestamps. Passwords are never
+      returned by the API. Requires a domain filter.
+    guide: >
+      Always filter by domain: `SELECT login, created_at
+      FROM mailgun.credentials
+      WHERE domain = 'example.com'`. Get domain names from
+      mailgun.domains first.
+    filters:
+      - name: domain
+        required: true
+    request:
+      method: GET
+      path: /v3/domains/{{filter.domain}}/credentials
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: domain
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Domain name (from URL filter).
+        expr:
+          kind: from_filter
+          key: domain
+      - name: login
+        type: Utf8
+        nullable: false
+        description: SMTP login username (e.g. postmaster@example.com).
+        expr:
+          kind: path
+          path:
+            - login
+      - name: mailbox
+        type: Utf8
+        nullable: true
+        description: Email address-style username for this credential.
+        expr:
+          kind: path
+          path:
+            - mailbox
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the credential was created (RFC 2822 format).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: size_bytes
+        type: Utf8
+        nullable: true
+        description: Credential storage size metadata, when present.
+        expr:
+          kind: path
+          path:
+            - size_bytes
+
+  # ──────────────────────────────────────────────────────────────────────
+  # routes — list all inbound routes
+  # ──────────────────────────────────────────────────────────────────────
+  - name: routes
+    description: >
+      Lists all inbound routing rules for the Mailgun account. Routes
+      are global (not domain-specific) and define match expressions and
+      actions for incoming messages.
+    guide: >
+      Start with `SELECT id, expression, priority, description
+      FROM mailgun.routes LIMIT 10`. Routes are account-wide and
+      do not require a domain filter.
+    request:
+      method: GET
+      path: /v3/routes
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique route identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: expression
+        type: Utf8
+        nullable: true
+        description: >-
+          Filter expression (e.g. match_recipient(".*@example.com")).
+        expr:
+          kind: path
+          path:
+            - expression
+      - name: actions
+        type: Json
+        nullable: true
+        description: >-
+          Array of action strings (e.g. forward(), stop(), store()).
+        expr:
+          kind: path
+          path:
+            - actions
+      - name: priority
+        type: Int64
+        nullable: true
+        description: >-
+          Route priority; lower numbers are processed first.
+          Defaults to 0.
+        expr:
+          kind: path
+          path:
+            - priority
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Human-readable name or description for the route.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the route was created (RFC 2822 format).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # bounces — bounced email addresses per domain
+  # ──────────────────────────────────────────────────────────────────────
+  - name: bounces
+    description: >
+      Lists bounced email addresses for a specific sending domain.
+      Bounces are addresses that have permanently failed delivery
+      and are automatically suppressed from future sends.
+      Requires a domain filter.
+    guide: >
+      Always filter by domain: `SELECT address, code, error,
+      created_at FROM mailgun.bounces
+      WHERE domain = 'example.com'`. Get domain names from
+      mailgun.domains first.
+    filters:
+      - name: domain
+        required: true
+    request:
+      method: GET
+      path: /v3/{{filter.domain}}/bounces
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: domain
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Domain name (from URL filter).
+        expr:
+          kind: from_filter
+          key: domain
+      - name: address
+        type: Utf8
+        nullable: false
+        description: Bounced email address.
+        expr:
+          kind: path
+          path:
+            - address
+      - name: code
+        type: Utf8
+        nullable: true
+        description: SMTP error code from the bounce (e.g. 550).
+        expr:
+          kind: path
+          path:
+            - code
+      - name: error
+        type: Utf8
+        nullable: true
+        description: SMTP error message from the bounce.
+        expr:
+          kind: path
+          path:
+            - error
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the bounce was recorded (RFC 2822 format).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # unsubscribes — unsubscribed addresses per domain
+  # ──────────────────────────────────────────────────────────────────────
+  - name: unsubscribes
+    description: >
+      Lists email addresses that have unsubscribed from a specific
+      sending domain. These addresses are automatically suppressed
+      from future sends. Requires a domain filter.
+    guide: >
+      Always filter by domain: `SELECT address, tags, created_at
+      FROM mailgun.unsubscribes
+      WHERE domain = 'example.com'`. Get domain names from
+      mailgun.domains first.
+    filters:
+      - name: domain
+        required: true
+    request:
+      method: GET
+      path: /v3/{{filter.domain}}/unsubscribes
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: domain
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Domain name (from URL filter).
+        expr:
+          kind: from_filter
+          key: domain
+      - name: address
+        type: Utf8
+        nullable: false
+        description: Unsubscribed email address.
+        expr:
+          kind: path
+          path:
+            - address
+      - name: tags
+        type: Json
+        nullable: true
+        description: >-
+          Array of tag strings associated with the unsubscribe event.
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the unsubscribe was recorded (RFC 2822 format).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # complaints — spam complaints per domain
+  # ──────────────────────────────────────────────────────────────────────
+  - name: complaints
+    description: >
+      Lists email addresses that have filed spam complaints for a
+      specific sending domain. These addresses are automatically
+      suppressed from future sends. Requires a domain filter.
+    guide: >
+      Always filter by domain: `SELECT address, created_at
+      FROM mailgun.complaints
+      WHERE domain = 'example.com'`. Get domain names from
+      mailgun.domains first.
+    filters:
+      - name: domain
+        required: true
+    request:
+      method: GET
+      path: /v3/{{filter.domain}}/complaints
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: skip
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: domain
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Domain name (from URL filter).
+        expr:
+          kind: from_filter
+          key: domain
+      - name: address
+        type: Utf8
+        nullable: false
+        description: Email address that filed the complaint.
+        expr:
+          kind: path
+          path:
+            - address
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the complaint was recorded (RFC 2822 format).
+        expr:
+          kind: path
+          path:
+            - created_at


### PR DESCRIPTION
## Summary

Adds a new community source for Mailgun under `sources/community/mailgun/`.

This source enables querying Mailgun account data (sending domains, SMTP credentials, inbound routes, and email suppression lists) through SQL using the Mailgun v3 REST API. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `BasicAuth`. No CLI, MCP, config, or runtime changes.

Closes #496 

## What changed

Added:

- `sources/community/mailgun/manifest.yaml`
- `sources/community/mailgun/README.md`

## Tables

| Table | Endpoint | Required Filters | Pagination | Notes |
|---|---|---|---|---|
| `domains` | `GET /domains` | — | offset (max 1000) | Domain config, DKIM, DNS records |
| `credentials` | `GET /domains/{domain}/credentials` | `domain` | offset (max 1000) | SMTP logins only (no passwords) |
| `routes` | `GET /routes` | — | offset (max 1000) | Global inbound routing rules |
| `bounces` | `GET /{domain}/bounces` | `domain` | offset (max 1000) | Bounced addresses + SMTP error codes |
| `unsubscribes` | `GET /{domain}/unsubscribes` | `domain` | offset (max 1000) | Unsubscribed addresses + tags |
| `complaints` | `GET /{domain}/complaints` | `domain` | offset (max 1000) | Spam complaint addresses |

## Auth

HTTP Basic Authentication with username `api` and password `<private_api_key>`.

Inputs:

- `MAILGUN_API_KEY` — required secret. Private API Key from https://app.mailgun.com/settings/api_security
- `MAILGUN_BASE_URL` — optional variable. Defaults to `https://api.mailgun.net/v3` (US). Set to `https://api.eu.mailgun.net/v3` for EU-hosted domains.

## Implementation notes

- All endpoints use offset pagination with `skip` and `limit` query parameters (max page size 1000, default 100)
- `base_url` uses `{{input.MAILGUN_BASE_URL}}` template to support both US and EU regions
- Timestamps are returned as Utf8 strings in RFC 2822 format (Mailgun does not use Unix epoch)
- DNS records (`receiving_dns_records`, `sending_dns_records`) are preserved as Json columns
- The `credentials` table only exposes login usernames — passwords are never returned by the Mailgun API
- The `domains` table intentionally excludes `smtp_password` to prevent credential leakage through SQL results
- `bounces`, `unsubscribes`, `complaints`, and `credentials` use `from_filter` virtual columns to echo the domain back into result rows
- The Events API is excluded from v1 because it uses cursor-based pagination with full URL cursors (`paging.next`), which doesn't map to Coral's `cursor_query` pagination mode

## Validation

- `coral source lint ./sources/community/mailgun/manifest.yaml` — passes
- `make lint-sources` — passes with no warnings
- `coral source add` with dummy key — successfully exposes 6 tables, proper 401 errors
- All filter-based table URLs verified correct:
  - `/v3/example.com/bounces` ✓
  - `/v3/domains/example.com/credentials` ✓
  - `/v3/example.com/unsubscribes` ✓
  - `/v3/example.com/complaints` ✓
- Live query validation — passed. All 6 tables queried successfully with a real Mailgun API key:
  - `domains`: 1 row returned with all 18 columns populated correctly (name, id, state, type, wildcard, spam_action, web_scheme, web_prefix, is_disabled, require_tls, skip_verification, encrypt_incoming_message, message_ttl, use_automatic_sender_security, tracking_host, archive_to, subaccount_id, disabled, created_at)
  - `routes`, `credentials`, `bounces`, `unsubscribes`, `complaints`: parsed correctly (0 rows on fresh sandbox domain, proper column headers, no errors)

## User-visible impact

New `mailgun` source installable via:

```bash
export MAILGUN_API_KEY="key-your-private-api-key"
coral source add --file sources/community/mailgun/manifest.yaml
```

Example queries:

```sql
-- List all domains with verification state
SELECT name, state, type, smtp_login,
       require_tls, dkim_key_size
FROM mailgun.domains;

-- Review bounce errors for a domain
SELECT address, code, error, created_at
FROM mailgun.bounces
WHERE domain = 'example.com';

-- Check unsubscribes with tags
SELECT address, tags, created_at
FROM mailgun.unsubscribes
WHERE domain = 'example.com';

-- List inbound routes by priority
SELECT id, priority, expression,
       actions, description
FROM mailgun.routes
ORDER BY priority;

-- Check SMTP credentials
SELECT login, created_at
FROM mailgun.credentials
WHERE domain = 'example.com';

-- List spam complaints
SELECT address, created_at
FROM mailgun.complaints
WHERE domain = 'example.com';
```

## Known limitations

- **Read-only** — no create, update, or delete operations
- **Suppression lists are per-domain** — `bounces`, `unsubscribes`, `complaints`, and `credentials` require a `domain` filter and return one domain's data at a time
- **No events table** — the Events API uses full-URL cursor pagination not supported by `cursor_query` mode
- **Timestamps as strings** — RFC 2822 format strings, not `Timestamp` type

## Out of scope

Not included in v1:

- Events API (email delivery, open, click tracking)
- IP and IP Pool management
- Mailing lists
- Tags API
- Webhooks management
- Write operations (create, update, delete)
