### PR TITLE
feat(sources/community/gmail): add Gmail community source

### DIFF
--- a/sources/community/gmail/README.md
+++ b/sources/community/gmail/README.md
@@ -1,0 +1,143 @@
+# Gmail
+
+**Version:** 1.0.0
+**Backend:** HTTP
+**Base URL:** `https://gmail.googleapis.com`
+
+Query Gmail labels, messages, threads, and message metadata as SQL tables. Search your inbox with Gmail's native search syntax, drill into individual messages, and join with other Coral sources for cross-source intelligence.
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|-------|-------------|-----------------|-----------------|
+| `gmail.labels` | Gmail system and user labels | none | none |
+| `gmail.messages` | Message search and list | none | `q`, `label_ids`, `max_results` |
+| `gmail.message_details` | Full metadata for one message | `message_id` | none |
+| `gmail.threads` | Gmail conversation threads | none | `q`, `label_ids` |
+| `gmail.thread_messages` | All messages inside one thread | `thread_id` | none |
+
+## Source-Scoped Table Functions
+
+| Function | Description |
+|----------|-------------|
+| `gmail.search_messages(q => '...')` | Pushes Gmail search syntax into the API and returns compact candidate IDs |
+| `gmail.get_message(message_id => '...')` | Fetches metadata for one message by ID |
+| `gmail.get_thread_messages(thread_id => '...')` | Expands one conversation into message rows |
+
+## Authentication
+
+Requires a `GOOGLE_ACCESS_TOKEN` with the `https://www.googleapis.com/auth/gmail.readonly` scope.
+
+**Quickest way to get a token (OAuth Playground):**
+
+1. Go to [developers.google.com/oauthplayground](https://developers.google.com/oauthplayground)
+2. Click the gear icon and check **Use your own OAuth credentials** — paste your Client ID and Secret
+3. Select the scope: `https://www.googleapis.com/auth/gmail.readonly`
+4. Click **Authorize APIs**, sign in, then **Exchange authorization code for tokens**
+5. Copy the **Access token**
+
+If you are connecting Gmail and Google Calendar together, authorize both scopes in the same flow:
+
+```
+https://www.googleapis.com/auth/gmail.readonly
+https://www.googleapis.com/auth/calendar.readonly
+```
+
+One token covers both connectors.
+
+**Using gcloud (recommended for daily use):**
+
+```bash
+gcloud auth login
+export GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token)
+```
+
+Access tokens expire after 1 hour. Re-run `gcloud auth print-access-token` to get a fresh one.
+
+## Install
+
+```bash
+coral source lint manifest.yaml
+coral source add --file manifest.yaml
+coral source test gmail
+```
+
+Or with the token inline:
+
+```bash
+GOOGLE_ACCESS_TOKEN=ya29.your-token coral source add --file manifest.yaml
+```
+
+## Example Queries
+
+List all labels:
+
+```sql
+SELECT id, name, type, messages_unread
+FROM gmail.labels
+ORDER BY name
+LIMIT 20;
+```
+
+Search recent unread messages:
+
+```sql
+SELECT id, thread_id
+FROM gmail.messages
+WHERE q = 'is:unread newer_than:7d'
+LIMIT 20;
+```
+
+Same search using a table function:
+
+```sql
+SELECT id, thread_id
+FROM gmail.search_messages(q => 'is:unread newer_than:7d')
+LIMIT 20;
+```
+
+Fetch metadata for one message:
+
+```sql
+SELECT subject, from_email, to_email, date, snippet
+FROM gmail.message_details
+WHERE message_id = 'MESSAGE_ID_HERE';
+```
+
+Expand one thread into rows:
+
+```sql
+SELECT subject, from_email, snippet, internal_datetime
+FROM gmail.thread_messages
+WHERE thread_id = 'THREAD_ID_HERE'
+ORDER BY internal_datetime ASC;
+```
+
+## Cross-Source JOIN Example
+
+Inbox pressure vs. meeting load in one query (requires `google_calendar` source also installed):
+
+```sql
+WITH urgent_emails AS (
+    SELECT COUNT(DISTINCT id) AS urgent_unread
+    FROM gmail.messages
+    WHERE q = 'is:unread (urgent OR deadline OR "due date") newer_than:30d'
+),
+meetings AS (
+    SELECT COUNT(DISTINCT id) AS meeting_count
+    FROM google_calendar.events_between(
+        calendar_id => 'primary',
+        time_min    => '2026-05-01T00:00:00Z',
+        time_max    => '2026-05-31T23:59:59Z'
+    )
+)
+SELECT urgent_unread, meeting_count
+FROM urgent_emails CROSS JOIN meetings;
+```
+
+## Notes
+
+- `gmail.messages` returns only `id` and `thread_id` from the list API. Use `gmail.message_details` or `gmail.get_message` to fetch subject, sender, and snippet for a specific message.
+- `allow_404_empty: true` is set on all single-item lookup tables — a missing or deleted message returns zero rows instead of an error.
+- Rate limiting is handled automatically via `rate_limit` config in the manifest.
+- Gmail timestamps (`internalDate`) are in milliseconds since epoch and are mapped to a `Timestamp` column via `format_timestamp`.

--- a/sources/community/gmail/manifest.yaml
+++ b/sources/community/gmail/manifest.yaml
@@ -1,0 +1,635 @@
+name: gmail
+version: 1.0.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Gmail messages, threads, and labels as SQL tables.
+  Search your inbox, find unread important emails, and join with
+  Notion tasks or Google Calendar events for personal intelligence.
+
+base_url: https://gmail.googleapis.com
+
+inputs:
+  GOOGLE_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      A valid Google OAuth2 access token with the following scopes:
+        https://www.googleapis.com/auth/gmail.readonly
+
+      How to get one quickly:
+        1. Install Google Cloud CLI: https://cloud.google.com/sdk/docs/install
+        2. Run: gcloud auth login
+        3. Run: gcloud auth print-access-token
+        4. Paste the token here.
+
+      Tip: If you also use google_calendar, the same access token
+      works for both — just add both scopes when authenticating.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.GOOGLE_ACCESS_TOKEN}}
+
+rate_limit:
+  extra_statuses:
+    - 429
+  retry_after_header: Retry-After
+
+test_queries:
+  - SELECT * FROM gmail.labels LIMIT 1
+  - SELECT id, thread_id FROM gmail.messages WHERE q = 'newer_than:30d' LIMIT 1
+  - SELECT id, snippet FROM gmail.threads WHERE q = 'newer_than:30d' LIMIT 1
+  - SELECT function_name FROM coral.table_functions WHERE schema_name = 'gmail' ORDER BY function_name LIMIT 1
+
+functions:
+  - name: search_messages
+    description: >-
+      Provider-native Gmail search as a Coral source-scoped table function.
+      Use this when an agent has a Gmail search expression and needs compact
+      candidate message IDs before a bounded drill-down.
+    fetch_limit_default: 50
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: label_ids
+        required: false
+        bind:
+          arg: label_ids
+      - name: max_results
+        required: false
+        bind:
+          arg: max_results
+    request:
+      method: GET
+      path: /gmail/v1/users/me/messages
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: labelIds
+          from: arg
+          key: label_ids
+        - name: maxResults
+          from: arg_int
+          key: max_results
+          default: 50
+    response:
+      rows_path:
+        - messages
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 50
+        max: 500
+        query_param: maxResults
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Message ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: Thread ID this message belongs to
+        expr:
+          kind: path
+          path:
+            - threadId
+
+tables:
+  - name: labels
+    description: >-
+      Gmail labels (system labels like INBOX, SENT, UNREAD and
+      custom user-defined labels). Use label IDs in messages filters.
+    guide: |
+      Start here to discover available labels.
+      System labels include: INBOX, SENT, DRAFTS, TRASH, SPAM,
+      UNREAD, IMPORTANT, STARRED.
+      Use `id` values in the messages table's `label_ids` filter.
+    request:
+      method: GET
+      path: /gmail/v1/users/me/labels
+    response:
+      rows_path:
+        - labels
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Label identifier (e.g. INBOX, Label_12345)
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the label
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Label type — system or user
+        expr:
+          kind: path
+          path:
+            - type
+      - name: messages_total
+        type: Int64
+        nullable: true
+        description: Total number of messages with this label
+        expr:
+          kind: path
+          path:
+            - messagesTotal
+      - name: messages_unread
+        type: Int64
+        nullable: true
+        description: Number of unread messages with this label
+        expr:
+          kind: path
+          path:
+            - messagesUnread
+      - name: threads_total
+        type: Int64
+        nullable: true
+        description: Total number of threads with this label
+        expr:
+          kind: path
+          path:
+            - threadsTotal
+      - name: threads_unread
+        type: Int64
+        nullable: true
+        description: Number of unread threads with this label
+        expr:
+          kind: path
+          path:
+            - threadsUnread
+
+  - name: messages
+    description: >-
+      Gmail message list. Returns message IDs matching the query and label filters.
+      The Gmail list endpoint returns only `id` and `thread_id` per message.
+      Use `gmail.message_details` with a specific `message_id` to fetch subject,
+      sender, date, and snippet for individual messages.
+    guide: |
+      Returns `id` and `thread_id` only — the Gmail list endpoint does not return
+      message headers or body content. Use `gmail.message_details` for full metadata.
+
+      Use `q` for Gmail search syntax. Examples:
+        is:unread is:important       — unread important emails
+        subject:deadline             — emails with "deadline" in subject
+        from:boss@company.com        — emails from a specific sender
+        newer_than:7d                — emails from last 7 days
+        label:INBOX is:unread        — unread inbox emails
+
+      Typical two-step pattern:
+        SELECT id FROM gmail.messages WHERE q = 'is:unread is:important' LIMIT 10;
+        SELECT subject, from_email, date, snippet
+        FROM gmail.message_details
+        WHERE message_id = '<id from above>';
+    filters:
+      - name: q
+        required: false
+      - name: label_ids
+        required: false
+      - name: max_results
+        required: false
+    request:
+      method: GET
+      path: /gmail/v1/users/me/messages
+      query:
+        - name: q
+          from: filter
+          key: q
+        - name: labelIds
+          from: filter
+          key: label_ids
+        - name: maxResults
+          from: filter_int
+          key: max_results
+          default: 50
+    response:
+      rows_path:
+        - messages
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 50
+        max: 500
+        query_param: maxResults
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Message ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: Thread ID this message belongs to
+        expr:
+          kind: path
+          path:
+            - threadId
+      - name: q
+        type: Utf8
+        nullable: true
+        description: Gmail search query filter (virtual)
+        expr:
+          kind: from_filter
+          key: q
+        virtual: true
+      - name: label_ids_filter
+        type: Utf8
+        nullable: true
+        description: Label ID filter applied (virtual)
+        expr:
+          kind: from_filter
+          key: label_ids
+        virtual: true
+
+  - name: message_details
+    description: >-
+      Metadata for one Gmail message. Start from `gmail.messages`, then query
+      this table with `message_id` when subject, sender, date, or snippet are needed.
+    guide: |
+      Requires `message_id` from gmail.messages.id.
+      Example:
+        SELECT subject, from_email, date, snippet
+        FROM gmail.message_details
+        WHERE message_id = '...'
+    filters:
+      - name: message_id
+        required: true
+    request:
+      method: GET
+      path: /gmail/v1/users/me/messages/{{filter.message_id}}
+      query:
+        - name: format
+          from: literal
+          value: metadata
+        - name: metadataHeaders
+          from: literal
+          value: Subject
+        - name: metadataHeaders
+          from: literal
+          value: From
+        - name: metadataHeaders
+          from: literal
+          value: To
+        - name: metadataHeaders
+          from: literal
+          value: Date
+    response:
+      row_strategy: direct
+      allow_404_empty: true
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Message ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: Thread ID this message belongs to
+        expr:
+          kind: path
+          path:
+            - threadId
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Email subject line
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: Subject
+          key_field: name
+          value_field: value
+      - name: from_email
+        type: Utf8
+        nullable: true
+        description: Sender email address
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: From
+          key_field: name
+          value_field: value
+      - name: to_email
+        type: Utf8
+        nullable: true
+        description: Recipient email address
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: To
+          key_field: name
+          value_field: value
+      - name: date
+        type: Utf8
+        nullable: true
+        description: Email date from the Date header
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: Date
+          key_field: name
+          value_field: value
+      - name: snippet
+        type: Utf8
+        nullable: true
+        description: First ~150 characters of the email body
+        expr:
+          kind: path
+          path:
+            - snippet
+      - name: label_ids
+        type: Utf8
+        nullable: true
+        description: Comma-separated list of label IDs
+        expr:
+          kind: join_array
+          path:
+            - labelIds
+      - name: internal_date
+        type: Utf8
+        nullable: true
+        description: Internal date as Unix timestamp milliseconds
+        expr:
+          kind: path
+          path:
+            - internalDate
+      - name: internal_datetime
+        type: Timestamp
+        nullable: true
+        description: Internal date as a Coral timestamp
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr:
+            kind: path
+            path:
+              - internalDate
+      - name: message_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Message ID filter
+        expr:
+          kind: from_filter
+          key: message_id
+
+  - name: threads
+    description: >-
+      Gmail threads (email conversations). Each thread groups related
+      messages. Use `q` for Gmail search syntax. `snippet` shows the
+      most recent message preview.
+    guide: |
+      Threads aggregate multiple messages from a conversation.
+      Use `q` filter with Gmail search syntax to narrow results.
+      `message_count` shows how active the thread is.
+    filters:
+      - name: q
+        required: false
+      - name: label_ids
+        required: false
+    request:
+      method: GET
+      path: /gmail/v1/users/me/threads
+      query:
+        - name: q
+          from: filter
+          key: q
+        - name: labelIds
+          from: filter
+          key: label_ids
+        - name: maxResults
+          from: literal
+          value: "50"
+    response:
+      rows_path:
+        - threads
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 50
+        max: 500
+        query_param: maxResults
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Thread ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: snippet
+        type: Utf8
+        nullable: true
+        description: Short preview of the most recent message
+        expr:
+          kind: path
+          path:
+            - snippet
+      - name: history_id
+        type: Utf8
+        nullable: true
+        description: History ID (for change tracking)
+        expr:
+          kind: path
+          path:
+            - historyId
+      - name: q
+        type: Utf8
+        nullable: true
+        description: Gmail search query filter (virtual)
+        expr:
+          kind: from_filter
+          key: q
+        virtual: true
+
+  - name: thread_messages
+    description: >-
+      Metadata rows for every message inside one Gmail thread. Start from
+      `gmail.threads`, then query this table with `thread_id` to inspect the
+      full conversation without making the agent stitch messages manually.
+    guide: |
+      Requires `thread_id` from gmail.threads.id or gmail.messages.thread_id.
+      This table turns a Gmail conversation into one SQL result set, which is
+      useful for joining customer escalations or deadline threads to Notion tasks.
+
+      Example:
+        SELECT subject, from_email, date, snippet
+        FROM gmail.thread_messages
+        WHERE thread_id = 'thread-id-from-gmail.threads'
+        ORDER BY internal_datetime ASC
+    filters:
+      - name: thread_id
+        required: true
+    request:
+      method: GET
+      path: /gmail/v1/users/me/threads/{{filter.thread_id}}
+      query:
+        - name: format
+          from: literal
+          value: metadata
+        - name: metadataHeaders
+          from: literal
+          value: Subject
+        - name: metadataHeaders
+          from: literal
+          value: From
+        - name: metadataHeaders
+          from: literal
+          value: To
+        - name: metadataHeaders
+          from: literal
+          value: Date
+    response:
+      rows_path:
+        - messages
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Message ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: Thread ID this message belongs to
+        expr:
+          kind: path
+          path:
+            - threadId
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Email subject line
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: Subject
+          key_field: name
+          value_field: value
+      - name: from_email
+        type: Utf8
+        nullable: true
+        description: Sender email address
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: From
+          key_field: name
+          value_field: value
+      - name: to_email
+        type: Utf8
+        nullable: true
+        description: Recipient email address
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: To
+          key_field: name
+          value_field: value
+      - name: date
+        type: Utf8
+        nullable: true
+        description: Email date from the Date header
+        expr:
+          kind: tag_value
+          path:
+            - payload
+            - headers
+          key: Date
+          key_field: name
+          value_field: value
+      - name: snippet
+        type: Utf8
+        nullable: true
+        description: First ~150 characters of the email body
+        expr:
+          kind: path
+          path:
+            - snippet
+      - name: label_ids
+        type: Utf8
+        nullable: true
+        description: Comma-separated list of label IDs
+        expr:
+          kind: join_array
+          path:
+            - labelIds
+      - name: internal_datetime
+        type: Timestamp
+        nullable: true
+        description: Internal date as a Coral timestamp
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr:
+            kind: path
+            path:
+              - internalDate
+      - name: thread_id_filter
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Thread ID filter
+        expr:
+          kind: from_filter
+          key: thread_id


### PR DESCRIPTION
## Summary

Adds a Gmail community source backed by the Gmail REST API v1.

- `gmail.labels` — all labels (system and custom) with message and thread counts. System labels include `INBOX`, `SENT`, `UNREAD`, `IMPORTANT`, `STARRED`. Use `id` values as the `label_ids` filter on `gmail.messages`.
- `gmail.messages` — message list via Gmail search syntax. Returns `id` and `thread_id` only — the Gmail list endpoint does not return headers or body content. Use `gmail.message_details` for subject, sender, date, and snippet.
- `gmail.message_details` — full metadata for a single message (`subject`, `from_email`, `to_email`, `date`, `snippet`, `label_ids`, `internal_datetime`) fetched with `format=metadata`. Requires `message_id` filter.
- `gmail.threads` — thread list via Gmail search syntax, returning `id`, `snippet`, and `history_id`.
- `gmail.thread_messages` — all messages inside one thread with full metadata (subject, from, date, snippet). Requires `thread_id` filter.
- `gmail.search_messages(q)` — source-scoped table function for Gmail search, returning `id` and `thread_id` pairs. Useful for agent workflows before drilling into `message_details`.

Auth: Google OAuth2 access token via `GOOGLE_ACCESS_TOKEN` (`Bearer` header).
Scope required: `https://www.googleapis.com/auth/gmail.readonly`

> **Note:** Google Calendar was originally included in this PR but has since been merged separately in #558. This PR now covers Gmail only.
