### PR TITLE
feat(sources/community/weaviate): add Weaviate community source

### DIFF
--- a/sources/community/weaviate/README.md
+++ b/sources/community/weaviate/README.md
@@ -1,0 +1,124 @@
+# Weaviate
+
+Query Weaviate server metadata, collection (class) schema, and per-node
+cluster health and object counts from a self-hosted or Weaviate Cloud vector
+database, through the Weaviate REST API.
+
+## Setup
+
+### Requirements
+
+- Network access to a Weaviate REST endpoint (default port `8080`).
+- For API-key-protected clusters or Weaviate Cloud: a Weaviate API key.
+  For an instance with anonymous access enabled, no key is needed.
+
+### Add the Source
+
+Set the inputs as environment variables, then add the source from this
+manifest:
+
+```bash
+export WEAVIATE_URL=http://localhost:8080
+export WEAVIATE_API_KEY=        # leave empty for anonymous instances
+coral source add --file sources/community/weaviate/manifest.yaml
+```
+
+Inputs:
+
+- `WEAVIATE_URL` — base URL including scheme and port, e.g.
+  `http://localhost:8080` or `https://my-cluster.weaviate.network`.
+  No trailing slash.
+- `WEAVIATE_API_KEY` — API key sent as `Authorization: Bearer <key>`.
+  Leave empty for anonymous instances; the header is then omitted.
+
+## Tables
+
+### `meta`
+Single-row server metadata from `/v1/meta`.
+
+**Useful for:**
+- Connectivity checks and version reporting
+- Listing enabled modules
+
+### `collections`
+One row per collection (class) from `/v1/schema`.
+
+**Useful for:**
+- Inventorying collections and their vectorizer
+- Auditing vector index type and distance metric
+- Reviewing replication factor, shard count, and multi-tenancy
+
+### `nodes`
+Per-node cluster health and object counts from `/v1/nodes` (verbose).
+
+**Useful for:**
+- Node health monitoring (`status = 'HEALTHY'`)
+- Tracking total object and shard counts
+- Watching batch ingestion queue length and indexing status
+
+## Authentication
+
+Weaviate uses bearer-token API keys. This source sends:
+
+```text
+Authorization: Bearer <WEAVIATE_API_KEY>
+```
+
+When `WEAVIATE_API_KEY` is empty, the header is omitted entirely so the
+source works against instances with anonymous access enabled. Username /
+password and OIDC flows are not configured by this source.
+
+## Limits
+
+- This source is **read-only**. It exposes metadata, schema, and node
+  endpoints only — no vector search, object reads/writes, or schema
+  changes.
+- The table covering collections is named `collections` (Weaviate's current
+  term); the underlying REST endpoint is `/v1/schema` and still calls them
+  classes.
+- Nested structures (`modules`, `properties`, `shards`) are exposed as
+  `Json` columns; query them with the JSON accessor functions, e.g.
+  `json_length(properties)`.
+- No server-side filtering: filter with SQL `WHERE` after fetching.
+
+## Example Queries
+
+### Server version and modules
+
+```sql
+SELECT version, hostname, modules FROM weaviate.meta
+```
+
+### Collections with their vector configuration
+
+```sql
+SELECT name, vectorizer, vector_index_type, vector_distance,
+       shard_count, json_length(properties) AS property_count
+FROM weaviate.collections
+ORDER BY name
+```
+
+### Node health and object counts
+
+```sql
+SELECT name, status, version, object_count, shard_count,
+       batch_queue_length
+FROM weaviate.nodes
+ORDER BY name
+```
+
+### Unhealthy nodes
+
+```sql
+SELECT name, status, version
+FROM weaviate.nodes
+WHERE status <> 'HEALTHY'
+```
+
+## Notes
+
+- Verified against Weaviate 1.27. The `/v1/meta`, `/v1/schema`, and
+  `/v1/nodes` endpoints are stable across recent releases.
+- For per-object inspection or vector search, use a regular Weaviate client
+  — that is intentionally outside this source's read-only observability
+  scope.

--- a/sources/community/weaviate/manifest.yaml
+++ b/sources/community/weaviate/manifest.yaml
@@ -1,0 +1,277 @@
+name: weaviate
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Weaviate server metadata, collection (class) schema, and per-node
+  cluster health and object counts from a self-hosted or Weaviate Cloud
+  vector database.
+base_url: "{{input.WEAVIATE_URL}}"
+inputs:
+  WEAVIATE_URL:
+    kind: variable
+    default: http://localhost:8080
+    hint: |
+      Base URL of the Weaviate REST endpoint, including scheme and port.
+      The default `http://localhost:8080` matches a local Weaviate. For
+      Weaviate Cloud use the cluster URL, e.g.
+      `https://my-cluster.weaviate.network`. Do not include a trailing
+      slash.
+  WEAVIATE_API_KEY:
+    kind: variable
+    default: ""
+    hint: |
+      Weaviate API key sent as `Authorization: Bearer <key>`. Leave empty
+      for an instance with anonymous access enabled (the header is then
+      omitted). Set it for API-key-protected clusters and Weaviate Cloud,
+      where it is the cluster's admin or read API key.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.WEAVIATE_API_KEY}}"
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM weaviate.meta LIMIT 1
+  - SELECT * FROM weaviate.collections LIMIT 1
+tables:
+  - name: meta
+    description: Server metadata from the /v1/meta endpoint
+    guide: |
+      Returns a single row describing the Weaviate server. `modules` is a
+      JSON object of enabled modules and their configuration; it is `{}`
+      when no modules are enabled. Use this table to confirm connectivity
+      and report the running server version.
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /v1/meta
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: hostname
+        type: Utf8
+        nullable: true
+        description: Hostname the server reports for itself
+        expr:
+          kind: path
+          path:
+            - hostname
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Weaviate server version
+        expr:
+          kind: path
+          path:
+            - version
+      - name: modules
+        type: Json
+        nullable: true
+        description: Enabled modules and their configuration, as a JSON object
+        expr:
+          kind: path
+          path:
+            - modules
+
+  - name: collections
+    description: Collection (class) schema from the /v1/schema endpoint
+    guide: |
+      Returns one row per Weaviate collection (called a class in the REST
+      API). `vectorizer` is `none` for bring-your-own-vector collections.
+      `properties` is the full property definition list as a JSON array —
+      use `json_length(properties)` for a property count or JSON accessors
+      to inspect individual properties. `vector_distance` is the configured
+      similarity metric (e.g. `cosine`, `dot`, `l2-squared`).
+    request:
+      method: GET
+      path: /v1/schema
+    response:
+      rows_path:
+        - classes
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Collection name (the class name)
+        expr:
+          kind: path
+          path:
+            - class
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Collection description, when set
+        expr:
+          kind: path
+          path:
+            - description
+      - name: vectorizer
+        type: Utf8
+        nullable: true
+        description: "Configured vectorizer module, or `none` for self-supplied vectors"
+        expr:
+          kind: path
+          path:
+            - vectorizer
+      - name: vector_index_type
+        type: Utf8
+        nullable: true
+        description: "Vector index type, e.g. hnsw or flat"
+        expr:
+          kind: path
+          path:
+            - vectorIndexType
+      - name: vector_distance
+        type: Utf8
+        nullable: true
+        description: "Distance metric, e.g. cosine, dot, l2-squared"
+        expr:
+          kind: path
+          path:
+            - vectorIndexConfig
+            - distance
+      - name: replication_factor
+        type: Int64
+        nullable: true
+        description: Configured replication factor for the collection
+        expr:
+          kind: path
+          path:
+            - replicationConfig
+            - factor
+      - name: shard_count
+        type: Int64
+        nullable: true
+        description: Actual number of physical shards for the collection
+        expr:
+          kind: path
+          path:
+            - shardingConfig
+            - actualCount
+      - name: multi_tenancy_enabled
+        type: Boolean
+        nullable: true
+        description: Whether multi-tenancy is enabled for the collection
+        expr:
+          kind: path
+          path:
+            - multiTenancyConfig
+            - enabled
+      - name: properties
+        type: Json
+        nullable: true
+        description: Property definitions for the collection, as a JSON array
+        expr:
+          kind: path
+          path:
+            - properties
+
+  - name: nodes
+    description: Per-node cluster health and object counts from /v1/nodes
+    guide: |
+      Returns one row per Weaviate node (verbose output). `status` is
+      `HEALTHY` on a healthy node. `object_count` and `shard_count` are
+      cluster-wide totals reported by that node. `shards` is a JSON array
+      with per-shard detail including each shard's class, object count, and
+      `vectorIndexingStatus` (`READY` when indexing is caught up). Use this
+      to monitor ingestion progress and node health.
+    request:
+      method: GET
+      path: /v1/nodes
+      query:
+        - name: output
+          from: literal
+          value: verbose
+    response:
+      rows_path:
+        - nodes
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Node name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: "Node status, e.g. HEALTHY or UNHEALTHY"
+        expr:
+          kind: path
+          path:
+            - status
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Weaviate version running on the node
+        expr:
+          kind: path
+          path:
+            - version
+      - name: git_hash
+        type: Utf8
+        nullable: true
+        description: Git commit hash of the running build
+        expr:
+          kind: path
+          path:
+            - gitHash
+      - name: object_count
+        type: Int64
+        nullable: true
+        description: Total object count reported by this node
+        expr:
+          kind: path
+          path:
+            - stats
+            - objectCount
+      - name: shard_count
+        type: Int64
+        nullable: true
+        description: Total shard count reported by this node
+        expr:
+          kind: path
+          path:
+            - stats
+            - shardCount
+      - name: batch_queue_length
+        type: Int64
+        nullable: true
+        description: Current batch indexing queue length on the node
+        expr:
+          kind: path
+          path:
+            - batchStats
+            - queueLength
+      - name: batch_rate_per_second
+        type: Int64
+        nullable: true
+        description: Current batch indexing rate per second on the node
+        expr:
+          kind: path
+          path:
+            - batchStats
+            - ratePerSecond
+      - name: shards
+        type: Json
+        nullable: true
+        description: Per-shard detail (class, object count, indexing status) as a JSON array
+        expr:
+          kind: path
+          path:
+            - shards


### PR DESCRIPTION
Adds a read-only Weaviate community source. Closes #571.

Tables:
- meta        — server version, hostname, enabled modules
- collections — class schema: vectorizer, vector index type/distance,
                replication, shards, multi-tenancy, properties (JSON)
- nodes       — per-node status, version, object/shard counts, batch stats

Auth: optional API key via Authorization: Bearer. When the key is empty
the header is omitted, so anonymous instances work; set it for API-key
clusters and Weaviate Cloud. Scope is observability/schema only — no
vector search, object writes, or schema changes.

Two deliberate choices worth noting:
- The collections table is named `collections` (Weaviate's current term),
  not `schema` as in the issue — `schema` is SQL-fragile. The endpoint is
  still /v1/schema.
- WEAVIATE_API_KEY is a `variable` (default ""), not a `secret`. Coral
  cannot install a blank secret, which would break the anonymous mode the
  issue asks for. Variable + empty default is what enables the verified
  dual-mode.

Verified against Weaviate 1.27 in all three auth scenarios:

$ coral source test weaviate
  2 declared · 2 passed · 0 failed   (3 tables)

$ coral sql "SELECT version, hostname FROM weaviate.meta"
| 1.27.0 | http://[::]:8080 |

$ coral sql "SELECT name, vectorizer, vector_index_type, shard_count FROM weaviate.collections"
| Article | none | hnsw | 1 |

$ coral sql "SELECT name, status, object_count FROM weaviate.nodes"
| 94d867d4af56 | HEALTHY | 1 |

- anonymous instance + empty key → pass
- API-key instance + correct key → pass
- API-key instance + empty key → fails (proves the key is sent/omitted)

Repro:

docker run -d --name weaviate-coral -p 8090:8080 \
  -e AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
  -e DEFAULT_VECTORIZER_MODULE=none \
  cr.weaviate.io/semitechnologies/weaviate:1.27.0
WEAVIATE_URL=http://localhost:8090 WEAVIATE_API_KEY="" \
  coral source add --file sources/community/weaviate/manifest.yaml
coral source test weaviate

Demo video : 
[Screencast from 2026-05-18 18-10-33.webm](https://github.com/user-attachments/assets/fb0cec83-04ce-4e67-b683-d339a6ed5136)

