### PR TITLE
feat(sources/community/google_calendar): add Google Calendar community source

### DIFF
--- a/sources/community/google_calendar/README.md
+++ b/sources/community/google_calendar/README.md
@@ -1,0 +1,204 @@
+# Google Calendar
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 3
+**Base URL:** `https://www.googleapis.com/calendar/v3`
+
+Query calendar lists, calendar metadata, and events from Google Calendar
+via the Google Calendar REST API v3.
+
+## Authentication
+
+Requires a `GOOGLE_CALENDAR_ACCESS_TOKEN`. This is an OAuth2 bearer access
+token scoped to `https://www.googleapis.com/auth/calendar.readonly`.
+
+Access tokens expire after approximately 1 hour. Re-run the appropriate
+command below to get a fresh token when needed.
+
+### Method A — Google Cloud CLI (recommended)
+
+If you have the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install)
+installed and authenticated:
+
+```bash
+gcloud auth login                          # first time only
+gcloud auth print-access-token            # copy the token printed here
+```
+
+Then install the source:
+
+```bash
+GOOGLE_CALENDAR_ACCESS_TOKEN=ya29.xxx \
+  coral source add --file sources/community/google_calendar/manifest.yaml
+```
+
+### Method B — OAuth2 Playground (no CLI required)
+
+1. Open <https://developers.google.com/oauthplayground>
+2. Under **Step 1**, paste this scope and click **Authorize APIs**:
+   ```
+   https://www.googleapis.com/auth/calendar.readonly
+   ```
+3. Sign in with your Google account and grant access.
+4. Under **Step 2**, click **Exchange authorization code for tokens**.
+5. Copy the **Access token** value (starts with `ya29.`).
+
+Then install the source:
+
+```bash
+GOOGLE_CALENDAR_ACCESS_TOKEN=ya29.xxx \
+  coral source add --file sources/community/google_calendar/manifest.yaml
+```
+
+Or interactively:
+
+```bash
+coral source add --file sources/community/google_calendar/manifest.yaml --interactive
+```
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `calendar_lists` | All calendars on the user's calendar list | — | — |
+| `calendars` | Metadata for a single calendar | `calendar_id` | — |
+| `events` | Events on a calendar | `calendar_id` | `time_min`, `time_max`, `single_events` |
+
+### `calendar_lists`
+
+Returns one row per calendar the authenticated user has on their list.
+Use the `id` column as the `calendar_id` filter on `calendars` and `events`.
+
+Key columns: `id`, `summary`, `time_zone`, `access_role`, `primary`, `selected`.
+
+### `calendars`
+
+Single-object lookup. Returns one row with metadata for the requested
+calendar. Use `primary` as the `calendar_id` to inspect the default calendar.
+
+Key columns: `id`, `summary`, `description`, `location`, `time_zone`.
+
+### `events`
+
+Returns events from the specified calendar. Without time filters the Google
+Calendar API returns events from approximately the past 6 months.
+
+Key columns: `id`, `summary`, `status`, `start__date_time`, `end__date_time`,
+`start__date`, `end__date`, `creator__email`, `organizer__email`, `attendees`,
+`recurring_event_id`, `html_link`.
+
+#### All-day vs timed events
+
+| Column | Timed events | All-day events |
+|---|---|---|
+| `start__date_time` | UTC Timestamp ✓ | NULL |
+| `start__date` | NULL | YYYY-MM-DD string ✓ |
+| `end__date_time` | UTC Timestamp ✓ | NULL |
+| `end__date` | NULL | YYYY-MM-DD string ✓ |
+
+#### `single_events` filter note
+
+Set `single_events = 'true'` to expand recurring event series into individual
+instances. Without this flag, only the master recurring event record is
+returned once. When enabled, results are ordered by `start__date_time`
+ascending by the API.
+
+## Quick start
+
+```bash
+# List all calendars — discover calendar IDs
+coral sql "SELECT id, summary, time_zone, access_role, primary FROM google_calendar.calendar_lists"
+
+# Inspect your primary calendar metadata
+coral sql "
+  SELECT id, summary, description, time_zone
+  FROM google_calendar.calendars
+  WHERE calendar_id = 'primary'
+"
+
+# Get the next 5 upcoming events on the primary calendar
+coral sql "
+  SELECT id, summary, status, start__date_time, end__date_time, location
+  FROM google_calendar.events
+  WHERE calendar_id = 'primary'
+    AND time_min = '$(date -u +%Y-%m-%dT%H:%M:%SZ)'
+    AND single_events = 'true'
+  LIMIT 5
+"
+
+# Find events with a specific keyword in the summary
+coral sql "
+  SELECT id, summary, start__date_time, organizer__email, html_link
+  FROM google_calendar.events
+  WHERE calendar_id = 'primary'
+    AND single_events = 'true'
+  LIMIT 50
+" | grep -i 'standup'
+
+# Get all events in a time range
+coral sql "
+  SELECT id, summary, start__date_time, end__date_time,
+         organizer__email, status
+  FROM google_calendar.events
+  WHERE calendar_id = 'primary'
+    AND time_min = '2026-05-01T00:00:00Z'
+    AND time_max = '2026-05-31T23:59:59Z'
+    AND single_events = 'true'
+  ORDER BY start__date_time
+"
+
+# Count events per organizer this month
+coral sql "
+  SELECT organizer__email, COUNT(*) AS event_count
+  FROM google_calendar.events
+  WHERE calendar_id = 'primary'
+    AND time_min = '2026-05-01T00:00:00Z'
+    AND time_max = '2026-05-31T23:59:59Z'
+    AND single_events = 'true'
+  GROUP BY organizer__email
+  ORDER BY event_count DESC
+"
+
+# List all-day events (no start__date_time)
+coral sql "
+  SELECT id, summary, start__date, end__date
+  FROM google_calendar.events
+  WHERE calendar_id = 'primary'
+    AND single_events = 'true'
+    AND start__date_time IS NULL
+  LIMIT 20
+"
+
+# Expand recurring events into individual instances
+coral sql "
+  SELECT id, summary, recurring_event_id, start__date_time
+  FROM google_calendar.events
+  WHERE calendar_id = 'primary'
+    AND time_min = '2026-05-01T00:00:00Z'
+    AND single_events = 'true'
+  ORDER BY start__date_time
+  LIMIT 20
+"
+```
+
+## Discovery order
+
+```text
+calendar_lists
+  → id (calendar_id)
+    → calendars (WHERE calendar_id = '...')
+    → events    (WHERE calendar_id = '...')
+
+events
+  → recurring_event_id  — groups instances of a recurring series
+  → i_cal_uid           — stable cross-calendar deduplication key
+  → attendees (JSON)    — parse with json_get_str for individual attendee data
+```
+
+## API reference
+
+- [Google Calendar REST API v3](https://developers.google.com/calendar/api/v3/reference)
+- [Events: list](https://developers.google.com/calendar/api/v3/reference/events/list)
+- [CalendarList: list](https://developers.google.com/calendar/api/v3/reference/calendarList/list)
+- [Calendars: get](https://developers.google.com/calendar/api/v3/reference/calendars/get)

--- a/sources/community/google_calendar/manifest.yaml
+++ b/sources/community/google_calendar/manifest.yaml
@@ -1,0 +1,607 @@
+name: google_calendar
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query calendar lists, calendar metadata, and events from Google Calendar
+  via the Google Calendar REST API v3.
+base_url: https://www.googleapis.com/calendar/v3
+inputs:
+  GOOGLE_CALENDAR_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      OAuth2 bearer access token for the Google Calendar API.
+
+      Method A — Google Cloud CLI (recommended):
+        gcloud auth print-access-token
+
+      Method B — OAuth2 Playground (no CLI required):
+        1. Go to https://developers.google.com/oauthplayground
+        2. Under "Step 1", enter scope:
+             https://www.googleapis.com/auth/calendar.readonly
+        3. Click "Authorize APIs" and sign in with your Google account.
+        4. Under "Step 2", click "Exchange authorization code for tokens".
+        5. Copy the "Access token" value.
+
+      Note: access tokens expire after ~1 hour. Re-run the command or
+      playground flow to get a fresh token when needed.
+  GOOGLE_CALENDAR_CALENDAR_ID:
+    kind: variable
+    default: primary
+    hint: |
+      Default calendar ID used when no calendar_id filter is supplied.
+      Use "primary" for the authenticated user's primary calendar.
+      Run `SELECT id FROM google_calendar.calendar_lists` to list all
+      available calendar IDs in the account.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.GOOGLE_CALENDAR_ACCESS_TOKEN}}
+test_queries:
+  - SELECT * FROM google_calendar.calendar_lists LIMIT 1
+  - SELECT id, summary, time_zone FROM google_calendar.calendars WHERE calendar_id = 'primary' LIMIT 1
+  - SELECT id, summary, start__date_time, end__date_time, status FROM google_calendar.events WHERE calendar_id = 'primary' LIMIT 5
+tables:
+  - name: calendar_lists
+    description: >-
+      All calendars on the authenticated user's calendar list. Each row is one
+      calendar entry. Use the `id` column as the `calendar_id` filter on the
+      `calendars` and `events` tables.
+    guide: |
+      Start here to discover all calendar IDs available to the authenticated
+      user. `primary = true` identifies the user's primary calendar.
+      `access_role` shows your permission level: `owner`, `writer`, `reader`,
+      or `freeBusyReader`.
+    request:
+      method: GET
+      path: /users/me/calendarList
+      query: []
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: cursor_query
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+      page_size:
+        default: 100
+        max: 250
+        query_param: maxResults
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Calendar ID. Use as the `calendar_id` filter on other tables.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: summary
+        type: Utf8
+        nullable: true
+        description: Title of the calendar.
+        expr:
+          kind: path
+          path:
+            - summary
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of the calendar.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: location
+        type: Utf8
+        nullable: true
+        description: Geographic location of the calendar as free-form text.
+        expr:
+          kind: path
+          path:
+            - location
+      - name: time_zone
+        type: Utf8
+        nullable: true
+        description: IANA time zone of the calendar (e.g. America/New_York).
+        expr:
+          kind: path
+          path:
+            - timeZone
+      - name: summary_override
+        type: Utf8
+        nullable: true
+        description: >-
+          Custom display name set by the user for this calendar on their list
+          (overrides the calendar's own summary).
+        expr:
+          kind: path
+          path:
+            - summaryOverride
+      - name: color_id
+        type: Utf8
+        nullable: true
+        description: Color ID referring to an entry in the calendar color list.
+        expr:
+          kind: path
+          path:
+            - colorId
+      - name: background_color
+        type: Utf8
+        nullable: true
+        description: "Background color of the calendar in hex format (e.g. #0d47a1)."
+        expr:
+          kind: path
+          path:
+            - backgroundColor
+      - name: foreground_color
+        type: Utf8
+        nullable: true
+        description: "Foreground color of the calendar in hex format (e.g. #ffffff)."
+        expr:
+          kind: path
+          path:
+            - foregroundColor
+      - name: access_role
+        type: Utf8
+        nullable: true
+        description: >-
+          Effective access role of the authenticated user on the calendar.
+          One of: owner, writer, reader, freeBusyReader.
+        expr:
+          kind: path
+          path:
+            - accessRole
+      - name: primary
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether this is the authenticated user's primary calendar.
+          True for exactly one row.
+        expr:
+          kind: path
+          path:
+            - primary
+      - name: selected
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether the calendar content is shown in the calendar UI.
+          True means the calendar is checked/visible.
+        expr:
+          kind: path
+          path:
+            - selected
+      - name: hidden
+        type: Boolean
+        nullable: true
+        description: Whether the calendar has been hidden from the list.
+        expr:
+          kind: path
+          path:
+            - hidden
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether the calendar has been deleted from the list. Deleted
+          calendars are normally omitted from responses.
+        expr:
+          kind: path
+          path:
+            - deleted
+
+  - name: calendars
+    description: >-
+      Metadata for a single calendar. Returns one row for the requested
+      calendar ID. Use `calendar_lists` to discover valid IDs first.
+    guide: |
+      Single-object lookup — always returns one row. Requires `calendar_id`.
+      Use `primary` as the `calendar_id` to inspect the authenticated user's
+      primary calendar without knowing its full ID.
+    filters:
+      - name: calendar_id
+        required: true
+    request:
+      method: GET
+      path: /calendars/{{filter.calendar_id}}
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: calendar_id
+        type: Utf8
+        nullable: false
+        description: Calendar ID passed as the filter.
+        expr:
+          kind: from_filter
+          key: calendar_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Calendar identifier returned by the API.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: summary
+        type: Utf8
+        nullable: true
+        description: Title of the calendar.
+        expr:
+          kind: path
+          path:
+            - summary
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of the calendar.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: location
+        type: Utf8
+        nullable: true
+        description: Geographic location of the calendar as free-form text.
+        expr:
+          kind: path
+          path:
+            - location
+      - name: time_zone
+        type: Utf8
+        nullable: true
+        description: IANA time zone of the calendar (e.g. America/New_York).
+        expr:
+          kind: path
+          path:
+            - timeZone
+
+  - name: events
+    description: >-
+      Events on a Google Calendar. Requires `calendar_id`. Use `time_min` and
+      `time_max` to scope the result window; without them the API returns
+      events from the past 6 months by default. Set `single_events = 'true'`
+      to expand recurring event instances into individual rows.
+    guide: |
+      Requires `calendar_id`. Use `primary` for the authenticated user's
+      primary calendar, or any ID from `google_calendar.calendar_lists`.
+
+      Time filters (`time_min`, `time_max`) accept RFC 3339 / ISO 8601
+      strings with a timezone offset, e.g. `2026-05-01T00:00:00Z`.
+
+      Set `single_events = 'true'` to expand recurring event series into
+      individual occurrences. Without this flag, only the master recurring
+      event is returned once. When `single_events` is true, results are
+      ordered by `start__date_time` ascending.
+
+      `start__date_time` is NULL for all-day events; use `start__date`
+      (a plain date string) for those rows instead.
+    filters:
+      - name: calendar_id
+        required: true
+      - name: time_min
+        required: false
+      - name: time_max
+        required: false
+      - name: single_events
+        required: false
+    request:
+      method: GET
+      path: /calendars/{{filter.calendar_id}}/events
+      query:
+        - name: timeMin
+          from: filter
+          key: time_min
+        - name: timeMax
+          from: filter
+          key: time_max
+        - name: singleEvents
+          from: filter
+          key: single_events
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: cursor_query
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+      page_size:
+        default: 250
+        max: 2500
+        query_param: maxResults
+    columns:
+      - name: calendar_id
+        type: Utf8
+        nullable: false
+        description: Calendar ID that was queried (echoed from filter).
+        expr:
+          kind: from_filter
+          key: calendar_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Opaque event identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: i_cal_uid
+        type: Utf8
+        nullable: true
+        description: >-
+          iCalendar UID for the event. Stable across calendar copies and
+          useful for deduplication across calendars.
+        expr:
+          kind: path
+          path:
+            - iCalUID
+      - name: summary
+        type: Utf8
+        nullable: true
+        description: Title / summary of the event.
+        expr:
+          kind: path
+          path:
+            - summary
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of the event (may contain HTML).
+        expr:
+          kind: path
+          path:
+            - description
+      - name: location
+        type: Utf8
+        nullable: true
+        description: Geographic location of the event as free-form text.
+        expr:
+          kind: path
+          path:
+            - location
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Confirmation status of the event.
+          One of: confirmed, tentative, cancelled.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: html_link
+        type: Utf8
+        nullable: true
+        description: URL to open the event in Google Calendar.
+        expr:
+          kind: path
+          path:
+            - htmlLink
+      - name: color_id
+        type: Utf8
+        nullable: true
+        description: Color ID of the event, overriding the calendar color.
+        expr:
+          kind: path
+          path:
+            - colorId
+      - name: start__date_time
+        type: Timestamp
+        nullable: true
+        description: >-
+          Start time of the event as a UTC Timestamp. NULL for all-day events
+          (use `start__date` instead).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - start
+              - dateTime
+      - name: start__date
+        type: Utf8
+        nullable: true
+        description: >-
+          Start date for all-day events (YYYY-MM-DD). NULL for timed events
+          (use `start__date_time` instead).
+        expr:
+          kind: path
+          path:
+            - start
+            - date
+      - name: start__time_zone
+        type: Utf8
+        nullable: true
+        description: IANA time zone in which `start__date_time` is specified.
+        expr:
+          kind: path
+          path:
+            - start
+            - timeZone
+      - name: end__date_time
+        type: Timestamp
+        nullable: true
+        description: >-
+          End time of the event as a UTC Timestamp. NULL for all-day events
+          (use `end__date` instead).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - end
+              - dateTime
+      - name: end__date
+        type: Utf8
+        nullable: true
+        description: >-
+          End date for all-day events (YYYY-MM-DD). NULL for timed events
+          (use `end__date_time` instead).
+        expr:
+          kind: path
+          path:
+            - end
+            - date
+      - name: end__time_zone
+        type: Utf8
+        nullable: true
+        description: IANA time zone in which `end__date_time` is specified.
+        expr:
+          kind: path
+          path:
+            - end
+            - timeZone
+      - name: recurring_event_id
+        type: Utf8
+        nullable: true
+        description: >-
+          ID of the recurring event master this instance belongs to.
+          NULL for non-recurring events.
+        expr:
+          kind: path
+          path:
+            - recurringEventId
+      - name: creator__email
+        type: Utf8
+        nullable: true
+        description: Email address of the event creator.
+        expr:
+          kind: path
+          path:
+            - creator
+            - email
+      - name: creator__display_name
+        type: Utf8
+        nullable: true
+        description: Display name of the event creator.
+        expr:
+          kind: path
+          path:
+            - creator
+            - displayName
+      - name: creator__self
+        type: Boolean
+        nullable: true
+        description: Whether the creator is the authenticated user.
+        expr:
+          kind: path
+          path:
+            - creator
+            - self
+      - name: organizer__email
+        type: Utf8
+        nullable: true
+        description: Email address of the event organizer.
+        expr:
+          kind: path
+          path:
+            - organizer
+            - email
+      - name: organizer__display_name
+        type: Utf8
+        nullable: true
+        description: Display name of the event organizer.
+        expr:
+          kind: path
+          path:
+            - organizer
+            - displayName
+      - name: organizer__self
+        type: Boolean
+        nullable: true
+        description: Whether the organizer is the authenticated user.
+        expr:
+          kind: path
+          path:
+            - organizer
+            - self
+      - name: attendees
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of attendees. Each object contains email, displayName,
+          responseStatus (needsAction, declined, tentative, accepted),
+          optional (boolean), and organizer (boolean).
+        expr:
+          kind: path
+          path:
+            - attendees
+      - name: conference_data
+        type: Json
+        nullable: true
+        description: >-
+          JSON object with conference details (e.g. Google Meet). Contains
+          entryPoints (uri, label, entryPointType) and conferenceSolution name.
+        expr:
+          kind: path
+          path:
+            - conferenceData
+      - name: reminders
+        type: Json
+        nullable: true
+        description: >-
+          JSON object describing reminder settings. Contains `useDefault`
+          (boolean) and optional `overrides` array of reminder objects.
+        expr:
+          kind: path
+          path:
+            - reminders
+      - name: created
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the event was created (UTC).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the event was last modified (UTC).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated
+      - name: time_min
+        type: Utf8
+        nullable: true
+        description: >-
+          Lower bound for event start time filter (ISO 8601 / RFC 3339),
+          e.g. 2026-05-01T00:00:00Z. Virtual — does not appear in event data.
+        expr:
+          kind: "null"
+        virtual: true
+      - name: time_max
+        type: Utf8
+        nullable: true
+        description: >-
+          Upper bound for event start time filter (ISO 8601 / RFC 3339),
+          e.g. 2026-06-01T00:00:00Z. Virtual — does not appear in event data.
+        expr:
+          kind: "null"
+        virtual: true
+      - name: single_events
+        type: Utf8
+        nullable: true
+        description: >-
+          Set to 'true' to expand recurring events into individual instances.
+          Virtual — does not appear in event data.
+        expr:
+          kind: from_filter
+          key: single_events
+        virtual: true


### PR DESCRIPTION
## Summary

Fixes #397

Add a new `google_calendar` community source that lets Coral query Google Calendar data through SQL. This makes calendar lists, calendar metadata, and events queryable via standard SQL — enabling personal planning agents, scheduling workflows, and cross-source joins with tools like Notion or Linear.

This change is manifest-only and uses Coral's existing HTTP source-spec model. It adds read-only Google Calendar visibility without changing CLI, MCP, config, runtime, or bundled-source contracts.

## What changed

Added:
- `sources/community/google_calendar/manifest.yaml`
- `sources/community/google_calendar/README.md`

## Source scope

Inputs:
- `GOOGLE_CALENDAR_ACCESS_TOKEN` — OAuth2 bearer token (secret)
- `GOOGLE_CALENDAR_CALENDAR_ID` — optional calendar selector, defaults to `primary`

Tables:
- `google_calendar.calendar_lists`
  - `GET /users/me/calendarList`
  - lists all calendars visible to the authenticated user
  - cursor pagination via `pageToken` / `nextPageToken`

- `google_calendar.calendars`
  - `GET /calendars/{calendar_id}`
  - requires `calendar_id` filter
  - returns single-row calendar metadata via `row_strategy: direct`

- `google_calendar.events`
  - `GET /calendars/{calendar_id}/events`
  - requires `calendar_id` filter
  - optional `time_min`, `time_max`, `single_events` filters
  - cursor pagination, up to 2500 results per page
  - flattens `start__date_time`, `end__date_time`, `creator__email`, `organizer__email` with double-underscore convention
  - keeps `attendees`, `conference_data`, `reminders` as `Json`

## Implementation notes

- uses Google Calendar API v3 bearer auth (`Authorization: Bearer <token>`)
- keeps v1 intentionally read-only
- `time_min` and `time_max` are `virtual: true` — consumed as query params, not in response body
- `single_events` echoes via `from_filter` following codebase convention
- ISO 8601 datetime fields use `format_timestamp: iso8601` for real `Timestamp` columns
- known limitation: OAuth2 access tokens expire ~1 hour; README documents two methods to obtain a token

## Validation

Local validation completed:
- `python3 -c "import yaml; doc=yaml.safe_load(open('sources/community/google_calendar/manifest.yaml')); print([t['name'] for t in doc['tables']])"` — passed
- YAML parses cleanly, all 3 tables confirmed, 3 test queries confirmed

## Out of scope

Not included in v1:
- event creation, updates, or deletion
- RSVP or attendee management  
- recurring event full expansion (use `event_instances` in a future PR)
- watch/webhook flows
- Google Tasks, Google Meet, or other Google Workspace sources
- write operations of any kind