### PR TITLE
feat(spec): parse source model manifests

### DIFF
--- a/crates/coral-spec/src/backends/mod.rs
+++ b/crates/coral-spec/src/backends/mod.rs
@@ -4,6 +4,7 @@
 //!
 //! - [`http`] for HTTP-backed sources
 //! - [`mod@file`] for file-backed sources such as `parquet` and `jsonl`
+//! - [`source_model`] for DSL v4 source-model-backed sources
 //!
 //! Parsing entry points remain crate-private. Callers should normally use
 //! [`crate::parse_source_manifest_yaml`] or [`crate::parse_source_manifest_value`]
@@ -11,3 +12,4 @@
 
 pub mod file;
 pub mod http;
+pub mod source_model;

--- a/crates/coral-spec/src/backends/source_model.rs
+++ b/crates/coral-spec/src/backends/source_model.rs
@@ -1,0 +1,351 @@
+#![allow(
+    missing_docs,
+    reason = "This module defines field-heavy declarative source-model manifest types."
+)]
+
+//! DSL v4 source-model manifest model and validation.
+//!
+//! Source-model manifests describe which API descriptions should be imported
+//! and which SQL projections should later resolve against materialized IR. They
+//! do not contain importer-produced entities, operations, or protocol bindings.
+
+use std::collections::{BTreeSet, HashSet};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::backends::http::{AuthSpec, RateLimitSpec};
+use crate::inputs::collect_source_inputs_value;
+use crate::validate::validate_template;
+use crate::{
+    ColumnSpec, HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec, ParsedTemplate,
+    ProjectionKind, Result, SourceBackend, SourceManifestCommon, SourceModelProjectionRef,
+    validate_columns, validate_test_queries,
+};
+
+/// Validated top-level manifest for a DSL v4 source-model-backed source.
+#[derive(Debug, Clone)]
+pub struct SourceModelSourceManifest {
+    pub common: SourceManifestCommon,
+    pub surfaces: Vec<SourceModelManifestSurface>,
+    pub projections: Vec<SourceModelManifestProjection>,
+    pub declared_inputs: Vec<ManifestInputSpec>,
+}
+
+/// One API description surface imported by a DSL v4 manifest.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceModelManifestSurface {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub surface_type: SurfaceDescriptionType,
+    pub url: String,
+    pub sha256: String,
+    pub base_url: ParsedTemplate,
+    #[serde(default)]
+    pub auth: AuthSpec,
+    #[serde(default)]
+    pub request_headers: Vec<HeaderSpec>,
+    #[serde(default)]
+    pub rate_limit: RateLimitSpec,
+}
+
+/// Supported author-facing API description formats for DSL v4 surfaces.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SurfaceDescriptionType {
+    OpenApi,
+}
+
+/// One explicit SQL projection declared by a DSL v4 manifest.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceModelManifestProjection {
+    pub name: String,
+    pub kind: ProjectionKind,
+    pub surface: String,
+    pub operation: String,
+    #[serde(default)]
+    pub columns: Vec<ColumnSpec>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawSourceModelSourceManifest {
+    dsl_version: u32,
+    name: String,
+    version: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    test_queries: Vec<String>,
+    backend: SourceBackend,
+    #[serde(default)]
+    inputs: Option<Value>,
+    surfaces: Vec<SourceModelManifestSurface>,
+    projections: Vec<SourceModelManifestProjection>,
+}
+
+impl SourceModelSourceManifest {
+    pub(crate) fn parse_manifest_value(value: Value) -> Result<Self> {
+        let declared_inputs = collect_source_inputs_value(&value)?;
+        let raw: RawSourceModelSourceManifest =
+            serde_json::from_value(value).map_err(ManifestError::deserialize)?;
+        let RawSourceModelSourceManifest {
+            dsl_version,
+            name,
+            version,
+            description,
+            test_queries,
+            backend: _backend,
+            inputs: _inputs,
+            surfaces,
+            projections,
+        } = raw;
+
+        validate_test_queries(&name, &test_queries)?;
+        validate_surfaces(&name, &surfaces)?;
+        validate_projections(&name, &surfaces, &projections)?;
+        let common =
+            SourceManifestCommon::new(dsl_version, name, version, description, test_queries);
+
+        Ok(Self {
+            common,
+            surfaces,
+            projections,
+            declared_inputs,
+        })
+    }
+
+    /// Returns the source secrets required by this manifest.
+    ///
+    /// In the input model, every declared input with `kind: secret` is required
+    /// because secrets cannot carry defaults.
+    pub fn required_secret_names(&self) -> BTreeSet<String> {
+        self.declared_inputs
+            .iter()
+            .filter(|input| input.kind == ManifestInputKind::Secret)
+            .map(|input| input.key.clone())
+            .collect()
+    }
+
+    /// Returns projection references in the shape needed to validate
+    /// materialized source-model IR.
+    pub fn projection_refs(&self) -> Vec<SourceModelProjectionRef> {
+        self.projections
+            .iter()
+            .map(|projection| SourceModelProjectionRef {
+                name: projection.name.clone(),
+                kind: projection.kind,
+                surface: projection.surface.clone(),
+                operation: projection.operation.clone(),
+            })
+            .collect()
+    }
+}
+
+fn validate_surfaces(source_name: &str, surfaces: &[SourceModelManifestSurface]) -> Result<()> {
+    if surfaces.is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' must define at least one surface"
+        )));
+    }
+
+    let mut seen = HashSet::new();
+    for surface in surfaces {
+        validate_non_empty(&surface.id, &format!("source '{source_name}' surface id"))?;
+        if !seen.insert(surface.id.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' declares surface '{}' more than once",
+                surface.id
+            )));
+        }
+        validate_non_empty(
+            &surface.url,
+            &format!("source '{source_name}' surface '{}' url", surface.id),
+        )?;
+        validate_sha256(source_name, surface)?;
+        if surface.base_url.raw().trim().is_empty() {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' surface '{}' must define a non-empty base_url",
+                surface.id
+            )));
+        }
+        validate_template(
+            &surface.base_url,
+            &HashSet::new(),
+            &format!("source '{source_name}' surface '{}'", surface.id),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn validate_sha256(source_name: &str, surface: &SourceModelManifestSurface) -> Result<()> {
+    let sha = surface.sha256.trim();
+    if sha.len() != 64 || !sha.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' surface '{}' sha256 must be a 64-character hex string",
+            surface.id
+        )));
+    }
+    Ok(())
+}
+
+fn validate_projections(
+    source_name: &str,
+    surfaces: &[SourceModelManifestSurface],
+    projections: &[SourceModelManifestProjection],
+) -> Result<()> {
+    if projections.is_empty() {
+        return Err(ManifestError::validation(format!(
+            "source '{source_name}' must define at least one projection"
+        )));
+    }
+
+    let surface_ids = surfaces
+        .iter()
+        .map(|surface| surface.id.as_str())
+        .collect::<HashSet<_>>();
+    let mut seen = HashSet::new();
+    for projection in projections {
+        validate_non_empty(
+            &projection.name,
+            &format!("source '{source_name}' projection name"),
+        )?;
+        if !seen.insert(projection.name.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' declares projection '{}' more than once",
+                projection.name
+            )));
+        }
+        if !surface_ids.contains(projection.surface.as_str()) {
+            return Err(ManifestError::validation(format!(
+                "source '{source_name}' projection '{}' references unknown surface '{}'",
+                projection.name, projection.surface
+            )));
+        }
+        validate_non_empty(
+            &projection.operation,
+            &format!(
+                "source '{source_name}' projection '{}' operation",
+                projection.name
+            ),
+        )?;
+        validate_columns(&projection.columns, source_name, &projection.name)?;
+    }
+
+    Ok(())
+}
+
+fn validate_non_empty(value: &str, context: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        return Err(ManifestError::validation(format!(
+            "{context} must not be empty"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::Value;
+
+    use crate::backends::source_model::{SourceModelSourceManifest, SurfaceDescriptionType};
+
+    fn source_model_manifest() -> Value {
+        serde_yaml::from_str(
+            r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+description: GitHub via imported OpenAPI
+inputs:
+  GITHUB_TOKEN:
+    kind: secret
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://example.com/github-openapi.yaml
+    sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    base_url: https://api.github.com
+    auth:
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: template
+          template: Bearer {{input.GITHUB_TOKEN}}
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+    columns:
+      - name: title
+        type: Utf8
+",
+        )
+        .expect("test manifest should parse as yaml")
+    }
+
+    #[test]
+    fn source_model_manifest_parses_surface_and_projection_metadata() {
+        let manifest = SourceModelSourceManifest::parse_manifest_value(source_model_manifest())
+            .expect("source model manifest should parse");
+
+        assert_eq!(manifest.common.name, "github");
+        assert_eq!(manifest.surfaces.len(), 1);
+        let surface = manifest
+            .surfaces
+            .first()
+            .expect("manifest should have a surface");
+        assert_eq!(surface.id, "github-rest");
+        assert_eq!(surface.surface_type, SurfaceDescriptionType::OpenApi);
+        assert_eq!(manifest.projections.len(), 1);
+        let projection_refs = manifest.projection_refs();
+        let projection_ref = projection_refs
+            .first()
+            .expect("manifest should have a projection ref");
+        assert_eq!(projection_ref.operation, "issues/list-for-repo");
+        assert_eq!(
+            manifest
+                .required_secret_names()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            ["GITHUB_TOKEN"]
+        );
+    }
+
+    #[test]
+    fn source_model_manifest_rejects_unknown_projection_surface() {
+        let manifest = serde_yaml::from_str(
+            r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://example.com/github-openapi.yaml
+    sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    base_url: https://api.github.com
+projections:
+  - name: issues
+    kind: table
+    surface: missing
+    operation: issues/list-for-repo
+",
+        )
+        .expect("test manifest should parse as yaml");
+
+        let error = SourceModelSourceManifest::parse_manifest_value(manifest)
+            .expect_err("unknown surface should fail");
+
+        assert_eq!(
+            error.to_string(),
+            "source 'github' projection 'issues' references unknown surface 'missing'"
+        );
+    }
+}

--- a/crates/coral-spec/src/common.rs
+++ b/crates/coral-spec/src/common.rs
@@ -64,6 +64,7 @@ pub enum SourceBackend {
     Http,
     Parquet,
     Jsonl,
+    SourceModel,
 }
 
 /// Normalized scalar data types supported by the source-spec DSL.

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -87,6 +87,10 @@ mod template;
 mod validate;
 
 pub use backends::http::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
+pub use backends::source_model::{
+    SourceModelManifestProjection, SourceModelManifestSurface, SourceModelSourceManifest,
+    SurfaceDescriptionType,
+};
 pub(crate) use common::validate_test_queries;
 pub use common::{
     BodyFieldSpec, BodySpec, ColumnSpec, DetailHintSpec, ExprSpec, FilterMode, FilterSpec,

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -10,6 +10,7 @@ use serde_json::Value;
 
 use crate::backends::file::{JsonlSourceManifest, ParquetSourceManifest};
 use crate::backends::http::HttpSourceManifest;
+use crate::backends::source_model::SourceModelSourceManifest;
 use crate::schema::validate_manifest_schema;
 use crate::{ManifestError, ManifestInputSpec, Result, SourceBackend};
 
@@ -28,6 +29,7 @@ enum ValidatedManifestKind {
     Http(Box<HttpSourceManifest>),
     Parquet(ParquetSourceManifest),
     Jsonl(JsonlSourceManifest),
+    SourceModel(SourceModelSourceManifest),
 }
 
 impl ValidatedSourceManifest {
@@ -42,6 +44,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(_) => SourceBackend::Http,
             ValidatedManifestKind::Parquet(_) => SourceBackend::Parquet,
             ValidatedManifestKind::Jsonl(_) => SourceBackend::Jsonl,
+            ValidatedManifestKind::SourceModel(_) => SourceBackend::SourceModel,
         }
     }
 
@@ -52,6 +55,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(manifest) => &manifest.common.name,
             ValidatedManifestKind::Parquet(manifest) => &manifest.common.name,
             ValidatedManifestKind::Jsonl(manifest) => &manifest.common.name,
+            ValidatedManifestKind::SourceModel(manifest) => &manifest.common.name,
         }
     }
 
@@ -62,6 +66,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(manifest) => &manifest.common.version,
             ValidatedManifestKind::Parquet(manifest) => &manifest.common.version,
             ValidatedManifestKind::Jsonl(manifest) => &manifest.common.version,
+            ValidatedManifestKind::SourceModel(manifest) => &manifest.common.version,
         }
     }
 
@@ -72,6 +77,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(manifest) => &manifest.common.description,
             ValidatedManifestKind::Parquet(manifest) => &manifest.common.description,
             ValidatedManifestKind::Jsonl(manifest) => &manifest.common.description,
+            ValidatedManifestKind::SourceModel(manifest) => &manifest.common.description,
         }
     }
 
@@ -82,6 +88,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(manifest) => &manifest.common.test_queries,
             ValidatedManifestKind::Parquet(manifest) => &manifest.common.test_queries,
             ValidatedManifestKind::Jsonl(manifest) => &manifest.common.test_queries,
+            ValidatedManifestKind::SourceModel(manifest) => &manifest.common.test_queries,
         }
     }
 
@@ -93,6 +100,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(manifest) => manifest.required_secret_names(),
             ValidatedManifestKind::Parquet(manifest) => manifest.required_secret_names(),
             ValidatedManifestKind::Jsonl(manifest) => manifest.required_secret_names(),
+            ValidatedManifestKind::SourceModel(manifest) => manifest.required_secret_names(),
         }
     }
 
@@ -103,6 +111,7 @@ impl ValidatedSourceManifest {
             ValidatedManifestKind::Http(manifest) => &manifest.declared_inputs,
             ValidatedManifestKind::Parquet(manifest) => &manifest.declared_inputs,
             ValidatedManifestKind::Jsonl(manifest) => &manifest.declared_inputs,
+            ValidatedManifestKind::SourceModel(manifest) => &manifest.declared_inputs,
         }
     }
 
@@ -129,6 +138,16 @@ impl ValidatedSourceManifest {
     pub fn as_jsonl(&self) -> Option<&JsonlSourceManifest> {
         match &self.inner {
             ValidatedManifestKind::Jsonl(manifest) => Some(manifest),
+            _ => None,
+        }
+    }
+
+    /// Returns the validated DSL v4 source-model source spec when
+    /// `backend: source_model`.
+    #[must_use]
+    pub fn as_source_model(&self) -> Option<&SourceModelSourceManifest> {
+        match &self.inner {
+            ValidatedManifestKind::SourceModel(manifest) => Some(manifest),
             _ => None,
         }
     }
@@ -171,6 +190,11 @@ pub fn parse_source_manifest_value(value: Value) -> Result<ValidatedSourceManife
         }),
         SourceBackend::Jsonl => Ok(ValidatedSourceManifest {
             inner: ValidatedManifestKind::Jsonl(JsonlSourceManifest::parse_manifest_value(value)?),
+        }),
+        SourceBackend::SourceModel => Ok(ValidatedSourceManifest {
+            inner: ValidatedManifestKind::SourceModel(
+                SourceModelSourceManifest::parse_manifest_value(value)?,
+            ),
         }),
     }
 }
@@ -282,6 +306,95 @@ functions:
         assert_eq!(http.functions.len(), 1);
         let function = http.functions.first().expect("HTTP function");
         assert_eq!(function.name, "search_issues");
+    }
+
+    #[test]
+    fn parse_source_manifest_accepts_source_model_manifest() {
+        let manifest = parse_source_manifest_yaml(
+            r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+description: GitHub via imported OpenAPI
+inputs:
+  GITHUB_TOKEN:
+    kind: secret
+test_queries:
+  - SELECT * FROM github.issues
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://example.com/github-openapi.yaml
+    sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    base_url: https://api.github.com
+    auth:
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: template
+          template: Bearer {{input.GITHUB_TOKEN}}
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+    columns:
+      - name: title
+        type: Utf8
+",
+        )
+        .expect("source-model manifest should parse");
+
+        let source_model = manifest
+            .as_source_model()
+            .expect("source-model manifest variant");
+        assert_eq!(manifest.backend(), crate::SourceBackend::SourceModel);
+        let surface = source_model
+            .surfaces
+            .first()
+            .expect("source-model manifest should have a surface");
+        assert_eq!(surface.id, "github-rest");
+        let projection = source_model
+            .projections
+            .first()
+            .expect("source-model manifest should have a projection");
+        assert_eq!(projection.name, "issues");
+        let projection_refs = source_model.projection_refs();
+        let projection_ref = projection_refs
+            .first()
+            .expect("source-model manifest should have a projection ref");
+        assert_eq!(projection_ref.operation, "issues/list-for-repo");
+    }
+
+    #[test]
+    fn parse_source_manifest_rejects_source_model_entities_block() {
+        let error = parse_source_manifest_yaml(
+            r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://example.com/github-openapi.yaml
+    sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    base_url: https://api.github.com
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+entities: []
+",
+        )
+        .expect_err("manifest-authored entities should fail");
+
+        assert!(
+            error.to_string().contains("entities"),
+            "error should identify entities block: {error}"
+        );
     }
 
     #[test]

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -56,6 +56,29 @@ tables:
 "
     }
 
+    fn valid_source_model_manifest() -> &'static str {
+        r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://example.com/github-openapi.yaml
+    sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    base_url: https://api.github.com
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+    columns:
+      - name: title
+        type: Utf8
+"
+    }
+
     fn manifest_json(raw: &str) -> JsonValue {
         serde_yaml::from_str(raw).expect("test manifest should parse as yaml")
     }
@@ -64,6 +87,13 @@ tables:
     fn validate_manifest_schema_accepts_valid_http_manifest() {
         let manifest = manifest_json(valid_http_manifest());
         validate_manifest_schema(&manifest).expect("valid manifest should pass schema validation");
+    }
+
+    #[test]
+    fn validate_manifest_schema_accepts_valid_source_model_manifest() {
+        let manifest = manifest_json(valid_source_model_manifest());
+        validate_manifest_schema(&manifest)
+            .expect("valid source-model manifest should pass schema validation");
     }
 
     #[test]
@@ -305,6 +335,61 @@ tables:
         assert_eq!(
             error.to_string(),
             "source manifest failed schema validation:\n  /tables/0/request/path: \"\" is shorter than 1 character"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_schema_surfaces_malformed_source_model_surface() {
+        let manifest = manifest_json(
+            r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://example.com/github-openapi.yaml
+    base_url: https://api.github.com
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+",
+        );
+        let error = validate_manifest_schema(&manifest).expect_err("schema should fail");
+        assert_eq!(
+            error.to_string(),
+            "source manifest failed schema validation:\n  /surfaces/0: \"sha256\" is a required property"
+        );
+    }
+
+    #[test]
+    fn validate_manifest_schema_surfaces_malformed_source_model_projection() {
+        let manifest = manifest_json(
+            r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://example.com/github-openapi.yaml
+    sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+    base_url: https://api.github.com
+projections:
+  - name: issues
+    kind: view
+    surface: github-rest
+    operation: issues/list-for-repo
+",
+        );
+        let error = validate_manifest_schema(&manifest).expect_err("schema should fail");
+        assert_eq!(
+            error.to_string(),
+            "source manifest failed schema validation:\n  /projections/0/kind: \"view\" is not one of [\"table\",\"function\"]"
         );
     }
 }

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -12,14 +12,16 @@
         "required": ["backend"]
       },
       "then": {
-        "anyOf": [
-          { "required": ["tables"] },
-          { "required": ["functions"] }
-        ],
         "properties": {
+          "dsl_version": { "const": 3 },
           "tables": {
             "items": { "$ref": "#/$defs/http_table" }
           }
+        },
+        "required": ["dsl_version"],
+        "anyOf": [{ "required": ["tables"] }, { "required": ["functions"] }],
+        "not": {
+          "anyOf": [{ "required": ["surfaces"] }, { "required": ["projections"] }]
         }
       }
     },
@@ -29,32 +31,44 @@
         "required": ["backend"]
       },
       "then": {
-        "required": ["tables"],
         "properties": {
+          "dsl_version": { "const": 3 },
           "tables": {
             "items": { "$ref": "#/$defs/file_table" }
           }
+        },
+        "required": ["dsl_version", "tables"],
+        "not": {
+          "anyOf": [{ "required": ["surfaces"] }, { "required": ["projections"] }]
         }
       }
     },
     {
       "if": {
-        "properties": {
-          "backend": { "not": { "enum": ["http", "jsonl", "parquet"] } }
-        },
+        "properties": { "backend": { "const": "source_model" } },
         "required": ["backend"]
       },
       "then": {
-        "properties": {
-          "tables": {
-            "items": false
-          }
+        "properties": { "dsl_version": { "const": 4 } },
+        "required": ["dsl_version", "surfaces", "projections"],
+        "not": {
+          "anyOf": [
+            { "required": ["tables"] },
+            { "required": ["functions"] },
+            { "required": ["base_url"] },
+            { "required": ["auth"] },
+            { "required": ["request_headers"] },
+            { "required": ["rate_limit"] },
+            { "required": ["entities"] },
+            { "required": ["operations"] },
+            { "required": ["bindings"] }
+          ]
         }
       }
     }
   ],
   "properties": {
-    "dsl_version": { "type": "integer", "const": 3 },
+    "dsl_version": { "type": "integer", "enum": [3, 4] },
     "name": { "type": "string", "minLength": 1 },
     "version": { "type": "string", "minLength": 1 },
     "description": { "type": "string" },
@@ -62,7 +76,7 @@
       "type": "array",
       "items": { "type": "string", "minLength": 1 }
     },
-    "backend": { "type": "string", "enum": ["http", "parquet", "jsonl"] },
+    "backend": { "type": "string", "enum": ["http", "parquet", "jsonl", "source_model"] },
     "inputs": { "$ref": "#/$defs/inputs" },
     "base_url": { "type": "string", "minLength": 1 },
     "auth": { "$ref": "#/$defs/auth" },
@@ -80,6 +94,16 @@
       "type": "array",
       "minItems": 1,
       "items": { "$ref": "#/$defs/table_function" }
+    },
+    "surfaces": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/source_model_surface" }
+    },
+    "projections": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/source_model_projection" }
     },
     "onboarding": {
       "type": "object",
@@ -171,6 +195,42 @@
         "retry_after_header": { "type": "string", "minLength": 1 },
         "remaining_header": { "type": "string", "minLength": 1 },
         "reset_header": { "type": "string", "minLength": 1 }
+      }
+    },
+    "source_model_surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "type", "url", "sha256", "base_url"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "type": { "type": "string", "enum": ["open-api"] },
+        "url": { "type": "string", "minLength": 1 },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9A-Fa-f]{64}$"
+        },
+        "base_url": { "type": "string", "minLength": 1 },
+        "auth": { "$ref": "#/$defs/auth" },
+        "request_headers": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/header" }
+        },
+        "rate_limit": { "$ref": "#/$defs/rate_limit" }
+      }
+    },
+    "source_model_projection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "kind", "surface", "operation"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "enum": ["table", "function"] },
+        "surface": { "type": "string", "minLength": 1 },
+        "operation": { "type": "string", "minLength": 1 },
+        "columns": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/column" }
+        }
       }
     },
     "http_table": {


### PR DESCRIPTION
Implements step 3 of the [DSL v4 PRD](https://github.com/withcoral/coral/blob/sw/05-19-chore_add_prd/plans/2026-05-19-source-dsl-v4-prd.md): the manifest schema and parser for DSL v4 source-model manifests.

- Adds `crates/coral-spec/src/backends/source_model.rs` with `SourceModelSourceManifest`, surface descriptors (`id`, `type: open-api`, `url`, `sha256`, `base_url`, `auth`, `request_headers`, `rate_limit`), and projection entries (`name`, `kind`, `surface`, `operation`).
- Adds a `backend: source_model` variant to the parser dispatch and updates `parser.rs` so DSL v4 manifests resolve into the new validated variant alongside existing v3 manifests, which continue to parse unchanged.
- Updates `schema/source_manifest.schema.json` to accept the new `surfaces` and `projections` sections and to reject hand-authored `entities`, `operations`, and `bindings` at the manifest layer (per the PRD anti-goals).
- Diagnostics call out malformed `surfaces` and `projections` entries clearly.

No importer or runtime is wired up here — that comes in the next PRs in the stack.

## Test plan

- [ ] `make rust-checks`
- [ ] Existing v3 manifest parser tests still pass.