### PR TITLE
feat(sources/community/shopify): add shopify community source

### DIFF
--- a/sources/community/shopify/README.md
+++ b/sources/community/shopify/README.md
@@ -70,6 +70,10 @@ The `query` filters use Shopify Admin API search syntax for the corresponding
 GraphQL connection. Examples include `status:active`, `sku:ABC-123`,
 `updated_at:>2026-01-01`, and `financial_status:paid`.
 
+Money amount columns expose both forms where arithmetic is common: the natural
+amount column is `Float64` for aggregation, and the matching `*_decimal` column
+keeps Shopify's exact decimal string.
+
 ## Example Queries
 
 ```sql
@@ -102,6 +106,11 @@ SELECT id, name, created_at, display_financial_status,
 FROM shopify.orders
 WHERE query = 'financial_status:paid fulfillment_status:unfulfilled'
 LIMIT 25;
+
+-- Total paid unfulfilled order value
+SELECT SUM(current_total_price_amount) AS total_unfulfilled_value
+FROM shopify.orders
+WHERE query = 'financial_status:paid fulfillment_status:unfulfilled';
 
 -- Highest-spend customers returned by a targeted Shopify search
 SELECT id, display_name, default_email, number_of_orders, amount_spent
@@ -139,11 +148,22 @@ coral sql "SELECT id, title, status FROM shopify.products LIMIT 10"
 
 - This source uses Shopify Admin GraphQL, not REST Admin API. Shopify marks REST
   Admin API as legacy and requires new public apps to use GraphQL Admin API.
+- The default `SHOPIFY_API_VERSION` should be reviewed when Shopify API
+  support windows move. Shopify releases stable API versions quarterly and
+  supports each stable version for at least 12 months. Before bumping the
+  default, check Shopify's API versioning release schedule:
+  https://shopify.dev/docs/api/usage/versioning#release-schedule. Version
+  bumps can require GraphQL query updates for renamed, deprecated, or removed
+  fields and enum values.
 - GraphQL connections are paginated with `first`, `after`, and
   `pageInfo.endCursor`. Coral requests up to 100 rows per page by default.
 - Shopify GraphQL IDs are exposed as `Utf8` global IDs such as
   `gid://shopify/Product/...`.
-- Date/time values are exposed as `Utf8` in v1.
+- Shopify money amounts are returned by the API as decimal strings. This source
+  keeps those exact values in `*_decimal` columns and exposes `Float64` amount
+  columns for arithmetic.
+- Shopify `DateTime` values are exposed as `Timestamp` columns for date-range
+  filtering and ordering.
 - Nested or repeatable values such as tags, selected options, and smart
   collection rule sets are exposed as `Json`.
 - Order and customer data can include protected customer data. Shopify may

--- a/sources/community/shopify/README.md
+++ b/sources/community/shopify/README.md
@@ -1,0 +1,161 @@
+# Shopify Community Source
+
+Query Shopify shop metadata, products, product variants, collections, orders,
+customers, locations, and inventory items through Coral SQL using the Shopify
+Admin GraphQL API.
+
+## Setup
+
+### 1. Create an Admin API access token
+
+Create or use a Shopify custom app or public app with an Admin API access
+token. Coral sends the token in the `X-Shopify-Access-Token` header.
+
+Grant only the read scopes needed for the tables you plan to query:
+
+| Table | Minimum scope |
+|---|---|
+| `shopify.shop` | Valid Admin API token |
+| `shopify.products` | `read_products` |
+| `shopify.product_variants` | `read_products` |
+| `shopify.collections` | `read_products` |
+| `shopify.orders` | `read_orders` |
+| `shopify.customers` | `read_customers` |
+| `shopify.locations` | `read_locations` |
+| `shopify.inventory_items` | `read_inventory` or `read_products` |
+
+Historical order access beyond Shopify's default recent-orders window requires
+approved `read_all_orders` in addition to `read_orders`.
+
+### 2. Add the source
+
+Set the shop domain without `https://` and without a trailing slash:
+
+```bash
+export SHOPIFY_SHOP_DOMAIN="example.myshopify.com"
+export SHOPIFY_ADMIN_ACCESS_TOKEN="shpat_..."
+coral source add --file sources/community/shopify/manifest.yaml
+```
+
+The source defaults `SHOPIFY_API_VERSION` to `2026-04`. Override it only after
+validating this source against another supported Shopify Admin GraphQL version:
+
+```bash
+export SHOPIFY_API_VERSION="2026-04"
+```
+
+### 3. Verify
+
+```bash
+coral source test shopify
+```
+
+The built-in test queries read `shopify.shop` and `shopify.products`, so the
+token needs access to shop metadata and products.
+
+## Tables
+
+| Table | Description | Optional filters | Pagination |
+|---|---|---|---|
+| `shopify.shop` | Shop metadata for the authenticated Admin API token | none | none |
+| `shopify.products` | Products in the Shopify catalog | `query` | cursor |
+| `shopify.product_variants` | Product variants, SKUs, pricing, inventory item metadata | `query` | cursor |
+| `shopify.collections` | Product collections and collection metadata | `query` | cursor |
+| `shopify.orders` | Orders, status, totals, tags, and customer summary fields | `query` | cursor |
+| `shopify.customers` | Customer profiles, order counts, spend, tags, and contact fields | `query` | cursor |
+| `shopify.locations` | Inventory and fulfillment locations | `query`, `include_inactive`, `include_legacy` | cursor |
+| `shopify.inventory_items` | Inventory item SKUs, tracking, shipping, origin, and location counts | `query` | cursor |
+
+The `query` filters use Shopify Admin API search syntax for the corresponding
+GraphQL connection. Examples include `status:active`, `sku:ABC-123`,
+`updated_at:>2026-01-01`, and `financial_status:paid`.
+
+## Example Queries
+
+```sql
+-- Confirm which shop the token belongs to
+SELECT id, name, myshopify_domain, currency_code
+FROM shopify.shop
+LIMIT 1;
+
+-- Active products updated recently
+SELECT id, title, status, vendor, total_inventory, updated_at
+FROM shopify.products
+WHERE query = 'status:active updated_at:>2026-01-01'
+LIMIT 25;
+
+-- Find variants by SKU prefix
+SELECT id, product_title, sku, price, inventory_quantity
+FROM shopify.product_variants
+WHERE query = 'sku:ABC*'
+LIMIT 25;
+
+-- Collections and product counts
+SELECT id, title, handle, products_count
+FROM shopify.collections
+ORDER BY title
+LIMIT 50;
+
+-- Paid orders that are not fulfilled
+SELECT id, name, created_at, display_financial_status,
+       display_fulfillment_status, current_total_price_amount
+FROM shopify.orders
+WHERE query = 'financial_status:paid fulfillment_status:unfulfilled'
+LIMIT 25;
+
+-- Highest-spend customers returned by a targeted Shopify search
+SELECT id, display_name, default_email, number_of_orders, amount_spent
+FROM shopify.customers
+WHERE query = 'orders_count:>0'
+LIMIT 25;
+
+-- Active fulfillment locations
+SELECT id, name, is_active, fulfills_online_orders, address__city
+FROM shopify.locations
+WHERE include_inactive IS FALSE
+LIMIT 25;
+
+-- Tracked inventory items by SKU
+SELECT id, sku, tracked, requires_shipping, locations_count
+FROM shopify.inventory_items
+WHERE query = 'sku:ABC*'
+LIMIT 25;
+```
+
+## Validation
+
+```bash
+export SHOPIFY_SHOP_DOMAIN="example.myshopify.com"
+export SHOPIFY_ADMIN_ACCESS_TOKEN="shpat_..."
+coral source lint sources/community/shopify/manifest.yaml
+coral source add --file sources/community/shopify/manifest.yaml
+coral source test shopify
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'shopify'"
+coral sql "SELECT table_name, column_name FROM coral.columns WHERE schema_name = 'shopify' ORDER BY table_name, ordinal_position"
+coral sql "SELECT id, title, status FROM shopify.products LIMIT 10"
+```
+
+## Notes
+
+- This source uses Shopify Admin GraphQL, not REST Admin API. Shopify marks REST
+  Admin API as legacy and requires new public apps to use GraphQL Admin API.
+- GraphQL connections are paginated with `first`, `after`, and
+  `pageInfo.endCursor`. Coral requests up to 100 rows per page by default.
+- Shopify GraphQL IDs are exposed as `Utf8` global IDs such as
+  `gid://shopify/Product/...`.
+- Date/time values are exposed as `Utf8` in v1.
+- Nested or repeatable values such as tags, selected options, and smart
+  collection rule sets are exposed as `Json`.
+- Order and customer data can include protected customer data. Shopify may
+  restrict access unless the app meets Shopify's protected customer data
+  requirements.
+
+## Out of scope for v1
+
+- Product, variant, inventory, customer, order, or fulfillment mutations
+- Fulfillment orders and inventory levels by location
+- Metafields as standalone query surfaces
+- Discounts, markets, returns, analytics, pages, blogs, themes, and webhooks
+- Bulk operations
+- Storefront API data
+- Write operations of any kind

--- a/sources/community/shopify/manifest.yaml
+++ b/sources/community/shopify/manifest.yaml
@@ -1,0 +1,1693 @@
+name: shopify
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Shopify shop metadata, products, product variants, collections,
+  orders, customers, locations, and inventory items.
+inputs:
+  SHOPIFY_SHOP_DOMAIN:
+    kind: variable
+    required: true
+    hint: |
+      Shopify shop domain for the Admin GraphQL API, for example
+      `example.myshopify.com`. Do not include `https://` or a trailing slash.
+  SHOPIFY_API_VERSION:
+    kind: variable
+    default: "2026-04"
+    required: false
+    hint: |
+      Shopify Admin GraphQL API version. Defaults to `2026-04`, the latest
+      stable version checked for this source. Override only when you have
+      validated the source against another supported Admin API version.
+  SHOPIFY_ADMIN_ACCESS_TOKEN:
+    kind: secret
+    required: true
+    hint: |
+      Shopify Admin API access token from a custom or public app. The token is
+      sent as `X-Shopify-Access-Token`. Grant only the read scopes needed for
+      the tables you use: `read_products`, `read_orders`, `read_customers`,
+      `read_locations`, and `read_inventory`. Historical orders require
+      approved `read_all_orders` in addition to `read_orders`.
+base_url: https://{{input.SHOPIFY_SHOP_DOMAIN}}/admin/api/{{input.SHOPIFY_API_VERSION}}
+auth:
+  type: HeaderAuth
+  headers:
+    - name: X-Shopify-Access-Token
+      from: template
+      template: "{{input.SHOPIFY_ADMIN_ACCESS_TOKEN}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+  - name: Content-Type
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT id, name, myshopify_domain FROM shopify.shop LIMIT 1
+  - SELECT id, title, status FROM shopify.products LIMIT 1
+tables:
+  - name: shop
+    description: Shopify shop metadata for the authenticated Admin API token.
+    guide: |
+      Start here to validate credentials and confirm which shop a token
+      belongs to. This table returns one row from the Admin GraphQL `shop`
+      query.
+    fetch_limit_default: 1
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyShop {
+              shop {
+                id
+                name
+                myshopifyDomain
+                email
+                contactEmail
+                currencyCode
+                ianaTimezone
+                timezoneAbbreviation
+                taxesIncluded
+                taxShipping
+                createdAt
+                updatedAt
+                url
+                weightUnit
+                primaryDomain {
+                  id
+                  host
+                  url
+                  sslEnabled
+                }
+                plan {
+                  displayName
+                  partnerDevelopment
+                  shopifyPlus
+                }
+              }
+            }
+    response:
+      rows_path: [data, shop]
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify shop ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Shop name.
+        expr:
+          kind: path
+          path: [name]
+      - name: myshopify_domain
+        type: Utf8
+        nullable: false
+        description: Canonical myshopify.com domain.
+        expr:
+          kind: path
+          path: [myshopifyDomain]
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Shop owner email address.
+        expr:
+          kind: path
+          path: [email]
+      - name: contact_email
+        type: Utf8
+        nullable: true
+        description: Public contact email address for the shop.
+        expr:
+          kind: path
+          path: [contactEmail]
+      - name: currency_code
+        type: Utf8
+        nullable: true
+        description: Shop currency code.
+        expr:
+          kind: path
+          path: [currencyCode]
+      - name: iana_timezone
+        type: Utf8
+        nullable: true
+        description: Shop IANA timezone.
+        expr:
+          kind: path
+          path: [ianaTimezone]
+      - name: timezone_abbreviation
+        type: Utf8
+        nullable: true
+        description: Shop timezone abbreviation.
+        expr:
+          kind: path
+          path: [timezoneAbbreviation]
+      - name: taxes_included
+        type: Boolean
+        nullable: true
+        description: Whether product prices include taxes.
+        expr:
+          kind: path
+          path: [taxesIncluded]
+      - name: tax_shipping
+        type: Boolean
+        nullable: true
+        description: Whether the shop charges taxes on shipping.
+        expr:
+          kind: path
+          path: [taxShipping]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Shop creation timestamp from Shopify.
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Shop last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Shop online store URL.
+        expr:
+          kind: path
+          path: [url]
+      - name: weight_unit
+        type: Utf8
+        nullable: true
+        description: Shop primary weight unit.
+        expr:
+          kind: path
+          path: [weightUnit]
+      - name: primary_domain__id
+        type: Utf8
+        nullable: true
+        description: Primary domain ID.
+        expr:
+          kind: path
+          path: [primaryDomain, id]
+      - name: primary_domain__host
+        type: Utf8
+        nullable: true
+        description: Primary domain host.
+        expr:
+          kind: path
+          path: [primaryDomain, host]
+      - name: primary_domain__url
+        type: Utf8
+        nullable: true
+        description: Primary domain URL.
+        expr:
+          kind: path
+          path: [primaryDomain, url]
+      - name: primary_domain__ssl_enabled
+        type: Boolean
+        nullable: true
+        description: Whether SSL is enabled on the primary domain.
+        expr:
+          kind: path
+          path: [primaryDomain, sslEnabled]
+      - name: plan__display_name
+        type: Utf8
+        nullable: true
+        description: Shopify plan display name.
+        expr:
+          kind: path
+          path: [plan, displayName]
+      - name: plan__partner_development
+        type: Boolean
+        nullable: true
+        description: Whether this is a partner development shop.
+        expr:
+          kind: path
+          path: [plan, partnerDevelopment]
+      - name: plan__shopify_plus
+        type: Boolean
+        nullable: true
+        description: Whether the shop is on Shopify Plus.
+        expr:
+          kind: path
+          path: [plan, shopifyPlus]
+
+  - name: products
+    description: Products in the Shopify catalog.
+    guide: |
+      Requires `read_products`. Use the optional `query` filter with Shopify
+      API search syntax, for example `status:active`, `vendor:Snowdevil`, or
+      `updated_at:>2026-01-01`. Join `id` to `product_variants.product_id`.
+    fetch_limit_default: 100
+    filters:
+      - name: query
+        required: false
+        mode: search
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyProducts($first: Int!, $after: String, $query: String) {
+              products(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  title
+                  handle
+                  status
+                  vendor
+                  productType
+                  tags
+                  totalInventory
+                  hasOnlyDefaultVariant
+                  createdAt
+                  updatedAt
+                  publishedAt
+                  priceRangeV2 {
+                    minVariantPrice {
+                      amount
+                      currencyCode
+                    }
+                    maxVariantPrice {
+                      amount
+                      currencyCode
+                    }
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path: [variables, first]
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: filter
+          key: query
+    response:
+      rows_path: [data, products, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, products, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Shopify API search query filter.
+        expr:
+          kind: from_filter
+          key: query
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify product ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Product title.
+        expr:
+          kind: path
+          path: [title]
+      - name: handle
+        type: Utf8
+        nullable: true
+        description: Product handle.
+        expr:
+          kind: path
+          path: [handle]
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Product status such as ACTIVE, DRAFT, or ARCHIVED.
+        expr:
+          kind: path
+          path: [status]
+      - name: vendor
+        type: Utf8
+        nullable: true
+        description: Product vendor.
+        expr:
+          kind: path
+          path: [vendor]
+      - name: product_type
+        type: Utf8
+        nullable: true
+        description: Merchant-defined product type.
+        expr:
+          kind: path
+          path: [productType]
+      - name: tags
+        type: Json
+        nullable: true
+        description: Product tags.
+        expr:
+          kind: path
+          path: [tags]
+      - name: total_inventory
+        type: Int64
+        nullable: true
+        description: Total inventory across variants.
+        expr:
+          kind: path
+          path: [totalInventory]
+      - name: has_only_default_variant
+        type: Boolean
+        nullable: true
+        description: Whether the product has only the default variant.
+        expr:
+          kind: path
+          path: [hasOnlyDefaultVariant]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Product creation timestamp from Shopify.
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Product last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: published_at
+        type: Utf8
+        nullable: true
+        description: Product publication timestamp, when present.
+        expr:
+          kind: path
+          path: [publishedAt]
+      - name: min_variant_price_amount
+        type: Utf8
+        nullable: true
+        description: Minimum variant price amount in the product price range.
+        expr:
+          kind: path
+          path: [priceRangeV2, minVariantPrice, amount]
+      - name: min_variant_price_currency_code
+        type: Utf8
+        nullable: true
+        description: Currency code for the minimum variant price.
+        expr:
+          kind: path
+          path: [priceRangeV2, minVariantPrice, currencyCode]
+      - name: max_variant_price_amount
+        type: Utf8
+        nullable: true
+        description: Maximum variant price amount in the product price range.
+        expr:
+          kind: path
+          path: [priceRangeV2, maxVariantPrice, amount]
+      - name: max_variant_price_currency_code
+        type: Utf8
+        nullable: true
+        description: Currency code for the maximum variant price.
+        expr:
+          kind: path
+          path: [priceRangeV2, maxVariantPrice, currencyCode]
+
+  - name: product_variants
+    description: Product variants and their SKU, price, and inventory item metadata.
+    guide: |
+      Requires `read_products`. Use the optional `query` filter with Shopify
+      API search syntax, for example `sku:ABC-123`, `barcode:ABC-abc-1234`,
+      `product_id:123`, or `collection_id:123`.
+    fetch_limit_default: 100
+    filters:
+      - name: query
+        required: false
+        mode: search
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyProductVariants($first: Int!, $after: String, $query: String) {
+              productVariants(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  title
+                  displayName
+                  sku
+                  barcode
+                  price
+                  compareAtPrice
+                  availableForSale
+                  inventoryQuantity
+                  inventoryPolicy
+                  selectedOptions {
+                    name
+                    value
+                  }
+                  createdAt
+                  updatedAt
+                  product {
+                    id
+                    title
+                    handle
+                  }
+                  inventoryItem {
+                    id
+                    sku
+                    tracked
+                    requiresShipping
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path: [variables, first]
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: filter
+          key: query
+    response:
+      rows_path: [data, productVariants, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, productVariants, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Shopify API search query filter.
+        expr:
+          kind: from_filter
+          key: query
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify product variant ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: product_id
+        type: Utf8
+        nullable: true
+        description: Parent product ID.
+        expr:
+          kind: path
+          path: [product, id]
+      - name: product_title
+        type: Utf8
+        nullable: true
+        description: Parent product title.
+        expr:
+          kind: path
+          path: [product, title]
+      - name: product_handle
+        type: Utf8
+        nullable: true
+        description: Parent product handle.
+        expr:
+          kind: path
+          path: [product, handle]
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Variant title.
+        expr:
+          kind: path
+          path: [title]
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name combining product and variant context.
+        expr:
+          kind: path
+          path: [displayName]
+      - name: sku
+        type: Utf8
+        nullable: true
+        description: Variant SKU.
+        expr:
+          kind: path
+          path: [sku]
+      - name: barcode
+        type: Utf8
+        nullable: true
+        description: Variant barcode.
+        expr:
+          kind: path
+          path: [barcode]
+      - name: price
+        type: Utf8
+        nullable: true
+        description: Variant price in the shop currency.
+        expr:
+          kind: path
+          path: [price]
+      - name: compare_at_price
+        type: Utf8
+        nullable: true
+        description: Variant compare-at price, when present.
+        expr:
+          kind: path
+          path: [compareAtPrice]
+      - name: available_for_sale
+        type: Boolean
+        nullable: true
+        description: Whether the variant is available for sale.
+        expr:
+          kind: path
+          path: [availableForSale]
+      - name: inventory_quantity
+        type: Int64
+        nullable: true
+        description: Total sellable quantity of the variant.
+        expr:
+          kind: path
+          path: [inventoryQuantity]
+      - name: inventory_policy
+        type: Utf8
+        nullable: true
+        description: Inventory policy for out-of-stock ordering.
+        expr:
+          kind: path
+          path: [inventoryPolicy]
+      - name: selected_options
+        type: Json
+        nullable: true
+        description: Selected option name/value pairs for the variant.
+        expr:
+          kind: path
+          path: [selectedOptions]
+      - name: inventory_item_id
+        type: Utf8
+        nullable: true
+        description: Inventory item ID connected to this variant.
+        expr:
+          kind: path
+          path: [inventoryItem, id]
+      - name: inventory_item_sku
+        type: Utf8
+        nullable: true
+        description: Inventory item SKU.
+        expr:
+          kind: path
+          path: [inventoryItem, sku]
+      - name: inventory_item_tracked
+        type: Boolean
+        nullable: true
+        description: Whether inventory tracking is enabled for the inventory item.
+        expr:
+          kind: path
+          path: [inventoryItem, tracked]
+      - name: inventory_item_requires_shipping
+        type: Boolean
+        nullable: true
+        description: Whether the inventory item requires shipping.
+        expr:
+          kind: path
+          path: [inventoryItem, requiresShipping]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Variant creation timestamp from Shopify.
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Variant last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]
+
+  - name: collections
+    description: Product collections in the Shopify catalog.
+    guide: |
+      Requires `read_products`. Use the optional `query` filter with Shopify
+      API search syntax, for example `collection_type:smart`,
+      `title:Summer`, or `updated_at:>2026-01-01`.
+    fetch_limit_default: 100
+    filters:
+      - name: query
+        required: false
+        mode: search
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyCollections($first: Int!, $after: String, $query: String) {
+              collections(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  title
+                  handle
+                  description
+                  descriptionHtml
+                  sortOrder
+                  templateSuffix
+                  updatedAt
+                  productsCount {
+                    count
+                    precision
+                  }
+                  seo {
+                    title
+                    description
+                  }
+                  ruleSet {
+                    appliedDisjunctively
+                    rules {
+                      column
+                      relation
+                      condition
+                    }
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path: [variables, first]
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: filter
+          key: query
+    response:
+      rows_path: [data, collections, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, collections, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Shopify API search query filter.
+        expr:
+          kind: from_filter
+          key: query
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify collection ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Collection title.
+        expr:
+          kind: path
+          path: [title]
+      - name: handle
+        type: Utf8
+        nullable: true
+        description: Collection handle.
+        expr:
+          kind: path
+          path: [handle]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Plain-text collection description.
+        expr:
+          kind: path
+          path: [description]
+      - name: description_html
+        type: Utf8
+        nullable: true
+        description: HTML collection description.
+        expr:
+          kind: path
+          path: [descriptionHtml]
+      - name: sort_order
+        type: Utf8
+        nullable: true
+        description: Default product sort order for the collection.
+        expr:
+          kind: path
+          path: [sortOrder]
+      - name: template_suffix
+        type: Utf8
+        nullable: true
+        description: Liquid template suffix for the collection.
+        expr:
+          kind: path
+          path: [templateSuffix]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Collection last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: products_count
+        type: Int64
+        nullable: true
+        description: Number of products in the collection.
+        expr:
+          kind: path
+          path: [productsCount, count]
+      - name: products_count_precision
+        type: Utf8
+        nullable: true
+        description: Precision of the products count.
+        expr:
+          kind: path
+          path: [productsCount, precision]
+      - name: seo__title
+        type: Utf8
+        nullable: true
+        description: SEO title for the collection.
+        expr:
+          kind: path
+          path: [seo, title]
+      - name: seo__description
+        type: Utf8
+        nullable: true
+        description: SEO description for the collection.
+        expr:
+          kind: path
+          path: [seo, description]
+      - name: rule_set
+        type: Json
+        nullable: true
+        description: Smart collection rule set, when present.
+        expr:
+          kind: path
+          path: [ruleSet]
+
+  - name: orders
+    description: Orders placed in the Shopify store.
+    guide: |
+      Requires `read_orders`. Shopify limits order access to the default recent
+      order window unless the app also has approved `read_all_orders`. Use the
+      optional `query` filter with Shopify API search syntax, for example
+      `financial_status:paid fulfillment_status:unfulfilled`,
+      `created_at:>=2026-01-01`, or `sku:ABC-123`.
+    fetch_limit_default: 100
+    filters:
+      - name: query
+        required: false
+        mode: search
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyOrders($first: Int!, $after: String, $query: String) {
+              orders(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  name
+                  createdAt
+                  updatedAt
+                  processedAt
+                  cancelledAt
+                  displayFinancialStatus
+                  displayFulfillmentStatus
+                  currencyCode
+                  currentTotalPriceSet {
+                    shopMoney {
+                      amount
+                      currencyCode
+                    }
+                  }
+                  currentSubtotalPriceSet {
+                    shopMoney {
+                      amount
+                      currencyCode
+                    }
+                  }
+                  currentTotalTaxSet {
+                    shopMoney {
+                      amount
+                      currencyCode
+                    }
+                  }
+                  subtotalLineItemsQuantity
+                  tags
+                  test
+                  customer {
+                    id
+                    displayName
+                    firstName
+                    lastName
+                    defaultEmailAddress {
+                      emailAddress
+                    }
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path: [variables, first]
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: filter
+          key: query
+    response:
+      rows_path: [data, orders, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, orders, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Shopify API search query filter.
+        expr:
+          kind: from_filter
+          key: query
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify order ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Merchant-facing order name, such as #1001.
+        expr:
+          kind: path
+          path: [name]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Order creation timestamp from Shopify.
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Order last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]
+      - name: processed_at
+        type: Utf8
+        nullable: true
+        description: Order processed timestamp from Shopify.
+        expr:
+          kind: path
+          path: [processedAt]
+      - name: cancelled_at
+        type: Utf8
+        nullable: true
+        description: Order cancellation timestamp, when cancelled.
+        expr:
+          kind: path
+          path: [cancelledAt]
+      - name: display_financial_status
+        type: Utf8
+        nullable: true
+        description: Financial status shown in the Shopify admin.
+        expr:
+          kind: path
+          path: [displayFinancialStatus]
+      - name: display_fulfillment_status
+        type: Utf8
+        nullable: true
+        description: Fulfillment status shown in the Shopify admin.
+        expr:
+          kind: path
+          path: [displayFulfillmentStatus]
+      - name: currency_code
+        type: Utf8
+        nullable: true
+        description: Order currency code.
+        expr:
+          kind: path
+          path: [currencyCode]
+      - name: current_total_price_amount
+        type: Utf8
+        nullable: true
+        description: Current total order price amount in the shop currency.
+        expr:
+          kind: path
+          path: [currentTotalPriceSet, shopMoney, amount]
+      - name: current_total_price_currency_code
+        type: Utf8
+        nullable: true
+        description: Current total order price currency code.
+        expr:
+          kind: path
+          path: [currentTotalPriceSet, shopMoney, currencyCode]
+      - name: current_subtotal_price_amount
+        type: Utf8
+        nullable: true
+        description: Current subtotal price amount in the shop currency.
+        expr:
+          kind: path
+          path: [currentSubtotalPriceSet, shopMoney, amount]
+      - name: current_subtotal_price_currency_code
+        type: Utf8
+        nullable: true
+        description: Current subtotal price currency code.
+        expr:
+          kind: path
+          path: [currentSubtotalPriceSet, shopMoney, currencyCode]
+      - name: current_total_tax_amount
+        type: Utf8
+        nullable: true
+        description: Current total tax amount in the shop currency.
+        expr:
+          kind: path
+          path: [currentTotalTaxSet, shopMoney, amount]
+      - name: current_total_tax_currency_code
+        type: Utf8
+        nullable: true
+        description: Current total tax currency code.
+        expr:
+          kind: path
+          path: [currentTotalTaxSet, shopMoney, currencyCode]
+      - name: subtotal_line_items_quantity
+        type: Int64
+        nullable: true
+        description: Total quantity of line items contributing to the order subtotal.
+        expr:
+          kind: path
+          path: [subtotalLineItemsQuantity]
+      - name: tags
+        type: Json
+        nullable: true
+        description: Order tags.
+        expr:
+          kind: path
+          path: [tags]
+      - name: test
+        type: Boolean
+        nullable: true
+        description: Whether this is a test order.
+        expr:
+          kind: path
+          path: [test]
+      - name: customer_id
+        type: Utf8
+        nullable: true
+        description: Customer ID associated with the order, when present.
+        expr:
+          kind: path
+          path: [customer, id]
+      - name: customer_display_name
+        type: Utf8
+        nullable: true
+        description: Customer display name associated with the order.
+        expr:
+          kind: path
+          path: [customer, displayName]
+      - name: customer_first_name
+        type: Utf8
+        nullable: true
+        description: Customer first name associated with the order.
+        expr:
+          kind: path
+          path: [customer, firstName]
+      - name: customer_last_name
+        type: Utf8
+        nullable: true
+        description: Customer last name associated with the order.
+        expr:
+          kind: path
+          path: [customer, lastName]
+      - name: customer_email
+        type: Utf8
+        nullable: true
+        description: Customer default email address associated with the order, when available.
+        expr:
+          kind: path
+          path: [customer, defaultEmailAddress, emailAddress]
+
+  - name: customers
+    description: Customer records in the Shopify store.
+    guide: |
+      Requires `read_customers` and may require protected customer data approval
+      for non-development stores. Use the optional `query` filter with Shopify
+      API search syntax, for example `email:buyer@example.com`,
+      `state:enabled`, or `created_at:>=2026-01-01`.
+    fetch_limit_default: 100
+    filters:
+      - name: query
+        required: false
+        mode: search
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyCustomers($first: Int!, $after: String, $query: String) {
+              customers(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  displayName
+                  firstName
+                  lastName
+                  createdAt
+                  updatedAt
+                  state
+                  numberOfOrders
+                  verifiedEmail
+                  taxExempt
+                  tags
+                  amountSpent {
+                    amount
+                    currencyCode
+                  }
+                  defaultEmailAddress {
+                    emailAddress
+                    marketingState
+                  }
+                  defaultPhoneNumber {
+                    phoneNumber
+                    marketingState
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path: [variables, first]
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: filter
+          key: query
+    response:
+      rows_path: [data, customers, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, customers, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Shopify API search query filter.
+        expr:
+          kind: from_filter
+          key: query
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify customer ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Customer display name.
+        expr:
+          kind: path
+          path: [displayName]
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: Customer first name.
+        expr:
+          kind: path
+          path: [firstName]
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Customer last name.
+        expr:
+          kind: path
+          path: [lastName]
+      - name: default_email
+        type: Utf8
+        nullable: true
+        description: Customer default email address, when available.
+        expr:
+          kind: path
+          path: [defaultEmailAddress, emailAddress]
+      - name: default_email_marketing_state
+        type: Utf8
+        nullable: true
+        description: Marketing state for the default email address.
+        expr:
+          kind: path
+          path: [defaultEmailAddress, marketingState]
+      - name: default_phone
+        type: Utf8
+        nullable: true
+        description: Customer default phone number, when available.
+        expr:
+          kind: path
+          path: [defaultPhoneNumber, phoneNumber]
+      - name: default_phone_marketing_state
+        type: Utf8
+        nullable: true
+        description: Marketing state for the default phone number.
+        expr:
+          kind: path
+          path: [defaultPhoneNumber, marketingState]
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Customer account state.
+        expr:
+          kind: path
+          path: [state]
+      - name: number_of_orders
+        type: Int64
+        nullable: true
+        description: Number of orders placed by the customer.
+        expr:
+          kind: path
+          path: [numberOfOrders]
+      - name: amount_spent
+        type: Utf8
+        nullable: true
+        description: Lifetime amount spent by the customer.
+        expr:
+          kind: path
+          path: [amountSpent, amount]
+      - name: amount_spent_currency_code
+        type: Utf8
+        nullable: true
+        description: Currency code for the lifetime amount spent.
+        expr:
+          kind: path
+          path: [amountSpent, currencyCode]
+      - name: verified_email
+        type: Boolean
+        nullable: true
+        description: Whether the customer has a verified email address.
+        expr:
+          kind: path
+          path: [verifiedEmail]
+      - name: tax_exempt
+        type: Boolean
+        nullable: true
+        description: Whether the customer is tax exempt.
+        expr:
+          kind: path
+          path: [taxExempt]
+      - name: tags
+        type: Json
+        nullable: true
+        description: Customer tags.
+        expr:
+          kind: path
+          path: [tags]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Customer creation timestamp from Shopify.
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Customer last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]
+
+  - name: locations
+    description: Shopify inventory locations where products can be stocked or fulfilled.
+    guide: |
+      Requires `read_locations` or an inventory-related scope. By default,
+      Shopify returns active locations. Use `include_inactive` or
+      `include_legacy` when you need deactivated or fulfillment-service
+      locations. The optional `query` filter uses Shopify API search syntax.
+    fetch_limit_default: 100
+    filters:
+      - name: query
+        required: false
+        mode: search
+      - name: include_inactive
+        required: false
+      - name: include_legacy
+        required: false
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyLocations(
+              $first: Int!,
+              $after: String,
+              $query: String,
+              $includeInactive: Boolean,
+              $includeLegacy: Boolean
+            ) {
+              locations(
+                first: $first,
+                after: $after,
+                query: $query,
+                includeInactive: $includeInactive,
+                includeLegacy: $includeLegacy
+              ) {
+                nodes {
+                  id
+                  name
+                  isActive
+                  isFulfillmentService
+                  fulfillsOnlineOrders
+                  hasActiveInventory
+                  shipsInventory
+                  createdAt
+                  updatedAt
+                  address {
+                    address1
+                    address2
+                    city
+                    country
+                    countryCode
+                    province
+                    provinceCode
+                    zip
+                  }
+                  fulfillmentService {
+                    handle
+                    serviceName
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path: [variables, first]
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: filter
+          key: query
+        - path: [variables, includeInactive]
+          from: filter_bool
+          key: include_inactive
+        - path: [variables, includeLegacy]
+          from: filter_bool
+          key: include_legacy
+    response:
+      rows_path: [data, locations, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, locations, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Shopify API search query filter.
+        expr:
+          kind: from_filter
+          key: query
+      - name: include_inactive
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Include deactivated locations when true.
+        expr:
+          kind: from_filter
+          key: include_inactive
+      - name: include_legacy
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Include legacy fulfillment-service locations when true.
+        expr:
+          kind: from_filter
+          key: include_legacy
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify location ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Location name.
+        expr:
+          kind: path
+          path: [name]
+      - name: is_active
+        type: Boolean
+        nullable: true
+        description: Whether the location is active.
+        expr:
+          kind: path
+          path: [isActive]
+      - name: is_fulfillment_service
+        type: Boolean
+        nullable: true
+        description: Whether the location belongs to a fulfillment service.
+        expr:
+          kind: path
+          path: [isFulfillmentService]
+      - name: fulfills_online_orders
+        type: Boolean
+        nullable: true
+        description: Whether the location can fulfill online orders.
+        expr:
+          kind: path
+          path: [fulfillsOnlineOrders]
+      - name: has_active_inventory
+        type: Boolean
+        nullable: true
+        description: Whether the location has active inventory.
+        expr:
+          kind: path
+          path: [hasActiveInventory]
+      - name: ships_inventory
+        type: Boolean
+        nullable: true
+        description: Whether the location ships inventory.
+        expr:
+          kind: path
+          path: [shipsInventory]
+      - name: address__address1
+        type: Utf8
+        nullable: true
+        description: Location address line 1.
+        expr:
+          kind: path
+          path: [address, address1]
+      - name: address__address2
+        type: Utf8
+        nullable: true
+        description: Location address line 2.
+        expr:
+          kind: path
+          path: [address, address2]
+      - name: address__city
+        type: Utf8
+        nullable: true
+        description: Location city.
+        expr:
+          kind: path
+          path: [address, city]
+      - name: address__country
+        type: Utf8
+        nullable: true
+        description: Location country.
+        expr:
+          kind: path
+          path: [address, country]
+      - name: address__country_code
+        type: Utf8
+        nullable: true
+        description: Location country code.
+        expr:
+          kind: path
+          path: [address, countryCode]
+      - name: address__province
+        type: Utf8
+        nullable: true
+        description: Location province or state.
+        expr:
+          kind: path
+          path: [address, province]
+      - name: address__province_code
+        type: Utf8
+        nullable: true
+        description: Location province or state code.
+        expr:
+          kind: path
+          path: [address, provinceCode]
+      - name: address__zip
+        type: Utf8
+        nullable: true
+        description: Location postal code.
+        expr:
+          kind: path
+          path: [address, zip]
+      - name: fulfillment_service__handle
+        type: Utf8
+        nullable: true
+        description: Fulfillment service handle, when the location is service-backed.
+        expr:
+          kind: path
+          path: [fulfillmentService, handle]
+      - name: fulfillment_service__service_name
+        type: Utf8
+        nullable: true
+        description: Fulfillment service name, when the location is service-backed.
+        expr:
+          kind: path
+          path: [fulfillmentService, serviceName]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Location creation timestamp from Shopify.
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Location last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]
+
+  - name: inventory_items
+    description: Shopify inventory item metadata connected to product variants.
+    guide: |
+      Requires `read_inventory` or `read_products`. Use the optional `query`
+      filter with Shopify API search syntax, for example `sku:ABC-123`,
+      `id:>=1234`, or `updated_at:>2026-01-01`. This table exposes inventory
+      item metadata, not per-location quantities.
+    fetch_limit_default: 100
+    filters:
+      - name: query
+        required: false
+        mode: search
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path: [query]
+          from: literal
+          value: |
+            query ShopifyInventoryItems($first: Int!, $after: String, $query: String) {
+              inventoryItems(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  sku
+                  tracked
+                  requiresShipping
+                  duplicateSkuCount
+                  countryCodeOfOrigin
+                  provinceCodeOfOrigin
+                  harmonizedSystemCode
+                  inventoryHistoryUrl
+                  locationsCount {
+                    count
+                    precision
+                  }
+                  createdAt
+                  updatedAt
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path: [variables, first]
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: filter
+          key: query
+    response:
+      rows_path: [data, inventoryItems, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, inventoryItems, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Shopify API search query filter.
+        expr:
+          kind: from_filter
+          key: query
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify inventory item ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: sku
+        type: Utf8
+        nullable: true
+        description: Inventory item SKU.
+        expr:
+          kind: path
+          path: [sku]
+      - name: tracked
+        type: Boolean
+        nullable: true
+        description: Whether inventory levels are tracked for this item.
+        expr:
+          kind: path
+          path: [tracked]
+      - name: requires_shipping
+        type: Boolean
+        nullable: true
+        description: Whether the inventory item requires shipping.
+        expr:
+          kind: path
+          path: [requiresShipping]
+      - name: duplicate_sku_count
+        type: Int64
+        nullable: true
+        description: Number of inventory items sharing the same SKU.
+        expr:
+          kind: path
+          path: [duplicateSkuCount]
+      - name: country_code_of_origin
+        type: Utf8
+        nullable: true
+        description: Country of origin code for the item.
+        expr:
+          kind: path
+          path: [countryCodeOfOrigin]
+      - name: province_code_of_origin
+        type: Utf8
+        nullable: true
+        description: Province of origin code for the item.
+        expr:
+          kind: path
+          path: [provinceCodeOfOrigin]
+      - name: harmonized_system_code
+        type: Utf8
+        nullable: true
+        description: Harmonized system code for customs.
+        expr:
+          kind: path
+          path: [harmonizedSystemCode]
+      - name: inventory_history_url
+        type: Utf8
+        nullable: true
+        description: Shopify admin URL for inventory history.
+        expr:
+          kind: path
+          path: [inventoryHistoryUrl]
+      - name: locations_count
+        type: Int64
+        nullable: true
+        description: Number of locations where this inventory item is stocked.
+        expr:
+          kind: path
+          path: [locationsCount, count]
+      - name: locations_count_precision
+        type: Utf8
+        nullable: true
+        description: Precision of the locations count.
+        expr:
+          kind: path
+          path: [locationsCount, precision]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Inventory item creation timestamp from Shopify.
+        expr:
+          kind: path
+          path: [createdAt]
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Inventory item last updated timestamp from Shopify.
+        expr:
+          kind: path
+          path: [updatedAt]

--- a/sources/community/shopify/manifest.yaml
+++ b/sources/community/shopify/manifest.yaml
@@ -8,21 +8,18 @@ description: >-
 inputs:
   SHOPIFY_SHOP_DOMAIN:
     kind: variable
-    required: true
     hint: |
       Shopify shop domain for the Admin GraphQL API, for example
       `example.myshopify.com`. Do not include `https://` or a trailing slash.
   SHOPIFY_API_VERSION:
     kind: variable
     default: "2026-04"
-    required: false
     hint: |
       Shopify Admin GraphQL API version. Defaults to `2026-04`, the latest
       stable version checked for this source. Override only when you have
       validated the source against another supported Admin API version.
   SHOPIFY_ADMIN_ACCESS_TOKEN:
     kind: secret
-    required: true
     hint: |
       Shopify Admin API access token from a custom or public app. The token is
       sent as `X-Shopify-Access-Token`. Grant only the read scopes needed for
@@ -167,19 +164,25 @@ tables:
           kind: path
           path: [taxShipping]
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Shop creation timestamp from Shopify.
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Shop last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
       - name: url
         type: Utf8
         nullable: true
@@ -253,7 +256,6 @@ tables:
     fetch_limit_default: 100
     filters:
       - name: query
-        required: false
         mode: search
     request:
       method: POST
@@ -384,30 +386,46 @@ tables:
           kind: path
           path: [hasOnlyDefaultVariant]
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Product creation timestamp from Shopify.
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Product last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
       - name: published_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Product publication timestamp, when present.
         expr:
-          kind: path
-          path: [publishedAt]
-      - name: min_variant_price_amount
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [publishedAt]
+      - name: min_variant_price_amount_decimal
         type: Utf8
         nullable: true
-        description: Minimum variant price amount in the product price range.
+        description: Minimum variant price amount as Shopify's decimal string.
+        expr:
+          kind: path
+          path: [priceRangeV2, minVariantPrice, amount]
+      - name: min_variant_price_amount
+        type: Float64
+        nullable: true
+        description: Minimum variant price amount as Float64 for arithmetic.
         expr:
           kind: path
           path: [priceRangeV2, minVariantPrice, amount]
@@ -418,10 +436,17 @@ tables:
         expr:
           kind: path
           path: [priceRangeV2, minVariantPrice, currencyCode]
-      - name: max_variant_price_amount
+      - name: max_variant_price_amount_decimal
         type: Utf8
         nullable: true
-        description: Maximum variant price amount in the product price range.
+        description: Maximum variant price amount as Shopify's decimal string.
+        expr:
+          kind: path
+          path: [priceRangeV2, maxVariantPrice, amount]
+      - name: max_variant_price_amount
+        type: Float64
+        nullable: true
+        description: Maximum variant price amount as Float64 for arithmetic.
         expr:
           kind: path
           path: [priceRangeV2, maxVariantPrice, amount]
@@ -442,7 +467,6 @@ tables:
     fetch_limit_default: 100
     filters:
       - name: query
-        required: false
         mode: search
     request:
       method: POST
@@ -570,17 +594,31 @@ tables:
         expr:
           kind: path
           path: [barcode]
-      - name: price
+      - name: price_decimal
         type: Utf8
         nullable: true
-        description: Variant price in the shop currency.
+        description: Variant price as Shopify's decimal string.
         expr:
           kind: path
           path: [price]
-      - name: compare_at_price
+      - name: price
+        type: Float64
+        nullable: true
+        description: Variant price as Float64 for arithmetic.
+        expr:
+          kind: path
+          path: [price]
+      - name: compare_at_price_decimal
         type: Utf8
         nullable: true
-        description: Variant compare-at price, when present.
+        description: Variant compare-at price as Shopify's decimal string.
+        expr:
+          kind: path
+          path: [compareAtPrice]
+      - name: compare_at_price
+        type: Float64
+        nullable: true
+        description: Variant compare-at price as Float64 for arithmetic.
         expr:
           kind: path
           path: [compareAtPrice]
@@ -641,19 +679,25 @@ tables:
           kind: path
           path: [inventoryItem, requiresShipping]
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Variant creation timestamp from Shopify.
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Variant last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
 
   - name: collections
     description: Product collections in the Shopify catalog.
@@ -664,7 +708,6 @@ tables:
     fetch_limit_default: 100
     filters:
       - name: query
-        required: false
         mode: search
     request:
       method: POST
@@ -783,12 +826,15 @@ tables:
           kind: path
           path: [templateSuffix]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Collection last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
       - name: products_count
         type: Int64
         nullable: true
@@ -836,7 +882,6 @@ tables:
     fetch_limit_default: 100
     filters:
       - name: query
-        required: false
         mode: search
     request:
       method: POST
@@ -935,33 +980,45 @@ tables:
           kind: path
           path: [name]
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Order creation timestamp from Shopify.
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Order last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
       - name: processed_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Order processed timestamp from Shopify.
         expr:
-          kind: path
-          path: [processedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [processedAt]
       - name: cancelled_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Order cancellation timestamp, when cancelled.
         expr:
-          kind: path
-          path: [cancelledAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [cancelledAt]
       - name: display_financial_status
         type: Utf8
         nullable: true
@@ -983,10 +1040,17 @@ tables:
         expr:
           kind: path
           path: [currencyCode]
-      - name: current_total_price_amount
+      - name: current_total_price_amount_decimal
         type: Utf8
         nullable: true
-        description: Current total order price amount in the shop currency.
+        description: Current total order price amount as Shopify's decimal string.
+        expr:
+          kind: path
+          path: [currentTotalPriceSet, shopMoney, amount]
+      - name: current_total_price_amount
+        type: Float64
+        nullable: true
+        description: Current total order price amount as Float64 for arithmetic.
         expr:
           kind: path
           path: [currentTotalPriceSet, shopMoney, amount]
@@ -997,10 +1061,17 @@ tables:
         expr:
           kind: path
           path: [currentTotalPriceSet, shopMoney, currencyCode]
-      - name: current_subtotal_price_amount
+      - name: current_subtotal_price_amount_decimal
         type: Utf8
         nullable: true
-        description: Current subtotal price amount in the shop currency.
+        description: Current subtotal price amount as Shopify's decimal string.
+        expr:
+          kind: path
+          path: [currentSubtotalPriceSet, shopMoney, amount]
+      - name: current_subtotal_price_amount
+        type: Float64
+        nullable: true
+        description: Current subtotal price amount as Float64 for arithmetic.
         expr:
           kind: path
           path: [currentSubtotalPriceSet, shopMoney, amount]
@@ -1011,10 +1082,17 @@ tables:
         expr:
           kind: path
           path: [currentSubtotalPriceSet, shopMoney, currencyCode]
-      - name: current_total_tax_amount
+      - name: current_total_tax_amount_decimal
         type: Utf8
         nullable: true
-        description: Current total tax amount in the shop currency.
+        description: Current total tax amount as Shopify's decimal string.
+        expr:
+          kind: path
+          path: [currentTotalTaxSet, shopMoney, amount]
+      - name: current_total_tax_amount
+        type: Float64
+        nullable: true
+        description: Current total tax amount as Float64 for arithmetic.
         expr:
           kind: path
           path: [currentTotalTaxSet, shopMoney, amount]
@@ -1092,7 +1170,6 @@ tables:
     fetch_limit_default: 100
     filters:
       - name: query
-        required: false
         mode: search
     request:
       method: POST
@@ -1230,10 +1307,17 @@ tables:
         expr:
           kind: path
           path: [numberOfOrders]
-      - name: amount_spent
+      - name: amount_spent_decimal
         type: Utf8
         nullable: true
-        description: Lifetime amount spent by the customer.
+        description: Lifetime amount spent as Shopify's decimal string.
+        expr:
+          kind: path
+          path: [amountSpent, amount]
+      - name: amount_spent
+        type: Float64
+        nullable: true
+        description: Lifetime amount spent as Float64 for arithmetic.
         expr:
           kind: path
           path: [amountSpent, amount]
@@ -1266,19 +1350,25 @@ tables:
           kind: path
           path: [tags]
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Customer creation timestamp from Shopify.
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Customer last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
 
   - name: locations
     description: Shopify inventory locations where products can be stocked or fulfilled.
@@ -1290,12 +1380,9 @@ tables:
     fetch_limit_default: 100
     filters:
       - name: query
-        required: false
         mode: search
       - name: include_inactive
-        required: false
       - name: include_legacy
-        required: false
     request:
       method: POST
       path: /graphql.json
@@ -1516,19 +1603,25 @@ tables:
           kind: path
           path: [fulfillmentService, serviceName]
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Location creation timestamp from Shopify.
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Location last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
 
   - name: inventory_items
     description: Shopify inventory item metadata connected to product variants.
@@ -1540,7 +1633,6 @@ tables:
     fetch_limit_default: 100
     filters:
       - name: query
-        required: false
         mode: search
     request:
       method: POST
@@ -1678,16 +1770,22 @@ tables:
           kind: path
           path: [locationsCount, precision]
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Inventory item creation timestamp from Shopify.
         expr:
-          kind: path
-          path: [createdAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Inventory item last updated timestamp from Shopify.
         expr:
-          kind: path
-          path: [updatedAt]
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]


### PR DESCRIPTION
## Summary

Adds a new community source for Shopify under `sources/community/shopify/`.

This source enables querying Shopify Admin GraphQL data through SQL. It covers
shop metadata, products, product variants, collections, orders, customers,
locations, and inventory items. The source is manifest-only, read-only, and
uses Coral's existing HTTP source-spec model with `POST` GraphQL requests,
`X-Shopify-Access-Token` auth, and cursor pagination. No CLI, MCP, config,
runtime, or source-spec changes are included.

Closes #522 
## What changed

**Added:**

- `sources/community/shopify/manifest.yaml`
- `sources/community/shopify/README.md`

### Tables

| Table | GraphQL root field | Pagination |
|---|---|---|
| `shop` | `shop` | none |
| `products` | `products` | cursor |
| `product_variants` | `productVariants` | cursor |
| `collections` | `collections` | cursor |
| `orders` | `orders` | cursor |
| `customers` | `customers` | cursor |
| `locations` | `locations` | cursor |
| `inventory_items` | `inventoryItems` | cursor |

### Auth

Admin API token auth via `SHOPIFY_ADMIN_ACCESS_TOKEN`.

**Inputs:**

- `SHOPIFY_SHOP_DOMAIN` - required variable. Shopify shop domain such as
  `example.myshopify.com`.
- `SHOPIFY_API_VERSION` - optional variable. Defaults to `2026-04`.
- `SHOPIFY_ADMIN_ACCESS_TOKEN` - required secret. Shopify Admin API access
  token from a custom or public app. Coral sends it as
  `X-Shopify-Access-Token`.

## Implementation notes

- **Admin GraphQL over HTTP** - all tables use `method: POST` against
  `/admin/api/{{input.SHOPIFY_API_VERSION}}/graphql.json`.
- **API version maintenance** - the source defaults to Shopify Admin GraphQL
  `2026-04`. Future bumps should check Shopify's API versioning release
  schedule (`https://shopify.dev/docs/api/usage/versioning#release-schedule`)
  because Shopify releases stable versions quarterly, supports each stable
  version for at least 12 months, and version bumps can require GraphQL query
  updates for renamed, deprecated, or removed fields and enum values.
- **HeaderAuth** - the manifest sends
  `X-Shopify-Access-Token: {{input.SHOPIFY_ADMIN_ACCESS_TOKEN}}`.
- **JSON request headers** - the source sends `Accept: application/json` and
  `Content-Type: application/json`.
- **Cursor body pagination** - connection tables use `mode: cursor_body` with
  `variables.after` and `data.<connection>.pageInfo.endCursor`.
- **Body page size** - connection tables send page size through
  `variables.first`, defaulting to 100 with max 250.
- **Optional Shopify search filters** - connection tables expose a `query`
  filter using Shopify Admin API search syntax. `locations` also exposes
  `include_inactive` and `include_legacy`.
- **IDs as Utf8** - Shopify GraphQL global IDs are exposed as strings.
- **Money amounts as raw and ergonomic columns** - Shopify money amount fields
  are preserved as exact decimal strings in `*_decimal` columns and also
  exposed through natural `Float64` amount columns for arithmetic.
- **Timestamps as Timestamp** - Shopify `DateTime` fields are parsed from ISO
  8601 and exposed as `Timestamp` columns for date-range filtering and
  ordering.
- **Nested data as Json** - arrays and richer structures such as product tags,
  selected options, order tags, customer tags, and smart collection rule sets
  are preserved as `Json`.
- **Read-only v1** - no product, inventory, customer, order, fulfillment, or
  other mutations are included.

## Endpoint verification

Checked against Shopify's public documentation on May 16, 2026:

| Check | Result |
|---|---|
| Admin GraphQL endpoint format is documented | pass |
| `X-Shopify-Access-Token` auth header is documented | pass |
| `2026-04` is the latest Admin GraphQL version shown by Shopify docs | pass |
| REST Admin API is marked legacy for new public apps | pass |
| `shop` query is public/documented | pass |
| `products` query is public/documented | pass |
| `productVariants` query is public/documented | pass |
| `collections` query is public/documented | pass |
| `orders` query is public/documented | pass |
| `customers` query is public/documented | pass |
| `locations` query is public/documented | pass |
| `inventoryItems` query is public/documented | pass |
| GraphQL cursor pagination with `first`, `after`, and `pageInfo.endCursor` is documented | pass |
| README table list, filters, and scopes match the manifest | pass |

Primary docs checked:

- https://shopify.dev/docs/api/admin-graphql/latest
- https://shopify.dev/docs/api/usage/access-scopes
- https://shopify.dev/docs/api/usage/pagination-graphql
- https://shopify.dev/docs/api/admin-rest/latest
- https://shopify.dev/docs/api/admin-graphql/latest/queries/shop
- https://shopify.dev/docs/api/admin-graphql/latest/queries/products
- https://shopify.dev/docs/api/admin-graphql/latest/queries/productVariants
- https://shopify.dev/docs/api/admin-graphql/latest/queries/collections
- https://shopify.dev/docs/api/admin-graphql/latest/queries/orders
- https://shopify.dev/docs/api/admin-graphql/latest/queries/customers
- https://shopify.dev/docs/api/admin-graphql/latest/queries/locations
- https://shopify.dev/docs/api/admin-graphql/latest/queries/inventoryItems

## Validation

Lint completed separately. Live validation was rerun on May 18, 2026 against a
Shopify development store (`coral-dev-testing.myshopify.com`).

### Lint

```
coral source lint sources/community/shopify/manifest.yaml
Manifest is valid
```

### Source add and test queries

```
coral source add --file sources/community/shopify/manifest.yaml
Added source shopify

  shopify connected successfully

    shopify (8 tables)
    - collections
    - customers
    - inventory_items
    - locations
    - orders
    - product_variants
    - products
    - shop
    Query tests
    2 declared, 2 passed, 0 failed

    PASS SELECT id, name, myshopify_domain FROM shopify.shop LIMIT 1
      1 row

    PASS SELECT id, title, status FROM shopify.products LIMIT 1
      0 rows
```

### Live SQL queries - all 8 tables

| Table | Query | Result |
|---|---|---|
| `shop` | `SELECT id, name, myshopify_domain FROM shopify.shop LIMIT 1` | 1 row: `gid://shopify/Shop/76681248933`, `Coral Dev Testing`, `coral-dev-testing.myshopify.com` |
| `products` | `SELECT id, title, status, min_variant_price_amount, min_variant_price_amount_decimal, created_at FROM shopify.products LIMIT 5` | 0 rows (empty dev store) - query ran without error |
| `product_variants` | `SELECT id, product_title, sku, price, price_decimal, created_at FROM shopify.product_variants LIMIT 5` | 0 rows - query ran without error |
| `collections` | `SELECT id, title, updated_at FROM shopify.collections LIMIT 5` | 1 row: `gid://shopify/Collection/335299084453`, `Home page`, `2026-05-16T14:23:34Z` |
| `orders` | `SELECT id, name, current_total_price_amount, current_total_price_amount_decimal, created_at FROM shopify.orders LIMIT 5` | 0 rows - query ran without error |
| `customers` | `SELECT id, display_name, amount_spent, amount_spent_decimal, created_at FROM shopify.customers LIMIT 5` | 0 rows - query ran without error |
| `locations` | `SELECT id, name, is_active, created_at FROM shopify.locations LIMIT 5` | 1 row: `gid://shopify/Location/86482845861`, `Shop location`, `true`, `2026-05-16T14:23:31Z` |
| `inventory_items` | `SELECT id, sku, tracked, created_at FROM shopify.inventory_items LIMIT 5` | 0 rows - query ran without error |

### Review-change validation

| Check | Query | Result |
|---|---|---|
| Float64 money aggregation | `SELECT SUM(current_total_price_amount) AS total_order_value FROM shopify.orders` | Query ran without error; result was `NULL` because the dev store has no orders |
| Timestamp date-range predicate | `SELECT id, title, updated_at FROM shopify.collections WHERE updated_at > NOW() - INTERVAL '30 days' LIMIT 5` | 1 row: `gid://shopify/Collection/335299084453`, `Home page`, `2026-05-16T14:23:34Z` |

All 8 tables responded successfully. Tables with 0 rows are expected on a
fresh development store with no sample products, orders, or customers
populated.

## User-visible impact

New `shopify` source installable via:

```sh
SHOPIFY_SHOP_DOMAIN=example.myshopify.com \
SHOPIFY_ADMIN_ACCESS_TOKEN=shpat_... \
coral source add --file sources/community/shopify/manifest.yaml
```

Example queries:

```sql
-- Confirm the authenticated shop
SELECT id, name, myshopify_domain
FROM shopify.shop
LIMIT 1;

-- Active products
SELECT id, title, status, vendor, total_inventory
FROM shopify.products
WHERE query = 'status:active'
LIMIT 25;

-- Product variants by SKU
SELECT id, product_title, sku, price, inventory_quantity
FROM shopify.product_variants
WHERE query = 'sku:ABC*'
LIMIT 25;

-- Paid unfulfilled orders
SELECT id, name, display_financial_status, display_fulfillment_status
FROM shopify.orders
WHERE query = 'financial_status:paid fulfillment_status:unfulfilled'
LIMIT 25;

-- Aggregate paid unfulfilled order value
SELECT SUM(current_total_price_amount) AS total_unfulfilled_value
FROM shopify.orders
WHERE query = 'financial_status:paid fulfillment_status:unfulfilled';

-- Inventory items by SKU
SELECT id, sku, tracked, locations_count
FROM shopify.inventory_items
WHERE query = 'sku:ABC*'
LIMIT 25;
```

## Known limitations

- Shopify Admin API access depends on app scopes. A token with only
  `read_products` can query catalog tables but not orders, customers,
  locations, or inventory tables that require other scopes.
- Historical orders require approved `read_all_orders` in addition to
  `read_orders`.
- Order and customer data can include protected customer data and may require
  Shopify protected customer data approval.
- Shopify GraphQL Admin API is cost-rate-limited. Users should prefer targeted
  Shopify search filters and SQL `LIMIT`.
- Shopify money amounts are exact decimal strings in the API. This source keeps
  exact raw values in `*_decimal` columns and exposes `Float64` amount columns
  for analytics.
- Shopify `DateTime` columns are exposed as `Timestamp` values parsed from ISO
  8601 strings.
- Nested structures are preserved as `Json` columns.

## Out of scope

Not included in v1:

- Product, variant, collection, order, customer, inventory, or fulfillment
  mutations
- Fulfillment orders
- Inventory levels by location
- Metafields as standalone tables or functions
- Discounts
- Markets
- Returns
- Analytics
- Pages, blogs, articles, and themes
- Bulk operations
- Storefront API data
- Webhooks or event subscriptions
- Write operations of any kind
