### PR TITLE
feat(sources/community/resend): add Resend community source

### DIFF
--- a/sources/community/resend/README.md
+++ b/sources/community/resend/README.md
@@ -1,0 +1,292 @@
+# Resend
+
+Query sent emails, domains, API keys, contacts, segments, topics,
+broadcasts, webhooks, API request logs, and legacy audiences from Resend.
+
+## Setup
+
+### Get Your API Key
+
+1. Log in to the [Resend Dashboard](https://resend.com)
+2. Navigate to **API Keys** at https://resend.com/api-keys
+3. Create a new API key with **Full access** permission
+4. Copy the key (starts with `re_`)
+
+### Add the Source
+
+```bash
+export RESEND_API_KEY="re_your_api_key_here"
+coral source add --file sources/community/resend/manifest.yaml
+```
+
+## Tables
+
+### `emails`
+
+Lists emails sent by the authenticated team. Returns sender,
+recipients, subject, delivery status, and timestamps.
+
+**Useful for:**
+
+- Monitoring email delivery status
+- Auditing sent emails and recipients
+- Tracking open and click rates via `last_event`
+
+**Example:**
+
+```sql
+SELECT id, "from", subject, last_event, created_at
+FROM resend.emails
+LIMIT 20;
+```
+
+### `domains`
+
+Lists all domains registered in the Resend account. Returns domain
+name, verification status, region, and capabilities.
+
+**Useful for:**
+
+- Domain inventory and verification status
+- Checking sending and receiving capabilities
+- Reviewing regional deployment
+
+### `api_keys`
+
+Lists all API keys for the authenticated user. Returns key name,
+creation time, and last usage timestamp. The actual key value is
+never returned after creation.
+
+**Useful for:**
+
+- Auditing API key usage and identifying unused keys
+- Security review of active keys
+
+**Example:**
+
+```sql
+SELECT id, name, created_at, last_used_at
+FROM resend.api_keys;
+```
+
+### `audiences`
+
+Lists legacy audiences for accounts that still have audience resources.
+Resend's current model uses global contacts plus segments.
+
+**Useful for:**
+
+- Legacy audience inventory
+- Migration checks when moving from audiences to segments
+
+### `segments`
+
+Lists all segments for the authenticated account. Segments group contacts
+for broadcast targeting.
+
+**Useful for:**
+
+- Segment inventory
+- Resolving `segment_id` values from broadcasts
+- Reviewing campaign targeting groups
+
+### `contacts`
+
+Lists global contacts for the authenticated account. Returns email
+address, name, subscription status, and creation timestamp.
+
+**Example:**
+
+```sql
+SELECT id, email, first_name, last_name, unsubscribed
+FROM resend.contacts
+LIMIT 20;
+```
+
+### `broadcasts`
+
+Lists all broadcasts (bulk email campaigns). Returns status,
+audience/segment targeting, schedule, and send timestamps.
+
+**Useful for:**
+
+- Monitoring broadcast campaign status
+- Auditing scheduled and sent campaigns
+- Reviewing segment and topic targeting
+
+**Example:**
+
+```sql
+SELECT id, status, segment_id, topic_id, scheduled_at, sent_at
+FROM resend.broadcasts;
+```
+
+### `topics`
+
+Lists subscription topics for the authenticated account. Topics let
+contacts manage preferences for different kinds of email.
+
+**Useful for:**
+
+- Topic inventory
+- Resolving `topic_id` values from broadcasts
+- Auditing public subscription preferences
+
+**Example:**
+
+```sql
+SELECT id, name, default_subscription, visibility
+FROM resend.topics;
+```
+
+### `webhooks`
+
+Lists all webhook endpoints configured in the account. Returns
+endpoint URL, enabled/disabled status, and subscribed event types.
+
+**Useful for:**
+
+- Auditing webhook integrations
+- Identifying disabled or misconfigured endpoints
+
+**Example:**
+
+```sql
+SELECT id, endpoint, status, events, created_at
+FROM resend.webhooks;
+```
+
+### `logs`
+
+Lists API request logs for the account. Returns endpoint, HTTP method,
+response status code, user agent, and timestamp.
+
+**Useful for:**
+
+- Debugging API integration issues
+- Auditing API request patterns and error rates
+- Identifying unexpected clients or user agents
+
+**Example:**
+
+```sql
+SELECT id, endpoint, method, response_status, created_at
+FROM resend.logs
+LIMIT 20;
+```
+
+## Authentication
+
+The source uses Bearer token authentication with your Resend API key.
+The key is sent as a `secret` input and never exposed in query results.
+
+**Important:** Resend requires a `User-Agent` header on all API
+requests. Coral's HTTP client includes one by default.
+
+## Limits
+
+- Resend's paginated list endpoints support up to 100 items per request.
+- Resend uses cursor-based pagination (`after`/`before` with item IDs),
+  which requires extracting the last item's ID from the response data
+  array. This is not currently supported by Coral's `cursor_query`
+  pagination mode. Each table returns the first page of results.
+- For `emails` and `contacts`, this means the most recent 100 items.
+  Most accounts will have fewer than 100 domains, legacy audiences,
+  segments, topics, API keys, webhooks, and broadcasts.
+- Timestamps are returned as ISO 8601 strings.
+- The default rate limit is 5 requests per second per team.
+
+## Example Queries
+
+### List all domains with their verification state
+
+```sql
+SELECT id, name, status, region, capabilities
+FROM resend.domains;
+```
+
+### Review recent email delivery status
+
+```sql
+SELECT id, "from", subject, last_event, created_at
+FROM resend.emails
+LIMIT 20;
+```
+
+### Find bounced emails
+
+```sql
+SELECT id, "from", subject, created_at
+FROM resend.emails
+WHERE last_event = 'bounced';
+```
+
+### Audit API key usage
+
+```sql
+SELECT name, created_at, last_used_at
+FROM resend.api_keys;
+```
+
+### List recent contacts
+
+```sql
+SELECT email, first_name, last_name, unsubscribed, created_at
+FROM resend.contacts
+LIMIT 20;
+```
+
+### Check unsubscribed contacts
+
+```sql
+SELECT email, first_name, last_name, created_at
+FROM resend.contacts
+WHERE unsubscribed = true;
+```
+
+### Review broadcast campaigns
+
+```sql
+SELECT id, status, segment_id, topic_id, scheduled_at, sent_at, created_at
+FROM resend.broadcasts;
+```
+
+### Resolve broadcast segments and topics
+
+```sql
+SELECT id, name, created_at
+FROM resend.segments;
+
+SELECT id, name, default_subscription, visibility
+FROM resend.topics;
+```
+
+### Audit webhooks
+
+```sql
+SELECT endpoint, status, events, created_at
+FROM resend.webhooks;
+```
+
+### Check API error rates
+
+```sql
+SELECT endpoint, method, response_status, user_agent, created_at
+FROM resend.logs
+WHERE response_status >= 400
+LIMIT 20;
+```
+
+## Notes
+
+- The source is read-only — no send, create, update, or delete
+  operations
+- API keys are never exposed in query results; the `api_keys` table
+  only shows metadata (name, creation time, last usage)
+- The `from` column in the `emails` table is a reserved SQL keyword;
+  use double quotes (`"from"`) in queries
+- Resend returns timestamps as ISO 8601 strings with timezone offsets
+- The `to`, `cc`, `bcc`, and `reply_to` fields in emails are JSON
+  arrays since emails can have multiple recipients
+- Cursor pagination support may be added in a future version to
+  enable paginating through large email and contact lists

--- a/sources/community/resend/manifest.yaml
+++ b/sources/community/resend/manifest.yaml
@@ -1,0 +1,744 @@
+name: resend
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query sent emails, domains, API keys, contacts, segments, topics,
+  broadcasts, webhooks, API request logs, and legacy audiences from Resend.
+base_url: https://api.resend.com
+
+inputs:
+  RESEND_API_KEY:
+    kind: secret
+    hint: >-
+      Resend API key. Create one at https://resend.com/api-keys.
+      Keys start with "re_". Use a key with full access permission
+      to query all tables.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.RESEND_API_KEY}}"
+
+test_queries:
+  - SELECT id, name, status FROM resend.domains LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # emails — list sent emails
+  # ──────────────────────────────────────────────────────────────────────
+  - name: emails
+    description: >
+      Lists emails sent by the authenticated team. Returns sender,
+      recipients, subject, delivery status, and timestamps.
+    guide: >
+      Start with `SELECT id, "from", subject, last_event, created_at
+      FROM resend.emails LIMIT 10`. The last_event field shows
+      delivery status (delivered, opened, bounced, etc.). Note: "from"
+      is a reserved SQL keyword and must be double-quoted.
+    request:
+      method: GET
+      path: /emails
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique email identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: to
+        type: Json
+        nullable: true
+        description: Array of recipient email addresses.
+        expr:
+          kind: path
+          path:
+            - to
+      - name: from
+        type: Utf8
+        nullable: true
+        description: >-
+          Sender email address with optional display name.
+        expr:
+          kind: path
+          path:
+            - from
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Email subject line.
+        expr:
+          kind: path
+          path:
+            - subject
+      - name: cc
+        type: Json
+        nullable: true
+        description: Array of CC recipient email addresses.
+        expr:
+          kind: path
+          path:
+            - cc
+      - name: bcc
+        type: Json
+        nullable: true
+        description: Array of BCC recipient email addresses.
+        expr:
+          kind: path
+          path:
+            - bcc
+      - name: reply_to
+        type: Json
+        nullable: true
+        description: Reply-to address or addresses.
+        expr:
+          kind: path
+          path:
+            - reply_to
+      - name: last_event
+        type: Utf8
+        nullable: true
+        description: >-
+          Status of the last delivery event (e.g. delivered, opened,
+          clicked, bounced, complained).
+        expr:
+          kind: path
+          path:
+            - last_event
+      - name: scheduled_at
+        type: Utf8
+        nullable: true
+        description: >-
+          Scheduled send time (ISO 8601), or null if sent immediately.
+        expr:
+          kind: path
+          path:
+            - scheduled_at
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the email was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # domains — list all domains
+  # ──────────────────────────────────────────────────────────────────────
+  - name: domains
+    description: >
+      Lists all domains registered in the Resend account. Returns domain
+      name, verification status, region, and capabilities.
+    guide: >
+      Start with `SELECT id, name, status, region, created_at
+      FROM resend.domains LIMIT 10`. Use the domain name as context
+      when reviewing emails or setting up contacts.
+    request:
+      method: GET
+      path: /domains
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique domain identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Fully qualified domain name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Domain verification status (e.g. not_started, pending,
+          verified, failed, temporary_failure).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: region
+        type: Utf8
+        nullable: true
+        description: >-
+          AWS region where the domain is hosted (e.g. us-east-1,
+          eu-west-1, sa-east-1).
+        expr:
+          kind: path
+          path:
+            - region
+      - name: capabilities
+        type: Json
+        nullable: true
+        description: >-
+          Domain capabilities object showing sending and receiving
+          status (e.g. {"sending": "enabled", "receiving": "disabled"}).
+        expr:
+          kind: path
+          path:
+            - capabilities
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the domain was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # api_keys — list API keys
+  # ──────────────────────────────────────────────────────────────────────
+  - name: api_keys
+    description: >
+      Lists all API keys for the authenticated user. Returns key name,
+      creation time, and last usage timestamp. The actual key value is
+      never returned after creation.
+    guide: >
+      Start with `SELECT id, name, created_at, last_used_at
+      FROM resend.api_keys`. Useful for auditing API key usage and
+      identifying unused keys.
+    request:
+      method: GET
+      path: /api-keys
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique API key identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Display name assigned to the API key.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the API key was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: last_used_at
+        type: Utf8
+        nullable: true
+        description: >-
+          When the API key was last used (ISO 8601), or null if
+          never used.
+        expr:
+          kind: path
+          path:
+            - last_used_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # audiences — list all audiences
+  # ──────────────────────────────────────────────────────────────────────
+  - name: audiences
+    description: >
+      Lists legacy audiences for the authenticated account. Resend's
+      current Contacts API uses global contacts plus segments; this table
+      is kept for accounts that still have audience resources.
+    guide: >
+      Start with `SELECT id, name, created_at
+      FROM resend.audiences`. For current contact grouping, use
+      resend.segments instead.
+    request:
+      method: GET
+      path: /audiences
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique audience identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Audience display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the audience was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # segments — list all segments
+  # ──────────────────────────────────────────────────────────────────────
+  - name: segments
+    description: >
+      Lists all segments for the authenticated account. Segments group
+      contacts for broadcast targeting.
+    guide: >
+      Start with `SELECT id, name, created_at
+      FROM resend.segments`. Use segment IDs to understand broadcast
+      targeting through resend.broadcasts.segment_id.
+    request:
+      method: GET
+      path: /segments
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique segment identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Segment display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the segment was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # contacts — list contacts
+  # ──────────────────────────────────────────────────────────────────────
+  - name: contacts
+    description: >
+      Lists all contacts for the authenticated account. Returns email
+      address, name, subscription status, and creation timestamp.
+    guide: >
+      Start with `SELECT id, email, first_name, last_name,
+      unsubscribed FROM resend.contacts LIMIT 20`. Contacts can
+      belong to segments; use resend.segments and
+      resend.broadcasts.segment_id for campaign targeting context.
+    request:
+      method: GET
+      path: /contacts
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique contact identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Contact email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: Contact first name.
+        expr:
+          kind: path
+          path:
+            - first_name
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Contact last name.
+        expr:
+          kind: path
+          path:
+            - last_name
+      - name: unsubscribed
+        type: Boolean
+        nullable: true
+        description: Whether the contact has unsubscribed.
+        expr:
+          kind: path
+          path:
+            - unsubscribed
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the contact was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # broadcasts — list all broadcasts
+  # ──────────────────────────────────────────────────────────────────────
+  - name: broadcasts
+    description: >
+      Lists all broadcasts (bulk email campaigns) for the authenticated
+      account. Returns broadcast status, audience/segment targeting,
+      schedule, and send timestamps.
+    guide: >
+      Start with `SELECT id, status, audience_id, segment_id,
+      created_at, sent_at FROM resend.broadcasts`. Filter by status
+      in SQL to find drafts or sent broadcasts. Use resend.segments
+      to resolve segment_id values.
+    request:
+      method: GET
+      path: /broadcasts
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique broadcast identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: audience_id
+        type: Utf8
+        nullable: true
+        description: Legacy target audience ID for the broadcast.
+        expr:
+          kind: path
+          path:
+            - audience_id
+      - name: segment_id
+        type: Utf8
+        nullable: true
+        description: >-
+          Target segment ID for the broadcast. Replaces audience_id
+          in newer API versions.
+        expr:
+          kind: path
+          path:
+            - segment_id
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Broadcast status (e.g. draft, queued, sending, sent).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: topic_id
+        type: Utf8
+        nullable: true
+        description: >-
+          Associated topic ID for subscription management.
+        expr:
+          kind: path
+          path:
+            - topic_id
+      - name: scheduled_at
+        type: Utf8
+        nullable: true
+        description: >-
+          Scheduled send time (ISO 8601), or null if not scheduled.
+        expr:
+          kind: path
+          path:
+            - scheduled_at
+      - name: sent_at
+        type: Utf8
+        nullable: true
+        description: >-
+          Actual send time (ISO 8601), or null if not yet sent.
+        expr:
+          kind: path
+          path:
+            - sent_at
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the broadcast was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # topics — list all topics
+  # ──────────────────────────────────────────────────────────────────────
+  - name: topics
+    description: >
+      Lists all topics for the authenticated account. Topics let contacts
+      manage subscription preferences for different kinds of email.
+    guide: >
+      Start with `SELECT id, name, default_subscription, visibility
+      FROM resend.topics`. Broadcasts may reference a topic_id when
+      sending to a specific subscription topic.
+    request:
+      method: GET
+      path: /topics
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique topic identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Topic display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Topic description shown to subscribers.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: default_subscription
+        type: Utf8
+        nullable: true
+        description: Default subscription state for new contacts.
+        expr:
+          kind: path
+          path:
+            - default_subscription
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Topic visibility, such as public or private.
+        expr:
+          kind: path
+          path:
+            - visibility
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the topic was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # webhooks — list all webhooks
+  # ──────────────────────────────────────────────────────────────────────
+  - name: webhooks
+    description: >
+      Lists all webhooks configured for the authenticated account.
+      Returns endpoint URL, status, subscribed events, and
+      creation timestamp.
+    guide: >
+      Start with `SELECT id, endpoint, status, events, created_at
+      FROM resend.webhooks`. Use this to audit webhook integrations
+      and identify disabled endpoints.
+    request:
+      method: GET
+      path: /webhooks
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique webhook identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: endpoint
+        type: Utf8
+        nullable: true
+        description: Webhook destination URL.
+        expr:
+          kind: path
+          path:
+            - endpoint
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Webhook status (enabled or disabled).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: events
+        type: Json
+        nullable: true
+        description: >-
+          Array of subscribed event types (e.g. email.sent,
+          email.delivered, email.bounced, email.received).
+        expr:
+          kind: path
+          path:
+            - events
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the webhook was created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # logs — API request logs
+  # ──────────────────────────────────────────────────────────────────────
+  - name: logs
+    description: >
+      Lists API request logs for the authenticated account. Returns
+      endpoint, HTTP method, response status, user agent, and
+      timestamp for each request.
+    guide: >
+      Start with `SELECT id, endpoint, method, response_status,
+      created_at FROM resend.logs LIMIT 20`. Useful for debugging
+      API integrations and auditing request patterns.
+    request:
+      method: GET
+      path: /logs
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique log entry identifier (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: endpoint
+        type: Utf8
+        nullable: true
+        description: API endpoint path (e.g. /emails, /domains).
+        expr:
+          kind: path
+          path:
+            - endpoint
+      - name: method
+        type: Utf8
+        nullable: true
+        description: HTTP method (GET, POST, PATCH, DELETE).
+        expr:
+          kind: path
+          path:
+            - method
+      - name: response_status
+        type: Int64
+        nullable: true
+        description: HTTP response status code (e.g. 200, 400, 401).
+        expr:
+          kind: path
+          path:
+            - response_status
+      - name: user_agent
+        type: Utf8
+        nullable: true
+        description: >-
+          User-Agent string of the API client (e.g.
+          resend-node:6.0.3, curl/8.7.1).
+        expr:
+          kind: path
+          path:
+            - user_agent
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: When the API request was made (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at


### PR DESCRIPTION
## Summary

Adds a new community source for Resend under `sources/community/resend/`.

This source enables querying Resend account data (sent emails, domains, API keys, contacts, segments, broadcasts, topics, webhooks, and API request logs) through SQL using the Resend REST API. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `HeaderAuth`. No CLI, MCP, config, or runtime changes.

Closes #499 

## What changed

Added:

- `sources/community/resend/manifest.yaml`
- `sources/community/resend/README.md`

## Tables

| Table | Endpoint | Required Filters | Pagination | Notes |
|---|---|---|---|---|
| `emails` | `GET /emails` | — | none (first 100) | Sent emails with delivery status |
| `domains` | `GET /domains` | — | none (first 100) | Domain verification, region, capabilities |
| `api_keys` | `GET /api-keys` | — | none | API key metadata (no key values) |
| `audiences` | `GET /audiences` | — | none | Legacy audiences (backward compat) |
| `segments` | `GET /segments` | — | none (first 100) | Contact segments for broadcast targeting |
| `contacts` | `GET /contacts` | — | none (first 100) | Global contacts with subscription status |
| `broadcasts` | `GET /broadcasts` | — | none | Bulk email campaigns with status |
| `topics` | `GET /topics` | — | none (first 100) | Subscription preference topics |
| `webhooks` | `GET /webhooks` | — | none | Webhook endpoints and subscribed events |
| `logs` | `GET /logs` | — | none (first 100) | API request audit trail |

## Auth

Bearer token authentication with `Authorization: Bearer <api_key>`.

Inputs:

- `RESEND_API_KEY` — required secret. Resend API key (starts with `re_`). Create at https://resend.com/api-keys. **Must have Full access permission** — Sending-only keys cannot read data and will return 401 `restricted_api_key`.

## Implementation notes

- All list endpoints return a standard envelope: `{"object": "list", "has_more": bool, "data": [...]}`. All tables use `rows_path: [data]`
- Pagination is set to `mode: none` because Resend uses item-ID cursor pagination (`after`/`before` query params where the cursor is the last row's UUID). Coral's `response_cursor_path` reads from a fixed JSON path and cannot extract the last array element's `id`. Each table returns the first page (up to 100 items).
- Contacts use the current global `GET /contacts` endpoint, not the legacy audience-scoped `GET /audiences/:id/contacts`
- `audiences` is kept as a legacy table alongside `segments` for accounts that haven't migrated
- `segments` and `topics` tables are included so `broadcasts.segment_id` and `broadcasts.topic_id` are resolvable via JOINs
- The `from` column in `emails` is a reserved SQL keyword — documented that users must double-quote it (`"from"`)
- Timestamps are ISO 8601 strings mapped as `Utf8` (varying timezone formats: `+00:00` vs `Z`)
- Multi-value fields (`to`, `cc`, `bcc`, `reply_to` in emails; `events` in webhooks; `capabilities` in domains) are mapped as `Json`
- API key values are never returned by the Resend API; the `api_keys` table only exposes metadata (name, creation time, last used)
- Rate limit is 5 requests per second per team (Resend default)

## Validation

- `coral source lint sources/community/resend/manifest.yaml` — passes
- `make lint-sources` — passes with no warnings
- `git diff --check` — passes
- `coral source add` with full-access key — successfully exposes 10 tables, test query passes
- Live query validation — **all 10 tables queried successfully** with a real Resend API key:
  - `api_keys`: 2 rows returned (coral-full, Onboarding) with all 4 columns populated correctly
  - `audiences`: 1 row returned (General) with id, name, created_at
  - `segments`: 1 row returned (General) with id, name, created_at
  - `logs`: 5 rows returned showing Coral's own API requests with endpoint, method, response_status (200), user_agent (coral/0.2.1), created_at
  - `domains`, `emails`, `contacts`, `broadcasts`, `topics`, `webhooks`: 0 rows (new account, no data configured) — proper empty results, correct column headers, no errors

## User-visible impact

New `resend` source installable via:

```bash
export RESEND_API_KEY="re_your_full_access_key"
coral source add --file sources/community/resend/manifest.yaml
```

Example queries:

```sql
-- Review recent email delivery status
SELECT id, "from", subject, last_event, created_at
FROM resend.emails
LIMIT 20;

-- List all domains with verification state
SELECT id, name, status, region, capabilities
FROM resend.domains;

-- Audit API key usage
SELECT name, created_at, last_used_at
FROM resend.api_keys;

-- List contacts with subscription status
SELECT email, first_name, last_name, unsubscribed
FROM resend.contacts
LIMIT 20;

-- Review broadcast campaigns
SELECT id, status, segment_id, topic_id, scheduled_at, sent_at
FROM resend.broadcasts;

-- Resolve segments and topics for broadcasts
SELECT id, name, created_at FROM resend.segments;
SELECT id, name, default_subscription, visibility FROM resend.topics;

-- Audit webhooks
SELECT endpoint, status, events, created_at
FROM resend.webhooks;

-- Check API error rates from logs
SELECT endpoint, method, response_status, user_agent, created_at
FROM resend.logs
WHERE response_status >= 400
LIMIT 20;

-- Find bounced emails
SELECT id, "from", subject, created_at
FROM resend.emails
WHERE last_event = 'bounced';

-- Check unsubscribed contacts
SELECT email, first_name, last_name, created_at
FROM resend.contacts
WHERE unsubscribed = true;
```

## Known limitations

- **Read-only** — no send, create, update, or delete operations
- **First-page only** — cursor pagination cannot be expressed with `response_cursor_path`, so each table returns at most 100 items
- **`from` is reserved** — the `from` column in `emails` must be double-quoted in SQL
- **Timestamps as strings** — ISO 8601 format strings, not `Timestamp` type
- **Full access key required** — Sending-only API keys return 401 on all GET endpoints

## Out of scope

Not included in v1:

- Received emails (`GET /emails/received`)
- Automations and automation runs
- Custom events
- Email templates
- Contact properties (custom metadata)
- Segment contacts (per-segment contact list)
- Write operations (send, create, update, delete)
- Cursor pagination for large email/contact lists
