### PR TITLE
feat(spec): remove search filter mode

### DIFF
--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -261,7 +261,7 @@ fn classify_filter(
     {
         let mode = filter_modes.get(col.name()).copied().unwrap_or_default();
         if matches!(mode, FilterMode::Search | FilterMode::Contains) {
-            // Inexact: the API receives the stripped search term (performance
+            // Inexact: the API receives the stripped search/contains term (performance
             // win) but DataFusion keeps a residual filter to enforce exact
             // LIKE/ILIKE semantics client-side (correctness win).
             return TableProviderFilterPushDown::Inexact;
@@ -318,23 +318,33 @@ mod tests {
         let pushdown = classify_filter(
             &like_expr("q", "%deploy runbook%"),
             &allowed(&["q"]),
-            &modes(&[("q", FilterMode::Search)]),
+            &modes(&[("q", FilterMode::Contains)]),
         );
         assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
     }
 
     #[test]
-    fn search_filter_also_accepts_equality() {
+    fn contains_filter_also_accepts_equality() {
         let pushdown = classify_filter(
             &binary_expr(col("query"), Operator::Eq, lit("deploy")),
             &allowed(&["query"]),
-            &modes(&[("query", FilterMode::Search)]),
+            &modes(&[("query", FilterMode::Contains)]),
         );
         assert_eq!(pushdown, TableProviderFilterPushDown::Exact);
     }
 
     #[test]
-    fn extracts_like_value_for_search_mode_filter() {
+    fn extracts_like_value_for_contains_mode_filter() {
+        let pushdown = classify_filter(
+            &like_expr("query", "%deploy%"),
+            &allowed(&["query"]),
+            &modes(&[("query", FilterMode::Contains)]),
+        );
+        assert_eq!(pushdown, TableProviderFilterPushDown::Inexact);
+    }
+
+    #[test]
+    fn extracts_like_value_for_legacy_search_mode_filter() {
         let pushdown = classify_filter(
             &like_expr("query", "%deploy%"),
             &allowed(&["query"]),

--- a/crates/coral-engine/src/backends/http/target.rs
+++ b/crates/coral-engine/src/backends/http/target.rs
@@ -83,7 +83,11 @@ impl HttpFetchTarget {
     }
 
     pub(crate) fn fetch_limit_default(&self) -> Option<usize> {
-        self.fetch_limit_default
+        self.fetch_limit_default.or_else(|| {
+            self.search_limits
+                .as_ref()
+                .map(|limits| limits.default_top_k)
+        })
     }
 
     pub(crate) fn search_limits(&self) -> Option<&SearchLimitsSpec> {

--- a/crates/coral-engine/src/backends/shared/filter_expr.rs
+++ b/crates/coral-engine/src/backends/shared/filter_expr.rs
@@ -218,8 +218,8 @@ mod tests {
     }
 
     #[test]
-    fn search_filter_also_accepts_equality() {
-        let filters = vec![filter("q", false, FilterMode::Search)];
+    fn contains_filter_also_accepts_equality() {
+        let filters = vec![filter("q", false, FilterMode::Contains)];
 
         let expr = equality_expr("q", "deploy");
         let values = extract_filter_values(&[expr], &filters);
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn strips_wildcards_from_like_pattern() {
-        let filters = vec![filter("q", false, FilterMode::Search)];
+        let filters = vec![filter("q", false, FilterMode::Contains)];
 
         let values = extract_filter_values(&[like_expr("q", "%deploy")], &filters);
         assert_eq!(values.get("q").map(String::as_str), Some("deploy"));
@@ -253,7 +253,17 @@ mod tests {
     }
 
     #[test]
-    fn extracts_like_value_for_search_mode_filter() {
+    fn extracts_like_value_for_contains_mode_filter() {
+        let filters = vec![filter("q", false, FilterMode::Contains)];
+
+        let expr = like_expr("q", "%deploy%");
+        let values = extract_filter_values(&[expr], &filters);
+
+        assert_eq!(values.get("q").map(String::as_str), Some("deploy"));
+    }
+
+    #[test]
+    fn extracts_like_value_for_legacy_search_mode_filter() {
         let filters = vec![filter("q", false, FilterMode::Search)];
 
         let expr = like_expr("q", "%deploy%");

--- a/crates/coral-engine/tests/engine/catalog_tests.rs
+++ b/crates/coral-engine/tests/engine/catalog_tests.rs
@@ -317,7 +317,7 @@ fn http_manifest_with_function() -> Value {
                     "name": "query",
                     "type": "Utf8",
                     "description": "Provider-native placeholder search text",
-                    "mode": "search"
+                    "mode": "contains"
                 }],
                 "search_limits": {
                     "default_top_k": 10,
@@ -576,7 +576,7 @@ async fn coral_filters_lists_filter_metadata() {
             &sources,
             test_runtime(),
             "SELECT table_name, filter_name, filter_mode, is_required, data_type, description \
-             FROM coral.filters WHERE schema_name = 'searchy' AND filter_mode = 'search'",
+             FROM coral.filters WHERE schema_name = 'searchy' AND filter_mode = 'contains'",
         )
         .await
         .expect("filters catalog query should succeed"),
@@ -587,7 +587,7 @@ async fn coral_filters_lists_filter_metadata() {
         vec![json!({
             "table_name": "placeholder",
             "filter_name": "query",
-            "filter_mode": "search",
+            "filter_mode": "contains",
             "is_required": false,
             "data_type": "Utf8",
             "description": "Provider-native placeholder search text",
@@ -617,7 +617,7 @@ async fn coral_columns_exposes_filter_mode_for_virtual_filters() {
             "column_name": "query",
             "is_virtual": true,
             "is_required_filter": false,
-            "filter_mode": "search",
+            "filter_mode": "contains",
         })]
     );
 }

--- a/crates/coral-engine/tests/engine/http_tests.rs
+++ b/crates/coral-engine/tests/engine/http_tests.rs
@@ -680,6 +680,61 @@ async fn source_scoped_table_function_conditionally_emits_arg_body_fields() {
 }
 
 #[tokio::test]
+async fn search_function_limit_is_capped_by_search_limits() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/search/issues"))
+        .and(query_param("q", "flaky"))
+        .and(query_param("limit", "2"))
+        .and(query_param("offset", "0"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [
+                { "title": "First", "score": 3.0 },
+                { "title": "Second", "score": 2.0 },
+                { "title": "Third", "score": 1.0 }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut manifest = search_function_manifest("capped_search", &server.uri());
+    manifest["functions"][0]["search_limits"] = json!({
+        "default_top_k": 1,
+        "max_top_k": 2,
+        "max_calls_per_query": 1
+    });
+    manifest["functions"][0]["pagination"] = json!({
+        "mode": "offset",
+        "offset_param": "offset",
+        "page_size": {
+            "default": 50,
+            "max": 500,
+            "query_param": "limit"
+        }
+    });
+
+    let source = build_source(manifest);
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title, score FROM capped_search.search_issues(q => 'flaky') LIMIT 3",
+        )
+        .await
+        .expect("search function query should succeed"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({ "title": "First", "score": 3.0 }),
+            json!({ "title": "Second", "score": 2.0 })
+        ]
+    );
+}
+
+#[tokio::test]
 async fn source_scoped_table_function_preserves_table_alias() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -1133,16 +1133,6 @@ mod tests {
     }
 
     #[test]
-    fn filter_mode_deserializes_search() {
-        let spec: FilterSpec = serde_json::from_value(serde_json::json!({
-            "name": "q",
-            "mode": "search"
-        }))
-        .unwrap();
-        assert_eq!(spec.mode, FilterMode::Search);
-    }
-
-    #[test]
     fn filter_mode_deserializes_contains() {
         let spec: FilterSpec = serde_json::from_value(serde_json::json!({
             "name": "q",
@@ -1160,6 +1150,16 @@ mod tests {
         }));
         let error = result.expect_err("unknown filter mode should fail");
         assert!(error.to_string().contains("unknown variant"));
+    }
+
+    #[test]
+    fn filter_mode_deserializes_legacy_search_value() {
+        let spec: FilterSpec = serde_json::from_value(serde_json::json!({
+            "name": "q",
+            "mode": "search"
+        }))
+        .unwrap();
+        assert_eq!(spec.mode, FilterMode::Search);
     }
 
     #[test]

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -67,6 +67,30 @@ tables:
     }
 
     #[test]
+    fn validate_manifest_schema_accepts_legacy_search_filter_mode() {
+        let manifest = manifest_json(
+            r"
+name: demo
+version: 1.0.0
+dsl_version: 3
+backend: http
+base_url: https://example.com
+tables:
+  - name: messages
+    description: Demo messages
+    filters:
+      - name: query
+        mode: search
+    request:
+      method: GET
+      path: /messages
+",
+        );
+        validate_manifest_schema(&manifest)
+            .expect("legacy search filter mode should pass schema validation");
+    }
+
+    #[test]
     fn parse_source_manifest_yaml_accepts_http_table_search_metadata() {
         parse_source_manifest_yaml(
             r"
@@ -80,7 +104,6 @@ tables:
     description: Demo messages
     filters:
       - name: query
-        mode: search
       - name: id
     search_limits:
       default_top_k: 5

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -403,11 +403,7 @@
         "mode": {
           "oneOf": [
             { "const": "equality" },
-            {
-              "const": "search",
-              "deprecated": true,
-              "description": "Compatibility-only virtual-filter marker. New provider-native search surfaces should use kind: search table functions."
-            },
+            { "const": "search" },
             { "const": "contains" }
           ]
         },

--- a/crates/coral-spec/src/validate.rs
+++ b/crates/coral-spec/src/validate.rs
@@ -51,8 +51,8 @@ pub(crate) fn validate_http_table(
 
     validate_columns(columns, schema, table_name)?;
     let known_filters = validate_filters_and_column_exprs(filters, columns, schema, table_name)?;
-    // Deprecated compatibility tables already use mode: search; new metadata is
-    // validated when present, but not forced onto every existing manifest here.
+    // Table-level search metadata is optional for legacy table surfaces; new
+    // provider-native retrieval surfaces should use search table functions.
     validate_search_metadata(
         schema,
         table_name,
@@ -916,7 +916,7 @@ mod tests {
                 {
                     "name": "search",
                     "description": "Search candidates",
-                    "filters": [{ "name": "query", "mode": "search" }],
+                    "filters": [{ "name": "query", "mode": "contains" }],
                     "search_limits": {
                         "default_top_k": 10,
                         "max_top_k": 100,
@@ -1342,12 +1342,12 @@ mod tests {
     }
 
     #[test]
-    fn validate_http_table_allows_deprecated_search_filters_without_search_limits() {
+    fn validate_http_table_allows_contains_filters_without_search_limits() {
         let filters = vec![FilterSpec {
             name: "query".to_string(),
             data_type: "Utf8".to_string(),
             required: false,
-            mode: FilterMode::Search,
+            mode: FilterMode::Contains,
             description: String::new(),
         }];
 
@@ -1362,7 +1362,7 @@ mod tests {
             None,
             &[],
         )
-        .expect("deprecated compatibility search filters should not force new metadata");
+        .expect("contains filters should not force search metadata");
     }
 
     #[test]
@@ -1400,7 +1400,7 @@ mod tests {
             name: "query".to_string(),
             data_type: "Utf8".to_string(),
             required: false,
-            mode: FilterMode::Search,
+            mode: FilterMode::Contains,
             description: String::new(),
         }];
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -395,6 +395,23 @@ FROM github.search_issues(q => 'repo:withcoral/coral source functions')
 LIMIT 10;
 ```
 
+`mode: contains` remains available for ordinary table filters whose provider
+API supports substring matching. It is not a retrieval marker and should not be
+used as a replacement for `kind: search`:
+
+```yaml
+filters:
+  - name: title
+    type: Utf8
+    description: Provider-side title substring.
+    mode: contains
+```
+
+`mode: search` is still accepted as a legacy compatibility marker for existing
+virtual-filter tables and is exposed through `coral.filters.filter_mode` and
+`coral.columns.filter_mode`. Do not use it for new provider-native retrieval
+surfaces; declare those as `kind: search` functions instead.
+
 `search_limits` values must be positive. `default_top_k` and `max_top_k` are
 capped at 1000, `max_calls_per_query` is capped at 100, and
 `max_top_k * max_calls_per_query` cannot exceed 10000 candidates.

--- a/sources/community/okta/manifest.yaml
+++ b/sources/community/okta/manifest.yaml
@@ -36,6 +36,491 @@ request_headers:
 test_queries:
   - SELECT id, login, email, status FROM okta.current_user LIMIT 1
 
+functions:
+  - name: search_users
+    kind: search
+    description: Provider-native search for Okta users using the q parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: filter
+        bind:
+          arg: filter
+    request:
+      method: GET
+      path: /api/v1/users
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: filter
+          from: arg
+          key: filter
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+      page_size:
+        default: 10
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Okta user ID.
+        expr: {kind: path, path: [id]}
+      - name: login
+        type: Utf8
+        nullable: true
+        description: User login.
+        expr: {kind: path, path: [profile, login]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email.
+        expr: {kind: path, path: [profile, email]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: User lifecycle status.
+        expr: {kind: path, path: [status]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: User creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw users search result.
+        expr:
+          kind: current_row
+  - name: search_users_by_expression
+    kind: search
+    description: Provider-native search for Okta users using the search parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: search
+        required: true
+        bind:
+          arg: search
+      - name: filter
+        bind:
+          arg: filter
+    request:
+      method: GET
+      path: /api/v1/users
+      query:
+        - name: search
+          from: arg
+          key: search
+        - name: filter
+          from: arg
+          key: filter
+    response:
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Okta user ID.
+        expr: {kind: path, path: [id]}
+      - name: login
+        type: Utf8
+        nullable: true
+        description: User login.
+        expr: {kind: path, path: [profile, login]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email.
+        expr: {kind: path, path: [profile, email]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: User lifecycle status.
+        expr: {kind: path, path: [status]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: User creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw users search result.
+        expr:
+          kind: current_row
+  - name: search_groups
+    kind: search
+    description: Provider-native search for Okta groups using the q parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: filter
+        bind:
+          arg: filter
+    request:
+      method: GET
+      path: /api/v1/groups
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: filter
+          from: arg
+          key: filter
+    response:
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Group ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Group profile name.
+        expr: {kind: path, path: [profile, name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Group profile description.
+        expr: {kind: path, path: [profile, description]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Group type.
+        expr: {kind: path, path: [type]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Group creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw groups search result.
+        expr:
+          kind: current_row
+  - name: search_groups_by_expression
+    kind: search
+    description: Provider-native search for Okta groups using the search parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: search
+        required: true
+        bind:
+          arg: search
+      - name: filter
+        bind:
+          arg: filter
+    request:
+      method: GET
+      path: /api/v1/groups
+      query:
+        - name: search
+          from: arg
+          key: search
+        - name: filter
+          from: arg
+          key: filter
+    response:
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Group ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Group profile name.
+        expr: {kind: path, path: [profile, name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Group profile description.
+        expr: {kind: path, path: [profile, description]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Group type.
+        expr: {kind: path, path: [type]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Group creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw groups search result.
+        expr:
+          kind: current_row
+  - name: search_apps
+    kind: search
+    description: Provider-native search for Okta apps using the q parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: filter
+        bind:
+          arg: filter
+    request:
+      method: GET
+      path: /api/v1/apps
+      query:
+        - name: q
+          from: arg
+          key: q
+        - name: filter
+          from: arg
+          key: filter
+    response:
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Application ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Application integration key.
+        expr: {kind: path, path: [name]}
+      - name: label
+        type: Utf8
+        nullable: true
+        description: Application label.
+        expr: {kind: path, path: [label]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Application status.
+        expr: {kind: path, path: [status]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Application creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw apps search result.
+        expr:
+          kind: current_row
+  - name: search_app_users
+    kind: search
+    description: Provider-native search for Okta app users using the q parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: app_id
+        required: true
+        bind:
+          arg: app_id
+    request:
+      method: GET
+      path: /api/v1/apps/{{arg.app_id}}/users
+      query:
+        - name: q
+          from: arg
+          key: q
+    response:
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: App user assignment ID.
+        expr: {kind: path, path: [id]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Assignment status.
+        expr: {kind: path, path: [status]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Assignment creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw app users search result.
+        expr:
+          kind: current_row
+  - name: search_system_log
+    kind: search
+    description: Provider-native search for Okta system log using the q parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: q
+        required: true
+        bind:
+          arg: q
+      - name: since
+        bind:
+          arg: since
+      - name: until
+        bind:
+          arg: until
+      - name: filter
+        bind:
+          arg: filter
+    request:
+      method: GET
+      path: /api/v1/logs
+      query:
+        - name: since
+          from: arg
+          key: since
+        - name: until
+          from: arg
+          key: until
+        - name: filter
+          from: arg
+          key: filter
+        - name: q
+          from: arg
+          key: q
+    response:
+      row_strategy: direct
+    pagination:
+      mode: link_header
+      max_pages: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: System Log event UUID.
+        expr: {kind: path, path: [uuid]}
+      - name: display_message
+        type: Utf8
+        nullable: true
+        description: Human-readable event message.
+        expr: {kind: path, path: [displayMessage]}
+      - name: severity
+        type: Utf8
+        nullable: true
+        description: Event severity.
+        expr: {kind: path, path: [severity]}
+      - name: event_type
+        type: Utf8
+        nullable: true
+        description: Okta event type.
+        expr: {kind: path, path: [eventType]}
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: Event publication time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [published]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw system log search result.
+        expr:
+          kind: current_row
 tables:
   - name: current_user
     description: Current Okta user associated with the API token.

--- a/sources/community/okta/manifest.yaml
+++ b/sources/community/okta/manifest.yaml
@@ -420,6 +420,11 @@ functions:
         nullable: false
         description: App user assignment ID.
         expr: {kind: path, path: [id]}
+      - name: app_id
+        type: Utf8
+        nullable: false
+        description: Application ID used for the request.
+        expr: {kind: from_arg, key: app_id}
       - name: status
         type: Utf8
         nullable: true

--- a/sources/community/opsgenie/manifest.yaml
+++ b/sources/community/opsgenie/manifest.yaml
@@ -37,6 +37,175 @@ request_headers:
 test_queries:
   - SELECT id, name, description FROM opsgenie.teams LIMIT 1
 
+functions:
+  - name: search_alerts
+    kind: search
+    description: Provider-native search for Opsgenie alerts using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        bind:
+          arg: query
+      - name: search_identifier
+        bind:
+          arg: search_identifier
+      - name: sort
+        bind:
+          arg: sort
+      - name: order
+        bind:
+          arg: order
+    request:
+      method: GET
+      path: /alerts
+      query:
+        - name: query
+          from: arg
+          key: query
+        - name: searchIdentifier
+          from: arg
+          key: search_identifier
+        - name: sort
+          from: arg
+          key: sort
+        - name: order
+          from: arg
+          key: order
+    response:
+      rows_path: [data]
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Alert ID.
+        expr: {kind: path, path: [id]}
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Alert message.
+        expr: {kind: path, path: [message]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Alert status.
+        expr: {kind: path, path: [status]}
+      - name: priority
+        type: Utf8
+        nullable: true
+        description: Alert priority.
+        expr: {kind: path, path: [priority]}
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Alert source.
+        expr: {kind: path, path: [source]}
+      - name: alias
+        type: Utf8
+        nullable: true
+        description: Alert alias.
+        expr: {kind: path, path: [alias]}
+      - name: tiny_id
+        type: Utf8
+        nullable: true
+        description: Short alert ID.
+        expr: {kind: path, path: [tinyId]}
+      - name: owner
+        type: Utf8
+        nullable: true
+        description: Alert owner.
+        expr: {kind: path, path: [owner]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Alert creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Alert update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updatedAt]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw alerts search result.
+        expr:
+          kind: current_row
+  - name: search_users
+    kind: search
+    description: Provider-native search for Opsgenie users using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: GET
+      path: /users
+      query:
+        - name: query
+          from: arg
+          key: query
+    response:
+      rows_path: [data]
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: User ID.
+        expr: {kind: path, path: [id]}
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: User full name.
+        expr: {kind: path, path: [fullName]}
+      - name: username
+        type: Utf8
+        nullable: true
+        description: User login or email.
+        expr: {kind: path, path: [username]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: User creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw users search result.
+        expr:
+          kind: current_row
 tables:
   - name: alerts
     description: Opsgenie alerts visible to the API key.

--- a/sources/community/shopify/manifest.yaml
+++ b/sources/community/shopify/manifest.yaml
@@ -43,6 +43,921 @@ request_headers:
 test_queries:
   - SELECT id, name, myshopify_domain FROM shopify.shop LIMIT 1
   - SELECT id, title, status FROM shopify.products LIMIT 1
+functions:
+  - name: search_products
+    kind: search
+    description: Provider-native search for Shopify products using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query ShopifyProducts($first: Int!, $after: String, $query: String) {
+              products(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  title
+                  handle
+                  status
+                  vendor
+                  productType
+                  tags
+                  totalInventory
+                  hasOnlyDefaultVariant
+                  createdAt
+                  updatedAt
+                  publishedAt
+                  priceRangeV2 {
+                    minVariantPrice {
+                      amount
+                      currencyCode
+                    }
+                    maxVariantPrice {
+                      amount
+                      currencyCode
+                    }
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: arg
+          key: query
+    response:
+      rows_path: [data, products, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, products, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify product ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Product title.
+        expr:
+          kind: path
+          path: [title]
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Product status such as ACTIVE, DRAFT, or ARCHIVED.
+        expr:
+          kind: path
+          path: [status]
+      - name: handle
+        type: Utf8
+        nullable: true
+        description: Product handle.
+        expr:
+          kind: path
+          path: [handle]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Product creation timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Product last updated timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: Product publication timestamp, when present.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [publishedAt]
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw products search result.
+        expr:
+          kind: current_row
+  - name: search_product_variants
+    kind: search
+    description: Provider-native search for Shopify product variants using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query ShopifyProductVariants($first: Int!, $after: String, $query: String) {
+              productVariants(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  title
+                  displayName
+                  sku
+                  barcode
+                  price
+                  compareAtPrice
+                  availableForSale
+                  inventoryQuantity
+                  inventoryPolicy
+                  selectedOptions {
+                    name
+                    value
+                  }
+                  createdAt
+                  updatedAt
+                  product {
+                    id
+                    title
+                    handle
+                  }
+                  inventoryItem {
+                    id
+                    sku
+                    tracked
+                    requiresShipping
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: arg
+          key: query
+    response:
+      rows_path: [data, productVariants, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, productVariants, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify product variant ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Variant title.
+        expr:
+          kind: path
+          path: [title]
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name combining product and variant context.
+        expr:
+          kind: path
+          path: [displayName]
+      - name: sku
+        type: Utf8
+        nullable: true
+        description: Variant SKU.
+        expr:
+          kind: path
+          path: [sku]
+      - name: barcode
+        type: Utf8
+        nullable: true
+        description: Variant barcode.
+        expr:
+          kind: path
+          path: [barcode]
+      - name: product_id
+        type: Utf8
+        nullable: true
+        description: Parent product ID.
+        expr:
+          kind: path
+          path: [product, id]
+      - name: product_title
+        type: Utf8
+        nullable: true
+        description: Parent product title.
+        expr:
+          kind: path
+          path: [product, title]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Variant creation timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Variant last updated timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw product variants search result.
+        expr:
+          kind: current_row
+  - name: search_collections
+    kind: search
+    description: Provider-native search for Shopify collections using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query ShopifyCollections($first: Int!, $after: String, $query: String) {
+              collections(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  title
+                  handle
+                  description
+                  descriptionHtml
+                  sortOrder
+                  templateSuffix
+                  updatedAt
+                  productsCount {
+                    count
+                    precision
+                  }
+                  seo {
+                    title
+                    description
+                  }
+                  ruleSet {
+                    appliedDisjunctively
+                    rules {
+                      column
+                      relation
+                      condition
+                    }
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: arg
+          key: query
+    response:
+      rows_path: [data, collections, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, collections, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify collection ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Collection title.
+        expr:
+          kind: path
+          path: [title]
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Plain-text collection description.
+        expr:
+          kind: path
+          path: [description]
+      - name: handle
+        type: Utf8
+        nullable: true
+        description: Collection handle.
+        expr:
+          kind: path
+          path: [handle]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Collection last updated timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw collections search result.
+        expr:
+          kind: current_row
+  - name: search_orders
+    kind: search
+    description: Provider-native search for Shopify orders using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query ShopifyOrders($first: Int!, $after: String, $query: String) {
+              orders(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  name
+                  createdAt
+                  updatedAt
+                  processedAt
+                  cancelledAt
+                  displayFinancialStatus
+                  displayFulfillmentStatus
+                  currencyCode
+                  currentTotalPriceSet {
+                    shopMoney {
+                      amount
+                      currencyCode
+                    }
+                  }
+                  currentSubtotalPriceSet {
+                    shopMoney {
+                      amount
+                      currencyCode
+                    }
+                  }
+                  currentTotalTaxSet {
+                    shopMoney {
+                      amount
+                      currencyCode
+                    }
+                  }
+                  subtotalLineItemsQuantity
+                  tags
+                  test
+                  customer {
+                    id
+                    displayName
+                    firstName
+                    lastName
+                    defaultEmailAddress {
+                      emailAddress
+                    }
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: arg
+          key: query
+    response:
+      rows_path: [data, orders, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, orders, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify order ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Merchant-facing order name, such as order 1001.
+        expr:
+          kind: path
+          path: [name]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Order creation timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Order last updated timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
+      - name: processed_at
+        type: Timestamp
+        nullable: true
+        description: Order processed timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [processedAt]
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw orders search result.
+        expr:
+          kind: current_row
+  - name: search_customers
+    kind: search
+    description: Provider-native search for Shopify customers using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query ShopifyCustomers($first: Int!, $after: String, $query: String) {
+              customers(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  displayName
+                  firstName
+                  lastName
+                  createdAt
+                  updatedAt
+                  state
+                  numberOfOrders
+                  verifiedEmail
+                  taxExempt
+                  tags
+                  amountSpent {
+                    amount
+                    currencyCode
+                  }
+                  defaultEmailAddress {
+                    emailAddress
+                    marketingState
+                  }
+                  defaultPhoneNumber {
+                    phoneNumber
+                    marketingState
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: arg
+          key: query
+    response:
+      rows_path: [data, customers, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, customers, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify customer ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Customer display name.
+        expr:
+          kind: path
+          path: [displayName]
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Customer account state.
+        expr:
+          kind: path
+          path: [state]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Customer creation timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Customer last updated timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw customers search result.
+        expr:
+          kind: current_row
+  - name: search_locations
+    kind: search
+    description: Provider-native search for Shopify locations using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+      - name: include_inactive
+        bind:
+          arg: include_inactive
+      - name: include_legacy
+        bind:
+          arg: include_legacy
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query ShopifyLocations(
+              $first: Int!,
+              $after: String,
+              $query: String,
+              $includeInactive: Boolean,
+              $includeLegacy: Boolean
+            ) {
+              locations(
+                first: $first,
+                after: $after,
+                query: $query,
+                includeInactive: $includeInactive,
+                includeLegacy: $includeLegacy
+              ) {
+                nodes {
+                  id
+                  name
+                  isActive
+                  isFulfillmentService
+                  fulfillsOnlineOrders
+                  hasActiveInventory
+                  shipsInventory
+                  createdAt
+                  updatedAt
+                  address {
+                    address1
+                    address2
+                    city
+                    country
+                    countryCode
+                    province
+                    provinceCode
+                    zip
+                  }
+                  fulfillmentService {
+                    handle
+                    serviceName
+                  }
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: arg
+          key: query
+        - path: [variables, includeInactive]
+          from: arg_bool
+          key: include_inactive
+        - path: [variables, includeLegacy]
+          from: arg_bool
+          key: include_legacy
+    response:
+      rows_path: [data, locations, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, locations, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify location ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Location name.
+        expr:
+          kind: path
+          path: [name]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Location creation timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Location last updated timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw locations search result.
+        expr:
+          kind: current_row
+  - name: search_inventory_items
+    kind: search
+    description: Provider-native search for Shopify inventory items using the query parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: query
+        required: true
+        bind:
+          arg: query
+    request:
+      method: POST
+      path: /graphql.json
+      body:
+        - path:
+            - query
+          from: literal
+          value: |
+            query ShopifyInventoryItems($first: Int!, $after: String, $query: String) {
+              inventoryItems(first: $first, after: $after, query: $query) {
+                nodes {
+                  id
+                  sku
+                  tracked
+                  requiresShipping
+                  duplicateSkuCount
+                  countryCodeOfOrigin
+                  provinceCodeOfOrigin
+                  harmonizedSystemCode
+                  inventoryHistoryUrl
+                  locationsCount {
+                    count
+                    precision
+                  }
+                  createdAt
+                  updatedAt
+                }
+                pageInfo {
+                  endCursor
+                  hasNextPage
+                }
+              }
+            }
+        - path:
+            - variables
+            - first
+          from: literal
+          value: 100
+        - path: [variables, query]
+          from: arg
+          key: query
+    response:
+      rows_path: [data, inventoryItems, nodes]
+      row_strategy: direct
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [variables, after]
+      response_cursor_path: [data, inventoryItems, pageInfo, endCursor]
+      page_size:
+        default: 100
+        max: 250
+        body_path: [variables, first]
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique Shopify inventory item ID.
+        expr:
+          kind: path
+          path: [id]
+      - name: sku
+        type: Utf8
+        nullable: true
+        description: Inventory item SKU.
+        expr:
+          kind: path
+          path: [sku]
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Inventory item creation timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [createdAt]
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Inventory item last updated timestamp from Shopify.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path: [updatedAt]
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw inventory items search result.
+        expr:
+          kind: current_row
 tables:
   - name: shop
     description: Shopify shop metadata for the authenticated Admin API token.
@@ -975,7 +1890,7 @@ tables:
       - name: name
         type: Utf8
         nullable: true
-        description: Merchant-facing order name, such as #1001.
+        description: Merchant-facing order name, such as order 1001.
         expr:
           kind: path
           path: [name]

--- a/sources/community/splunk/manifest.yaml
+++ b/sources/community/splunk/manifest.yaml
@@ -34,6 +34,287 @@ request_headers:
 test_queries:
   - SELECT name, version, server_name FROM splunk.server_info LIMIT 1
 
+functions:
+  - name: search_indexes
+    kind: search
+    description: Provider-native search for Splunk indexes using the search parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: search
+        required: true
+        bind:
+          arg: search
+    request:
+      method: GET
+      path: /services/data/indexes
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: arg
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Index name.
+        expr: {kind: path, path: [name]}
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Index title.
+        expr: {kind: path, path: [content, title]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw indexes search result.
+        expr:
+          kind: current_row
+  - name: search_saved_searches
+    kind: search
+    description: Provider-native search for Splunk saved searches using the search parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: search
+        required: true
+        bind:
+          arg: search
+    request:
+      method: GET
+      path: /servicesNS/-/-/saved/searches
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: arg
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Saved search name.
+        expr: {kind: path, path: [name]}
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Saved search title.
+        expr: {kind: path, path: [content, title]}
+      - name: author
+        type: Utf8
+        nullable: true
+        description: Saved search author.
+        expr: {kind: path, path: [author]}
+      - name: app
+        type: Utf8
+        nullable: true
+        description: Splunk app namespace.
+        expr: {kind: path, path: [acl, app]}
+      - name: owner
+        type: Utf8
+        nullable: true
+        description: Splunk owner namespace.
+        expr: {kind: path, path: [acl, owner]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw saved searches search result.
+        expr:
+          kind: current_row
+  - name: search_apps
+    kind: search
+    description: Provider-native search for Splunk apps using the search parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: search
+        required: true
+        bind:
+          arg: search
+    request:
+      method: GET
+      path: /services/apps/local
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: arg
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: App name.
+        expr: {kind: path, path: [name]}
+      - name: label
+        type: Utf8
+        nullable: true
+        description: App label.
+        expr: {kind: path, path: [content, label]}
+      - name: author
+        type: Utf8
+        nullable: true
+        description: App author.
+        expr: {kind: path, path: [content, author]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw apps search result.
+        expr:
+          kind: current_row
+  - name: search_users
+    kind: search
+    description: Provider-native search for Splunk users using the search parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: search
+        required: true
+        bind:
+          arg: search
+    request:
+      method: GET
+      path: /services/authentication/users
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: arg
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Username.
+        expr: {kind: path, path: [name]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+        expr: {kind: path, path: [content, email]}
+      - name: realname
+        type: Utf8
+        nullable: true
+        description: User real name.
+        expr: {kind: path, path: [content, realname]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: User type.
+        expr: {kind: path, path: [content, type]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw users search result.
+        expr:
+          kind: current_row
+  - name: search_search_jobs
+    kind: search
+    description: Provider-native search for Splunk search jobs using the search parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: search
+        required: true
+        bind:
+          arg: search
+    request:
+      method: GET
+      path: /services/search/jobs
+      query:
+        - name: output_mode
+          from: literal
+          value: json
+        - name: search
+          from: arg
+          key: search
+    response:
+      rows_path: [entry]
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: count
+    columns:
+      - name: sid
+        type: Utf8
+        nullable: false
+        description: Search job ID.
+        expr: {kind: path, path: [name]}
+      - name: label
+        type: Utf8
+        nullable: true
+        description: Search job label.
+        expr: {kind: path, path: [content, label]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw search jobs search result.
+        expr:
+          kind: current_row
 tables:
   - name: server_info
     description: Splunk server information.

--- a/sources/community/splunk/manifest.yaml
+++ b/sources/community/splunk/manifest.yaml
@@ -198,7 +198,7 @@ functions:
         type: Utf8
         nullable: true
         description: App author.
-        expr: {kind: path, path: [content, author]}
+        expr: {kind: path, path: [author]}
       - name: raw
         type: Json
         nullable: false

--- a/sources/core/notion/manifest.yaml
+++ b/sources/core/notion/manifest.yaml
@@ -173,6 +173,73 @@ functions:
         description: Full raw Notion search result
         expr:
           kind: current_row
+  - name: search_data_source_templates
+    kind: search
+    description: Provider-native search for Notion data source templates using the name parameter.
+    fetch_limit_default: 10
+    search_limits:
+      default_top_k: 10
+      max_top_k: 100
+      max_calls_per_query: 1
+    args:
+      - name: name
+        required: true
+        bind:
+          arg: name
+      - name: data_source_id
+        required: true
+        bind:
+          arg: data_source_id
+    request:
+      method: GET
+      path: /v1/data_sources/{{arg.data_source_id}}/templates
+      query:
+        - name: name
+          from: arg
+          key: name
+    response:
+      rows_path:
+        - templates
+    pagination:
+      mode: cursor_query
+      cursor_param: start_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 100
+        query_param: page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Template page ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Template name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: is_default
+        type: Boolean
+        nullable: false
+        description: Whether this template is the data source default
+        expr:
+          kind: path
+          path:
+            - is_default
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw data source templates search result.
+        expr:
+          kind: current_row
 tables:
   - name: search
     description: Pages and data sources shared with the integration

--- a/sources/core/notion/manifest.yaml
+++ b/sources/core/notion/manifest.yaml
@@ -218,6 +218,13 @@ functions:
           kind: path
           path:
             - id
+      - name: data_source_id
+        type: Utf8
+        nullable: false
+        description: Data source ID used for the request
+        expr:
+          kind: from_arg
+          key: data_source_id
       - name: name
         type: Utf8
         nullable: false


### PR DESCRIPTION
## Summary
- migrate bundled sources that used legacy `mode: search` table filters by adding provider-native `kind: search` table functions
- preserve legacy `mode: search` compatibility for existing/custom table filters, including manifest deserialization, JSON schema validation, `coral.filters`/`coral.columns.filter_mode`, and LIKE pushdown behavior
- enforce advertised `search_limits.max_top_k` during HTTP execution by capping SQL-requested limits/page sizes before provider fetches
- keep compatibility-table contracts stable while migrating: Opsgenie saved-search lookups can use `search_identifier` without `query`, Splunk table columns are restored, and existing compatibility filters keep their old search semantics

## API verification links
- Okta: [Users](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/user/listusers), [Groups](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/group/listgroups), [Applications](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/application/listapplications), [Application Users](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/applicationusers/listapplicationusers), [System Log](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/systemlog/listlogevents)
- Opsgenie: [Alerts](https://docs.opsgenie.com/docs/alert-api), [Users](https://docs.opsgenie.com/docs/user-api), [Schedules](https://docs.opsgenie.com/docs/schedule-api), [Escalations](https://docs.opsgenie.com/docs/escalation-api)
- Shopify: [Admin GraphQL overview](https://shopify.dev/docs/api/admin-graphql/latest), [GraphQL pagination](https://shopify.dev/docs/api/usage/pagination-graphql), [products](https://shopify.dev/docs/api/admin-graphql/latest/queries/products), [productVariants](https://shopify.dev/docs/api/admin-graphql/latest/queries/productVariants), [collections](https://shopify.dev/docs/api/admin-graphql/latest/queries/collections), [orders](https://shopify.dev/docs/api/admin-graphql/latest/queries/orders), [customers](https://shopify.dev/docs/api/admin-graphql/latest/queries/customers), [locations](https://shopify.dev/docs/api/admin-graphql/latest/queries/locations), [inventoryItems](https://shopify.dev/docs/api/admin-graphql/latest/queries/inventoryItems)
- Splunk: [data/indexes](https://help.splunk.com/en/splunk-enterprise/rest-api-reference/10.2/introspection-endpoints/introspection-endpoint-descriptions), [saved/searches and search/jobs](https://help.splunk.com/en/splunk-enterprise/rest-api-reference/10.2/search-endpoints/search-endpoint-descriptions), [apps/local](https://help.splunk.com/en/splunk-enterprise/leverage-rest-apis/rest-api-reference/10.4/application-endpoints/application-endpoint-descriptions), [authentication/users](https://help.splunk.com/en/splunk-enterprise/rest-api-reference/10.2/access-endpoints/access-endpoint-descriptions)
- Notion: [Search](https://developers.notion.com/reference/post-search), [List data source templates](https://developers.notion.com/reference/list-data-source-templates)

## Validation
- `make lint-sources`
- `cargo fmt --check`
- `cargo run --locked -p xtask -- generate-docs --check`
- `cargo test -p coral-spec`
- `cargo test -p coral-engine --lib`
- `cargo test -p coral-engine --test engine search_function_limit_is_capped_by_search_limits`
