### PR TITLE
feat(sources/community/zulip): add zulip community source

### DIFF
--- a/sources/community/zulip/README.md
+++ b/sources/community/zulip/README.md
@@ -1,0 +1,207 @@
+# Zulip
+
+Query users, channels, topics, and bounded message windows from Zulip.
+
+## Setup
+
+### Get Your Zulip API Key
+
+1. Open your Zulip organization.
+2. Go to personal settings and copy your Zulip API email and API key, or use a
+   bot account's email and API key.
+3. Copy the organization base URL, for example
+   `https://example.zulipchat.com`.
+
+Zulip documents API key setup at https://zulip.com/api/api-keys.
+
+### Add the Source
+
+```bash
+ZULIP_SITE=https://example.zulipchat.com \
+ZULIP_EMAIL=bot@example.zulipchat.com \
+ZULIP_API_KEY=zulip_api_key \
+coral source add --file sources/community/zulip/manifest.yaml
+```
+
+## Authentication
+
+The source uses Zulip HTTP Basic authentication. Coral sends
+`ZULIP_EMAIL` as the Basic auth username and `ZULIP_API_KEY` as the Basic auth
+password.
+
+The authenticated user or bot determines which users, channels, topics, and
+messages are visible. Private channels, protected history, guest permissions,
+bot subscriptions, and organization email-visibility settings can affect the
+rows and fields returned by the Zulip API.
+
+## Tables
+
+### `me`
+
+Returns one row for the authenticated Zulip user or bot account. Use this table
+to verify credentials and identify which account Coral is using.
+
+**Example:**
+
+```sql
+SELECT user_id, email, full_name, is_bot, is_admin
+FROM zulip.me
+LIMIT 1;
+```
+
+### `users`
+
+Returns Zulip organization users visible to the authenticated account.
+
+Optional filters:
+
+- `client_gravatar`
+- `include_custom_profile_fields`
+- `user_ids`, as a Zulip JSON array string such as `[1,2,3]`
+
+**Example:**
+
+```sql
+SELECT user_id, full_name, email, is_bot, is_active
+FROM zulip.users
+WHERE include_custom_profile_fields = true
+LIMIT 50;
+```
+
+### `channels`
+
+Returns Zulip channels visible to the authenticated account. Zulip's public API
+path still uses the older term `streams`; this source exposes the current
+product term `channels`.
+
+Optional filters:
+
+- `include_public`
+- `include_subscribed`
+- `exclude_archived`
+- `include_all`
+- `include_all_active`
+- `include_default`
+- `include_web_public`
+- `include_owner_subscribed`
+- `include_can_access_content`
+
+**Example:**
+
+```sql
+SELECT stream_id, name, description, is_archived, invite_only
+FROM zulip.channels
+WHERE include_public = true
+LIMIT 50;
+```
+
+### `topics`
+
+Returns topics in one Zulip channel.
+
+Required filter:
+
+- `stream_id`
+
+Optional filter:
+
+- `allow_empty_topic_name`
+
+**Example:**
+
+```sql
+SELECT stream_id, name, max_id
+FROM zulip.topics
+WHERE stream_id = 1
+ORDER BY max_id DESC
+LIMIT 50;
+```
+
+### `messages`
+
+Returns a bounded window of Zulip messages around an anchor. Zulip's message API
+uses `anchor`, `num_before`, and `num_after` instead of cursor/page pagination,
+so this table requires those filters.
+
+Required filters:
+
+- `anchor`, such as `newest`, `oldest`, `first_unread`, or a message ID
+- `num_before`
+- `num_after`
+
+Optional filters:
+
+- `narrow`, as a Zulip JSON narrow string
+- `include_anchor`
+- `apply_markdown`
+- `client_gravatar`
+- `allow_empty_topic_name`
+
+**Latest visible messages:**
+
+```sql
+SELECT id, sender_full_name, type, stream_id, subject, content, timestamp
+FROM zulip.messages
+WHERE anchor = 'newest'
+  AND num_before = 100
+  AND num_after = 0
+ORDER BY id DESC;
+```
+
+**Messages from a channel and topic:**
+
+```sql
+SELECT id, sender_full_name, subject, content, timestamp
+FROM zulip.messages
+WHERE anchor = 'newest'
+  AND num_before = 100
+  AND num_after = 0
+  AND narrow = '[{"operator":"channel","operand":"general"},{"operator":"topic","operand":"announcements"}]'
+ORDER BY id DESC;
+```
+
+**Messages matching a search term:**
+
+```sql
+SELECT id, sender_full_name, subject, content, timestamp
+FROM zulip.messages
+WHERE anchor = 'newest'
+  AND num_before = 100
+  AND num_after = 0
+  AND narrow = '[{"operator":"search","operand":"deploy"}]'
+ORDER BY id DESC;
+```
+
+## Limits
+
+- `messages` returns bounded windows, not automatic full-history scans.
+- Zulip recommends requesting at most 1000 messages in a batch; the documented
+  maximum is 5000 messages per request.
+- Message visibility depends on subscriptions, private-channel access,
+  protected history, and bot/user permissions.
+- Email fields can be redacted or replaced with API-only email addresses
+  depending on organization visibility settings.
+- Nested fields such as message flags, reactions, recipients, edit history,
+  submessages, topic links, and user profile data are exposed as `Json`.
+- Zulip rate limits API clients. The source maps Zulip rate-limit headers so
+  Coral can classify rate-limit responses.
+
+## Public API Mapping
+
+| Table | Zulip endpoint | Response rows |
+|---|---|---|
+| `me` | `GET /api/v1/users/me` | response object |
+| `users` | `GET /api/v1/users` | `members` |
+| `channels` | `GET /api/v1/streams` | `streams` |
+| `topics` | `GET /api/v1/users/me/{stream_id}/topics` | `topics` |
+| `messages` | `GET /api/v1/messages` | `messages` |
+
+Primary Zulip docs:
+
+- https://zulip.com/api/http-headers
+- https://zulip.com/api/api-keys
+- https://zulip.com/api/get-own-user
+- https://zulip.com/api/get-users
+- https://zulip.com/api/get-streams
+- https://zulip.com/api/get-stream-topics
+- https://zulip.com/api/get-messages

--- a/sources/community/zulip/manifest.yaml
+++ b/sources/community/zulip/manifest.yaml
@@ -1,0 +1,858 @@
+name: zulip
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query users, channels, topics, and bounded message windows from Zulip.
+inputs:
+  ZULIP_SITE:
+    kind: variable
+    hint: |
+      Base URL for your Zulip organization, without a trailing slash. Use a
+      Zulip Cloud URL such as `https://example.zulipchat.com`, or the base URL
+      of a self-hosted Zulip server.
+  ZULIP_EMAIL:
+    kind: variable
+    hint: |
+      Zulip API email address for the user or bot account. Find this together
+      with the API key in Zulip personal settings, or use the email address of
+      a bot account.
+  ZULIP_API_KEY:
+    kind: secret
+    hint: |
+      Zulip API key for the same user or bot account as `ZULIP_EMAIL`. Zulip
+      API requests use HTTP Basic authentication with the email as username and
+      this API key as password. See https://zulip.com/api/api-keys.
+base_url: "{{input.ZULIP_SITE}}"
+auth:
+  type: BasicAuth
+  username: "{{input.ZULIP_EMAIL}}"
+  password: "{{input.ZULIP_API_KEY}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+rate_limit:
+  remaining_header: X-RateLimit-Remaining
+  reset_header: X-RateLimit-Reset
+test_queries:
+  - SELECT user_id, email, full_name FROM zulip.me LIMIT 1
+  - SELECT stream_id, name FROM zulip.channels LIMIT 1
+tables:
+  - name: me
+    description: Authenticated Zulip user or bot account metadata
+    guide: |
+      Use this table first to verify credentials and identify the Zulip
+      account used by Coral. It returns one row for the authenticated user or
+      bot.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /api/v1/users/me
+    response: {}
+    columns:
+      - name: user_id
+        type: Int64
+        nullable: false
+        description: Zulip user ID of the authenticated account
+        expr:
+          kind: path
+          path: [user_id]
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Zulip API email address
+        expr:
+          kind: path
+          path: [email]
+      - name: delivery_email
+        type: Utf8
+        nullable: true
+        description: Real delivery email address when visible
+        expr:
+          kind: path
+          path: [delivery_email]
+      - name: full_name
+        type: Utf8
+        nullable: false
+        description: Full display name
+        expr:
+          kind: path
+          path: [full_name]
+      - name: role
+        type: Int64
+        nullable: true
+        description: Zulip role value for the account
+        expr:
+          kind: path
+          path: [role]
+      - name: timezone
+        type: Utf8
+        nullable: true
+        description: IANA timezone identifier
+        expr:
+          kind: path
+          path: [timezone]
+      - name: date_joined
+        type: Timestamp
+        nullable: true
+        description: Time when the account joined the organization
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [date_joined]
+      - name: avatar_url
+        type: Utf8
+        nullable: true
+        description: Avatar URL for the account
+        expr:
+          kind: path
+          path: [avatar_url]
+      - name: is_admin
+        type: Boolean
+        nullable: true
+        description: Whether the account is an organization administrator
+        expr:
+          kind: path
+          path: [is_admin]
+      - name: is_owner
+        type: Boolean
+        nullable: true
+        description: Whether the account is an organization owner
+        expr:
+          kind: path
+          path: [is_owner]
+      - name: is_bot
+        type: Boolean
+        nullable: true
+        description: Whether the account is a bot
+        expr:
+          kind: path
+          path: [is_bot]
+      - name: is_active
+        type: Boolean
+        nullable: true
+        description: Whether the account is active
+        expr:
+          kind: path
+          path: [is_active]
+
+  - name: users
+    description: Zulip organization users visible to the authenticated account
+    guide: |
+      Use this table to inventory users and bots. Email visibility, custom
+      profile fields, and guest access depend on Zulip organization settings
+      and the authenticated account's permissions.
+    request:
+      method: GET
+      path: /api/v1/users
+      query:
+        - name: client_gravatar
+          from: filter_bool
+          key: client_gravatar
+        - name: include_custom_profile_fields
+          from: filter_bool
+          key: include_custom_profile_fields
+        - name: user_ids
+          from: filter
+          key: user_ids
+    response:
+      rows_path: [members]
+    columns:
+      - name: user_id
+        type: Int64
+        nullable: false
+        description: Zulip user ID
+        expr:
+          kind: path
+          path: [user_id]
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Zulip API email address
+        expr:
+          kind: path
+          path: [email]
+      - name: delivery_email
+        type: Utf8
+        nullable: true
+        description: Real delivery email address when visible
+        expr:
+          kind: path
+          path: [delivery_email]
+      - name: full_name
+        type: Utf8
+        nullable: false
+        description: Full display name
+        expr:
+          kind: path
+          path: [full_name]
+      - name: role
+        type: Int64
+        nullable: true
+        description: Zulip role value
+        expr:
+          kind: path
+          path: [role]
+      - name: timezone
+        type: Utf8
+        nullable: true
+        description: IANA timezone identifier
+        expr:
+          kind: path
+          path: [timezone]
+      - name: date_joined
+        type: Timestamp
+        nullable: true
+        description: Time when the user joined the organization
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [date_joined]
+      - name: avatar_url
+        type: Utf8
+        nullable: true
+        description: Avatar URL for the user
+        expr:
+          kind: path
+          path: [avatar_url]
+      - name: is_admin
+        type: Boolean
+        nullable: true
+        description: Whether the user is an organization administrator
+        expr:
+          kind: path
+          path: [is_admin]
+      - name: is_owner
+        type: Boolean
+        nullable: true
+        description: Whether the user is an organization owner
+        expr:
+          kind: path
+          path: [is_owner]
+      - name: is_guest
+        type: Boolean
+        nullable: true
+        description: Whether the user is a guest
+        expr:
+          kind: path
+          path: [is_guest]
+      - name: is_bot
+        type: Boolean
+        nullable: true
+        description: Whether the user is a bot
+        expr:
+          kind: path
+          path: [is_bot]
+      - name: is_active
+        type: Boolean
+        nullable: true
+        description: Whether the user account is active
+        expr:
+          kind: path
+          path: [is_active]
+      - name: is_billing_admin
+        type: Boolean
+        nullable: true
+        description: Whether the user is a billing administrator on older Zulip servers
+        expr:
+          kind: path
+          path: [is_billing_admin]
+      - name: bot_type
+        type: Int64
+        nullable: true
+        description: Bot type value when the row represents a bot
+        expr:
+          kind: path
+          path: [bot_type]
+      - name: profile_data
+        type: Json
+        nullable: true
+        description: Custom profile fields when requested and visible
+        expr:
+          kind: path
+          path: [profile_data]
+      - name: client_gravatar
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether Zulip should omit gravatar URLs and let the client compute
+          them (virtual)
+        expr:
+          kind: from_filter
+          key: client_gravatar
+        virtual: true
+      - name: include_custom_profile_fields
+        type: Boolean
+        nullable: true
+        description: Whether to request custom profile field data (virtual)
+        expr:
+          kind: from_filter
+          key: include_custom_profile_fields
+        virtual: true
+      - name: user_ids
+        type: Utf8
+        nullable: true
+        description: JSON array of user IDs to request, such as [1,2,3] (virtual)
+        expr:
+          kind: from_filter
+          key: user_ids
+        virtual: true
+    filters:
+      - name: client_gravatar
+      - name: include_custom_profile_fields
+      - name: user_ids
+
+  - name: channels
+    description: Zulip channels visible to the authenticated account
+    guide: |
+      Zulip's API path still uses the older term `streams`; this table uses
+      the current product term `channels`. Use `stream_id` values from this
+      table when querying `zulip.topics`.
+    request:
+      method: GET
+      path: /api/v1/streams
+      query:
+        - name: include_public
+          from: filter_bool
+          key: include_public
+        - name: include_subscribed
+          from: filter_bool
+          key: include_subscribed
+        - name: exclude_archived
+          from: filter_bool
+          key: exclude_archived
+        - name: include_all
+          from: filter_bool
+          key: include_all
+        - name: include_all_active
+          from: filter_bool
+          key: include_all_active
+        - name: include_default
+          from: filter_bool
+          key: include_default
+        - name: include_web_public
+          from: filter_bool
+          key: include_web_public
+        - name: include_owner_subscribed
+          from: filter_bool
+          key: include_owner_subscribed
+        - name: include_can_access_content
+          from: filter_bool
+          key: include_can_access_content
+    response:
+      rows_path: [streams]
+    columns:
+      - name: stream_id
+        type: Int64
+        nullable: false
+        description: Zulip channel ID
+        expr:
+          kind: path
+          path: [stream_id]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Channel name
+        expr:
+          kind: path
+          path: [name]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Channel description
+        expr:
+          kind: path
+          path: [description]
+      - name: date_created
+        type: Timestamp
+        nullable: true
+        description: Channel creation time
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path: [date_created]
+      - name: creator_id
+        type: Int64
+        nullable: true
+        description: User ID of the channel creator
+        expr:
+          kind: path
+          path: [creator_id]
+      - name: first_message_id
+        type: Int64
+        nullable: true
+        description: First message ID in the channel when available
+        expr:
+          kind: path
+          path: [first_message_id]
+      - name: is_archived
+        type: Boolean
+        nullable: true
+        description: Whether the channel is archived
+        expr:
+          kind: path
+          path: [is_archived]
+      - name: invite_only
+        type: Boolean
+        nullable: true
+        description: Whether the channel is private/invite-only
+        expr:
+          kind: path
+          path: [invite_only]
+      - name: is_web_public
+        type: Boolean
+        nullable: true
+        description: Whether the channel is web-public
+        expr:
+          kind: path
+          path: [is_web_public]
+      - name: stream_post_policy
+        type: Int64
+        nullable: true
+        description: Zulip stream post policy value
+        expr:
+          kind: path
+          path: [stream_post_policy]
+      - name: message_retention_days
+        type: Int64
+        nullable: true
+        description: Message retention period in days when configured
+        expr:
+          kind: path
+          path: [message_retention_days]
+      - name: stream_weekly_traffic
+        type: Int64
+        nullable: true
+        description: Estimated average weekly message traffic when returned
+        expr:
+          kind: path
+          path: [stream_weekly_traffic]
+      - name: is_default
+        type: Boolean
+        nullable: true
+        description: Whether the channel is a default channel when include_default is true
+        expr:
+          kind: path
+          path: [is_default]
+      - name: include_public
+        type: Boolean
+        nullable: true
+        description: Include public channels (virtual)
+        expr:
+          kind: from_filter
+          key: include_public
+        virtual: true
+      - name: include_subscribed
+        type: Boolean
+        nullable: true
+        description: Include subscribed channels (virtual)
+        expr:
+          kind: from_filter
+          key: include_subscribed
+        virtual: true
+      - name: exclude_archived
+        type: Boolean
+        nullable: true
+        description: Exclude archived channels from results (virtual)
+        expr:
+          kind: from_filter
+          key: exclude_archived
+        virtual: true
+      - name: include_all
+        type: Boolean
+        nullable: true
+        description: Include all channels the user has metadata access to (virtual)
+        expr:
+          kind: from_filter
+          key: include_all
+        virtual: true
+      - name: include_all_active
+        type: Boolean
+        nullable: true
+        description: >-
+          Deprecated Zulip filter to include all active channels visible to the
+          account (virtual)
+        expr:
+          kind: from_filter
+          key: include_all_active
+        virtual: true
+      - name: include_default
+        type: Boolean
+        nullable: true
+        description: Include default channel metadata (virtual)
+        expr:
+          kind: from_filter
+          key: include_default
+        virtual: true
+      - name: include_web_public
+        type: Boolean
+        nullable: true
+        description: Include web-public channels (virtual)
+        expr:
+          kind: from_filter
+          key: include_web_public
+        virtual: true
+      - name: include_owner_subscribed
+        type: Boolean
+        nullable: true
+        description: For bots, include channels the bot owner is subscribed to (virtual)
+        expr:
+          kind: from_filter
+          key: include_owner_subscribed
+        virtual: true
+      - name: include_can_access_content
+        type: Boolean
+        nullable: true
+        description: Include channels the user has content access to (virtual)
+        expr:
+          kind: from_filter
+          key: include_can_access_content
+        virtual: true
+    filters:
+      - name: include_public
+      - name: include_subscribed
+      - name: exclude_archived
+      - name: include_all
+      - name: include_all_active
+      - name: include_default
+      - name: include_web_public
+      - name: include_owner_subscribed
+      - name: include_can_access_content
+
+  - name: topics
+    description: Topics in a Zulip channel visible to the authenticated account
+    guide: |
+      Requires a `stream_id` from `zulip.channels`. Private channels and
+      protected history can limit which topics are visible to the authenticated
+      user or bot.
+    request:
+      method: GET
+      path: /api/v1/users/me/{{filter.stream_id}}/topics
+      query:
+        - name: allow_empty_topic_name
+          from: filter_bool
+          key: allow_empty_topic_name
+    response:
+      rows_path: [topics]
+    columns:
+      - name: stream_id
+        type: Int64
+        nullable: false
+        description: Channel ID used for the request
+        expr:
+          kind: from_filter
+          key: stream_id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Topic name
+        expr:
+          kind: path
+          path: [name]
+      - name: max_id
+        type: Int64
+        nullable: true
+        description: Message ID of the most recent message in the topic
+        expr:
+          kind: path
+          path: [max_id]
+      - name: allow_empty_topic_name
+        type: Boolean
+        nullable: true
+        description: Whether to return empty topic names as empty strings (virtual)
+        expr:
+          kind: from_filter
+          key: allow_empty_topic_name
+        virtual: true
+    filters:
+      - name: stream_id
+        required: true
+      - name: allow_empty_topic_name
+
+  - name: messages
+    description: Bounded Zulip message windows matching an anchor and optional narrow
+    guide: |
+      Requires `anchor`, `num_before`, and `num_after` because Zulip fetches
+      messages by a bounded range around an anchor rather than by cursor
+      pagination. Use `anchor = 'newest'`, `num_before = 100`, and
+      `num_after = 0` for the latest visible messages. Use `narrow` for Zulip
+      JSON narrow filters such as channel, topic, sender, or search terms.
+    request:
+      method: GET
+      path: /api/v1/messages
+      query:
+        - name: anchor
+          from: filter
+          key: anchor
+        - name: num_before
+          from: filter_int
+          key: num_before
+        - name: num_after
+          from: filter_int
+          key: num_after
+        - name: narrow
+          from: filter
+          key: narrow
+        - name: include_anchor
+          from: filter_bool
+          key: include_anchor
+        - name: apply_markdown
+          from: filter_bool
+          key: apply_markdown
+        - name: client_gravatar
+          from: filter_bool
+          key: client_gravatar
+        - name: allow_empty_topic_name
+          from: filter_bool
+          key: allow_empty_topic_name
+    response:
+      rows_path: [messages]
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique Zulip message ID
+        expr:
+          kind: path
+          path: [id]
+      - name: sender_id
+        type: Int64
+        nullable: true
+        description: User ID of the message sender
+        expr:
+          kind: path
+          path: [sender_id]
+      - name: sender_email
+        type: Utf8
+        nullable: true
+        description: Zulip API email address of the sender
+        expr:
+          kind: path
+          path: [sender_email]
+      - name: sender_full_name
+        type: Utf8
+        nullable: true
+        description: Full display name of the sender
+        expr:
+          kind: path
+          path: [sender_full_name]
+      - name: sender_realm_str
+        type: Utf8
+        nullable: true
+        description: Realm string for the sender
+        expr:
+          kind: path
+          path: [sender_realm_str]
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Message type such as stream or private
+        expr:
+          kind: path
+          path: [type]
+      - name: stream_id
+        type: Int64
+        nullable: true
+        description: Channel ID for channel messages
+        expr:
+          kind: path
+          path: [stream_id]
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Topic name for channel messages
+        expr:
+          kind: path
+          path: [subject]
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Message content, rendered or raw depending on apply_markdown
+        expr:
+          kind: path
+          path: [content]
+      - name: content_type
+        type: Utf8
+        nullable: true
+        description: Content type returned by Zulip
+        expr:
+          kind: path
+          path: [content_type]
+      - name: timestamp
+        type: Timestamp
+        nullable: true
+        description: Time when the message was sent
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path: [timestamp]
+      - name: last_edit_timestamp
+        type: Timestamp
+        nullable: true
+        description: Time when the message content was last edited
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path: [last_edit_timestamp]
+      - name: last_moved_timestamp
+        type: Timestamp
+        nullable: true
+        description: Time when the message was last moved
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path: [last_moved_timestamp]
+      - name: recipient_id
+        type: Int64
+        nullable: true
+        description: Recipient/conversation ID
+        expr:
+          kind: path
+          path: [recipient_id]
+      - name: is_me_message
+        type: Boolean
+        nullable: true
+        description: Whether the message is a /me status message
+        expr:
+          kind: path
+          path: [is_me_message]
+      - name: client
+        type: Utf8
+        nullable: true
+        description: Zulip client that sent the message
+        expr:
+          kind: path
+          path: [client]
+      - name: flags
+        type: Json
+        nullable: true
+        description: Message flags for the authenticated user
+        expr:
+          kind: path
+          path: [flags]
+      - name: reactions
+        type: Json
+        nullable: true
+        description: Message reactions
+        expr:
+          kind: path
+          path: [reactions]
+      - name: display_recipient
+        type: Json
+        nullable: true
+        description: Channel name or direct-message recipient objects
+        expr:
+          kind: path
+          path: [display_recipient]
+      - name: edit_history
+        type: Json
+        nullable: true
+        description: Message edit history when visible
+        expr:
+          kind: path
+          path: [edit_history]
+      - name: submessages
+        type: Json
+        nullable: true
+        description: Experimental submessage data
+        expr:
+          kind: path
+          path: [submessages]
+      - name: topic_links
+        type: Json
+        nullable: true
+        description: Linkification data for the topic
+        expr:
+          kind: path
+          path: [topic_links]
+      - name: anchor
+        type: Utf8
+        nullable: false
+        description: Message anchor such as newest, oldest, first_unread, or a message ID (virtual)
+        expr:
+          kind: from_filter
+          key: anchor
+        virtual: true
+      - name: num_before
+        type: Int64
+        nullable: false
+        description: Number of messages before the anchor to request (virtual)
+        expr:
+          kind: from_filter
+          key: num_before
+        virtual: true
+      - name: num_after
+        type: Int64
+        nullable: false
+        description: Number of messages after the anchor to request (virtual)
+        expr:
+          kind: from_filter
+          key: num_after
+        virtual: true
+      - name: narrow
+        type: Utf8
+        nullable: true
+        description: Zulip JSON narrow filter string (virtual)
+        expr:
+          kind: from_filter
+          key: narrow
+        virtual: true
+      - name: include_anchor
+        type: Boolean
+        nullable: true
+        description: Whether to include the anchor message when it matches (virtual)
+        expr:
+          kind: from_filter
+          key: include_anchor
+        virtual: true
+      - name: apply_markdown
+        type: Boolean
+        nullable: true
+        description: Whether Zulip should return rendered HTML content (virtual)
+        expr:
+          kind: from_filter
+          key: apply_markdown
+        virtual: true
+      - name: client_gravatar
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether Zulip should omit gravatar URLs and let the client compute
+          them (virtual)
+        expr:
+          kind: from_filter
+          key: client_gravatar
+        virtual: true
+      - name: allow_empty_topic_name
+        type: Boolean
+        nullable: true
+        description: Whether to return empty topic names as empty strings (virtual)
+        expr:
+          kind: from_filter
+          key: allow_empty_topic_name
+        virtual: true
+    filters:
+      - name: anchor
+        required: true
+      - name: num_before
+        required: true
+      - name: num_after
+        required: true
+      - name: narrow
+      - name: include_anchor
+      - name: apply_markdown
+      - name: client_gravatar
+      - name: allow_empty_topic_name


### PR DESCRIPTION
## Summary

Adds a new community source for Zulip under `sources/community/zulip/`.

This source enables querying Zulip organization data through SQL. It covers the authenticated account, users, channels, topics, and bounded message windows. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with Zulip REST requests, HTTP Basic auth, JSON response mapping, required filters for scoped child tables, and no source-spec runtime changes. No CLI, MCP, config, runtime, or source-spec changes are included.

Closes #534

## What changed

**Added:**

- `sources/community/zulip/manifest.yaml`
- `sources/community/zulip/README.md`

### Tables

| Table | Zulip endpoint | Response rows | Pagination/windowing |
|---|---|---|---|
| `me` | `GET /api/v1/users/me` | response object | none |
| `users` | `GET /api/v1/users` | `members` | none documented |
| `channels` | `GET /api/v1/streams` | `streams` | none documented |
| `topics` | `GET /api/v1/users/me/{stream_id}/topics` | `topics` | required `stream_id` |
| `messages` | `GET /api/v1/messages` | `messages` | required bounded window filters |

### Auth

Zulip HTTP Basic auth using `ZULIP_EMAIL` and `ZULIP_API_KEY`.

**Inputs:**

- `ZULIP_SITE` - required variable. Zulip organization base URL such as `https://example.zulipchat.com`, or a self-hosted Zulip server base URL.
- `ZULIP_EMAIL` - required variable. Zulip API email address for a user or bot account.
- `ZULIP_API_KEY` - required secret. Zulip API key for the same user or bot account. Coral sends it as the Basic auth password.

## Implementation notes

- **REST over HTTP** - all tables use `method: GET` against documented Zulip REST API endpoints under `/api/v1`.
- **BasicAuth** - the manifest uses `ZULIP_EMAIL` as the username and `ZULIP_API_KEY` as the password.
- **Configurable base URL** - `ZULIP_SITE` supports Zulip Cloud and self-hosted Zulip organizations.
- **JSON request headers** - the source sends `Accept: application/json`.
- **Rate-limit headers** - the source maps `X-RateLimit-Remaining` and `X-RateLimit-Reset`.
- **Response mapping** - list tables use Zulip's documented array fields: `members`, `streams`, `topics`, and `messages`; `me` uses the response object as a single row.
- **Scoped topic table** - `topics` requires `stream_id` from `zulip.channels`.
- **Bounded message windows** - `messages` requires `anchor`, `num_before`, and `num_after` because Zulip's message API uses anchor/range fetching instead of cursor/page/offset pagination.
- **Optional Zulip filters** - `users`, `channels`, `topics`, and `messages` expose documented optional query parameters as virtual filter columns.
- **Timestamps** - Zulip ISO timestamps and Unix-second timestamps are exposed as Coral `Timestamp` columns where practical.
- **Nested data as Json** - richer structures such as custom profile data, message flags, reactions, recipients, edit history, submessages, and topic links are preserved as `Json`.
- **Read-only v1** - no message sending, edits, deletes, reactions, flag updates, invites, user changes, channel changes, event queues, or other write operations are included.

## Endpoint verification

Checked against Zulip's public documentation on May 16, 2026:

| Check | Result |
|---|---|
| REST API uses `/api/v1` endpoints | pass |
| HTTP Basic auth with email and API key is documented | pass |
| API key setup is documented | pass |
| `GET /api/v1/users/me` is public/documented | pass |
| `GET /api/v1/users` is public/documented | pass |
| `GET /api/v1/streams` is public/documented | pass |
| `GET /api/v1/users/me/{stream_id}/topics` is public/documented | pass |
| `GET /api/v1/messages` is public/documented | pass |
| Message API anchor/range parameters are documented | pass |
| README table list, filters, and endpoint mapping match the manifest | pass |

Primary docs checked:

- https://zulip.com/api/rest
- https://zulip.com/api/http-headers
- https://zulip.com/api/api-keys
- https://zulip.com/api/get-own-user
- https://zulip.com/api/get-users
- https://zulip.com/api/get-streams
- https://zulip.com/api/get-stream-topics
- https://zulip.com/api/get-messages

## Validation

Lint
```
coral source lint sources/community/zulip/manifest.yaml
Manifest is valid
```
Live validation completed on May 16, 2026 against a Zulip Cloud organization .

### Source add and test queries

```text
cargo run -p coral-cli -- source add --file sources/community/zulip/manifest.yaml
Added source zulip

  zulip connected successfully

    zulip (5 tables)
    - channels
    - me
    - messages
    - topics
    - users
    Query tests
    2 declared · 2 passed · 0 failed

    SELECT user_id, email, full_name FROM zulip.me LIMIT 1
      1 row

    SELECT stream_id, name FROM zulip.channels LIMIT 1
      1 row
```

### Live SQL queries - all 5 tables

| Table | Query | Result |
|---|---|---|
| `me` | `SELECT user_id, email, full_name, is_bot, is_admin FROM zulip.me LIMIT 1` | 1 row: `1900522`, `Yash Agarwal`, `false`, `true` |
| `users` | `SELECT user_id, full_name, email, is_bot, is_active FROM zulip.users LIMIT 10` | 1 row: `1900522`, `Yash Agarwal`, `false`, `true` |
| `channels` | `SELECT stream_id, name, description, is_archived, invite_only FROM zulip.channels LIMIT 10` | 3 rows: `Zulip`, `general`, `sandbox` |
| `topics` | `SELECT stream_id, name, max_id FROM zulip.topics WHERE stream_id = 601341 LIMIT 10` | 1 row: `601341`, `greetings`, `595501236` |
| `messages` | `SELECT id, sender_full_name, type, stream_id, subject, timestamp FROM zulip.messages WHERE anchor = 'newest' AND num_before = 10 AND num_after = 0 LIMIT 10` | 10 rows from `Welcome Bot`, including `sandbox`, `general`, `Zulip`, and one private message |

All five tables responded successfully with live Zulip data.

## User-visible impact

New `zulip` source installable via:

```sh
ZULIP_SITE=https://example.zulipchat.com \
ZULIP_EMAIL=bot@example.zulipchat.com \
ZULIP_API_KEY=... \
coral source add --file sources/community/zulip/manifest.yaml
```

Example queries:

```sql
-- Confirm the authenticated account
SELECT user_id, email, full_name, is_bot
FROM zulip.me
LIMIT 1;

-- List visible channels
SELECT stream_id, name, description, is_archived, invite_only
FROM zulip.channels
WHERE include_public = true
LIMIT 50;

-- List recent topics in a channel
SELECT stream_id, name, max_id
FROM zulip.topics
WHERE stream_id = 1
ORDER BY max_id DESC
LIMIT 50;

-- Latest visible messages
SELECT id, sender_full_name, type, stream_id, subject, content, timestamp
FROM zulip.messages
WHERE anchor = 'newest'
  AND num_before = 100
  AND num_after = 0
ORDER BY id DESC;

-- Search messages with a Zulip narrow
SELECT id, sender_full_name, subject, content, timestamp
FROM zulip.messages
WHERE anchor = 'newest'
  AND num_before = 100
  AND num_after = 0
  AND narrow = '[{"operator":"search","operand":"deploy"}]'
ORDER BY id DESC;
```

## Known limitations

- `messages` returns bounded windows, not automatic full-history scans.
- Zulip recommends requesting at most 1000 messages in a batch; the documented maximum is 5000 messages per request.
- Message visibility depends on subscriptions, private-channel access,  protected history, and bot/user permissions.
- Email fields can be redacted or replaced with API-only email addresses depending on organization visibility settings.
- `narrow` is exposed as a raw Zulip JSON narrow string in v1.
- `channels` uses the current product term while the Zulip API endpoint and  response still use the older `streams` term.
- Nested structures are preserved as `Json` columns.

## Out of scope

Not included in v1:

- Message sending, editing, deleting, reactions, or flag updates
- Channel creation, updates, archiving, subscriptions, or subscriber lists
- User creation, updates, deactivation, status, or presence
- User groups
- Attachments
- Drafts, reminders, saved snippets, alert words, custom emoji, and linkifiers
- Organization/server settings
- Real-time event queues
- Write operations of any kind
