### PR TITLE
docs(plugins/coral): clarify skill table references

### DIFF
--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -33,7 +33,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 
 ## Query Rules
 
-- Use each table's `sql_reference`; write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
+- Use each table's `sql_reference` when available. If building a reference from `schema_name` and `table_name`, write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Use each table function's `sql_call_example`, filling in required arguments before querying it.
 - Keep metadata discovery bounded: page catalog discovery, query `coral.columns` for one table or `coral.table_functions` for one source when possible, and add `LIMIT` when reading broad metadata directly.
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.


### PR DESCRIPTION
Migrates withcoral/skills#14 into the canonical in-repo Coral skills tree.

## Summary
- Clarifies that agents should use a table's `sql_reference` when available.
- Preserves the manual `schema_name` plus `table_name` guidance for cases where a SQL reference has to be assembled from metadata.
- Keeps the quoted-qualified-name warning close to the Coral skill query rules.

## Validation
- `git diff --check`
- `RUSTC_WRAPPER= cargo run --locked -p xtask -- export-skills --dest /private/tmp/coral-skills-export-source-507`
