### PR TITLE
feat(spec): add source-model projection model

### DIFF
--- a/crates/coral-spec/src/backends/source_model.rs
+++ b/crates/coral-spec/src/backends/source_model.rs
@@ -18,8 +18,8 @@ use crate::backends::http::{AuthSpec, RateLimitSpec};
 use crate::inputs::collect_source_inputs_value;
 use crate::validate::validate_template;
 use crate::{
-    ColumnSpec, HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec, ParsedTemplate,
-    ProjectionKind, Result, SourceBackend, SourceManifestCommon, SourceModelProjectionRef,
+    HeaderSpec, ManifestError, ManifestInputKind, ManifestInputSpec, ParsedTemplate, Result,
+    SourceBackend, SourceManifestCommon, SourceModelProjection, SourceModelProjectionRef,
     validate_columns, validate_test_queries,
 };
 
@@ -28,7 +28,7 @@ use crate::{
 pub struct SourceModelSourceManifest {
     pub common: SourceManifestCommon,
     pub surfaces: Vec<SourceModelManifestSurface>,
-    pub projections: Vec<SourceModelManifestProjection>,
+    pub projections: Vec<SourceModelProjection>,
     pub declared_inputs: Vec<ManifestInputSpec>,
 }
 
@@ -57,18 +57,6 @@ pub enum SurfaceDescriptionType {
     OpenApi,
 }
 
-/// One explicit SQL projection declared by a DSL v4 manifest.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct SourceModelManifestProjection {
-    pub name: String,
-    pub kind: ProjectionKind,
-    pub surface: String,
-    pub operation: String,
-    #[serde(default)]
-    pub columns: Vec<ColumnSpec>,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawSourceModelSourceManifest {
@@ -83,7 +71,7 @@ struct RawSourceModelSourceManifest {
     #[serde(default)]
     inputs: Option<Value>,
     surfaces: Vec<SourceModelManifestSurface>,
-    projections: Vec<SourceModelManifestProjection>,
+    projections: Vec<SourceModelProjection>,
 }
 
 impl SourceModelSourceManifest {
@@ -134,12 +122,7 @@ impl SourceModelSourceManifest {
     pub fn projection_refs(&self) -> Vec<SourceModelProjectionRef> {
         self.projections
             .iter()
-            .map(|projection| SourceModelProjectionRef {
-                name: projection.name.clone(),
-                kind: projection.kind,
-                surface: projection.surface.clone(),
-                operation: projection.operation.clone(),
-            })
+            .map(SourceModelProjection::reference)
             .collect()
     }
 }
@@ -195,7 +178,7 @@ fn validate_sha256(source_name: &str, surface: &SourceModelManifestSurface) -> R
 fn validate_projections(
     source_name: &str,
     surfaces: &[SourceModelManifestSurface],
-    projections: &[SourceModelManifestProjection],
+    projections: &[SourceModelProjection],
 ) -> Result<()> {
     if projections.is_empty() {
         return Err(ManifestError::validation(format!(
@@ -219,14 +202,14 @@ fn validate_projections(
                 projection.name
             )));
         }
-        if !surface_ids.contains(projection.surface.as_str()) {
+        if !surface_ids.contains(projection.operation.surface.as_str()) {
             return Err(ManifestError::validation(format!(
                 "source '{source_name}' projection '{}' references unknown surface '{}'",
-                projection.name, projection.surface
+                projection.name, projection.operation.surface
             )));
         }
         validate_non_empty(
-            &projection.operation,
+            &projection.operation.operation,
             &format!(
                 "source '{source_name}' projection '{}' operation",
                 projection.name
@@ -251,6 +234,7 @@ fn validate_non_empty(value: &str, context: &str) -> Result<()> {
 mod tests {
     use serde_json::Value;
 
+    use crate::ProjectionKind;
     use crate::backends::source_model::{SourceModelSourceManifest, SurfaceDescriptionType};
 
     fn source_model_manifest() -> Value {
@@ -303,11 +287,21 @@ projections:
         assert_eq!(surface.id, "github-rest");
         assert_eq!(surface.surface_type, SurfaceDescriptionType::OpenApi);
         assert_eq!(manifest.projections.len(), 1);
+        let projection = manifest
+            .projections
+            .first()
+            .expect("manifest should have a parsed projection");
+        assert_eq!(projection.name, "issues");
+        assert_eq!(projection.kind, ProjectionKind::Table);
+        assert_eq!(projection.operation.surface, "github-rest");
+        assert_eq!(projection.operation.operation, "issues/list-for-repo");
+        assert_eq!(projection.columns.len(), 1);
         let projection_refs = manifest.projection_refs();
         let projection_ref = projection_refs
             .first()
             .expect("manifest should have a projection ref");
-        assert_eq!(projection_ref.operation, "issues/list-for-repo");
+        assert_eq!(projection_ref.operation.surface, "github-rest");
+        assert_eq!(projection_ref.operation.operation, "issues/list-for-repo");
         assert_eq!(
             manifest
                 .required_secret_names()

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -82,6 +82,7 @@ mod inputs;
 mod loader;
 pub mod openapi;
 mod parser;
+mod projection;
 mod schema;
 pub mod source_model;
 mod template;
@@ -89,8 +90,7 @@ mod validate;
 
 pub use backends::http::{AuthSpec, BasicAuthSpec, CustomAuthSpec, HeaderAuthSpec};
 pub use backends::source_model::{
-    SourceModelManifestProjection, SourceModelManifestSurface, SourceModelSourceManifest,
-    SurfaceDescriptionType,
+    SourceModelManifestSurface, SourceModelSourceManifest, SurfaceDescriptionType,
 };
 pub(crate) use common::validate_test_queries;
 pub use common::{
@@ -110,14 +110,17 @@ pub use openapi::{
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
 };
+pub use projection::{
+    ProjectionKind, SourceModelOperationRef, SourceModelProjection, SourceModelProjectionRef,
+};
 pub use source_model::{
     EntityCandidate, EnumValue, FieldPath, GraphqlOperationDetails, GraphqlOperationKind,
     GraphqlPagination, GraphqlPartialDataPolicy, GraphqlSelectionPolicy, GraphqlVariable,
     IdentityKey, InputField, ObjectField, OperationDetails, OperationInput, OperationResult,
-    ProjectionKind, RestOperationDetails, RestPagination, RestParameter, RestParameterLocation,
-    RestRequestBody, RestResponse, RestStatusCode, SOURCE_MODEL_IR_VERSION, ScalarType,
-    SourceModelIr, SourceModelOperation, SourceModelProjectionRef, SourceModelSurface,
-    SurfaceProtocol, TypeDefinition, TypeDefinitionKind, TypeRef, TypeRefKind,
+    RestOperationDetails, RestPagination, RestParameter, RestParameterLocation, RestRequestBody,
+    RestResponse, RestStatusCode, SOURCE_MODEL_IR_VERSION, ScalarType, SourceModelIr,
+    SourceModelOperation, SourceModelSurface, SurfaceProtocol, TypeDefinition, TypeDefinitionKind,
+    TypeRef, TypeRefKind,
 };
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -364,7 +364,8 @@ projections:
         let projection_ref = projection_refs
             .first()
             .expect("source-model manifest should have a projection ref");
-        assert_eq!(projection_ref.operation, "issues/list-for-repo");
+        assert_eq!(projection_ref.operation.surface, "github-rest");
+        assert_eq!(projection_ref.operation.operation, "issues/list-for-repo");
     }
 
     #[test]

--- a/crates/coral-spec/src/projection.rs
+++ b/crates/coral-spec/src/projection.rs
@@ -1,0 +1,61 @@
+#![allow(
+    missing_docs,
+    reason = "This module defines field-heavy DSL v4 projection types."
+)]
+
+//! Explicit SQL projection model for DSL v4 source-model manifests.
+//!
+//! Projections are author-facing SQL exposure metadata. They are intentionally
+//! separate from [`crate::source_model`], which is importer-produced provider IR.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ColumnSpec;
+
+/// One explicit SQL projection declared by a DSL v4 manifest.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SourceModelProjection {
+    pub name: String,
+    pub kind: ProjectionKind,
+    #[serde(flatten)]
+    pub operation: SourceModelOperationRef,
+    #[serde(default)]
+    pub columns: Vec<ColumnSpec>,
+}
+
+impl SourceModelProjection {
+    pub fn reference(&self) -> SourceModelProjectionRef {
+        SourceModelProjectionRef {
+            name: self.name.clone(),
+            kind: self.kind,
+            operation: self.operation.clone(),
+        }
+    }
+}
+
+/// Stable surface-scoped operation reference used by DSL v4 projections.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SourceModelOperationRef {
+    pub surface: String,
+    pub operation: String,
+}
+
+/// Projection reference shape used to validate authored projections against IR.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SourceModelProjectionRef {
+    pub name: String,
+    pub kind: ProjectionKind,
+    #[serde(flatten)]
+    pub operation: SourceModelOperationRef,
+}
+
+/// SQL affordance type exposed by a DSL v4 projection.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectionKind {
+    Table,
+    Function,
+}

--- a/crates/coral-spec/src/source_model.rs
+++ b/crates/coral-spec/src/source_model.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{HttpMethod, ManifestError, Result};
+use crate::{HttpMethod, ManifestError, Result, SourceModelProjectionRef};
 
 pub const SOURCE_MODEL_IR_VERSION: u32 = 1;
 
@@ -419,22 +419,6 @@ pub struct IdentityKey {
 }
 
 pub type FieldPath = Vec<String>;
-
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct SourceModelProjectionRef {
-    pub name: String,
-    pub kind: ProjectionKind,
-    pub surface: String,
-    pub operation: String,
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum ProjectionKind {
-    Table,
-    Function,
-}
 
 impl SourceModelIr {
     pub fn validate(&self, projections: &[SourceModelProjectionRef]) -> Result<()> {
@@ -933,10 +917,13 @@ fn validate_projection_refs(
                 projection.name
             )));
         }
-        if !operations.contains(&(projection.surface.as_str(), projection.operation.as_str())) {
+        if !operations.contains(&(
+            projection.operation.surface.as_str(),
+            projection.operation.operation.as_str(),
+        )) {
             return Err(ManifestError::validation(format!(
                 "source model projection '{}' references unknown operation '{}.{}'",
-                projection.name, projection.surface, projection.operation
+                projection.name, projection.operation.surface, projection.operation.operation
             )));
         }
     }
@@ -1027,13 +1014,12 @@ mod tests {
     use super::{
         EntityCandidate, GraphqlOperationDetails, GraphqlOperationKind, GraphqlPagination,
         GraphqlPartialDataPolicy, GraphqlSelectionPolicy, IdentityKey, ObjectField,
-        OperationDetails, OperationInput, OperationResult, ProjectionKind, RestOperationDetails,
-        RestPagination, RestParameter, RestParameterLocation, RestResponse, RestStatusCode,
+        OperationDetails, OperationInput, OperationResult, RestOperationDetails, RestPagination,
+        RestParameter, RestParameterLocation, RestResponse, RestStatusCode,
         SOURCE_MODEL_IR_VERSION, ScalarType, SourceModelIr, SourceModelOperation,
-        SourceModelProjectionRef, SourceModelSurface, SurfaceProtocol, TypeDefinition,
-        TypeDefinitionKind, TypeRef,
+        SourceModelSurface, SurfaceProtocol, TypeDefinition, TypeDefinitionKind, TypeRef,
     };
-    use crate::HttpMethod;
+    use crate::{HttpMethod, ProjectionKind, SourceModelOperationRef, SourceModelProjectionRef};
 
     #[test]
     fn source_model_ir_round_trips_representative_rest_fragment() {
@@ -1041,8 +1027,10 @@ mod tests {
         let projections = vec![SourceModelProjectionRef {
             name: "issues".to_string(),
             kind: ProjectionKind::Table,
-            surface: "github-rest".to_string(),
-            operation: "issues/list-for-repo".to_string(),
+            operation: SourceModelOperationRef {
+                surface: "github-rest".to_string(),
+                operation: "issues/list-for-repo".to_string(),
+            },
         }];
 
         model
@@ -1064,8 +1052,10 @@ mod tests {
         let projections = vec![SourceModelProjectionRef {
             name: "repository_issues".to_string(),
             kind: ProjectionKind::Function,
-            surface: "github-graphql".to_string(),
-            operation: "repository.issues".to_string(),
+            operation: SourceModelOperationRef {
+                surface: "github-graphql".to_string(),
+                operation: "repository.issues".to_string(),
+            },
         }];
 
         model
@@ -1107,8 +1097,10 @@ mod tests {
         let projections = vec![SourceModelProjectionRef {
             name: "missing".to_string(),
             kind: ProjectionKind::Table,
-            surface: "github-rest".to_string(),
-            operation: "missing/op".to_string(),
+            operation: SourceModelOperationRef {
+                surface: "github-rest".to_string(),
+                operation: "missing/op".to_string(),
+            },
         }];
 
         let error = model


### PR DESCRIPTION
Implements step 6 of the [DSL v4 PRD](https://github.com/withcoral/coral/blob/sw/05-19-chore_add_prd/plans/2026-05-19-source-dsl-v4-prd.md): the explicit SQL projection model.

- Adds `crates/coral-spec/src/projection.rs` with `SourceModelProjection`, `SourceModelOperationRef`, `SourceModelProjectionRef`, and a `ProjectionKind` enum (`table`, `function`). Projections carry a SQL name, a kind, a stable `(surface, operation)` reference, and column metadata.
- Splits projections out of `source_model.rs` so the importer-produced IR stays separate from the author-facing SQL exposure model (per the PRD: projections are the manifest author's opinionated surface; the IR is importer output).
- Updates the manifest backend and parser to consume the new types, so a v4 manifest's `projections:` block deserialises into these structs and references operations by `(surface, operation)`.

No runtime registration yet — that lands in the engine PR later in the stack.

## Test plan

- [ ] `make rust-checks`