### PR TITLE
feat(sources/community/figma): add Figma source

### DIFF
--- a/sources/community/figma/README.md
+++ b/sources/community/figma/README.md
@@ -1,0 +1,332 @@
+# Figma
+
+Query projects, files, file versions, comments, published
+components, component sets, styles, webhooks, dev resources,
+and library analytics from Figma.
+
+## Setup
+
+### Get Your Access Token
+
+1. Log in to [Figma](https://www.figma.com)
+2. Go to **Settings > Account > Personal access tokens**
+   or visit the [API docs](https://www.figma.com/developers/api#access-tokens)
+3. Generate a new personal access token with the scopes needed
+   for the tables you want to query
+4. Copy the token
+
+### Find Your Team ID
+
+Your team ID is in the URL when viewing your team page:
+
+```
+https://www.figma.com/files/team/<TEAM_ID>/...
+```
+
+### Add the Source
+
+```bash
+export FIGMA_ACCESS_TOKEN="your_token"
+export FIGMA_TEAM_ID="your_team_id"
+coral source add --file sources/community/figma/manifest.yaml
+```
+
+## Tables
+
+### `team_projects`
+
+Lists all projects in the configured team (2 columns).
+
+**Example:**
+
+```sql
+SELECT id, name
+FROM figma.team_projects;
+```
+
+### `project_files`
+
+Lists all files in a project with name, last modified time,
+thumbnail URL, and branch metadata (6 columns).
+
+**Requires:** `project_id` filter
+
+**Example:**
+
+```sql
+SELECT key, name, last_modified, thumbnail_url
+FROM figma.project_files
+WHERE project_id = '12345';
+```
+
+### `file_versions`
+
+Lists version history for a file with label, description,
+creator, and creation time (8 columns).
+
+**Requires:** `file_key` filter
+
+**Example:**
+
+```sql
+SELECT id, label, description, created_at, user_handle
+FROM figma.file_versions
+WHERE file_key = 'abcXYZ123';
+```
+
+### `file_comments`
+
+Lists all comments on a file with message, author, creation
+time, resolution status, positioning metadata, and reactions
+(12 columns).
+
+**Requires:** `file_key` filter
+
+**Example:**
+
+```sql
+SELECT id, message, user_handle, created_at, resolved_at
+FROM figma.file_comments
+WHERE file_key = 'abcXYZ123';
+```
+
+### `team_components`
+
+Lists all published components in the team library with name,
+description, file key, containing frame, and creator
+(11 columns). Cursor-paginated with up to 1000 per page.
+
+**Example:**
+
+```sql
+SELECT key, name, description, file_key, created_at
+FROM figma.team_components
+LIMIT 20;
+```
+
+### `team_component_sets`
+
+Lists all published component sets (variant groups) in the
+team library with name, description, file key, and creator
+(11 columns). Cursor-paginated.
+
+**Example:**
+
+```sql
+SELECT key, name, description, file_key
+FROM figma.team_component_sets
+LIMIT 20;
+```
+
+### `team_styles`
+
+Lists all published styles in the team library with name,
+type (PAINT, TEXT, EFFECT, GRID), file key, sort position,
+and creator (12 columns). Cursor-paginated.
+
+**Example:**
+
+```sql
+SELECT key, name, style_type, file_key, created_at
+FROM figma.team_styles
+LIMIT 20;
+```
+
+### `webhooks`
+
+Lists all webhooks for the configured team with event type,
+endpoint URL, status, context, and description (11 columns).
+
+**Example:**
+
+```sql
+SELECT id, event_type, endpoint, status
+FROM figma.webhooks;
+```
+
+### `file_dev_resources`
+
+Lists all dev resources attached to nodes in a file
+(5 columns). Returns resource ID, name, URL, and target
+node ID.
+
+**Requires:** `file_key` filter
+
+**Example:**
+
+```sql
+SELECT id, name, url, node_id
+FROM figma.file_dev_resources
+WHERE file_key = 'abcXYZ123';
+```
+
+### `library_component_actions`
+
+Lists library analytics for component actions (inserts,
+detaches) in a library file (8 columns). Cursor-paginated.
+
+> **Note:** Enterprise plan only.
+
+**Requires:** `library_file_key` filter
+
+**Example:**
+
+```sql
+SELECT component_name, week, insertions, detachments
+FROM figma.library_component_actions
+WHERE library_file_key = 'abcXYZ123';
+```
+
+### `library_component_usages`
+
+Lists library analytics for component usages in a library
+file (8 columns). Cursor-paginated.
+
+> **Note:** Enterprise plan only.
+
+**Requires:** `library_file_key` filter
+
+**Example:**
+
+```sql
+SELECT component_name, usages, teams_using, files_using
+FROM figma.library_component_usages
+WHERE library_file_key = 'abcXYZ123';
+```
+
+## Authentication
+
+The source uses the `X-Figma-Token` header with a personal
+access token. Generate personal access tokens in your Figma
+account settings.
+
+Some tables require additional scopes or token types:
+
+- `team_projects`, `project_files`, `file_versions`, and
+  `file_comments` require access to the relevant team/project/file
+- `team_components`, `team_component_sets`, and `team_styles`
+  require `team_library_content:read`
+- `webhooks` requires `webhooks:read`
+- `file_dev_resources` requires `file_dev_resources:read`
+- `library_component_actions` and `library_component_usages`
+  require `library_analytics:read`
+
+## Inputs
+
+| Input | Kind | Description |
+|---|---|---|
+| `FIGMA_ACCESS_TOKEN` | secret | Personal access token |
+| `FIGMA_TEAM_ID` | variable | Team ID from the URL |
+
+## Pagination
+
+Tables use different pagination strategies:
+
+- **Cursor pagination** (`page_size` + `after` cursor):
+  `team_components`, `team_component_sets`, `team_styles`
+  (default 30, max 1000 per page)
+- **Cursor pagination** (`cursor`):
+  `library_component_actions`, `library_component_usages`
+- **No pagination**: `team_projects`, `project_files`,
+  `file_versions`, `file_comments`, `webhooks`,
+  `file_dev_resources`
+
+## Example Queries
+
+### List all projects and their files
+
+```sql
+SELECT p.id AS project_id, p.name AS project_name
+FROM figma.team_projects p;
+
+-- Then for each project:
+SELECT key, name, last_modified
+FROM figma.project_files
+WHERE project_id = '<project_id>';
+```
+
+### Find unresolved comments on a file
+
+```sql
+SELECT id, message, user_handle, created_at
+FROM figma.file_comments
+WHERE file_key = 'abcXYZ123'
+  AND resolved_at IS NULL;
+```
+
+### Audit design system components
+
+```sql
+SELECT name, description, file_key, updated_at
+FROM figma.team_components
+WHERE description IS NOT NULL;
+```
+
+### List styles by type
+
+```sql
+SELECT name, style_type, file_key, updated_at
+FROM figma.team_styles
+WHERE style_type = 'PAINT';
+```
+
+### Review file version history
+
+```sql
+SELECT label, description, user_handle, created_at
+FROM figma.file_versions
+WHERE file_key = 'abcXYZ123';
+```
+
+### Audit active webhooks
+
+```sql
+SELECT event_type, endpoint, status, description
+FROM figma.webhooks
+WHERE status = 'ACTIVE';
+```
+
+### List dev resources on a file
+
+```sql
+SELECT name, url, node_id
+FROM figma.file_dev_resources
+WHERE file_key = 'abcXYZ123';
+```
+
+### Audit component adoption (Enterprise)
+
+```sql
+SELECT component_name, usages, teams_using, files_using
+FROM figma.library_component_usages
+WHERE library_file_key = 'abcXYZ123';
+```
+
+## Notes
+
+- The source is read-only — no create, update, or delete operations
+- All exposed timestamps are ISO 8601 strings
+- The `FIGMA_TEAM_ID` input is used for team-scoped endpoints
+  (projects, components, component sets, styles, webhooks)
+- File-scoped tables (`project_files`, `file_versions`,
+  `file_comments`, `file_dev_resources`) require a filter
+  to specify which project or file to query
+- The `containing_frame` column in components/component_sets
+  is a JSON object with frame metadata
+- The `client_meta` column in comments is a JSON object whose
+  structure varies by comment type (Vector, FrameOffset, Region)
+- The `reactions` column in comments is a JSON array of
+  reaction objects
+- Published components, component sets, and styles are
+  team-library resources — they only include items published
+  to the team library, not local/unpublished items
+- **Enterprise-only tables**: `library_component_actions`
+  and `library_component_usages` require an Enterprise plan
+  and org admin access
+- `activity_logs` is intentionally not included because Figma's
+  Activity Logs API requires OAuth-style authentication, while
+  this source is personal-access-token based
+- `file_dev_resources` requires the `file_dev_resources:read`
+  scope on the access token
+- Figma for Government uses a different base URL
+  (`https://api.figma-gov.com`) — update the manifest if needed

--- a/sources/community/figma/manifest.yaml
+++ b/sources/community/figma/manifest.yaml
@@ -1,0 +1,1109 @@
+name: figma
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query projects, files, file versions, comments, published
+  components, component sets, styles, webhooks, dev resources,
+  and library analytics from Figma.
+base_url: https://api.figma.com
+
+inputs:
+  FIGMA_TEAM_ID:
+    kind: variable
+    hint: >-
+      Your Figma team ID. Find it in the URL when viewing your
+      team page: https://www.figma.com/files/team/<TEAM_ID>/...
+  FIGMA_ACCESS_TOKEN:
+    kind: secret
+    hint: >-
+      Figma personal access token. Generate one at
+      https://www.figma.com/developers/api#access-tokens
+      (Settings > Account > Personal access tokens). Some endpoints
+      require specific scopes.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: X-Figma-Token
+      from: input
+      key: FIGMA_ACCESS_TOKEN
+
+test_queries:
+  - >-
+    SELECT id, name
+    FROM figma.team_projects
+    LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # team_projects
+  # ──────────────────────────────────────────────────────────────────────
+  - name: team_projects
+    description: >
+      Lists all projects in the configured team. Returns project
+      ID and name.
+    guide: >
+      `SELECT id, name FROM figma.team_projects`.
+      Start here to discover project IDs for the project_files table.
+    request:
+      method: GET
+      path: /v1/teams/{{input.FIGMA_TEAM_ID}}/projects
+    response:
+      rows_path:
+        - projects
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique project ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Project name.
+        expr:
+          kind: path
+          path:
+            - name
+
+  # ──────────────────────────────────────────────────────────────────────
+  # project_files
+  # ──────────────────────────────────────────────────────────────────────
+  - name: project_files
+    description: >
+      Lists all files in a project. Returns file key, name,
+      last modified time, and thumbnail URL.
+    guide: >
+      Requires `project_id` filter. Get project IDs from
+      `figma.team_projects` first.
+      `SELECT key, name, last_modified FROM figma.project_files
+      WHERE project_id = '<id>'`.
+    request:
+      method: GET
+      path: /v1/projects/{{filter.project_id}}/files
+    response:
+      rows_path:
+        - files
+    pagination:
+      mode: none
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Project ID from required filter.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: key
+        type: Utf8
+        nullable: false
+        description: Unique file key.
+        expr:
+          kind: path
+          path:
+            - key
+      - name: name
+        type: Utf8
+        nullable: true
+        description: File name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: last_modified
+        type: Utf8
+        nullable: true
+        description: Last modification timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - last_modified
+      - name: thumbnail_url
+        type: Utf8
+        nullable: true
+        description: URL of the file thumbnail.
+        expr:
+          kind: path
+          path:
+            - thumbnail_url
+      - name: branches
+        type: Json
+        nullable: true
+        description: Array of branch metadata objects.
+        expr:
+          kind: path
+          path:
+            - branches
+    filters:
+      - name: project_id
+        required: true
+
+  # ──────────────────────────────────────────────────────────────────────
+  # file_versions
+  # ──────────────────────────────────────────────────────────────────────
+  - name: file_versions
+    description: >
+      Lists version history for a file. Returns version ID,
+      label, description, creator, and creation time.
+    guide: >
+      Requires `file_key` filter. Get file keys from
+      `figma.project_files`.
+      `SELECT id, label, created_at FROM figma.file_versions
+      WHERE file_key = '<key>'`.
+    request:
+      method: GET
+      path: /v1/files/{{filter.file_key}}/versions
+    response:
+      rows_path:
+        - versions
+    pagination:
+      mode: none
+    columns:
+      - name: file_key
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: File key from required filter.
+        expr:
+          kind: from_filter
+          key: file_key
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique version ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: label
+        type: Utf8
+        nullable: true
+        description: Version label.
+        expr:
+          kind: path
+          path:
+            - label
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Version description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: ID of the user who created the version.
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: user_handle
+        type: Utf8
+        nullable: true
+        description: Handle of the user who created the version.
+        expr:
+          kind: path
+          path:
+            - user
+            - handle
+      - name: user_img_url
+        type: Utf8
+        nullable: true
+        description: Profile image URL of the creator.
+        expr:
+          kind: path
+          path:
+            - user
+            - img_url
+    filters:
+      - name: file_key
+        required: true
+
+  # ──────────────────────────────────────────────────────────────────────
+  # file_comments
+  # ──────────────────────────────────────────────────────────────────────
+  - name: file_comments
+    description: >
+      Lists all comments on a file. Returns comment ID, message,
+      author, creation time, resolution status, and thread info.
+    guide: >
+      Requires `file_key` filter.
+      `SELECT id, message, user_handle, created_at, resolved_at
+      FROM figma.file_comments WHERE file_key = '<key>'`.
+    request:
+      method: GET
+      path: /v1/files/{{filter.file_key}}/comments
+    response:
+      rows_path:
+        - comments
+    pagination:
+      mode: none
+    columns:
+      - name: file_key
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: File key from required filter.
+        expr:
+          kind: from_filter
+          key: file_key
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique comment ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Comment text.
+        expr:
+          kind: path
+          path:
+            - message
+      - name: parent_id
+        type: Utf8
+        nullable: true
+        description: Parent comment ID (for replies).
+        expr:
+          kind: path
+          path:
+            - parent_id
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: resolved_at
+        type: Utf8
+        nullable: true
+        description: Resolution timestamp (ISO 8601), null if unresolved.
+        expr:
+          kind: path
+          path:
+            - resolved_at
+      - name: order_id
+        type: Float64
+        nullable: true
+        description: Ordering position for top-level comments.
+        expr:
+          kind: path
+          path:
+            - order_id
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: Author user ID.
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: user_handle
+        type: Utf8
+        nullable: true
+        description: Author handle.
+        expr:
+          kind: path
+          path:
+            - user
+            - handle
+      - name: user_img_url
+        type: Utf8
+        nullable: true
+        description: Author profile image URL.
+        expr:
+          kind: path
+          path:
+            - user
+            - img_url
+      - name: client_meta
+        type: Json
+        nullable: true
+        description: >
+          Comment positioning metadata (node_id, coordinates,
+          region). Structure varies by comment type.
+        expr:
+          kind: path
+          path:
+            - client_meta
+      - name: reactions
+        type: Json
+        nullable: true
+        description: Array of reaction objects on this comment.
+        expr:
+          kind: path
+          path:
+            - reactions
+    filters:
+      - name: file_key
+        required: true
+
+  # ──────────────────────────────────────────────────────────────────────
+  # team_components
+  # ──────────────────────────────────────────────────────────────────────
+  - name: team_components
+    description: >
+      Lists all published components in the team library.
+      Returns component key, name, description, containing
+      frame, file key, and creator.
+    guide: >
+      `SELECT key, name, description, file_key, created_at
+      FROM figma.team_components LIMIT 20`.
+      Cursor-paginated with up to 1000 per page.
+    request:
+      method: GET
+      path: /v1/teams/{{input.FIGMA_TEAM_ID}}/components
+    response:
+      rows_path:
+        - meta
+        - components
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path:
+        - meta
+        - cursor
+        - after
+      page_size:
+        default: 30
+        max: 1000
+        query_param: page_size
+    columns:
+      - name: key
+        type: Utf8
+        nullable: false
+        description: Unique component key.
+        expr:
+          kind: path
+          path:
+            - key
+      - name: file_key
+        type: Utf8
+        nullable: true
+        description: Key of the file containing this component.
+        expr:
+          kind: path
+          path:
+            - file_key
+      - name: node_id
+        type: Utf8
+        nullable: true
+        description: Node ID within the file.
+        expr:
+          kind: path
+          path:
+            - node_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Component name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Component description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: thumbnail_url
+        type: Utf8
+        nullable: true
+        description: Thumbnail image URL.
+        expr:
+          kind: path
+          path:
+            - thumbnail_url
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last update timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: Creator user ID.
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: user_handle
+        type: Utf8
+        nullable: true
+        description: Creator handle.
+        expr:
+          kind: path
+          path:
+            - user
+            - handle
+      - name: containing_frame
+        type: Json
+        nullable: true
+        description: >
+          Metadata about the frame containing this component
+          (name, node_id, page_id, page_name, etc.).
+        expr:
+          kind: path
+          path:
+            - containing_frame
+
+  # ──────────────────────────────────────────────────────────────────────
+  # team_component_sets
+  # ──────────────────────────────────────────────────────────────────────
+  - name: team_component_sets
+    description: >
+      Lists all published component sets (variant groups) in the
+      team library. Returns set key, name, description, file key,
+      and creator.
+    guide: >
+      `SELECT key, name, description, file_key
+      FROM figma.team_component_sets LIMIT 20`.
+    request:
+      method: GET
+      path: /v1/teams/{{input.FIGMA_TEAM_ID}}/component_sets
+    response:
+      rows_path:
+        - meta
+        - component_sets
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path:
+        - meta
+        - cursor
+        - after
+      page_size:
+        default: 30
+        max: 1000
+        query_param: page_size
+    columns:
+      - name: key
+        type: Utf8
+        nullable: false
+        description: Unique component set key.
+        expr:
+          kind: path
+          path:
+            - key
+      - name: file_key
+        type: Utf8
+        nullable: true
+        description: Key of the file containing this component set.
+        expr:
+          kind: path
+          path:
+            - file_key
+      - name: node_id
+        type: Utf8
+        nullable: true
+        description: Node ID within the file.
+        expr:
+          kind: path
+          path:
+            - node_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Component set name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Component set description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: thumbnail_url
+        type: Utf8
+        nullable: true
+        description: Thumbnail image URL.
+        expr:
+          kind: path
+          path:
+            - thumbnail_url
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last update timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: Creator user ID.
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: user_handle
+        type: Utf8
+        nullable: true
+        description: Creator handle.
+        expr:
+          kind: path
+          path:
+            - user
+            - handle
+      - name: containing_frame
+        type: Json
+        nullable: true
+        description: Metadata about the containing frame.
+        expr:
+          kind: path
+          path:
+            - containing_frame
+
+  # ──────────────────────────────────────────────────────────────────────
+  # team_styles
+  # ──────────────────────────────────────────────────────────────────────
+  - name: team_styles
+    description: >
+      Lists all published styles in the team library. Returns
+      style key, name, type (PAINT, TEXT, EFFECT, GRID),
+      file key, and creator.
+    guide: >
+      `SELECT key, name, style_type, file_key
+      FROM figma.team_styles LIMIT 20`.
+    request:
+      method: GET
+      path: /v1/teams/{{input.FIGMA_TEAM_ID}}/styles
+    response:
+      rows_path:
+        - meta
+        - styles
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path:
+        - meta
+        - cursor
+        - after
+      page_size:
+        default: 30
+        max: 1000
+        query_param: page_size
+    columns:
+      - name: key
+        type: Utf8
+        nullable: false
+        description: Unique style key.
+        expr:
+          kind: path
+          path:
+            - key
+      - name: file_key
+        type: Utf8
+        nullable: true
+        description: Key of the file containing this style.
+        expr:
+          kind: path
+          path:
+            - file_key
+      - name: node_id
+        type: Utf8
+        nullable: true
+        description: Node ID within the file.
+        expr:
+          kind: path
+          path:
+            - node_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Style name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Style description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: style_type
+        type: Utf8
+        nullable: true
+        description: Style type (PAINT, TEXT, EFFECT, or GRID).
+        expr:
+          kind: path
+          path:
+            - style_type
+      - name: sort_position
+        type: Utf8
+        nullable: true
+        description: Sort position within the library.
+        expr:
+          kind: path
+          path:
+            - sort_position
+      - name: thumbnail_url
+        type: Utf8
+        nullable: true
+        description: Thumbnail image URL.
+        expr:
+          kind: path
+          path:
+            - thumbnail_url
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Last update timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: Creator user ID.
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: user_handle
+        type: Utf8
+        nullable: true
+        description: Creator handle.
+        expr:
+          kind: path
+          path:
+            - user
+            - handle
+
+  # ──────────────────────────────────────────────────────────────────────
+  # webhooks
+  # ──────────────────────────────────────────────────────────────────────
+  - name: webhooks
+    description: >
+      Lists all webhooks for the configured team. Returns webhook
+      ID, event type, endpoint, status, and description.
+    guide: >
+      `SELECT id, event_type, endpoint, status
+      FROM figma.webhooks`.
+    request:
+      method: GET
+      path: /v2/webhooks
+      query:
+        - name: context
+          from: literal
+          value: team
+        - name: context_id
+          from: input
+          key: FIGMA_TEAM_ID
+    response:
+      rows_path:
+        - webhooks
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique webhook ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: event_type
+        type: Utf8
+        nullable: true
+        description: Event type that triggers this webhook.
+        expr:
+          kind: path
+          path:
+            - event_type
+      - name: team_id
+        type: Utf8
+        nullable: true
+        description: Team ID the webhook is scoped to.
+        expr:
+          kind: path
+          path:
+            - team_id
+      - name: context
+        type: Utf8
+        nullable: true
+        description: Context type this webhook is attached to.
+        expr:
+          kind: path
+          path:
+            - context
+      - name: context_id
+        type: Utf8
+        nullable: true
+        description: Context ID this webhook is attached to.
+        expr:
+          kind: path
+          path:
+            - context_id
+      - name: plan_api_id
+        type: Utf8
+        nullable: true
+        description: Plan API ID where this webhook was created.
+        expr:
+          kind: path
+          path:
+            - plan_api_id
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Webhook status (ACTIVE, PAUSED).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: endpoint
+        type: Utf8
+        nullable: true
+        description: Webhook endpoint URL.
+        expr:
+          kind: path
+          path:
+            - endpoint
+      - name: passcode
+        type: Utf8
+        nullable: true
+        description: Webhook passcode.
+        expr:
+          kind: path
+          path:
+            - passcode
+      - name: client_id
+        type: Utf8
+        nullable: true
+        description: OAuth client ID that registered the webhook, if any.
+        expr:
+          kind: path
+          path:
+            - client_id
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Webhook description.
+        expr:
+          kind: path
+          path:
+            - description
+  # ──────────────────────────────────────────────────────────────────────
+  # file_dev_resources
+  # ──────────────────────────────────────────────────────────────────────
+  - name: file_dev_resources
+    description: >
+      Lists all dev resources attached to nodes in a file.
+      Returns resource ID, name, URL, node ID, and file key.
+    guide: >
+      Requires `file_key` filter.
+      `SELECT id, name, url, node_id FROM figma.file_dev_resources
+      WHERE file_key = '<key>'`.
+    request:
+      method: GET
+      path: /v1/files/{{filter.file_key}}/dev_resources
+    response:
+      rows_path:
+        - dev_resources
+    pagination:
+      mode: none
+    columns:
+      - name: file_key
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: File key from required filter.
+        expr:
+          kind: from_filter
+          key: file_key
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique dev resource ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Dev resource name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Dev resource URL.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: node_id
+        type: Utf8
+        nullable: true
+        description: ID of the node this resource is attached to.
+        expr:
+          kind: path
+          path:
+            - node_id
+    filters:
+      - name: file_key
+        required: true
+
+  # ──────────────────────────────────────────────────────────────────────
+  # library_component_actions
+  # ──────────────────────────────────────────────────────────────────────
+  - name: library_component_actions
+    description: >
+      Lists library analytics for component actions (inserts,
+      detaches) in a library file. Returns component name,
+      action counts, team, and file info. Enterprise plan only.
+    guide: >
+      Requires `library_file_key` filter.
+      `SELECT component_name, week, insertions, detachments
+      FROM figma.library_component_actions
+      WHERE library_file_key = '<key>'`.
+    request:
+      method: GET
+      path: /v1/analytics/libraries/{{filter.library_file_key}}/component/actions
+      query:
+        - name: group_by
+          from: literal
+          value: component
+    response:
+      rows_path:
+        - rows
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - cursor
+    columns:
+      - name: library_file_key
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Library file key from required filter.
+        expr:
+          kind: from_filter
+          key: library_file_key
+      - name: component_name
+        type: Utf8
+        nullable: true
+        description: Name of the component.
+        expr:
+          kind: path
+          path:
+            - component_name
+      - name: component_key
+        type: Utf8
+        nullable: true
+        description: Component key.
+        expr:
+          kind: path
+          path:
+            - component_key
+      - name: component_set_key
+        type: Utf8
+        nullable: true
+        description: Component set key.
+        expr:
+          kind: path
+          path:
+            - component_set_key
+      - name: component_set_name
+        type: Utf8
+        nullable: true
+        description: Component set name.
+        expr:
+          kind: path
+          path:
+            - component_set_name
+      - name: week
+        type: Utf8
+        nullable: true
+        description: Week represented by this analytics row.
+        expr:
+          kind: path
+          path:
+            - week
+      - name: insertions
+        type: Int64
+        nullable: true
+        description: Number of component insertions.
+        expr:
+          kind: path
+          path:
+            - insertions
+      - name: detachments
+        type: Int64
+        nullable: true
+        description: Number of component detachments.
+        expr:
+          kind: path
+          path:
+            - detachments
+    filters:
+      - name: library_file_key
+        required: true
+
+  # ──────────────────────────────────────────────────────────────────────
+  # library_component_usages
+  # ──────────────────────────────────────────────────────────────────────
+  - name: library_component_usages
+    description: >
+      Lists library analytics for component usages in a library
+      file. Returns component name, usage counts, team, and
+      file info. Enterprise plan only.
+    guide: >
+      Requires `library_file_key` filter.
+      `SELECT component_name, usages, teams_using, files_using
+      FROM figma.library_component_usages
+      WHERE library_file_key = '<key>'`.
+    request:
+      method: GET
+      path: /v1/analytics/libraries/{{filter.library_file_key}}/component/usages
+      query:
+        - name: group_by
+          from: literal
+          value: component
+    response:
+      rows_path:
+        - rows
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - cursor
+    columns:
+      - name: library_file_key
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Library file key from required filter.
+        expr:
+          kind: from_filter
+          key: library_file_key
+      - name: component_name
+        type: Utf8
+        nullable: true
+        description: Name of the component.
+        expr:
+          kind: path
+          path:
+            - component_name
+      - name: component_key
+        type: Utf8
+        nullable: true
+        description: Component key.
+        expr:
+          kind: path
+          path:
+            - component_key
+      - name: component_set_key
+        type: Utf8
+        nullable: true
+        description: Component set key.
+        expr:
+          kind: path
+          path:
+            - component_set_key
+      - name: component_set_name
+        type: Utf8
+        nullable: true
+        description: Component set name.
+        expr:
+          kind: path
+          path:
+            - component_set_name
+      - name: usages
+        type: Int64
+        nullable: true
+        description: Number of usages of this component.
+        expr:
+          kind: path
+          path:
+            - usages
+      - name: teams_using
+        type: Int64
+        nullable: true
+        description: Number of teams using this component.
+        expr:
+          kind: path
+          path:
+            - teams_using
+      - name: files_using
+        type: Int64
+        nullable: true
+        description: Number of files using this component.
+        expr:
+          kind: path
+          path:
+            - files_using
+    filters:
+      - name: library_file_key
+        required: true


### PR DESCRIPTION
## Summary

Adds a new community source for **Figma** under `sources/community/figma/`.

This source enables querying Figma team data (projects, files, version history, comments, published components, component sets, styles, webhooks, dev resources, and library analytics) through SQL using the Figma REST API v1/v2. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `HeaderAuth`. No CLI, MCP, config, or runtime changes.

Closes #536 

## What changed

Added:

- `sources/community/figma/manifest.yaml` (1109 lines)
- `sources/community/figma/README.md` (332 lines)

## Tables

| Table | Endpoint | Pagination | Columns |
|---|---|---|---|
| `team_projects` | `GET /v1/teams/:id/projects` | none | 2 |
| `project_files` | `GET /v1/projects/:id/files` | none | 6 |
| `file_versions` | `GET /v1/files/:key/versions` | none | 8 |
| `file_comments` | `GET /v1/files/:key/comments` | none | 12 |
| `team_components` | `GET /v1/teams/:id/components` | cursor (max 1000) | 11 |
| `team_component_sets` | `GET /v1/teams/:id/component_sets` | cursor (max 1000) | 11 |
| `team_styles` | `GET /v1/teams/:id/styles` | cursor (max 1000) | 12 |
| `webhooks` | `GET /v2/webhooks?context=team&context_id=:id` | none | 11 |
| `file_dev_resources` | `GET /v1/files/:key/dev_resources` | none | 5 |
| `library_component_actions` | `GET /v1/analytics/libraries/:key/component/actions` | cursor | 8 |
| `library_component_usages` | `GET /v1/analytics/libraries/:key/component/usages` | cursor | 8 |

## Auth

`X-Figma-Token` header authentication with a personal access token (PAT).

Inputs:

- `FIGMA_ACCESS_TOKEN` — required secret. Personal access token from Settings > Account > Personal access tokens.
- `FIGMA_TEAM_ID` — required variable. Team ID from the URL (`https://www.figma.com/files/team/<TEAM_ID>/...`).

## Implementation notes

- **X-Figma-Token header** — Figma PATs use the `X-Figma-Token` header, not `Authorization: Bearer`
- **Webhooks v2 context-based API** — uses `GET /v2/webhooks?context=team&context_id=<id>` (the deprecated `GET /v2/teams/:id/webhooks` path is not used); `context` is sent as a literal query param
- **Cursor pagination** — team_components, team_component_sets, and team_styles use `cursor_query` mode with `after` cursor param and `page_size` query param (default 30, max 1000); the cursor path is `meta.cursor.after`
- **Library analytics cursor** — library_component_actions and library_component_usages use `cursor_query` mode with `cursor` param; no page_size
- **Library analytics group_by** — both library analytics endpoints require `group_by=component` as a literal query param per Figma docs
- **Nested response paths** — components are at `meta.components`, component_sets at `meta.component_sets`, styles at `meta.styles`; library analytics rows are at `rows`
- **Virtual filter columns** — all `from_filter` columns (`project_id`, `file_key`, `library_file_key`) are marked `virtual: true`
- **JSON columns** — `containing_frame` (components/component_sets), `client_meta` (comments), `reactions` (comments), and `branches` (project_files) are exposed as `Json` type since their structure is complex or variable
- **Activity logs excluded** — Figma's Activity Logs API requires OAuth 2 with `org:activity_log_read` scope; PATs are explicitly not supported, so this endpoint is intentionally omitted
- **Enterprise-only tables** — `library_component_actions` and `library_component_usages` require `library_analytics:read` scope, available only on Enterprise plans
- **Scope requirements** — different tables require different PAT scopes: `projects:read`, `file_versions:read`, `file_comments:read`, `team_library_content:read`, `webhooks:read`, `file_dev_resources:read`, `library_analytics:read`

## Validation

- `coral source lint sources/community/figma/manifest.yaml` — passes
- `coral source add` with real PAT — 11 tables exposed, test query passes (1 row)
- **Live query validation — 8 of 11 tables queried successfully using real PAT:**
  - `team_projects` — 1 project returned
  - `project_files` — 2 files returned (library + design file)
  - `team_styles` — 5 styles returned (Fuschia/80, Iris/60, Iris/100, Header 1, Iris/80)
  - `file_versions`, `file_comments`, `team_components`, `team_component_sets`, `webhooks` — valid empty results
- **3 tables return expected permission errors:**
  - `file_dev_resources` — 404 (no dev resources attached to test files)
  - `library_component_actions` — 403 (requires Enterprise `library_analytics:read` scope)
  - `library_component_usages` — 403 (requires Enterprise `library_analytics:read` scope)

## User-visible impact

New `figma` source installable via:

```bash
export FIGMA_ACCESS_TOKEN="figd_your_token_here"
export FIGMA_TEAM_ID="1234567890"
coral source add --file sources/community/figma/manifest.yaml
```

Example queries:

```sql
-- List all projects
SELECT id, name FROM figma.team_projects;

-- List files in a project
SELECT key, name, last_modified
FROM figma.project_files
WHERE project_id = '342761503';

-- Audit design system styles
SELECT name, style_type, file_key, updated_at
FROM figma.team_styles
WHERE style_type = 'FILL';

-- Find unresolved comments on a file
SELECT id, message, user_handle, created_at
FROM figma.file_comments
WHERE file_key = 'abcXYZ123'
  AND resolved_at IS NULL;

-- Review published components
SELECT key, name, description, file_key, updated_at
FROM figma.team_components;

-- Audit active webhooks
SELECT event_type, endpoint, status, description
FROM figma.webhooks
WHERE status = 'ACTIVE';

-- Review file version history
SELECT label, description, user_handle, created_at
FROM figma.file_versions
WHERE file_key = 'abcXYZ123';

-- Component adoption analytics (Enterprise)
SELECT component_name, usages, teams_using, files_using
FROM figma.library_component_usages
WHERE library_file_key = 'abcXYZ123';
```

## Known limitations

- **Read-only** — no create, update, or delete operations
- **Activity logs excluded** — requires OAuth 2 auth, not compatible with PAT-based source
- **Enterprise-only analytics** — `library_component_actions` and `library_component_usages` require Enterprise plan and `library_analytics:read` scope
- **No file content** — the source exposes metadata, not the file document tree (which is very large)
- **No variables** — Figma's variables API returns map-keyed objects, not arrays, which don't map cleanly to table rows
- **Figma for Government** — uses a different base URL (`https://api.figma-gov.com`); users must manually update the manifest
- **File-scoped tables require filters** — `project_files`, `file_versions`, `file_comments`, `file_dev_resources` require a filter to specify which project or file to query
