### PR TITLE
feat(ui): add resizable trace span detail panel

### DIFF
--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -136,40 +136,93 @@ export const spinner = style({ animation: `${spin} 1s linear infinite` })
 export const detailRoot = style({ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 })
 export const detailEmpty = style({ alignItems: 'center', display: 'flex', flex: 1, flexDirection: 'column', gap: 8, justifyContent: 'center', padding: 32, textAlign: 'center' })
 export const detailHeaderActions = style({ alignItems: 'center', display: 'flex', flexShrink: 0, gap: 4 })
-export const scrollBody = style({ flex: 1, minHeight: 0, overflow: 'auto' })
-export const content = style({ display: 'flex', flexDirection: 'column', gap: 16, padding: 16 })
+export const scrollBody = style({ display: 'flex', flex: 1, minHeight: 0, overflow: 'auto' })
+export const content = style({ display: 'flex', flex: 1, flexDirection: 'column', gap: 16, minHeight: '100%', padding: 16 })
 export const sqlBlock = style({ backgroundColor: theme.surface.main, border: `1px solid ${theme.stroke.primary}`, borderRadius: 8, overflow: 'hidden', position: 'relative' })
 export const statGrid = style({ display: 'flex', flexWrap: 'wrap', gap: 12 })
 export const statCard = style({ backgroundColor: theme.surface.onMainContent, border: `1px solid ${theme.stroke.secondary}`, borderRadius: 12, display: 'flex', flexDirection: 'column', flexShrink: 0, minWidth: 100, paddingBlock: 12, paddingInline: 16 })
 export const tabList = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, display: 'flex', gap: 4 })
 export const tabTrigger = style({ background: 'none', border: 'none', borderBlockEnd: '2px solid transparent', color: theme.content.tertiary, cursor: 'pointer', fontSize: 14, fontWeight: 500, lineHeight: 1.65, marginBlockEnd: -1, paddingBlock: 8, paddingInline: 12 })
 export const tabTriggerActive = style({ borderBlockEndColor: theme.pill.green.color, color: theme.content.primary })
-export const tabContent = style({ paddingBlockStart: 16 })
+export const tabContent = style({ display: 'flex', flex: '1 1 280px', flexDirection: 'column', minHeight: 280, overflow: 'hidden', paddingBlockStart: 16 })
 
 export const waterfallRoot = style({
   alignItems: 'stretch',
-  display: 'grid',
-  gridTemplateAreas: '"labelAxis timelineAxis" "labels timelineBody"',
-  gridTemplateColumns: '220px minmax(0, 1fr)',
-  gridTemplateRows: 'auto minmax(0, 1fr)',
-  minHeight: 'min(620px, calc(100vh - 360px))',
+  display: 'flex',
+  flex: 1,
+  gap: 8,
+  height: '100%',
+  minHeight: 280,
+  overflow: 'hidden',
   paddingBlock: 8,
   paddingInline: 12,
+})
+export const waterfallTimelinePane = style({
+  display: 'flex',
+  flex: '1 1 auto',
+  flexDirection: 'column',
+  minHeight: 0,
+  minWidth: 360,
+  overflow: 'hidden',
   rowGap: 10,
 })
 export const waterfallTickRow = style({
-  display: 'contents',
+  display: 'grid',
+  flexShrink: 0,
+  gridTemplateColumns: '220px minmax(0, 1fr)',
 })
-export const waterfallLabel = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, gridArea: 'labelAxis', height: 24, minWidth: 0, paddingBlockEnd: 4 })
-export const waterfallTimeline = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, gridArea: 'timelineAxis', height: 24, minWidth: 0, overflow: 'hidden', paddingBlockEnd: 4, position: 'relative' })
+export const waterfallLabel = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, height: 24, minWidth: 0, paddingBlockEnd: 4 })
+export const waterfallTimeline = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, height: 24, minWidth: 0, overflow: 'hidden', paddingBlockEnd: 4, position: 'relative' })
 export const waterfallTick = style({ color: theme.content.tertiary, fontFamily: codeFontFamily, fontSize: 12, lineHeight: '16px', position: 'absolute', whiteSpace: 'nowrap' })
-export const waterfallLabelsColumn = style({ display: 'flex', flexDirection: 'column', gap: 10, gridArea: 'labels', minWidth: 0 })
+export const waterfallResizeHandle = style({
+  alignSelf: 'stretch',
+  backgroundColor: theme.stroke.primary,
+  borderRadius: 999,
+  cursor: 'col-resize',
+  flex: '0 0 6px',
+  minHeight: 0,
+  outline: 'none',
+  opacity: 0,
+  transform: 'scaleX(0.5)',
+  transition: 'opacity 180ms ease, transform 180ms ease, background-color 120ms ease',
+  selectors: {
+    '&:hover, &:focus-visible': { backgroundColor: theme.pill.blue.color },
+    '&[data-open="true"]': { opacity: 1, transform: 'scaleX(1)' },
+    '&[data-resizing="true"]': { transition: 'none' },
+  },
+})
+export const waterfallSidePanel = style({
+  display: 'flex',
+  flex: '0 0 auto',
+  minHeight: 0,
+  minWidth: 320,
+  opacity: 0,
+  overflow: 'hidden',
+  transform: 'translateX(12px)',
+  transition: 'opacity 140ms ease, transform 180ms ease',
+  selectors: {
+    '&[data-open="true"]': { opacity: 1, transform: 'translateX(0)' },
+    '&[data-resizing="true"]': { transition: 'none' },
+  },
+})
+export const waterfallRowsViewport = style({
+  flex: 1,
+  minHeight: 0,
+  minWidth: 0,
+  overflow: 'auto',
+})
+export const waterfallRowsGrid = style({
+  alignItems: 'start',
+  display: 'grid',
+  gridTemplateColumns: '220px minmax(0, 1fr)',
+  minWidth: 0,
+})
+export const waterfallLabelsColumn = style({ display: 'flex', flexDirection: 'column', gap: 10, minWidth: 0 })
 export const waterfallTimelineBody = style({
   alignSelf: 'stretch',
   display: 'flex',
   flexDirection: 'column',
   gap: 10,
-  gridArea: 'timelineBody',
   minHeight: 0,
   minWidth: 0,
 })
@@ -295,9 +348,31 @@ export const waterfallHttpDetail = style({
   minHeight: 0,
   minWidth: 0,
   overflow: 'hidden',
-  paddingBlock: 10,
+})
+export const waterfallHttpDetailHeader = style({
+  alignItems: 'center',
+  borderBlockEnd: `1px solid ${theme.stroke.primary}`,
+  display: 'flex',
+  flexShrink: 0,
+  gap: 8,
+  justifyContent: 'space-between',
+  minWidth: 0,
+  paddingBlock: 6,
   paddingInline: 12,
 })
+export const waterfallHttpDetailTitle = style({
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+})
+export const waterfallHttpDetailHeaderActions = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
+  gap: 2,
+})
+export const waterfallHttpDetailScroll = style({ flex: 1, minHeight: 0, minWidth: 0, overflow: 'hidden' })
+export const waterfallHttpDetailContent = style({ display: 'flex', flexDirection: 'column', gap: 10, minHeight: 0, minWidth: 0, paddingBlockEnd: 10, paddingInline: 12 })
 export const waterfallHttpTabRow = style({ alignItems: 'center', display: 'flex', gap: 12, justifyContent: 'space-between', minWidth: 0 })
 export const httpMetaRow = style({ display: 'flex', flexWrap: 'wrap', gap: 6 })
 export const httpMetaChip = style({

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import classNames from 'classnames'
 
 import * as Button from '@/wax/components/button'
+import * as ScrollArea from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 import type { TraceSpan } from '@/generated/coral/v1/traces_pb'
 
@@ -118,7 +119,23 @@ function metaChip(label: string, value: React.ReactNode) {
   )
 }
 
-export function HttpSpanDetail({ span, traceStart }: { span: TraceSpan; traceStart: bigint }) {
+export function HttpSpanDetail({
+  canSelectNextSpan,
+  canSelectPreviousSpan,
+  onClose,
+  onSelectNextSpan,
+  onSelectPreviousSpan,
+  span,
+  traceStart,
+}: {
+  canSelectNextSpan: boolean
+  canSelectPreviousSpan: boolean
+  onClose: () => void
+  onSelectNextSpan: () => void
+  onSelectPreviousSpan: () => void
+  span: TraceSpan
+  traceStart: bigint
+}) {
   const [activeTab, setActiveTab] = useState<HttpDetailTab>('response')
   const [copyState, setCopyState] = useState<CopyKind | 'failed' | 'idle'>('idle')
   const attrs = parseJsonObject(span.attributesJson)
@@ -182,59 +199,94 @@ export function HttpSpanDetail({ span, traceStart }: { span: TraceSpan; traceSta
   }
 
   return (
-    <div className={s.waterfallHttpDetail} onClick={(event) => event.stopPropagation()}>
-      <div className={s.requestUrlRow}>
-        <Typography.CodeSmallInline as="span" className={s.methodBadge}>{spanOperation(span)}</Typography.CodeSmallInline>
-        <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>{url || 'No URL recorded'}</Typography.Body>
-      </div>
-      <div className={s.httpMetaRow}>
-        {statusCode && metaChip('Status', statusCode)}
-        {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}
-        {metaChip('Start', `+${formatDuration(offsetMs)}`)}
-        {requestId && metaChip('Request', `#${requestId}`)}
-        {attempt && metaChip('Attempt', attempt)}
-        {source && metaChip('Source', table ? `${source}.${table}` : source)}
-      </div>
-      <div className={s.waterfallHttpTabRow}>
-        <div className={s.tabList} role="tablist" aria-label="HTTP span details">
-          {tabs.map((tab) => (
-            <button
-              aria-controls={`http-detail-${span.spanId}-${tab.id}`}
-              aria-selected={activeTab === tab.id}
-              className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
-              id={`http-detail-tab-${span.spanId}-${tab.id}`}
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              role="tab"
-              type="button"
-            >
-              <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
-            </button>
-          ))}
+    <div className={s.waterfallHttpDetail} data-span-inspector="true" onClick={(event) => event.stopPropagation()}>
+      <div className={s.waterfallHttpDetailHeader}>
+        <div className={s.waterfallHttpDetailTitle}>
+          <Typography.BodySmallStrong as="span">Span details</Typography.BodySmallStrong>
+          <Typography.BodySmall as="span" variant="tertiary" truncate>{spanOperation(span)}</Typography.BodySmall>
         </div>
-        <div className={s.copyButtonGroup}>
-          {hasSeparateRawCopy && (
-            <Button.TextButton disabled={!rawCopyValue} onClick={() => copyValueToClipboard(rawCopyValue, 'raw')} size="22" variant="secondary">
-              {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
-            </Button.TextButton>
-          )}
-          <Button.TextButton disabled={!copyValue} onClick={() => copyValueToClipboard(copyValue, 'formatted')} size="22" variant="secondary">
-            {copyState === 'formatted' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy formatted'}
-          </Button.TextButton>
+        <div className={s.waterfallHttpDetailHeaderActions}>
+          <Button.IconButton
+            disabled={!canSelectPreviousSpan}
+            name="ArrowUp"
+            onClick={onSelectPreviousSpan}
+            size="32"
+            tooltipText="Previous span"
+            variant="bare"
+          />
+          <Button.IconButton
+            disabled={!canSelectNextSpan}
+            name="ArrowDown"
+            onClick={onSelectNextSpan}
+            size="32"
+            tooltipText="Next span"
+            variant="bare"
+          />
+          <Button.IconButton
+            name="X"
+            onClick={onClose}
+            size="32"
+            tooltipText="Close span details"
+            variant="bare"
+          />
         </div>
       </div>
-      <section
-        aria-labelledby={`http-detail-tab-${span.spanId}-${activeTab}`}
-        className={s.waterfallHttpDetailSection}
-        id={`http-detail-${span.spanId}-${activeTab}`}
-        role="tabpanel"
-      >
-        <DetailPre emptyText={activeEmptyText} value={activeValue} />
-      </section>
-      <details>
-        <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>
-        <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
-      </details>
+      <ScrollArea.Container className={s.waterfallHttpDetailScroll} constrainWidth fade="bottom" height="100%">
+        <div className={s.waterfallHttpDetailContent}>
+          <div className={s.requestUrlRow}>
+            <Typography.CodeSmallInline as="span" className={s.methodBadge}>{spanOperation(span)}</Typography.CodeSmallInline>
+            <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>{url || 'No URL recorded'}</Typography.Body>
+          </div>
+          <div className={s.httpMetaRow}>
+            {statusCode && metaChip('Status', statusCode)}
+            {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}
+            {metaChip('Start', `+${formatDuration(offsetMs)}`)}
+            {requestId && metaChip('Request', `#${requestId}`)}
+            {attempt && metaChip('Attempt', attempt)}
+            {source && metaChip('Source', table ? `${source}.${table}` : source)}
+          </div>
+          <div className={s.waterfallHttpTabRow}>
+            <div className={s.tabList} role="tablist" aria-label="HTTP span details">
+              {tabs.map((tab) => (
+                <button
+                  aria-controls={`http-detail-${span.spanId}-${tab.id}`}
+                  aria-selected={activeTab === tab.id}
+                  className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
+                  id={`http-detail-tab-${span.spanId}-${tab.id}`}
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  role="tab"
+                  type="button"
+                >
+                  <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
+                </button>
+              ))}
+            </div>
+            <div className={s.copyButtonGroup}>
+              {hasSeparateRawCopy && (
+                <Button.TextButton disabled={!rawCopyValue} onClick={() => copyValueToClipboard(rawCopyValue, 'raw')} size="22" variant="secondary">
+                  {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
+                </Button.TextButton>
+              )}
+              <Button.TextButton disabled={!copyValue} onClick={() => copyValueToClipboard(copyValue, 'formatted')} size="22" variant="secondary">
+                {copyState === 'formatted' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy formatted'}
+              </Button.TextButton>
+            </div>
+          </div>
+          <section
+            aria-labelledby={`http-detail-tab-${span.spanId}-${activeTab}`}
+            className={s.waterfallHttpDetailSection}
+            id={`http-detail-${span.spanId}-${activeTab}`}
+            role="tabpanel"
+          >
+            <DetailPre emptyText={activeEmptyText} value={activeValue} />
+          </section>
+          <details>
+            <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>
+            <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
+          </details>
+        </div>
+      </ScrollArea.Container>
     </div>
   )
 }

--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import classNames from 'classnames'
 
 import * as Button from '@/wax/components/button'
@@ -32,7 +32,16 @@ export type DetailTab = 'timeline' | 'api'
 type WaterfallTone = 'query' | 'http' | 'span' | 'error'
 
 const INDENT_PX = 14
+const DETAIL_PANEL_DEFAULT_RATIO = 0.4
+const DETAIL_PANEL_MIN_RATIO = 0.28
+const DETAIL_PANEL_MAX_RATIO = 0.6
+const DETAIL_PANEL_KEYBOARD_STEP = 0.05
+const DETAIL_PANEL_ANIMATION_MS = 180
 const NOISY_INTERNAL_SPAN_MAX_MS = 1
+
+function clampDetailPanelRatio(ratio: number) {
+  return Math.max(DETAIL_PANEL_MIN_RATIO, Math.min(DETAIL_PANEL_MAX_RATIO, ratio))
+}
 
 export interface ExtraDetailTab {
   id: string
@@ -108,6 +117,26 @@ function WaterfallBar({ left, tone, width, label }: { left: number; tone: Waterf
       </div>
       {narrow && <span className={s.waterfallBarLabelOutside} data-align={outsideLabelLeft > 86 ? 'end' : 'start'} style={outsideLabelStyle}>{label}</span>}
     </div>
+  )
+}
+
+function spanTiming(span: TraceSpan, traceStart: bigint, durationMs: number) {
+  const offsetMs = Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n)
+  return {
+    left: (Math.max(0, offsetMs) / durationMs) * 100,
+    width: (nanosToMs(span.durationNanos) / durationMs) * 100,
+  }
+}
+
+function SpanTimingBar({ durationMs, span, traceStart }: { durationMs: number; span: TraceSpan; traceStart: bigint }) {
+  const timing = spanTiming(span, traceStart, durationMs)
+  return (
+    <WaterfallBar
+      left={timing.left}
+      tone={spanTone(span)}
+      width={timing.width}
+      label={formatDurationFromNanos(span.durationNanos)}
+    />
   )
 }
 
@@ -205,10 +234,6 @@ function WaterfallBarSlot({
   traceStart: bigint
 }) {
   const { span } = row
-  const offsetMs = Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n)
-  const left = (Math.max(0, offsetMs) / durationMs) * 100
-  const width = (nanosToMs(span.durationNanos) / durationMs) * 100
-  const tone = spanTone(span)
   const canExpandHttp = isHttpSpan(span)
 
   return (
@@ -225,7 +250,7 @@ function WaterfallBarSlot({
       role={canExpandHttp ? 'button' : undefined}
       tabIndex={canExpandHttp ? 0 : undefined}
     >
-      <WaterfallBar left={left} tone={tone} width={width} label={formatDurationFromNanos(span.durationNanos)} />
+      <SpanTimingBar durationMs={durationMs} span={span} traceStart={traceStart} />
     </div>
   )
 }
@@ -259,6 +284,7 @@ function WaterfallRow({
       aria-expanded={childCount > 0 ? !collapsed : undefined}
       aria-level={depth + 1}
       className={s.waterfallRowShell}
+      data-span-row-id={span.spanId}
       role="treeitem"
     >
       <div
@@ -302,12 +328,135 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
   const proMode = useProMode()
   const timelineSpans = useMemo(() => proMode ? spans : spans.filter(isHttpSpan), [proMode, spans])
   const { collapsedSpanIds, rows, toggleSpan } = useTimelineTree(timelineSpans, summary?.rootSpanId, summary?.traceId)
+  const hasRenderedDetailPanel = useRef(false)
+  const panelAnimationFrame = useRef<number | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
   const [hoveredSpanId, setHoveredSpanId] = useState<string | null>(null)
+  const [detailPanelRatio, setDetailPanelRatio] = useState(DETAIL_PANEL_DEFAULT_RATIO)
+  const [animatedDetailPanelRatio, setAnimatedDetailPanelRatio] = useState(expandedHttpSpanId ? DETAIL_PANEL_DEFAULT_RATIO : 0)
+  const [isResizingDetailPanel, setIsResizingDetailPanel] = useState(false)
+  const [renderedHttpSpanId, setRenderedHttpSpanId] = useState<string | null>(expandedHttpSpanId)
+  const [detailPanelVisible, setDetailPanelVisible] = useState(Boolean(expandedHttpSpanId))
+  const [detailPanelSettled, setDetailPanelSettled] = useState(Boolean(expandedHttpSpanId))
   useEffect(() => onExpandedHttpSpanIdChange(null), [onExpandedHttpSpanIdChange, summary?.traceId])
   useEffect(() => setHoveredSpanId(null), [summary?.traceId])
+  useEffect(() => setDetailPanelRatio(DETAIL_PANEL_DEFAULT_RATIO), [summary?.traceId])
+  useEffect(() => {
+    if (panelAnimationFrame.current !== null) {
+      window.cancelAnimationFrame(panelAnimationFrame.current)
+      panelAnimationFrame.current = null
+    }
+
+    const animatePanelRatio = (from: number, to: number, onDone?: () => void) => {
+      const start = performance.now()
+      const step = (now: number) => {
+        const progress = Math.min(1, (now - start) / DETAIL_PANEL_ANIMATION_MS)
+        const eased = 1 - Math.pow(1 - progress, 3)
+        setAnimatedDetailPanelRatio(from + (to - from) * eased)
+        if (progress < 1) {
+          panelAnimationFrame.current = window.requestAnimationFrame(step)
+        } else {
+          panelAnimationFrame.current = null
+          onDone?.()
+        }
+      }
+      setAnimatedDetailPanelRatio(from)
+      panelAnimationFrame.current = window.requestAnimationFrame(step)
+    }
+
+    if (expandedHttpSpanId) {
+      const shouldAnimateOpen = !hasRenderedDetailPanel.current
+      hasRenderedDetailPanel.current = true
+      setRenderedHttpSpanId(expandedHttpSpanId)
+      if (!shouldAnimateOpen) {
+        setDetailPanelVisible(true)
+        setDetailPanelSettled(true)
+        setAnimatedDetailPanelRatio(detailPanelRatio)
+        return
+      }
+
+      setDetailPanelVisible(true)
+      setDetailPanelSettled(false)
+      animatePanelRatio(0, detailPanelRatio, () => setDetailPanelSettled(true))
+      return () => {
+        if (panelAnimationFrame.current !== null) window.cancelAnimationFrame(panelAnimationFrame.current)
+      }
+    }
+
+    hasRenderedDetailPanel.current = false
+    setDetailPanelVisible(false)
+    setDetailPanelSettled(false)
+    animatePanelRatio(animatedDetailPanelRatio, 0, () => setRenderedHttpSpanId(null))
+    return () => {
+      if (panelAnimationFrame.current !== null) window.cancelAnimationFrame(panelAnimationFrame.current)
+    }
+    // Keep the animation target stable during a single open/close transition.
+    // Drag resizing updates both detailPanelRatio and animatedDetailPanelRatio directly.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedHttpSpanId])
   useEffect(() => {
     onNavigableSpanIdsChange(rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId))
   }, [onNavigableSpanIdsChange, rows])
+  const traceStart = BigInt(summary?.startTimeUnixNanos || rows[0]?.span.startTimeUnixNanos || 0)
+  const durationMs = Math.max(nanosToMs(summary?.durationNanos || '0'), 1)
+  const navigableSpanIds = useMemo(() => rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId), [rows])
+  const renderedHttpSpanIndex = renderedHttpSpanId ? navigableSpanIds.indexOf(renderedHttpSpanId) : -1
+  const renderedHttpRow = rows.find((row) => row.span.spanId === renderedHttpSpanId)
+  const renderedHttpSpan = renderedHttpRow?.span
+
+  const selectAdjacentSpan = useCallback((direction: -1 | 1) => {
+    if (renderedHttpSpanIndex < 0) return
+    const nextSpanId = navigableSpanIds[renderedHttpSpanIndex + direction]
+    if (!nextSpanId) return
+    onExpandedHttpSpanIdChange(nextSpanId)
+    window.requestAnimationFrame(() => {
+      const escapedSpanId = nextSpanId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      document.querySelector(`[data-span-row-id="${escapedSpanId}"]`)?.scrollIntoView({ block: 'nearest' })
+    })
+  }, [renderedHttpSpanIndex, navigableSpanIds, onExpandedHttpSpanIdChange])
+
+  const resizeDetailPanel = useCallback((clientX: number) => {
+    const root = rootRef.current
+    if (!root) return
+    const rect = root.getBoundingClientRect()
+    const distanceFromRight = rect.right - clientX
+    const nextRatio = clampDetailPanelRatio(distanceFromRight / rect.width)
+    setDetailPanelRatio(nextRatio)
+    setAnimatedDetailPanelRatio(nextRatio)
+  }, [])
+
+  const handleResizePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setIsResizingDetailPanel(true)
+    event.currentTarget.setPointerCapture(event.pointerId)
+    resizeDetailPanel(event.clientX)
+  }, [resizeDetailPanel])
+
+  const handleResizePointerEnd = useCallback(() => {
+    setIsResizingDetailPanel(false)
+  }, [])
+
+  const handleResizePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+    resizeDetailPanel(event.clientX)
+  }, [resizeDetailPanel])
+
+  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault()
+      setDetailPanelRatio((ratio) => clampDetailPanelRatio(ratio + DETAIL_PANEL_KEYBOARD_STEP))
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault()
+      setDetailPanelRatio((ratio) => clampDetailPanelRatio(ratio - DETAIL_PANEL_KEYBOARD_STEP))
+    } else if (event.key === 'Home') {
+      event.preventDefault()
+      setDetailPanelRatio(DETAIL_PANEL_MIN_RATIO)
+    } else if (event.key === 'End') {
+      event.preventDefault()
+      setDetailPanelRatio(DETAIL_PANEL_MAX_RATIO)
+    }
+  }, [])
+
   if (rows.length === 0) {
     return (
       <EmptyState
@@ -316,57 +465,84 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
       />
     )
   }
-  const traceStart = BigInt(summary?.startTimeUnixNanos || rows[0]?.span.startTimeUnixNanos || 0)
-  const durationMs = Math.max(nanosToMs(summary?.durationNanos || '0'), 1)
-  const expandedHttpRow = rows.find((row) => row.span.spanId === expandedHttpSpanId)
-  const expandedHttpSpan = expandedHttpRow?.span
 
   return (
-    <div className={s.waterfallRoot} role="tree">
-      <WaterfallTickRow durationMs={durationMs} />
-      <div className={s.waterfallLabelsColumn}>
-        {rows.map((row) => (
-          <WaterfallRow
-            collapsed={collapsedSpanIds.has(row.span.spanId)}
-            expanded={expandedHttpSpanId === row.span.spanId}
-            hovered={hoveredSpanId === row.span.spanId}
-            key={row.span.spanId}
-            onHover={setHoveredSpanId}
-            onToggle={toggleSpan}
-            onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
-            row={row}
+    <div className={s.waterfallRoot} ref={rootRef}>
+      <div className={s.waterfallTimelinePane}>
+        <WaterfallTickRow durationMs={durationMs} />
+        <div className={s.waterfallRowsViewport} role="tree">
+          <div className={s.waterfallRowsGrid}>
+            <div className={s.waterfallLabelsColumn}>
+              {rows.map((row) => (
+                <WaterfallRow
+                  collapsed={collapsedSpanIds.has(row.span.spanId)}
+                  expanded={expandedHttpSpanId === row.span.spanId}
+                  hovered={hoveredSpanId === row.span.spanId}
+                  key={row.span.spanId}
+                  onHover={setHoveredSpanId}
+                  onToggle={toggleSpan}
+                  onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
+                  row={row}
+                />
+              ))}
+            </div>
+            <div className={s.waterfallTimelineBody}>
+              {rows.map((row) => (
+                <WaterfallBarSlot
+                  active={expandedHttpSpanId === row.span.spanId}
+                  durationMs={durationMs}
+                  hovered={hoveredSpanId === row.span.spanId}
+                  key={row.span.spanId}
+                  onHover={setHoveredSpanId}
+                  onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
+                  row={row}
+                  traceStart={traceStart}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      {renderedHttpSpan && (
+        <>
+          <div
+            aria-label="Resize span detail panel"
+            aria-orientation="vertical"
+            aria-valuemax={Math.round(DETAIL_PANEL_MAX_RATIO * 100)}
+            aria-valuemin={Math.round(DETAIL_PANEL_MIN_RATIO * 100)}
+            aria-valuenow={Math.round(detailPanelRatio * 100)}
+            className={s.waterfallResizeHandle}
+            data-open={detailPanelVisible || undefined}
+            data-resizing={isResizingDetailPanel || undefined}
+            onKeyDown={handleResizeKeyDown}
+            onLostPointerCapture={handleResizePointerEnd}
+            onPointerDown={handleResizePointerDown}
+            onPointerMove={handleResizePointerMove}
+            onPointerUp={handleResizePointerEnd}
+            role="separator"
+            tabIndex={0}
           />
-        ))}
-      </div>
-      <div className={s.waterfallTimelineBody}>
-        {expandedHttpRow && expandedHttpSpan ? (
-          <>
-            <WaterfallBarSlot
-              active
-              durationMs={durationMs}
-              hovered
-              key={`${expandedHttpSpan.spanId}-selected-bar`}
-              onHover={setHoveredSpanId}
-              onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
-              row={expandedHttpRow}
+          <aside
+            className={s.waterfallSidePanel}
+            data-open={detailPanelVisible || undefined}
+            data-resizing={isResizingDetailPanel || undefined}
+            style={{
+              flexBasis: `${animatedDetailPanelRatio * 100}%`,
+              minWidth: detailPanelSettled ? 320 : 0,
+            }}
+          >
+            <HttpSpanDetail
+              canSelectNextSpan={renderedHttpSpanIndex < navigableSpanIds.length - 1}
+              canSelectPreviousSpan={renderedHttpSpanIndex > 0}
+              onClose={() => onExpandedHttpSpanIdChange(null)}
+              onSelectNextSpan={() => selectAdjacentSpan(1)}
+              onSelectPreviousSpan={() => selectAdjacentSpan(-1)}
+              span={renderedHttpSpan}
               traceStart={traceStart}
             />
-            <HttpSpanDetail span={expandedHttpSpan} traceStart={traceStart} />
-          </>
-        ) : (
-          rows.map((row) => (
-            <WaterfallBarSlot
-              durationMs={durationMs}
-              hovered={hoveredSpanId === row.span.spanId}
-              key={row.span.spanId}
-              onHover={setHoveredSpanId}
-              onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
-              row={row}
-              traceStart={traceStart}
-            />
-          ))
-        )}
-      </div>
+          </aside>
+        </>
+      )}
     </div>
   )
 }
@@ -412,7 +588,12 @@ export function TraceDetail({
     if (!expandedHttpSpanId) return
     const currentIndex = navigableSpanIds.indexOf(expandedHttpSpanId)
     const nextSpanId = currentIndex >= 0 ? navigableSpanIds[currentIndex + direction] : null
-    if (nextSpanId) setExpandedHttpSpanId(nextSpanId)
+    if (!nextSpanId) return
+    setExpandedHttpSpanId(nextSpanId)
+    window.requestAnimationFrame(() => {
+      const escapedSpanId = nextSpanId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+      document.querySelector(`[data-span-row-id="${escapedSpanId}"]`)?.scrollIntoView({ block: 'nearest' })
+    })
   }, [expandedHttpSpanId, navigableSpanIds])
 
   const handleEscapeShortcut = useCallback((event: KeyboardEvent) => {
@@ -426,12 +607,14 @@ export function TraceDetail({
 
   const handlePreviousSpanShortcut = useCallback((event: KeyboardEvent) => {
     if (!expandedHttpSpanId) return
+    if (event.target instanceof HTMLElement && event.target.closest('[data-span-inspector="true"]')) return
     event.preventDefault()
     selectAdjacentSpan(-1)
   }, [expandedHttpSpanId, selectAdjacentSpan])
 
   const handleNextSpanShortcut = useCallback((event: KeyboardEvent) => {
     if (!expandedHttpSpanId) return
+    if (event.target instanceof HTMLElement && event.target.closest('[data-span-inspector="true"]')) return
     event.preventDefault()
     selectAdjacentSpan(1)
   }, [expandedHttpSpanId, selectAdjacentSpan])


### PR DESCRIPTION
Constraint: Opening and closing span details should feel smooth, but manual resize must stay immediate.
Rejected: CSS layout transitions on flex-basis and min-width | They fought the explicit ratio animation and caused an end-of-transition glitch.
Confidence: medium
Scope-risk: moderate
Directive: Keep layout animation driven by the panel ratio state; reserve CSS transitions for visual opacity/translate effects and disable transitions during drag resize.
Tested: npm run type-check --prefix ui; npm run build --prefix ui; playwright-cli opened a many-span trace and exercised open/close timing.
Not-tested: Full embedded-ui cargo smoke was not rerun for this UI-only branch.  
  
![image.png](https://app.graphite.com/user-attachments/assets/45da0d7f-65ff-43a8-9e3a-5ef5c2352f73.png)

![image.png](https://app.graphite.com/user-attachments/assets/3c17d153-9c23-4df7-af0d-959eb62d006b.png)



[trace-ui-side-panel-demo.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/7b0b5266-83a7-409f-92f1-ae641c804efc.mp4" />](https://app.graphite.com/user-attachments/video/7b0b5266-83a7-409f-92f1-ae641c804efc.mp4)