### PR TITLE
docs(plugins/coral): update skill discovery guidance

### DIFF
--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -66,8 +66,8 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
    - `coral source add` is non-interactive by default: each input `key` is read from the matching environment variable. Export required variables and secrets before running, or pass `--interactive` to be prompted.
    - repo sources or already-named sources: `coral source test <name>`
 6. Inspect the exposed shape:
-   - inspect `coral.tables`
-   - inspect `coral.columns`
+   - inspect `coral.tables` for visible tables, descriptions, guides, and required filters; keep metadata queries bounded with `LIMIT`/`OFFSET`
+   - inspect `coral.columns` for canonical column metadata, including `is_virtual` and `is_required_filter`; filter by one table or page large column sets
    - inspect `coral.inputs` to verify variables, secrets, defaults, hints, and required flags
 7. Query representative tables with `coral sql`.
 8. If you are relying on `coral source test`, make sure `test_queries` gives you a basic smoke/connection check for the source.
@@ -138,8 +138,9 @@ Use this loop during authoring:
 # or pass --interactive to be prompted.
 coral source lint ./my-source.yaml
 coral source add --file ./my-source.yaml
-coral sql "SELECT * FROM coral.tables WHERE schema_name = 'my_source'"
-coral sql "SELECT * FROM coral.columns WHERE schema_name = 'my_source'"
+coral source test my_source
+coral sql "SELECT schema_name, table_name, description, required_filters FROM coral.tables WHERE schema_name = 'my_source' ORDER BY schema_name, table_name LIMIT 50 OFFSET 0"
+coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, description FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
 coral sql "SELECT key, kind, value, default_value, hint, required, is_set FROM coral.inputs WHERE schema_name = 'my_source' ORDER BY key"
 ```
 

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -88,8 +88,9 @@ Use this loop while iterating:
 # default. Export them first, or pass `--interactive` to be prompted.
 coral source lint ./my-source.yaml
 coral source add --file ./my-source.yaml
-coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'my_source'"
-coral sql "SELECT table_name, column_name, is_required_filter FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, column_name"
+coral source test my_source
+coral sql "SELECT table_name, description, required_filters FROM coral.tables WHERE schema_name = 'my_source' ORDER BY table_name LIMIT 50 OFFSET 0"
+coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, description FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
 ```
 
 If the source is named or lives in the Coral repo, add representative `test_queries` for a basic smoke/connection check and run:

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -23,7 +23,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 ## Workflow
 
 1. Identify the needed source, entity, and scope from the user request.
-2. Discover tables with `list_tables`; page large catalogs and narrow by schema when useful.
+2. Discover tables with `list_tables`; page large catalogs and narrow by schema or topic when useful.
 3. Read `list_tables`, `coral://guide`, or `coral://tables` for `sql_reference`, `required_filters`, and examples.
 4. Inspect `coral.columns` for candidate columns, required filters, virtual columns, and descriptions.
 5. Inspect `coral.inputs` when source configuration affects the answer.
@@ -33,6 +33,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 ## Query Rules
 
 - Use each table's `sql_reference`; write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+- Keep metadata discovery bounded: page table discovery, query `coral.columns` for one table when possible, and add `LIMIT` when reading broad metadata directly.
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.
 - Required filters must appear in `WHERE`; inspect `required_filters` and `is_required_filter`.
 - Secret inputs always return `value = NULL`; use `is_set`.


### PR DESCRIPTION
Migrates withcoral/skills#13 into the canonical in-repo Coral skills tree.

## Summary
- Adds bounded metadata guidance for `coral.tables` and `coral.columns` source-authoring checks.
- Updates source validation loops to run `coral source test` and use paged metadata queries.
- Mirrors the bounded-discovery rule in the Coral skill's MCP-oriented workflow.

## Validation
- `git diff --check`
- `RUSTC_WRAPPER= cargo run --locked -p xtask -- export-skills --dest /private/tmp/coral-skills-export-source-459`
