### PR TITLE
feat(sources/community/sendgrid): add SendGrid community source

### DIFF
--- a/sources/community/sendgrid/README.md
+++ b/sources/community/sendgrid/README.md
@@ -206,7 +206,8 @@ SendGrid API endpoint:
 
 - **Offset pagination** (`limit` + `offset`): `teammates`,
   `bounces`, `blocks`, `spam_reports`, `invalid_emails`
-- **Fixed-size single request**: `api_keys`, `templates`,
+- **Fixed-size single request**: `api_keys`
+- **Single-page fetch (may be incomplete)**: `templates`,
   `marketing_lists`, `singlesends`
 - **No pagination**: `verified_senders`, `suppression_groups`,
   `marketing_senders`

--- a/sources/community/sendgrid/README.md
+++ b/sources/community/sendgrid/README.md
@@ -1,0 +1,291 @@
+# SendGrid
+
+Query email templates, suppression lists (bounces, blocks, spam
+reports, invalid emails), marketing lists, single sends,
+suppression groups, sender identities, verified senders,
+API keys, and teammates from Twilio SendGrid.
+
+## Setup
+
+### Get Your API Key
+
+1. Log in to [SendGrid](https://app.sendgrid.com)
+2. Navigate to **Settings > API Keys** or visit
+   [API Keys settings](https://app.sendgrid.com/settings/api_keys)
+3. Click **Create API Key** with at least **Read Access** to the
+   resources you want to query
+4. Copy the generated key (it starts with `SG.`)
+
+### Add the Source
+
+```bash
+export SENDGRID_API_KEY="SG.your_api_key_here"
+coral source add --file sources/community/sendgrid/manifest.yaml
+```
+
+## Tables
+
+### `api_keys`
+
+Lists all API keys on the account (2 columns).
+
+**Example:**
+
+```sql
+SELECT api_key_id, name
+FROM sendgrid.api_keys;
+```
+
+### `teammates`
+
+Lists all teammates on the account with username, email,
+admin status, user type, and permission scopes (7 columns).
+
+**Useful for:**
+
+- Auditing team access and admin privileges
+- Reviewing permission scopes per teammate
+
+**Example:**
+
+```sql
+SELECT username, email, is_admin, user_type
+FROM sendgrid.teammates;
+```
+
+### `verified_senders`
+
+Lists all verified sender identities with email, name,
+reply-to, company address, and verification status (11 columns).
+
+**Example:**
+
+```sql
+SELECT id, nickname, from_email, from_name, verified
+FROM sendgrid.verified_senders;
+```
+
+### `templates`
+
+Lists all transactional email templates with name, generation
+(legacy/dynamic), last update time, and version details
+(5 columns). Both legacy and dynamic templates are returned.
+
+**Example:**
+
+```sql
+SELECT id, name, generation, updated_at
+FROM sendgrid.templates;
+```
+
+### `suppression_groups`
+
+Lists all suppression (unsubscribe) groups with name,
+description, default status, and unsubscribe count (5 columns).
+
+**Example:**
+
+```sql
+SELECT id, name, description, is_default, unsubscribes
+FROM sendgrid.suppression_groups;
+```
+
+### `bounces`
+
+Lists all bounced email addresses with reason, enhanced
+SMTP status code, and creation timestamp (4 columns).
+
+**Useful for:**
+
+- Auditing delivery issues and bounce patterns
+- Identifying problematic recipient addresses
+
+**Example:**
+
+```sql
+SELECT email, reason, status, created
+FROM sendgrid.bounces
+LIMIT 50;
+```
+
+### `blocks`
+
+Lists all blocked email addresses with reason, status
+code, and creation timestamp (4 columns).
+
+**Example:**
+
+```sql
+SELECT email, reason, status, created
+FROM sendgrid.blocks
+LIMIT 50;
+```
+
+### `spam_reports`
+
+Lists all spam report email addresses with the IP that
+sent the reported email and creation timestamp (3 columns).
+
+**Example:**
+
+```sql
+SELECT email, ip, created
+FROM sendgrid.spam_reports
+LIMIT 50;
+```
+
+### `invalid_emails`
+
+Lists all invalid email addresses with reason for invalidity
+and creation timestamp (3 columns).
+
+**Example:**
+
+```sql
+SELECT email, reason, created
+FROM sendgrid.invalid_emails
+LIMIT 50;
+```
+
+### `marketing_lists`
+
+Lists all marketing contact lists with name and contact
+count (3 columns).
+
+**Example:**
+
+```sql
+SELECT id, name, contact_count
+FROM sendgrid.marketing_lists;
+```
+
+### `marketing_senders`
+
+Lists all marketing sender identities with nickname,
+from/reply-to addresses, verification status, and physical
+address (13 columns).
+
+**Example:**
+
+```sql
+SELECT id, nickname, from_email, from_name, reply_to_email
+FROM sendgrid.marketing_senders;
+```
+
+### `singlesends`
+
+Lists all marketing single sends with name, status, scheduled
+send time, categories, and A/B test flag (8 columns).
+
+**Example:**
+
+```sql
+SELECT id, name, status, send_at, categories
+FROM sendgrid.singlesends;
+```
+
+## Authentication
+
+The source uses Bearer token authentication with your
+SendGrid API key.
+
+- API keys start with `SG.`
+- Create keys at **Settings > API Keys** in the SendGrid dashboard
+- Use the minimum required permissions (Read Access)
+
+## Inputs
+
+| Input | Kind | Description |
+|---|---|---|
+| `SENDGRID_API_KEY` | secret | SendGrid API key |
+
+## Pagination
+
+Tables use different pagination strategies based on the
+SendGrid API endpoint:
+
+- **Offset pagination** (`limit` + `offset`): `teammates`,
+  `bounces`, `blocks`, `spam_reports`, `invalid_emails`
+- **Fixed-size single request**: `api_keys`, `templates`,
+  `marketing_lists`, `singlesends`
+- **No pagination**: `verified_senders`, `suppression_groups`,
+  `marketing_senders`
+
+## Example Queries
+
+### Audit API key inventory
+
+```sql
+SELECT api_key_id, name
+FROM sendgrid.api_keys;
+```
+
+### Review team access
+
+```sql
+SELECT username, email, is_admin, user_type
+FROM sendgrid.teammates;
+```
+
+### Audit verified sender identities
+
+```sql
+SELECT nickname, from_email, reply_to, verified
+FROM sendgrid.verified_senders;
+```
+
+### Find bounced emails by status code
+
+```sql
+SELECT email, reason, status
+FROM sendgrid.bounces
+WHERE status LIKE '5.%'
+LIMIT 20;
+```
+
+### Review suppression group unsubscribe counts
+
+```sql
+SELECT name, description, unsubscribes, is_default
+FROM sendgrid.suppression_groups;
+```
+
+### List marketing campaigns and their status
+
+```sql
+SELECT name, status, send_at, is_abtest
+FROM sendgrid.singlesends;
+```
+
+### Review marketing list sizes
+
+```sql
+SELECT name, contact_count
+FROM sendgrid.marketing_lists
+ORDER BY contact_count DESC;
+```
+
+### Audit sender verification status
+
+```sql
+SELECT nickname, from_email, from_name, verified
+FROM sendgrid.marketing_senders;
+```
+
+## Notes
+
+- The source is read-only — no create, update, or delete operations
+- API keys start with `SG.` — do not confuse with other token formats
+- Suppression timestamps (`created` in bounces, blocks, spam_reports,
+  invalid_emails) are Unix epoch integers, not ISO 8601 strings
+- Marketing sender `verified` is a boolean
+- Marketing sender `created_at`/`updated_at` are Unix epoch integers
+- The `templates` table returns both legacy and dynamic templates
+  by default (filtered via `generations=legacy,dynamic`)
+- The `templates`, `marketing_lists`, and `singlesends` APIs expose
+  page-token pagination that Coral cannot fully follow yet, so this
+  source requests the largest documented first page where supported
+- The `versions` column in templates is a JSON array containing
+  version details (id, name, subject, active status)
+- EU-hosted SendGrid accounts should update the base URL to
+  `https://api.eu.sendgrid.com/v3` in the manifest

--- a/sources/community/sendgrid/README.md
+++ b/sources/community/sendgrid/README.md
@@ -20,6 +20,8 @@ API keys, and teammates from Twilio SendGrid.
 
 ```bash
 export SENDGRID_API_KEY="SG.your_api_key_here"
+# Optional for EU-hosted accounts:
+# export SENDGRID_BASE_URL="https://api.eu.sendgrid.com/v3"
 coral source add --file sources/community/sendgrid/manifest.yaml
 ```
 
@@ -93,57 +95,63 @@ FROM sendgrid.suppression_groups;
 ### `bounces`
 
 Lists all bounced email addresses with reason, enhanced
-SMTP status code, and creation timestamp (4 columns).
+SMTP status code, and creation timestamp (7 columns).
 
 **Useful for:**
 
 - Auditing delivery issues and bounce patterns
 - Identifying problematic recipient addresses
+- Filtering large suppression lists by `start_time`, `end_time`, or `email`
 
 **Example:**
 
 ```sql
 SELECT email, reason, status, created
 FROM sendgrid.bounces
+WHERE start_time = 1714521600
+  AND end_time = 1715126399
 LIMIT 50;
 ```
 
 ### `blocks`
 
 Lists all blocked email addresses with reason, status
-code, and creation timestamp (4 columns).
+code, and creation timestamp (7 columns).
 
 **Example:**
 
 ```sql
 SELECT email, reason, status, created
 FROM sendgrid.blocks
+WHERE email = 'user@example.com'
 LIMIT 50;
 ```
 
 ### `spam_reports`
 
 Lists all spam report email addresses with the IP that
-sent the reported email and creation timestamp (3 columns).
+sent the reported email and creation timestamp (6 columns).
 
 **Example:**
 
 ```sql
 SELECT email, ip, created
 FROM sendgrid.spam_reports
+WHERE start_time = 1714521600
 LIMIT 50;
 ```
 
 ### `invalid_emails`
 
 Lists all invalid email addresses with reason for invalidity
-and creation timestamp (3 columns).
+and creation timestamp (6 columns).
 
 **Example:**
 
 ```sql
 SELECT email, reason, created
 FROM sendgrid.invalid_emails
+WHERE email = 'user@example.com'
 LIMIT 50;
 ```
 
@@ -163,7 +171,7 @@ FROM sendgrid.marketing_lists;
 
 Lists all marketing sender identities with nickname,
 from/reply-to addresses, verification status, and physical
-address (13 columns).
+address (15 columns).
 
 **Example:**
 
@@ -197,6 +205,7 @@ SendGrid API key.
 
 | Input | Kind | Description |
 |---|---|---|
+| `SENDGRID_BASE_URL` | variable | SendGrid API base URL (defaults to US API) |
 | `SENDGRID_API_KEY` | secret | SendGrid API key |
 
 ## Pagination
@@ -211,6 +220,10 @@ SendGrid API endpoint:
   `marketing_lists`, `singlesends`
 - **No pagination**: `verified_senders`, `suppression_groups`,
   `marketing_senders`
+
+`templates`, `marketing_lists`, and `singlesends` return `_metadata.next` as a
+full URL. Coral cannot follow that as a cursor yet, so those tables request the
+largest documented first page where possible.
 
 ## Example Queries
 
@@ -240,7 +253,9 @@ FROM sendgrid.verified_senders;
 ```sql
 SELECT email, reason, status
 FROM sendgrid.bounces
-WHERE status LIKE '5.%'
+WHERE start_time = 1714521600
+  AND end_time = 1715126399
+  AND status LIKE '5.%'
 LIMIT 20;
 ```
 
@@ -277,16 +292,19 @@ FROM sendgrid.marketing_senders;
 
 - The source is read-only — no create, update, or delete operations
 - API keys start with `SG.` — do not confuse with other token formats
-- Suppression timestamps (`created` in bounces, blocks, spam_reports,
-  invalid_emails) are Unix epoch integers, not ISO 8601 strings
+- Suppression tables expose `created_i` as raw Unix epoch seconds and
+  `created` as a derived timestamp
 - Marketing sender `verified` is a boolean
-- Marketing sender `created_at`/`updated_at` are Unix epoch integers
+- Marketing sender `created_at_i`/`updated_at_i` are raw Unix epoch seconds;
+  `created_at`/`updated_at` are derived timestamps
 - The `templates` table returns both legacy and dynamic templates
   by default (filtered via `generations=legacy,dynamic`)
+- Template `updated_at` values use SendGrid's `YYYY-MM-DD HH:MM:SS` format,
+  not ISO 8601
 - The `templates`, `marketing_lists`, and `singlesends` APIs expose
   page-token pagination that Coral cannot fully follow yet, so this
   source requests the largest documented first page where supported
 - The `versions` column in templates is a JSON array containing
   version details (id, name, subject, active status)
-- EU-hosted SendGrid accounts should update the base URL to
-  `https://api.eu.sendgrid.com/v3` in the manifest
+- EU-hosted SendGrid accounts should set `SENDGRID_BASE_URL` to
+  `https://api.eu.sendgrid.com/v3`

--- a/sources/community/sendgrid/manifest.yaml
+++ b/sources/community/sendgrid/manifest.yaml
@@ -7,14 +7,21 @@ description: >-
   reports, invalid emails), marketing lists, single sends,
   suppression groups, sender identities, verified senders,
   API keys, and teammates from Twilio SendGrid.
-base_url: https://api.sendgrid.com/v3
 
 inputs:
+  SENDGRID_BASE_URL:
+    kind: variable
+    default: https://api.sendgrid.com/v3
+    hint: >-
+      Base URL for the SendGrid API. The default works for US-hosted
+      accounts. For EU-hosted accounts use https://api.eu.sendgrid.com/v3.
   SENDGRID_API_KEY:
     kind: secret
     hint: >-
       SendGrid API key. Create one at https://app.sendgrid.com/settings/api_keys
       with at least read-only access to the resources you want to query.
+
+base_url: "{{input.SENDGRID_BASE_URL}}"
 
 auth:
   type: HeaderAuth
@@ -25,6 +32,8 @@ auth:
 
 test_queries:
   - SELECT api_key_id, name FROM sendgrid.api_keys LIMIT 1
+  - SELECT id, nickname FROM sendgrid.verified_senders LIMIT 1
+  - SELECT email FROM sendgrid.bounces LIMIT 1
 
 tables:
   # ──────────────────────────────────────────────────────────────────────
@@ -36,6 +45,8 @@ tables:
       and creation/last-used metadata.
     guide: >
       `SELECT api_key_id, name FROM sendgrid.api_keys`.
+      SendGrid documents `limit` for this endpoint, but no offset or cursor;
+      this table requests the first 100 API keys.
     request:
       method: GET
       path: /api_keys
@@ -266,6 +277,9 @@ tables:
     guide: >
       `SELECT id, name, generation, updated_at
       FROM sendgrid.templates LIMIT 20`.
+      This endpoint returns `_metadata.next` as a full URL, which Coral
+      cannot follow as a cursor yet, so the table requests the largest
+      documented first page.
     request:
       method: GET
       path: /templates
@@ -309,7 +323,7 @@ tables:
       - name: updated_at
         type: Utf8
         nullable: true
-        description: Last update timestamp.
+        description: Last update timestamp in `YYYY-MM-DD HH:MM:SS` format.
         expr:
           kind: path
           path:
@@ -392,9 +406,27 @@ tables:
     guide: >
       `SELECT email, reason, status, created
       FROM sendgrid.bounces LIMIT 50`.
+      Optional filters: `start_time`, `end_time`, and `email`.
+    filters:
+      - name: start_time
+        required: false
+      - name: end_time
+        required: false
+      - name: email
+        required: false
     request:
       method: GET
       path: /suppression/bounces
+      query:
+        - name: start_time
+          from: filter
+          key: start_time
+        - name: end_time
+          from: filter
+          key: end_time
+        - name: email
+          from: filter
+          key: email
     response:
       row_strategy: direct
     pagination:
@@ -406,6 +438,22 @@ tables:
         max: 500
         query_param: limit
     columns:
+      - name: start_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional start time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: start_time
+      - name: end_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional end time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: end_time
       - name: email
         type: Utf8
         nullable: false
@@ -430,7 +478,7 @@ tables:
           kind: path
           path:
             - status
-      - name: created
+      - name: created_i
         type: Int64
         nullable: true
         description: Unix timestamp when the bounce was recorded.
@@ -438,6 +486,17 @@ tables:
           kind: path
           path:
             - created
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: When the bounce was recorded.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - created
 
   # ──────────────────────────────────────────────────────────────────────
   # blocks
@@ -449,9 +508,27 @@ tables:
     guide: >
       `SELECT email, reason, status, created
       FROM sendgrid.blocks LIMIT 50`.
+      Optional filters: `start_time`, `end_time`, and `email`.
+    filters:
+      - name: start_time
+        required: false
+      - name: end_time
+        required: false
+      - name: email
+        required: false
     request:
       method: GET
       path: /suppression/blocks
+      query:
+        - name: start_time
+          from: filter
+          key: start_time
+        - name: end_time
+          from: filter
+          key: end_time
+        - name: email
+          from: filter
+          key: email
     response:
       row_strategy: direct
     pagination:
@@ -463,6 +540,22 @@ tables:
         max: 500
         query_param: limit
     columns:
+      - name: start_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional start time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: start_time
+      - name: end_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional end time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: end_time
       - name: email
         type: Utf8
         nullable: false
@@ -487,7 +580,7 @@ tables:
           kind: path
           path:
             - status
-      - name: created
+      - name: created_i
         type: Int64
         nullable: true
         description: Unix timestamp when the block was recorded.
@@ -495,6 +588,17 @@ tables:
           kind: path
           path:
             - created
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: When the block was recorded.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - created
 
   # ──────────────────────────────────────────────────────────────────────
   # spam_reports
@@ -506,9 +610,27 @@ tables:
     guide: >
       `SELECT email, ip, created
       FROM sendgrid.spam_reports LIMIT 50`.
+      Optional filters: `start_time`, `end_time`, and `email`.
+    filters:
+      - name: start_time
+        required: false
+      - name: end_time
+        required: false
+      - name: email
+        required: false
     request:
       method: GET
       path: /suppression/spam_reports
+      query:
+        - name: start_time
+          from: filter
+          key: start_time
+        - name: end_time
+          from: filter
+          key: end_time
+        - name: email
+          from: filter
+          key: email
     response:
       row_strategy: direct
     pagination:
@@ -520,6 +642,22 @@ tables:
         max: 500
         query_param: limit
     columns:
+      - name: start_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional start time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: start_time
+      - name: end_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional end time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: end_time
       - name: email
         type: Utf8
         nullable: false
@@ -536,7 +674,7 @@ tables:
           kind: path
           path:
             - ip
-      - name: created
+      - name: created_i
         type: Int64
         nullable: true
         description: Unix timestamp when the spam report was recorded.
@@ -544,6 +682,17 @@ tables:
           kind: path
           path:
             - created
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: When the spam report was recorded.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - created
 
   # ──────────────────────────────────────────────────────────────────────
   # invalid_emails
@@ -555,9 +704,27 @@ tables:
     guide: >
       `SELECT email, reason, created
       FROM sendgrid.invalid_emails LIMIT 50`.
+      Optional filters: `start_time`, `end_time`, and `email`.
+    filters:
+      - name: start_time
+        required: false
+      - name: end_time
+        required: false
+      - name: email
+        required: false
     request:
       method: GET
       path: /suppression/invalid_emails
+      query:
+        - name: start_time
+          from: filter
+          key: start_time
+        - name: end_time
+          from: filter
+          key: end_time
+        - name: email
+          from: filter
+          key: email
     response:
       row_strategy: direct
     pagination:
@@ -569,6 +736,22 @@ tables:
         max: 500
         query_param: limit
     columns:
+      - name: start_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional start time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: start_time
+      - name: end_time
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional end time filter as Unix epoch seconds.
+        expr:
+          kind: from_filter
+          key: end_time
       - name: email
         type: Utf8
         nullable: false
@@ -585,7 +768,7 @@ tables:
           kind: path
           path:
             - reason
-      - name: created
+      - name: created_i
         type: Int64
         nullable: true
         description: Unix timestamp when recorded.
@@ -593,6 +776,17 @@ tables:
           kind: path
           path:
             - created
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: When the invalid email was recorded.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - created
 
   # ──────────────────────────────────────────────────────────────────────
   # marketing_lists
@@ -604,6 +798,9 @@ tables:
     guide: >
       `SELECT id, name, contact_count
       FROM sendgrid.marketing_lists`.
+      This endpoint returns `_metadata.next` as a full URL, which Coral
+      cannot follow as a cursor yet, so the table requests the largest
+      documented first page.
     request:
       method: GET
       path: /marketing/lists
@@ -753,7 +950,7 @@ tables:
           kind: path
           path:
             - locked
-      - name: created_at
+      - name: created_at_i
         type: Int64
         nullable: true
         description: Unix timestamp of creation.
@@ -761,7 +958,18 @@ tables:
           kind: path
           path:
             - created_at
-      - name: updated_at
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the sender identity was created.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at_i
         type: Int64
         nullable: true
         description: Unix timestamp of last update.
@@ -769,6 +977,17 @@ tables:
           kind: path
           path:
             - updated_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the sender identity was last updated.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - updated_at
 
   # ──────────────────────────────────────────────────────────────────────
   # singlesends
@@ -780,6 +999,9 @@ tables:
     guide: >
       `SELECT id, name, status, send_at
       FROM sendgrid.singlesends LIMIT 20`.
+      This endpoint returns `_metadata.next` as a full URL, which Coral
+      cannot follow as a cursor yet, so the table requests the largest
+      documented first page.
     request:
       method: GET
       path: /marketing/singlesends

--- a/sources/community/sendgrid/manifest.yaml
+++ b/sources/community/sendgrid/manifest.yaml
@@ -1,0 +1,859 @@
+name: sendgrid
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query email templates, suppression lists (bounces, blocks, spam
+  reports, invalid emails), marketing lists, single sends,
+  suppression groups, sender identities, verified senders,
+  API keys, and teammates from Twilio SendGrid.
+base_url: https://api.sendgrid.com/v3
+
+inputs:
+  SENDGRID_API_KEY:
+    kind: secret
+    hint: >-
+      SendGrid API key. Create one at https://app.sendgrid.com/settings/api_keys
+      with at least read-only access to the resources you want to query.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.SENDGRID_API_KEY}}"
+
+test_queries:
+  - SELECT api_key_id, name FROM sendgrid.api_keys LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # api_keys
+  # ──────────────────────────────────────────────────────────────────────
+  - name: api_keys
+    description: >
+      Lists all API keys on the account. Returns key ID, name,
+      and creation/last-used metadata.
+    guide: >
+      `SELECT api_key_id, name FROM sendgrid.api_keys`.
+    request:
+      method: GET
+      path: /api_keys
+      query:
+        - name: limit
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - result
+    pagination:
+      mode: none
+    columns:
+      - name: api_key_id
+        type: Utf8
+        nullable: false
+        description: Unique API key identifier.
+        expr:
+          kind: path
+          path:
+            - api_key_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Human-readable key name.
+        expr:
+          kind: path
+          path:
+            - name
+
+  # ──────────────────────────────────────────────────────────────────────
+  # teammates
+  # ──────────────────────────────────────────────────────────────────────
+  - name: teammates
+    description: >
+      Lists all teammates on the account. Returns username, email,
+      name, admin status, and user type.
+    guide: >
+      `SELECT username, email, is_admin, user_type
+      FROM sendgrid.teammates`.
+    request:
+      method: GET
+      path: /teammates
+    response:
+      rows_path:
+        - result
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 50
+        max: 500
+        query_param: limit
+    columns:
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Teammate username.
+        expr:
+          kind: path
+          path:
+            - username
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Teammate email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: First name.
+        expr:
+          kind: path
+          path:
+            - first_name
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Last name.
+        expr:
+          kind: path
+          path:
+            - last_name
+      - name: is_admin
+        type: Boolean
+        nullable: true
+        description: Whether the teammate is an admin.
+        expr:
+          kind: path
+          path:
+            - is_admin
+      - name: user_type
+        type: Utf8
+        nullable: true
+        description: User type (admin, teammate, etc.).
+        expr:
+          kind: path
+          path:
+            - user_type
+      - name: scopes
+        type: Json
+        nullable: true
+        description: Array of permission scopes.
+        expr:
+          kind: path
+          path:
+            - scopes
+
+  # ──────────────────────────────────────────────────────────────────────
+  # verified_senders
+  # ──────────────────────────────────────────────────────────────────────
+  - name: verified_senders
+    description: >
+      Lists all verified sender identities. Returns sender email,
+      name, reply-to, company address, and verification status.
+    guide: >
+      `SELECT id, nickname, from_email, from_name, verified
+      FROM sendgrid.verified_senders`.
+    request:
+      method: GET
+      path: /verified_senders
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique sender identity ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: nickname
+        type: Utf8
+        nullable: true
+        description: Sender nickname.
+        expr:
+          kind: path
+          path:
+            - nickname
+      - name: from_email
+        type: Utf8
+        nullable: true
+        description: Sender email address.
+        expr:
+          kind: path
+          path:
+            - from_email
+      - name: from_name
+        type: Utf8
+        nullable: true
+        description: Sender display name.
+        expr:
+          kind: path
+          path:
+            - from_name
+      - name: reply_to
+        type: Utf8
+        nullable: true
+        description: Reply-to email address.
+        expr:
+          kind: path
+          path:
+            - reply_to
+      - name: reply_to_name
+        type: Utf8
+        nullable: true
+        description: Reply-to display name.
+        expr:
+          kind: path
+          path:
+            - reply_to_name
+      - name: address
+        type: Utf8
+        nullable: true
+        description: Company street address.
+        expr:
+          kind: path
+          path:
+            - address
+      - name: city
+        type: Utf8
+        nullable: true
+        description: Company city.
+        expr:
+          kind: path
+          path:
+            - city
+      - name: country
+        type: Utf8
+        nullable: true
+        description: Company country.
+        expr:
+          kind: path
+          path:
+            - country
+      - name: verified
+        type: Boolean
+        nullable: true
+        description: Whether the sender identity is verified.
+        expr:
+          kind: path
+          path:
+            - verified
+      - name: locked
+        type: Boolean
+        nullable: true
+        description: Whether the sender identity is locked.
+        expr:
+          kind: path
+          path:
+            - locked
+
+  # ──────────────────────────────────────────────────────────────────────
+  # templates
+  # ──────────────────────────────────────────────────────────────────────
+  - name: templates
+    description: >
+      Lists all transactional email templates. Returns template ID,
+      name, generation (legacy/dynamic), and last update time.
+    guide: >
+      `SELECT id, name, generation, updated_at
+      FROM sendgrid.templates LIMIT 20`.
+    request:
+      method: GET
+      path: /templates
+      query:
+        - name: generations
+          from: literal
+          value: legacy,dynamic
+        - name: page_size
+          from: literal
+          value: 200
+    response:
+      rows_path:
+        - result
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique template ID (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Template name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: generation
+        type: Utf8
+        nullable: true
+        description: Template generation (legacy or dynamic).
+        expr:
+          kind: path
+          path:
+            - generation
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last update timestamp.
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: versions
+        type: Json
+        nullable: true
+        description: Array of template version objects.
+        expr:
+          kind: path
+          path:
+            - versions
+
+  # ──────────────────────────────────────────────────────────────────────
+  # suppression_groups
+  # ──────────────────────────────────────────────────────────────────────
+  - name: suppression_groups
+    description: >
+      Lists all suppression (unsubscribe) groups. Returns group name,
+      description, default status, and unsubscribe count.
+    guide: >
+      `SELECT id, name, description, is_default, unsubscribes
+      FROM sendgrid.suppression_groups`.
+    request:
+      method: GET
+      path: /asm/groups
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique suppression group ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Suppression group name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Group description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: is_default
+        type: Boolean
+        nullable: true
+        description: Whether this is the default suppression group.
+        expr:
+          kind: path
+          path:
+            - is_default
+      - name: unsubscribes
+        type: Int64
+        nullable: true
+        description: Number of unsubscribes in this group.
+        expr:
+          kind: path
+          path:
+            - unsubscribes
+
+  # ──────────────────────────────────────────────────────────────────────
+  # bounces
+  # ──────────────────────────────────────────────────────────────────────
+  - name: bounces
+    description: >
+      Lists all bounced email addresses. Returns email, bounce reason,
+      enhanced status code, and creation timestamp.
+    guide: >
+      `SELECT email, reason, status, created
+      FROM sendgrid.bounces LIMIT 50`.
+    request:
+      method: GET
+      path: /suppression/bounces
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Bounced email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: reason
+        type: Utf8
+        nullable: true
+        description: Bounce reason message.
+        expr:
+          kind: path
+          path:
+            - reason
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Enhanced SMTP bounce status code.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: created
+        type: Int64
+        nullable: true
+        description: Unix timestamp when the bounce was recorded.
+        expr:
+          kind: path
+          path:
+            - created
+
+  # ──────────────────────────────────────────────────────────────────────
+  # blocks
+  # ──────────────────────────────────────────────────────────────────────
+  - name: blocks
+    description: >
+      Lists all blocked email addresses. Returns email, block reason,
+      status code, and creation timestamp.
+    guide: >
+      `SELECT email, reason, status, created
+      FROM sendgrid.blocks LIMIT 50`.
+    request:
+      method: GET
+      path: /suppression/blocks
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Blocked email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: reason
+        type: Utf8
+        nullable: true
+        description: Block reason message.
+        expr:
+          kind: path
+          path:
+            - reason
+      - name: status
+        type: Utf8
+        nullable: true
+        description: SMTP status code.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: created
+        type: Int64
+        nullable: true
+        description: Unix timestamp when the block was recorded.
+        expr:
+          kind: path
+          path:
+            - created
+
+  # ──────────────────────────────────────────────────────────────────────
+  # spam_reports
+  # ──────────────────────────────────────────────────────────────────────
+  - name: spam_reports
+    description: >
+      Lists all spam report email addresses. Returns email, IP
+      address that sent the email, and creation timestamp.
+    guide: >
+      `SELECT email, ip, created
+      FROM sendgrid.spam_reports LIMIT 50`.
+    request:
+      method: GET
+      path: /suppression/spam_reports
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Email address that filed spam report.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: ip
+        type: Utf8
+        nullable: true
+        description: IP address that sent the reported email.
+        expr:
+          kind: path
+          path:
+            - ip
+      - name: created
+        type: Int64
+        nullable: true
+        description: Unix timestamp when the spam report was recorded.
+        expr:
+          kind: path
+          path:
+            - created
+
+  # ──────────────────────────────────────────────────────────────────────
+  # invalid_emails
+  # ──────────────────────────────────────────────────────────────────────
+  - name: invalid_emails
+    description: >
+      Lists all invalid email addresses. Returns email, reason
+      for invalidity, and creation timestamp.
+    guide: >
+      `SELECT email, reason, created
+      FROM sendgrid.invalid_emails LIMIT 50`.
+    request:
+      method: GET
+      path: /suppression/invalid_emails
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 500
+        query_param: limit
+    columns:
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Invalid email address.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: reason
+        type: Utf8
+        nullable: true
+        description: Reason the email is invalid.
+        expr:
+          kind: path
+          path:
+            - reason
+      - name: created
+        type: Int64
+        nullable: true
+        description: Unix timestamp when recorded.
+        expr:
+          kind: path
+          path:
+            - created
+
+  # ──────────────────────────────────────────────────────────────────────
+  # marketing_lists
+  # ──────────────────────────────────────────────────────────────────────
+  - name: marketing_lists
+    description: >
+      Lists all marketing contact lists. Returns list name,
+      contact count, and metadata.
+    guide: >
+      `SELECT id, name, contact_count
+      FROM sendgrid.marketing_lists`.
+    request:
+      method: GET
+      path: /marketing/lists
+      query:
+        - name: page_size
+          from: literal
+          value: 1000
+    response:
+      rows_path:
+        - result
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique list ID (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: List name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: contact_count
+        type: Int64
+        nullable: true
+        description: Number of contacts in the list.
+        expr:
+          kind: path
+          path:
+            - contact_count
+
+  # ──────────────────────────────────────────────────────────────────────
+  # marketing_senders
+  # ──────────────────────────────────────────────────────────────────────
+  - name: marketing_senders
+    description: >
+      Lists all marketing sender identities. Returns sender
+      nickname, from/reply-to addresses, and verification status.
+    guide: >
+      `SELECT id, nickname, from_email, from_name, verified
+      FROM sendgrid.marketing_senders`.
+    request:
+      method: GET
+      path: /marketing/senders
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique sender identity ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: nickname
+        type: Utf8
+        nullable: true
+        description: Sender nickname.
+        expr:
+          kind: path
+          path:
+            - nickname
+      - name: from_email
+        type: Utf8
+        nullable: true
+        description: From email address.
+        expr:
+          kind: path
+          path:
+            - from
+            - email
+      - name: from_name
+        type: Utf8
+        nullable: true
+        description: From display name.
+        expr:
+          kind: path
+          path:
+            - from
+            - name
+      - name: reply_to_email
+        type: Utf8
+        nullable: true
+        description: Reply-to email address.
+        expr:
+          kind: path
+          path:
+            - reply_to
+            - email
+      - name: reply_to_name
+        type: Utf8
+        nullable: true
+        description: Reply-to display name.
+        expr:
+          kind: path
+          path:
+            - reply_to
+            - name
+      - name: address
+        type: Utf8
+        nullable: true
+        description: Physical address line 1.
+        expr:
+          kind: path
+          path:
+            - address
+      - name: city
+        type: Utf8
+        nullable: true
+        description: City.
+        expr:
+          kind: path
+          path:
+            - city
+      - name: country
+        type: Utf8
+        nullable: true
+        description: Country.
+        expr:
+          kind: path
+          path:
+            - country
+      - name: verified
+        type: Boolean
+        nullable: true
+        description: Whether the sender identity is verified.
+        expr:
+          kind: path
+          path:
+            - verified
+      - name: locked
+        type: Boolean
+        nullable: true
+        description: Whether the sender is locked.
+        expr:
+          kind: path
+          path:
+            - locked
+      - name: created_at
+        type: Int64
+        nullable: true
+        description: Unix timestamp of creation.
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Int64
+        nullable: true
+        description: Unix timestamp of last update.
+        expr:
+          kind: path
+          path:
+            - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────
+  # singlesends
+  # ──────────────────────────────────────────────────────────────────────
+  - name: singlesends
+    description: >
+      Lists all marketing single sends. Returns send name, status,
+      scheduled send time, and categories.
+    guide: >
+      `SELECT id, name, status, send_at
+      FROM sendgrid.singlesends LIMIT 20`.
+    request:
+      method: GET
+      path: /marketing/singlesends
+      query:
+        - name: page_size
+          from: literal
+          value: 100
+    response:
+      rows_path:
+        - result
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique single send ID (UUID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Single send name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Status (draft, scheduled, triggered).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: send_at
+        type: Utf8
+        nullable: true
+        description: Scheduled send time (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - send_at
+      - name: categories
+        type: Json
+        nullable: true
+        description: Array of category strings.
+        expr:
+          kind: path
+          path:
+            - categories
+      - name: is_abtest
+        type: Boolean
+        nullable: true
+        description: Whether this is an A/B test.
+        expr:
+          kind: path
+          path:
+            - is_abtest
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last update timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updated_at


### PR DESCRIPTION
## Summary

Adds a new community source for Twilio SendGrid under `sources/community/sendgrid/`.

This source enables querying SendGrid account data (API keys, teammates, sender identities, templates, suppression lists, marketing resources) through SQL using the SendGrid Web API v3. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `HeaderAuth`. No CLI, MCP, config, or runtime changes.

Closes #532 

## What changed

Added:

- `sources/community/sendgrid/manifest.yaml` (859 lines)
- `sources/community/sendgrid/README.md` (291 lines)

## Tables

| Table | Endpoint | Pagination | Columns |
|---|---|---|---|
| `api_keys` | `GET /api_keys` | none | 2 |
| `teammates` | `GET /teammates` | offset (max 500) | 7 |
| `verified_senders` | `GET /verified_senders` | none | 11 |
| `templates` | `GET /templates` | none | 5 |
| `suppression_groups` | `GET /asm/groups` | none | 5 |
| `bounces` | `GET /suppression/bounces` | offset (max 500) | 4 |
| `blocks` | `GET /suppression/blocks` | offset (max 500) | 4 |
| `spam_reports` | `GET /suppression/spam_reports` | offset (max 500) | 3 |
| `invalid_emails` | `GET /suppression/invalid_emails` | offset (max 500) | 3 |
| `marketing_lists` | `GET /marketing/lists` | none | 3 |
| `marketing_senders` | `GET /marketing/senders` | none | 13 |
| `singlesends` | `GET /marketing/singlesends` | none | 8 |

## Auth

Bearer token authentication with `Authorization: Bearer <SG.key>`.

Input:

- `SENDGRID_API_KEY` — required secret. SendGrid API key from Settings > API Keys.

## Implementation notes

- **Mixed response shapes** — endpoints return data as `result` array (api_keys, teammates, templates, lists, singlesends), `results` array (verified_senders, marketing_senders), or top-level JSON array via `row_strategy: direct` (suppression groups, bounces, blocks, spam_reports, invalid_emails)
- **Offset pagination** — teammates and suppression endpoints use `limit` + `offset`; other endpoints return full results in a single request
- **Page-token limitation** — templates, marketing_lists, and singlesends support page_token-based pagination that Coral can't follow; source requests largest documented first page where possible
- **Static query param** — templates sends `generations=legacy,dynamic` to return both template types
- **Marketing senders** — uses `/marketing/senders` (not `/senders`), flattens nested `from.email`/`from.name` and `reply_to.email`/`reply_to.name` into separate columns
- **Unix timestamps** — suppression tables use integer epoch timestamps for `created`; marketing_senders uses integer `created_at`/`updated_at`
- **EU support** — EU-hosted accounts need to change base_url to `https://api.eu.sendgrid.com/v3`

## Validation

- `coral source lint sources/community/sendgrid/manifest.yaml` — passes
- `coral source add` with real key — 12 tables exposed, test query passes
- **Live query validation — all 12 tables queried successfully using real API key:**
- **Mock server validation** — docs-shaped responses verified for all 12 tables including nested from/reply_to flattening and template versions JSON

## User-visible impact

New `sendgrid` source installable via:

```bash
export SENDGRID_API_KEY="SG.your_key_here"
coral source add --file sources/community/sendgrid/manifest.yaml
```

Example queries:

```sql
-- Audit API keys
SELECT api_key_id, name FROM sendgrid.api_keys;

-- Review team access
SELECT username, email, is_admin, user_type
FROM sendgrid.teammates;

-- Check bounces by status code
SELECT email, reason, status
FROM sendgrid.bounces
WHERE status LIKE '5.%'
LIMIT 20;

-- Review suppression group stats
SELECT name, description, unsubscribes, is_default
FROM sendgrid.suppression_groups;

-- List marketing campaigns
SELECT name, status, send_at, is_abtest
FROM sendgrid.singlesends;

-- Audit sender verification
SELECT nickname, from_email, from_name, verified
FROM sendgrid.marketing_senders;
```

## Known limitations

- **Read-only** — no create, update, or delete operations
- **No global stats** — would require date-range filters and time-series modeling
- **No contacts** — contact export requires async jobs
- **Page-token tables** — templates (>200), marketing_lists (>1000), singlesends may not return all data on large accounts
- **EU accounts** — must manually update base_url in manifest
