### PR TITLE
feat(sources/community/prefect): added prefect source

### DIFF
--- a/sources/community/prefect/README.md
+++ b/sources/community/prefect/README.md
@@ -1,0 +1,204 @@
+# Prefect source
+
+Query Prefect flows, flow runs, deployments, work pools, and task runs to
+monitor pipeline health and orchestration state. Works with both
+**Prefect Cloud** and **self-hosted Prefect Server**.
+
+## Authentication
+
+| Mode | `PREFECT_API_URL` | `PREFECT_API_KEY` |
+|---|---|---|
+| Prefect Cloud | `https://api.prefect.cloud/api/accounts/<account-id>/workspaces/<workspace-id>` | Required — API key from account settings |
+| Self-hosted (with auth) | `http://<host>:4200/api` | Required — configured in server |
+| Self-hosted (no auth) | `http://<host>:4200/api` | Any non-empty placeholder |
+
+---
+
+## Option A — Prefect Cloud
+
+### 1. Find your API URL
+
+Log in to [app.prefect.cloud](https://app.prefect.cloud). Your workspace URL
+contains both IDs you need:
+
+```
+https://app.prefect.cloud/account/<ACCOUNT-ID>/workspace/<WORKSPACE-ID>/dashboard
+```
+
+Your API URL is:
+
+```
+https://api.prefect.cloud/api/accounts/<ACCOUNT-ID>/workspaces/<WORKSPACE-ID>
+```
+
+### 2. Generate an API key
+
+1. Click the account icon in the bottom-left corner of the UI
+2. Select **API Keys**
+3. Click **+**, give it a name and expiry, then copy the key immediately —
+   it cannot be shown again after you close the dialog
+
+### 3. Install the source
+
+```bash
+PREFECT_API_URL=https://api.prefect.cloud/api/accounts/<account-id>/workspaces/<workspace-id> \
+PREFECT_API_KEY=pnu_xxxxxxxxxxxxxxxxxxxxxxxxxxxx \
+coral source add --file manifest.yaml
+```
+
+---
+
+## Option B — Self-hosted Prefect Server (pip)
+
+### 1. Install and start the server
+
+```bash
+pip install prefect
+prefect server start
+```
+
+The server starts at `http://localhost:4200`. The UI is at
+`http://localhost:4200/api/docs`. Keep this terminal running.
+
+### 2. Install the source
+
+Self-hosted Prefect Server has no authentication by default. Use any
+non-empty placeholder for the API key:
+
+```bash
+PREFECT_API_URL=http://localhost:4200/api \
+PREFECT_API_KEY=placeholder \
+coral source add --file manifest.yaml
+```
+
+---
+
+## Option C — Self-hosted Prefect Server (Docker)
+
+### 1. Start the server
+
+```bash
+docker run -d --name prefect-server \
+  -p 4200:4200 \
+  prefecthq/prefect:3-latest \
+  prefect server start --host 0.0.0.0
+```
+
+Wait a few seconds, then verify it is up:
+
+```bash
+curl http://localhost:4200/api/health
+# → true
+```
+
+### 2. Install the source
+
+```bash
+PREFECT_API_URL=http://localhost:4200/api \
+PREFECT_API_KEY=placeholder \
+coral source add --file manifest.yaml
+```
+
+### Docker Compose (optional)
+
+For a persistent setup with a PostgreSQL backend:
+
+```yaml
+version: "3"
+services:
+  prefect-db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: prefect
+      POSTGRES_PASSWORD: prefect
+      POSTGRES_DB: prefect
+    volumes:
+      - prefect-db:/var/lib/postgresql/data
+
+  prefect-server:
+    image: prefecthq/prefect:3-latest
+    command: prefect server start --host 0.0.0.0
+    ports:
+      - "4200:4200"
+    environment:
+      PREFECT_API_DATABASE_CONNECTION_URL: postgresql+asyncpg://prefect:prefect@prefect-db:5432/prefect
+    depends_on:
+      - prefect-db
+
+volumes:
+  prefect-db:
+```
+
+```bash
+docker compose up -d
+```
+
+---
+
+## Tables
+
+| Table | Description |
+|---|---|
+| `flows` | All registered flows with name, tags, labels, and creation time |
+| `flow_runs` | Run history with state, timing, deployment, and work pool |
+| `deployments` | Deployment definitions with schedule, status, entrypoint, and last poll time |
+| `work_pools` | Work pool inventory with type, pause status, and concurrency limits |
+| `task_runs` | Task-level run history with state and parent flow run link |
+
+## Example queries
+
+```sql
+-- Which flows have run recently and what was their outcome?
+SELECT f.name, fr.name AS run_name, fr.state_type, fr.total_run_time, fr.start_time
+FROM prefect.flows f
+JOIN prefect.flow_runs fr ON f.id = fr.flow_id
+ORDER BY fr.start_time DESC
+LIMIT 20;
+
+-- All failed flow runs
+SELECT f.name, fr.id, fr.start_time, fr.end_time, fr.total_run_time
+FROM prefect.flow_runs fr
+JOIN prefect.flows f ON fr.flow_id = f.id
+WHERE fr.state_type = 'FAILED'
+ORDER BY fr.start_time DESC;
+
+-- Deployment health — which are ready and which have no workers polling?
+SELECT name, status, paused, work_queue_name, last_polled, entrypoint
+FROM prefect.deployments
+ORDER BY status, name;
+
+-- Work pool overview
+SELECT name, type, status, is_paused, active_slots, concurrency_limit
+FROM prefect.work_pools;
+
+-- Task-level breakdown for a specific flow run
+SELECT name, task_key, state_type, total_run_time, start_time
+FROM prefect.task_runs
+WHERE flow_run_id = '<flow-run-id>'
+ORDER BY start_time;
+
+-- Slowest flows by average run time
+SELECT f.name, COUNT(fr.id) AS runs, AVG(fr.total_run_time) AS avg_seconds
+FROM prefect.flows f
+JOIN prefect.flow_runs fr ON f.id = fr.flow_id
+WHERE fr.state_type = 'COMPLETED'
+GROUP BY f.name
+ORDER BY avg_seconds DESC;
+```
+
+## Notes
+
+- **`total_run_time`** is in seconds (Float64). It excludes scheduling wait
+  time — only the actual execution window.
+- **`labels`** is a JSON key-value dict. Prefect automatically populates
+  `prefect.flow.id` on flow runs; you can add custom labels (e.g.
+  `env: production`, `team: data-eng`) via deployment configuration.
+- **`task_runs`** has very high cardinality — one row per task per flow run.
+  Always use `LIMIT` or filter by `flow_run_id` for targeted queries.
+- **`flow_runs`** and **`task_runs`** default to the 200 most recent entries.
+  Use SQL `LIMIT` or `WHERE state_type = '...'` to narrow results.
+- **`work_pools`** status `NOT_READY` means no worker process is currently
+  polling. This is normal for on-demand infrastructure; `READY` means a
+  worker is actively listening.
+- **`deployments`** `last_polled = null` means no worker has checked in for
+  this deployment. `status = READY` requires at least one active worker.

--- a/sources/community/prefect/manifest.yaml
+++ b/sources/community/prefect/manifest.yaml
@@ -1,0 +1,775 @@
+dsl_version: 3
+name: prefect
+version: 1.0.0
+description: >-
+  Query Prefect flows, flow runs, deployments, work pools, and task runs to
+  monitor pipeline health and orchestration state.
+backend: http
+base_url: "{{input.PREFECT_API_URL}}"
+inputs:
+  PREFECT_API_URL:
+    kind: variable
+    hint: |
+      Full URL of the Prefect API — include the path prefix but no trailing
+      slash. Prefect Cloud example:
+      `https://api.prefect.cloud/api/accounts/<account-id>/workspaces/<workspace-id>`
+      Self-hosted Prefect Server example: `http://localhost:4200/api`
+  PREFECT_API_KEY:
+    kind: secret
+    hint: |
+      Prefect API key for authentication. Generate one in Prefect Cloud at
+      https://app.prefect.cloud/my/api-keys under Settings → API Keys.
+      For self-hosted Prefect Server running without authentication, enter
+      any non-empty placeholder — the header is sent but ignored.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.PREFECT_API_KEY}}
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM prefect.flows LIMIT 1
+  - SELECT * FROM prefect.flow_runs LIMIT 1
+tables:
+  - name: flows
+    description: Prefect flows registered in the workspace
+    guide: |
+      Returns all flows visible to the configured API key, newest first.
+      Filter on `name` or `tags` using SQL WHERE clauses.
+
+      `tags` is a JSON array of string labels. Each flow can have many
+      flow runs — join on `id` to `prefect.flow_runs.flow_id` for run
+      history, or to `prefect.deployments.flow_id` for deployment info.
+    fetch_limit_default: 200
+    request:
+      method: POST
+      path: /flows/filter
+      body:
+        - path:
+            - limit
+          from: literal
+          value: 200
+        - path:
+            - sort
+          from: literal
+          value: CREATED_DESC
+    response:
+      rows_path: []
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Flow UUID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Flow name as defined in the Python code
+        expr:
+          kind: path
+          path:
+            - name
+      - name: tags
+        type: Json
+        nullable: true
+        description: List of string tags assigned to this flow
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: labels
+        type: Json
+        nullable: true
+        description: Key-value label pairs (e.g. env, team, cost-center)
+        expr:
+          kind: path
+          path:
+            - labels
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: Time the flow was first registered
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Time the flow record was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated
+
+  - name: flow_runs
+    description: Prefect flow run history with state, timing, and deployment info
+    guide: |
+      Returns the 200 most recent flow runs, newest first. Use an explicit
+      SQL LIMIT to narrow results — this table can have millions of rows on
+      busy workspaces.
+
+      Key values for `state_type`: SCHEDULED, PENDING, RUNNING, COMPLETED,
+      FAILED, CRASHED, CANCELLING, CANCELLED, PAUSED.
+
+      `total_run_time` is in seconds (Float64). `start_time` and `end_time`
+      are null while the run is still pending or running. `deployment_id`
+      is null for runs triggered directly without a deployment.
+
+      Join to `prefect.flows` on `flow_id` to get the flow name.
+      Join to `prefect.deployments` on `deployment_id` for schedule info.
+    fetch_limit_default: 200
+    request:
+      method: POST
+      path: /flow_runs/filter
+      body:
+        - path:
+            - limit
+          from: literal
+          value: 200
+        - path:
+            - sort
+          from: literal
+          value: START_TIME_DESC
+    response:
+      rows_path: []
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Flow run UUID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Auto-generated flow run name (e.g. fuzzy-wolverine)
+        expr:
+          kind: path
+          path:
+            - name
+      - name: flow_id
+        type: Utf8
+        nullable: false
+        description: UUID of the parent flow — join to prefect.flows.id
+        expr:
+          kind: path
+          path:
+            - flow_id
+      - name: deployment_id
+        type: Utf8
+        nullable: true
+        description: UUID of the deployment that triggered this run; null for manual runs
+        expr:
+          kind: path
+          path:
+            - deployment_id
+      - name: state_type
+        type: Utf8
+        nullable: true
+        description: "Terminal state category: COMPLETED, FAILED, CRASHED, CANCELLED; or transient: RUNNING, PENDING, SCHEDULED"
+        expr:
+          kind: path
+          path:
+            - state_type
+      - name: state_name
+        type: Utf8
+        nullable: true
+        description: Human-readable state name (e.g. Completed, Failed, Running)
+        expr:
+          kind: path
+          path:
+            - state_name
+      - name: work_pool_name
+        type: Utf8
+        nullable: true
+        description: Work pool that executed this run
+        expr:
+          kind: path
+          path:
+            - work_pool_name
+      - name: work_queue_name
+        type: Utf8
+        nullable: true
+        description: Work queue within the work pool
+        expr:
+          kind: path
+          path:
+            - work_queue_name
+      - name: tags
+        type: Json
+        nullable: true
+        description: List of string tags on this run
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: labels
+        type: Json
+        nullable: true
+        description: Key-value label pairs inherited from the deployment or set at runtime
+        expr:
+          kind: path
+          path:
+            - labels
+      - name: run_count
+        type: Int64
+        nullable: true
+        description: Number of times this run has been attempted (increments on retry)
+        expr:
+          kind: path
+          path:
+            - run_count
+      - name: auto_scheduled
+        type: Boolean
+        nullable: true
+        description: Whether this run was created automatically by a schedule
+        expr:
+          kind: path
+          path:
+            - auto_scheduled
+      - name: expected_start_time
+        type: Timestamp
+        nullable: true
+        description: Scheduled start time; null for unscheduled runs
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - expected_start_time
+      - name: start_time
+        type: Timestamp
+        nullable: true
+        description: Actual start time; null if not yet started
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - start_time
+      - name: end_time
+        type: Timestamp
+        nullable: true
+        description: Completion time; null if still running
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - end_time
+      - name: total_run_time
+        type: Float64
+        nullable: true
+        description: Total wall-clock duration in seconds (excludes scheduling wait time)
+        expr:
+          kind: path
+          path:
+            - total_run_time
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: Time the flow run record was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Time the flow run record was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated
+
+  - name: deployments
+    description: Prefect deployment definitions with schedule and work pool assignment
+    guide: |
+      Returns all deployments visible to the configured API key.
+      A deployment is a server-side configuration that tells Prefect how
+      and when to run a flow.
+
+      `paused` indicates whether the deployment schedule is active.
+      `entrypoint` is the Python import path to the flow function.
+      `last_polled` shows when a worker last checked for scheduled runs —
+      null means no worker is currently polling this deployment.
+
+      Join to `prefect.flows` on `flow_id` to get the flow name.
+    fetch_limit_default: 200
+    request:
+      method: POST
+      path: /deployments/filter
+      body:
+        - path:
+            - limit
+          from: literal
+          value: 200
+        - path:
+            - sort
+          from: literal
+          value: CREATED_DESC
+    response:
+      rows_path: []
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Deployment UUID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Deployment name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: flow_id
+        type: Utf8
+        nullable: false
+        description: UUID of the flow this deployment runs — join to prefect.flows.id
+        expr:
+          kind: path
+          path:
+            - flow_id
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Deployment version string
+        expr:
+          kind: path
+          path:
+            - version
+      - name: paused
+        type: Boolean
+        nullable: true
+        description: Whether the deployment schedule is paused
+        expr:
+          kind: path
+          path:
+            - paused
+      - name: status
+        type: Utf8
+        nullable: true
+        description: "Deployment readiness status: READY or NOT_READY"
+        expr:
+          kind: path
+          path:
+            - status
+      - name: concurrency_limit
+        type: Int64
+        nullable: true
+        description: Maximum number of concurrent runs allowed; null means unlimited
+        expr:
+          kind: path
+          path:
+            - concurrency_limit
+      - name: work_queue_name
+        type: Utf8
+        nullable: true
+        description: Work queue this deployment submits runs to
+        expr:
+          kind: path
+          path:
+            - work_queue_name
+      - name: entrypoint
+        type: Utf8
+        nullable: true
+        description: Python import path to the flow function (e.g. my_module:my_flow)
+        expr:
+          kind: path
+          path:
+            - entrypoint
+      - name: path
+        type: Utf8
+        nullable: true
+        description: Working directory path for the deployment
+        expr:
+          kind: path
+          path:
+            - path
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Optional deployment description
+        expr:
+          kind: path
+          path:
+            - description
+      - name: tags
+        type: Json
+        nullable: true
+        description: List of string tags on this deployment
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: labels
+        type: Json
+        nullable: true
+        description: Key-value label pairs for environment, team, or cost attribution
+        expr:
+          kind: path
+          path:
+            - labels
+      - name: last_polled
+        type: Timestamp
+        nullable: true
+        description: Time a worker last polled for scheduled runs; null if no worker is active
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - last_polled
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: Time the deployment was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Time the deployment was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated
+
+  - name: work_pools
+    description: Prefect work pools with type, status, and concurrency configuration
+    guide: |
+      Returns all work pools in the workspace. Work pools route flow runs
+      to the appropriate infrastructure (Kubernetes, ECS, Docker, etc.).
+
+      `is_paused` — when true, no new runs are dispatched from this pool.
+      `status` — READY means workers are polling; NOT_READY means no active
+      workers. `active_slots` shows how many runs are currently executing.
+      `concurrency_limit` caps concurrent runs; null means unlimited.
+
+      Use `name` values from this table to scope flow run results with a
+      SQL WHERE clause: `WHERE work_pool_name = '...'` on
+      `prefect.flow_runs` (local filter, not pushed to the API).
+    request:
+      method: POST
+      path: /work_pools/filter
+      body:
+        - path:
+            - limit
+          from: literal
+          value: 200
+        - path:
+            - sort
+          from: literal
+          value: NAME_ASC
+    response:
+      rows_path: []
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Work pool UUID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Work pool name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: false
+        description: "Infrastructure type: kubernetes, ecs, docker, process, etc."
+        expr:
+          kind: path
+          path:
+            - type
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Optional work pool description
+        expr:
+          kind: path
+          path:
+            - description
+      - name: is_paused
+        type: Boolean
+        nullable: true
+        description: Whether this work pool is paused — no new runs dispatched when true
+        expr:
+          kind: path
+          path:
+            - is_paused
+      - name: status
+        type: Utf8
+        nullable: true
+        description: "Worker connectivity status: READY (workers polling) or NOT_READY"
+        expr:
+          kind: path
+          path:
+            - status
+      - name: concurrency_limit
+        type: Int64
+        nullable: true
+        description: Maximum concurrent runs; null means unlimited
+        expr:
+          kind: path
+          path:
+            - concurrency_limit
+      - name: active_slots
+        type: Int64
+        nullable: true
+        description: Number of runs currently executing in this pool
+        expr:
+          kind: path
+          path:
+            - active_slots
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: Time the work pool was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Time the work pool was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated
+
+  - name: task_runs
+    description: Prefect task run history with state, timing, and parent flow run
+    guide: |
+      Returns the 200 most recent task runs ordered by end time, with
+      running or pending tasks (null end_time) sorted last. Task runs are
+      the individual units of work within a flow run. Use SQL LIMIT to
+      narrow results — this table has very high cardinality on busy
+      workspaces (one row per task per flow run).
+
+      `flow_run_id` links to `prefect.flow_runs.id`. `task_key` is the
+      stable identifier for the task function; `name` is the per-run
+      generated name. `total_run_time` is in seconds (Float64).
+
+      Key values for `state_type`: COMPLETED, FAILED, CRASHED, RUNNING,
+      PENDING, CACHED, PAUSED.
+    fetch_limit_default: 200
+    request:
+      method: POST
+      path: /task_runs/filter
+      body:
+        - path:
+            - limit
+          from: literal
+          value: 200
+        - path:
+            - sort
+          from: literal
+          value: END_TIME_DESC
+    response:
+      rows_path: []
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Task run UUID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Auto-generated task run name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: flow_run_id
+        type: Utf8
+        nullable: true
+        description: UUID of the parent flow run — join to prefect.flow_runs.id
+        expr:
+          kind: path
+          path:
+            - flow_run_id
+      - name: task_key
+        type: Utf8
+        nullable: false
+        description: Stable identifier for the task function across runs
+        expr:
+          kind: path
+          path:
+            - task_key
+      - name: task_version
+        type: Utf8
+        nullable: true
+        description: Task version string, if set
+        expr:
+          kind: path
+          path:
+            - task_version
+      - name: state_type
+        type: Utf8
+        nullable: true
+        description: "State category: COMPLETED, FAILED, CRASHED, RUNNING, PENDING, CACHED, PAUSED"
+        expr:
+          kind: path
+          path:
+            - state_type
+      - name: state_name
+        type: Utf8
+        nullable: true
+        description: Human-readable state name
+        expr:
+          kind: path
+          path:
+            - state_name
+      - name: run_count
+        type: Int64
+        nullable: true
+        description: Number of times this task has been attempted
+        expr:
+          kind: path
+          path:
+            - run_count
+      - name: tags
+        type: Json
+        nullable: true
+        description: List of string tags on this task run
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: labels
+        type: Json
+        nullable: true
+        description: Key-value label pairs on this task run
+        expr:
+          kind: path
+          path:
+            - labels
+      - name: start_time
+        type: Timestamp
+        nullable: true
+        description: Time the task run started; null if not yet started
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - start_time
+      - name: end_time
+        type: Timestamp
+        nullable: true
+        description: Time the task run completed; null if still running
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - end_time
+      - name: total_run_time
+        type: Float64
+        nullable: true
+        description: Total execution duration in seconds
+        expr:
+          kind: path
+          path:
+            - total_run_time
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: Time the task run record was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Time the task run record was last updated
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated


### PR DESCRIPTION
closes #520 

## What changed

Added `sources/community/prefect/manifest.yaml` and `README.md` — a new
community source that exposes five Prefect orchestration resources as
queryable SQL tables via the Prefect REST API. Works with both
**Prefect Cloud** and **self-hosted Prefect Server** using a single
`PREFECT_API_URL` variable input.

| Table | Endpoint | Description |
|---|---|---|
| `flows` | `POST /flows/filter` | All registered flows with name, tags, and labels |
| `flow_runs` | `POST /flow_runs/filter` | Run history with state, timing, deployment, and work pool |
| `deployments` | `POST /deployments/filter` | Deployment definitions with schedule, status, entrypoint, and last poll time |
| `work_pools` | `POST /work_pools/filter` | Work pool inventory with type, pause status, and concurrency limits |
| `task_runs` | `POST /task_runs/filter` | Task-level run history with state and parent flow run link |

## Why

Coral already covers observability (Datadog, Sentry, PagerDuty) and source
control (GitHub, GitLab) but nothing that knows which data pipelines are
running, failing, or degraded. Prefect is one of the most widely adopted
open-source orchestration tools — alongside Airflow — and is the canonical
source of truth for pipeline health in data teams.

This source enables questions that no monitoring tool can answer alone:

- "Which flows failed in the last hour?"
- "What deployments are scheduled but have no active worker?"
- "Which tasks within a flow run are slowest?"

And powers cross-source joins — failed Prefect flow + PagerDuty incident +
GitHub commit → full incident story in one query.

## Authentication

Bearer token via `Authorization: Bearer` using Coral's existing `HeaderAuth`.

- **Prefect Cloud**: API key from account settings; API URL includes account
  and workspace IDs as path segments
- **Self-hosted**: API URL is `http://<host>:4200/api`; authentication is
  optional by default (the hint explains how to use a placeholder)

## Implementation notes

- **POST-based filter endpoints** — Prefect uses `POST /resource/filter`
  with a JSON body for all collection queries, unlike typical REST APIs that
  use GET. Coral supports this via the `body` field on requests. `Content-Type:
  application/json` is set globally.
- **Root-level array response** — Prefect filter endpoints return a plain
  JSON array `[{}, {}]`, not a wrapped object. `rows_path: []` handles this.
- **`mode: none` pagination** — Prefect's API caps `limit` at 200 per
  request and returns no cursor token. `fetch_limit_default` guards
  high-cardinality tables (`flow_runs`, `task_runs`).
- **`total_run_time` as `Float64`** — Python `timedelta` serialises to float
  seconds in JSON. Documented clearly in guides and README.
- **Sort enum validated against live API** — `START_TIME_DESC` is valid for
  `flow_runs` but not `task_runs`; `END_TIME_DESC` is used for task runs
  after verifying the accepted enum from a 422 response.

## Example queries

```sql
-- Failed flows in the last N runs
SELECT f.name, fr.state_type, fr.total_run_time, fr.start_time
FROM prefect.flows f
JOIN prefect.flow_runs fr ON f.id = fr.flow_id
WHERE fr.state_type = 'FAILED'
ORDER BY fr.start_time DESC
LIMIT 20;

-- Deployment health overview
SELECT name, status, paused, last_polled, entrypoint
FROM prefect.deployments
ORDER BY status, name;

-- Work pool capacity
SELECT name, type, status, is_paused, active_slots, concurrency_limit
FROM prefect.work_pools;

-- Task breakdown for a specific run
SELECT name, task_key, state_type, total_run_time
FROM prefect.task_runs
WHERE flow_run_id = '<id>'
ORDER BY start_time;
```

## Known limitations

- **200-row cap per request** — Prefect's API enforces `limit ≤ 200` on all
  filter endpoints. There is no cursor/token returned, so auto-pagination
  across pages is not possible. `fetch_limit_default` and SQL `LIMIT` are
  the recommended workarounds.
- **`task_runs` cardinality** — one row per task per flow run; busy
  workspaces accumulate very quickly. Documented in the guide with a warning.
- **Self-hosted default auth** — Prefect Server ships with no authentication.
  The `PREFECT_API_KEY` secret input must be non-empty to install, so the
  hint explains using any placeholder for unauthenticated instances.
- **No schedule columns** — `deployments.schedules` is a nested array of
  schedule objects; flattening it usefully would require multiple rows per
  deployment. Left as a follow-on.