### PR TITLE
fix(sources/community/weaviate): store API key as secret

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@
   ambient process environment directly.
 - Changes to CLI or MCP surfaces must include corresponding documentation
   updates under `docs/` in the same change.
+- Source inputs that carry credentials must be `kind: secret`, never
+  `kind: variable`. This includes API keys, bearer tokens, access tokens,
+  passwords, private keys, authorization header values, and admin/read keys,
+  even when the credential is read-only or the source also supports anonymous
+  access.
 - Keep maintained Coral agent skills in `plugins/coral/skills`. External
   distribution repos or packages should mirror from that directory rather than
   becoming a separate source of truth. Use

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -119,6 +119,11 @@ fn collect_declared_inputs(root: &Value) -> Result<Vec<ManifestInputSpec>> {
                 "manifest secret input '{key}' must not declare a default"
             )));
         }
+        if kind == ManifestInputKind::Variable && credential_like_input_key(key) {
+            return Err(ManifestError::validation(format!(
+                "manifest input '{key}' looks credential-like and must use kind: secret"
+            )));
+        }
         let hint = input
             .get("hint")
             .and_then(Value::as_str)
@@ -133,6 +138,30 @@ fn collect_declared_inputs(root: &Value) -> Result<Vec<ManifestInputSpec>> {
     }
 
     Ok(ordered)
+}
+
+fn credential_like_input_key(key: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "API_KEY",
+        "APPLICATION_KEY",
+        "ACCESS_KEY",
+        "ACCESS_KEY_ID",
+        "ACCESS_TOKEN",
+        "ADMIN_KEY",
+        "AUTHORIZATION",
+        "BEARER_TOKEN",
+        "CLIENT_SECRET",
+        "PASSWORD",
+        "PRIVATE_KEY",
+        "READ_KEY",
+        "SECRET",
+        "TOKEN",
+    ];
+
+    let key = key.to_ascii_uppercase();
+    MARKERS
+        .iter()
+        .any(|marker| key == *marker || key.ends_with(&format!("_{marker}")))
 }
 
 fn validate_input_references(root: &Value, inputs: &[ManifestInputSpec]) -> Result<()> {
@@ -380,5 +409,25 @@ tables: []
 ";
         let error = collect(manifest).expect_err("secret default");
         assert!(error.to_string().contains("must not declare a default"));
+    }
+
+    #[test]
+    fn credential_like_variables_are_rejected() {
+        let manifest = r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  SERVICE_API_KEY:
+    kind: variable
+tables: []
+";
+        let error = collect(manifest).expect_err("credential variable");
+        assert!(
+            error
+                .to_string()
+                .contains("SERVICE_API_KEY' looks credential-like")
+        );
     }
 }

--- a/crates/coral-spec/src/inputs.rs
+++ b/crates/coral-spec/src/inputs.rs
@@ -159,9 +159,12 @@ fn credential_like_input_key(key: &str) -> bool {
     ];
 
     let key = key.to_ascii_uppercase();
-    MARKERS
-        .iter()
-        .any(|marker| key == *marker || key.ends_with(&format!("_{marker}")))
+    MARKERS.iter().any(|marker| {
+        key == *marker
+            || key.contains(&format!("_{marker}_"))
+            || key.ends_with(&format!("_{marker}"))
+            || key.starts_with(&format!("{marker}_"))
+    })
 }
 
 fn validate_input_references(root: &Value, inputs: &[ManifestInputSpec]) -> Result<()> {
@@ -413,21 +416,44 @@ tables: []
 
     #[test]
     fn credential_like_variables_are_rejected() {
+        for key in [
+            "SERVICE_API_KEY",
+            "STRIPE_SECRET_KEY",
+            "WEAVIATE_API_KEY_STAGING",
+        ] {
+            let manifest = format!(
+                r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+inputs:
+  {key}:
+    kind: variable
+tables: []
+"
+            );
+            let error = collect(&manifest).expect_err("credential variable");
+            assert!(error.to_string().contains("looks credential-like"));
+        }
+    }
+
+    #[test]
+    fn credential_like_check_respects_underscore_boundaries() {
         let manifest = r"
 name: demo
 version: 1.0.0
 dsl_version: 3
 backend: http
 inputs:
-  SERVICE_API_KEY:
+  SERVICE_SECRETARIAT_URL:
     kind: variable
 tables: []
 ";
-        let error = collect(manifest).expect_err("credential variable");
-        assert!(
-            error
-                .to_string()
-                .contains("SERVICE_API_KEY' looks credential-like")
-        );
+        let inputs = collect(manifest).expect("non-credential variable");
+        let [input] = inputs.as_slice() else {
+            panic!("expected one input, got {inputs:?}");
+        };
+        assert_eq!(input.key, "SERVICE_SECRETARIAT_URL");
     }
 }

--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -193,7 +193,7 @@ tables:
         type: Utf8
 ```
 
-When you run `coral source add --file`, Coral reads each declared `input` from an environment variable of the same name, or prompts for them when you pass `--interactive`. `kind: variable` values go to source variables; `kind: secret` values go to the secret store.
+When you run `coral source add --file`, Coral reads each declared `input` from an environment variable of the same name, or prompts for them when you pass `--interactive`. `kind: variable` values go to source variables; `kind: secret` values go to the secret store. API keys, bearer tokens, passwords, private keys, and authorization values must be secrets, even when the API key is read-only.
 
 For the full set of HTTP response, pagination, auth, and column fields, see [HTTP-backed tables](/reference/source-spec-reference#http-backed-tables).
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -677,6 +677,7 @@ Rules:
 - `default` is allowed only for variables
 - `hint` is optional and shown alongside the input during `coral source add --interactive`
 - references elsewhere in the manifest use `{{input.KEY}}` templates or `from: input`
+- credential-like inputs such as API keys, tokens, passwords, secrets, private keys, and bearer or authorization values must be `kind: secret`; Coral rejects those names as variables because variable values are visible through source APIs and `coral.inputs`
 
 At runtime, installed source inputs are also surfaced through `coral.inputs`.
 This is useful when agents or scripts need to inspect non-secret source config

--- a/plugins/coral/skills/coral-review-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-review-source-spec/SKILL.md
@@ -38,6 +38,8 @@ These checks should be based on the authoritative API docs for the API the sourc
 
 - Top-level `description` says what a user can query, not just what vendor API is wrapped.
 - `inputs` distinguish secrets from variables correctly, use clear environment-style names, and include enough hints for first success. Environment-style names are prefixed with a service-specific prefix (e.g. `GITHUB_API_TOKEN`, not `API_TOKEN`.)
+- Treat credential-like inputs as secrets, regardless of read-only scope or optional auth mode. Inputs named or described as `API_KEY`, `TOKEN`, `ACCESS_TOKEN`, `PASSWORD`, `SECRET`, `APPLICATION_KEY`, `READ_KEY`, `ADMIN_KEY`, private keys, bearer values, or authorization header values must be `kind: secret`; endpoint/base URL/site/region/domain/org/account/user/email values may be `kind: variable`.
+- Do not make a credential a variable with an empty default to simulate optional authentication. For the current source-spec surface, require the secret or call out the missing optional-auth design explicitly; never expose a token just to support anonymous installs.
 - Auth docs mention required token type, scopes or permissions, and where to get credentials.
 - Non-trivial sources include README or manifest guides with setup, schema orientation, and example queries.
 - Behavior changes, setup changes, source semantics, and examples are documented in the same PR.

--- a/sources/community/weaviate/README.md
+++ b/sources/community/weaviate/README.md
@@ -9,8 +9,7 @@ database, through the Weaviate REST API.
 ### Requirements
 
 - Network access to a Weaviate REST endpoint (default port `8080`).
-- For API-key-protected clusters or Weaviate Cloud: a Weaviate API key.
-  For an instance with anonymous access enabled, no key is needed.
+- A Weaviate API key for the target cluster.
 
 ### Add the Source
 
@@ -19,7 +18,7 @@ manifest:
 
 ```bash
 export WEAVIATE_URL=http://localhost:8080
-export WEAVIATE_API_KEY=        # leave empty for anonymous instances
+export WEAVIATE_API_KEY=your_weaviate_api_key
 coral source add --file sources/community/weaviate/manifest.yaml
 ```
 
@@ -29,7 +28,6 @@ Inputs:
   `http://localhost:8080` or `https://my-cluster.weaviate.network`.
   No trailing slash.
 - `WEAVIATE_API_KEY` — API key sent as `Authorization: Bearer <key>`.
-  Leave empty for anonymous instances; the header is then omitted.
 
 ## Tables
 
@@ -64,9 +62,7 @@ Weaviate uses bearer-token API keys. This source sends:
 Authorization: Bearer <WEAVIATE_API_KEY>
 ```
 
-When `WEAVIATE_API_KEY` is empty, the header is omitted entirely so the
-source works against instances with anonymous access enabled. Username /
-password and OIDC flows are not configured by this source.
+Username / password and OIDC flows are not configured by this source.
 
 ## Limits
 

--- a/sources/community/weaviate/manifest.yaml
+++ b/sources/community/weaviate/manifest.yaml
@@ -1,5 +1,5 @@
 name: weaviate
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-
@@ -18,13 +18,11 @@ inputs:
       `https://my-cluster.weaviate.network`. Do not include a trailing
       slash.
   WEAVIATE_API_KEY:
-    kind: variable
-    default: ""
+    kind: secret
     hint: |
-      Weaviate API key sent as `Authorization: Bearer <key>`. Leave empty
-      for an instance with anonymous access enabled (the header is then
-      omitted). Set it for API-key-protected clusters and Weaviate Cloud,
-      where it is the cluster's admin or read API key.
+      Weaviate API key sent as `Authorization: Bearer <key>`. Use the
+      cluster's admin or read API key for API-key-protected clusters and
+      Weaviate Cloud.
 auth:
   type: HeaderAuth
   headers:


### PR DESCRIPTION
## Intent

Weaviate API keys are bearer credentials, so they need to stay behind Coral secret handling instead of being stored and returned as visible source variables. This fixes the Weaviate source and adds guardrails so future source reviews and manifest validation catch the same class of mistake before it merges.

## Changes

- Store `WEAVIATE_API_KEY` as a secret in the Weaviate source manifest and update the setup docs to require a key.
- Reject credential-like source input names when they are declared as `kind: variable`.
- Document the credential boundary in the source spec reference, custom source guide, AGENTS guidance, and the source review skill.

## Verification

- `cargo test -p coral-spec inputs::tests`
- `cargo run -p coral-cli -- source lint sources/community/weaviate/manifest.yaml`
- `rg -n -U "(?m)^  [A-Z0-9_]*(API_KEY|TOKEN|SECRET|PASSWORD|ACCESS_KEY|APPLICATION_KEY|PRIVATE_KEY|CLIENT_SECRET|ADMIN_KEY|READ_KEY)[A-Z0-9_]*:\\n    kind: variable" sources/core sources/community`
- `git diff --check`
- `make rust-checks`
