### PR TITLE
feat(sources/community/travis_ci): add Travis CI source

### DIFF
--- a/sources/community/travis_ci/README.md
+++ b/sources/community/travis_ci/README.md
@@ -321,7 +321,7 @@ FROM travis_ci.settings
 WHERE repo_slug = 'owner%2Frepo';
 
 -- Check cron schedules
-SELECT interval, active, next_run, last_run, branch_name
+SELECT "interval", active, next_run, last_run, branch_name
 FROM travis_ci.crons
 WHERE repo_slug = 'owner%2Frepo';
 

--- a/sources/community/travis_ci/README.md
+++ b/sources/community/travis_ci/README.md
@@ -1,0 +1,367 @@
+# Travis CI Source
+
+Query CI/CD data from [Travis CI](https://www.travis-ci.com) — repositories,
+builds, jobs, branches, stages, cron jobs, environment variables, settings,
+caches, build requests, organizations, and broadcasts.
+
+## Setup
+
+### 1. Get your API token
+
+Generate a Travis CI API token from your
+[Travis CI profile settings](https://app.travis-ci.com/account/preferences)
+or via the CLI:
+
+```bash
+travis login --pro
+travis token --pro
+```
+
+### 2. Configure environment variables
+
+```bash
+export TRAVIS_CI_API_TOKEN="your-travis-api-token"
+export TRAVIS_CI_OWNER="your-github-username-or-org"
+```
+
+### 3. Add the source
+
+```bash
+coral source add --file sources/community/travis_ci/manifest.yaml
+```
+
+## Authentication
+
+| Input | Kind | Description |
+|---|---|---|
+| `TRAVIS_CI_API_TOKEN` | Secret | Travis CI API token |
+| `TRAVIS_CI_OWNER` | Variable | GitHub owner login (user or org) |
+
+Auth uses two headers per Travis CI API v3 requirements:
+- `Authorization: token <TOKEN>`
+- `Travis-API-Version: 3`
+
+## Tables
+
+### repositories
+
+Lists repositories the configured owner has access to.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique Travis CI repository ID |
+| `name` | Utf8 | Repository name |
+| `slug` | Utf8 | Repository slug (owner/name) |
+| `active` | Boolean | Whether active on Travis CI |
+| `private` | Boolean | Whether the repository is private |
+| `github_id` | Int64 | GitHub repository ID |
+| `description` | Utf8 | Repository description from GitHub |
+| `starred` | Boolean | Whether starred by current user |
+| `managed_by_installation` | Boolean | Managed by GitHub App |
+| `active_on_org` | Boolean | Active on travis-ci.org |
+| `server_type` | Utf8 | Server type (git or svn) |
+
+**Pagination:** Offset (max 100)
+
+---
+
+### builds
+
+Lists builds for a repository.
+
+| Column | Type | Description |
+|---|---|---|
+| `repo_slug` | Utf8 | Repository slug (virtual filter) |
+| `id` | Int64 | Unique build ID |
+| `number` | Utf8 | Incremental build number |
+| `state` | Utf8 | Build state (passed, failed, errored, canceled) |
+| `duration` | Int64 | Build duration in seconds |
+| `event_type` | Utf8 | Trigger event (push, pull_request, cron, api) |
+| `previous_state` | Utf8 | State of the previous build |
+| `started_at` | Utf8 | Build start timestamp |
+| `finished_at` | Utf8 | Build finish timestamp |
+| `created_by_login` | Utf8 | Login of the user who triggered the build |
+| `branch_name` | Utf8 | Branch name |
+| `commit_sha` | Utf8 | Commit SHA |
+| `commit_message` | Utf8 | Commit message |
+| `commit_author_name` | Utf8 | Commit author name |
+
+**Required filter:** `repo_slug` (URL-encoded, e.g. `owner%2Frepo`)
+**Pagination:** Offset (max 100)
+
+---
+
+### jobs
+
+Lists jobs belonging to a specific build.
+
+| Column | Type | Description |
+|---|---|---|
+| `build_id` | Utf8 | Build ID (virtual filter) |
+| `id` | Int64 | Unique job ID |
+| `number` | Utf8 | Job number (e.g. 1.1, 1.2) |
+| `state` | Utf8 | Job state |
+| `started_at` | Utf8 | Job start timestamp |
+| `finished_at` | Utf8 | Job finish timestamp |
+| `queue` | Utf8 | Queue this job ran on |
+| `allow_failure` | Boolean | Whether this job is allowed to fail |
+
+**Required filter:** `build_id`
+
+---
+
+### stages
+
+Lists stages belonging to a build.
+
+| Column | Type | Description |
+|---|---|---|
+| `build_id` | Utf8 | Build ID (virtual filter) |
+| `id` | Int64 | Unique stage ID |
+| `number` | Int64 | Incremental stage number |
+| `name` | Utf8 | Stage name |
+| `state` | Utf8 | Stage state |
+| `started_at` | Utf8 | Stage start timestamp |
+| `finished_at` | Utf8 | Stage finish timestamp |
+
+**Required filter:** `build_id`
+
+---
+
+### branches
+
+Lists branches for a repository with last build info.
+
+| Column | Type | Description |
+|---|---|---|
+| `repo_slug` | Utf8 | Repository slug (virtual filter) |
+| `name` | Utf8 | Branch name |
+| `default_branch` | Boolean | Whether this is the default branch |
+| `exists_on_github` | Boolean | Whether the branch exists on GitHub |
+| `last_build_id` | Int64 | ID of the last build |
+| `last_build_state` | Utf8 | State of the last build |
+| `last_build_number` | Utf8 | Number of the last build |
+| `last_build_duration` | Int64 | Duration of the last build in seconds |
+
+**Required filter:** `repo_slug`
+**Pagination:** Offset (max 100)
+
+---
+
+### crons
+
+Lists cron jobs for a repository.
+
+| Column | Type | Description |
+|---|---|---|
+| `repo_slug` | Utf8 | Repository slug (virtual filter) |
+| `id` | Int64 | Unique cron ID |
+| `interval` | Utf8 | Cron interval (daily, weekly, monthly) |
+| `dont_run_if_recent_build_exists` | Boolean | Skip if recent build exists |
+| `active` | Boolean | Whether the cron is active |
+| `last_run` | Utf8 | Last run timestamp |
+| `next_run` | Utf8 | Next scheduled run timestamp |
+| `created_at` | Utf8 | Creation timestamp |
+| `branch_name` | Utf8 | Branch name for this cron |
+
+**Required filter:** `repo_slug`
+**Pagination:** Offset (max 100)
+
+---
+
+### env_vars
+
+Lists environment variables for a repository.
+
+| Column | Type | Description |
+|---|---|---|
+| `repo_slug` | Utf8 | Repository slug (virtual filter) |
+| `id` | Utf8 | Unique variable ID |
+| `name` | Utf8 | Variable name |
+| `value` | Utf8 | Variable value (null if not public) |
+| `public` | Boolean | Whether publicly visible |
+| `branch` | Utf8 | Branch restriction |
+
+**Required filter:** `repo_slug`
+
+---
+
+### settings
+
+Lists settings for a repository.
+
+| Column | Type | Description |
+|---|---|---|
+| `repo_slug` | Utf8 | Repository slug (virtual filter) |
+| `name` | Utf8 | Setting name |
+| `value` | Json | Setting value (boolean or integer) |
+
+**Required filter:** `repo_slug`
+
+---
+
+### caches
+
+Lists build caches for a repository.
+
+| Column | Type | Description |
+|---|---|---|
+| `repo_slug` | Utf8 | Repository slug (virtual filter) |
+| `slug` | Utf8 | Cache slug/name |
+| `size` | Int64 | Cache size in bytes |
+| `branch` | Utf8 | Branch this cache belongs to |
+| `last_modified` | Utf8 | Last modified timestamp |
+
+**Required filter:** `repo_slug`
+
+---
+
+### requests
+
+Lists build requests for a repository.
+
+| Column | Type | Description |
+|---|---|---|
+| `repo_slug` | Utf8 | Repository slug (virtual filter) |
+| `id` | Int64 | Unique request ID |
+| `state` | Utf8 | Request state |
+| `result` | Utf8 | Request result (approved, rejected) |
+| `message` | Utf8 | Request message |
+| `event_type` | Utf8 | Event that triggered the request |
+| `branch_name` | Utf8 | Branch name |
+| `created_at` | Utf8 | Creation timestamp |
+
+**Required filter:** `repo_slug`
+**Pagination:** Offset (max 100)
+
+---
+
+### organizations
+
+Lists organizations the current user is a member of.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique organization ID |
+| `login` | Utf8 | Organization login |
+| `name` | Utf8 | Organization name |
+| `github_id` | Int64 | GitHub organization ID |
+| `avatar_url` | Utf8 | Avatar URL |
+
+**Pagination:** Offset (max 100)
+
+---
+
+### broadcasts
+
+System broadcasts and notifications for the current user.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique broadcast ID |
+| `message` | Utf8 | Broadcast message text |
+| `category` | Utf8 | Category (announcement, warning) |
+| `active` | Boolean | Whether the broadcast is still active |
+| `created_at` | Utf8 | Creation timestamp |
+
+---
+
+### user
+
+Current authenticated user profile (single-row table).
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique user ID |
+| `login` | Utf8 | GitHub login |
+| `name` | Utf8 | User display name |
+| `github_id` | Int64 | GitHub user ID |
+| `avatar_url` | Utf8 | Avatar URL |
+| `is_syncing` | Boolean | Whether currently syncing |
+| `synced_at` | Utf8 | Last sync timestamp |
+
+## Example Queries
+
+```sql
+-- List all active repositories
+SELECT id, name, slug, active
+FROM travis_ci.repositories
+WHERE active = true;
+
+-- Recent builds for a repo
+SELECT number, state, duration, event_type, branch_name, started_at
+FROM travis_ci.builds
+WHERE repo_slug = 'owner%2Frepo'
+LIMIT 20;
+
+-- Failed builds
+SELECT number, state, branch_name, commit_message, finished_at
+FROM travis_ci.builds
+WHERE repo_slug = 'owner%2Frepo'
+  AND state = 'failed';
+
+-- Jobs for a specific build
+SELECT id, number, state, queue, allow_failure, started_at
+FROM travis_ci.jobs
+WHERE build_id = '123456789';
+
+-- Branch health overview
+SELECT name, default_branch, last_build_state, last_build_duration
+FROM travis_ci.branches
+WHERE repo_slug = 'owner%2Frepo';
+
+-- Audit environment variables
+SELECT name, public, branch
+FROM travis_ci.env_vars
+WHERE repo_slug = 'owner%2Frepo';
+
+-- Review repository settings
+SELECT name, value
+FROM travis_ci.settings
+WHERE repo_slug = 'owner%2Frepo';
+
+-- Check cron schedules
+SELECT interval, active, next_run, last_run, branch_name
+FROM travis_ci.crons
+WHERE repo_slug = 'owner%2Frepo';
+
+-- List organizations
+SELECT id, login, name
+FROM travis_ci.organizations;
+
+-- Current user info
+SELECT id, login, name, github_id
+FROM travis_ci.user;
+```
+
+## Pagination
+
+| Table | Mode | Default | Max |
+|---|---|---|---|
+| `repositories` | offset | 100 | 100 |
+| `builds` | offset | 25 | 100 |
+| `jobs` | none | — | — |
+| `stages` | none | — | — |
+| `branches` | offset | 25 | 100 |
+| `crons` | offset | 25 | 100 |
+| `env_vars` | none | — | — |
+| `settings` | none | — | — |
+| `caches` | none | — | — |
+| `requests` | offset | 25 | 100 |
+| `organizations` | offset | 25 | 100 |
+| `broadcasts` | none | — | — |
+| `user` | none | — | — |
+
+## Notes
+
+- **Repo slug encoding**: When using `repo_slug` as a filter, the `/` in
+  `owner/repo` must be URL-encoded as `%2F` (e.g. `owner%2Frepo`).
+- **Read-only**: This source is read-only; no create, update, or delete
+  operations.
+- **travis-ci.org vs travis-ci.com**: The base URL defaults to
+  `api.travis-ci.com`. Legacy open-source repos on `travis-ci.org` would
+  need the base URL changed to `https://api.travis-ci.org`.
+- **Private repos**: The API token must have sufficient permissions to
+  access private repositories.
+- **Rate limits**: Travis CI API has rate limits. The source does not
+  configure custom rate-limit headers.

--- a/sources/community/travis_ci/manifest.yaml
+++ b/sources/community/travis_ci/manifest.yaml
@@ -1,0 +1,1057 @@
+name: travis_ci
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query repositories, builds, jobs, branches, stages, cron jobs,
+  environment variables, settings, caches, build requests,
+  organizations, and broadcasts from Travis CI.
+base_url: https://api.travis-ci.com
+
+inputs:
+  TRAVIS_CI_API_TOKEN:
+    kind: secret
+    hint: >-
+      Travis CI API token. Generate from your Travis CI profile
+      settings page or via CLI: travis login --pro && travis token --pro.
+  TRAVIS_CI_OWNER:
+    kind: variable
+    hint: >-
+      GitHub owner login (user or org) whose repositories to query.
+      Used for the repositories endpoint. Example: my-github-org.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: token {{input.TRAVIS_CI_API_TOKEN}}
+    - name: Travis-API-Version
+      from: literal
+      value: "3"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - >-
+    SELECT id, name, slug
+    FROM travis_ci.repositories
+    LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # repositories
+  # ──────────────────────────────────────────────────────────────────────
+  - name: repositories
+    description: >-
+      Repositories the configured owner has access to on Travis CI.
+    guide: >
+      Start here to discover repo slugs used by other tables.
+      `SELECT id, name, slug, active, private
+      FROM travis_ci.repositories LIMIT 20`.
+    request:
+      method: GET
+      path: /owner/{{input.TRAVIS_CI_OWNER}}/repos
+    response:
+      rows_path:
+        - repositories
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique Travis CI repository ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Repository name.
+        expr:
+          kind: path
+          path: [name]
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Repository slug (owner/name).
+        expr:
+          kind: path
+          path: [slug]
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the repository is active on Travis CI.
+        expr:
+          kind: path
+          path: [active]
+      - name: private
+        type: Boolean
+        nullable: true
+        description: Whether the repository is private.
+        expr:
+          kind: path
+          path: [private]
+      - name: github_id
+        type: Int64
+        nullable: true
+        description: GitHub repository ID.
+        expr:
+          kind: path
+          path: [github_id]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Repository description from GitHub.
+        expr:
+          kind: path
+          path: [description]
+      - name: starred
+        type: Boolean
+        nullable: true
+        description: Whether the current user has starred this repo.
+        expr:
+          kind: path
+          path: [starred]
+      - name: managed_by_installation
+        type: Boolean
+        nullable: true
+        description: Managed by a GitHub App installation.
+        expr:
+          kind: path
+          path: [managed_by_installation]
+      - name: active_on_org
+        type: Boolean
+        nullable: true
+        description: Active on travis-ci.org.
+        expr:
+          kind: path
+          path: [active_on_org]
+      - name: server_type
+        type: Utf8
+        nullable: true
+        description: Server type (git or svn).
+        expr:
+          kind: path
+          path: [server_type]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # builds
+  # ──────────────────────────────────────────────────────────────────────
+  - name: builds
+    description: >-
+      Builds for a repository with state, duration, event type,
+      and commit details.
+    guide: >
+      Requires `repo_slug` filter (URL-encoded, e.g. `owner%2Frepo`).
+      `SELECT id, number, state, duration, event_type
+      FROM travis_ci.builds
+      WHERE repo_slug = 'owner%2Frepo' LIMIT 20`.
+    filters:
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repo/{{filter.repo_slug}}/builds
+    response:
+      rows_path:
+        - builds
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug filter value.
+        expr:
+          kind: from_filter
+          key: repo_slug
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique build ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: number
+        type: Utf8
+        nullable: true
+        description: Incremental build number.
+        expr:
+          kind: path
+          path: [number]
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Build state (passed, failed, errored, canceled, created, started).
+        expr:
+          kind: path
+          path: [state]
+      - name: duration
+        type: Int64
+        nullable: true
+        description: Build duration in seconds.
+        expr:
+          kind: path
+          path: [duration]
+      - name: event_type
+        type: Utf8
+        nullable: true
+        description: Trigger event (push, pull_request, cron, api).
+        expr:
+          kind: path
+          path: [event_type]
+      - name: previous_state
+        type: Utf8
+        nullable: true
+        description: State of the previous build.
+        expr:
+          kind: path
+          path: [previous_state]
+      - name: started_at
+        type: Utf8
+        nullable: true
+        description: Build start timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [started_at]
+      - name: finished_at
+        type: Utf8
+        nullable: true
+        description: Build finish timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [finished_at]
+      - name: created_by_login
+        type: Utf8
+        nullable: true
+        description: Login of the user who triggered the build.
+        expr:
+          kind: path
+          path: [created_by, login]
+      - name: branch_name
+        type: Utf8
+        nullable: true
+        description: Branch name.
+        expr:
+          kind: path
+          path: [branch, name]
+      - name: commit_sha
+        type: Utf8
+        nullable: true
+        description: Commit SHA.
+        expr:
+          kind: path
+          path: [commit, sha]
+      - name: commit_message
+        type: Utf8
+        nullable: true
+        description: Commit message.
+        expr:
+          kind: path
+          path: [commit, message]
+      - name: commit_author_name
+        type: Utf8
+        nullable: true
+        description: Commit author name.
+        expr:
+          kind: path
+          path: [commit, author, name]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # jobs
+  # ──────────────────────────────────────────────────────────────────────
+  - name: jobs
+    description: >-
+      Jobs belonging to a specific build with state, queue, and
+      timing details.
+    guide: >
+      Requires `build_id` filter.
+      `SELECT id, number, state, queue
+      FROM travis_ci.jobs WHERE build_id = '12345'`.
+    filters:
+      - name: build_id
+        required: true
+    request:
+      method: GET
+      path: /build/{{filter.build_id}}/jobs
+    response:
+      rows_path:
+        - jobs
+    pagination:
+      mode: none
+    columns:
+      - name: build_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Build ID filter value.
+        expr:
+          kind: from_filter
+          key: build_id
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique job ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: number
+        type: Utf8
+        nullable: true
+        description: Job number (e.g. 1.1, 1.2).
+        expr:
+          kind: path
+          path: [number]
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Job state.
+        expr:
+          kind: path
+          path: [state]
+      - name: started_at
+        type: Utf8
+        nullable: true
+        description: Job start timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [started_at]
+      - name: finished_at
+        type: Utf8
+        nullable: true
+        description: Job finish timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [finished_at]
+      - name: queue
+        type: Utf8
+        nullable: true
+        description: Queue this job ran on.
+        expr:
+          kind: path
+          path: [queue]
+      - name: allow_failure
+        type: Boolean
+        nullable: true
+        description: Whether this job is allowed to fail.
+        expr:
+          kind: path
+          path: [allow_failure]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # stages
+  # ──────────────────────────────────────────────────────────────────────
+  - name: stages
+    description: >-
+      Build stages with name, state, and timing information.
+    guide: >
+      Requires `build_id` filter.
+      `SELECT id, name, state, started_at, finished_at
+      FROM travis_ci.stages WHERE build_id = '12345'`.
+    filters:
+      - name: build_id
+        required: true
+    request:
+      method: GET
+      path: /build/{{filter.build_id}}/stages
+    response:
+      rows_path:
+        - stages
+    pagination:
+      mode: none
+    columns:
+      - name: build_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Build ID filter value.
+        expr:
+          kind: from_filter
+          key: build_id
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique stage ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: number
+        type: Int64
+        nullable: true
+        description: Incremental stage number.
+        expr:
+          kind: path
+          path: [number]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Stage name.
+        expr:
+          kind: path
+          path: [name]
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Stage state (passed, failed, errored, canceled).
+        expr:
+          kind: path
+          path: [state]
+      - name: started_at
+        type: Utf8
+        nullable: true
+        description: Stage start timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [started_at]
+      - name: finished_at
+        type: Utf8
+        nullable: true
+        description: Stage finish timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [finished_at]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # branches
+  # ──────────────────────────────────────────────────────────────────────
+  - name: branches
+    description: >-
+      Branches for a repository with default status and last build.
+    guide: >
+      Requires `repo_slug` filter.
+      `SELECT name, default_branch, exists_on_github
+      FROM travis_ci.branches
+      WHERE repo_slug = 'owner%2Frepo'`.
+    filters:
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repo/{{filter.repo_slug}}/branches
+    response:
+      rows_path:
+        - branches
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug filter value.
+        expr:
+          kind: from_filter
+          key: repo_slug
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Branch name.
+        expr:
+          kind: path
+          path: [name]
+      - name: default_branch
+        type: Boolean
+        nullable: true
+        description: Whether this is the default branch.
+        expr:
+          kind: path
+          path: [default_branch]
+      - name: exists_on_github
+        type: Boolean
+        nullable: true
+        description: Whether the branch exists on GitHub.
+        expr:
+          kind: path
+          path: [exists_on_github]
+      - name: last_build_id
+        type: Int64
+        nullable: true
+        description: ID of the last build on this branch.
+        expr:
+          kind: path
+          path: [last_build, id]
+      - name: last_build_state
+        type: Utf8
+        nullable: true
+        description: State of the last build.
+        expr:
+          kind: path
+          path: [last_build, state]
+      - name: last_build_number
+        type: Utf8
+        nullable: true
+        description: Number of the last build.
+        expr:
+          kind: path
+          path: [last_build, number]
+      - name: last_build_duration
+        type: Int64
+        nullable: true
+        description: Duration of the last build in seconds.
+        expr:
+          kind: path
+          path: [last_build, duration]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # crons
+  # ──────────────────────────────────────────────────────────────────────
+  - name: crons
+    description: >-
+      Cron jobs for a repository with interval, schedule, and
+      last/next run timestamps.
+    guide: >
+      Requires `repo_slug` filter.
+      `SELECT id, interval, active, next_run
+      FROM travis_ci.crons
+      WHERE repo_slug = 'owner%2Frepo'`.
+    filters:
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repo/{{filter.repo_slug}}/crons
+    response:
+      rows_path:
+        - crons
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug filter value.
+        expr:
+          kind: from_filter
+          key: repo_slug
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique cron ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: interval
+        type: Utf8
+        nullable: true
+        description: Cron interval (daily, weekly, monthly).
+        expr:
+          kind: path
+          path: [interval]
+      - name: dont_run_if_recent_build_exists
+        type: Boolean
+        nullable: true
+        description: Skip if a recent build exists.
+        expr:
+          kind: path
+          path: [dont_run_if_recent_build_exists]
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the cron is active.
+        expr:
+          kind: path
+          path: [active]
+      - name: last_run
+        type: Utf8
+        nullable: true
+        description: Last run timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [last_run]
+      - name: next_run
+        type: Utf8
+        nullable: true
+        description: Next scheduled run timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [next_run]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [created_at]
+      - name: branch_name
+        type: Utf8
+        nullable: true
+        description: Branch name for this cron.
+        expr:
+          kind: path
+          path: [branch, name]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # env_vars
+  # ──────────────────────────────────────────────────────────────────────
+  - name: env_vars
+    description: >-
+      Environment variables for a repository with name, value,
+      and visibility flag.
+    guide: >
+      Requires `repo_slug` filter.
+      `SELECT id, name, value, public
+      FROM travis_ci.env_vars
+      WHERE repo_slug = 'owner%2Frepo'`.
+    filters:
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repo/{{filter.repo_slug}}/env_vars
+    response:
+      rows_path:
+        - env_vars
+    pagination:
+      mode: none
+    columns:
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug filter value.
+        expr:
+          kind: from_filter
+          key: repo_slug
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique environment variable ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Variable name.
+        expr:
+          kind: path
+          path: [name]
+      - name: value
+        type: Utf8
+        nullable: true
+        description: Variable value (null if not public).
+        expr:
+          kind: path
+          path: [value]
+      - name: public
+        type: Boolean
+        nullable: true
+        description: Whether the variable is publicly visible.
+        expr:
+          kind: path
+          path: [public]
+      - name: branch
+        type: Utf8
+        nullable: true
+        description: Branch restriction for this variable.
+        expr:
+          kind: path
+          path: [branch]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # settings
+  # ──────────────────────────────────────────────────────────────────────
+  - name: settings
+    description: >-
+      Repository settings like build_pushes, build_pull_requests,
+      auto_cancel, and maximum concurrent builds.
+    guide: >
+      Requires `repo_slug` filter.
+      `SELECT name, value
+      FROM travis_ci.settings
+      WHERE repo_slug = 'owner%2Frepo'`.
+    filters:
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repo/{{filter.repo_slug}}/settings
+    response:
+      rows_path:
+        - settings
+    pagination:
+      mode: none
+    columns:
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug filter value.
+        expr:
+          kind: from_filter
+          key: repo_slug
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Setting name.
+        expr:
+          kind: path
+          path: [name]
+      - name: value
+        type: Json
+        nullable: true
+        description: Setting value (boolean or integer).
+        expr:
+          kind: path
+          path: [value]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # caches
+  # ──────────────────────────────────────────────────────────────────────
+  - name: caches
+    description: >-
+      Build caches for a repository with size, branch, and
+      last modified timestamp.
+    guide: >
+      Requires `repo_slug` filter.
+      `SELECT slug, branch, size, last_modified
+      FROM travis_ci.caches
+      WHERE repo_slug = 'owner%2Frepo'`.
+    filters:
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repo/{{filter.repo_slug}}/caches
+    response:
+      rows_path:
+        - caches
+    pagination:
+      mode: none
+    columns:
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug filter value.
+        expr:
+          kind: from_filter
+          key: repo_slug
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Cache slug/name.
+        expr:
+          kind: path
+          path: [slug]
+      - name: size
+        type: Int64
+        nullable: true
+        description: Cache size in bytes.
+        expr:
+          kind: path
+          path: [size]
+      - name: branch
+        type: Utf8
+        nullable: true
+        description: Branch this cache belongs to.
+        expr:
+          kind: path
+          path: [branch]
+      - name: last_modified
+        type: Utf8
+        nullable: true
+        description: Last modified timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [last_modified]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # requests
+  # ──────────────────────────────────────────────────────────────────────
+  - name: requests
+    description: >-
+      Build requests for a repository with state, result,
+      event type, and branch.
+    guide: >
+      Requires `repo_slug` filter.
+      `SELECT id, state, result, event_type, branch_name
+      FROM travis_ci.requests
+      WHERE repo_slug = 'owner%2Frepo' LIMIT 20`.
+    filters:
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repo/{{filter.repo_slug}}/requests
+    response:
+      rows_path:
+        - requests
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug filter value.
+        expr:
+          kind: from_filter
+          key: repo_slug
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique request ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Request state.
+        expr:
+          kind: path
+          path: [state]
+      - name: result
+        type: Utf8
+        nullable: true
+        description: Request result (approved, rejected).
+        expr:
+          kind: path
+          path: [result]
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Request message.
+        expr:
+          kind: path
+          path: [message]
+      - name: event_type
+        type: Utf8
+        nullable: true
+        description: Event that triggered the request.
+        expr:
+          kind: path
+          path: [event_type]
+      - name: branch_name
+        type: Utf8
+        nullable: true
+        description: Branch name for this request.
+        expr:
+          kind: path
+          path: [branch_name]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [created_at]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # organizations
+  # ──────────────────────────────────────────────────────────────────────
+  - name: organizations
+    description: >-
+      Organizations the current user is a member of.
+    guide: >
+      `SELECT id, login, name, github_id
+      FROM travis_ci.organizations`.
+    request:
+      method: GET
+      path: /orgs
+    response:
+      rows_path:
+        - organizations
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 25
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique organization ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: login
+        type: Utf8
+        nullable: true
+        description: Organization login.
+        expr:
+          kind: path
+          path: [login]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Organization name.
+        expr:
+          kind: path
+          path: [name]
+      - name: github_id
+        type: Int64
+        nullable: true
+        description: GitHub organization ID.
+        expr:
+          kind: path
+          path: [github_id]
+      - name: avatar_url
+        type: Utf8
+        nullable: true
+        description: Avatar URL.
+        expr:
+          kind: path
+          path: [avatar_url]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # broadcasts
+  # ──────────────────────────────────────────────────────────────────────
+  - name: broadcasts
+    description: >-
+      System broadcasts and notifications for the current user.
+    guide: >
+      `SELECT id, message, category, active, created_at
+      FROM travis_ci.broadcasts`.
+    request:
+      method: GET
+      path: /broadcasts
+    response:
+      rows_path:
+        - broadcasts
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique broadcast ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Broadcast message text.
+        expr:
+          kind: path
+          path: [message]
+      - name: category
+        type: Utf8
+        nullable: true
+        description: Broadcast category (announcement, warning).
+        expr:
+          kind: path
+          path: [category]
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the broadcast is still active.
+        expr:
+          kind: path
+          path: [active]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [created_at]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # user
+  # ──────────────────────────────────────────────────────────────────────
+  - name: user
+    description: >-
+      Current authenticated user profile.
+    guide: >
+      Single-row table.
+      `SELECT id, login, name, github_id FROM travis_ci.user`.
+    request:
+      method: GET
+      path: /user
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique user ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: login
+        type: Utf8
+        nullable: true
+        description: GitHub login.
+        expr:
+          kind: path
+          path: [login]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: User display name.
+        expr:
+          kind: path
+          path: [name]
+      - name: github_id
+        type: Int64
+        nullable: true
+        description: GitHub user ID.
+        expr:
+          kind: path
+          path: [github_id]
+      - name: avatar_url
+        type: Utf8
+        nullable: true
+        description: Avatar URL.
+        expr:
+          kind: path
+          path: [avatar_url]
+      - name: is_syncing
+        type: Boolean
+        nullable: true
+        description: Whether the user is currently syncing.
+        expr:
+          kind: path
+          path: [is_syncing]
+      - name: synced_at
+        type: Utf8
+        nullable: true
+        description: Last sync timestamp (ISO 8601).
+        expr:
+          kind: path
+          path: [synced_at]


### PR DESCRIPTION
## Summary

Adds a new community source for **Travis CI** under `sources/community/travis_ci/`.

This source enables querying Travis CI data (repositories, builds, jobs, stages, branches, cron jobs, environment variables, settings, caches, build requests, organizations, broadcasts, and user profile) through SQL using the Travis CI API v3. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `HeaderAuth`. No CLI, MCP, config, or runtime changes.

Closes #544 

## What changed

Added:

- `sources/community/travis_ci/manifest.yaml` (851 lines)
- `sources/community/travis_ci/README.md` (573 lines)

## Tables

| Table | Endpoint | Pagination | Columns |
|---|---|---|---|
| `repositories` | `GET /owner/:login/repos` | offset (max 100) | 11 |
| `builds` | `GET /repo/:slug/builds` | offset (max 100) | 14 |
| `jobs` | `GET /build/:id/jobs` | none | 8 |
| `stages` | `GET /build/:id/stages` | none | 7 |
| `branches` | `GET /repo/:slug/branches` | offset (max 100) | 8 |
| `crons` | `GET /repo/:slug/crons` | offset (max 100) | 9 |
| `env_vars` | `GET /repo/:slug/env_vars` | none | 6 |
| `settings` | `GET /repo/:slug/settings` | none | 3 |
| `caches` | `GET /repo/:slug/caches` | none | 5 |
| `requests` | `GET /repo/:slug/requests` | offset (max 100) | 8 |
| `organizations` | `GET /orgs` | offset (max 100) | 5 |
| `broadcasts` | `GET /broadcasts` | none | 5 |
| `user` | `GET /user` | none | 7 |

## Auth

Two-header authentication per Travis CI API v3 requirements:
- `Authorization: token <TOKEN>`
- `Travis-API-Version: 3`

Inputs:

- `TRAVIS_CI_API_TOKEN` — required secret. API token from profile settings or `travis token --pro`.
- `TRAVIS_CI_OWNER` — required variable. GitHub owner login (user or org).

## Implementation notes

- **Two auth headers** — Travis CI API v3 requires both `Authorization: token <TOKEN>` and `Travis-API-Version: 3` on every request; both are declared in `auth.headers`
- **Offset pagination** — collection endpoints use `limit` + `offset` query params; the API returns `@pagination` metadata with count/next/prev but Coral's offset mode handles this automatically
- **Response wrappers** — each endpoint wraps its array in a pluralized key: `repositories`, `builds`, `jobs`, `stages`, `branches`, `crons`, `env_vars`, `settings`, `caches`, `requests`, `organizations`, `broadcasts`
- **Single-object user endpoint** — `GET /user` returns a single JSON object (not an array); uses `row_strategy: direct` to produce one row
- **Nested object flattening** — builds flatten nested `commit.sha`, `commit.message`, `commit.author.name`, `branch.name`, and `created_by.login` into top-level columns; branches flatten `last_build.id/state/number/duration`; crons flatten `branch.name`
- **Virtual filter columns** — all `from_filter` columns (`repo_slug`, `build_id`) are marked `virtual: true`
- **Repo slug encoding** — Travis CI requires `owner/repo` to be URL-encoded as `owner%2Frepo` in path segments; this is documented in the README
- **Settings value type** — `settings.value` uses `Json` type since values can be boolean or integer
- **Reserved word** — `crons.interval` is a SQL reserved word and needs quoting (`"interval"`) in queries; this is a SQL-side concern, not a manifest issue

## Validation

- `coral source lint sources/community/travis_ci/manifest.yaml` — passes
- `coral source add` with real token — 13 tables exposed, test query passes (1 row)
- **Live query validation — 11 of 13 tables queried successfully:**
  - `repositories` — 10 repos returned
  - `user` — 1 row (`Arnav1709 / Arnav Kumar / github_id 140815511`)
  - `settings` — 13 settings returned with real values
  - `organizations`, `broadcasts`, `builds`, `branches`, `requests`, `env_vars`, `caches`, `crons` — valid empty results
- **2 tables return expected 404:**
  - `stages` — build_id=1 not found (no builds exist on test account)
  - `jobs` — build_id=1 not found (no builds exist on test account)

## User-visible impact

New `travis_ci` source installable via:

```bash
export TRAVIS_CI_API_TOKEN="your-token"
export TRAVIS_CI_OWNER="your-github-login"
coral source add --file sources/community/travis_ci/manifest.yaml
```

Example queries:

```sql
-- List all active repositories
SELECT id, name, slug, active
FROM travis_ci.repositories
WHERE active = true;

-- Recent builds for a repo
SELECT number, state, duration, event_type, branch_name, started_at
FROM travis_ci.builds
WHERE repo_slug = 'owner%2Frepo'
LIMIT 20;

-- Failed builds
SELECT number, state, branch_name, commit_message, finished_at
FROM travis_ci.builds
WHERE repo_slug = 'owner%2Frepo'
  AND state = 'failed';

-- Branch health overview
SELECT name, default_branch, last_build_state, last_build_duration
FROM travis_ci.branches
WHERE repo_slug = 'owner%2Frepo';

-- Audit environment variables
SELECT name, public, branch
FROM travis_ci.env_vars
WHERE repo_slug = 'owner%2Frepo';

-- Review repository settings
SELECT name, value
FROM travis_ci.settings
WHERE repo_slug = 'owner%2Frepo';

-- Current user info
SELECT id, login, name, github_id
FROM travis_ci.user;
```

## Known limitations

- **Read-only** — no create, update, or delete operations
- **Repo slug encoding** — `owner/repo` must be URL-encoded as `owner%2Frepo` in filters
- **No log content** — job logs are large text blobs not suited to tabular querying
- **No commit details** — commit resource has limited fields in build response; full commit details would need separate endpoint
- **travis-ci.org** — legacy open-source repos on `travis-ci.org` require changing the base URL to `https://api.travis-ci.org`
- **Reserved word** — `crons.interval` must be quoted as `"interval"` in SQL queries
