### PR TITLE
ci: update zizmor action and fix workflow audit findings

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
           repositories: coral
 
       - name: Run release-please

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -23,6 +23,7 @@ jobs:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-issues: write
           permission-pull-requests: write
           repositories: coral
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
-          cache: npm
-          cache-dependency-path: ui/package-lock.json
+          package-manager-cache: false
       - name: Install UI dependencies
         if: steps.detect-ui.outputs.has-ui == 'true'
         run: npm ci --prefix ui
@@ -95,21 +94,27 @@ jobs:
           cargo install cargo-binstall --locked
           cargo binstall --no-confirm --force --disable-strategies compile cross@0.2.5
       - name: Build
+        env:
+          CROSS: ${{ matrix.cross }}
+          HAS_UI: ${{ needs.build-ui.outputs.has-ui }}
+          TARGET: ${{ matrix.target }}
         run: |
-          feature_args=""
-          if [ "${{ needs.build-ui.outputs.has-ui }}" = "true" ]; then
-            feature_args="--features embedded-ui"
+          feature_args=()
+          if [ "$HAS_UI" = "true" ]; then
+            feature_args=(--features embedded-ui)
           fi
 
-          if [ "${{ matrix.cross }}" = "true" ]; then
-            cross build --locked --release --target ${{ matrix.target }} $feature_args
+          if [ "$CROSS" = "true" ]; then
+            cross build --locked --release --target "$TARGET" "${feature_args[@]}"
           else
-            cargo build --locked --release --target ${{ matrix.target }} $feature_args
+            cargo build --locked --release --target "$TARGET" "${feature_args[@]}"
           fi
       - name: Package
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
-          archive="coral-${{ matrix.target }}.tar.gz"
-          cd "target/${{ matrix.target }}/release"
+          archive="coral-${TARGET}.tar.gz"
+          cd "target/${TARGET}/release"
           tar czf "../../../${archive}" coral
           cd ../../../
       - name: Upload artifact
@@ -160,6 +165,7 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
           repositories: |
             coral
             homebrew-tap

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -163,8 +163,9 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
         with:
+          version: v1.25.2
           annotations: ${{ github.event_name == 'pull_request' }}
           advanced-security: ${{ github.event_name != 'pull_request' }}
           min-severity: low


### PR DESCRIPTION
## Summary

- Update the CI zizmor action pin to the latest `zizmor-action` release and explicitly pin the supported `zizmor` version.
- Restrict GitHub App installation tokens to the permissions each workflow needs.
- Disable package-manager caching in release UI setup and avoid direct workflow-expression expansion inside release shell scripts.

zizmor run after the initial commit: https://github.com/withcoral/coral/actions/runs/26013857295/job/76459787551

## Why

The latest `zizmor` audit flagged release workflow risks around blanket GitHub App token permissions, release-time dependency caching, and shell template expansion. The action update also requires pinning the `zizmor` version explicitly so CI does not rely on the action default.

## Validation

- `git diff --check`
- `GH_TOKEN="$(gh auth token)" zizmor .`