### PR TITLE
feat(sources/community/mixpanel): add Mixpanel source

### DIFF
--- a/sources/community/mixpanel/README.md
+++ b/sources/community/mixpanel/README.md
@@ -1,0 +1,234 @@
+# Mixpanel Source
+
+Query analytics metadata from [Mixpanel](https://mixpanel.com) — projects,
+cohorts, annotations, annotation tags, Lexicon schemas (all, event, profile),
+and dashboards.
+
+## Setup
+
+### 1. Create a service account
+
+Go to **Organization Settings > Service Accounts** in the Mixpanel dashboard
+and create a new service account. Save the **username** and **secret**.
+
+See: [Mixpanel Service Accounts](https://docs.mixpanel.com/docs/orgs-and-projects/managing-projects#service-accounts)
+
+### 2. Find your project ID
+
+Go to **Project Settings > Overview** in the Mixpanel dashboard. The numeric
+project ID is displayed at the top.
+
+### 3. Configure environment variables
+
+```bash
+export MIXPANEL_SERVICE_ACCOUNT_USERNAME="your-service-account-username"
+export MIXPANEL_SERVICE_ACCOUNT_SECRET="your-service-account-secret"
+export MIXPANEL_PROJECT_ID="1234567"
+```
+
+For EU or India data residency, also set:
+
+```bash
+export MIXPANEL_BASE_URL="https://eu.mixpanel.com"   # EU
+export MIXPANEL_BASE_URL="https://in.mixpanel.com"   # India
+```
+
+### 4. Add the source
+
+```bash
+coral source add --file sources/community/mixpanel/manifest.yaml
+```
+
+## Authentication
+
+| Input | Kind | Description |
+|---|---|---|
+| `MIXPANEL_SERVICE_ACCOUNT_USERNAME` | Secret | Service account username |
+| `MIXPANEL_SERVICE_ACCOUNT_SECRET` | Secret | Service account secret |
+| `MIXPANEL_PROJECT_ID` | Variable | Numeric project ID |
+| `MIXPANEL_BASE_URL` | Variable | API base URL (default: `https://mixpanel.com`) |
+
+Uses HTTP Basic Auth with the service account credentials. The project ID is
+passed as a path or query parameter to project-scoped endpoints.
+
+## Tables
+
+### projects
+
+Projects accessible by the authenticated service account.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique project ID |
+| `name` | Utf8 | Project display name |
+| `timezone` | Utf8 | Project timezone |
+| `token` | Utf8 | Project token (for client-side tracking) |
+| `created_at` | Utf8 | Project creation timestamp |
+
+---
+
+### cohorts
+
+Saved cohorts for the configured project. **Requires a paid Mixpanel plan.**
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique cohort ID |
+| `name` | Utf8 | Cohort name |
+| `description` | Utf8 | Cohort description |
+| `count` | Int64 | Number of users in the cohort |
+| `created` | Utf8 | Cohort creation date |
+| `is_visible` | Int64 | Cohort visibility flag (0 hidden, 1 visible) |
+
+---
+
+### annotations
+
+Project annotations marking significant events (releases, campaigns).
+
+| Column | Type | Description |
+|---|---|---|
+| `from_date` | Utf8 | Start date filter (virtual, optional) |
+| `to_date` | Utf8 | End date filter (virtual, optional) |
+| `id` | Int64 | Unique annotation ID |
+| `date` | Utf8 | Annotation date (YYYY-MM-DD HH:mm:ss) |
+| `description` | Utf8 | Annotation text |
+| `user_id` | Int64 | ID of the annotation creator |
+| `user_first_name` | Utf8 | Creator first name |
+| `user_last_name` | Utf8 | Creator last name |
+
+**Optional filters:** `from_date`, `to_date` (YYYY-MM-DD format)
+
+---
+
+### annotation_tags
+
+Tags that have been added to annotations.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique tag ID |
+| `name` | Utf8 | Tag name |
+| `project_id` | Int64 | Project ID |
+| `has_annotations` | Boolean | Whether attached to any annotations |
+
+---
+
+### schemas
+
+All Lexicon schema entries (events and profile properties).
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | Event or property name |
+| `entity_type` | Utf8 | Entity type (event or profile) |
+| `description` | Utf8 | Human-readable description |
+| `schema_json` | Json | Full schema definition |
+
+---
+
+### event_schemas
+
+Lexicon schemas filtered to event entities only.
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | Event name |
+| `entity_type` | Utf8 | Entity type (always event) |
+| `description` | Utf8 | Event description |
+| `schema_json` | Json | Full event schema definition |
+
+---
+
+### profile_schemas
+
+Lexicon schemas filtered to profile entities only.
+
+| Column | Type | Description |
+|---|---|---|
+| `name` | Utf8 | Profile property name |
+| `entity_type` | Utf8 | Entity type (always profile) |
+| `description` | Utf8 | Property description |
+| `schema_json` | Json | Full profile schema definition |
+
+---
+
+### dashboards
+
+Dashboards defined in the project.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Int64 | Unique dashboard ID |
+| `title` | Utf8 | Dashboard title |
+| `description` | Utf8 | Dashboard description |
+| `creator_name` | Utf8 | Name of the dashboard creator |
+| `creator_email` | Utf8 | Email of the dashboard creator |
+| `creator_id` | Int64 | ID of the creator |
+| `is_private` | Boolean | Whether the dashboard is private |
+| `created` | Utf8 | Creation timestamp |
+| `last_modified` | Utf8 | Last modification timestamp |
+
+## Example Queries
+
+```sql
+-- List all projects
+SELECT id, name, timezone
+FROM mixpanel.projects;
+
+-- List cohorts with user counts (requires paid plan)
+SELECT id, name, description, count
+FROM mixpanel.cohorts;
+
+-- View all annotations
+SELECT id, date, description, user_first_name, user_last_name
+FROM mixpanel.annotations;
+
+-- Annotations in a date range
+SELECT id, date, description
+FROM mixpanel.annotations
+WHERE from_date = '2024-01-01'
+  AND to_date = '2024-12-31';
+
+-- List annotation tags
+SELECT id, name, has_annotations
+FROM mixpanel.annotation_tags;
+
+-- Browse all Lexicon schemas
+SELECT name, entity_type, description
+FROM mixpanel.schemas;
+
+-- Event schemas only
+SELECT name, description
+FROM mixpanel.event_schemas;
+
+-- Profile property schemas
+SELECT name, description
+FROM mixpanel.profile_schemas;
+
+-- Dashboards
+SELECT id, title, creator_name, creator_email, is_private
+FROM mixpanel.dashboards;
+```
+
+## Pagination
+
+No endpoints in this source use pagination. All tables return complete
+result sets in a single request.
+
+## Notes
+
+- **Read-only**: This source is read-only; no create, update, or delete
+  operations.
+- **Data residency**: `MIXPANEL_BASE_URL` defaults to `https://mixpanel.com`
+  (US). For EU projects, use `https://eu.mixpanel.com`. For India projects,
+  use `https://in.mixpanel.com`.
+- **Paid plan required for cohorts**: The cohorts endpoint requires a paid
+  Mixpanel plan. Free-tier accounts will receive a 402 error.
+- **Service account permissions**: The service account must have at least
+  Analyst role on the project to read annotations and schemas.
+- **Rate limits**: The Query API has a limit of approximately 60 queries
+  per hour. Metadata endpoints (projects, schemas) have higher limits.
+- **Schemas response**: The `schema_json` column contains the full
+  Lexicon schema definition as a JSON value, which may include
+  `required_properties`, `metadata`, and `tags`.

--- a/sources/community/mixpanel/manifest.yaml
+++ b/sources/community/mixpanel/manifest.yaml
@@ -1,0 +1,533 @@
+name: mixpanel
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query projects, cohorts, annotations, annotation tags,
+  Lexicon schemas, and dashboards from Mixpanel.
+base_url: "{{input.MIXPANEL_BASE_URL}}"
+
+inputs:
+  MIXPANEL_BASE_URL:
+    kind: variable
+    default: https://mixpanel.com
+    hint: >-
+      Mixpanel API base URL. Use https://mixpanel.com for US,
+      https://eu.mixpanel.com for EU, or https://in.mixpanel.com
+      for India projects.
+  MIXPANEL_SERVICE_ACCOUNT_USERNAME:
+    kind: secret
+    hint: >-
+      Service account username. Create one from Organization Settings >
+      Service Accounts in the Mixpanel dashboard.
+  MIXPANEL_SERVICE_ACCOUNT_SECRET:
+    kind: secret
+    hint: >-
+      Service account secret (password). Generated alongside the
+      service account username. Keep this value secure.
+  MIXPANEL_PROJECT_ID:
+    kind: variable
+    hint: >-
+      Numeric Mixpanel project ID. Find it in Project Settings >
+      Overview in the Mixpanel dashboard (e.g. 1234567).
+
+auth:
+  type: BasicAuth
+  username: "{{input.MIXPANEL_SERVICE_ACCOUNT_USERNAME}}"
+  password: "{{input.MIXPANEL_SERVICE_ACCOUNT_SECRET}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - >-
+    SELECT id, name
+    FROM mixpanel.projects
+    LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # projects
+  # ──────────────────────────────────────────────────────────────────────
+  - name: projects
+    description: >-
+      Projects accessible by the authenticated service account.
+    guide: >
+      Start here to discover project IDs.
+      `SELECT id, name FROM mixpanel.projects`.
+    request:
+      method: GET
+      path: /api/app/projects
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique project ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Project display name.
+        expr:
+          kind: path
+          path: [name]
+      - name: timezone
+        type: Utf8
+        nullable: true
+        description: Project timezone.
+        expr:
+          kind: path
+          path: [timezone]
+      - name: token
+        type: Utf8
+        nullable: true
+        description: Project token (for client-side tracking).
+        expr:
+          kind: path
+          path: [token]
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Project creation timestamp.
+        expr:
+          kind: path
+          path: [created_at]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # cohorts  (requires paid Mixpanel plan)
+  # ──────────────────────────────────────────────────────────────────────
+  - name: cohorts
+    description: >-
+      Saved cohorts for the configured project with name,
+      description, and user count. Requires a paid Mixpanel plan.
+    guide: >
+      `SELECT id, name, description, count
+      FROM mixpanel.cohorts`.
+      Note: this endpoint requires a paid Mixpanel plan.
+    request:
+      method: GET
+      path: /api/2.0/cohorts/list
+      query:
+        - name: project_id
+          from: input
+          key: MIXPANEL_PROJECT_ID
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique cohort ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Cohort name.
+        expr:
+          kind: path
+          path: [name]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Cohort description.
+        expr:
+          kind: path
+          path: [description]
+      - name: count
+        type: Int64
+        nullable: true
+        description: Number of users in the cohort.
+        expr:
+          kind: path
+          path: [count]
+      - name: created
+        type: Utf8
+        nullable: true
+        description: Cohort creation date.
+        expr:
+          kind: path
+          path: [created]
+      - name: is_visible
+        type: Int64
+        nullable: true
+        description: Cohort visibility flag (0 if hidden, 1 if visible).
+        expr:
+          kind: path
+          path: [is_visible]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # annotations
+  # ──────────────────────────────────────────────────────────────────────
+  - name: annotations
+    description: >-
+      Project annotations marking significant events like
+      releases or campaigns. Optionally filter by date range.
+    guide: >
+      `SELECT id, date, description
+      FROM mixpanel.annotations`.
+      Optional date range:
+      `WHERE from_date = '2024-01-01'
+        AND to_date = '2024-12-31'`.
+    filters:
+      - name: from_date
+        required: false
+      - name: to_date
+        required: false
+    request:
+      method: GET
+      path: /api/app/projects/{{input.MIXPANEL_PROJECT_ID}}/annotations
+      query:
+        - name: from_date
+          from: filter
+          key: from_date
+        - name: to_date
+          from: filter
+          key: to_date
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: from_date
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Start date filter value (YYYY-MM-DD).
+        expr:
+          kind: from_filter
+          key: from_date
+      - name: to_date
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: End date filter value (YYYY-MM-DD).
+        expr:
+          kind: from_filter
+          key: to_date
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique annotation ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: date
+        type: Utf8
+        nullable: true
+        description: Annotation date (YYYY-MM-DD HH:mm:ss).
+        expr:
+          kind: path
+          path: [date]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Annotation text.
+        expr:
+          kind: path
+          path: [description]
+      - name: user_id
+        type: Int64
+        nullable: true
+        description: ID of the user who created the annotation.
+        expr:
+          kind: path
+          path: [user, id]
+      - name: user_first_name
+        type: Utf8
+        nullable: true
+        description: First name of the annotation creator.
+        expr:
+          kind: path
+          path: [user, first_name]
+      - name: user_last_name
+        type: Utf8
+        nullable: true
+        description: Last name of the annotation creator.
+        expr:
+          kind: path
+          path: [user, last_name]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # annotation_tags
+  # ──────────────────────────────────────────────────────────────────────
+  - name: annotation_tags
+    description: >-
+      Tags that have been added to annotations in the project.
+    guide: >
+      `SELECT id, name, has_annotations
+      FROM mixpanel.annotation_tags`.
+    request:
+      method: GET
+      path: /api/app/projects/{{input.MIXPANEL_PROJECT_ID}}/annotations/tags
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique tag ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Tag name.
+        expr:
+          kind: path
+          path: [name]
+      - name: project_id
+        type: Int64
+        nullable: true
+        description: Project ID this tag belongs to.
+        expr:
+          kind: path
+          path: [project_id]
+      - name: has_annotations
+        type: Boolean
+        nullable: true
+        description: Whether this tag is attached to any annotations.
+        expr:
+          kind: path
+          path: [has_annotations]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # schemas
+  # ──────────────────────────────────────────────────────────────────────
+  - name: schemas
+    description: >-
+      Lexicon schema entries (events and profile properties)
+      for the configured project.
+    guide: >
+      `SELECT name, entity_type, description
+      FROM mixpanel.schemas`.
+    request:
+      method: GET
+      path: /api/app/projects/{{input.MIXPANEL_PROJECT_ID}}/schemas
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Event or property name.
+        expr:
+          kind: path
+          path: [name]
+      - name: entity_type
+        type: Utf8
+        nullable: true
+        description: Entity type (event or profile).
+        expr:
+          kind: path
+          path: [entityType]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Human-readable description.
+        expr:
+          kind: path
+          path: [description]
+      - name: schema_json
+        type: Json
+        nullable: true
+        description: Full schema definition as JSON.
+        expr:
+          kind: path
+          path: [schemaJson]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # event_schemas
+  # ──────────────────────────────────────────────────────────────────────
+  - name: event_schemas
+    description: >-
+      Lexicon schemas filtered to event-type entities only.
+    guide: >
+      `SELECT name, description FROM mixpanel.event_schemas`.
+    request:
+      method: GET
+      path: /api/app/projects/{{input.MIXPANEL_PROJECT_ID}}/schemas/event
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Event name.
+        expr:
+          kind: path
+          path: [name]
+      - name: entity_type
+        type: Utf8
+        nullable: true
+        description: Entity type (always event).
+        expr:
+          kind: path
+          path: [entityType]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Event description.
+        expr:
+          kind: path
+          path: [description]
+      - name: schema_json
+        type: Json
+        nullable: true
+        description: Full event schema definition.
+        expr:
+          kind: path
+          path: [schemaJson]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # profile_schemas
+  # ──────────────────────────────────────────────────────────────────────
+  - name: profile_schemas
+    description: >-
+      Lexicon schemas filtered to profile-type entities only.
+    guide: >
+      `SELECT name, description
+      FROM mixpanel.profile_schemas`.
+    request:
+      method: GET
+      path: /api/app/projects/{{input.MIXPANEL_PROJECT_ID}}/schemas/profile
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Profile property name.
+        expr:
+          kind: path
+          path: [name]
+      - name: entity_type
+        type: Utf8
+        nullable: true
+        description: Entity type (always profile).
+        expr:
+          kind: path
+          path: [entityType]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Property description.
+        expr:
+          kind: path
+          path: [description]
+      - name: schema_json
+        type: Json
+        nullable: true
+        description: Full profile schema definition.
+        expr:
+          kind: path
+          path: [schemaJson]
+
+  # ──────────────────────────────────────────────────────────────────────
+  # dashboards
+  # ──────────────────────────────────────────────────────────────────────
+  - name: dashboards
+    description: >-
+      Dashboards defined in the project with title, creator,
+      and modification timestamps.
+    guide: >
+      `SELECT id, title, creator_name, created
+      FROM mixpanel.dashboards`.
+    request:
+      method: GET
+      path: /api/app/projects/{{input.MIXPANEL_PROJECT_ID}}/dashboards
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique dashboard ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Dashboard title.
+        expr:
+          kind: path
+          path: [title]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Dashboard description.
+        expr:
+          kind: path
+          path: [description]
+      - name: creator_name
+        type: Utf8
+        nullable: true
+        description: Name of the dashboard creator.
+        expr:
+          kind: path
+          path: [creator_name]
+      - name: creator_email
+        type: Utf8
+        nullable: true
+        description: Email of the dashboard creator.
+        expr:
+          kind: path
+          path: [creator_email]
+      - name: creator_id
+        type: Int64
+        nullable: true
+        description: ID of the user who created the dashboard.
+        expr:
+          kind: path
+          path: [creator_id]
+      - name: is_private
+        type: Boolean
+        nullable: true
+        description: Whether the dashboard is private.
+        expr:
+          kind: path
+          path: [is_private]
+      - name: created
+        type: Utf8
+        nullable: true
+        description: Creation timestamp.
+        expr:
+          kind: path
+          path: [created]
+      - name: last_modified
+        type: Utf8
+        nullable: true
+        description: Last modification timestamp.
+        expr:
+          kind: path
+          path: [last_modified]


### PR DESCRIPTION
## Summary

Adds a new community source for **Mixpanel** under `sources/community/mixpanel/`.

This source enables querying Mixpanel analytics metadata (projects, cohorts, annotations, annotation tags, Lexicon schemas, and dashboards) through SQL using the Mixpanel API. The source is manifest-only, read-only, and uses Coral's existing HTTP source-spec model with `BasicAuth`. No CLI, MCP, config, or runtime changes.

Closes #547 

## What changed

Added:

- `sources/community/mixpanel/manifest.yaml` (519 lines)
- `sources/community/mixpanel/README.md` (243 lines)

## Tables

| Table | Endpoint | Method | Pagination | Columns |
|---|---|---|---|---|
| `projects` | `/api/app/projects` | GET | none | 5 |
| `cohorts` | `/api/2.0/cohorts/list` | GET | none | 6 |
| `annotations` | `/api/app/projects/{id}/annotations` | GET | none | 8 |
| `annotation_tags` | `/api/app/projects/{id}/annotations/tags` | GET | none | 4 |
| `schemas` | `/api/app/projects/{id}/schemas` | GET | none | 4 |
| `event_schemas` | `/api/app/projects/{id}/schemas/event` | GET | none | 4 |
| `profile_schemas` | `/api/app/projects/{id}/schemas/profile` | GET | none | 4 |
| `dashboards` | `/api/app/projects/{id}/dashboards` | GET | none | 9 |

## Auth

HTTP Basic Auth with Mixpanel service account credentials.

Inputs:

- `MIXPANEL_SERVICE_ACCOUNT_USERNAME` — required secret. Service account username from Organization Settings.
- `MIXPANEL_SERVICE_ACCOUNT_SECRET` — required secret. Service account secret.
- `MIXPANEL_PROJECT_ID` — required variable. Numeric project ID from Project Settings.
- `MIXPANEL_BASE_URL` — variable with default `https://mixpanel.com`. Change for EU/India residency.

## Implementation notes

- **Response wrapper** — all Mixpanel API responses wrap arrays in `{status: "ok", results: [...]}`. The `projects` table uses `rows_path: [results]` (confirmed via live API — earlier assumption of `[projects]` key was incorrect).
- **Cohorts endpoint** — the cohorts API (`/api/2.0/cohorts/list`) requires a paid Mixpanel plan. Free-tier accounts receive a 402 error. The response is a direct JSON array (no wrapper), hence `row_strategy: direct`.
- **Annotation tags** — discovered via the Mixpanel OpenAPI spec at `GET /projects/{id}/annotations/tags`. Returns `{status, results: [...]}`.
- **Dashboards** — the field is `title` (not `name`), and includes `creator_name`, `creator_email`, `is_private`. Confirmed via live API.
- **Custom events removed** — `/api/app/projects/{id}/custom-events` returns 404; this endpoint does not exist in the public API. Removed from the source.
- **Annotations filters optional** — per the Mixpanel OpenAPI spec, `fromDate`/`toDate` are `required: false`. Filters are optional.
- **Data residency** — configurable via `MIXPANEL_BASE_URL` input with default `https://mixpanel.com`.

## Validation

- `coral source lint sources/community/mixpanel/manifest.yaml` — passes
- `coral source add` with real service account — 8 tables exposed, test query passes (1 row)
- **Live query validation — 7 of 8 tables queried successfully:**
  - `projects` — 1 project returned (id: 4024928, name: "Testing")
  - `schemas` — 1 schema returned (`$user` profile)
  - `profile_schemas` — 1 profile schema returned
  - `dashboards` — 1 dashboard returned (🌱 Starter Board, creator: Mixpanel)
  - `annotations`, `annotation_tags`, `event_schemas` — valid empty results
- **1 table returns expected 402:**
  - `cohorts` — "Your plan does not allow API calls" (requires paid plan)

## User-visible impact

New `mixpanel` source installable via:

```bash
export MIXPANEL_SERVICE_ACCOUNT_USERNAME="your-username"
export MIXPANEL_SERVICE_ACCOUNT_SECRET="your-secret"
export MIXPANEL_PROJECT_ID="1234567"
coral source add --file sources/community/mixpanel/manifest.yaml
```

Example queries:

```sql
-- List all projects
SELECT id, name, timezone FROM mixpanel.projects;

-- Browse Lexicon schemas
SELECT name, entity_type, description FROM mixpanel.schemas;

-- View dashboards
SELECT id, title, creator_name, is_private FROM mixpanel.dashboards;

-- Annotations with date range
SELECT id, date, description
FROM mixpanel.annotations
WHERE from_date = '2024-01-01' AND to_date = '2024-12-31';
```

## Known limitations

- **Read-only** — no create, update, or delete operations
- **Cohorts require paid plan** — free-tier Mixpanel accounts cannot access the cohorts API
- **No pagination** — all metadata endpoints return complete results in one request
- **No event export** — raw event data export uses NDJSON format and time-window filtering, not suited for this source model
- **No user profiles** — the Engage API uses POST with complex query syntax, not a simple GET
