### PR TITLE
feat(sources/core/github): add source-model issue projections

### DIFF
--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -369,6 +369,58 @@ projections:
     }
 
     #[test]
+    fn parse_source_manifest_accepts_staged_github_source_model_manifest() {
+        let manifest = parse_source_manifest_yaml(include_str!(
+            "../../../sources/core/github/manifest.source_model.yaml"
+        ))
+        .expect("staged GitHub source-model manifest should parse");
+
+        let source_model = manifest
+            .as_source_model()
+            .expect("source-model manifest variant");
+        assert_eq!(manifest.schema_name(), "github");
+        assert_eq!(source_model.surfaces.len(), 1);
+        assert_eq!(
+            source_model
+                .surfaces
+                .first()
+                .expect("GitHub source-model manifest should have a surface")
+                .id,
+            "github-rest"
+        );
+
+        let projection_refs = source_model.projection_refs();
+        let explicit_refs = projection_refs
+            .iter()
+            .map(|projection| {
+                (
+                    projection.name.as_str(),
+                    projection.operation.surface.as_str(),
+                    projection.operation.operation.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            explicit_refs,
+            vec![
+                ("issues", "github-rest", "issues/list-for-repo"),
+                (
+                    "search_issues",
+                    "github-rest",
+                    "search/issues-and-pull-requests",
+                ),
+                ("issue", "github-rest", "issues/get"),
+            ]
+        );
+        assert!(
+            source_model
+                .projections
+                .iter()
+                .all(|projection| { !projection.columns.is_empty() })
+        );
+    }
+
+    #[test]
     fn parse_source_manifest_rejects_source_model_entities_block() {
         let error = parse_source_manifest_yaml(
             r"

--- a/sources/core/github/manifest.source_model.yaml
+++ b/sources/core/github/manifest.source_model.yaml
@@ -1,0 +1,175 @@
+name: github
+version: 1.1.6-source-model.0
+dsl_version: 4
+backend: source_model
+description: >-
+  Query GitHub repository issues through the DSL v4 source-model path.
+inputs:
+  GITHUB_API_BASE:
+    kind: variable
+    default: https://api.github.com
+    hint: |
+      Base URL for the GitHub REST API. Keep the default for GitHub
+      Cloud; for GitHub Enterprise Server, use
+      `https://<host>/api/v3`.
+  GITHUB_TOKEN:
+    kind: secret
+    hint: |
+      If you're already authenticated in GitHub CLI, run
+      `gh auth token`, or create a new personal access token (PAT).
+      Grant read access to the repositories you plan to query.
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://raw.githubusercontent.com/github/rest-api-description/f5d3342150d3748e7307c81639635706f8338a12/descriptions/api.github.com/api.github.com.yaml
+    sha256: 2d2094fd1bab20958ae7f7b885fe818f19e57deea0bfdcbde7c9db450d5cc5a0
+    base_url: "{{input.GITHUB_API_BASE}}"
+    auth:
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: template
+          template: Bearer {{input.GITHUB_TOKEN}}
+    request_headers:
+      - name: Accept
+        from: literal
+        value: application/vnd.github+json
+      - name: X-GitHub-Api-Version
+        from: literal
+        value: "2022-11-28"
+    rate_limit:
+      extra_statuses: [403]
+      remaining_header: x-ratelimit-remaining
+      reset_header: x-ratelimit-reset
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        expr: {kind: path, path: [id]}
+      - name: number
+        type: Int64
+        nullable: true
+        expr: {kind: path, path: [number]}
+      - name: title
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [title]}
+      - name: state
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [state]}
+      - name: html_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [html_url]}
+      - name: user_login
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [user, login]}
+      - name: repository_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [repository_url]}
+      - name: created_at
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [updated_at]}
+      - name: pull_request
+        type: Json
+        nullable: true
+        expr: {kind: path, path: [pull_request]}
+  - name: search_issues
+    kind: function
+    surface: github-rest
+    operation: search/issues-and-pull-requests
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        expr: {kind: path, path: [id]}
+      - name: number
+        type: Int64
+        nullable: true
+        expr: {kind: path, path: [number]}
+      - name: title
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [title]}
+      - name: state
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [state]}
+      - name: html_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [html_url]}
+      - name: user_login
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [user, login]}
+      - name: repository_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [repository_url]}
+      - name: score
+        type: Float64
+        nullable: true
+        expr: {kind: path, path: [score]}
+      - name: pull_request
+        type: Json
+        nullable: true
+        expr: {kind: path, path: [pull_request]}
+  - name: issue
+    kind: function
+    surface: github-rest
+    operation: issues/get
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        expr: {kind: path, path: [id]}
+      - name: number
+        type: Int64
+        nullable: true
+        expr: {kind: path, path: [number]}
+      - name: title
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [title]}
+      - name: state
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [state]}
+      - name: html_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [html_url]}
+      - name: user_login
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [user, login]}
+      - name: repository_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [repository_url]}
+      - name: created_at
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [updated_at]}
+      - name: pull_request
+        type: Json
+        nullable: true
+        expr: {kind: path, path: [pull_request]}


### PR DESCRIPTION
Implements step 7 of the [DSL v4 PRD](https://github.com/withcoral/coral/blob/sw/05-19-chore_add_prd/plans/2026-05-19-source-dsl-v4-prd.md): explicit GitHub issue projections in a v4 manifest.

- Adds `sources/core/github/manifest.source_model.yaml` as the first DSL v4 bundled source. It pins a `type: open-api` surface descriptor (immutable raw.githubusercontent URL + `sha256`) and declares explicit projections for `list repository issues`, `search issues`, and `get issue` against surface-scoped operation IDs.
- Updates `crates/coral-spec/src/parser.rs` so the bundled v4 manifest loads through the existing source-loading path alongside the legacy v3 `manifest.yaml`.
- No automatic projection derivation — projections are hand-authored, as scoped by the PRD.

The runtime that registers and executes these projections lands in the next PRs in the stack.

## Test plan

- [ ] `make rust-checks`
- [ ] Manifest parses; projections reference operation IDs that exist in the imported IR.