### PR TITLE
feat(sources/community/signoz): add SigNoz community source

### DIFF
--- a/sources/community/signoz/README.md
+++ b/sources/community/signoz/README.md
@@ -18,7 +18,7 @@ To create one:
 2. Click **New Service Account**, give it a name, and click **Create**.
 3. In the **Overview** tab, assign the **SigNoz-Viewer** role and click **Save**.
 4. Switch to the **Keys** tab, click **Add Key**, enter a name, and click **Create**.
-5. Copy the key immediately â€” it is shown only once.
+5. Copy the key immediately -- it is shown only once.
 
 See the [SigNoz service accounts docs](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/).
 
@@ -40,11 +40,11 @@ SIGNOZ_API_KEY=<your-key> \
 
 | Table | Description | Required filters |
 |---|---|---|
-| `services` | APM services reporting to SigNoz | â€” |
+| `services` | APM services reporting to SigNoz | -- |
 | `logs` | Log query results via query_range API | `start_time`, `end_time` |
 | `traces` | Trace query results via query_range API | `start_time`, `end_time` |
-| `dashboards` | Dashboards configured in SigNoz | â€” |
-| `alerts` | Alert rules configured in SigNoz | â€” |
+| `dashboards` | Dashboards configured in SigNoz | -- |
+| `alerts` | Alert rules configured in SigNoz | -- |
 
 ### Time filter note
 
@@ -65,7 +65,7 @@ coral sql "
 
 # Search recent logs (supply epoch-ms timestamps)
 coral sql "
-  SELECT queryName, nextCursor, rows
+  SELECT query_name, next_cursor, rows
   FROM signoz.logs
   WHERE start_time = 1700000000000
     AND end_time   = 1700003600000
@@ -73,7 +73,7 @@ coral sql "
 
 # Search recent trace spans
 coral sql "
-  SELECT queryName, nextCursor, rows
+  SELECT query_name, next_cursor, rows
   FROM signoz.traces
   WHERE start_time = 1700000000000
     AND end_time   = 1700003600000
@@ -97,17 +97,17 @@ coral sql "
 
 ```text
 services
-  â†’ serviceName
+  -> serviceName
 
 logs   (WHERE start_time = ... AND end_time = ...)
-  â†’ rows (JSON array of log objects)
+  -> rows (JSON array of log objects)
 
 traces (WHERE start_time = ... AND end_time = ...)
-  â†’ rows (JSON array of span objects)
+  -> rows (JSON array of span objects)
 
 dashboards
-  â†’ uuid
+  -> uuid
 
 alerts
-  â†’ id
+  -> id
 ```

--- a/sources/community/signoz/README.md
+++ b/sources/community/signoz/README.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP
-**Tables:** 6
+**Tables:** 5
 **Base URL:** your SigNoz instance URL (set via `SIGNOZ_URL`)
 
 Query services, logs, traces, dashboards, and alerts from SigNoz
@@ -18,7 +18,7 @@ To create one:
 2. Click **New Service Account**, give it a name, and click **Create**.
 3. In the **Overview** tab, assign the **SigNoz-Viewer** role and click **Save**.
 4. Switch to the **Keys** tab, click **Add Key**, enter a name, and click **Create**.
-5. Copy the key immediately — it is shown only once.
+5. Copy the key immediately â€” it is shown only once.
 
 See the [SigNoz service accounts docs](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/).
 
@@ -38,19 +38,20 @@ SIGNOZ_API_KEY=<your-key> \
 
 ## Tables
 
-| Table | Description | Required filters | Optional filters |
-|---|---|---|---|
-| `services` | APM services reporting to SigNoz | — | — |
-| `operations` | Span operation names for a service | `service_name` | — |
-| `logs` | Log entries via query_range API | `start_time`, `end_time` | — |
-| `traces` | Trace spans via query_range API | `start_time`, `end_time` | — |
-| `dashboards` | Dashboards configured in SigNoz | — | — |
-| `alerts` | Alert rules configured in SigNoz | — | — |
+| Table | Description | Required filters |
+|---|---|---|
+| `services` | APM services reporting to SigNoz | â€” |
+| `logs` | Log query results via query_range API | `start_time`, `end_time` |
+| `traces` | Trace query results via query_range API | `start_time`, `end_time` |
+| `dashboards` | Dashboards configured in SigNoz | â€” |
+| `alerts` | Alert rules configured in SigNoz | â€” |
 
 ### Time filter note
 
 `start_time` and `end_time` on the `logs` and `traces` tables are **epoch milliseconds**.
-Each query returns up to 100 rows ordered by timestamp descending.
+Each query returns result envelopes from `data.data.results`; the `rows` column
+contains the actual log or span objects as JSON. Returns an empty result set when
+no data exists for the given time range.
 
 ## Quick start
 
@@ -62,29 +63,20 @@ coral sql "
   ORDER BY errorRate DESC
 "
 
-# List operations for a service
+# Search recent logs (supply epoch-ms timestamps)
 coral sql "
-  SELECT operation
-  FROM signoz.operations
-  WHERE service_name = 'frontend'
-"
-
-# Search recent error logs
-coral sql "
-  SELECT timestamp, body, severity_text, trace_id
+  SELECT queryName, nextCursor, rows
   FROM signoz.logs
   WHERE start_time = 1700000000000
     AND end_time   = 1700003600000
-  LIMIT 50
 "
 
 # Search recent trace spans
 coral sql "
-  SELECT timestamp, traceID, spanID, name, serviceName, durationNano, statusCode
+  SELECT queryName, nextCursor, rows
   FROM signoz.traces
   WHERE start_time = 1700000000000
     AND end_time   = 1700003600000
-  LIMIT 50
 "
 
 # List all dashboards
@@ -105,16 +97,17 @@ coral sql "
 
 ```text
 services
-  → serviceName
-    → operations (WHERE service_name = '...')
-    → traces     (WHERE start_time = ... AND end_time = ...)
+  â†’ serviceName
 
-logs
-  → trace_id → traces.traceID
+logs   (WHERE start_time = ... AND end_time = ...)
+  â†’ rows (JSON array of log objects)
+
+traces (WHERE start_time = ... AND end_time = ...)
+  â†’ rows (JSON array of span objects)
 
 dashboards
-  → uuid
+  â†’ uuid
 
 alerts
-  → id
+  â†’ id
 ```

--- a/sources/community/signoz/README.md
+++ b/sources/community/signoz/README.md
@@ -1,0 +1,120 @@
+# SigNoz
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 6
+**Base URL:** your SigNoz instance URL (set via `SIGNOZ_URL`)
+
+Query services, logs, traces, dashboards, and alerts from SigNoz
+(Cloud or self-hosted).
+
+## Authentication
+
+Requires a `SIGNOZ_API_KEY` from a service account with the **SigNoz-Viewer** role.
+
+To create one:
+
+1. Open **Settings > Service Accounts** in your SigNoz instance.
+2. Click **New Service Account**, give it a name, and click **Create**.
+3. In the **Overview** tab, assign the **SigNoz-Viewer** role and click **Save**.
+4. Switch to the **Keys** tab, click **Add Key**, enter a name, and click **Create**.
+5. Copy the key immediately — it is shown only once.
+
+See the [SigNoz service accounts docs](https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/).
+
+```bash
+SIGNOZ_URL=https://signoz.example.com \
+SIGNOZ_API_KEY=<your-key> \
+  coral source add --file sources/community/signoz/manifest.yaml
+```
+
+Run from the repo root. Or interactively:
+
+```bash
+SIGNOZ_URL=https://signoz.example.com \
+SIGNOZ_API_KEY=<your-key> \
+  coral source add --file sources/community/signoz/manifest.yaml --interactive
+```
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `services` | APM services reporting to SigNoz | — | — |
+| `operations` | Span operation names for a service | `service_name` | — |
+| `logs` | Log entries via query_range API | `start_time`, `end_time` | — |
+| `traces` | Trace spans via query_range API | `start_time`, `end_time` | — |
+| `dashboards` | Dashboards configured in SigNoz | — | — |
+| `alerts` | Alert rules configured in SigNoz | — | — |
+
+### Time filter note
+
+`start_time` and `end_time` on the `logs` and `traces` tables are **epoch milliseconds**.
+Each query returns up to 100 rows ordered by timestamp descending.
+
+## Quick start
+
+```bash
+# List all instrumented services
+coral sql "
+  SELECT serviceName, p99, avgDuration, numCalls, errorRate
+  FROM signoz.services
+  ORDER BY errorRate DESC
+"
+
+# List operations for a service
+coral sql "
+  SELECT operation
+  FROM signoz.operations
+  WHERE service_name = 'frontend'
+"
+
+# Search recent error logs
+coral sql "
+  SELECT timestamp, body, severity_text, trace_id
+  FROM signoz.logs
+  WHERE start_time = 1700000000000
+    AND end_time   = 1700003600000
+  LIMIT 50
+"
+
+# Search recent trace spans
+coral sql "
+  SELECT timestamp, traceID, spanID, name, serviceName, durationNano, statusCode
+  FROM signoz.traces
+  WHERE start_time = 1700000000000
+    AND end_time   = 1700003600000
+  LIMIT 50
+"
+
+# List all dashboards
+coral sql "
+  SELECT uuid, title, description, created_by, updated_at
+  FROM signoz.dashboards
+"
+
+# List all alert rules
+coral sql "
+  SELECT id, alert, alertType, state, severity, disabled
+  FROM signoz.alerts
+  ORDER BY state, alert
+"
+```
+
+## Discovery order
+
+```text
+services
+  → serviceName
+    → operations (WHERE service_name = '...')
+    → traces     (WHERE start_time = ... AND end_time = ...)
+
+logs
+  → trace_id → traces.traceID
+
+dashboards
+  → uuid
+
+alerts
+  → id
+```

--- a/sources/community/signoz/README.md
+++ b/sources/community/signoz/README.md
@@ -58,9 +58,9 @@ no data exists for the given time range.
 ```bash
 # List all instrumented services
 coral sql "
-  SELECT serviceName, p99, avgDuration, numCalls, errorRate
+  SELECT service_name, p99, avg_duration, num_calls, error_rate
   FROM signoz.services
-  ORDER BY errorRate DESC
+  ORDER BY error_rate DESC
 "
 
 # Search recent logs (supply epoch-ms timestamps)
@@ -87,7 +87,7 @@ coral sql "
 
 # List all alert rules
 coral sql "
-  SELECT id, alert, alertType, state, severity, disabled
+  SELECT id, alert, alert_type, state, severity, disabled
   FROM signoz.alerts
   ORDER BY state, alert
 "

--- a/sources/community/signoz/README.md
+++ b/sources/community/signoz/README.md
@@ -97,7 +97,7 @@ coral sql "
 
 ```text
 services
-  -> serviceName
+  -> service_name
 
 logs   (WHERE start_time = ... AND end_time = ...)
   -> rows (JSON array of log objects)

--- a/sources/community/signoz/manifest.yaml
+++ b/sources/community/signoz/manifest.yaml
@@ -94,8 +94,10 @@ tables:
     guide: >
       Requires start_time and end_time filters (epoch milliseconds).
       Each query returns a single result envelope row. The rows column is a
-      JSON array of log objects -- use JSON extraction to access individual
-      fields. If rows is null the time range has no log data.
+      JSON array of up to 1000 log objects -- use JSON extraction to access
+      individual fields. Narrow the time range to stay within this cap.
+      If rows is null the time range has no log data.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/v5/query_range
@@ -108,7 +110,7 @@ tables:
         content:
           from: template
           template: >-
-            {"start":{{filter.start_time}},"end":{{filter.end_time}},"requestType":"raw","compositeQuery":{"queries":[{"type":"builder_query","spec":{"name":"A","signal":"logs","filter":{"expression":""},"order":[{"key":{"name":"timestamp"},"direction":"desc"},{"key":{"name":"id"},"direction":"desc"}],"offset":0,"limit":100}}]}}
+            {"start":{{filter.start_time}},"end":{{filter.end_time}},"requestType":"raw","compositeQuery":{"queries":[{"type":"builder_query","spec":{"name":"A","signal":"logs","filter":{"expression":""},"order":[{"key":{"name":"timestamp"},"direction":"desc"},{"key":{"name":"id"},"direction":"desc"}],"offset":0,"limit":1000}}]}}
     response:
       rows_path: [data, data, results]
     pagination:
@@ -154,8 +156,10 @@ tables:
     guide: >
       Requires start_time and end_time filters (epoch milliseconds).
       Each query returns a single result envelope row. The rows column is a
-      JSON array of span objects -- use JSON extraction to access individual
-      fields. If rows is null the time range has no trace data.
+      JSON array of up to 1000 span objects -- use JSON extraction to access
+      individual fields. Narrow the time range to stay within this cap.
+      If rows is null the time range has no trace data.
+    fetch_limit_default: 1000
     request:
       method: POST
       path: /api/v5/query_range
@@ -168,7 +172,7 @@ tables:
         content:
           from: template
           template: >-
-            {"start":{{filter.start_time}},"end":{{filter.end_time}},"requestType":"raw","compositeQuery":{"queries":[{"type":"builder_query","spec":{"name":"A","signal":"traces","filter":{"expression":""},"order":[{"key":{"name":"timestamp"},"direction":"desc"}],"offset":0,"limit":100}}]}}
+            {"start":{{filter.start_time}},"end":{{filter.end_time}},"requestType":"raw","compositeQuery":{"queries":[{"type":"builder_query","spec":{"name":"A","signal":"traces","filter":{"expression":""},"order":[{"key":{"name":"timestamp"},"direction":"desc"}],"offset":0,"limit":1000}}]}}
     response:
       rows_path: [data, data, results]
     pagination:

--- a/sources/community/signoz/manifest.yaml
+++ b/sources/community/signoz/manifest.yaml
@@ -36,10 +36,10 @@ tables:
     description: APM services instrumented and reporting to SigNoz.
     guide: >
       Start here to get a list of all services sending traces to SigNoz.
-      Use serviceName values from this table as filters in the operations table.
+      Returns an empty list when no instrumented services have reported data.
     request:
       method: GET
-      path: /api/v1/services
+      path: /api/v1/services/list
       query:
         - name: start
           from: now_epoch_minus_seconds
@@ -47,8 +47,7 @@ tables:
         - name: end
           from: now_epoch_minus_seconds
           seconds: 0
-    response:
-      rows_path: [data]
+    response: {}
     pagination:
       mode: none
     columns:
@@ -88,130 +87,45 @@ tables:
         description: Error rate as a fraction of total calls
         expr: {kind: path, path: [errorRate]}
 
-  - name: operations
-    description: Operations (span names) for a given service in SigNoz APM.
-    guide: >
-      Requires a service_name filter. Use serviceName values from the services
-      table. Returns the list of operation names seen for that service.
-    request:
-      method: GET
-      path: /api/v1/services/{{filter.service_name}}/operations
-      query:
-        - name: start
-          from: now_epoch_minus_seconds
-          seconds: 3600
-        - name: end
-          from: now_epoch_minus_seconds
-          seconds: 0
-    response:
-      rows_path: [data]
-    pagination:
-      mode: none
-    columns:
-      - name: operation
-        type: Utf8
-        nullable: true
-        description: Operation name
-        expr: {kind: current_row}
-      - name: service_name
-        type: Utf8
-        nullable: true
-        description: Service name (echoes the required filter)
-        expr: {kind: from_filter, key: service_name}
-        virtual: true
-    filters:
-      - name: service_name
-        required: true
-
   - name: logs
     description: Search logs stored in SigNoz via the query_range API.
     guide: >
       Requires start_time and end_time filters (epoch milliseconds).
-      Returns up to 100 log entries per query ordered by timestamp descending.
-      The response wraps results under data.result[].list; rows_path targets
-      data.newResult which is a flattened list available in newer SigNoz builds.
-      If no rows come back, verify the time range contains log data.
+      Returns result envelopes; the rows column contains the actual log
+      objects as a JSON array. If rows is null the time range has no data.
     request:
       method: POST
       path: /api/v5/query_range
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
       body:
-        format: json
-        fields:
-          - path: [start]
-            from: filter_int
-            key: start_time
-          - path: [end]
-            from: filter_int
-            key: end_time
-          - path: [requestType]
-            from: literal
-            value: raw
-          - path: [compositeQuery, queries]
-            from: literal
-            value:
-              - type: builder_query
-                spec:
-                  name: A
-                  signal: logs
-                  filter:
-                    expression: ""
-                  order:
-                    - key: {name: timestamp}
-                      direction: desc
-                    - key: {name: id}
-                      direction: desc
-                  offset: 0
-                  limit: 100
+        format: text
+        content:
+          from: template
+          template: >-
+            {"start":{{filter.start_time}},"end":{{filter.end_time}},"requestType":"raw","compositeQuery":{"queries":[{"type":"builder_query","spec":{"name":"A","signal":"logs","filter":{"expression":""},"order":[{"key":{"name":"timestamp"},"direction":"desc"},{"key":{"name":"id"},"direction":"desc"}],"offset":0,"limit":100}}]}}
     response:
-      rows_path: [data, newResult]
+      rows_path: [data, data, results]
     pagination:
       mode: none
     columns:
-      - name: timestamp
+      - name: query_name
         type: Utf8
         nullable: true
-        description: Log event timestamp (nanoseconds epoch as string)
-        expr: {kind: path, path: [timestamp]}
-      - name: id
+        description: Query name
+        expr: {kind: path, path: [queryName]}
+      - name: next_cursor
         type: Utf8
         nullable: true
-        description: Unique log entry identifier
-        expr: {kind: path, path: [data, id]}
-      - name: body
-        type: Utf8
-        nullable: true
-        description: Log message body
-        expr: {kind: path, path: [data, body]}
-      - name: severity_text
-        type: Utf8
-        nullable: true
-        description: Log severity level (INFO, WARN, ERROR, etc.)
-        expr: {kind: path, path: [data, severity_text]}
-      - name: severity_number
-        type: Int64
-        nullable: true
-        description: Numeric severity level
-        expr: {kind: path, path: [data, severity_number]}
-      - name: trace_id
-        type: Utf8
-        nullable: true
-        description: Trace ID associated with this log entry
-        expr: {kind: path, path: [data, trace_id]}
-      - name: span_id
-        type: Utf8
-        nullable: true
-        description: Span ID associated with this log entry
-        expr: {kind: path, path: [data, span_id]}
-      - name: resources_string
+        description: Cursor for the next page of results
+        expr: {kind: path, path: [nextCursor]}
+      - name: rows
         type: Json
         nullable: true
-        description: Resource attributes as a JSON object
-        expr: {kind: path, path: [data, resources_string]}
-      - name: attributes_string
-        type: Json
-        nullable: true
-        description: Log attributes as a JSON object
-        expr: {kind: path, path: [data, attributes_string]}
+        description: Array of log row objects returned by this query
+        expr: {kind: path, path: [rows]}
       - name: start_time
         type: Int64
         nullable: true
@@ -234,92 +148,41 @@ tables:
     description: Search trace spans stored in SigNoz via the query_range API.
     guide: >
       Requires start_time and end_time filters (epoch milliseconds).
-      Returns raw span records ordered by timestamp descending.
-      If no rows come back, verify the time range contains trace data.
+      Returns result envelopes; the rows column contains the actual span
+      objects as a JSON array. If rows is null the time range has no data.
     request:
       method: POST
       path: /api/v5/query_range
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
       body:
-        format: json
-        fields:
-          - path: [start]
-            from: filter_int
-            key: start_time
-          - path: [end]
-            from: filter_int
-            key: end_time
-          - path: [requestType]
-            from: literal
-            value: raw
-          - path: [compositeQuery, queries]
-            from: literal
-            value:
-              - type: builder_query
-                spec:
-                  name: A
-                  signal: traces
-                  filter:
-                    expression: ""
-                  order:
-                    - key: {name: timestamp}
-                      direction: desc
-                  offset: 0
-                  limit: 100
+        format: text
+        content:
+          from: template
+          template: >-
+            {"start":{{filter.start_time}},"end":{{filter.end_time}},"requestType":"raw","compositeQuery":{"queries":[{"type":"builder_query","spec":{"name":"A","signal":"traces","filter":{"expression":""},"order":[{"key":{"name":"timestamp"},"direction":"desc"}],"offset":0,"limit":100}}]}}
     response:
-      rows_path: [data, newResult]
+      rows_path: [data, data, results]
     pagination:
       mode: none
     columns:
-      - name: timestamp
+      - name: query_name
         type: Utf8
         nullable: true
-        description: Span start timestamp (nanoseconds epoch as string)
-        expr: {kind: path, path: [timestamp]}
-      - name: traceID
+        description: Query name
+        expr: {kind: path, path: [queryName]}
+      - name: next_cursor
         type: Utf8
         nullable: true
-        description: Trace identifier grouping related spans
-        expr: {kind: path, path: [data, traceID]}
-      - name: spanID
-        type: Utf8
+        description: Cursor for the next page of results
+        expr: {kind: path, path: [nextCursor]}
+      - name: rows
+        type: Json
         nullable: true
-        description: Unique span identifier
-        expr: {kind: path, path: [data, spanID]}
-      - name: parentSpanID
-        type: Utf8
-        nullable: true
-        description: Parent span identifier
-        expr: {kind: path, path: [data, parentSpanID]}
-      - name: name
-        type: Utf8
-        nullable: true
-        description: Span operation name
-        expr: {kind: path, path: [data, name]}
-      - name: serviceName
-        type: Utf8
-        nullable: true
-        description: Service that emitted the span
-        expr: {kind: path, path: [data, serviceName]}
-      - name: durationNano
-        type: Int64
-        nullable: true
-        description: Span duration in nanoseconds
-        expr: {kind: path, path: [data, durationNano]}
-      - name: statusCode
-        type: Int64
-        nullable: true
-        description: Span status code (0=Unset, 1=Ok, 2=Error)
-        expr: {kind: path, path: [data, statusCode]}
-      - name: statusMessage
-        type: Utf8
-        nullable: true
-        description: Span status message
-        expr: {kind: path, path: [data, statusMessage]}
-      - name: kind
-        type: Int64
-        nullable: true
-        description: Span kind (0=Unspecified, 1=Internal, 2=Server, 3=Client, 4=Producer, 5=Consumer)
-        expr: {kind: path, path: [data, kind]}
+        description: Array of trace span objects returned by this query
+        expr: {kind: path, path: [rows]}
       - name: start_time
         type: Int64
         nullable: true
@@ -394,7 +257,7 @@ tables:
       method: GET
       path: /api/v1/rules
     response:
-      rows_path: [data]
+      rows_path: [data, rules]
     pagination:
       mode: none
     columns:

--- a/sources/community/signoz/manifest.yaml
+++ b/sources/community/signoz/manifest.yaml
@@ -51,7 +51,7 @@ tables:
     pagination:
       mode: none
     columns:
-      - name: serviceName
+      - name: service_name
         type: Utf8
         nullable: true
         description: Name of the service
@@ -61,38 +61,41 @@ tables:
         nullable: true
         description: P99 latency in milliseconds
         expr: {kind: path, path: [p99]}
-      - name: avgDuration
+      - name: avg_duration
         type: Float64
         nullable: true
         description: Average request duration in milliseconds
         expr: {kind: path, path: [avgDuration]}
-      - name: numCalls
+      - name: num_calls
         type: Int64
         nullable: true
         description: Total number of calls in the time window
         expr: {kind: path, path: [numCalls]}
-      - name: callRate
+      - name: call_rate
         type: Float64
         nullable: true
         description: Calls per second
         expr: {kind: path, path: [callRate]}
-      - name: numErrors
+      - name: num_errors
         type: Int64
         nullable: true
         description: Number of errors in the time window
         expr: {kind: path, path: [numErrors]}
-      - name: errorRate
+      - name: error_rate
         type: Float64
         nullable: true
         description: Error rate as a fraction of total calls
         expr: {kind: path, path: [errorRate]}
 
   - name: logs
-    description: Search logs stored in SigNoz via the query_range API.
+    description: >-
+      Search logs stored in SigNoz via the query_range API. Returns one result
+      envelope per query; individual log fields are in the rows JSON column.
     guide: >
       Requires start_time and end_time filters (epoch milliseconds).
-      Returns result envelopes; the rows column contains the actual log
-      objects as a JSON array. If rows is null the time range has no data.
+      Each query returns a single result envelope row. The rows column is a
+      JSON array of log objects -- use JSON extraction to access individual
+      fields. If rows is null the time range has no log data.
     request:
       method: POST
       path: /api/v5/query_range
@@ -145,11 +148,14 @@ tables:
         required: true
 
   - name: traces
-    description: Search trace spans stored in SigNoz via the query_range API.
+    description: >-
+      Search trace spans stored in SigNoz via the query_range API. Returns one
+      result envelope per query; individual span fields are in the rows JSON column.
     guide: >
       Requires start_time and end_time filters (epoch milliseconds).
-      Returns result envelopes; the rows column contains the actual span
-      objects as a JSON array. If rows is null the time range has no data.
+      Each query returns a single result envelope row. The rows column is a
+      JSON array of span objects -- use JSON extraction to access individual
+      fields. If rows is null the time range has no trace data.
     request:
       method: POST
       path: /api/v5/query_range
@@ -271,7 +277,7 @@ tables:
         nullable: true
         description: Alert rule name
         expr: {kind: path, path: [alert]}
-      - name: alertType
+      - name: alert_type
         type: Utf8
         nullable: true
         description: Alert type (METRIC_BASED_ALERT, LOG_BASED_ALERT, TRACES_BASED_ALERT, etc.)

--- a/sources/community/signoz/manifest.yaml
+++ b/sources/community/signoz/manifest.yaml
@@ -1,0 +1,445 @@
+name: signoz
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query services, logs, traces, dashboards, and alerts from SigNoz
+  (Cloud or self-hosted).
+inputs:
+  SIGNOZ_URL:
+    kind: variable
+    hint: |
+      Base URL of your SigNoz instance, for example `https://signoz.example.com`
+      or `http://localhost:3301`.
+      For SigNoz Cloud, use your cloud instance URL.
+  SIGNOZ_API_KEY:
+    kind: secret
+    hint: |
+      Service account API key for SigNoz. Generate one in
+      Settings > Service Accounts: create a service account, assign it the
+      SigNoz-Viewer role, then open its Keys tab and click Add Key.
+      The key is shown only once at creation time.
+      See https://signoz.io/docs/manage/administrator-guide/iam/service-accounts/
+base_url: "{{input.SIGNOZ_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: SIGNOZ-API-KEY
+      from: input
+      key: SIGNOZ_API_KEY
+
+test_queries:
+  - SELECT * FROM signoz.services LIMIT 1
+
+tables:
+  - name: services
+    description: APM services instrumented and reporting to SigNoz.
+    guide: >
+      Start here to get a list of all services sending traces to SigNoz.
+      Use serviceName values from this table as filters in the operations table.
+    request:
+      method: GET
+      path: /api/v1/services
+      query:
+        - name: start
+          from: now_epoch_minus_seconds
+          seconds: 3600
+        - name: end
+          from: now_epoch_minus_seconds
+          seconds: 0
+    response:
+      rows_path: [data]
+    pagination:
+      mode: none
+    columns:
+      - name: serviceName
+        type: Utf8
+        nullable: true
+        description: Name of the service
+        expr: {kind: path, path: [serviceName]}
+      - name: p99
+        type: Float64
+        nullable: true
+        description: P99 latency in milliseconds
+        expr: {kind: path, path: [p99]}
+      - name: avgDuration
+        type: Float64
+        nullable: true
+        description: Average request duration in milliseconds
+        expr: {kind: path, path: [avgDuration]}
+      - name: numCalls
+        type: Int64
+        nullable: true
+        description: Total number of calls in the time window
+        expr: {kind: path, path: [numCalls]}
+      - name: callRate
+        type: Float64
+        nullable: true
+        description: Calls per second
+        expr: {kind: path, path: [callRate]}
+      - name: numErrors
+        type: Int64
+        nullable: true
+        description: Number of errors in the time window
+        expr: {kind: path, path: [numErrors]}
+      - name: errorRate
+        type: Float64
+        nullable: true
+        description: Error rate as a fraction of total calls
+        expr: {kind: path, path: [errorRate]}
+
+  - name: operations
+    description: Operations (span names) for a given service in SigNoz APM.
+    guide: >
+      Requires a service_name filter. Use serviceName values from the services
+      table. Returns the list of operation names seen for that service.
+    request:
+      method: GET
+      path: /api/v1/services/{{filter.service_name}}/operations
+      query:
+        - name: start
+          from: now_epoch_minus_seconds
+          seconds: 3600
+        - name: end
+          from: now_epoch_minus_seconds
+          seconds: 0
+    response:
+      rows_path: [data]
+    pagination:
+      mode: none
+    columns:
+      - name: operation
+        type: Utf8
+        nullable: true
+        description: Operation name
+        expr: {kind: current_row}
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: Service name (echoes the required filter)
+        expr: {kind: from_filter, key: service_name}
+        virtual: true
+    filters:
+      - name: service_name
+        required: true
+
+  - name: logs
+    description: Search logs stored in SigNoz via the query_range API.
+    guide: >
+      Requires start_time and end_time filters (epoch milliseconds).
+      Returns up to 100 log entries per query ordered by timestamp descending.
+      The response wraps results under data.result[].list; rows_path targets
+      data.newResult which is a flattened list available in newer SigNoz builds.
+      If no rows come back, verify the time range contains log data.
+    request:
+      method: POST
+      path: /api/v5/query_range
+      body:
+        format: json
+        fields:
+          - path: [start]
+            from: filter_int
+            key: start_time
+          - path: [end]
+            from: filter_int
+            key: end_time
+          - path: [requestType]
+            from: literal
+            value: raw
+          - path: [compositeQuery, queries]
+            from: literal
+            value:
+              - type: builder_query
+                spec:
+                  name: A
+                  signal: logs
+                  filter:
+                    expression: ""
+                  order:
+                    - key: {name: timestamp}
+                      direction: desc
+                    - key: {name: id}
+                      direction: desc
+                  offset: 0
+                  limit: 100
+    response:
+      rows_path: [data, newResult]
+    pagination:
+      mode: none
+    columns:
+      - name: timestamp
+        type: Utf8
+        nullable: true
+        description: Log event timestamp (nanoseconds epoch as string)
+        expr: {kind: path, path: [timestamp]}
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Unique log entry identifier
+        expr: {kind: path, path: [data, id]}
+      - name: body
+        type: Utf8
+        nullable: true
+        description: Log message body
+        expr: {kind: path, path: [data, body]}
+      - name: severity_text
+        type: Utf8
+        nullable: true
+        description: Log severity level (INFO, WARN, ERROR, etc.)
+        expr: {kind: path, path: [data, severity_text]}
+      - name: severity_number
+        type: Int64
+        nullable: true
+        description: Numeric severity level
+        expr: {kind: path, path: [data, severity_number]}
+      - name: trace_id
+        type: Utf8
+        nullable: true
+        description: Trace ID associated with this log entry
+        expr: {kind: path, path: [data, trace_id]}
+      - name: span_id
+        type: Utf8
+        nullable: true
+        description: Span ID associated with this log entry
+        expr: {kind: path, path: [data, span_id]}
+      - name: resources_string
+        type: Json
+        nullable: true
+        description: Resource attributes as a JSON object
+        expr: {kind: path, path: [data, resources_string]}
+      - name: attributes_string
+        type: Json
+        nullable: true
+        description: Log attributes as a JSON object
+        expr: {kind: path, path: [data, attributes_string]}
+      - name: start_time
+        type: Int64
+        nullable: true
+        description: Query start time in epoch milliseconds (virtual filter, required)
+        expr: {kind: 'null'}
+        virtual: true
+      - name: end_time
+        type: Int64
+        nullable: true
+        description: Query end time in epoch milliseconds (virtual filter, required)
+        expr: {kind: 'null'}
+        virtual: true
+    filters:
+      - name: start_time
+        required: true
+      - name: end_time
+        required: true
+
+  - name: traces
+    description: Search trace spans stored in SigNoz via the query_range API.
+    guide: >
+      Requires start_time and end_time filters (epoch milliseconds).
+      Returns raw span records ordered by timestamp descending.
+      If no rows come back, verify the time range contains trace data.
+    request:
+      method: POST
+      path: /api/v5/query_range
+      body:
+        format: json
+        fields:
+          - path: [start]
+            from: filter_int
+            key: start_time
+          - path: [end]
+            from: filter_int
+            key: end_time
+          - path: [requestType]
+            from: literal
+            value: raw
+          - path: [compositeQuery, queries]
+            from: literal
+            value:
+              - type: builder_query
+                spec:
+                  name: A
+                  signal: traces
+                  filter:
+                    expression: ""
+                  order:
+                    - key: {name: timestamp}
+                      direction: desc
+                  offset: 0
+                  limit: 100
+    response:
+      rows_path: [data, newResult]
+    pagination:
+      mode: none
+    columns:
+      - name: timestamp
+        type: Utf8
+        nullable: true
+        description: Span start timestamp (nanoseconds epoch as string)
+        expr: {kind: path, path: [timestamp]}
+      - name: traceID
+        type: Utf8
+        nullable: true
+        description: Trace identifier grouping related spans
+        expr: {kind: path, path: [data, traceID]}
+      - name: spanID
+        type: Utf8
+        nullable: true
+        description: Unique span identifier
+        expr: {kind: path, path: [data, spanID]}
+      - name: parentSpanID
+        type: Utf8
+        nullable: true
+        description: Parent span identifier
+        expr: {kind: path, path: [data, parentSpanID]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Span operation name
+        expr: {kind: path, path: [data, name]}
+      - name: serviceName
+        type: Utf8
+        nullable: true
+        description: Service that emitted the span
+        expr: {kind: path, path: [data, serviceName]}
+      - name: durationNano
+        type: Int64
+        nullable: true
+        description: Span duration in nanoseconds
+        expr: {kind: path, path: [data, durationNano]}
+      - name: statusCode
+        type: Int64
+        nullable: true
+        description: Span status code (0=Unset, 1=Ok, 2=Error)
+        expr: {kind: path, path: [data, statusCode]}
+      - name: statusMessage
+        type: Utf8
+        nullable: true
+        description: Span status message
+        expr: {kind: path, path: [data, statusMessage]}
+      - name: kind
+        type: Int64
+        nullable: true
+        description: Span kind (0=Unspecified, 1=Internal, 2=Server, 3=Client, 4=Producer, 5=Consumer)
+        expr: {kind: path, path: [data, kind]}
+      - name: start_time
+        type: Int64
+        nullable: true
+        description: Query start time in epoch milliseconds (virtual filter, required)
+        expr: {kind: 'null'}
+        virtual: true
+      - name: end_time
+        type: Int64
+        nullable: true
+        description: Query end time in epoch milliseconds (virtual filter, required)
+        expr: {kind: 'null'}
+        virtual: true
+    filters:
+      - name: start_time
+        required: true
+      - name: end_time
+        required: true
+
+  - name: dashboards
+    description: Dashboards configured in SigNoz.
+    guide: >
+      Returns all dashboards. No filters required.
+    request:
+      method: GET
+      path: /api/v1/dashboards
+    response:
+      rows_path: [data]
+    pagination:
+      mode: none
+    columns:
+      - name: uuid
+        type: Utf8
+        nullable: true
+        description: Dashboard UUID
+        expr: {kind: path, path: [uuid]}
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Dashboard title
+        expr: {kind: path, path: [data, title]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Dashboard description
+        expr: {kind: path, path: [data, description]}
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp
+        expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last updated timestamp
+        expr: {kind: path, path: [updated_at]}
+      - name: created_by
+        type: Utf8
+        nullable: true
+        description: Email of the user who created the dashboard
+        expr: {kind: path, path: [created_by]}
+      - name: updated_by
+        type: Utf8
+        nullable: true
+        description: Email of the user who last updated the dashboard
+        expr: {kind: path, path: [updated_by]}
+
+  - name: alerts
+    description: Alert rules configured in SigNoz.
+    guide: >
+      Returns all alert rules. No filters required.
+    request:
+      method: GET
+      path: /api/v1/rules
+    response:
+      rows_path: [data]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        description: Alert rule ID
+        expr: {kind: path, path: [id]}
+      - name: alert
+        type: Utf8
+        nullable: true
+        description: Alert rule name
+        expr: {kind: path, path: [alert]}
+      - name: alertType
+        type: Utf8
+        nullable: true
+        description: Alert type (METRIC_BASED_ALERT, LOG_BASED_ALERT, TRACES_BASED_ALERT, etc.)
+        expr: {kind: path, path: [alertType]}
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Current alert state (firing, inactive, etc.)
+        expr: {kind: path, path: [state]}
+      - name: severity
+        type: Utf8
+        nullable: true
+        description: Alert severity label
+        expr: {kind: path, path: [labels, severity]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Alert description annotation
+        expr: {kind: path, path: [annotations, description]}
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp
+        expr: {kind: path, path: [createAt]}
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last updated timestamp
+        expr: {kind: path, path: [updateAt]}
+      - name: disabled
+        type: Boolean
+        nullable: true
+        description: Whether the alert rule is disabled
+        expr: {kind: path, path: [disabled]}


### PR DESCRIPTION
Closes #514

## What changed

Adds a new community source for SigNoz under `sources/community/signoz/`.

### Tables (5)

| Table | Description |
|---|---|
| services | APM services currently reporting to SigNoz; surfaces service name, p99 latency, average duration, call rate, error count, and error rate over the last hour |
| logs | Log search via the `POST /api/v5/query_range` API; requires `start_time` and `end_time` filters (epoch milliseconds); returns result envelopes with the raw log rows as a JSON column |
| traces | Trace span search via the same `query_range` API; requires `start_time` and `end_time` filters; returns result envelopes with raw span rows as a JSON column |
| dashboards | All dashboards configured in the SigNoz instance with UUID, title, description, and audit timestamps |
| alerts | All alert rules with type, state, severity, description, and enabled/disabled status |

### Auth

Authentication uses the `SIGNOZ-API-KEY` header with a service account API key.

Path:

```text
Settings → Service Accounts → Keys
```

Requirements:

- Minimum required role: `SigNoz-Viewer`
- Works with both:
  - SigNoz Cloud
  - self-hosted SigNoz instances

Configured via:

```env
SIGNOZ_URL
SIGNOZ_API_KEY
```

---

## Why it changed

SigNoz is a widely used open-source OpenTelemetry-native observability platform.

Being able to query:

- service health
- latency metrics
- error rates
- alert states
- logs
- traces

through SQL is a natural fit for Coral, especially for teams running:

- incident reviews
- SLO tracking
- operational dashboards
- observability analytics
- reliability workflows

---

## What was tested

- `coral source lint` — passes
- `coral source add --file sources/community/signoz/manifest.yaml` — 1/1 test query passes

### Live queries verified against a real SigNoz Cloud instance

- `services`
  - returns correct schema
  - empty when no instrumented services have reported data

- `dashboards`
  - returns correct schema

- `alerts`
  - returns correct schema with `[data, rules]` `rows_path` matching the actual response envelope

- `logs`
  - returns result envelope with:
    - `query_name`
    - `next_cursor`
    - `rows`

- `traces`
  - returns result envelope with:
    - `query_name`
    - `next_cursor`
    - `rows`

---

## User-visible impact

New `signoz` source installable via:

```bash
SIGNOZ_URL=https://signoz.example.com \
SIGNOZ_API_KEY=<your-key> \
coral source add --file sources/community/signoz/manifest.yaml
```

---

## Implementation notes

- `/api/v1/services` is a SPA frontend route on SigNoz Cloud instances
- The correct backend path is:

```text
/api/v1/services/list
```

- `logs` and `traces` use `format: text` with a filter-interpolated JSON template body
- The `from:` literal approach with deeply nested YAML objects triggers a multi-document YAML parse error in the Coral manifest parser
- `alerts` response envelope is:

```json
{"data":{"rules":[...]}}
```

Therefore:

```yaml
rows_path: [data, rules]
```

---

## Follow-on

Potential future additions:

- `operations` table (`GET /api/v1/services/{name}/operations`) once the SPA route conflict on Cloud is resolved upstream
- metrics aggregation table via `query_range` with `signal: metrics`