### PR TITLE
feat(sources/community/codecov): add Codecov community source

### DIFF
--- a/sources/community/codecov/README.md
+++ b/sources/community/codecov/README.md
@@ -138,7 +138,7 @@ are named groups of file paths defined in `codecov.yml`.
 **Example:**
 
 ```sql
-SELECT component_id, name, coverage, files, lines, hits, misses
+SELECT component_id, name, coverage
 FROM codecov.components
 WHERE repo = 'my-repo';
 ```

--- a/sources/community/codecov/README.md
+++ b/sources/community/codecov/README.md
@@ -1,0 +1,255 @@
+# Codecov
+
+Query repositories, commits, pull requests, branches, flags,
+components, and commit uploads from Codecov.
+
+## Setup
+
+### Get Your API Token
+
+1. Log in to [Codecov](https://app.codecov.io)
+2. Navigate to **Settings > Access**
+3. Generate an API access token
+4. Copy the token
+
+### Add the Source
+
+```bash
+export CODECOV_API_TOKEN="your_api_token"
+export CODECOV_SERVICE="github"        # or gitlab, bitbucket
+export CODECOV_OWNER="your_org_name"   # GitHub/GitLab username or org
+coral source add --file sources/community/codecov/manifest.yaml
+```
+
+## Tables
+
+### `repos`
+
+Lists all repositories for the authenticated owner. Returns
+repository name, language, activation status, and aggregate
+coverage totals.
+
+**Useful for:**
+
+- Repository coverage inventory
+- Identifying repos with low or missing coverage
+- Auditing active vs inactive repositories
+
+**Example:**
+
+```sql
+SELECT name, language, active, coverage, lines, hits, misses
+FROM codecov.repos
+LIMIT 20;
+```
+
+### `commits`
+
+Lists commits with coverage data for a specific repository.
+Returns commit SHA, message, branch, CI status, and per-commit
+coverage totals.
+
+**Requires:** `repo` filter
+
+**Useful for:**
+
+- Tracking coverage trends across commits
+- Identifying commits that dropped coverage
+- Correlating CI failures with coverage changes
+
+**Example:**
+
+```sql
+SELECT commitid, message, branch, coverage, ci_passed, timestamp
+FROM codecov.commits
+WHERE repo = 'my-repo'
+LIMIT 20;
+```
+
+### `pulls`
+
+Lists pull requests with coverage data for a specific repository.
+Returns pull number, title, state, CI status, patch coverage, and
+base/head coverage totals.
+
+**Requires:** `repo` filter
+
+**Useful for:**
+
+- Reviewing PR coverage impact
+- Finding PRs that introduced coverage regressions
+- Filtering by state (open/merged/closed)
+
+**Example:**
+
+```sql
+SELECT pullid, title, state, coverage, base_coverage, patch_coverage
+FROM codecov.pulls
+WHERE repo = 'my-repo' AND state = 'open';
+```
+
+### `branches`
+
+Lists branches for a specific repository with their last update time.
+
+**Requires:** `repo` filter
+
+**Example:**
+
+```sql
+SELECT name, updatestamp
+FROM codecov.branches
+WHERE repo = 'my-repo';
+```
+
+### `flags`
+
+Lists coverage flags for a specific repository. Flags segment
+coverage by test suite, component, or custom grouping.
+
+**Requires:** `repo` filter
+
+**Useful for:**
+
+- Comparing coverage across test suites (unit, integration, e2e)
+- Identifying flags with declining coverage
+- Auditing flag configurations
+
+**Example:**
+
+```sql
+SELECT flag_name, coverage
+FROM codecov.flags
+WHERE repo = 'my-repo';
+```
+
+### `components`
+
+Lists coverage components for a specific repository. Components
+are named groups of file paths defined in `codecov.yml`.
+
+**Requires:** `repo` filter
+
+**Useful for:**
+
+- Tracking coverage for logical areas (frontend, backend, API)
+- Identifying components with low coverage
+
+**Example:**
+
+```sql
+SELECT component_id, name, coverage, files, lines, hits, misses
+FROM codecov.components
+WHERE repo = 'my-repo';
+```
+
+### `commit_uploads`
+
+Lists coverage report uploads for a specific commit. Useful for
+debugging CI upload issues.
+
+**Requires:** `repo` and `commitid` filters
+
+**Example:**
+
+```sql
+SELECT upload_type, state, provider, build_url, flags, created_at
+FROM codecov.commit_uploads
+WHERE repo = 'my-repo' AND commitid = 'abc123def456';
+```
+
+## Authentication
+
+The source uses Bearer token authentication. Generate a token at
+https://app.codecov.io/account (Settings > Access). The token
+must have read access to the target organization.
+
+## Inputs
+
+| Input | Kind | Default | Description |
+|---|---|---|---|
+| `CODECOV_API_TOKEN` | secret | — | API access token |
+| `CODECOV_SERVICE` | variable | `github` | Git hosting provider (github, gitlab, bitbucket, etc.) |
+| `CODECOV_OWNER` | variable | — | Owner username or org name |
+
+## Pagination
+
+All paginated tables use page-number pagination (`page` + `page_size`
+query parameters). Coral will automatically paginate through all
+pages to return complete results.
+
+- Default page size: 20
+- Maximum page size: 100
+
+The `components` table is not paginated (returns all components
+in a single response).
+
+## Example Queries
+
+### Find repos with coverage below 50%
+
+```sql
+SELECT name, language, coverage, lines, misses
+FROM codecov.repos
+WHERE coverage < 50
+ORDER BY coverage ASC;
+```
+
+### Track coverage over recent commits
+
+```sql
+SELECT commitid, message, coverage, hits, misses, timestamp
+FROM codecov.commits
+WHERE repo = 'my-repo'
+LIMIT 50;
+```
+
+### Compare coverage across test flags
+
+```sql
+SELECT flag_name, coverage
+FROM codecov.flags
+WHERE repo = 'my-repo'
+ORDER BY coverage ASC;
+```
+
+### Find merged PRs that dropped coverage
+
+```sql
+SELECT pullid, title, coverage, base_coverage, patch_coverage, updatestamp
+FROM codecov.pulls
+WHERE repo = 'my-repo' AND state = 'merged'
+LIMIT 20;
+```
+
+### Audit CI uploads for a commit
+
+```sql
+SELECT provider, upload_type, state, build_url, flags
+FROM codecov.commit_uploads
+WHERE repo = 'my-repo' AND commitid = 'abc123def456';
+```
+
+### Search repositories by name
+
+```sql
+SELECT name, coverage, active
+FROM codecov.repos
+WHERE search = 'api';
+```
+
+## Notes
+
+- The source is read-only — no create, update, or delete operations
+- All queries are scoped to a single `CODECOV_OWNER` organization
+- Coverage values are percentages from 0 to 100 (Float64)
+- The `totals` object from the API is flattened into top-level
+  columns (coverage, files, lines, hits, misses, etc.)
+- Timestamps are ISO 8601 strings
+- The `commits`, `pulls`, `branches`, `flags`, `components`, and
+  `commit_uploads` tables require a `repo` filter
+- `commit_uploads` additionally requires a `commitid` filter
+- The `flags` table exposes the flag name and aggregate coverage
+- The `components` table is not paginated and returns all components
+- `CODECOV_SERVICE` supports: `github`, `github_enterprise`, `gitlab`,
+  `gitlab_enterprise`, `bitbucket`, `bitbucket_server`

--- a/sources/community/codecov/manifest.yaml
+++ b/sources/community/codecov/manifest.yaml
@@ -1,0 +1,1027 @@
+name: codecov
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query repositories, commits, pull requests, branches, flags,
+  components, and coverage totals from Codecov.
+base_url: https://api.codecov.io/api/v2
+
+inputs:
+  CODECOV_API_TOKEN:
+    kind: secret
+    hint: >-
+      Codecov API access token. Generate one at
+      https://app.codecov.io/account (Settings > Access).
+      The token must have read access to the target organization.
+  CODECOV_SERVICE:
+    kind: variable
+    default: github
+    hint: >-
+      Git hosting service provider. One of: github,
+      github_enterprise, gitlab, gitlab_enterprise, bitbucket,
+      bitbucket_server. Defaults to github.
+  CODECOV_OWNER:
+    kind: variable
+    hint: >-
+      Username or organization name on the hosting service
+      (e.g. your GitHub username or org name). All queries
+      are scoped to this owner.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.CODECOV_API_TOKEN}}"
+
+test_queries:
+  - SELECT name, language, active, coverage FROM codecov.repos LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # repos — list repositories
+  # ──────────────────────────────────────────────────────────────────────
+  - name: repos
+    description: >
+      Lists all repositories for the authenticated owner. Returns
+      repository name, language, activation status, default branch,
+      and aggregate coverage totals.
+    guide: >
+      Start with `SELECT name, language, active, coverage,
+      lines, hits, misses FROM codecov.repos LIMIT 20`. Filter
+      by active status or search by name. The totals columns
+      (coverage, lines, hits, misses, etc.) show the latest
+      aggregate coverage for the default branch.
+    filters:
+      - name: search
+      - name: active
+      - name: names
+    request:
+      method: GET
+      path: /{{input.CODECOV_SERVICE}}/{{input.CODECOV_OWNER}}/repos
+      query:
+        - name: search
+          from: filter
+          key: search
+        - name: active
+          from: filter
+          key: active
+        - name: names
+          from: filter
+          key: names
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 20
+        max: 100
+        query_param: page_size
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Repository name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: private
+        type: Boolean
+        nullable: true
+        description: Whether the repository is private.
+        expr:
+          kind: path
+          path:
+            - private
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Primary programming language.
+        expr:
+          kind: path
+          path:
+            - language
+      - name: branch
+        type: Utf8
+        nullable: true
+        description: Default branch name.
+        expr:
+          kind: path
+          path:
+            - branch
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the repository has received an upload.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: activated
+        type: Boolean
+        nullable: true
+        description: Whether the repository is activated in Codecov.
+        expr:
+          kind: path
+          path:
+            - activated
+      - name: coverage
+        type: Float64
+        nullable: true
+        description: Overall coverage percentage (0-100).
+        expr:
+          kind: path
+          path:
+            - totals
+            - coverage
+      - name: files
+        type: Int64
+        nullable: true
+        description: Total number of files with coverage data.
+        expr:
+          kind: path
+          path:
+            - totals
+            - files
+      - name: lines
+        type: Int64
+        nullable: true
+        description: Total number of coverable lines.
+        expr:
+          kind: path
+          path:
+            - totals
+            - lines
+      - name: hits
+        type: Int64
+        nullable: true
+        description: Number of lines hit (covered).
+        expr:
+          kind: path
+          path:
+            - totals
+            - hits
+      - name: misses
+        type: Int64
+        nullable: true
+        description: Number of lines missed (uncovered).
+        expr:
+          kind: path
+          path:
+            - totals
+            - misses
+      - name: partials
+        type: Int64
+        nullable: true
+        description: Number of partially covered lines.
+        expr:
+          kind: path
+          path:
+            - totals
+            - partials
+      - name: branches
+        type: Int64
+        nullable: true
+        description: Number of branch paths tracked.
+        expr:
+          kind: path
+          path:
+            - totals
+            - branches
+      - name: methods
+        type: Int64
+        nullable: true
+        description: Number of methods tracked.
+        expr:
+          kind: path
+          path:
+            - totals
+            - methods
+      - name: complexity
+        type: Float64
+        nullable: true
+        description: Cyclomatic complexity.
+        expr:
+          kind: path
+          path:
+            - totals
+            - complexity
+      - name: complexity_total
+        type: Float64
+        nullable: true
+        description: Total complexity.
+        expr:
+          kind: path
+          path:
+            - totals
+            - complexity_total
+      - name: author__service
+        type: Utf8
+        nullable: true
+        description: Owner's hosting service.
+        expr:
+          kind: path
+          path:
+            - author
+            - service
+      - name: author__username
+        type: Utf8
+        nullable: true
+        description: Owner username.
+        expr:
+          kind: path
+          path:
+            - author
+            - username
+      - name: author__name
+        type: Utf8
+        nullable: true
+        description: Owner display name.
+        expr:
+          kind: path
+          path:
+            - author
+            - name
+      - name: updatestamp
+        type: Utf8
+        nullable: true
+        description: Last update time (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updatestamp
+      - name: search
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter by repository name search term.
+        expr:
+          kind: from_filter
+          key: search
+      - name: active_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter by active status.
+        expr:
+          kind: from_filter
+          key: active
+      - name: names_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter by repository names (comma-separated).
+        expr:
+          kind: from_filter
+          key: names
+
+  # ──────────────────────────────────────────────────────────────────────
+  # commits — list commits with coverage
+  # ──────────────────────────────────────────────────────────────────────
+  - name: commits
+    description: >
+      Lists commits with coverage data for a specific repository.
+      Returns commit SHA, message, author, branch, CI status, and
+      aggregate coverage totals per commit.
+    guide: >
+      Always filter by repo: `SELECT commitid, message, branch,
+      coverage, ci_passed FROM codecov.commits
+      WHERE repo = 'my-repo' LIMIT 20`. Optionally filter by
+      branch name.
+    filters:
+      - name: repo
+        required: true
+      - name: branch
+    request:
+      method: GET
+      path: /{{input.CODECOV_SERVICE}}/{{input.CODECOV_OWNER}}/repos/{{filter.repo}}/commits
+      query:
+        - name: branch
+          from: filter
+          key: branch
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 20
+        max: 100
+        query_param: page_size
+    columns:
+      - name: repo
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository name (from filter).
+        expr:
+          kind: from_filter
+          key: repo
+      - name: commitid
+        type: Utf8
+        nullable: false
+        description: Full commit SHA.
+        expr:
+          kind: path
+          path:
+            - commitid
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Commit message.
+        expr:
+          kind: path
+          path:
+            - message
+      - name: branch
+        type: Utf8
+        nullable: true
+        description: Branch this commit belongs to.
+        expr:
+          kind: path
+          path:
+            - branch
+      - name: state
+        type: Utf8
+        nullable: true
+        description: >-
+          Commit processing state (e.g. complete, pending, error).
+        expr:
+          kind: path
+          path:
+            - state
+      - name: ci_passed
+        type: Boolean
+        nullable: true
+        description: Whether CI passed for this commit.
+        expr:
+          kind: path
+          path:
+            - ci_passed
+      - name: parent
+        type: Utf8
+        nullable: true
+        description: Parent commit SHA.
+        expr:
+          kind: path
+          path:
+            - parent
+      - name: author__username
+        type: Utf8
+        nullable: true
+        description: Commit author username.
+        expr:
+          kind: path
+          path:
+            - author
+            - username
+      - name: author__name
+        type: Utf8
+        nullable: true
+        description: Commit author display name.
+        expr:
+          kind: path
+          path:
+            - author
+            - name
+      - name: author__service
+        type: Utf8
+        nullable: true
+        description: Commit author hosting service.
+        expr:
+          kind: path
+          path:
+            - author
+            - service
+      - name: timestamp
+        type: Utf8
+        nullable: true
+        description: Commit timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: coverage
+        type: Float64
+        nullable: true
+        description: Overall coverage percentage for this commit.
+        expr:
+          kind: path
+          path:
+            - totals
+            - coverage
+      - name: files
+        type: Int64
+        nullable: true
+        description: Number of files with coverage data.
+        expr:
+          kind: path
+          path:
+            - totals
+            - files
+      - name: lines
+        type: Int64
+        nullable: true
+        description: Total coverable lines.
+        expr:
+          kind: path
+          path:
+            - totals
+            - lines
+      - name: hits
+        type: Int64
+        nullable: true
+        description: Lines hit (covered).
+        expr:
+          kind: path
+          path:
+            - totals
+            - hits
+      - name: misses
+        type: Int64
+        nullable: true
+        description: Lines missed (uncovered).
+        expr:
+          kind: path
+          path:
+            - totals
+            - misses
+      - name: partials
+        type: Int64
+        nullable: true
+        description: Partially covered lines.
+        expr:
+          kind: path
+          path:
+            - totals
+            - partials
+      - name: complexity
+        type: Float64
+        nullable: true
+        description: Cyclomatic complexity.
+        expr:
+          kind: path
+          path:
+            - totals
+            - complexity
+      - name: branch_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter by branch name.
+        expr:
+          kind: from_filter
+          key: branch
+
+  # ──────────────────────────────────────────────────────────────────────
+  # pulls — list pull requests with coverage
+  # ──────────────────────────────────────────────────────────────────────
+  - name: pulls
+    description: >
+      Lists pull requests with coverage data for a specific repository.
+      Returns pull number, title, state, author, CI status, patch
+      coverage, and base/head coverage totals.
+    guide: >
+      Always filter by repo: `SELECT pullid, title, state,
+      coverage FROM codecov.pulls WHERE repo = 'my-repo'
+      LIMIT 20`. Filter by state (open/merged/closed) or
+      start_date for narrower results.
+    filters:
+      - name: repo
+        required: true
+      - name: state
+      - name: start_date
+      - name: ordering
+    request:
+      method: GET
+      path: /{{input.CODECOV_SERVICE}}/{{input.CODECOV_OWNER}}/repos/{{filter.repo}}/pulls
+      query:
+        - name: state
+          from: filter
+          key: state
+        - name: start_date
+          from: filter
+          key: start_date
+        - name: ordering
+          from: filter
+          key: ordering
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 20
+        max: 100
+        query_param: page_size
+    columns:
+      - name: repo
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository name (from filter).
+        expr:
+          kind: from_filter
+          key: repo
+      - name: pullid
+        type: Int64
+        nullable: false
+        description: Pull request number.
+        expr:
+          kind: path
+          path:
+            - pullid
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Pull request title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: state
+        type: Utf8
+        nullable: true
+        description: >-
+          Pull request state (open, merged, closed).
+        expr:
+          kind: path
+          path:
+            - state
+      - name: ci_passed
+        type: Boolean
+        nullable: true
+        description: Whether CI passed for this pull request.
+        expr:
+          kind: path
+          path:
+            - ci_passed
+      - name: author__username
+        type: Utf8
+        nullable: true
+        description: Pull request author username.
+        expr:
+          kind: path
+          path:
+            - author
+            - username
+      - name: author__name
+        type: Utf8
+        nullable: true
+        description: Pull request author display name.
+        expr:
+          kind: path
+          path:
+            - author
+            - name
+      - name: author__service
+        type: Utf8
+        nullable: true
+        description: Pull request author hosting service.
+        expr:
+          kind: path
+          path:
+            - author
+            - service
+      - name: coverage
+        type: Float64
+        nullable: true
+        description: Head coverage percentage for this PR.
+        expr:
+          kind: path
+          path:
+            - head_totals
+            - coverage
+      - name: files
+        type: Int64
+        nullable: true
+        description: Number of files with head coverage data.
+        expr:
+          kind: path
+          path:
+            - head_totals
+            - files
+      - name: lines
+        type: Int64
+        nullable: true
+        description: Total coverable lines in the PR head.
+        expr:
+          kind: path
+          path:
+            - head_totals
+            - lines
+      - name: hits
+        type: Int64
+        nullable: true
+        description: Lines hit in the PR head.
+        expr:
+          kind: path
+          path:
+            - head_totals
+            - hits
+      - name: misses
+        type: Int64
+        nullable: true
+        description: Lines missed in the PR head.
+        expr:
+          kind: path
+          path:
+            - head_totals
+            - misses
+      - name: partials
+        type: Int64
+        nullable: true
+        description: Partially covered lines in the PR head.
+        expr:
+          kind: path
+          path:
+            - head_totals
+            - partials
+      - name: base_coverage
+        type: Float64
+        nullable: true
+        description: Base coverage percentage for this PR.
+        expr:
+          kind: path
+          path:
+            - base_totals
+            - coverage
+      - name: patch_coverage
+        type: Float64
+        nullable: true
+        description: Patch coverage percentage for changed lines.
+        expr:
+          kind: path
+          path:
+            - patch
+            - coverage
+      - name: patch_hits
+        type: Int64
+        nullable: true
+        description: Patch lines hit.
+        expr:
+          kind: path
+          path:
+            - patch
+            - hits
+      - name: patch_misses
+        type: Int64
+        nullable: true
+        description: Patch lines missed.
+        expr:
+          kind: path
+          path:
+            - patch
+            - misses
+      - name: patch_partials
+        type: Int64
+        nullable: true
+        description: Patch lines partially covered.
+        expr:
+          kind: path
+          path:
+            - patch
+            - partials
+      - name: updatestamp
+        type: Utf8
+        nullable: true
+        description: Last update time (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updatestamp
+      - name: state_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the state filter.
+        expr:
+          kind: from_filter
+          key: state
+      - name: start_date_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the start_date filter.
+        expr:
+          kind: from_filter
+          key: start_date
+      - name: ordering_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the ordering filter.
+        expr:
+          kind: from_filter
+          key: ordering
+
+  # ──────────────────────────────────────────────────────────────────────
+  # branches — list branches
+  # ──────────────────────────────────────────────────────────────────────
+  - name: branches
+    description: >
+      Lists branches with coverage data for a specific repository.
+      Returns branch name and last update timestamp.
+    guide: >
+      Always filter by repo: `SELECT name, updatestamp
+      FROM codecov.branches WHERE repo = 'my-repo' LIMIT 20`.
+    filters:
+      - name: repo
+        required: true
+    request:
+      method: GET
+      path: /{{input.CODECOV_SERVICE}}/{{input.CODECOV_OWNER}}/repos/{{filter.repo}}/branches
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 20
+        max: 100
+        query_param: page_size
+    columns:
+      - name: repo
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository name (from filter).
+        expr:
+          kind: from_filter
+          key: repo
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Branch name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: updatestamp
+        type: Utf8
+        nullable: true
+        description: Last update time (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updatestamp
+
+  # ──────────────────────────────────────────────────────────────────────
+  # flags — list coverage flags
+  # ──────────────────────────────────────────────────────────────────────
+  - name: flags
+    description: >
+      Lists coverage flags for a specific repository. Flags let you
+      segment coverage by test suite, component, or any grouping
+      defined in your CI configuration.
+    guide: >
+      Always filter by repo: `SELECT flag_name, coverage
+      FROM codecov.flags WHERE repo = 'my-repo'`.
+    filters:
+      - name: repo
+        required: true
+    request:
+      method: GET
+      path: /{{input.CODECOV_SERVICE}}/{{input.CODECOV_OWNER}}/repos/{{filter.repo}}/flags
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 20
+        max: 100
+        query_param: page_size
+    columns:
+      - name: repo
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository name (from filter).
+        expr:
+          kind: from_filter
+          key: repo
+      - name: flag_name
+        type: Utf8
+        nullable: false
+        description: Flag name as defined in CI configuration.
+        expr:
+          kind: path
+          path:
+            - flag_name
+      - name: coverage
+        type: Float64
+        nullable: true
+        description: Coverage percentage for this flag.
+        expr:
+          kind: path
+          path:
+            - coverage
+
+  # ──────────────────────────────────────────────────────────────────────
+  # components — list coverage components
+  # ──────────────────────────────────────────────────────────────────────
+  - name: components
+    description: >
+      Lists coverage components for a specific repository. Components
+      are named groups of file paths defined in your codecov.yml
+      that let you track coverage for logical areas of your codebase.
+    guide: >
+      Always filter by repo: `SELECT component_id, name,
+      coverage FROM codecov.components WHERE repo = 'my-repo'`.
+    filters:
+      - name: repo
+        required: true
+    request:
+      method: GET
+      path: /{{input.CODECOV_SERVICE}}/{{input.CODECOV_OWNER}}/repos/{{filter.repo}}/components
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: repo
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository name (from filter).
+        expr:
+          kind: from_filter
+          key: repo
+      - name: component_id
+        type: Utf8
+        nullable: false
+        description: Unique component identifier.
+        expr:
+          kind: path
+          path:
+            - component_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Component display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: coverage
+        type: Float64
+        nullable: true
+        description: Coverage percentage for this component.
+        expr:
+          kind: path
+          path:
+            - coverage
+
+  # ──────────────────────────────────────────────────────────────────────
+  # commit_uploads — list uploads for a commit
+  # ──────────────────────────────────────────────────────────────────────
+  - name: commit_uploads
+    description: >
+      Lists coverage report uploads for a specific commit. Returns
+      upload provider, build information, flags, job code, and
+      timestamps. Useful for debugging CI upload issues.
+    guide: >
+      Filter by repo and commitid: `SELECT upload_type, state,
+      provider, flags, job_code FROM codecov.commit_uploads
+      WHERE repo = 'my-repo' AND commitid = '<sha>'`.
+    filters:
+      - name: repo
+        required: true
+      - name: commitid
+        required: true
+    request:
+      method: GET
+      path: /{{input.CODECOV_SERVICE}}/{{input.CODECOV_OWNER}}/repos/{{filter.repo}}/commits/{{filter.commitid}}/uploads/
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 20
+        max: 100
+        query_param: page_size
+    columns:
+      - name: repo
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository name (from filter).
+        expr:
+          kind: from_filter
+          key: repo
+      - name: commitid
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Commit SHA (from filter).
+        expr:
+          kind: from_filter
+          key: commitid
+      - name: upload_type
+        type: Utf8
+        nullable: true
+        description: >-
+          Upload type (e.g. uploaded, carriedforward).
+        expr:
+          kind: path
+          path:
+            - upload_type
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Upload processing state.
+        expr:
+          kind: path
+          path:
+            - state
+      - name: provider
+        type: Utf8
+        nullable: true
+        description: CI provider name.
+        expr:
+          kind: path
+          path:
+            - provider
+      - name: build_code
+        type: Utf8
+        nullable: true
+        description: CI build identifier.
+        expr:
+          kind: path
+          path:
+            - build_code
+      - name: build_url
+        type: Utf8
+        nullable: true
+        description: URL to the CI build.
+        expr:
+          kind: path
+          path:
+            - build_url
+      - name: job_code
+        type: Utf8
+        nullable: true
+        description: CI job identifier.
+        expr:
+          kind: path
+          path:
+            - job_code
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Upload name or label.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: env
+        type: Json
+        nullable: true
+        description: >-
+          Environment variables captured during upload (JSON object).
+        expr:
+          kind: path
+          path:
+            - env
+      - name: flags
+        type: Json
+        nullable: true
+        description: >-
+          Array of flag names associated with this upload.
+        expr:
+          kind: path
+          path:
+            - flags
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Upload creation time (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Upload last update time (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updated_at


### PR DESCRIPTION
## Summary

Adds a new community source for Codecov under `sources/community/codecov/`.

This source enables querying Codecov account data (repositories, commits, pull requests, branches, coverage flags, components, and commit uploads) through SQL using the Codecov REST API v2. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `HeaderAuth`. No CLI, MCP, config, or runtime changes.

Closes #502

## What changed

Added:

- `sources/community/codecov/manifest.yaml`
- `sources/community/codecov/README.md`

## Tables

| Table | Endpoint | Required Filters | Pagination | Notes |
|---|---|---|---|---|
| `repos` | `GET /{service}/{owner}/repos` | — | page (max 100) | Aggregate coverage totals |
| `commits` | `GET /.../repos/{repo}/commits` | `repo` | page (max 100) | Per-commit coverage + CI status |
| `pulls` | `GET /.../repos/{repo}/pulls` | `repo` | page (max 100) | Head, base, and patch coverage |
| `branches` | `GET /.../repos/{repo}/branches` | `repo` | page (max 100) | Branch names + timestamps |
| `flags` | `GET /.../repos/{repo}/flags` | `repo` | page (max 100) | Flag name + top-level coverage |
| `components` | `GET /.../repos/{repo}/components` | `repo` | none (array) | Component name + top-level coverage |
| `commit_uploads` | `GET /.../repos/{repo}/commits/{sha}/uploads/` | `repo`, `commitid` | page (max 100) | CI provider, flags, build info |

## Auth

Bearer token authentication with `Authorization: Bearer <token>`.

Inputs:

- `CODECOV_API_TOKEN` — required secret. Generate at https://app.codecov.io/account (Settings > Access)
- `CODECOV_SERVICE` — optional variable. Git hosting provider. Defaults to `github`. Also supports `github_enterprise`, `gitlab`, `gitlab_enterprise`, `bitbucket`, `bitbucket_server`.
- `CODECOV_OWNER` — required variable. Username or organization name on the hosting service.

## Implementation notes

- All paginated endpoints use `page` + `page_size` with `page_start: 1` (Codecov rejects page 0 with `{"detail":"Invalid page."}`)
- Response envelope is Django REST Framework style: `{count, next, previous, results: [...]}`; all paginated tables use `rows_path: [results]`
- The `components` endpoint returns a top-level JSON array (not `{results: [...]}`), so it uses `row_strategy: direct` with `mode: none`
- **Inconsistent coverage paths across endpoints:**
  - `repos` and `commits`: coverage under `totals.coverage`
  - `pulls`: uses `head_totals`, `base_totals`, and `patch` objects (not `totals`)
  - `flags` and `components`: `coverage` at top level (no `totals` wrapper)
- Nested `totals` objects are flattened into top-level columns (coverage, files, lines, hits, misses, partials)
- Nested `author` objects are flattened with `__` separator (author__username, author__name, author__service)
- All queries scoped to `CODECOV_SERVICE` + `CODECOV_OWNER` set at install time
- Timestamps are ISO 8601 strings mapped as `Utf8`
- `commit_uploads.flags` and `commit_uploads.env` are mapped as `Json` (arrays/objects)

## Validation

- `coral source lint sources/community/codecov/manifest.yaml` — passes
- `make lint-sources` — passes
- `git diff --check` — passes
- `coral source add` with real token — successfully exposes 7 tables, test query passes
- Live query validation — **all 7 tables queried successfully** against the `codecov/umbrella` organization:
  - `repos`: 5 rows with coverage data (umbrella: 91.9%, wrapper: 97.14%)
  - `commits`: 5 rows with commit SHAs, messages, branches, coverage, CI status
  - `pulls`: 3 rows with PR numbers, titles, head/base/patch coverage (e.g. PR #920: head 91.9%, base 91.9%, patch 100%)
  - `branches`: 5 rows with branch names and timestamps (main, feature branches)
  - `flags`: 5 rows with per-flag coverage (apiunit: 94.96%, workerunit: 90.37%, workerintegration: 58.54%)
  - `components`: 3 rows with coverage (worker: 93.66%, codecov-api: 94.95%, shared: 85.69%)
  - `commit_uploads`: 5 rows with upload types (uploaded, carriedforward), providers (github-actions), flags

## User-visible impact

New `codecov` source installable via:

```bash
export CODECOV_API_TOKEN="your_token"
export CODECOV_SERVICE="github"
export CODECOV_OWNER="your_org"
coral source add --file sources/community/codecov/manifest.yaml
```

Example queries:

```sql
-- Find repos with low coverage
SELECT name, language, coverage, lines, misses
FROM codecov.repos
WHERE coverage < 50
ORDER BY coverage ASC;

-- Track coverage across recent commits
SELECT commitid, message, branch, coverage, ci_passed, timestamp
FROM codecov.commits
WHERE repo = 'my-repo'
LIMIT 50;

-- Review PR coverage impact
SELECT pullid, title, state, coverage, base_coverage, patch_coverage
FROM codecov.pulls
WHERE repo = 'my-repo' AND state = 'open';

-- Compare coverage across test flags
SELECT flag_name, coverage
FROM codecov.flags
WHERE repo = 'my-repo'
ORDER BY coverage ASC;

-- Track component coverage
SELECT component_id, name, coverage
FROM codecov.components
WHERE repo = 'my-repo';

-- Audit CI uploads for a commit
SELECT provider, upload_type, state, flags, created_at
FROM codecov.commit_uploads
WHERE repo = 'my-repo' AND commitid = 'abc123';

-- List active branches
SELECT name, updatestamp
FROM codecov.branches
WHERE repo = 'my-repo';

-- Search repositories by name
SELECT name, coverage, active
FROM codecov.repos
WHERE search = 'api';
```

## Known limitations

- **Read-only** — no create, update, or delete operations
- **Single owner per install** — queries are scoped to `CODECOV_OWNER`; multiple orgs need multiple installs
- **Components are simple** — the API only returns `component_id`, `name`, and `coverage` (no files/lines breakdown)
- **Flags are simple** — the flags list only returns `flag_name` and `coverage` (no line counts)
- **Timestamps as strings** — ISO 8601 format, not `Timestamp` type

## Out of scope

Not included in v1:

- Coverage report tree (hierarchical file-level data)
- Coverage totals endpoint (single-row, overlaps with repos table)
- Comparison endpoint (complex diff data)
- Coverage trends time-series
- Write operations
