### PR TITLE
feat(app): materialize source-model IR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1015,6 +1016,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -140,6 +140,20 @@ message ImportSourceResponse {
   Source source = 1;
 }
 
+// Refreshes materialized artifacts for an installed source.
+message RefreshSourceRequest {
+  // Owning workspace resource.
+  Workspace workspace = 1;
+  // Bare source name to refresh.
+  string name = 2;
+}
+
+// Returns the refreshed source.
+message RefreshSourceResponse {
+  // The refreshed source resource.
+  Source source = 1;
+}
+
 // Lists all registered sources in one workspace.
 message ListSourcesRequest {
   // Workspace whose sources should be listed.
@@ -250,6 +264,8 @@ service SourceService {
   rpc CreateBundledSource(CreateBundledSourceRequest) returns (CreateBundledSourceResponse);
   // Imports one user-provided source manifest.
   rpc ImportSource(ImportSourceRequest) returns (ImportSourceResponse);
+  // Refreshes materialized artifacts for one installed source.
+  rpc RefreshSource(RefreshSourceRequest) returns (RefreshSourceResponse);
   // Deletes a registered source.
   rpc DeleteSource(DeleteSourceRequest) returns (DeleteSourceResponse);
   // Validates that a registered source is queryable.

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -24,6 +24,7 @@ reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }
@@ -36,6 +37,7 @@ tower.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
 tracing-subscriber.workspace = true
+url.workspace = true
 uuid.workspace = true
 
 coral-api.workspace = true

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -18,6 +18,7 @@ use crate::bootstrap::AppError;
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
+use crate::sources::materialization::load_materialized_source_model_manifest;
 use crate::sources::model::InstalledSource;
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
 use crate::workspaces::WorkspaceName;
@@ -188,6 +189,14 @@ impl QueryManager {
     ) -> Result<(QuerySource, String), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
+        if let Some(source_model) = source_spec.as_source_model() {
+            load_materialized_source_model_manifest(
+                &self.layout,
+                workspace_name,
+                &source.name,
+                source_model,
+            )?;
+        }
         validate_required_variables(source, source_spec.declared_inputs())?;
         let stored_secrets = self
             .secret_store

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -7,11 +7,14 @@ use crate::sources::SourceName;
 use crate::sources::catalog::{
     describe_manifest, list_bundled_sources, load_bundled_source, resolve_installed_manifest,
 };
+use crate::sources::materialization::{
+    materialize_source_model_manifest, refresh_source_model_manifest,
+};
 use crate::sources::model::{CandidateSource, InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore, SecretStore};
 use crate::storage::fs;
 use crate::workspaces::WorkspaceName;
-use coral_spec::ManifestInputKind;
+use coral_spec::{ManifestInputKind, ValidatedSourceManifest, parse_source_manifest_yaml};
 use tracing::warn;
 
 #[derive(Clone)]
@@ -49,6 +52,7 @@ struct ValidatedBindings {
 
 struct PersistSourceRequest<'a> {
     candidate: &'a CandidateSource,
+    source_spec: &'a ValidatedSourceManifest,
     manifest_yaml: Option<&'a str>,
     bindings: ValidatedBindings,
     origin: SourceOrigin,
@@ -133,30 +137,36 @@ impl SourceManager {
         list_bundled_sources(&installed)
     }
 
-    pub(crate) fn create_bundled_source(
+    pub(crate) async fn create_bundled_source(
         &self,
         workspace_name: &WorkspaceName,
         command: &CreateBundledSourceCommand,
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
+        let source_spec = parse_source_manifest_yaml(&bundled.manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
         let bindings = validate_bindings(&candidate, &command.bindings)?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
                 candidate: &candidate,
+                source_spec: &source_spec,
                 manifest_yaml: None,
                 bindings,
                 origin: SourceOrigin::Bundled,
             },
         )
+        .await
     }
 
-    pub(crate) fn import_source(
+    pub(crate) async fn import_source(
         &self,
         workspace_name: &WorkspaceName,
         command: &ImportSourceCommand,
     ) -> Result<InstalledSource, AppError> {
+        let source_spec = parse_source_manifest_yaml(&command.manifest_yaml)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
         let mut candidate =
             describe_manifest(&command.manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
@@ -165,11 +175,30 @@ impl SourceManager {
             workspace_name,
             PersistSourceRequest {
                 candidate: &candidate,
+                source_spec: &source_spec,
                 manifest_yaml: Some(&command.manifest_yaml),
                 bindings,
                 origin: SourceOrigin::Imported,
             },
         )
+        .await
+    }
+
+    pub(crate) async fn refresh_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<InstalledSource, AppError> {
+        let stored = self.config_store.get_source(workspace_name, source_name)?;
+        let installed = resolve_installed_manifest(workspace_name, &stored, &self.layout)?;
+        let Some(source_model) = installed.source_spec.as_source_model() else {
+            return Err(AppError::InvalidInput(format!(
+                "source '{source_name}' is not a source-model source"
+            )));
+        };
+        refresh_source_model_manifest(&self.layout, workspace_name, source_name, source_model)
+            .await?;
+        self.populate_source_version(workspace_name, stored)
     }
 
     pub(crate) fn delete_source(
@@ -220,7 +249,7 @@ impl SourceManager {
         Ok(candidate)
     }
 
-    fn persist_source(
+    async fn persist_source(
         &self,
         workspace_name: &WorkspaceName,
         request: PersistSourceRequest<'_>,
@@ -229,6 +258,19 @@ impl SourceManager {
         let previous = self.load_source_rollback_state(workspace_name, &source_name)?;
         if let Err(error) =
             self.persist_manifest_artifact(workspace_name, &source_name, request.manifest_yaml)
+        {
+            self.restore_source_rollback_state(workspace_name, &source_name, previous);
+            return Err(error);
+        }
+
+        if let Some(source_model) = request.source_spec.as_source_model()
+            && let Err(error) = materialize_source_model_manifest(
+                &self.layout,
+                workspace_name,
+                &source_name,
+                source_model,
+            )
+            .await
         {
             self.restore_source_rollback_state(workspace_name, &source_name, previous);
             return Err(error);
@@ -544,11 +586,16 @@ fn cleanup_empty_parent(root: &std::path::Path, path: Option<&std::path::Path>) 
 #[cfg(test)]
 mod tests {
     use tempfile::TempDir;
+    use url::Url;
+
+    use coral_spec::parse_source_manifest_yaml;
 
     use super::{
         ImportSourceCommand, SourceBinding, SourceBindings, SourceManager, normalize_binding_key,
     };
     use crate::sources::SourceName;
+    use crate::sources::materialization::load_materialized_source_model_manifest;
+    use crate::sources::materialization::test_support::document_sha256;
     use crate::state::{AppStateLayout, ConfigStore, SecretStore};
     use crate::workspaces::WorkspaceName;
 
@@ -589,8 +636,72 @@ tables:
         .to_string()
     }
 
-    #[test]
-    fn import_restores_prior_state_when_secret_persistence_fails() {
+    fn source_model_openapi_document() -> &'static str {
+        r"
+openapi: 3.0.3
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /repos/{owner}/{repo}/issues:
+    get:
+      operationId: issues/list-for-repo
+      parameters:
+        - name: owner
+          in: path
+          required: true
+          schema: { type: string }
+        - name: repo
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Issue'
+components:
+  schemas:
+    Issue:
+      type: object
+      required: [id, title]
+      properties:
+        id: { type: integer }
+        title: { type: string }
+"
+    }
+
+    fn source_model_manifest(surface_url: &str, sha256: &str) -> String {
+        format!(
+            r"
+name: github
+version: 1.0.0
+dsl_version: 4
+backend: source_model
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: {surface_url}
+    sha256: {sha256}
+    base_url: https://api.github.com
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+    columns:
+      - name: title
+        type: Utf8
+"
+        )
+    }
+
+    #[tokio::test]
+    async fn import_restores_prior_state_when_secret_persistence_fails() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -624,6 +735,7 @@ tables:
                     },
                 },
             )
+            .await
             .expect_err("secret persistence should fail");
 
         assert!(
@@ -679,8 +791,8 @@ tables:
         assert!(error.to_string().contains("must not start with '#'"));
     }
 
-    #[test]
-    fn import_materializes_variable_defaults_server_side() {
+    #[tokio::test]
+    async fn import_materializes_variable_defaults_server_side() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
             AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
@@ -705,11 +817,112 @@ tables:
                     },
                 },
             )
+            .await
             .expect("import source");
 
         assert_eq!(
             source.variables.get("API_BASE").map(String::as_str),
             Some("https://example.com")
+        );
+    }
+
+    #[tokio::test]
+    async fn import_materializes_source_model_ir_from_pinned_file_url() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let document_path = temp.path().join("openapi.yaml");
+        std::fs::write(&document_path, source_model_openapi_document()).expect("write openapi");
+        let surface_url = Url::from_file_path(&document_path)
+            .expect("file url")
+            .to_string();
+        let manifest = source_model_manifest(
+            &surface_url,
+            &document_sha256(source_model_openapi_document()),
+        );
+        let manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            SecretStore::new(layout.clone()),
+            layout.clone(),
+        );
+
+        manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest.clone(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .await
+            .expect("import source-model source");
+
+        let parsed = parse_source_manifest_yaml(&manifest).expect("parse manifest");
+        let source_model = parsed.as_source_model().expect("source-model manifest");
+        std::fs::remove_file(&document_path).expect("remove source OpenAPI document");
+        let materialized = load_materialized_source_model_manifest(
+            &layout,
+            &default_workspace(),
+            &SourceName::parse("github").expect("source"),
+            source_model,
+        )
+        .expect("load materialized IR");
+        assert!(
+            materialized
+                .operations
+                .iter()
+                .any(|operation| operation.id == "issues/list-for-repo")
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_rejects_changed_document_hash_and_reports_actual_hash() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let document_path = temp.path().join("openapi.yaml");
+        std::fs::write(&document_path, source_model_openapi_document()).expect("write openapi");
+        let surface_url = Url::from_file_path(&document_path)
+            .expect("file url")
+            .to_string();
+        let pinned_hash = document_sha256(source_model_openapi_document());
+        let manifest = source_model_manifest(&surface_url, &pinned_hash);
+        let manager = SourceManager::new(
+            ConfigStore::new(layout.clone()),
+            SecretStore::new(layout.clone()),
+            layout,
+        );
+        let source_name = SourceName::parse("github").expect("source");
+        manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest,
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .await
+            .expect("import source-model source");
+
+        let changed_document = source_model_openapi_document().replace("Test API", "Changed API");
+        std::fs::write(&document_path, &changed_document).expect("rewrite openapi");
+        let changed_hash = document_sha256(&changed_document);
+
+        let error = manager
+            .refresh_source(&default_workspace(), &source_name)
+            .await
+            .expect_err("refresh should reject changed hash");
+
+        let message = error.to_string();
+        assert!(
+            message.contains(&pinned_hash),
+            "missing pinned hash: {message}"
+        );
+        assert!(
+            message.contains(&changed_hash),
+            "missing actual hash: {message}"
         );
     }
 }

--- a/crates/coral-app/src/sources/materialization.rs
+++ b/crates/coral-app/src/sources/materialization.rs
@@ -1,0 +1,346 @@
+//! Source-model IR materialization for DSL v4 sources.
+
+use std::path::PathBuf;
+
+use chrono::Utc;
+use coral_spec::{
+    OPENAPI_IMPORTER_VERSION, SourceModelIr, SourceModelSourceManifest, import_openapi_surface,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use url::Url;
+
+use crate::bootstrap::AppError;
+use crate::sources::SourceName;
+use crate::state::AppStateLayout;
+use crate::storage::fs;
+use crate::workspaces::WorkspaceName;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MaterializedSourceModelMetadata {
+    source_name: String,
+    source_version: String,
+    surface_id: String,
+    surface_type: String,
+    retrieval_url: String,
+    pinned_sha256: String,
+    content_sha256: String,
+    importer_version: String,
+    fetched_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    etag: Option<String>,
+}
+
+struct MaterializedSurface {
+    key: String,
+    metadata: MaterializedSourceModelMetadata,
+    ir: SourceModelIr,
+}
+
+struct FetchedSurfaceDocument {
+    bytes: Vec<u8>,
+    etag: Option<String>,
+}
+
+pub(crate) async fn materialize_source_model_manifest(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    manifest: &SourceModelSourceManifest,
+) -> Result<(), AppError> {
+    materialize_source_model_manifest_inner(
+        layout,
+        workspace_name,
+        source_name,
+        manifest,
+        MaterializationMode::Install,
+    )
+    .await
+}
+
+pub(crate) async fn refresh_source_model_manifest(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    manifest: &SourceModelSourceManifest,
+) -> Result<(), AppError> {
+    materialize_source_model_manifest_inner(
+        layout,
+        workspace_name,
+        source_name,
+        manifest,
+        MaterializationMode::Refresh,
+    )
+    .await
+}
+
+pub(crate) fn load_materialized_source_model_manifest(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    manifest: &SourceModelSourceManifest,
+) -> Result<SourceModelIr, AppError> {
+    let mut entries = Vec::new();
+    for surface in &manifest.surfaces {
+        let key = materialization_key(manifest.common.version.as_str(), surface);
+        let metadata_path =
+            layout.source_model_metadata_file(workspace_name, source_name, key.as_str());
+        let metadata: MaterializedSourceModelMetadata =
+            serde_json::from_slice(&std::fs::read(&metadata_path).map_err(|error| {
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    AppError::FailedPrecondition(format!(
+                        "source '{source_name}' surface '{}' has no materialized source-model IR; run `coral source refresh {source_name}` or reinstall the source",
+                        surface.id
+                    ))
+                } else {
+                    error.into()
+                }
+            })?)?;
+        validate_metadata(
+            source_name,
+            manifest.common.version.as_str(),
+            surface,
+            &metadata,
+        )?;
+        let ir_path = layout.source_model_ir_file(workspace_name, source_name, key.as_str());
+        let ir: SourceModelIr = serde_json::from_slice(&std::fs::read(ir_path)?)?;
+        entries.push(ir);
+    }
+
+    let ir = combine_surface_irs(entries);
+    ir.validate(&manifest.projection_refs())
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+    Ok(ir)
+}
+
+#[derive(Clone, Copy)]
+enum MaterializationMode {
+    Install,
+    Refresh,
+}
+
+async fn materialize_source_model_manifest_inner(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    manifest: &SourceModelSourceManifest,
+    mode: MaterializationMode,
+) -> Result<(), AppError> {
+    let mut materialized = Vec::new();
+    for surface in &manifest.surfaces {
+        let fetched = fetch_surface_document(surface.url.as_str()).await?;
+        let actual_sha256 = sha256_hex(&fetched.bytes);
+        if !actual_sha256.eq_ignore_ascii_case(surface.sha256.trim()) {
+            let message = match mode {
+                MaterializationMode::Install => format!(
+                    "source '{source_name}' surface '{}' OpenAPI document sha256 mismatch: expected {}, got {actual_sha256}",
+                    surface.id, surface.sha256
+                ),
+                MaterializationMode::Refresh => format!(
+                    "source '{source_name}' surface '{}' OpenAPI document sha256 mismatch during refresh: expected {}, got {actual_sha256}; update the manifest pin before refreshing",
+                    surface.id, surface.sha256
+                ),
+            };
+            return Err(AppError::InvalidInput(message));
+        }
+        let imported = import_openapi_surface(surface, &fetched.bytes)
+            .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+        let metadata = MaterializedSourceModelMetadata {
+            source_name: source_name.as_str().to_string(),
+            source_version: manifest.common.version.clone(),
+            surface_id: surface.id.clone(),
+            surface_type: "open-api".to_string(),
+            retrieval_url: surface.url.clone(),
+            pinned_sha256: surface.sha256.clone(),
+            content_sha256: actual_sha256,
+            importer_version: OPENAPI_IMPORTER_VERSION.to_string(),
+            fetched_at: Utc::now().to_rfc3339(),
+            etag: fetched.etag,
+        };
+        materialized.push(MaterializedSurface {
+            key: materialization_key(manifest.common.version.as_str(), surface),
+            metadata,
+            ir: imported.ir,
+        });
+    }
+
+    let combined = combine_surface_irs(materialized.iter().map(|entry| entry.ir.clone()));
+    combined
+        .validate(&manifest.projection_refs())
+        .map_err(|error| AppError::InvalidInput(error.to_string()))?;
+
+    for entry in materialized {
+        write_materialized_surface(layout, workspace_name, source_name, &entry)?;
+    }
+
+    Ok(())
+}
+
+async fn fetch_surface_document(url: &str) -> Result<FetchedSurfaceDocument, AppError> {
+    if let Ok(parsed) = Url::parse(url) {
+        match parsed.scheme() {
+            "file" => {
+                let path = parsed.to_file_path().map_err(|()| {
+                    AppError::InvalidInput(format!("invalid file URL for OpenAPI surface: {url}"))
+                })?;
+                return Ok(FetchedSurfaceDocument {
+                    bytes: std::fs::read(path)?,
+                    etag: None,
+                });
+            }
+            "http" | "https" => {
+                let response = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()
+                    .map_err(|error| {
+                        AppError::FailedPrecondition(format!(
+                            "failed to create OpenAPI fetch client: {error}"
+                        ))
+                    })?
+                    .get(url)
+                    .send()
+                    .await
+                    .map_err(|error| {
+                        AppError::FailedPrecondition(format!(
+                            "failed to fetch OpenAPI surface '{url}': {error}"
+                        ))
+                    })?
+                    .error_for_status()
+                    .map_err(|error| {
+                        AppError::FailedPrecondition(format!(
+                            "failed to fetch OpenAPI surface '{url}': {error}"
+                        ))
+                    })?;
+                let etag = response
+                    .headers()
+                    .get(reqwest::header::ETAG)
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string);
+                let bytes = response.bytes().await.map_err(|error| {
+                    AppError::FailedPrecondition(format!(
+                        "failed to read OpenAPI surface '{url}': {error}"
+                    ))
+                })?;
+                return Ok(FetchedSurfaceDocument {
+                    bytes: bytes.to_vec(),
+                    etag,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    let path = PathBuf::from(url);
+    if path.is_absolute() {
+        return Ok(FetchedSurfaceDocument {
+            bytes: std::fs::read(path)?,
+            etag: None,
+        });
+    }
+
+    Err(AppError::InvalidInput(format!(
+        "OpenAPI surface url must be http, https, file, or an absolute local path: {url}"
+    )))
+}
+
+fn write_materialized_surface(
+    layout: &AppStateLayout,
+    workspace_name: &WorkspaceName,
+    source_name: &SourceName,
+    entry: &MaterializedSurface,
+) -> Result<(), AppError> {
+    let dir = layout.source_model_materialization_dir(workspace_name, source_name, &entry.key);
+    fs::ensure_dir(&dir)?;
+    let ir_path = layout.source_model_ir_file(workspace_name, source_name, &entry.key);
+    let metadata_path = layout.source_model_metadata_file(workspace_name, source_name, &entry.key);
+    let ir_json = serde_json::to_vec_pretty(&entry.ir)?;
+    let metadata_json = serde_json::to_vec_pretty(&entry.metadata)?;
+    fs::write_atomic(&ir_path, &ir_json)?;
+    fs::write_atomic(&metadata_path, &metadata_json)?;
+    Ok(())
+}
+
+fn validate_metadata(
+    source_name: &SourceName,
+    source_version: &str,
+    surface: &coral_spec::SourceModelManifestSurface,
+    metadata: &MaterializedSourceModelMetadata,
+) -> Result<(), AppError> {
+    if metadata.source_name != source_name.as_str()
+        || metadata.source_version != source_version
+        || metadata.surface_id != surface.id
+        || metadata.retrieval_url != surface.url
+        || !metadata
+            .pinned_sha256
+            .eq_ignore_ascii_case(surface.sha256.trim())
+        || metadata.importer_version != OPENAPI_IMPORTER_VERSION
+    {
+        return Err(AppError::FailedPrecondition(format!(
+            "source '{source_name}' surface '{}' materialized source-model IR does not match the current manifest; run `coral source refresh {source_name}` or reinstall the source",
+            surface.id
+        )));
+    }
+    Ok(())
+}
+
+fn combine_surface_irs<I>(entries: I) -> SourceModelIr
+where
+    I: IntoIterator<Item = SourceModelIr>,
+{
+    let mut combined = SourceModelIr {
+        ir_version: coral_spec::SOURCE_MODEL_IR_VERSION,
+        surfaces: Vec::new(),
+        types: Vec::new(),
+        operations: Vec::new(),
+        entities: Vec::new(),
+    };
+    for entry in entries {
+        combined.surfaces.extend(entry.surfaces);
+        combined.types.extend(entry.types);
+        combined.operations.extend(entry.operations);
+        combined.entities.extend(entry.entities);
+    }
+    combined
+}
+
+fn materialization_key(
+    source_version: &str,
+    surface: &coral_spec::SourceModelManifestSurface,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(source_version.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(surface.id.as_bytes());
+    hasher.update(b"\0open-api\0");
+    hasher.update(surface.url.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(surface.sha256.to_ascii_lowercase().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(OPENAPI_IMPORTER_VERSION.as_bytes());
+    hex_digest(hasher.finalize())
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex_digest(hasher.finalize())
+}
+
+fn hex_digest(digest: impl AsRef<[u8]>) -> String {
+    let digest = digest.as_ref();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(&mut out, "{byte:02x}").expect("writing to a string cannot fail");
+    }
+    out
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::sha256_hex;
+
+    pub(crate) fn document_sha256(document: &str) -> String {
+        sha256_hex(document.as_bytes())
+    }
+}

--- a/crates/coral-app/src/sources/mod.rs
+++ b/crates/coral-app/src/sources/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod catalog;
 pub(crate) mod manager;
+pub(crate) mod materialization;
 pub(crate) mod model;
 pub(crate) mod name;
 pub(crate) mod service;

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -5,9 +5,10 @@ use coral_api::v1::{
     CreateBundledSourceRequest, CreateBundledSourceResponse, DeleteSourceRequest,
     DeleteSourceResponse, DiscoverSourcesRequest, DiscoverSourcesResponse, GetSourceInfoRequest,
     GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
-    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, Source, SourceInfo,
-    SourceInputKind, SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret,
-    SourceVariable, ValidateSourceRequest, ValidateSourceResponse,
+    ImportSourceResponse, ListSourcesRequest, ListSourcesResponse, RefreshSourceRequest,
+    RefreshSourceResponse, Source, SourceInfo, SourceInputKind, SourceInputSpec,
+    SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
+    ValidateSourceResponse,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use tonic::{Request, Response, Status};
@@ -138,6 +139,7 @@ impl SourceServiceApi for SourceService {
             };
             let installed = sources
                 .create_bundled_source(&workspace_name, &command)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(&workspace_name, installed)),
@@ -161,9 +163,31 @@ impl SourceServiceApi for SourceService {
             };
             let installed = sources
                 .import_source(&workspace_name, &command)
+                .await
                 .map_err(app_status)?;
             Ok(Response::new(ImportSourceResponse {
                 source: Some(installed_source_to_proto(&workspace_name, installed)),
+            }))
+        })
+        .await
+    }
+
+    async fn refresh_source(
+        &self,
+        request: Request<RefreshSourceRequest>,
+    ) -> Result<Response<RefreshSourceResponse>, Status> {
+        let span = grpc_span(&request);
+        let sources = self.sources.clone();
+        instrument_grpc(span, async move {
+            let request = request.into_inner();
+            let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
+            let source_name = SourceName::parse(&request.name).map_err(app_status)?;
+            let refreshed = sources
+                .refresh_source(&workspace_name, &source_name)
+                .await
+                .map_err(app_status)?;
+            Ok(Response::new(RefreshSourceResponse {
+                source: Some(installed_source_to_proto(&workspace_name, refreshed)),
             }))
         })
         .await

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -11,6 +11,9 @@ use crate::workspaces::WorkspaceName;
 
 pub(crate) const INSTALLED_MANIFEST_FILE_NAME: &str = "manifest.yaml";
 pub(crate) const INSTALLED_SECRETS_FILE_NAME: &str = "secrets.env";
+pub(crate) const SOURCE_MODEL_MATERIALIZATIONS_DIR_NAME: &str = "source-model-ir";
+pub(crate) const SOURCE_MODEL_IR_FILE_NAME: &str = "ir.json";
+pub(crate) const SOURCE_MODEL_METADATA_FILE_NAME: &str = "metadata.json";
 
 #[derive(Debug, Clone)]
 pub(crate) struct AppStateLayout {
@@ -107,6 +110,45 @@ impl AppStateLayout {
         self.source_dir(workspace_name, source_name)
             .join(INSTALLED_SECRETS_FILE_NAME)
     }
+
+    pub(crate) fn source_model_materializations_dir(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> PathBuf {
+        self.source_dir(workspace_name, source_name)
+            .join(SOURCE_MODEL_MATERIALIZATIONS_DIR_NAME)
+    }
+
+    pub(crate) fn source_model_materialization_dir(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        materialization_key: &str,
+    ) -> PathBuf {
+        self.source_model_materializations_dir(workspace_name, source_name)
+            .join(materialization_key)
+    }
+
+    pub(crate) fn source_model_ir_file(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        materialization_key: &str,
+    ) -> PathBuf {
+        self.source_model_materialization_dir(workspace_name, source_name, materialization_key)
+            .join(SOURCE_MODEL_IR_FILE_NAME)
+    }
+
+    pub(crate) fn source_model_metadata_file(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+        materialization_key: &str,
+    ) -> PathBuf {
+        self.source_model_materialization_dir(workspace_name, source_name, materialization_key)
+            .join(SOURCE_MODEL_METADATA_FILE_NAME)
+    }
 }
 
 #[cfg(test)]
@@ -134,6 +176,12 @@ mod tests {
         assert_eq!(
             layout.secret_file(&workspace_name, &source_name),
             std::path::Path::new("/tmp/coral-config/workspaces/default/sources/github/secrets.env")
+        );
+        assert_eq!(
+            layout.source_model_ir_file(&workspace_name, &source_name, "abc123"),
+            std::path::Path::new(
+                "/tmp/coral-config/workspaces/default/sources/github/source-model-ir/abc123/ir.json"
+            )
         );
         assert_eq!(
             layout.feedback_reports_file(&workspace_name),

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -166,6 +166,11 @@ enum SourceCommand {
         /// Name of the source to test
         name: String,
     },
+    /// Refresh materialized artifacts for a source
+    Refresh {
+        /// Name of the source to refresh
+        name: String,
+    },
     /// Remove a source
     Remove {
         /// Name of the source to remove
@@ -524,6 +529,10 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
             )
             .await?;
         }
+        SourceCommand::Refresh { name } => {
+            source_ops::refresh_source(app, &name).await?;
+            println!("Refreshed source {name}");
+        }
         SourceCommand::Remove { name } => {
             source_ops::remove_and_print(app, &name).await?;
         }
@@ -707,6 +716,20 @@ mod tests {
         let cli = Cli::try_parse_from(["coral", "source", "list"]).expect("source list parses");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::AppClient);
+    }
+
+    #[test]
+    fn source_refresh_parses() {
+        let cli = Cli::try_parse_from(["coral", "source", "refresh", "github"])
+            .expect("source refresh parses");
+
+        let super::Command::Source(args) = cli.command else {
+            panic!("expected source command");
+        };
+        let super::SourceCommand::Refresh { name } = args.command else {
+            panic!("expected source refresh command");
+        };
+        assert_eq!(name, "github");
     }
 
     #[test]

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -5,9 +5,9 @@ use std::path::Path;
 use coral_api::CORAL_ERROR_REASON_SOURCE_NOT_FOUND;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, GetSourceInfoRequest,
-    ImportSourceRequest, ListSourcesRequest, QueryTestFailure, QueryTestSuccess, Source,
-    SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin, SourceSecret, SourceVariable,
-    ValidateSourceRequest, ValidateSourceResponse, query_test_result,
+    ImportSourceRequest, ListSourcesRequest, QueryTestFailure, QueryTestSuccess,
+    RefreshSourceRequest, Source, SourceInfo, SourceInputKind, SourceInputSpec, SourceOrigin,
+    SourceSecret, SourceVariable, ValidateSourceRequest, ValidateSourceResponse, query_test_result,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::{
@@ -115,6 +115,20 @@ pub(crate) async fn import_source(
     response
         .source
         .ok_or_else(|| anyhow::anyhow!("import source response missing source"))
+}
+
+pub(crate) async fn refresh_source(app: &AppClient, name: &str) -> Result<Source, anyhow::Error> {
+    let response = app
+        .source_client()
+        .refresh_source(Request::new(RefreshSourceRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+        }))
+        .await?
+        .into_inner();
+    response
+        .source
+        .ok_or_else(|| anyhow::anyhow!("refresh source response missing source"))
 }
 
 pub(crate) async fn validate_source(

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -22,8 +22,9 @@ use coral_api::v1::{
     GetSourceInfoResponse, GetSourceRequest, GetSourceResponse, ImportSourceRequest,
     ImportSourceResponse, ListCatalogRequest, ListCatalogResponse, ListColumnsRequest,
     ListColumnsResponse, ListSourcesRequest, ListSourcesResponse, PaginationRequest,
-    PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse, Source, SourceInfo,
-    SourceInputKind, SourceInputSpec, SourceOrigin, Table, TableSummary, ValidateSourceRequest,
+    PaginationResponse, QueryPlan, RefreshSourceRequest, RefreshSourceResponse,
+    SearchCatalogRequest, SearchCatalogResponse, Source, SourceInfo, SourceInputKind,
+    SourceInputSpec, SourceOrigin, Table, TableSummary, ValidateSourceRequest,
     ValidateSourceResponse, Workspace, catalog_item,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
@@ -551,6 +552,7 @@ struct Captured {
     get_source_info: Mutex<Vec<GetSourceInfoRequest>>,
     create_bundled_source: Mutex<Vec<CreateBundledSourceRequest>>,
     import_source: Mutex<Vec<ImportSourceRequest>>,
+    refresh_source: Mutex<Vec<RefreshSourceRequest>>,
     delete_source: Mutex<Vec<DeleteSourceRequest>>,
     validate_source: Mutex<Vec<ValidateSourceRequest>>,
 }
@@ -868,6 +870,20 @@ impl SourceService for MockSourceService {
         }))
     }
 
+    async fn refresh_source(
+        &self,
+        request: Request<RefreshSourceRequest>,
+    ) -> Result<Response<RefreshSourceResponse>, Status> {
+        self.captured
+            .refresh_source
+            .lock()
+            .expect("refresh_source capture")
+            .push(request.into_inner());
+        Ok(Response::new(RefreshSourceResponse {
+            source: Some(mock_source()),
+        }))
+    }
+
     async fn delete_source(
         &self,
         request: Request<DeleteSourceRequest>,
@@ -1038,6 +1054,14 @@ impl MockServer {
             .delete_source
             .lock()
             .expect("delete_source capture")
+            .clone()
+    }
+
+    pub(crate) fn refresh_source_requests(&self) -> Vec<RefreshSourceRequest> {
+        self.captured
+            .refresh_source
+            .lock()
+            .expect("refresh_source capture")
             .clone()
     }
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -98,6 +98,14 @@ coral source test github
 coral source test local_messages
 ```
 
+### `coral source refresh <NAME>`
+
+Refresh materialized artifacts for an installed source. For DSL v4 source-model sources, Coral re-fetches each pinned OpenAPI descriptor, verifies the manifest `sha256`, re-imports IR, validates projections, and replaces the local materialized IR only if the pin still matches.
+
+```shellscript
+coral source refresh github
+```
+
 ### `coral source remove <NAME>`
 
 Remove an installed source.


### PR DESCRIPTION
Implements step 5 of the [DSL v4 PRD](https://github.com/withcoral/coral/blob/sw/05-19-chore_add_prd/plans/2026-05-19-source-dsl-v4-prd.md): source-model IR materialisation during `source add`.

- Adds `crates/coral-app/src/sources/materialization.rs`, which fetches the pinned OpenAPI document, verifies its `sha256`, runs the OpenAPI importer, validates projections against the resulting IR, and writes materialised IR plus fingerprint metadata (content hash, optional ETag, `fetched_at`, importer version) under the existing app data layout.
- Updates `state/layout.rs` to namespace materialised IR by `(workspace, source name, source version, pinned surface descriptor, importer version)`. Importer-version or descriptor changes make old entries unreachable on the normal load path.
- Wires the source manager and gRPC service so `source add` and a new refresh path call materialisation; subsequent loads of an installed source read materialised IR with no network access and no importer execution. Adds the `coral source refresh` CLI surface and a corresponding proto message.
- Mismatched hashes, malformed documents, or projection-validation failures fail the install/refresh and surface a diagnostic; refresh writes atomically and only replaces the local IR if validation still passes.

Bundled and user-installed v4 sources both go through the same local materialisation path — the binary never embeds OpenAPI documents or pre-built IR.

## Test plan

- [ ] `make rust-checks`
- [ ] `coral source add` for a v4 source writes materialised IR; a second load performs no network I/O.
- [ ] `coral source refresh` updates materialised IR atomically and fails clearly on `sha256` mismatch.