### PR TITLE
feat(sources/community/elasticsearch): add Elasticsearch community source

### DIFF
--- a/sources/community/elasticsearch/README.md
+++ b/sources/community/elasticsearch/README.md
@@ -8,8 +8,8 @@ templates, and pending cluster tasks through the native REST and `_cat` APIs.
 ### Requirements
 
 - Network access to an Elasticsearch HTTP endpoint (default port `9200`).
-- A user with the `monitor` cluster privilege (the built-in `elastic`
-  superuser works for every table).
+- A user with sufficient privileges (see [Required privileges](#required-privileges)).
+  The built-in `elastic` superuser works for every table.
 
 ### Add the Source
 
@@ -91,6 +91,37 @@ HTTP Basic against the Elasticsearch security realm:
 Authorization: Basic base64(ELASTICSEARCH_USER:ELASTICSEARCH_PASSWORD)
 ```
 
+## Required privileges
+
+The built-in `elastic` superuser works out of the box. For a least-privilege
+user, the `monitor` **cluster** privilege alone is **not** enough — it covers
+cluster-level APIs only. The `indices`, `shards`, and `aliases` tables read
+the `_cat` index APIs and additionally require an **index-level** privilege
+on the indices you want visible.
+
+| Table | Endpoint | Required privilege |
+| ----- | -------- | ------------------ |
+| `cluster_health` | `/_cluster/health` | cluster `monitor` |
+| `nodes` | `/_cat/nodes` | cluster `monitor` |
+| `templates` | `/_cat/templates` | cluster `monitor` |
+| `pending_tasks` | `/_cat/pending_tasks` | cluster `monitor` |
+| `indices` | `/_cat/indices` | index `monitor` (or `view_index_metadata`) |
+| `shards` | `/_cat/shards` | index `monitor` (or `view_index_metadata`) |
+| `aliases` | `/_cat/aliases` | index `view_index_metadata` (or `monitor`) |
+
+A role that covers every table:
+
+```json
+{
+  "cluster": ["monitor"],
+  "indices": [
+    { "names": ["*"], "privileges": ["monitor", "view_index_metadata"] }
+  ]
+}
+```
+
+Narrow `names` to the index patterns you actually need to expose.
+
 ## Limits
 
 - This source is **read-only**. It exposes monitoring and `_cat` endpoints
@@ -150,4 +181,6 @@ ORDER BY heap_pct DESC
 - Works with self-managed Elasticsearch and Elastic Cloud. OpenSearch
   exposes the same `_cat` and `_cluster/health` shapes and is largely
   compatible, but is not officially targeted here.
-- The `monitor` cluster privilege is the minimum required role.
+- See [Required privileges](#required-privileges) for the least-privilege
+  role; `monitor` cluster privilege alone does not cover the index-level
+  tables (`indices`, `shards`, `aliases`).

--- a/sources/community/elasticsearch/README.md
+++ b/sources/community/elasticsearch/README.md
@@ -1,0 +1,153 @@
+# Elasticsearch
+
+Inspect Elasticsearch cluster health, nodes, indices, shards, aliases, index
+templates, and pending cluster tasks through the native REST and `_cat` APIs.
+
+## Setup
+
+### Requirements
+
+- Network access to an Elasticsearch HTTP endpoint (default port `9200`).
+- A user with the `monitor` cluster privilege (the built-in `elastic`
+  superuser works for every table).
+
+### Add the Source
+
+```bash
+coral source add elasticsearch
+```
+
+Provide:
+
+- `ELASTICSEARCH_URL` — base URL including scheme and port, e.g.
+  `http://localhost:9200` or
+  `https://<deployment>.es.<region>.cloud.es.io:9243`. No trailing slash.
+- `ELASTICSEARCH_USER` — username (defaults to `elastic`).
+- `ELASTICSEARCH_PASSWORD` — password for that user.
+
+Authentication is HTTP Basic. A non-empty password is required because Coral
+cannot install a source with a blank secret.
+
+## Tables
+
+### `cluster_health`
+Single-row cluster-wide health summary from `/_cluster/health`.
+
+**Useful for:**
+- Alerting on `status = 'red'` or `'yellow'`
+- Tracking `unassigned_shards` and `number_of_pending_tasks`
+- Cluster capacity overviews
+
+### `nodes`
+Per-node heap, RAM, CPU, load, and disk usage from `_cat/nodes`.
+
+**Useful for:**
+- Finding nodes under heap or disk pressure
+- Identifying the elected master (`master = '*'`)
+- Version drift checks across the cluster
+
+### `indices`
+Per-index document counts and storage from `_cat/indices`.
+
+**Useful for:**
+- Largest-index and document-count reporting
+- Finding `red`/`yellow` indices
+- Storage growth analysis
+
+### `shards`
+Per-shard allocation and state from `_cat/shards`.
+
+**Useful for:**
+- Explaining why a cluster is `yellow` or `red`
+- Listing `UNASSIGNED` shards and their reasons
+- Spotting long-running `RELOCATING` shards
+
+### `aliases`
+Alias-to-index mappings from `_cat/aliases`.
+
+**Useful for:**
+- Mapping logical aliases to concrete indices
+- Finding the write index for rollover aliases
+
+### `templates`
+Index templates from `_cat/templates`.
+
+**Useful for:**
+- Auditing which patterns are covered by templates
+- Reviewing composed component templates
+
+### `pending_tasks`
+Cluster state update tasks waiting in the master queue.
+
+**Useful for:**
+- Detecting master node pressure
+- Debugging slow cluster state changes
+
+## Authentication
+
+HTTP Basic against the Elasticsearch security realm:
+
+```text
+Authorization: Basic base64(ELASTICSEARCH_USER:ELASTICSEARCH_PASSWORD)
+```
+
+## Limits
+
+- This source is **read-only**. It exposes monitoring and `_cat` endpoints
+  only — no document search, indexing, mapping changes, or cluster settings
+  mutations.
+- `_cat` endpoints return all values as JSON strings. Numeric-looking
+  columns (counts, sizes, percentages) are typed as `Utf8`. Use SQL `CAST`
+  for arithmetic, e.g. `CAST("docs_count" AS BIGINT)`.
+- `cluster_health` returns proper JSON numbers and is typed accordingly.
+- No server-side filtering: filter with SQL `WHERE` after the rows are
+  fetched.
+- On clusters with very many indices or shards, `indices` and `shards`
+  return large result sets — apply `LIMIT` for exploratory queries.
+
+## Example Queries
+
+### Cluster health at a glance
+
+```sql
+SELECT cluster_name, status, number_of_nodes, unassigned_shards,
+       active_shards_percent_as_number
+FROM elasticsearch.cluster_health
+```
+
+### Largest indices by document count
+
+```sql
+SELECT index, health, CAST("docs_count" AS BIGINT) AS docs,
+       CAST(store_size AS BIGINT) AS bytes
+FROM elasticsearch.indices
+WHERE index NOT LIKE '.%'
+ORDER BY docs DESC
+LIMIT 20
+```
+
+### Unassigned shards and why
+
+```sql
+SELECT index, shard, prirep, unassigned_reason
+FROM elasticsearch.shards
+WHERE state = 'UNASSIGNED'
+ORDER BY index
+```
+
+### Nodes under heap pressure
+
+```sql
+SELECT name, ip, CAST(heap_percent AS INTEGER) AS heap_pct,
+       CAST(disk_used_percent AS DOUBLE) AS disk_pct
+FROM elasticsearch.nodes
+WHERE CAST(heap_percent AS INTEGER) > 85
+ORDER BY heap_pct DESC
+```
+
+## Notes
+
+- Works with self-managed Elasticsearch and Elastic Cloud. OpenSearch
+  exposes the same `_cat` and `_cluster/health` shapes and is largely
+  compatible, but is not officially targeted here.
+- The `monitor` cluster privilege is the minimum required role.

--- a/sources/community/elasticsearch/manifest.yaml
+++ b/sources/community/elasticsearch/manifest.yaml
@@ -21,8 +21,12 @@ inputs:
     default: elastic
     hint: |
       Elasticsearch username. Defaults to `elastic` for the built-in
-      superuser. A user with the `monitor` cluster privilege is sufficient
-      for every table in this source.
+      superuser. For a least-privilege user, grant the `monitor` cluster
+      privilege (covers cluster_health, nodes, templates, pending_tasks)
+      plus the `monitor` index privilege on the indices you want visible
+      (required for the indices, shards, and aliases tables) — e.g. a role
+      with cluster `["monitor"]` and indices `[{names:["*"],
+      privileges:["monitor","view_index_metadata"]}]`.
   ELASTICSEARCH_PASSWORD:
     kind: secret
     hint: |

--- a/sources/community/elasticsearch/manifest.yaml
+++ b/sources/community/elasticsearch/manifest.yaml
@@ -1,0 +1,692 @@
+dsl_version: 3
+name: elasticsearch
+version: 1.0.0
+description: >-
+  Inspect Elasticsearch cluster health, nodes, indices, shards, aliases,
+  index templates, and pending cluster tasks through the native REST and
+  _cat APIs.
+backend: http
+base_url: "{{input.ELASTICSEARCH_URL}}"
+inputs:
+  ELASTICSEARCH_URL:
+    kind: variable
+    default: http://localhost:9200
+    hint: |
+      Base URL of your Elasticsearch HTTP endpoint, including scheme and
+      port. Default is `http://localhost:9200` for a local node. For
+      Elastic Cloud use `https://<deployment>.es.<region>.cloud.es.io:9243`.
+      Do not include a trailing slash.
+  ELASTICSEARCH_USER:
+    kind: variable
+    default: elastic
+    hint: |
+      Elasticsearch username. Defaults to `elastic` for the built-in
+      superuser. A user with the `monitor` cluster privilege is sufficient
+      for every table in this source.
+  ELASTICSEARCH_PASSWORD:
+    kind: secret
+    hint: |
+      Password for the Elasticsearch user. A non-empty password is required —
+      Coral cannot install a source with a blank secret. On a local cluster
+      with security disabled, enable the built-in security realm and set a
+      password, or front the cluster with an authenticating proxy.
+auth:
+  type: BasicAuth
+  username: "{{input.ELASTICSEARCH_USER}}"
+  password: "{{input.ELASTICSEARCH_PASSWORD}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM elasticsearch.cluster_health LIMIT 1
+  - SELECT * FROM elasticsearch.indices LIMIT 1
+tables:
+  - name: cluster_health
+    description: Overall cluster health summary from the _cluster/health API
+    guide: |
+      Returns a single row describing cluster-wide health. `status` is the
+      key indicator: `green` (all shards allocated), `yellow` (all primaries
+      allocated, some replicas unassigned), or `red` (some primaries
+      unassigned — data is unavailable). A non-zero `unassigned_shards` or
+      `number_of_pending_tasks` usually signals allocation or master
+      pressure. Numeric fields are returned as proper JSON numbers.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /_cluster/health
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: cluster_name
+        type: Utf8
+        nullable: false
+        description: Name of the cluster
+        expr:
+          kind: path
+          path:
+            - cluster_name
+      - name: status
+        type: Utf8
+        nullable: false
+        description: "Cluster health: green, yellow, or red"
+        expr:
+          kind: path
+          path:
+            - status
+      - name: number_of_nodes
+        type: Int64
+        nullable: true
+        description: Total number of nodes in the cluster
+        expr:
+          kind: path
+          path:
+            - number_of_nodes
+      - name: number_of_data_nodes
+        type: Int64
+        nullable: true
+        description: Number of data-holding nodes
+        expr:
+          kind: path
+          path:
+            - number_of_data_nodes
+      - name: active_primary_shards
+        type: Int64
+        nullable: true
+        description: Number of active primary shards
+        expr:
+          kind: path
+          path:
+            - active_primary_shards
+      - name: active_shards
+        type: Int64
+        nullable: true
+        description: Total number of active primary and replica shards
+        expr:
+          kind: path
+          path:
+            - active_shards
+      - name: relocating_shards
+        type: Int64
+        nullable: true
+        description: Number of shards currently relocating
+        expr:
+          kind: path
+          path:
+            - relocating_shards
+      - name: initializing_shards
+        type: Int64
+        nullable: true
+        description: Number of shards currently initializing
+        expr:
+          kind: path
+          path:
+            - initializing_shards
+      - name: unassigned_shards
+        type: Int64
+        nullable: true
+        description: Number of unassigned shards; non-zero on yellow or red
+        expr:
+          kind: path
+          path:
+            - unassigned_shards
+      - name: delayed_unassigned_shards
+        type: Int64
+        nullable: true
+        description: Shards whose allocation is intentionally delayed
+        expr:
+          kind: path
+          path:
+            - delayed_unassigned_shards
+      - name: number_of_pending_tasks
+        type: Int64
+        nullable: true
+        description: Cluster state update tasks waiting to be processed
+        expr:
+          kind: path
+          path:
+            - number_of_pending_tasks
+      - name: number_of_in_flight_fetch
+        type: Int64
+        nullable: true
+        description: Number of unfinished shard info fetches
+        expr:
+          kind: path
+          path:
+            - number_of_in_flight_fetch
+      - name: task_max_waiting_in_queue_millis
+        type: Int64
+        nullable: true
+        description: Longest time a pending task has waited, in milliseconds
+        expr:
+          kind: path
+          path:
+            - task_max_waiting_in_queue_millis
+      - name: active_shards_percent_as_number
+        type: Float64
+        nullable: true
+        description: Percentage of active shards out of all shards
+        expr:
+          kind: path
+          path:
+            - active_shards_percent_as_number
+
+  - name: nodes
+    description: Per-node resource usage from the _cat/nodes API
+    guide: |
+      Returns one row per node with heap, RAM, CPU, load, disk, and role
+      information. `master` is `*` for the elected master and `-` otherwise.
+      Values come from the _cat API as strings; numeric-looking fields are
+      typed as text and may need CAST in SQL (e.g.
+      `CAST(heap_percent AS INTEGER)`). Use this to spot nodes under heap or
+      disk pressure.
+    request:
+      method: GET
+      path: /_cat/nodes
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: bytes
+          from: literal
+          value: b
+        - name: h
+          from: literal
+          value: name,ip,node.role,master,version,heap.percent,ram.percent,cpu,load_1m,load_5m,load_15m,disk.used_percent,uptime
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Node name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: ip
+        type: Utf8
+        nullable: true
+        description: Node IP address
+        expr:
+          kind: path
+          path:
+            - ip
+      - name: node_role
+        type: Utf8
+        nullable: true
+        description: "Node roles abbreviation (e.g. dim, m, d)"
+        expr:
+          kind: path
+          path:
+            - node.role
+      - name: master
+        type: Utf8
+        nullable: true
+        description: "* for the elected master node, - otherwise"
+        expr:
+          kind: path
+          path:
+            - master
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Elasticsearch version running on the node
+        expr:
+          kind: path
+          path:
+            - version
+      - name: heap_percent
+        type: Utf8
+        nullable: true
+        description: Used heap as a percentage (string from _cat)
+        expr:
+          kind: path
+          path:
+            - heap.percent
+      - name: ram_percent
+        type: Utf8
+        nullable: true
+        description: Used RAM as a percentage (string from _cat)
+        expr:
+          kind: path
+          path:
+            - ram.percent
+      - name: cpu
+        type: Utf8
+        nullable: true
+        description: Recent CPU usage percentage (string from _cat)
+        expr:
+          kind: path
+          path:
+            - cpu
+      - name: load_1m
+        type: Utf8
+        nullable: true
+        description: 1-minute load average (string from _cat)
+        expr:
+          kind: path
+          path:
+            - load_1m
+      - name: load_5m
+        type: Utf8
+        nullable: true
+        description: 5-minute load average (string from _cat)
+        expr:
+          kind: path
+          path:
+            - load_5m
+      - name: load_15m
+        type: Utf8
+        nullable: true
+        description: 15-minute load average (string from _cat)
+        expr:
+          kind: path
+          path:
+            - load_15m
+      - name: disk_used_percent
+        type: Utf8
+        nullable: true
+        description: Percentage of disk used (string from _cat)
+        expr:
+          kind: path
+          path:
+            - disk.used_percent
+      - name: uptime
+        type: Utf8
+        nullable: true
+        description: Node uptime as a human-readable duration
+        expr:
+          kind: path
+          path:
+            - uptime
+
+  - name: indices
+    description: Per-index document counts and storage from the _cat/indices API
+    guide: |
+      Returns one row per index (including system indices). `health` and
+      `status` mirror cluster_health semantics at the index level. Counts
+      and sizes come from the _cat API as strings and are typed as text;
+      CAST in SQL when you need arithmetic (e.g.
+      `CAST("docs_count" AS BIGINT)`). Filter with a SQL WHERE clause on
+      `index` after fetching.
+    request:
+      method: GET
+      path: /_cat/indices
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: bytes
+          from: literal
+          value: b
+        - name: h
+          from: literal
+          value: health,status,index,uuid,pri,rep,docs.count,docs.deleted,store.size,pri.store.size
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: index
+        type: Utf8
+        nullable: false
+        description: Index name
+        expr:
+          kind: path
+          path:
+            - index
+      - name: uuid
+        type: Utf8
+        nullable: true
+        description: Index UUID
+        expr:
+          kind: path
+          path:
+            - uuid
+      - name: health
+        type: Utf8
+        nullable: true
+        description: "Index health: green, yellow, or red"
+        expr:
+          kind: path
+          path:
+            - health
+      - name: status
+        type: Utf8
+        nullable: true
+        description: "Index status: open or close"
+        expr:
+          kind: path
+          path:
+            - status
+      - name: pri
+        type: Utf8
+        nullable: true
+        description: Number of primary shards (string from _cat)
+        expr:
+          kind: path
+          path:
+            - pri
+      - name: rep
+        type: Utf8
+        nullable: true
+        description: Number of replicas per primary (string from _cat)
+        expr:
+          kind: path
+          path:
+            - rep
+      - name: docs_count
+        type: Utf8
+        nullable: true
+        description: Number of documents (string from _cat)
+        expr:
+          kind: path
+          path:
+            - docs.count
+      - name: docs_deleted
+        type: Utf8
+        nullable: true
+        description: Number of deleted documents not yet merged away
+        expr:
+          kind: path
+          path:
+            - docs.deleted
+      - name: store_size
+        type: Utf8
+        nullable: true
+        description: Total store size in bytes including replicas (string)
+        expr:
+          kind: path
+          path:
+            - store.size
+      - name: pri_store_size
+        type: Utf8
+        nullable: true
+        description: Primary-only store size in bytes (string from _cat)
+        expr:
+          kind: path
+          path:
+            - pri.store.size
+
+  - name: shards
+    description: Per-shard allocation and state from the _cat/shards API
+    guide: |
+      Returns one row per shard copy. `prirep` is `p` for primary and `r`
+      for replica. `state` values include STARTED, RELOCATING,
+      INITIALIZING, and UNASSIGNED. Rows with state UNASSIGNED and a
+      populated `unassigned_reason` explain why a cluster is yellow or red.
+      `node` is null for unassigned shards.
+    request:
+      method: GET
+      path: /_cat/shards
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: bytes
+          from: literal
+          value: b
+        - name: h
+          from: literal
+          value: index,shard,prirep,state,docs,store,node,unassigned.reason
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: index
+        type: Utf8
+        nullable: false
+        description: Index the shard belongs to
+        expr:
+          kind: path
+          path:
+            - index
+      - name: shard
+        type: Utf8
+        nullable: true
+        description: Shard number (string from _cat)
+        expr:
+          kind: path
+          path:
+            - shard
+      - name: prirep
+        type: Utf8
+        nullable: true
+        description: "p for primary shard, r for replica shard"
+        expr:
+          kind: path
+          path:
+            - prirep
+      - name: state
+        type: Utf8
+        nullable: true
+        description: "Shard state: STARTED, RELOCATING, INITIALIZING, UNASSIGNED"
+        expr:
+          kind: path
+          path:
+            - state
+      - name: docs
+        type: Utf8
+        nullable: true
+        description: Number of documents in the shard (string from _cat)
+        expr:
+          kind: path
+          path:
+            - docs
+      - name: store
+        type: Utf8
+        nullable: true
+        description: Shard store size in bytes (string from _cat)
+        expr:
+          kind: path
+          path:
+            - store
+      - name: node
+        type: Utf8
+        nullable: true
+        description: Node holding the shard; null when unassigned
+        expr:
+          kind: path
+          path:
+            - node
+      - name: unassigned_reason
+        type: Utf8
+        nullable: true
+        description: Reason the shard is unassigned, when applicable
+        expr:
+          kind: path
+          path:
+            - unassigned.reason
+
+  - name: aliases
+    description: Index alias mappings from the _cat/aliases API
+    guide: |
+      Returns one row per alias-to-index mapping. `is_write_index` marks the
+      target that receives writes for a multi-index alias. `filter`,
+      `routing_index`, and `routing_search` are `-` when not configured.
+    request:
+      method: GET
+      path: /_cat/aliases
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: h
+          from: literal
+          value: alias,index,filter,routing.index,routing.search,is_write_index
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: alias
+        type: Utf8
+        nullable: false
+        description: Alias name
+        expr:
+          kind: path
+          path:
+            - alias
+      - name: index
+        type: Utf8
+        nullable: false
+        description: Concrete index the alias points to
+        expr:
+          kind: path
+          path:
+            - index
+      - name: filter
+        type: Utf8
+        nullable: true
+        description: "- when no filter is configured, otherwise a filter marker"
+        expr:
+          kind: path
+          path:
+            - filter
+      - name: routing_index
+        type: Utf8
+        nullable: true
+        description: Index routing value, or - when unset
+        expr:
+          kind: path
+          path:
+            - routing.index
+      - name: routing_search
+        type: Utf8
+        nullable: true
+        description: Search routing value, or - when unset
+        expr:
+          kind: path
+          path:
+            - routing.search
+      - name: is_write_index
+        type: Utf8
+        nullable: true
+        description: Whether this index is the alias write target
+        expr:
+          kind: path
+          path:
+            - is_write_index
+
+  - name: templates
+    description: Index templates from the _cat/templates API
+    guide: |
+      Returns one row per index template. `index_patterns` is a string
+      representation of the patterns the template applies to. `order` and
+      `version` come from the _cat API as strings.
+    request:
+      method: GET
+      path: /_cat/templates
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: h
+          from: literal
+          value: name,index_patterns,order,version,composed_of
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Template name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: index_patterns
+        type: Utf8
+        nullable: true
+        description: Index patterns the template matches
+        expr:
+          kind: path
+          path:
+            - index_patterns
+      - name: order
+        type: Utf8
+        nullable: true
+        description: Merge order for legacy templates (string from _cat)
+        expr:
+          kind: path
+          path:
+            - order
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Template version, when set
+        expr:
+          kind: path
+          path:
+            - version
+      - name: composed_of
+        type: Utf8
+        nullable: true
+        description: Component templates this index template composes
+        expr:
+          kind: path
+          path:
+            - composed_of
+
+  - name: pending_tasks
+    description: Cluster state update tasks waiting in the master queue
+    guide: |
+      Returns one row per pending cluster-level task from
+      _cat/pending_tasks. A consistently non-empty result with high
+      `time_in_queue` indicates master node pressure. An empty result is
+      healthy and expected on an idle cluster.
+    request:
+      method: GET
+      path: /_cat/pending_tasks
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: h
+          from: literal
+          value: insertOrder,timeInQueue,priority,source
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: insert_order
+        type: Utf8
+        nullable: true
+        description: Order in which the task was inserted (string from _cat)
+        expr:
+          kind: path
+          path:
+            - insertOrder
+      - name: time_in_queue
+        type: Utf8
+        nullable: true
+        description: How long the task has waited in the queue
+        expr:
+          kind: path
+          path:
+            - timeInQueue
+      - name: priority
+        type: Utf8
+        nullable: true
+        description: "Task priority (e.g. URGENT, HIGH, NORMAL)"
+        expr:
+          kind: path
+          path:
+            - priority
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Description of the cluster state change
+        expr:
+          kind: path
+          path:
+            - source


### PR DESCRIPTION
Adds a read-only Elasticsearch community source. Closes #515.

**Tables**: cluster_health, nodes, indices, shards, aliases, templates, pending_tasks.

**Auth**: HTTP Basic (monitor cluster privilege is enough). Scope: monitoring/observability only — no search, indexing, or settings changes. Works with self-managed Elasticsearch and Elastic Cloud.

Verified locally against Elasticsearch 8.15.0:

$ coral source test elasticsearch
  ✓ elasticsearch connected successfully
    elasticsearch (7 tables)
    2 declared · 2 passed · 0 failed

$ coral sql "SELECT cluster_name, status, unassigned_shards FROM elasticsearch.cluster_health"
| docker-cluster | yellow | 1 |

$ coral sql "SELECT index, shard, prirep, state FROM elasticsearch.shards WHERE state = 'UNASSIGNED'"
| orders | 0 | r | UNASSIGNED |

**Repro**:

docker run -d --name es-coral -p 9200:9200 \
  -e discovery.type=single-node -e xpack.security.enabled=true \
  -e xpack.security.http.ssl.enabled=false \
  -e ES_JAVA_OPTS="-Xms1g -Xmx1g" -e ELASTIC_PASSWORD=coraltest123 \
  docker.elastic.co/elasticsearch/elasticsearch:8.15.0

ELASTICSEARCH_URL=http://localhost:9200 
ELASTICSEARCH_USER=elastic \
ELASTICSEARCH_PASSWORD=coraltest123 \
coral source add --file sources/community/elasticsearch/manifest.yaml
coral source test elasticsearch

**Demo video below:** 
[Screencast from 2026-05-16 15-10-49.webm](https://github.com/user-attachments/assets/6f096320-3c58-4e02-9bb6-979ee4800211)

