### PR TITLE
feat(sources/community/splunk): add Splunk source spec

### DIFF
--- a/sources/community/splunk/README.md
+++ b/sources/community/splunk/README.md
@@ -1,0 +1,226 @@
+# Splunk Community Source
+
+Query Splunk Enterprise or Splunk Cloud management REST API inventory through
+Coral SQL.
+
+## Setup
+
+### 1. Create a Splunk authentication token
+
+Create a Splunk authentication token for a user or service account with read
+access to the resources you plan to inspect. Splunk REST API tokens can be used
+with an `Authorization: Bearer <token>` header.
+
+### 2. Configure the API base URL
+
+Set `SPLUNK_API_BASE` to the Splunk management REST API URL. The default is
+`https://localhost:8089`.
+
+```bash
+export SPLUNK_API_BASE="https://splunk.example.com:8089"
+export SPLUNK_TOKEN="<your-token>"
+```
+
+### 3. Add the source
+
+```bash
+coral source add --file sources/community/splunk/manifest.yaml
+```
+
+### 4. Verify
+
+```bash
+coral source test splunk
+```
+
+The default test query reads `splunk.server_info`.
+
+## Tables
+
+### `splunk.server_info`
+
+Basic Splunk server metadata.
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | Entry name |
+| `server_name` | Utf8 | Splunk server name |
+| `host` | Utf8 | Server host |
+| `version` | Utf8 | Splunk version |
+| `build` | Utf8 | Splunk build |
+| `guid` | Utf8 | Server GUID |
+| `license_signature` | Utf8 | License signature |
+| `os_name` | Utf8 | Operating system name |
+| `os_version` | Utf8 | Operating system version |
+| `cpu_arch` | Utf8 | CPU architecture |
+
+### `splunk.indexes`
+
+Indexes visible to the authenticated token.
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | Index name |
+| `title` | Utf8 | Index title |
+| `disabled` | Boolean | Whether the index is disabled |
+| `datatype` | Utf8 | Index data type |
+| `home_path` | Utf8 | Hot/warm bucket path |
+| `cold_path` | Utf8 | Cold bucket path |
+| `thawed_path` | Utf8 | Thawed bucket path |
+| `current_db_size_mb` | Int64 | Current size in MB |
+| `total_event_count` | Int64 | Total event count |
+| `max_total_data_size_mb` | Int64 | Max total data size in MB |
+| `frozen_time_period_in_secs` | Int64 | Retention period before freezing |
+| `updated` | Timestamp | Entry update time |
+| `acl` | Json | Access control metadata |
+
+**Optional filter:** `search`
+
+### `splunk.saved_searches`
+
+Saved searches, reports, and alert searches across Splunk namespaces.
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | Saved search name |
+| `title` | Utf8 | Saved search title |
+| `author` | Utf8 | Author |
+| `app` | Utf8 | Splunk app namespace |
+| `owner` | Utf8 | Owner namespace |
+| `sharing` | Utf8 | Sharing scope |
+| `disabled` | Boolean | Whether disabled |
+| `is_scheduled` | Boolean | Whether scheduled |
+| `cron_schedule` | Utf8 | Cron schedule |
+| `search` | Utf8 | SPL search string |
+| `alert_type` | Utf8 | Alert type |
+| `alert_comparator` | Utf8 | Alert comparator |
+| `alert_threshold` | Utf8 | Alert threshold |
+| `actions` | Utf8 | Comma-separated alert actions |
+| `dispatch_earliest_time` | Utf8 | Earliest dispatch time |
+| `dispatch_latest_time` | Utf8 | Latest dispatch time |
+| `updated` | Timestamp | Entry update time |
+
+**Optional filter:** `search`
+
+### `splunk.apps`
+
+Installed Splunk apps.
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | App name |
+| `label` | Utf8 | App label |
+| `version` | Utf8 | App version |
+| `author` | Utf8 | App author |
+| `disabled` | Boolean | Whether disabled |
+| `visible` | Boolean | Whether visible in launcher |
+| `configured` | Boolean | Whether setup completed |
+| `state` | Utf8 | App state |
+| `updated` | Timestamp | Entry update time |
+
+**Optional filter:** `search`
+
+### `splunk.users`
+
+Users visible to the authenticated token.
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | Username |
+| `realname` | Utf8 | Real name |
+| `email` | Utf8 | Email |
+| `default_app` | Utf8 | Default app |
+| `type` | Utf8 | User type |
+| `roles` | Json | Assigned roles |
+| `updated` | Timestamp | Entry update time |
+
+**Optional filter:** `search`
+
+### `splunk.search_jobs`
+
+Search jobs visible to the authenticated token.
+
+| Column | Type | Description |
+|---|---|---|
+| `sid` | Utf8 | Search job ID |
+| `label` | Utf8 | Search job label |
+| `dispatch_state` | Utf8 | Dispatch state |
+| `is_done` | Boolean | Whether done |
+| `is_failed` | Boolean | Whether failed |
+| `is_paused` | Boolean | Whether paused |
+| `event_count` | Int64 | Matching event count |
+| `result_count` | Int64 | Result count |
+| `scan_count` | Int64 | Scanned event count |
+| `done_progress` | Float64 | Completion progress |
+| `run_duration` | Float64 | Run duration in seconds |
+| `earliest_time` | Timestamp | Earliest event time |
+| `latest_time` | Timestamp | Latest event time |
+| `updated` | Timestamp | Entry update time |
+| `search` | Utf8 | Search string |
+
+**Optional filter:** `search`
+
+## Example Queries
+
+```sql
+-- Check Splunk version and host metadata
+SELECT server_name, host, version, build
+FROM splunk.server_info;
+
+-- Find large indexes
+SELECT name, current_db_size_mb, total_event_count, frozen_time_period_in_secs
+FROM splunk.indexes
+ORDER BY current_db_size_mb DESC
+LIMIT 20;
+
+-- Review enabled scheduled searches and alerts
+SELECT app, owner, name, cron_schedule, alert_type, actions
+FROM splunk.saved_searches
+WHERE disabled = false AND is_scheduled = true
+ORDER BY app, name;
+
+-- Inventory installed apps
+SELECT name, label, version, disabled, visible
+FROM splunk.apps
+ORDER BY name;
+
+-- Find failed or incomplete search jobs
+SELECT sid, dispatch_state, is_failed, run_duration, result_count
+FROM splunk.search_jobs
+WHERE is_done = false OR is_failed = true
+ORDER BY updated DESC;
+```
+
+## Validation
+
+```bash
+export SPLUNK_API_BASE="https://splunk.example.com:8089"
+export SPLUNK_TOKEN="<your-token>"
+coral source lint sources/community/splunk/manifest.yaml
+coral source add --file sources/community/splunk/manifest.yaml
+coral source test splunk
+coral sql "SELECT * FROM coral.tables WHERE schema_name = 'splunk'"
+coral sql "SELECT * FROM coral.columns WHERE schema_name = 'splunk'"
+coral sql "SELECT name, version, server_name FROM splunk.server_info"
+```
+
+## Limitations
+
+- **Read-only.** This source does not create search jobs, edit saved searches,
+  mutate indexes, manage apps, or update users.
+- **Management API required.** The Splunk management REST API is commonly
+  exposed on port `8089`. Network and role restrictions may prevent access.
+- **Token permissions.** Results depend on the authenticated token's Splunk
+  capabilities and namespace access.
+- **No event export in v1.** This source focuses on inventory and operational
+  metadata. Search result export requires form-encoded POST behavior and is
+  left for a future source revision.
+
+## Out of scope for v1
+
+- Creating or exporting ad hoc searches
+- Raw event/result retrieval
+- Knowledge objects beyond saved searches
+- Cluster manager and indexer cluster administration
+- License usage and license pool management
+- Write operations

--- a/sources/community/splunk/manifest.yaml
+++ b/sources/community/splunk/manifest.yaml
@@ -1,0 +1,563 @@
+name: splunk
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query Splunk server info, indexes, saved searches, apps, users, and search jobs.
+base_url: "{{input.SPLUNK_API_BASE}}"
+
+inputs:
+  SPLUNK_API_BASE:
+    kind: variable
+    default: https://localhost:8089
+    hint: |
+      Base URL for the Splunk management REST API, for example
+      `https://splunk.example.com:8089`. Do not include a trailing slash.
+  SPLUNK_TOKEN:
+    kind: secret
+    hint: |
+      Splunk authentication token for REST API access. Create a Splunk
+      authentication token and grant read access to the indexes, saved
+      searches, apps, users, and search jobs you plan to query.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.SPLUNK_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT name, version, server_name FROM splunk.server_info LIMIT 1
+
+tables:
+  - name: server_info
+    description: Splunk server information.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /services/server/info
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Entry name.
+        expr: {kind: path, path: [name]}
+      - name: server_name
+        type: Utf8
+        nullable: true
+        description: Splunk server name.
+        expr: {kind: path, path: [content, serverName]}
+      - name: host
+        type: Utf8
+        nullable: true
+        description: Splunk server host.
+        expr: {kind: path, path: [content, host]}
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Splunk version.
+        expr: {kind: path, path: [content, version]}
+      - name: build
+        type: Utf8
+        nullable: true
+        description: Splunk build.
+        expr: {kind: path, path: [content, build]}
+      - name: guid
+        type: Utf8
+        nullable: true
+        description: Splunk server GUID.
+        expr: {kind: path, path: [content, guid]}
+      - name: license_signature
+        type: Utf8
+        nullable: true
+        description: License signature.
+        expr: {kind: path, path: [content, licenseSignature]}
+      - name: os_name
+        type: Utf8
+        nullable: true
+        description: Operating system name.
+        expr: {kind: path, path: [content, os_name]}
+      - name: os_version
+        type: Utf8
+        nullable: true
+        description: Operating system version.
+        expr: {kind: path, path: [content, os_version]}
+      - name: cpu_arch
+        type: Utf8
+        nullable: true
+        description: CPU architecture.
+        expr: {kind: path, path: [content, cpu_arch]}
+
+  - name: indexes
+    description: Splunk indexes visible to the authenticated token.
+    filters:
+      - name: search
+        mode: search
+    request:
+      method: GET
+      path: /services/data/indexes
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: filter
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Index name.
+        expr: {kind: path, path: [name]}
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Index title.
+        expr: {kind: path, path: [content, title]}
+      - name: disabled
+        type: Boolean
+        nullable: true
+        description: Whether the index is disabled.
+        expr: {kind: path, path: [content, disabled]}
+      - name: datatype
+        type: Utf8
+        nullable: true
+        description: Index data type.
+        expr: {kind: path, path: [content, datatype]}
+      - name: home_path
+        type: Utf8
+        nullable: true
+        description: Home path for hot and warm buckets.
+        expr: {kind: path, path: [content, homePath]}
+      - name: cold_path
+        type: Utf8
+        nullable: true
+        description: Cold bucket path.
+        expr: {kind: path, path: [content, coldPath]}
+      - name: thawed_path
+        type: Utf8
+        nullable: true
+        description: Thawed bucket path.
+        expr: {kind: path, path: [content, thawedPath]}
+      - name: current_db_size_mb
+        type: Int64
+        nullable: true
+        description: Current index size in MB.
+        expr: {kind: path, path: [content, currentDBSizeMB]}
+      - name: total_event_count
+        type: Int64
+        nullable: true
+        description: Total event count.
+        expr: {kind: path, path: [content, totalEventCount]}
+      - name: max_total_data_size_mb
+        type: Int64
+        nullable: true
+        description: Maximum total data size in MB.
+        expr: {kind: path, path: [content, maxTotalDataSizeMB]}
+      - name: frozen_time_period_in_secs
+        type: Int64
+        nullable: true
+        description: Retention period in seconds before data is frozen.
+        expr: {kind: path, path: [content, frozenTimePeriodInSecs]}
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Entry update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated]}
+      - name: acl
+        type: Json
+        nullable: true
+        description: Access control metadata.
+        expr: {kind: path, path: [acl]}
+
+  - name: saved_searches
+    description: Saved searches, reports, and alert searches across Splunk namespaces.
+    filters:
+      - name: search
+        mode: search
+    request:
+      method: GET
+      path: /servicesNS/-/-/saved/searches
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: filter
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Saved search name.
+        expr: {kind: path, path: [name]}
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Saved search title.
+        expr: {kind: path, path: [content, title]}
+      - name: author
+        type: Utf8
+        nullable: true
+        description: Saved search author.
+        expr: {kind: path, path: [author]}
+      - name: app
+        type: Utf8
+        nullable: true
+        description: Splunk app namespace.
+        expr: {kind: path, path: [acl, app]}
+      - name: owner
+        type: Utf8
+        nullable: true
+        description: Splunk owner namespace.
+        expr: {kind: path, path: [acl, owner]}
+      - name: sharing
+        type: Utf8
+        nullable: true
+        description: Sharing scope.
+        expr: {kind: path, path: [acl, sharing]}
+      - name: disabled
+        type: Boolean
+        nullable: true
+        description: Whether the saved search is disabled.
+        expr: {kind: path, path: [content, disabled]}
+      - name: is_scheduled
+        type: Boolean
+        nullable: true
+        description: Whether the saved search is scheduled.
+        expr: {kind: path, path: [content, is_scheduled]}
+      - name: cron_schedule
+        type: Utf8
+        nullable: true
+        description: Cron schedule.
+        expr: {kind: path, path: [content, cron_schedule]}
+      - name: search
+        type: Utf8
+        nullable: true
+        description: SPL search string.
+        expr: {kind: path, path: [content, search]}
+      - name: alert_type
+        type: Utf8
+        nullable: true
+        description: Alert type.
+        expr: {kind: path, path: [content, alert_type]}
+      - name: alert_comparator
+        type: Utf8
+        nullable: true
+        description: Alert comparator.
+        expr: {kind: path, path: [content, alert_comparator]}
+      - name: alert_threshold
+        type: Utf8
+        nullable: true
+        description: Alert threshold.
+        expr: {kind: path, path: [content, alert_threshold]}
+      - name: actions
+        type: Utf8
+        nullable: true
+        description: Comma-separated alert actions.
+        expr: {kind: path, path: [content, actions]}
+      - name: dispatch_earliest_time
+        type: Utf8
+        nullable: true
+        description: Earliest dispatch time.
+        expr: {kind: path, path: [content, dispatch.earliest_time]}
+      - name: dispatch_latest_time
+        type: Utf8
+        nullable: true
+        description: Latest dispatch time.
+        expr: {kind: path, path: [content, dispatch.latest_time]}
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Entry update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated]}
+
+  - name: apps
+    description: Installed Splunk apps.
+    filters:
+      - name: search
+        mode: search
+    request:
+      method: GET
+      path: /services/apps/local
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: filter
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: App name.
+        expr: {kind: path, path: [name]}
+      - name: label
+        type: Utf8
+        nullable: true
+        description: App label.
+        expr: {kind: path, path: [content, label]}
+      - name: version
+        type: Utf8
+        nullable: true
+        description: App version.
+        expr: {kind: path, path: [content, version]}
+      - name: author
+        type: Utf8
+        nullable: true
+        description: App author.
+        expr: {kind: path, path: [author]}
+      - name: disabled
+        type: Boolean
+        nullable: true
+        description: Whether the app is disabled.
+        expr: {kind: path, path: [content, disabled]}
+      - name: visible
+        type: Boolean
+        nullable: true
+        description: Whether the app is visible in the launcher.
+        expr: {kind: path, path: [content, visible]}
+      - name: configured
+        type: Boolean
+        nullable: true
+        description: Whether the app has completed setup.
+        expr: {kind: path, path: [content, configured]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: App state.
+        expr: {kind: path, path: [content, state]}
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Entry update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated]}
+
+  - name: users
+    description: Splunk users visible to the authenticated token.
+    filters:
+      - name: search
+        mode: search
+    request:
+      method: GET
+      path: /services/authentication/users
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: filter
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Username.
+        expr: {kind: path, path: [name]}
+      - name: realname
+        type: Utf8
+        nullable: true
+        description: User real name.
+        expr: {kind: path, path: [content, realname]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+        expr: {kind: path, path: [content, email]}
+      - name: default_app
+        type: Utf8
+        nullable: true
+        description: Default Splunk app.
+        expr: {kind: path, path: [content, defaultApp]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: User type.
+        expr: {kind: path, path: [content, type]}
+      - name: roles
+        type: Json
+        nullable: true
+        description: Roles assigned to the user.
+        expr: {kind: path, path: [content, roles]}
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Entry update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated]}
+
+  - name: search_jobs
+    description: Search jobs visible to the authenticated token.
+    filters:
+      - name: search
+        mode: search
+    request:
+      method: GET
+      path: /services/search/jobs
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: filter
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: sid
+        type: Utf8
+        nullable: false
+        description: Search job ID.
+        expr: {kind: path, path: [name]}
+      - name: label
+        type: Utf8
+        nullable: true
+        description: Search job label.
+        expr: {kind: path, path: [content, label]}
+      - name: dispatch_state
+        type: Utf8
+        nullable: true
+        description: Dispatch state.
+        expr: {kind: path, path: [content, dispatchState]}
+      - name: is_done
+        type: Boolean
+        nullable: true
+        description: Whether the job is done.
+        expr: {kind: path, path: [content, isDone]}
+      - name: is_failed
+        type: Boolean
+        nullable: true
+        description: Whether the job failed.
+        expr: {kind: path, path: [content, isFailed]}
+      - name: is_paused
+        type: Boolean
+        nullable: true
+        description: Whether the job is paused.
+        expr: {kind: path, path: [content, isPaused]}
+      - name: event_count
+        type: Int64
+        nullable: true
+        description: Number of matching events.
+        expr: {kind: path, path: [content, eventCount]}
+      - name: result_count
+        type: Int64
+        nullable: true
+        description: Number of search results.
+        expr: {kind: path, path: [content, resultCount]}
+      - name: scan_count
+        type: Int64
+        nullable: true
+        description: Number of scanned events.
+        expr: {kind: path, path: [content, scanCount]}
+      - name: done_progress
+        type: Float64
+        nullable: true
+        description: Search completion progress.
+        expr: {kind: path, path: [content, doneProgress]}
+      - name: run_duration
+        type: Float64
+        nullable: true
+        description: Search run duration in seconds.
+        expr: {kind: path, path: [content, runDuration]}
+      - name: earliest_time
+        type: Timestamp
+        nullable: true
+        description: Earliest event time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [content, earliestTime]}
+      - name: latest_time
+        type: Timestamp
+        nullable: true
+        description: Latest event time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [content, latestTime]}
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Entry update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated]}
+      - name: search
+        type: Utf8
+        nullable: true
+        description: Search string.
+        expr: {kind: path, path: [content, search]}


### PR DESCRIPTION
## Summary
- closes #509
- add a community Splunk HTTP source spec for server info, indexes, saved searches, apps, users, and search jobs
- document setup, table columns, example SQL, validation, and v1 limitations
- checked existing repo sources, open PRs, and open issues before implementation; Splunk was not present and no existing Splunk PR/issue was found before creating #509

## Validation
- Ruby YAML parse: passed
- coral source lint sources/community/splunk/manifest.yaml: passed
- git diff --check: passed
- live coral source test: not run because no Splunk instance/token is available in this environment
- make rust-checks: not run because cargo is not installed in this environment

## Contributor behavior
- No agent/contributor operating guidance changed.