### PR TITLE
fix(ci): avoid exposing skills write token during export

### DIFF
--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -30,6 +30,20 @@ jobs:
       - name: Install Rust toolchain
         run: rustup show
 
+      - name: Check out skills distribution
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          repository: withcoral/skills
+          ref: main
+          path: skills-dist
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Export skills
+        run: |
+          set -euo pipefail
+          cargo run --locked -p xtask -- export-skills --dest skills-dist
+
       - name: Create GitHub App token
         id: github-app-token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
@@ -39,21 +53,6 @@ jobs:
           permission-contents: write
           repositories: |
             skills
-
-      - name: Check out skills distribution
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          repository: withcoral/skills
-          ref: main
-          path: skills-dist
-          token: ${{ steps.github-app-token.outputs.token }}
-          persist-credentials: true
-          fetch-depth: 0
-
-      - name: Export skills
-        run: |
-          set -euo pipefail
-          cargo run --locked -p xtask -- export-skills --dest skills-dist
 
       - name: Commit and publish changes
         run: |
@@ -70,4 +69,4 @@ jobs:
           git commit \
             -m "chore: sync skills from coral" \
             -m "Source: withcoral/coral@${GITHUB_SHA}"
-          git push origin HEAD:main
+          git push "https://x-access-token:${{ steps.github-app-token.outputs.token }}@github.com/withcoral/skills.git" HEAD:main


### PR DESCRIPTION
### Motivation
- Prevent a supply-chain integrity risk where a write-scoped GitHub App token for `withcoral/skills` was minted and persisted into the `skills-dist` checkout before running repository-controlled code, allowing that code to read or reuse the credential during `export-skills`.

### Description
- Update `.github/workflows/sync-skills.yml` so the `withcoral/skills` checkout uses `persist-credentials: false` and therefore does not store push credentials in the checkout config.
- Reorder the workflow to run `cargo run --locked -p xtask -- export-skills --dest skills-dist` before creating the GitHub App token so repository-controlled code executes without any write-scoped token present.
- Replace the plain `git push` with a one-off authenticated HTTPS push URL that embeds `steps.github-app-token.outputs.token` so the token is only used at the final publish step.

### Testing
- Ran `git diff --check` and it completed with no issues.
- Verified the modified workflow file reflects the new ordering and `persist-credentials: false` setting by inspecting `.github/workflows/sync-skills.yml` and confirming the push uses the ephemeral authenticated URL.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0af5a64be8832aa722e5e54284bb53)