### PR TITLE
feat(sources/community/plausible): add Plausible Analytics community source

### DIFF
--- a/sources/community/plausible/README.md
+++ b/sources/community/plausible/README.md
@@ -1,0 +1,180 @@
+# Plausible
+
+**Version:** 1.0.0
+**Backend:** HTTP
+**Base URL:** `https://plausible.io`
+
+Query Plausible Analytics web stats as SQL tables. Get aggregate metrics, time-series data, and traffic breakdowns by page and source for any site in your Plausible account. Join with GitHub activity, Linear issues, or Notion pages for cross-source product intelligence.
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|-------|-------------|-----------------|-----------------|
+| `plausible.aggregate` | Single-row aggregate metrics for a site and period | `site_id` | `period`, `date` |
+| `plausible.timeseries` | Time-bucketed metrics — one row per day or month | `site_id` | `period`, `interval`, `date` |
+| `plausible.pages` | Top pages ranked by visitors | `site_id` | `period`, `date` |
+| `plausible.sources` | Traffic sources ranked by visitors | `site_id` | `period`, `date` |
+
+## Source-Scoped Table Functions
+
+| Function | Description |
+|----------|-------------|
+| `plausible.breakdown(site_id => '...', property => '...')` | Break down stats by any Plausible property — page, source, country, device, browser, OS, UTM |
+
+## Authentication
+
+Requires a `PLAUSIBLE_API_KEY`.
+
+**To get your API key:**
+
+1. Log in to [plausible.io](https://plausible.io)
+2. Go to **Settings** (top right) → **API keys**
+3. Click **New API key**, give it a name, click **Create API key**
+4. Copy the key — it will not be shown again
+
+## Install
+
+```bash
+coral source lint manifest.yaml
+coral source add --file manifest.yaml
+coral source test plausible
+```
+
+Or with the key inline:
+
+```bash
+PLAUSIBLE_API_KEY=your-key coral source add --file manifest.yaml
+```
+
+## The `period` filter
+
+All tables accept a `period` filter. Valid values:
+
+| Value | Meaning |
+|-------|---------|
+| `12mo` | Last 12 calendar months |
+| `6mo` | Last 6 calendar months |
+| `month` | Current calendar month |
+| `30d` | Last 30 days (default when omitted) |
+| `7d` | Last 7 days |
+| `day` | Today |
+| `custom` | Custom range — requires `date = 'YYYY-MM-DD,YYYY-MM-DD'` |
+
+## Example Queries
+
+Aggregate stats for the last 30 days:
+
+```sql
+SELECT visitors, pageviews, bounce_rate, visit_duration
+FROM plausible.aggregate
+WHERE site_id = 'yourdomain.com'
+  AND period = '30d';
+```
+
+Daily visitor trend over the last 7 days:
+
+```sql
+SELECT date, visitors, pageviews
+FROM plausible.timeseries
+WHERE site_id = 'yourdomain.com'
+  AND period = '7d'
+ORDER BY date ASC;
+```
+
+Top 10 pages this month:
+
+```sql
+SELECT page, visitors, pageviews, bounce_rate
+FROM plausible.pages
+WHERE site_id = 'yourdomain.com'
+  AND period = 'month'
+ORDER BY visitors DESC
+LIMIT 10;
+```
+
+Top traffic sources last 30 days:
+
+```sql
+SELECT source, visitors, bounce_rate
+FROM plausible.sources
+WHERE site_id = 'yourdomain.com'
+  AND period = '30d'
+ORDER BY visitors DESC
+LIMIT 10;
+```
+
+Country breakdown using the table function:
+
+```sql
+SELECT country, visitors, pageviews
+FROM plausible.breakdown(
+    site_id   => 'yourdomain.com',
+    property  => 'visit:country',
+    period    => '30d'
+)
+ORDER BY visitors DESC
+LIMIT 20;
+```
+
+Custom date range:
+
+```sql
+SELECT date, visitors
+FROM plausible.timeseries
+WHERE site_id = 'yourdomain.com'
+  AND period = 'custom'
+  AND date = '2026-01-01,2026-01-31'
+ORDER BY date ASC;
+```
+
+## Cross-Source JOIN Example
+
+Traffic trend alongside GitHub deploy activity (requires `github` source installed):
+
+```sql
+WITH web AS (
+    SELECT date, visitors, pageviews
+    FROM plausible.timeseries
+    WHERE site_id = 'yourdomain.com'
+      AND period = '30d'
+),
+deploys AS (
+    SELECT SUBSTR(merged_at, 1, 10) AS deploy_date,
+           COUNT(*) AS prs_merged
+    FROM github.pulls
+    WHERE owner = 'your-org'
+      AND repo = 'your-repo'
+    GROUP BY SUBSTR(merged_at, 1, 10)
+)
+SELECT w.date, w.visitors, w.pageviews, COALESCE(d.prs_merged, 0) AS deploys
+FROM web w
+LEFT JOIN deploys d ON d.deploy_date = w.date
+ORDER BY w.date DESC;
+```
+
+## The `breakdown` Table Function
+
+`plausible.breakdown` supports any Plausible property. The dimension column matching your property is populated; others are NULL.
+
+Supported `property` values:
+
+| Property | Populated column |
+|----------|-----------------|
+| `event:page` | `page` |
+| `visit:source` | `source` |
+| `visit:country` | `country` |
+| `visit:device` | `device` |
+| `visit:browser` | `browser` |
+| `visit:os` | `os` |
+| `visit:utm_source` | `utm_source` |
+| `visit:utm_campaign` | `utm_campaign` |
+
+## Notes
+
+- `site_id` is the domain you registered in Plausible (e.g. `yourdomain.com`, not a URL).
+- All tables are strictly read-only.
+- `period` defaults to `30d` when omitted — Plausible's API default.
+- `plausible.aggregate` returns exactly one row. `row_strategy: direct` is used since the API returns a single results object, not an array.
+- `plausible.timeseries` returns all date buckets at once — no pagination needed.
+- `plausible.pages` and `plausible.sources` paginate via Plausible's `page`/`limit` params (up to 1000 rows per page).
+- Rate limit is 600 requests per hour. Handled automatically via `rate_limit` config in the manifest.

--- a/sources/community/plausible/manifest.yaml
+++ b/sources/community/plausible/manifest.yaml
@@ -1,0 +1,626 @@
+name: plausible
+version: 1.0.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Plausible Analytics web stats as SQL tables. Get aggregate metrics,
+  time-series data, and traffic breakdowns by page and source for any site
+  in your Plausible account. Join with GitHub, Linear, or Notion for
+  cross-source product intelligence.
+
+base_url: https://plausible.io
+
+inputs:
+  PLAUSIBLE_API_KEY:
+    kind: secret
+    hint: |
+      Your Plausible API key. Generate one from:
+      plausible.io → Settings → API keys → New API key
+      See https://plausible.io/docs/stats-api
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.PLAUSIBLE_API_KEY}}
+
+rate_limit:
+  extra_statuses:
+    - 429
+  retry_after_header: Retry-After
+
+test_queries:
+  - SELECT function_name FROM coral.table_functions WHERE schema_name = 'plausible' ORDER BY function_name LIMIT 1
+
+functions:
+  - name: breakdown
+    description: >-
+      Break down Plausible stats by any supported property for a site and period.
+      Supported property values: event:page, visit:source, visit:country,
+      visit:device, visit:browser, visit:os, visit:utm_source, visit:utm_campaign.
+      Dimension column matching the property is populated; others are NULL.
+    fetch_limit_default: 100
+    args:
+      - name: site_id
+        required: true
+        bind:
+          arg: site_id
+      - name: property
+        required: true
+        bind:
+          arg: property
+      - name: period
+        required: false
+        bind:
+          arg: period
+    request:
+      method: GET
+      path: /api/v1/stats/breakdown
+      query:
+        - name: site_id
+          from: arg
+          key: site_id
+        - name: property
+          from: arg
+          key: property
+        - name: period
+          from: arg
+          key: period
+        - name: metrics
+          from: literal
+          value: visitors,pageviews,bounce_rate,visits,visit_duration
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: page
+        type: Utf8
+        nullable: true
+        description: Page path dimension value — populated when property is event:page
+        expr:
+          kind: path
+          path:
+            - page
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Traffic source dimension — populated when property is visit:source
+        expr:
+          kind: path
+          path:
+            - source
+      - name: country
+        type: Utf8
+        nullable: true
+        description: Country code dimension — populated when property is visit:country
+        expr:
+          kind: path
+          path:
+            - country
+      - name: device
+        type: Utf8
+        nullable: true
+        description: Device type dimension — populated when property is visit:device
+        expr:
+          kind: path
+          path:
+            - device
+      - name: browser
+        type: Utf8
+        nullable: true
+        description: Browser name dimension — populated when property is visit:browser
+        expr:
+          kind: path
+          path:
+            - browser
+      - name: os
+        type: Utf8
+        nullable: true
+        description: Operating system dimension — populated when property is visit:os
+        expr:
+          kind: path
+          path:
+            - os
+      - name: utm_source
+        type: Utf8
+        nullable: true
+        description: UTM source dimension — populated when property is visit:utm_source
+        expr:
+          kind: path
+          path:
+            - utm_source
+      - name: utm_campaign
+        type: Utf8
+        nullable: true
+        description: UTM campaign dimension — populated when property is visit:utm_campaign
+        expr:
+          kind: path
+          path:
+            - utm_campaign
+      - name: visitors
+        type: Int64
+        nullable: true
+        description: Unique visitors
+        expr:
+          kind: path
+          path:
+            - visitors
+      - name: pageviews
+        type: Int64
+        nullable: true
+        description: Total page views
+        expr:
+          kind: path
+          path:
+            - pageviews
+      - name: bounce_rate
+        type: Float64
+        nullable: true
+        description: Bounce rate as a percentage (0-100)
+        expr:
+          kind: path
+          path:
+            - bounce_rate
+      - name: visits
+        type: Int64
+        nullable: true
+        description: Total sessions
+        expr:
+          kind: path
+          path:
+            - visits
+      - name: visit_duration
+        type: Float64
+        nullable: true
+        description: Average visit duration in seconds
+        expr:
+          kind: path
+          path:
+            - visit_duration
+
+tables:
+  - name: aggregate
+    description: >-
+      Aggregate web metrics for a Plausible site over a time period.
+      Returns one row with visitors, pageviews, bounce_rate, visits, and
+      visit_duration. Requires site_id. period defaults to 30d when omitted.
+    guide: |
+      Requires site_id (your tracked domain, e.g. yourdomain.com).
+      period values: 12mo, 6mo, month, 30d, 7d, day (default: 30d when omitted).
+      For a custom range use period = 'custom' and date = 'YYYY-MM-DD,YYYY-MM-DD'.
+
+      Example:
+        SELECT visitors, pageviews, bounce_rate, visit_duration
+        FROM plausible.aggregate
+        WHERE site_id = 'yourdomain.com' AND period = '30d'
+    filters:
+      - name: site_id
+        required: true
+      - name: period
+        required: false
+      - name: date
+        required: false
+    request:
+      method: GET
+      path: /api/v1/stats/aggregate
+      query:
+        - name: site_id
+          from: filter
+          key: site_id
+        - name: period
+          from: filter
+          key: period
+        - name: date
+          from: filter
+          key: date
+        - name: metrics
+          from: literal
+          value: visitors,pageviews,bounce_rate,visits,visit_duration
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: visitors
+        type: Int64
+        nullable: true
+        description: Unique visitors in the period
+        expr:
+          kind: path
+          path:
+            - results
+            - visitors
+            - value
+      - name: pageviews
+        type: Int64
+        nullable: true
+        description: Total page views in the period
+        expr:
+          kind: path
+          path:
+            - results
+            - pageviews
+            - value
+      - name: bounce_rate
+        type: Float64
+        nullable: true
+        description: Bounce rate as a percentage (0-100)
+        expr:
+          kind: path
+          path:
+            - results
+            - bounce_rate
+            - value
+      - name: visits
+        type: Int64
+        nullable: true
+        description: Total sessions in the period
+        expr:
+          kind: path
+          path:
+            - results
+            - visits
+            - value
+      - name: visit_duration
+        type: Float64
+        nullable: true
+        description: Average visit duration in seconds
+        expr:
+          kind: path
+          path:
+            - results
+            - visit_duration
+            - value
+      - name: site_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Site domain filter applied to this query (virtual)
+        expr:
+          kind: from_filter
+          key: site_id
+      - name: period
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Period filter applied to this query (virtual)
+        expr:
+          kind: from_filter
+          key: period
+
+  - name: timeseries
+    description: >-
+      Time-bucketed web metrics for a Plausible site. Returns one row per day
+      or month. Use to chart visitor trends or spot traffic spikes over time.
+      Requires site_id. period defaults to 30d when omitted.
+    guide: |
+      Requires site_id. period values: 12mo, 6mo, month, 30d, 7d, day.
+      interval: day (default) or month. Omit interval to let Plausible auto-select.
+      For a custom range use period = 'custom' and date = 'YYYY-MM-DD,YYYY-MM-DD'.
+
+      Example:
+        SELECT date, visitors, pageviews
+        FROM plausible.timeseries
+        WHERE site_id = 'yourdomain.com' AND period = '30d'
+        ORDER BY date DESC
+    filters:
+      - name: site_id
+        required: true
+      - name: period
+        required: false
+      - name: interval
+        required: false
+      - name: date
+        required: false
+    request:
+      method: GET
+      path: /api/v1/stats/timeseries
+      query:
+        - name: site_id
+          from: filter
+          key: site_id
+        - name: period
+          from: filter
+          key: period
+        - name: interval
+          from: filter
+          key: interval
+        - name: date
+          from: filter
+          key: date
+        - name: metrics
+          from: literal
+          value: visitors,pageviews,bounce_rate,visits,visit_duration
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: none
+    columns:
+      - name: date
+        type: Utf8
+        nullable: false
+        description: Date bucket — YYYY-MM-DD for day interval, YYYY-MM for month interval
+        expr:
+          kind: path
+          path:
+            - date
+      - name: visitors
+        type: Int64
+        nullable: true
+        description: Unique visitors for this date bucket
+        expr:
+          kind: path
+          path:
+            - visitors
+      - name: pageviews
+        type: Int64
+        nullable: true
+        description: Total page views for this date bucket
+        expr:
+          kind: path
+          path:
+            - pageviews
+      - name: bounce_rate
+        type: Float64
+        nullable: true
+        description: Bounce rate as a percentage (0-100) for this date bucket
+        expr:
+          kind: path
+          path:
+            - bounce_rate
+      - name: visits
+        type: Int64
+        nullable: true
+        description: Total sessions for this date bucket
+        expr:
+          kind: path
+          path:
+            - visits
+      - name: visit_duration
+        type: Float64
+        nullable: true
+        description: Average visit duration in seconds for this date bucket
+        expr:
+          kind: path
+          path:
+            - visit_duration
+      - name: site_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Site domain filter applied to this query (virtual)
+        expr:
+          kind: from_filter
+          key: site_id
+
+  - name: pages
+    description: >-
+      Top pages for a Plausible site ranked by visitors. Each row is one page
+      path with visitor, pageview, and bounce rate metrics. Requires site_id.
+      period defaults to 30d when omitted.
+    guide: |
+      Requires site_id. Returns top pages by visitors descending.
+
+      Example:
+        SELECT page, visitors, pageviews, bounce_rate
+        FROM plausible.pages
+        WHERE site_id = 'yourdomain.com' AND period = '30d'
+        ORDER BY visitors DESC
+        LIMIT 20
+    filters:
+      - name: site_id
+        required: true
+      - name: period
+        required: false
+      - name: date
+        required: false
+    request:
+      method: GET
+      path: /api/v1/stats/breakdown
+      query:
+        - name: site_id
+          from: filter
+          key: site_id
+        - name: period
+          from: filter
+          key: period
+        - name: date
+          from: filter
+          key: date
+        - name: property
+          from: literal
+          value: event:page
+        - name: metrics
+          from: literal
+          value: visitors,pageviews,bounce_rate,visits,visit_duration
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: page
+        type: Utf8
+        nullable: false
+        description: Page path (e.g. /blog/post-title)
+        expr:
+          kind: path
+          path:
+            - page
+      - name: visitors
+        type: Int64
+        nullable: true
+        description: Unique visitors who viewed this page
+        expr:
+          kind: path
+          path:
+            - visitors
+      - name: pageviews
+        type: Int64
+        nullable: true
+        description: Total page views for this page
+        expr:
+          kind: path
+          path:
+            - pageviews
+      - name: bounce_rate
+        type: Float64
+        nullable: true
+        description: Bounce rate for sessions starting on this page (0-100)
+        expr:
+          kind: path
+          path:
+            - bounce_rate
+      - name: visits
+        type: Int64
+        nullable: true
+        description: Total sessions that included this page
+        expr:
+          kind: path
+          path:
+            - visits
+      - name: visit_duration
+        type: Float64
+        nullable: true
+        description: Average visit duration for sessions including this page in seconds
+        expr:
+          kind: path
+          path:
+            - visit_duration
+      - name: site_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Site domain filter applied to this query (virtual)
+        expr:
+          kind: from_filter
+          key: site_id
+
+  - name: sources
+    description: >-
+      Traffic sources for a Plausible site ranked by visitors. Each row is one
+      referral source. Direct and untracked traffic appears as "(Direct / None)".
+      Requires site_id. period defaults to 30d when omitted.
+    guide: |
+      Requires site_id. Returns traffic sources by visitor count descending.
+      "(Direct / None)" represents direct or untracked traffic.
+
+      Example:
+        SELECT source, visitors, bounce_rate
+        FROM plausible.sources
+        WHERE site_id = 'yourdomain.com' AND period = '30d'
+        ORDER BY visitors DESC
+        LIMIT 10
+    filters:
+      - name: site_id
+        required: true
+      - name: period
+        required: false
+      - name: date
+        required: false
+    request:
+      method: GET
+      path: /api/v1/stats/breakdown
+      query:
+        - name: site_id
+          from: filter
+          key: site_id
+        - name: period
+          from: filter
+          key: period
+        - name: date
+          from: filter
+          key: date
+        - name: property
+          from: literal
+          value: visit:source
+        - name: metrics
+          from: literal
+          value: visitors,pageviews,bounce_rate,visits,visit_duration
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: source
+        type: Utf8
+        nullable: false
+        description: Traffic source name (e.g. Google, Twitter, or "(Direct / None)")
+        expr:
+          kind: path
+          path:
+            - source
+      - name: visitors
+        type: Int64
+        nullable: true
+        description: Unique visitors from this source
+        expr:
+          kind: path
+          path:
+            - visitors
+      - name: pageviews
+        type: Int64
+        nullable: true
+        description: Total page views from this source
+        expr:
+          kind: path
+          path:
+            - pageviews
+      - name: bounce_rate
+        type: Float64
+        nullable: true
+        description: Bounce rate for sessions from this source (0-100)
+        expr:
+          kind: path
+          path:
+            - bounce_rate
+      - name: visits
+        type: Int64
+        nullable: true
+        description: Total sessions from this source
+        expr:
+          kind: path
+          path:
+            - visits
+      - name: visit_duration
+        type: Float64
+        nullable: true
+        description: Average visit duration for sessions from this source in seconds
+        expr:
+          kind: path
+          path:
+            - visit_duration
+      - name: site_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Site domain filter applied to this query (virtual)
+        expr:
+          kind: from_filter
+          key: site_id


### PR DESCRIPTION
## Summary

Adds a Plausible Analytics community source backed by the Plausible Stats API v1.

- `plausible.aggregate` — single-row aggregate metrics (visitors, pageviews, bounce_rate, visits, visit_duration) for a site and period. Uses `row_strategy: direct` since the API returns a nested `{results: {metric: {value: N}}}` object, not an array.
- `plausible.timeseries` — time-bucketed metrics (day or month interval), one row per bucket.
- `plausible.pages` — top pages ranked by visitors (breakdown by `event:page`).
- `plausible.sources` — traffic sources ranked by visitors (breakdown by `visit:source`).
- `plausible.breakdown(site_id, property, period)` — generic breakdown by any supported property: `event:page`, `visit:source`, `visit:country`, `visit:device`, `visit:browser`, `visit:os`, `visit:utm_source`, `visit:utm_campaign`. Dimension columns are nullable; the column matching the requested property is populated.

Auth via `PLAUSIBLE_API_KEY` Bearer token. Rate limit at 600 req/hr with `Retry-After` header support.

Closes #583
