### PR TITLE
feat(sources/community/dbt_cloud): add dbt cloud source

### DIFF
--- a/sources/community/dbt_cloud/README.md
+++ b/sources/community/dbt_cloud/README.md
@@ -1,46 +1,117 @@
-# dbt Cloud Source
+# dbt Cloud community source
 
-Query dbt Cloud metadata including models, jobs, runs, environments, and exposures using SQL.
+The `dbt_cloud` community source exposes read-only dbt Cloud job, run, and
+environment data through Coral SQL.
 
-## Authentication
+## Setup
 
-1. Go to [dbt Cloud](https://cloud.getdbt.com) → Account Settings → Service Tokens
-2. Create a token with **Metadata Only** permissions
-3. Find your Account ID in the URL: `https://cloud.getdbt.com/#/accounts/<account_id>/`
+Create a service token in dbt Cloud:
 
-```bash
-coral source add --file sources/community/dbt_cloud/manifest.yaml
-```
+- Open dbt Cloud and go to **Account Settings** > **Service Tokens**
+- Click **+ New Token** and give it a name
+- Add **Member** permission for your account
+- Copy the generated token
 
-## Example Queries
+Find your account ID in the dbt Cloud URL:
+`https://cloud.getdbt.com/#/accounts/<account_id>/`
 
-Most frequently failing jobs:
-```sql
-SELECT job_id, count(*) AS failures
-FROM dbt_cloud.runs
-WHERE status = 'error'
-GROUP BY job_id
-ORDER BY failures DESC
-```
+Then install the source:
 
-Longest-running jobs:
-```sql
-SELECT id, duration, status
-FROM dbt_cloud.runs
-ORDER BY duration DESC
-LIMIT 20
-```
-
-All environments:
-```sql
-SELECT id, name, type, dbt_version
-FROM dbt_cloud.environments
+```sh
+export DBT_CLOUD_ACCOUNT_ID="<account_id>"
+export DBT_CLOUD_API_TOKEN="<token>"
+cargo run -p coral-cli -- source add --file sources/community/dbt_cloud/manifest.yaml
 ```
 
 ## Tables
 
-| Table | Description |
-|-------|-------------|
-| `dbt_cloud.jobs` | Jobs, schedules, and orchestration metadata |
-| `dbt_cloud.environments` | Environments and deployment configuration |
-| `dbt_cloud.runs` | Job runs with execution state and duration |
+| Table | Purpose |
+| --- | --- |
+| `dbt_cloud.jobs` | dbt Cloud jobs with schedules, execution state, and orchestration metadata. |
+| `dbt_cloud.runs` | Job runs with execution state, duration, and status metadata. |
+| `dbt_cloud.environments` | Environments with deployment metadata and execution configuration. |
+
+All tables are read-only. This source does not create, trigger, or modify
+dbt Cloud resources.
+
+## Example queries
+
+List all jobs:
+
+```sql
+SELECT id, name, project_id, environment_id, state
+FROM dbt_cloud.jobs
+ORDER BY name;
+```
+
+Most frequently failing runs:
+
+```sql
+SELECT job_id, count(*) AS failures
+FROM dbt_cloud.runs
+WHERE status = 20
+GROUP BY job_id
+ORDER BY failures DESC;
+```
+
+Longest-running jobs:
+
+```sql
+SELECT id, duration, status, started_at
+FROM dbt_cloud.runs
+ORDER BY duration DESC
+LIMIT 20;
+```
+
+Runs for a specific job:
+
+```sql
+SELECT id, status, duration, started_at, finished_at
+FROM dbt_cloud.runs
+WHERE job_id = '<job_id>'
+ORDER BY started_at DESC
+LIMIT 50;
+```
+
+List all environments:
+
+```sql
+SELECT id, name, type, dbt_version, project_id
+FROM dbt_cloud.environments
+ORDER BY name;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/dbt_cloud/manifest.yaml
+```
+
+Install and test with real credentials:
+
+```sh
+export DBT_CLOUD_ACCOUNT_ID="<account_id>"
+export DBT_CLOUD_API_TOKEN="<token>"
+cargo run -p coral-cli -- source add --file sources/community/dbt_cloud/manifest.yaml
+cargo run -p coral-cli -- source test dbt_cloud
+```
+
+Inspect the registered source:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'dbt_cloud'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name FROM coral.columns WHERE schema_name = 'dbt_cloud' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- Uses the dbt Cloud Administrative API v2.
+- The base URL is `https://cloud.getdbt.com`. Enterprise or single-tenant
+  deployments may use a different base URL.
+- Run status codes: 1 = Queued, 3 = Running, 10 = Success, 20 = Error,
+  30 = Cancelled.
+- Nested fields are preserved as JSON in the `raw` column for each table.
+- The Discovery API (GraphQL) is not used in this source. Models, tests,
+  and sources metadata require the Discovery API and are out of scope for v1.

--- a/sources/community/dbt_cloud/README.md
+++ b/sources/community/dbt_cloud/README.md
@@ -1,0 +1,46 @@
+# dbt Cloud Source
+
+Query dbt Cloud metadata including models, jobs, runs, environments, and exposures using SQL.
+
+## Authentication
+
+1. Go to [dbt Cloud](https://cloud.getdbt.com) → Account Settings → Service Tokens
+2. Create a token with **Metadata Only** permissions
+3. Find your Account ID in the URL: `https://cloud.getdbt.com/#/accounts/<account_id>/`
+
+```bash
+coral source add --file sources/community/dbt_cloud/manifest.yaml
+```
+
+## Example Queries
+
+Most frequently failing jobs:
+```sql
+SELECT job_id, count(*) AS failures
+FROM dbt_cloud.runs
+WHERE status = 'error'
+GROUP BY job_id
+ORDER BY failures DESC
+```
+
+Longest-running jobs:
+```sql
+SELECT id, duration, status
+FROM dbt_cloud.runs
+ORDER BY duration DESC
+LIMIT 20
+```
+
+All environments:
+```sql
+SELECT id, name, type, dbt_version
+FROM dbt_cloud.environments
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `dbt_cloud.jobs` | Jobs, schedules, and orchestration metadata |
+| `dbt_cloud.environments` | Environments and deployment configuration |
+| `dbt_cloud.runs` | Job runs with execution state and duration |

--- a/sources/community/dbt_cloud/manifest.yaml
+++ b/sources/community/dbt_cloud/manifest.yaml
@@ -1,0 +1,326 @@
+name: dbt_cloud
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query dbt Cloud metadata including models, jobs, runs, tests, sources,
+  environments, and exposures through SQL.
+inputs:
+  DBT_CLOUD_ACCOUNT_ID:
+    kind: secret
+    hint: |
+      Your dbt Cloud account ID. Found in the URL when logged in:
+      https://cloud.getdbt.com/#/accounts/<account_id>/
+  DBT_CLOUD_API_TOKEN:
+    kind: secret
+    hint: |
+      Create a service token in dbt Cloud under
+      Account Settings -> Service Tokens with Metadata Only permissions.
+      See https://docs.getdbt.com/docs/dbt-apis/service-tokens
+  DBT_CLOUD_BASE_URL:
+    kind: optional
+    hint: |
+      Base URL for your dbt Cloud deployment.
+      Defaults to https://cloud.getdbt.com
+      Use https://emea.dbt.com for EMEA or https://au.dbt.com for APAC.
+base_url: https://cloud.getdbt.com
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.DBT_CLOUD_API_TOKEN}}
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/json
+test_queries:
+  - SELECT * FROM dbt_cloud.jobs LIMIT 1
+  - SELECT * FROM dbt_cloud.environments LIMIT 1
+tables:
+  - name: jobs
+    description: dbt jobs, schedules, execution state, triggers, and orchestration metadata
+    request:
+      method: GET
+      path: /api/v2/accounts/{{input.DBT_CLOUD_ACCOUNT_ID}}/jobs/
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Job ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: account_id
+        type: Int64
+        nullable: true
+        description: Account ID
+        expr:
+          kind: path
+          path:
+            - account_id
+      - name: project_id
+        type: Int64
+        nullable: true
+        description: Project ID
+        expr:
+          kind: path
+          path:
+            - project_id
+      - name: environment_id
+        type: Int64
+        nullable: true
+        description: Environment ID
+        expr:
+          kind: path
+          path:
+            - environment_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Job name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: execute_steps
+        type: Json
+        nullable: true
+        description: Steps to execute
+        expr:
+          kind: path
+          path:
+            - execute_steps
+      - name: state
+        type: Int64
+        nullable: true
+        description: Job state
+        expr:
+          kind: path
+          path:
+            - state
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Creation timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw job object
+        expr:
+          kind: current_row
+
+  - name: environments
+    description: dbt environments, deployment metadata, and execution configuration
+    request:
+      method: GET
+      path: /api/v2/accounts/{{input.DBT_CLOUD_ACCOUNT_ID}}/environments/
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Environment ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: account_id
+        type: Int64
+        nullable: true
+        description: Account ID
+        expr:
+          kind: path
+          path:
+            - account_id
+      - name: project_id
+        type: Int64
+        nullable: true
+        description: Project ID
+        expr:
+          kind: path
+          path:
+            - project_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Environment name
+        expr:
+          kind: path
+          path:
+            - name
+      - name: dbt_version
+        type: Utf8
+        nullable: true
+        description: dbt version used
+        expr:
+          kind: path
+          path:
+            - dbt_version
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Environment type (development/production)
+        expr:
+          kind: path
+          path:
+            - type
+      - name: state
+        type: Int64
+        nullable: true
+        description: Environment state
+        expr:
+          kind: path
+          path:
+            - state
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Creation timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw environment object
+        expr:
+          kind: current_row
+
+  - name: runs
+    description: dbt job runs with execution state and duration metadata
+    filters:
+      - name: job_id
+        required: false
+    request:
+      method: GET
+      path: /api/v2/accounts/{{input.DBT_CLOUD_ACCOUNT_ID}}/runs/
+      query:
+        - name: job_definition_id
+          from: filter
+          key: job_id
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Run ID
+        expr:
+          kind: path
+          path:
+            - id
+      - name: job_id
+        type: Int64
+        nullable: true
+        description: Job ID
+        expr:
+          kind: path
+          path:
+            - job_id
+      - name: account_id
+        type: Int64
+        nullable: true
+        description: Account ID
+        expr:
+          kind: path
+          path:
+            - account_id
+      - name: status
+        type: Int64
+        nullable: true
+        description: Run status
+        expr:
+          kind: path
+          path:
+            - status
+      - name: status_message
+        type: Utf8
+        nullable: true
+        description: Status message
+        expr:
+          kind: path
+          path:
+            - status_message
+      - name: duration
+        type: Utf8
+        nullable: true
+        description: Run duration
+        expr:
+          kind: path
+          path:
+            - duration
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: Run start timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - started_at
+      - name: finished_at
+        type: Timestamp
+        nullable: true
+        description: Run finish timestamp
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - finished_at
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw run object
+        expr:
+          kind: current_row


### PR DESCRIPTION
Closes #555

## What changed

Adds a new `dbt_cloud` community source under `sources/community/dbt_cloud/`.

Tables (3):

- `dbt_cloud.jobs` — dbt Cloud jobs with schedules, execution state, triggers, and orchestration metadata
- `dbt_cloud.runs` — job runs with execution state, duration, queuing, and status metadata
- `dbt_cloud.environments` — environments with deployment metadata and execution configuration

Authentication:

- Uses dbt Cloud Administrative API v2 with Bearer Token authentication
- Requires `DBT_CLOUD_ACCOUNT_ID`
- Requires `DBT_CLOUD_API_TOKEN`

Features:

- Read-only access to dbt Cloud metadata via Coral SQL
- Supports querying jobs, runs, and environments
- Exposes execution and orchestration metadata for workflow monitoring

## Why it changed

dbt Cloud is widely used for analytics engineering and orchestration workflows. Exposing job, run, and environment metadata through Coral enables operational monitoring, pipeline visibility, and scheduling analytics directly through SQL queries.

## What was tested

- `coral source lint` — passes
- `make lint-sources` / `yamllint` — passes
- `coral source test dbt_cloud` — test queries pass

Example queries verified:

```sql
-- Most frequently failing jobs
SELECT job_id, count(*) AS failures
FROM dbt_cloud.runs
WHERE status = 20
GROUP BY job_id
ORDER BY failures DESC;

-- Longest-running jobs
SELECT id, duration, started_at
FROM dbt_cloud.runs
ORDER BY duration DESC
LIMIT 20;
```

Live verification confirms:

- `dbt_cloud.jobs` returns job metadata correctly
- `dbt_cloud.runs` returns execution history and status information
- `dbt_cloud.environments` returns deployment environment metadata

## User-visible impact

New `dbt_cloud` source installable via:

```bash
export DBT_CLOUD_ACCOUNT_ID=...
export DBT_CLOUD_API_TOKEN=...

coral source add --file sources/community/dbt_cloud/manifest.yaml
```

Users can query:

```sql
SELECT * FROM dbt_cloud.jobs;
SELECT * FROM dbt_cloud.runs;
SELECT * FROM dbt_cloud.environments;
```

## Follow-on

- Add Discovery API (GraphQL) support for models, sources, tests, and lineage
- Add additional filtering and analytics capabilities
- Improve support for large accounts and pagination