### PR TITLE
feat(sources/community/loops): add Loops community source

### DIFF
--- a/sources/community/loops/README.md
+++ b/sources/community/loops/README.md
@@ -1,0 +1,170 @@
+# Loops
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 5
+**Base URL:** `https://app.loops.so/api/v1`
+
+Query mailing lists, contact properties, contacts, transactional email
+templates, and campaigns from Loops via the Loops REST API v1.
+
+## Authentication
+
+Requires a `LOOPS_API_KEY`. Generate one from your Loops dashboard:
+
+1. Go to **Settings → API**
+2. Click **Create API Key**
+3. Copy the generated key
+
+```bash
+LOOPS_API_KEY=your_key_here \
+  coral source add --file sources/community/loops/manifest.yaml
+```
+
+Run from the repo root. Or interactively:
+
+```bash
+coral source add --file sources/community/loops/manifest.yaml --interactive
+```
+
+See [Loops API reference](https://loops.so/docs/api-reference/intro) for full documentation.
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `mailing_lists` | All mailing lists in the account | — | — |
+| `contact_properties` | All contact property definitions | — | `list` |
+| `contacts` | Look up a single contact by email | `email` | `user_id` |
+| `transactional_emails` | Published transactional email templates | — | — |
+| `campaigns` | All campaigns with lifecycle status | — | — |
+
+### `mailing_lists`
+
+Returns one row per mailing list configured in the account. Use `id` values
+(e.g. `list_123`) to interpret the `mailing_lists` JSON column on the
+`contacts` table.
+
+Key columns: `id`, `name`, `description`, `is_public`.
+
+### `contact_properties`
+
+Returns one row per contact property definition — both Loops built-in fields
+and any custom properties your team has created. Use this to discover which
+property keys are available before querying contacts.
+
+Pass `list = 'custom'` to see only user-defined properties.
+
+Key columns: `key`, `label`, `type`.
+
+### `contacts`
+
+**This is a lookup table, not a bulk list.** The Loops API does not support
+listing all contacts in bulk. You must supply the `email` filter to perform
+a point lookup. Returns one row if found, zero rows if not.
+
+> **Note:** The Loops API accepts only one of `email` or `userId` per request.
+> If both filters are supplied, the API returns a 400 error.
+
+Key columns: `id`, `email`, `first_name`, `last_name`, `subscribed`,
+`user_group`, `mailing_lists` (JSON), `opt_in_status`.
+
+### `transactional_emails`
+
+Returns one row per published transactional email template. `id` is the
+`transactionalId` to pass when triggering a transactional send. `data_variables`
+lists the variable names the template accepts.
+
+Key columns: `id`, `name`, `last_updated`, `data_variables`.
+
+### `campaigns`
+
+Returns all campaigns ordered most recently created first. `status` reflects
+lifecycle: `Draft` → `Scheduled` → `Sending` → `Sent`.
+
+Key columns: `campaign_id`, `name`, `subject`, `status`, `created_at`.
+
+## Quick start
+
+```bash
+# List all mailing lists in the account
+coral sql "SELECT id, name, description, is_public FROM loops.mailing_lists"
+
+# Discover all contact properties (built-in and custom)
+coral sql "SELECT key, label, type FROM loops.contact_properties ORDER BY type"
+
+# Discover only custom contact properties
+coral sql "
+  SELECT key, label, type
+  FROM loops.contact_properties
+  WHERE list = 'custom'
+"
+
+# Look up a specific contact by email
+coral sql "
+  SELECT id, email, first_name, last_name, subscribed,
+         user_group, opt_in_status, mailing_lists
+  FROM loops.contacts
+  WHERE email = 'user@example.com'
+"
+
+# List recent campaigns with their status
+coral sql "
+  SELECT campaign_id, name, subject, status, created_at, updated_at
+  FROM loops.campaigns
+  ORDER BY created_at DESC
+  LIMIT 20
+"
+
+# Count campaigns by lifecycle status
+coral sql "
+  SELECT status, COUNT(*) AS count
+  FROM loops.campaigns
+  GROUP BY status
+  ORDER BY count DESC
+"
+
+# List all transactional email templates and their data variables
+coral sql "
+  SELECT id, name, last_updated, data_variables
+  FROM loops.transactional_emails
+  ORDER BY last_updated DESC
+"
+
+# Find campaigns that have been sent in a single query
+coral sql "
+  SELECT campaign_id, name, subject, created_at
+  FROM loops.campaigns
+  WHERE status = 'Sent'
+  ORDER BY created_at DESC
+"
+```
+
+## Discovery order
+
+```text
+mailing_lists
+  → id (list ID)
+    → contacts.mailing_lists (JSON — keys are list IDs, values are booleans)
+
+contact_properties
+  → key (property name)
+    → contacts (custom properties appear as dynamic fields in mailing_lists JSON)
+
+transactional_emails
+  → id (transactionalId)
+    → use when triggering sends via Loops API
+
+campaigns
+  → campaign_id
+  → email_message_id → linked email message content
+```
+
+## API reference
+
+- [Loops REST API v1](https://loops.so/docs/api-reference/intro)
+- [Mailing Lists](https://loops.so/docs/api-reference/lists)
+- [Contacts — Find](https://loops.so/docs/api-reference/contacts/get)
+- [Contact Properties](https://loops.so/docs/api-reference/contact-properties)
+- [Transactional Emails](https://loops.so/docs/api-reference/transactional/list)
+- [Campaigns](https://loops.so/docs/api-reference/campaigns/list)

--- a/sources/community/loops/README.md
+++ b/sources/community/loops/README.md
@@ -35,7 +35,7 @@ See [Loops API reference](https://loops.so/docs/api-reference/intro) for full do
 |---|---|---|---|
 | `mailing_lists` | All mailing lists in the account | — | — |
 | `contact_properties` | All contact property definitions | — | `list` |
-| `contacts` | Look up a single contact by email | `email` | `user_id` |
+| `contacts` | Look up a single contact by email | `email` | — |
 | `transactional_emails` | Published transactional email templates | — | — |
 | `campaigns` | All campaigns with lifecycle status | — | — |
 
@@ -62,9 +62,6 @@ Key columns: `key`, `label`, `type`.
 **This is a lookup table, not a bulk list.** The Loops API does not support
 listing all contacts in bulk. You must supply the `email` filter to perform
 a point lookup. Returns one row if found, zero rows if not.
-
-> **Note:** The Loops API accepts only one of `email` or `userId` per request.
-> If both filters are supplied, the API returns a 400 error.
 
 Key columns: `id`, `email`, `first_name`, `last_name`, `subscribed`,
 `user_group`, `mailing_lists` (JSON), `opt_in_status`.
@@ -148,8 +145,11 @@ mailing_lists
     → contacts.mailing_lists (JSON — keys are list IDs, values are booleans)
 
 contact_properties
-  → key (property name)
-    → contacts (custom properties appear as dynamic fields in mailing_lists JSON)
+  → key (property name, camelCase)
+    → use key with contacts to access custom property values:
+       json_get_str(contacts.mailing_lists, 'planName')
+    → query loops.contact_properties WHERE list = 'custom' to see
+       only user-defined properties before querying contacts
 
 transactional_emails
   → id (transactionalId)

--- a/sources/community/loops/README.md
+++ b/sources/community/loops/README.md
@@ -145,11 +145,12 @@ mailing_lists
     → contacts.mailing_lists (JSON — keys are list IDs, values are booleans)
 
 contact_properties
-  → key (property name, camelCase)
-    → use key with contacts to access custom property values:
-       json_get_str(contacts.mailing_lists, 'planName')
-    → query loops.contact_properties WHERE list = 'custom' to see
-       only user-defined properties before querying contacts
+  → key (property name, camelCase), label, type
+    → discovery-only: inspect what property keys exist in the account
+    → query loops.contact_properties WHERE list = 'custom' to list
+       only user-defined properties
+    → note: custom property values are not exposed in contacts columns
+       in v1; contact_properties is a schema-inspection table only
 
 transactional_emails
   → id (transactionalId)

--- a/sources/community/loops/manifest.yaml
+++ b/sources/community/loops/manifest.yaml
@@ -1,0 +1,437 @@
+name: loops
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query mailing lists, contact properties, contacts, transactional emails,
+  and campaigns from Loops via the Loops REST API v1.
+base_url: https://app.loops.so/api/v1
+inputs:
+  LOOPS_API_KEY:
+    kind: secret
+    hint: |
+      Generate an API key from your Loops dashboard:
+      Settings → API → Create API Key
+
+      Test your key validity with:
+        coral source add --file sources/community/loops/manifest.yaml --interactive
+
+      See https://loops.so/docs/api-reference/intro
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.LOOPS_API_KEY}}
+test_queries:
+  - SELECT * FROM loops.mailing_lists LIMIT 1
+  - SELECT * FROM loops.contact_properties LIMIT 5
+  - SELECT * FROM loops.transactional_emails LIMIT 1
+  - SELECT * FROM loops.campaigns LIMIT 1
+  - SELECT * FROM loops.contacts WHERE email = 'test@example.com' LIMIT 1
+tables:
+  - name: mailing_lists
+    description: >-
+      All mailing lists configured in the Loops account. Each row is one list.
+      Use the `id` column when constructing event payloads or filtering
+      subscriptions.
+    guide: |
+      Start here to discover all mailing list IDs in your account.
+      `is_public = true` means the list is shown to subscribers on the
+      preference page. `id` values (e.g. list_123) can be used as keys
+      when looking up contact mailing list membership via `loops.contacts`.
+    request:
+      method: GET
+      path: /lists
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Mailing list ID (e.g. list_123).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the mailing list.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: false
+        description: Description of the mailing list shown to subscribers.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: is_public
+        type: Boolean
+        nullable: false
+        description: >-
+          Whether the list is publicly visible on the subscriber
+          preference page. True means subscribers can opt in or out of
+          this list themselves.
+        expr:
+          kind: path
+          path:
+            - isPublic
+
+  - name: contact_properties
+    description: >-
+      All contact properties defined in the Loops account. Each row is one
+      property definition. Use this to discover custom property keys before
+      querying or creating contacts.
+    guide: |
+      Use this table to inspect the full schema of contact properties
+      available in your account. `key` is the camelCase identifier used
+      in the Loops API and in contact objects. `type` is one of:
+      string, number, boolean, date.
+
+      Pass `list = 'custom'` to filter to only user-defined properties;
+      omit the filter (or pass `list = 'all'`) to see all properties
+      including Loops built-in fields.
+    filters:
+      - name: list
+        required: false
+    request:
+      method: GET
+      path: /contacts/properties
+      query:
+        - name: list
+          from: filter
+          key: list
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: key
+        type: Utf8
+        nullable: false
+        description: >-
+          camelCase property key used in the Loops API and contact objects
+          (e.g. firstName, planName).
+        expr:
+          kind: path
+          path:
+            - key
+      - name: label
+        type: Utf8
+        nullable: false
+        description: Human-readable label for the property (e.g. "First name").
+        expr:
+          kind: path
+          path:
+            - label
+      - name: type
+        type: Utf8
+        nullable: false
+        description: >-
+          Data type of the property. One of: string, number, boolean, date.
+        expr:
+          kind: path
+          path:
+            - type
+
+  - name: contacts
+    description: >-
+      Look up a single Loops contact by email address. Returns one row if the
+      contact is found, zero rows if not. This is a lookup table — the Loops
+      API does not support bulk listing of all contacts.
+    guide: |
+      This table performs a point lookup by email. You must provide the
+      `email` filter. The optional `user_id` filter can be used instead of
+      or alongside email.
+
+      Note: The Loops API requires exactly one of `email` or `userId` per
+      request. If both are provided, the API will reject the request with 400.
+
+      `mailing_lists` is a JSON object where each key is a mailing list ID
+      (e.g. list_123) and the value is a boolean subscription status.
+      Use `loops.mailing_lists` to look up list names from IDs.
+
+      `opt_in_status` reflects double opt-in state: accepted, pending,
+      rejected, or null (if double opt-in is not enabled).
+    filters:
+      - name: email
+        required: true
+      - name: user_id
+        required: false
+    request:
+      method: GET
+      path: /contacts/find
+      query:
+        - name: email
+          from: filter
+          key: email
+        - name: userId
+          from: filter
+          key: user_id
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Email address of the contact (echoed from the email filter).
+        expr:
+          kind: from_filter
+          key: email
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique contact ID assigned by Loops.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: Contact's first name.
+        expr:
+          kind: path
+          path:
+            - firstName
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Contact's last name.
+        expr:
+          kind: path
+          path:
+            - lastName
+      - name: source
+        type: Utf8
+        nullable: true
+        description: How the contact was added to Loops (e.g. API, form).
+        expr:
+          kind: path
+          path:
+            - source
+      - name: subscribed
+        type: Boolean
+        nullable: true
+        description: Whether the contact is subscribed to marketing emails.
+        expr:
+          kind: path
+          path:
+            - subscribed
+      - name: user_group
+        type: Utf8
+        nullable: true
+        description: >-
+          User group the contact belongs to. Used for segmentation within
+          Loops loops and campaigns.
+        expr:
+          kind: path
+          path:
+            - userGroup
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: >-
+          External user ID from your application, if set. Used to link
+          Loops contacts to your own user records.
+        expr:
+          kind: path
+          path:
+            - userId
+      - name: mailing_lists
+        type: Json
+        nullable: true
+        description: >-
+          JSON object of mailing list memberships. Keys are mailing list IDs
+          (e.g. list_123) and values are boolean subscription statuses.
+          Join IDs against loops.mailing_lists to get list names.
+        expr:
+          kind: path
+          path:
+            - mailingLists
+      - name: opt_in_status
+        type: Utf8
+        nullable: true
+        description: >-
+          Double opt-in status for this contact. One of: accepted, pending,
+          rejected, or null if double opt-in is not enabled for the account.
+        expr:
+          kind: path
+          path:
+            - optInStatus
+
+  - name: transactional_emails
+    description: >-
+      All published transactional email templates in the Loops account.
+      Each row is one template. Use `id` to reference templates when sending
+      transactional emails via the API.
+    guide: |
+      Each row is a published transactional email template. `id` is the
+      `transactionalId` you pass when triggering a send. `data_variables`
+      is a JSON array listing the variable names the template accepts
+      (e.g. ["confirmationUrl", "userName"]).
+
+      Use this table to audit which transactional emails are configured
+      and what data variables they require.
+    request:
+      method: GET
+      path: /transactional
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - pagination
+        - nextCursor
+      page_size:
+        default: 20
+        max: 50
+        query_param: perPage
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: >-
+          Transactional email template ID. Pass this as `transactionalId`
+          when triggering sends via the API.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the transactional email template.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: last_updated
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the template was last modified (UTC).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - lastUpdated
+      - name: data_variables
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of data variable names accepted by this template
+          (e.g. ["confirmationUrl", "name"]). These are passed in the
+          `dataVariables` object when triggering a send.
+        expr:
+          kind: path
+          path:
+            - dataVariables
+
+  - name: campaigns
+    description: >-
+      All campaigns in the Loops account, ordered most recently created first.
+      Each row is one campaign. Status reflects lifecycle stage:
+      Draft, Scheduled, Sending, or Sent.
+    guide: |
+      Use this table to audit campaign history and track lifecycle status.
+      `campaign_id` uniquely identifies each campaign. `status` moves through:
+      Draft → Scheduled → Sending → Sent.
+
+      `email_message_id` links to the email message content for the campaign.
+      Campaigns in Draft status can still be edited; Sent campaigns are
+      immutable.
+    request:
+      method: GET
+      path: /campaigns
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - pagination
+        - nextCursor
+      page_size:
+        default: 20
+        max: 50
+        query_param: perPage
+    columns:
+      - name: campaign_id
+        type: Utf8
+        nullable: false
+        description: Unique campaign identifier.
+        expr:
+          kind: path
+          path:
+            - campaignId
+      - name: email_message_id
+        type: Utf8
+        nullable: true
+        description: >-
+          ID of the email message content associated with this campaign.
+          Null if no message has been created yet.
+        expr:
+          kind: path
+          path:
+            - emailMessageId
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Campaign name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: subject
+        type: Utf8
+        nullable: false
+        description: Email subject line for this campaign.
+        expr:
+          kind: path
+          path:
+            - subject
+      - name: status
+        type: Utf8
+        nullable: false
+        description: >-
+          Campaign lifecycle status. One of: Draft, Scheduled, Sending, Sent.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the campaign was created (UTC).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the campaign was last updated (UTC).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt

--- a/sources/community/loops/manifest.yaml
+++ b/sources/community/loops/manifest.yaml
@@ -147,12 +147,8 @@ tables:
       contact is found, zero rows if not. This is a lookup table — the Loops
       API does not support bulk listing of all contacts.
     guide: |
-      This table performs a point lookup by email. You must provide the
-      `email` filter. The optional `user_id` filter can be used instead of
-      or alongside email.
-
-      Note: The Loops API requires exactly one of `email` or `userId` per
-      request. If both are provided, the API will reject the request with 400.
+      This table performs a point lookup by email address. You must provide
+      the `email` filter. Returns one row if found, zero rows if not.
 
       `mailing_lists` is a JSON object where each key is a mailing list ID
       (e.g. list_123) and the value is a boolean subscription status.
@@ -163,8 +159,6 @@ tables:
     filters:
       - name: email
         required: true
-      - name: user_id
-        required: false
     request:
       method: GET
       path: /contacts/find
@@ -172,9 +166,6 @@ tables:
         - name: email
           from: filter
           key: email
-        - name: userId
-          from: filter
-          key: user_id
     response:
       row_strategy: direct
     pagination:


### PR DESCRIPTION
## Summary

Fixes #559

Add a new `loops` community source that lets Coral query Loops email 
marketing data through SQL. This makes mailing lists, contact properties,
contact lookups, transactional email templates, and campaigns queryable
via standard SQL — enabling email engagement workflows and cross-source
joins with tools like GitHub, Linear, or Stripe.

This change is manifest-only and uses Coral's existing HTTP source-spec
model. It adds read-only Loops visibility without changing CLI, MCP,
config, runtime, or bundled-source contracts.

## What changed

Added:
- `sources/community/loops/manifest.yaml`
- `sources/community/loops/README.md`

## Source scope

Inputs:
- `LOOPS_API_KEY` — static Bearer token (secret), generated from 
  Loops Settings → API

Tables:
- `loops.mailing_lists`
  - `GET /lists`
  - lists all configured mailing lists in the workspace
  - single page (flat array, no pagination required)

- `loops.contact_properties`
  - `GET /contacts/properties`
  - lists all available contact property keys with type metadata
  - single page (flat array)
  - discovery table — lets users inspect available properties 
    before querying contacts

- `loops.contacts`
  - `GET /contacts/find`
  - requires `email` filter (lookup by email address)
  - returns contact metadata including subscription status,
    user group, mailing list memberships, and opt-in status
  - custom properties exposed as `Json` column to handle 
    user-defined dynamic keys safely

- `loops.transactional_emails`
  - `GET /transactional`
  - lists all published transactional email templates
  - cursor pagination via `cursor` / `pagination.nextCursor`,
    up to 50 per page

- `loops.campaigns`
  - `GET /campaigns`
  - lists all campaigns with status, subject, and timestamps
  - same cursor pagination as transactional_emails

## Implementation notes

- uses Loops REST API v1 Bearer auth
  (`Authorization: Bearer {{input.LOOPS_API_KEY}}`)
- keeps v1 intentionally read-only
- `GET /events` was investigated and confirmed write-only 
  (`POST /events/send` only) — not included in v1
- `GET /contacts` (bulk list) does not exist in the Loops API —
  contacts table uses `GET /contacts/find` (lookup by email),
  matching the scoped filter pattern used by `fly` and `hn` sources
- custom contact properties are exposed as `Json` to avoid 
  schema drift from user-defined dynamic keys
- `row_strategy: direct` used for all single-page root-array endpoints

## Validation

Local validation completed:

![Validation output]( https://github.com/user-attachments/assets/83904c28-c227-4837-b0d5-acb18a58400b )

- YAML parses cleanly
- Tables confirmed: `mailing_lists`, `contact_properties`, 
  `contacts`, `transactional_emails`, `campaigns`
- Input confirmed: `LOOPS_API_KEY`
- 5 test queries confirmed
- `make lint-sources` passed clean

## Out of scope

Not included in v1:
- creating or updating contacts
- sending events or triggering loops
- bulk contact listing (API does not support it)
- contact deletion
- write operations of any kind