### PR TITLE
feat(sources/community/postmark): add postmark community source

### DIFF
--- a/sources/community/postmark/README.md
+++ b/sources/community/postmark/README.md
@@ -1,0 +1,227 @@
+# Postmark
+
+Query server metadata, message streams, messages, bounces, templates, and
+outbound delivery statistics from Postmark.
+
+## Setup
+
+### Get Your Postmark Server Token
+
+Create or copy a server API token from the API Tokens tab for the Postmark
+server you want to query. This source uses server-level read endpoints with the
+`X-Postmark-Server-Token` header.
+
+Postmark documents API authentication at
+https://postmarkapp.com/developer/api/overview.
+
+### Add the Source
+
+```bash
+POSTMARK_SERVER_TOKEN=server_api_token \
+coral source add --file sources/community/postmark/manifest.yaml
+```
+
+## Authentication
+
+The source sends `POSTMARK_SERVER_TOKEN` in the
+`X-Postmark-Server-Token` request header. The token determines which Postmark
+server Coral can query.
+
+This v1 source does not use Postmark account tokens and does not query
+account-level server inventory.
+
+## Tables
+
+### `server`
+
+Returns one row with metadata for the Postmark server associated with the
+server token. Use this table to verify credentials and identify the server.
+
+The source intentionally does not expose server API token values returned by the
+provider.
+
+**Example:**
+
+```sql
+SELECT id, name, delivery_type, track_opens, track_links
+FROM postmark.server
+LIMIT 1;
+```
+
+### `message_streams`
+
+Returns message streams configured for the authenticated Postmark server.
+
+Optional filters:
+
+- `message_stream_type`, such as `All`, `Inbound`, `Transactional`, or
+  `Broadcasts`
+- `include_archived_streams`
+
+**Example:**
+
+```sql
+SELECT id, name, message_stream_type, created_at, archived_at
+FROM postmark.message_streams
+WHERE include_archived_streams = true
+ORDER BY name;
+```
+
+### `outbound_messages`
+
+Returns outbound message search results. Postmark searches are offset-paginated
+with `count` and `offset`, and a single search can return up to 10,000
+messages. Use date and other filters for larger investigations.
+
+Optional filters:
+
+- `recipient`
+- `from_email`
+- `tag`
+- `status`
+- `to_date`
+- `from_date`
+- `subject`
+- `message_stream`
+
+**Example:**
+
+```sql
+SELECT message_id, message_stream, from_email, subject, status, received_at
+FROM postmark.outbound_messages
+WHERE from_date = '2026-05-01'
+  AND to_date = '2026-05-16'
+  AND message_stream = 'outbound'
+ORDER BY received_at DESC
+LIMIT 100;
+```
+
+### `inbound_messages`
+
+Returns inbound message search results. The inbound message `date` column
+preserves Postmark's email Date header value as text.
+
+Optional filters:
+
+- `recipient`
+- `from_email`
+- `tag`
+- `subject`
+- `mailbox_hash`
+- `status`
+- `to_date`
+- `from_date`
+
+**Example:**
+
+```sql
+SELECT message_id, from_email, to_email, subject, status, date
+FROM postmark.inbound_messages
+WHERE status = 'processed'
+LIMIT 100;
+```
+
+### `bounces`
+
+Returns bounce records from Postmark bounce search.
+
+Optional filters:
+
+- `type`
+- `inactive`
+- `email_filter`
+- `tag`
+- `message_id`
+- `from_date`
+- `to_date`
+- `message_stream`
+
+**Example:**
+
+```sql
+SELECT id, type, email, from_email, bounced_at, inactive, can_activate
+FROM postmark.bounces
+WHERE inactive = true
+ORDER BY bounced_at DESC
+LIMIT 100;
+```
+
+### `templates`
+
+Returns templates associated with the authenticated Postmark server.
+
+Optional filters:
+
+- `template_type`, such as `All`, `Standard`, or `Layout`
+- `layout_template`
+
+**Example:**
+
+```sql
+SELECT template_id, name, alias, template_type, active
+FROM postmark.templates
+WHERE template_type = 'Standard'
+ORDER BY name;
+```
+
+### `outbound_stats`
+
+Returns one row with aggregate outbound email statistics for the authenticated
+server. Postmark stats use EST timezone and return all-time stats when no date
+filters are supplied.
+
+Optional filters:
+
+- `tag`
+- `from_date`
+- `to_date`
+- `message_stream`
+
+**Example:**
+
+```sql
+SELECT sent, bounced, bounce_rate, spam_complaints, opens, total_clicks
+FROM postmark.outbound_stats
+WHERE from_date = '2026-05-01'
+  AND to_date = '2026-05-16'
+  AND message_stream = 'outbound';
+```
+
+## Limits
+
+- This source is read-only.
+- `outbound_messages`, `inbound_messages`, and `bounces` are Postmark search
+  endpoints capped at 10,000 records per search. Use `from_date`, `to_date`,
+  and other filters to inspect larger histories.
+- Postmark messages expire after the server's retention period. The default
+  retention period is 45 days, but Postmark can be configured from 7 to 365
+  days.
+- Raw message dumps, bounce dumps, message details, inbound bypass/retry,
+  sending, template writes, server edits, stream writes, webhooks,
+  suppressions, and data removal operations are not included in v1.
+- Postmark's dynamic outbound `metadata_` search parameters are not exposed in
+  v1 because Coral source-spec query parameter names are static.
+- Nested fields such as recipients, attachments, metadata, sender/recipient
+  objects, and subscription management configuration are exposed as `Json`.
+
+## Public API Mapping
+
+| Table | Postmark endpoint | Response rows | Pagination |
+|---|---|---|---|
+| `server` | `GET /server` | response object | none |
+| `message_streams` | `GET /message-streams` | `MessageStreams` | none documented |
+| `outbound_messages` | `GET /messages/outbound` | `Messages` | `count` + `offset` |
+| `inbound_messages` | `GET /messages/inbound` | `InboundMessages` | `count` + `offset` |
+| `bounces` | `GET /bounces` | `Bounces` | `count` + `offset` |
+| `templates` | `GET /templates` | `Templates` | `count` + `offset` |
+| `outbound_stats` | `GET /stats/outbound` | response object | none |
+
+Primary Postmark docs:
+
+- https://postmarkapp.com/developer/api/overview
+- https://postmarkapp.com/developer/api/server-api
+- https://postmarkapp.com/developer/api/message-streams-api
+- https://postmarkapp.com/developer/api/messages-api
+- https://postmarkapp.com/developer/api/bounce-api
+- https://postmarkapp.com/developer/api/templates-api
+- https://postmarkapp.com/developer/api/stats-api

--- a/sources/community/postmark/manifest.yaml
+++ b/sources/community/postmark/manifest.yaml
@@ -1,0 +1,1306 @@
+name: postmark
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query server metadata, message streams, messages, bounces, templates, and
+  outbound delivery statistics from Postmark.
+inputs:
+  POSTMARK_SERVER_TOKEN:
+    kind: secret
+    hint: |
+      Postmark server API token. Find it in the API Tokens tab for the
+      Postmark server you want to query. This source uses server-level
+      read endpoints with the X-Postmark-Server-Token header.
+base_url: https://api.postmarkapp.com
+auth:
+  type: HeaderAuth
+  headers:
+    - name: X-Postmark-Server-Token
+      from: input
+      key: POSTMARK_SERVER_TOKEN
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT id, name, delivery_type FROM postmark.server LIMIT 1
+  - SELECT id, name, message_stream_type FROM postmark.message_streams LIMIT 1
+tables:
+  - name: server
+    description: Postmark server metadata for the authenticated server token
+    guide: |
+      Use this table first to verify the server token and identify the
+      Postmark server Coral is querying. API token values returned by the
+      provider are intentionally not exposed as columns.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /server
+    response: {}
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Postmark server ID
+        expr:
+          kind: path
+          path: [ID]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Server name
+        expr:
+          kind: path
+          path: [Name]
+      - name: color
+        type: Utf8
+        nullable: true
+        description: Server color in Postmark
+        expr:
+          kind: path
+          path: [Color]
+      - name: smtp_api_activated
+        type: Boolean
+        nullable: true
+        description: Whether SMTP API sending is enabled
+        expr:
+          kind: path
+          path: [SmtpApiActivated]
+      - name: raw_email_enabled
+        type: Boolean
+        nullable: true
+        description: Whether raw email content is included with inbound webhooks
+        expr:
+          kind: path
+          path: [RawEmailEnabled]
+      - name: delivery_type
+        type: Utf8
+        nullable: true
+        description: Server delivery type such as Live or Sandbox
+        expr:
+          kind: path
+          path: [DeliveryType]
+      - name: server_link
+        type: Utf8
+        nullable: true
+        description: URL for this server in Postmark
+        expr:
+          kind: path
+          path: [ServerLink]
+      - name: inbound_address
+        type: Utf8
+        nullable: true
+        description: Inbound email address for this server
+        expr:
+          kind: path
+          path: [InboundAddress]
+      - name: inbound_hook_url
+        type: Utf8
+        nullable: true
+        description: Inbound webhook URL
+        expr:
+          kind: path
+          path: [InboundHookUrl]
+      - name: bounce_hook_url
+        type: Utf8
+        nullable: true
+        description: Bounce webhook URL
+        expr:
+          kind: path
+          path: [BounceHookUrl]
+      - name: open_hook_url
+        type: Utf8
+        nullable: true
+        description: Open tracking webhook URL
+        expr:
+          kind: path
+          path: [OpenHookUrl]
+      - name: delivery_hook_url
+        type: Utf8
+        nullable: true
+        description: Delivery webhook URL
+        expr:
+          kind: path
+          path: [DeliveryHookUrl]
+      - name: click_hook_url
+        type: Utf8
+        nullable: true
+        description: Click tracking webhook URL
+        expr:
+          kind: path
+          path: [ClickHookUrl]
+      - name: inbound_domain
+        type: Utf8
+        nullable: true
+        description: Inbound domain for MX setup
+        expr:
+          kind: path
+          path: [InboundDomain]
+      - name: inbound_hash
+        type: Utf8
+        nullable: true
+        description: Inbound hash for the server inbound address
+        expr:
+          kind: path
+          path: [InboundHash]
+      - name: inbound_spam_threshold
+        type: Int64
+        nullable: true
+        description: Maximum spam score before inbound messages are blocked
+        expr:
+          kind: path
+          path: [InboundSpamThreshold]
+      - name: post_first_open_only
+        type: Boolean
+        nullable: true
+        description: Whether only first opens trigger open webhooks
+        expr:
+          kind: path
+          path: [PostFirstOpenOnly]
+      - name: track_opens
+        type: Boolean
+        nullable: true
+        description: Whether open tracking is enabled for outgoing email
+        expr:
+          kind: path
+          path: [TrackOpens]
+      - name: track_links
+        type: Utf8
+        nullable: true
+        description: Link tracking mode for outgoing email
+        expr:
+          kind: path
+          path: [TrackLinks]
+      - name: include_bounce_content_in_hook
+        type: Boolean
+        nullable: true
+        description: Whether bounce content is included in bounce webhooks
+        expr:
+          kind: path
+          path: [IncludeBounceContentInHook]
+      - name: enable_smtp_api_error_hooks
+        type: Boolean
+        nullable: true
+        description: Whether SMTP API errors are included with bounce webhooks
+        expr:
+          kind: path
+          path: [EnableSmtpApiErrorHooks]
+
+  - name: message_streams
+    description: Message streams configured for the authenticated Postmark server
+    guide: |
+      Use this table to list transactional, broadcast, and inbound streams.
+      Filter by `message_stream_type` or set `include_archived_streams = true`
+      to include archived streams.
+    request:
+      method: GET
+      path: /message-streams
+      query:
+        - name: MessageStreamType
+          from: filter
+          key: message_stream_type
+        - name: IncludeArchivedStreams
+          from: filter_bool
+          key: include_archived_streams
+    response:
+      rows_path: [MessageStreams]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Message stream ID
+        expr:
+          kind: path
+          path: [ID]
+      - name: server_id
+        type: Int64
+        nullable: true
+        description: Postmark server ID
+        expr:
+          kind: path
+          path: [ServerID]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Message stream name
+        expr:
+          kind: path
+          path: [Name]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Message stream description
+        expr:
+          kind: path
+          path: [Description]
+      - name: message_stream_type
+        type: Utf8
+        nullable: true
+        description: Stream type such as Transactional, Broadcasts, or Inbound
+        expr:
+          kind: path
+          path: [MessageStreamType]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Stream creation timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [CreatedAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Stream last updated timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [UpdatedAt]
+      - name: archived_at
+        type: Timestamp
+        nullable: true
+        description: Stream archived timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [ArchivedAt]
+      - name: expected_purge_date
+        type: Timestamp
+        nullable: true
+        description: Expected purge time for archived streams
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [ExpectedPurgeDate]
+      - name: subscription_management_configuration
+        type: Json
+        nullable: true
+        description: Subscription management configuration
+        expr:
+          kind: path
+          path: [SubscriptionManagementConfiguration]
+      - name: message_stream_type_filter
+        type: Utf8
+        nullable: true
+        description: Message stream type filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: message_stream_type
+        virtual: true
+      - name: include_archived_streams
+        type: Boolean
+        nullable: true
+        description: Whether archived streams were requested (virtual)
+        expr:
+          kind: from_filter
+          key: include_archived_streams
+        virtual: true
+    filters:
+      - name: message_stream_type
+      - name: include_archived_streams
+
+  - name: outbound_messages
+    description: Outbound Postmark message search results for the authenticated server
+    guide: |
+      Use this table to inspect outbound message activity. Postmark search
+      uses `count` and `offset` pagination and caps each search at 10,000
+      messages; narrow with `from_date`, `to_date`, status, recipient, tag, or
+      message stream for larger investigations.
+    fetch_limit_default: 10000
+    request:
+      method: GET
+      path: /messages/outbound
+      query:
+        - name: recipient
+          from: filter
+          key: recipient
+        - name: fromemail
+          from: filter
+          key: from_email
+        - name: tag
+          from: filter
+          key: tag
+        - name: status
+          from: filter
+          key: status
+        - name: todate
+          from: filter
+          key: to_date
+        - name: fromdate
+          from: filter
+          key: from_date
+        - name: subject
+          from: filter
+          key: subject
+        - name: messagestream
+          from: filter
+          key: message_stream
+    response:
+      rows_path: [Messages]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      offset_step: 500
+      max_pages: 20
+      page_size:
+        default: 500
+        max: 500
+        query_param: count
+    columns:
+      - name: message_id
+        type: Utf8
+        nullable: false
+        description: Unique Postmark message ID
+        expr:
+          kind: path
+          path: [MessageID]
+      - name: tag
+        type: Utf8
+        nullable: true
+        description: Message tag
+        expr:
+          kind: path
+          path: [Tag]
+      - name: message_stream
+        type: Utf8
+        nullable: true
+        description: Message stream used for sending
+        expr:
+          kind: path
+          path: [MessageStream]
+      - name: from_email
+        type: Utf8
+        nullable: true
+        description: Sender email address or formatted sender value
+        expr:
+          kind: path
+          path: [From]
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Email subject
+        expr:
+          kind: path
+          path: [Subject]
+      - name: received_at
+        type: Timestamp
+        nullable: true
+        description: Time when Postmark received or processed the message
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [ReceivedAt]
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Message status such as Sent, Processed, or Queued
+        expr:
+          kind: path
+          path: [Status]
+      - name: track_opens
+        type: Boolean
+        nullable: true
+        description: Whether open tracking was enabled
+        expr:
+          kind: path
+          path: [TrackOpens]
+      - name: track_links
+        type: Utf8
+        nullable: true
+        description: Link tracking mode
+        expr:
+          kind: path
+          path: [TrackLinks]
+      - name: sandboxed
+        type: Boolean
+        nullable: true
+        description: Whether the message was sandboxed
+        expr:
+          kind: path
+          path: [Sandboxed]
+      - name: to
+        type: Json
+        nullable: true
+        description: To recipients
+        expr:
+          kind: path
+          path: [To]
+      - name: cc
+        type: Json
+        nullable: true
+        description: Cc recipients
+        expr:
+          kind: path
+          path: [Cc]
+      - name: bcc
+        type: Json
+        nullable: true
+        description: Bcc recipients
+        expr:
+          kind: path
+          path: [Bcc]
+      - name: recipients
+        type: Json
+        nullable: true
+        description: Recipient email addresses
+        expr:
+          kind: path
+          path: [Recipients]
+      - name: attachments
+        type: Json
+        nullable: true
+        description: Message attachments
+        expr:
+          kind: path
+          path: [Attachments]
+      - name: metadata
+        type: Json
+        nullable: true
+        description: Message metadata object
+        expr:
+          kind: path
+          path: [Metadata]
+      - name: recipient
+        type: Utf8
+        nullable: true
+        description: Recipient filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: recipient
+        virtual: true
+      - name: from_email_filter
+        type: Utf8
+        nullable: true
+        description: Sender filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: from_email
+        virtual: true
+      - name: tag_filter
+        type: Utf8
+        nullable: true
+        description: Tag filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: tag
+        virtual: true
+      - name: status_filter
+        type: Utf8
+        nullable: true
+        description: Status filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: status
+        virtual: true
+      - name: to_date
+        type: Utf8
+        nullable: true
+        description: Upper date/time filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: to_date
+        virtual: true
+      - name: from_date
+        type: Utf8
+        nullable: true
+        description: Lower date/time filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: from_date
+        virtual: true
+      - name: subject_filter
+        type: Utf8
+        nullable: true
+        description: Subject filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: subject
+        virtual: true
+      - name: message_stream_filter
+        type: Utf8
+        nullable: true
+        description: Message stream filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: message_stream
+        virtual: true
+    filters:
+      - name: recipient
+      - name: from_email
+      - name: tag
+      - name: status
+      - name: to_date
+      - name: from_date
+      - name: subject
+      - name: message_stream
+
+  - name: inbound_messages
+    description: Inbound Postmark message search results for the authenticated server
+    guide: |
+      Use this table to inspect inbound message processing. Postmark search
+      uses `count` and `offset` pagination and caps each search at 10,000
+      messages; narrow with dates, status, recipient, sender, tag, subject, or
+      mailbox hash for larger investigations.
+    fetch_limit_default: 10000
+    request:
+      method: GET
+      path: /messages/inbound
+      query:
+        - name: recipient
+          from: filter
+          key: recipient
+        - name: fromemail
+          from: filter
+          key: from_email
+        - name: tag
+          from: filter
+          key: tag
+        - name: subject
+          from: filter
+          key: subject
+        - name: mailboxhash
+          from: filter
+          key: mailbox_hash
+        - name: status
+          from: filter
+          key: status
+        - name: todate
+          from: filter
+          key: to_date
+        - name: fromdate
+          from: filter
+          key: from_date
+    response:
+      rows_path: [InboundMessages]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      offset_step: 500
+      max_pages: 20
+      page_size:
+        default: 500
+        max: 500
+        query_param: count
+    columns:
+      - name: message_id
+        type: Utf8
+        nullable: false
+        description: Unique Postmark inbound message ID
+        expr:
+          kind: path
+          path: [MessageID]
+      - name: from_email
+        type: Utf8
+        nullable: true
+        description: Sender email address
+        expr:
+          kind: path
+          path: [From]
+      - name: from_name
+        type: Utf8
+        nullable: true
+        description: Sender display name
+        expr:
+          kind: path
+          path: [FromName]
+      - name: from_full
+        type: Json
+        nullable: true
+        description: Structured sender object
+        expr:
+          kind: path
+          path: [FromFull]
+      - name: to_email
+        type: Utf8
+        nullable: true
+        description: Primary recipient value
+        expr:
+          kind: path
+          path: [To]
+      - name: to_full
+        type: Json
+        nullable: true
+        description: Structured To recipients
+        expr:
+          kind: path
+          path: [ToFull]
+      - name: cc
+        type: Utf8
+        nullable: true
+        description: Cc recipient string
+        expr:
+          kind: path
+          path: [Cc]
+      - name: cc_full
+        type: Json
+        nullable: true
+        description: Structured Cc recipients
+        expr:
+          kind: path
+          path: [CcFull]
+      - name: reply_to
+        type: Utf8
+        nullable: true
+        description: Reply-To value
+        expr:
+          kind: path
+          path: [ReplyTo]
+      - name: original_recipient
+        type: Utf8
+        nullable: true
+        description: Original inbound recipient address
+        expr:
+          kind: path
+          path: [OriginalRecipient]
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Email subject
+        expr:
+          kind: path
+          path: [Subject]
+      - name: date
+        type: Utf8
+        nullable: true
+        description: Inbound email Date header value
+        expr:
+          kind: path
+          path: [Date]
+      - name: mailbox_hash
+        type: Utf8
+        nullable: true
+        description: Mailbox hash
+        expr:
+          kind: path
+          path: [MailboxHash]
+      - name: tag
+        type: Utf8
+        nullable: true
+        description: Message tag
+        expr:
+          kind: path
+          path: [Tag]
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Inbound processing status
+        expr:
+          kind: path
+          path: [Status]
+      - name: attachments
+        type: Json
+        nullable: true
+        description: Inbound message attachments
+        expr:
+          kind: path
+          path: [Attachments]
+      - name: recipient
+        type: Utf8
+        nullable: true
+        description: Recipient filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: recipient
+        virtual: true
+      - name: from_email_filter
+        type: Utf8
+        nullable: true
+        description: Sender filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: from_email
+        virtual: true
+      - name: tag_filter
+        type: Utf8
+        nullable: true
+        description: Tag filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: tag
+        virtual: true
+      - name: subject_filter
+        type: Utf8
+        nullable: true
+        description: Subject filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: subject
+        virtual: true
+      - name: mailbox_hash_filter
+        type: Utf8
+        nullable: true
+        description: Mailbox hash filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: mailbox_hash
+        virtual: true
+      - name: status_filter
+        type: Utf8
+        nullable: true
+        description: Status filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: status
+        virtual: true
+      - name: to_date
+        type: Utf8
+        nullable: true
+        description: Upper date/time filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: to_date
+        virtual: true
+      - name: from_date
+        type: Utf8
+        nullable: true
+        description: Lower date/time filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: from_date
+        virtual: true
+    filters:
+      - name: recipient
+      - name: from_email
+      - name: tag
+      - name: subject
+      - name: mailbox_hash
+      - name: status
+      - name: to_date
+      - name: from_date
+
+  - name: bounces
+    description: Bounce records returned by Postmark bounce search
+    guide: |
+      Use this table to investigate bounced recipients, inactive addresses,
+      bounce types, and related outbound messages. Postmark bounce search uses
+      `count` and `offset` pagination and caps each search at 10,000 bounces.
+    fetch_limit_default: 10000
+    request:
+      method: GET
+      path: /bounces
+      query:
+        - name: type
+          from: filter
+          key: type
+        - name: inactive
+          from: filter_bool
+          key: inactive
+        - name: emailFilter
+          from: filter
+          key: email_filter
+        - name: tag
+          from: filter
+          key: tag
+        - name: messageID
+          from: filter
+          key: message_id
+        - name: fromdate
+          from: filter
+          key: from_date
+        - name: todate
+          from: filter
+          key: to_date
+        - name: messagestream
+          from: filter
+          key: message_stream
+    response:
+      rows_path: [Bounces]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      offset_step: 500
+      max_pages: 20
+      page_size:
+        default: 500
+        max: 500
+        query_param: count
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Bounce ID
+        expr:
+          kind: path
+          path: [ID]
+      - name: record_type
+        type: Utf8
+        nullable: true
+        description: Record type
+        expr:
+          kind: path
+          path: [RecordType]
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Bounce type
+        expr:
+          kind: path
+          path: [Type]
+      - name: type_code
+        type: Int64
+        nullable: true
+        description: Bounce type code
+        expr:
+          kind: path
+          path: [TypeCode]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Bounce type name
+        expr:
+          kind: path
+          path: [Name]
+      - name: tag
+        type: Utf8
+        nullable: true
+        description: Message tag
+        expr:
+          kind: path
+          path: [Tag]
+      - name: message_id
+        type: Utf8
+        nullable: true
+        description: Related message ID
+        expr:
+          kind: path
+          path: [MessageID]
+      - name: server_id
+        type: Int64
+        nullable: true
+        description: Postmark server ID
+        expr:
+          kind: path
+          path: [ServerID]
+      - name: message_stream
+        type: Utf8
+        nullable: true
+        description: Outbound message stream
+        expr:
+          kind: path
+          path: [MessageStream]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Bounce description
+        expr:
+          kind: path
+          path: [Description]
+      - name: details
+        type: Utf8
+        nullable: true
+        description: Bounce details
+        expr:
+          kind: path
+          path: [Details]
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Email address that bounced
+        expr:
+          kind: path
+          path: [Email]
+      - name: from_email
+        type: Utf8
+        nullable: true
+        description: Original sender address when available
+        expr:
+          kind: path
+          path: [From]
+      - name: bounced_at
+        type: Timestamp
+        nullable: true
+        description: Bounce timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [BouncedAt]
+      - name: dump_available
+        type: Boolean
+        nullable: true
+        description: Whether a raw bounce dump is available
+        expr:
+          kind: path
+          path: [DumpAvailable]
+      - name: inactive
+        type: Boolean
+        nullable: true
+        description: Whether Postmark deactivated the recipient
+        expr:
+          kind: path
+          path: [Inactive]
+      - name: can_activate
+        type: Boolean
+        nullable: true
+        description: Whether the recipient can be reactivated
+        expr:
+          kind: path
+          path: [CanActivate]
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Original message subject
+        expr:
+          kind: path
+          path: [Subject]
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Bounce content when returned
+        expr:
+          kind: path
+          path: [Content]
+      - name: type_filter
+        type: Utf8
+        nullable: true
+        description: Bounce type filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: type
+        virtual: true
+      - name: inactive_filter
+        type: Boolean
+        nullable: true
+        description: Inactive filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: inactive
+        virtual: true
+      - name: email_filter
+        type: Utf8
+        nullable: true
+        description: Email filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: email_filter
+        virtual: true
+      - name: tag_filter
+        type: Utf8
+        nullable: true
+        description: Tag filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: tag
+        virtual: true
+      - name: message_id_filter
+        type: Utf8
+        nullable: true
+        description: Message ID filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: message_id
+        virtual: true
+      - name: from_date
+        type: Utf8
+        nullable: true
+        description: Lower date/time filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: from_date
+        virtual: true
+      - name: to_date
+        type: Utf8
+        nullable: true
+        description: Upper date/time filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: to_date
+        virtual: true
+      - name: message_stream_filter
+        type: Utf8
+        nullable: true
+        description: Message stream filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: message_stream
+        virtual: true
+    filters:
+      - name: type
+      - name: inactive
+      - name: email_filter
+      - name: tag
+      - name: message_id
+      - name: from_date
+      - name: to_date
+      - name: message_stream
+
+  - name: templates
+    description: Templates associated with the authenticated Postmark server
+    guide: |
+      Use this table to inventory active standard and layout templates. Filter
+      by `template_type` or `layout_template` when narrowing template lists.
+    fetch_limit_default: 1000
+    request:
+      method: GET
+      path: /templates
+      query:
+        - name: TemplateType
+          from: filter
+          key: template_type
+        - name: LayoutTemplate
+          from: filter
+          key: layout_template
+    response:
+      rows_path: [Templates]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      offset_step: 100
+      max_pages: 10
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: template_id
+        type: Int64
+        nullable: false
+        description: Template ID
+        expr:
+          kind: path
+          path: [TemplateId]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Template name
+        expr:
+          kind: path
+          path: [Name]
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether this template can be used for sending email
+        expr:
+          kind: path
+          path: [Active]
+      - name: alias
+        type: Utf8
+        nullable: true
+        description: Template alias
+        expr:
+          kind: path
+          path: [Alias]
+      - name: template_type
+        type: Utf8
+        nullable: true
+        description: Template type such as Standard or Layout
+        expr:
+          kind: path
+          path: [TemplateType]
+      - name: layout_template
+        type: Utf8
+        nullable: true
+        description: Layout template alias for standard templates
+        expr:
+          kind: path
+          path: [LayoutTemplate]
+      - name: template_type_filter
+        type: Utf8
+        nullable: true
+        description: Template type filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: template_type
+        virtual: true
+      - name: layout_template_filter
+        type: Utf8
+        nullable: true
+        description: Layout template filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: layout_template
+        virtual: true
+    filters:
+      - name: template_type
+      - name: layout_template
+
+  - name: outbound_stats
+    description: Aggregate outbound email statistics for the authenticated server
+    guide: |
+      Use this table for high-level sent, bounce, complaint, open, and click
+      counts. Postmark stats use EST timezone and return all-time stats when no
+      date filters are supplied.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /stats/outbound
+      query:
+        - name: tag
+          from: filter
+          key: tag
+        - name: fromdate
+          from: filter
+          key: from_date
+        - name: todate
+          from: filter
+          key: to_date
+        - name: messagestream
+          from: filter
+          key: message_stream
+    response: {}
+    columns:
+      - name: sent
+        type: Int64
+        nullable: true
+        description: Number of sent emails
+        expr:
+          kind: path
+          path: [Sent]
+      - name: bounced
+        type: Int64
+        nullable: true
+        description: Number of bounced emails
+        expr:
+          kind: path
+          path: [Bounced]
+      - name: smtp_api_errors
+        type: Int64
+        nullable: true
+        description: Number of SMTP API errors
+        expr:
+          kind: path
+          path: [SMTPApiErrors]
+      - name: bounce_rate
+        type: Float64
+        nullable: true
+        description: Bounce rate percentage calculated by total sent
+        expr:
+          kind: path
+          path: [BounceRate]
+      - name: spam_complaints
+        type: Int64
+        nullable: true
+        description: Number of spam complaints
+        expr:
+          kind: path
+          path: [SpamComplaints]
+      - name: spam_complaints_rate
+        type: Float64
+        nullable: true
+        description: Spam complaint percentage calculated by total sent
+        expr:
+          kind: path
+          path: [SpamComplaintsRate]
+      - name: opens
+        type: Int64
+        nullable: true
+        description: Number of opens
+        expr:
+          kind: path
+          path: [Opens]
+      - name: unique_opens
+        type: Int64
+        nullable: true
+        description: Number of unique opens
+        expr:
+          kind: path
+          path: [UniqueOpens]
+      - name: tracked
+        type: Int64
+        nullable: true
+        description: Emails sent with link or open tracking enabled
+        expr:
+          kind: path
+          path: [Tracked]
+      - name: with_link_tracking
+        type: Int64
+        nullable: true
+        description: Emails sent with link tracking enabled
+        expr:
+          kind: path
+          path: [WithLinkTracking]
+      - name: with_open_tracking
+        type: Int64
+        nullable: true
+        description: Emails sent with open tracking enabled
+        expr:
+          kind: path
+          path: [WithOpenTracking]
+      - name: total_tracked_links_sent
+        type: Int64
+        nullable: true
+        description: Total tracked links sent in emails
+        expr:
+          kind: path
+          path: [TotalTrackedLinksSent]
+      - name: unique_links_clicked
+        type: Int64
+        nullable: true
+        description: Number of unique tracked links clicked
+        expr:
+          kind: path
+          path: [UniqueLinksClicked]
+      - name: total_clicks
+        type: Int64
+        nullable: true
+        description: Total clicks from tracked links
+        expr:
+          kind: path
+          path: [TotalClicks]
+      - name: with_client_recorded
+        type: Int64
+        nullable: true
+        description: Emails where client was tracked
+        expr:
+          kind: path
+          path: [WithClientRecorded]
+      - name: with_platform_recorded
+        type: Int64
+        nullable: true
+        description: Emails where platform was tracked
+        expr:
+          kind: path
+          path: [WithPlatformRecorded]
+      - name: tag
+        type: Utf8
+        nullable: true
+        description: Tag filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: tag
+        virtual: true
+      - name: from_date
+        type: Utf8
+        nullable: true
+        description: Lower date filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: from_date
+        virtual: true
+      - name: to_date
+        type: Utf8
+        nullable: true
+        description: Upper date filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: to_date
+        virtual: true
+      - name: message_stream
+        type: Utf8
+        nullable: true
+        description: Message stream filter used for the request (virtual)
+        expr:
+          kind: from_filter
+          key: message_stream
+        virtual: true
+    filters:
+      - name: tag
+      - name: from_date
+      - name: to_date
+      - name: message_stream


### PR DESCRIPTION
## Summary

Adds a new community source for Postmark under `sources/community/postmark/`.

This source enables querying Postmark server data through SQL. It covers the authenticated server, message streams, outbound message search, inbound message search, bounces, templates, and outbound delivery statistics. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with Postmark REST requests, server-token header auth, JSON response mapping, offset pagination for search/list endpoints, optional filters, and no source-spec runtime changes. No CLI, MCP, config, runtime, or source-spec changes are included.

Closes #543 

## What changed

**Added:**

- `sources/community/postmark/manifest.yaml`
- `sources/community/postmark/README.md`

### Tables

| Table | Postmark endpoint | Response rows | Pagination |
|---|---|---|---|
| `server` | `GET /server` | response object | none |
| `message_streams` | `GET /message-streams` | `MessageStreams` | none documented |
| `outbound_messages` | `GET /messages/outbound` | `Messages` | `count` + `offset` |
| `inbound_messages` | `GET /messages/inbound` | `InboundMessages` | `count` + `offset` |
| `bounces` | `GET /bounces` | `Bounces` | `count` + `offset` |
| `templates` | `GET /templates` | `Templates` | `count` + `offset` |
| `outbound_stats` | `GET /stats/outbound` | response object | none |

### Auth

Postmark server-token auth using `X-Postmark-Server-Token`.

**Inputs:**

- `POSTMARK_SERVER_TOKEN` - required secret. Postmark server API token from the API Tokens tab for the Postmark server Coral should query.

## Implementation notes

- **REST over HTTP** - all tables use `method: GET` against documented Postmark REST API endpoints under `https://api.postmarkapp.com`.
- **HeaderAuth** - the manifest sends `POSTMARK_SERVER_TOKEN` as the `X-Postmark-Server-Token` request header.
- **Server-token v1** - all included endpoints use the same Postmark server-level auth header. Account-level `GET /servers` is intentionally not included because it requires `X-Postmark-Account-Token`.
- **JSON request headers** - the source sends `Accept: application/json`.
- **Response mapping** - list tables use Postmark's documented array fields: `MessageStreams`, `Messages`, `InboundMessages`, `Bounces`, and `Templates`; `server` and `outbound_stats` use the response object as a single row.
- **Offset pagination** - `outbound_messages`, `inbound_messages`, `bounces`, and `templates` use Postmark's documented `count` and `offset` parameters.
- **10,000-row search cap** - message and bounce search tables use `count = 500`, `offset_step = 500`, and `max_pages = 20` so default scans stay within Postmark's documented `count + offset <= 10000` search limit.
- **Conservative template paging** - `templates` uses `count = 100` based on Postmark's documented example request.
- **Optional Postmark filters** - search/list/stat tables expose documented optional query parameters as virtual filter columns.
- **Timestamps** - Postmark ISO timestamps are exposed as Coral `Timestamp` columns where practical.
- **Inbound Date header** - inbound email `Date` header values are preserved as `Utf8` because they are email header values rather than the ISO timestamp shape used by most Postmark API fields.
- **Nested data as Json** - richer structures such as recipients, attachments, metadata, sender/recipient objects, and subscription management configuration are preserved as `Json`.
- **Secret-like server token list omitted** - Postmark's `ApiTokens` field from `GET /server` is intentionally not exposed as a column.
- **Read-only v1** - no email sending, template writes, server edits, message-stream writes, bounce activation, inbound bypass/retry, webhook changes, suppressions, data removal, or other write operations are included.

## Endpoint verification

Checked against Postmark's public documentation on May 16, 2026:

| Check | Result |
|---|---|
| REST API base URL is `https://api.postmarkapp.com` | pass |
| Server-token auth with `X-Postmark-Server-Token` is documented | pass |
| `GET /server` is public/documented | pass |
| `GET /message-streams` is public/documented | pass |
| `GET /messages/outbound` is public/documented | pass |
| `GET /messages/inbound` is public/documented | pass |
| `GET /bounces` is public/documented | pass |
| `GET /templates` is public/documented | pass |
| `GET /stats/outbound` is public/documented | pass |
| Message, bounce, and template `count`/`offset` pagination is documented | pass |
| README table list, filters, and endpoint mapping match the manifest | pass |

Primary docs checked:

- https://postmarkapp.com/developer/api/overview
- https://postmarkapp.com/developer/api/server-api
- https://postmarkapp.com/developer/api/message-streams-api
- https://postmarkapp.com/developer/api/messages-api
- https://postmarkapp.com/developer/api/bounce-api
- https://postmarkapp.com/developer/api/templates-api
- https://postmarkapp.com/developer/api/stats-api

## Validation

Lint
```
coral source lint sources/community/zulip/manifest.yaml
Manifest is valid
```

Live validation completed 

### Source add and test queries

```text
wsl bash -lc "cd /mnt/c/Users/BIT/Desktop/coral && cargo run -p coral-cli -- source add --file sources/community/postmark/manifest.yaml"
Added source postmark

  postmark connected successfully

    postmark (7 tables)
    - bounces
    - inbound_messages
    - message_streams
    - outbound_messages
    - outbound_stats
    - server
    - templates
    Query tests
    2 declared · 2 passed · 0 failed

    SELECT id, name, delivery_type FROM postmark.server LIMIT 1
      1 row

    SELECT id, name, message_stream_type FROM postmark.message_streams LIMIT 1
      1 row
```

### Live SQL queries - all 7 tables

| Table | Query | Result |
|---|---|---|
| `server` | `SELECT id, name, delivery_type FROM postmark.server LIMIT 1` | 1 row: `19782206`, `My First Server`, `Live` |
| `message_streams` | `SELECT id, name, message_stream_type FROM postmark.message_streams LIMIT 10` | 3 rows: `inbound`, `outbound`, `broadcast` |
| `outbound_messages` | `SELECT message_id, from_email, subject, status, received_at FROM postmark.outbound_messages LIMIT 10` | 0 rows |
| `inbound_messages` | `SELECT message_id, from_email, subject, status, date FROM postmark.inbound_messages LIMIT 10` | 0 rows |
| `bounces` | `SELECT id, type, email, bounced_at, inactive FROM postmark.bounces LIMIT 10` | 0 rows |
| `templates` | `SELECT template_id, name, active, template_type FROM postmark.templates LIMIT 10` | 0 rows |
| `outbound_stats` | `SELECT sent, bounced, bounce_rate, opens, unique_opens FROM postmark.outbound_stats LIMIT 1` | 1 row: `0`, `0`, `0.0`, `0`, `0` |

All seven tables responded successfully with live Postmark API data or valid empty result sets for this server.

### Static checks completed

| Check | Result |
|---|---|
| Manifest uses only existing Coral HTTP source-spec features | pass |
| Manifest is read-only and uses only `GET` requests | pass |
| README table list matches manifest table list | pass |
| README public API mapping matches manifest request paths and response rows | pass |
| README filter lists match manifest filter lists | pass |
| Account-token endpoints are not included | pass |
| Raw dump/detail/write endpoints are not included | pass |

## User-visible impact

New `postmark` source installable via:

```sh
POSTMARK_SERVER_TOKEN=... \
coral source add --file sources/community/postmark/manifest.yaml
```

Example queries:

```sql
-- Confirm the authenticated server
SELECT id, name, delivery_type, track_opens, track_links
FROM postmark.server
LIMIT 1;

-- List message streams
SELECT id, name, message_stream_type, created_at, archived_at
FROM postmark.message_streams
WHERE include_archived_streams = true
ORDER BY name;

-- Recent outbound messages
SELECT message_id, message_stream, from_email, subject, status, received_at
FROM postmark.outbound_messages
WHERE from_date = '2026-05-01'
  AND to_date = '2026-05-16'
  AND message_stream = 'outbound'
ORDER BY received_at DESC
LIMIT 100;

-- Inbound processing activity
SELECT message_id, from_email, to_email, subject, status, date
FROM postmark.inbound_messages
WHERE status = 'processed'
LIMIT 100;

-- Inactive bounced recipients
SELECT id, type, email, from_email, bounced_at, inactive, can_activate
FROM postmark.bounces
WHERE inactive = true
ORDER BY bounced_at DESC
LIMIT 100;

-- Template inventory
SELECT template_id, name, alias, template_type, active
FROM postmark.templates
WHERE template_type = 'Standard'
ORDER BY name;

-- Outbound delivery statistics
SELECT sent, bounced, bounce_rate, spam_complaints, opens, total_clicks
FROM postmark.outbound_stats
WHERE from_date = '2026-05-01'
  AND to_date = '2026-05-16'
  AND message_stream = 'outbound';
```

## Known limitations

- The source is server-token scoped and does not include account-level server inventory.
- `outbound_messages`, `inbound_messages`, and `bounces` return capped offset-paginated searches, not automatic full-history scans.
- Postmark message rows depend on the server's configured retention period. The default retention period is 45 days, configurable from 7 to 365 days.
- Postmark stats use EST timezone.
- Dynamic outbound `metadata_` search parameters are not exposed in v1 because Coral source-spec query parameter names are static.
- Raw message dumps, bounce dumps, and message details are not included in v1.
- Nested structures are preserved as `Json` columns.

## Out of scope

Not included in v1:

- Sending email or bulk email
- Sending email with templates
- Template create, edit, delete, validate, or push operations
- Server edits or account-level server inventory
- Message stream create, edit, archive, or unarchive operations
- Outbound/inbound message detail and dump endpoints
- Message opens and clicks detail endpoints
- Bounce activation and bounce dumps
- Inbound bypass or retry operations
- Domains, sender signatures, inbound rules, webhooks, suppressions, and data
  removal requests
- Write operations of any kind
