### PR TITLE
feat(sources/community/replicate): add Replicate community source

### DIFF
--- a/sources/community/replicate/README.md
+++ b/sources/community/replicate/README.md
@@ -9,8 +9,8 @@ learning models.
 Requires a **Replicate API token**.
 
 1. Log in to Replicate → [Account → API tokens](https://replicate.com/account/api-tokens) → **New API token**.
-2. Give it a name (e.g. "coral-read") and copy the generated token.
-3. A read-only token is sufficient for all tables in this source.
+2. Give it a name (e.g. "coral") and copy the generated token.
+3. This source only performs read-only GET requests. Any Replicate API token is sufficient — Replicate does not provide scoped or read-only token variants.
 
 ```sh
 export REPLICATE_API_TOKEN="r8_..."
@@ -18,13 +18,13 @@ coral source add --file sources/community/replicate/manifest.yaml
 ```
 
 See the [Replicate API authentication docs](https://replicate.com/docs/reference/http)
-for details on token management and permissions.
+for details on token management.
 
 ## Tables
 
 | Table | Description | Filters |
 |---|---|---|
-| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | — |
+| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | `created_after`, `created_before`, `source` (optional) |
 | `replicate.models` | Global public ML model catalog — browse and discover models by owner, latest updates, or creation date | `sort_by`, `sort_direction` (optional) |
 | `replicate.deployments` | Deployed models configured for the authenticated account, with hardware and scaling config | — |
 | `replicate.collections` | Curated model groups maintained by Replicate (e.g. "super-resolution", "text-to-image") | — |
@@ -32,8 +32,8 @@ for details on token management and permissions.
 
 ### `replicate.predictions`
 
-Returns all predictions made by the authenticated user, newest first.
-No filter is required — the API token scopes results to the account automatically.
+Returns predictions made by the authenticated user, newest first.
+Results are limited to the first page (up to 100 predictions) because Replicate's full-URL pagination is not supported. To filter predictions upstream, use `created_after`, `created_before`, or `source` filters.
 
 Key columns:
 
@@ -46,16 +46,21 @@ Key columns:
 | `created_at` | `Timestamp` | When the prediction was created |
 | `started_at` | `Timestamp` | When the model began processing |
 | `completed_at` | `Timestamp` | When the prediction finished |
+| `source` | `Utf8` | How the prediction was created — `"api"` or `"web"` |
 | `input` | `Json` | Model-specific input parameters |
 | `output` | `Json` | Model-specific output (URL, string, or object) |
 | `error` | `Utf8` | Error message when `status = 'failed'` |
 | `metrics__total_time` | `Float64` | Total wall-clock duration in seconds |
 | `data_removed` | `Boolean` | True when output data has been deleted by retention policy |
+| `created_after` | `Utf8` (Virtual) | Filter predictions created after this ISO 8601 timestamp (pushdown) |
+| `created_before` | `Utf8` (Virtual) | Filter predictions created before this ISO 8601 timestamp (pushdown) |
 
 ### `replicate.models`
 
 Global public model catalog. All public models are returned; private models
-are excluded. Supports optional `sort_by` and `sort_direction` filters.
+are excluded. Supports optional `sort_by` and `sort_direction` filters. Results
+are limited to the first page (up to 100 models) because Replicate's full-URL
+pagination is not supported.
 
 | Filter | Values | Description |
 |---|---|---|
@@ -66,13 +71,15 @@ are excluded. Supports optional `sort_by` and `sort_direction` filters.
 
 Account-scoped deployments with current release details. The `release_hardware`
 column contains the hardware SKU — join against `replicate.hardware` on `sku`
-to get the human-readable name.
+to get the human-readable name. Results are limited to the first page (up to 100
+deployments) because Replicate's full-URL pagination is not supported.
 
 ### `replicate.collections`
 
 Curated collections grouping models by theme. Only three fields are returned
 by the list endpoint (`name`, `slug`, `description`). Browse models in a
-collection at `replicate.com/collections/<slug>`.
+collection at `replicate.com/collections/<slug>`. Results are limited to the first
+page (up to 100 collections) because Replicate's full-URL pagination is not supported.
 
 ### `replicate.hardware`
 
@@ -111,6 +118,21 @@ FROM replicate.predictions
 WHERE status = 'failed'
 ORDER BY created_at DESC
 LIMIT 50;
+```
+
+### Filter predictions by creation source and date range (upstream pushdown)
+
+```sql
+SELECT
+  id,
+  model,
+  status,
+  created_at
+FROM replicate.predictions
+WHERE source = 'api'
+  AND created_after = '2026-05-01T00:00:00Z'
+  AND created_before = '2026-05-20T23:59:59Z'
+ORDER BY created_at DESC;
 ```
 
 ### Browse recently updated public models
@@ -157,6 +179,6 @@ FROM replicate.hardware;
 ## Auth
 
 This source uses the `Authorization: Bearer <token>` header with a Replicate
-API token. See the
+API token. The source only performs read-only GET requests, and any valid Replicate API token is sufficient. See the
 [Replicate API reference](https://replicate.com/docs/reference/http) for full
 documentation on authentication and API tokens.

--- a/sources/community/replicate/README.md
+++ b/sources/community/replicate/README.md
@@ -1,0 +1,162 @@
+# Replicate
+
+Query predictions, models, deployments, and collections from
+[Replicate](https://replicate.com/) — the cloud API for running machine
+learning models.
+
+## Authentication
+
+Requires a **Replicate API token**.
+
+1. Log in to Replicate → [Account → API tokens](https://replicate.com/account/api-tokens) → **New API token**.
+2. Give it a name (e.g. "coral-read") and copy the generated token.
+3. A read-only token is sufficient for all tables in this source.
+
+```sh
+export REPLICATE_API_TOKEN="r8_..."
+coral source add --file sources/community/replicate/manifest.yaml
+```
+
+See the [Replicate API authentication docs](https://replicate.com/docs/reference/http)
+for details on token management and permissions.
+
+## Tables
+
+| Table | Description | Filters |
+|---|---|---|
+| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | — |
+| `replicate.models` | Global public ML model catalog — browse and discover models by owner, run count, or sort order | `sort_by`, `sort_direction` (optional) |
+| `replicate.deployments` | Deployed models configured for the authenticated account, with hardware and scaling config | — |
+| `replicate.collections` | Curated model groups maintained by Replicate (e.g. "super-resolution", "text-to-image") | — |
+| `replicate.hardware` | Available GPU and CPU hardware options and their SKU identifiers | — |
+
+### `replicate.predictions`
+
+Returns all predictions made by the authenticated user, newest first.
+No filter is required — the API token scopes results to the account automatically.
+
+Key columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `Utf8` | Unique prediction ID |
+| `model` | `Utf8` | Model in `owner/name` format (e.g. `stability-ai/sdxl`) |
+| `version` | `Utf8` | 64-char version ID, or `"hidden"` for official models |
+| `status` | `Utf8` | `starting` · `processing` · `succeeded` · `failed` · `canceled` · `aborted` |
+| `created_at` | `Timestamp` | When the prediction was created |
+| `started_at` | `Timestamp` | When the model began processing |
+| `completed_at` | `Timestamp` | When the prediction finished |
+| `input` | `Json` | Model-specific input parameters |
+| `output` | `Json` | Model-specific output (URL, string, or object) |
+| `error` | `Utf8` | Error message when `status = 'failed'` |
+| `metrics__total_time` | `Float64` | Total wall-clock duration in seconds |
+| `data_removed` | `Boolean` | True when output data has been deleted by retention policy |
+
+### `replicate.models`
+
+Global public model catalog. All public models are returned; private models
+are excluded. Supports optional `sort_by` and `sort_direction` filters.
+
+| Filter | Values | Description |
+|---|---|---|
+| `sort_by` | `model_created_at`, `latest_version_created_at` | Sort field (default: `latest_version_created_at`) |
+| `sort_direction` | `asc`, `desc` | Sort direction (default: `desc`) |
+
+### `replicate.deployments`
+
+Account-scoped deployments with current release details. The `release_hardware`
+column contains the hardware SKU — join against `replicate.hardware` on `sku`
+to get the human-readable name.
+
+### `replicate.collections`
+
+Curated collections grouping models by theme. Only three fields are returned
+by the list endpoint (`name`, `slug`, `description`). Browse models in a
+collection at `replicate.com/collections/<slug>`.
+
+### `replicate.hardware`
+
+Static reference list of hardware tiers. Typically fewer than 20 entries.
+`sku` values correspond to `release_hardware` in `replicate.deployments`.
+
+## Example queries
+
+### List recent predictions with status
+
+```sql
+SELECT
+  id,
+  model,
+  version,
+  status,
+  created_at,
+  completed_at,
+  metrics__total_time
+FROM replicate.predictions
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+### Find failed predictions with error details
+
+```sql
+SELECT
+  id,
+  model,
+  status,
+  created_at,
+  error,
+  logs
+FROM replicate.predictions
+WHERE status = 'failed'
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+### Browse the most-run public models
+
+```sql
+SELECT
+  owner,
+  name,
+  description,
+  run_count,
+  is_official,
+  url
+FROM replicate.models
+WHERE sort_by = 'model_created_at'
+  AND sort_direction = 'desc'
+LIMIT 25;
+```
+
+### List your deployments with hardware and scaling configuration
+
+```sql
+SELECT
+  owner,
+  name,
+  release_model,
+  release_version,
+  release_hardware,
+  release_min_instances,
+  release_max_instances,
+  release_created_at
+FROM replicate.deployments
+ORDER BY release_created_at DESC;
+```
+
+### Show available hardware options
+
+```sql
+SELECT
+  name,
+  sku
+FROM replicate.hardware;
+```
+
+## Auth
+
+This source uses the `Authorization: Bearer <token>` header with a Replicate
+API token. See the
+[Replicate API reference](https://replicate.com/docs/reference/http) for full
+documentation on authentication and API tokens.

--- a/sources/community/replicate/README.md
+++ b/sources/community/replicate/README.md
@@ -24,7 +24,7 @@ for details on token management.
 
 | Table | Description | Filters |
 |---|---|---|
-| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | `created_after`, `created_before` (optional) |
+| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | `created_after`, `created_before`, `source` (optional) |
 | `replicate.models` | Global public ML model catalog — browse and discover models by owner, latest updates, or creation date | `sort_by`, `sort_direction` (optional) |
 | `replicate.deployments` | Deployed models configured for the authenticated account, with hardware and scaling config | — |
 | `replicate.collections` | Curated model groups maintained by Replicate (e.g. "super-resolution", "text-to-image") | — |
@@ -33,7 +33,7 @@ for details on token management.
 ### `replicate.predictions`
 
 Returns predictions made by the authenticated user, newest first.
-Results are limited to the first page (up to 100 predictions) because Replicate's full-URL pagination is not supported. To filter predictions upstream, use `created_after` or `created_before` filters.
+Results are limited to the first page (up to 100 predictions) because Replicate's full-URL pagination is not supported. To filter predictions upstream, use `created_after`, `created_before`, or `source` filters.
 
 Key columns:
 
@@ -46,7 +46,7 @@ Key columns:
 | `created_at` | `Timestamp` | When the prediction was created |
 | `started_at` | `Timestamp` | When the model began processing |
 | `completed_at` | `Timestamp` | When the prediction finished |
-| `source` | `Utf8` | How the prediction was created — `"api"` or `"web"` (Note: not supported as an upstream pushdown filter) |
+| `source` | `Utf8` | How the prediction was created — `"api"` or `"web"`. (Note: Replicate's API only supports upstream pushdown for `source = 'web'`. Other values are filtered locally). |
 | `input` | `Json` | Model-specific input parameters |
 | `output` | `Json` | Model-specific output (URL, string, or object) |
 | `error` | `Utf8` | Error message when `status = 'failed'` |
@@ -120,7 +120,7 @@ ORDER BY created_at DESC
 LIMIT 50;
 ```
 
-### Filter predictions by date range (upstream pushdown)
+### Filter predictions by source and date range (upstream pushdown)
 
 ```sql
 SELECT
@@ -129,7 +129,8 @@ SELECT
   status,
   created_at
 FROM replicate.predictions
-WHERE created_after = '2026-05-01T00:00:00Z'
+WHERE source = 'web'
+  AND created_after = '2026-05-01T00:00:00Z'
   AND created_before = '2026-05-20T23:59:59Z'
 ORDER BY created_at DESC;
 ```

--- a/sources/community/replicate/README.md
+++ b/sources/community/replicate/README.md
@@ -25,7 +25,7 @@ for details on token management and permissions.
 | Table | Description | Filters |
 |---|---|---|
 | `replicate.predictions` | Your AI inference history — every model run under the authenticated account | — |
-| `replicate.models` | Global public ML model catalog — browse and discover models by owner, run count, or sort order | `sort_by`, `sort_direction` (optional) |
+| `replicate.models` | Global public ML model catalog — browse and discover models by owner, latest updates, or creation date | `sort_by`, `sort_direction` (optional) |
 | `replicate.deployments` | Deployed models configured for the authenticated account, with hardware and scaling config | — |
 | `replicate.collections` | Curated model groups maintained by Replicate (e.g. "super-resolution", "text-to-image") | — |
 | `replicate.hardware` | Available GPU and CPU hardware options and their SKU identifiers | — |
@@ -113,7 +113,7 @@ ORDER BY created_at DESC
 LIMIT 50;
 ```
 
-### Browse the most-run public models
+### Browse recently updated public models
 
 ```sql
 SELECT
@@ -124,7 +124,7 @@ SELECT
   is_official,
   url
 FROM replicate.models
-WHERE sort_by = 'model_created_at'
+WHERE sort_by = 'latest_version_created_at'
   AND sort_direction = 'desc'
 LIMIT 25;
 ```

--- a/sources/community/replicate/README.md
+++ b/sources/community/replicate/README.md
@@ -24,7 +24,7 @@ for details on token management.
 
 | Table | Description | Filters |
 |---|---|---|
-| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | `created_after`, `created_before`, `source` (optional) |
+| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | `created_after`, `created_before` (optional) |
 | `replicate.models` | Global public ML model catalog — browse and discover models by owner, latest updates, or creation date | `sort_by`, `sort_direction` (optional) |
 | `replicate.deployments` | Deployed models configured for the authenticated account, with hardware and scaling config | — |
 | `replicate.collections` | Curated model groups maintained by Replicate (e.g. "super-resolution", "text-to-image") | — |
@@ -33,7 +33,7 @@ for details on token management.
 ### `replicate.predictions`
 
 Returns predictions made by the authenticated user, newest first.
-Results are limited to the first page (up to 100 predictions) because Replicate's full-URL pagination is not supported. To filter predictions upstream, use `created_after`, `created_before`, or `source` filters.
+Results are limited to the first page (up to 100 predictions) because Replicate's full-URL pagination is not supported. To filter predictions upstream, use `created_after` or `created_before` filters.
 
 Key columns:
 
@@ -46,7 +46,7 @@ Key columns:
 | `created_at` | `Timestamp` | When the prediction was created |
 | `started_at` | `Timestamp` | When the model began processing |
 | `completed_at` | `Timestamp` | When the prediction finished |
-| `source` | `Utf8` | How the prediction was created — `"api"` or `"web"` |
+| `source` | `Utf8` | How the prediction was created — `"api"` or `"web"` (Note: not supported as an upstream pushdown filter) |
 | `input` | `Json` | Model-specific input parameters |
 | `output` | `Json` | Model-specific output (URL, string, or object) |
 | `error` | `Utf8` | Error message when `status = 'failed'` |
@@ -120,7 +120,7 @@ ORDER BY created_at DESC
 LIMIT 50;
 ```
 
-### Filter predictions by creation source and date range (upstream pushdown)
+### Filter predictions by date range (upstream pushdown)
 
 ```sql
 SELECT
@@ -129,8 +129,7 @@ SELECT
   status,
   created_at
 FROM replicate.predictions
-WHERE source = 'api'
-  AND created_after = '2026-05-01T00:00:00Z'
+WHERE created_after = '2026-05-01T00:00:00Z'
   AND created_before = '2026-05-20T23:59:59Z'
 ORDER BY created_at DESC;
 ```
@@ -175,6 +174,18 @@ SELECT
   sku
 FROM replicate.hardware;
 ```
+
+## Rate Limits and Limitations
+
+### Rate Limits
+Replicate enforces rate limits based on your account type and the action being performed:
+* **Prediction Creation**: 600 requests per minute (RPM).
+* **Other Endpoints**: 3,000 requests per minute (RPM).
+
+If these limits are exceeded, Replicate returns an HTTP `429 Too Many Requests` status code. Coral will propagate this error status back to your client. For details, refer to the [Replicate rate limit documentation](https://replicate.com/docs/topics/predictions/rate-limits).
+
+### Known Limitations
+* **Pagination**: The `replicate.predictions`, `replicate.models`, `replicate.deployments`, and `replicate.collections` tables only retrieve the first page of results (up to 100 records) due to Coral not yet supporting Replicate's full-URL based pagination. Use pushdown filters (such as `created_after` or `created_before` on `replicate.predictions`) to retrieve relevant data.
 
 ## Auth
 

--- a/sources/community/replicate/README.md
+++ b/sources/community/replicate/README.md
@@ -24,7 +24,7 @@ for details on token management.
 
 | Table | Description | Filters |
 |---|---|---|
-| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | `created_after`, `created_before`, `source` (optional) |
+| `replicate.predictions` | Your AI inference history — every model run under the authenticated account | `created_after`, `created_before` (optional, upstream pushdown) |
 | `replicate.models` | Global public ML model catalog — browse and discover models by owner, latest updates, or creation date | `sort_by`, `sort_direction` (optional) |
 | `replicate.deployments` | Deployed models configured for the authenticated account, with hardware and scaling config | — |
 | `replicate.collections` | Curated model groups maintained by Replicate (e.g. "super-resolution", "text-to-image") | — |
@@ -33,7 +33,7 @@ for details on token management.
 ### `replicate.predictions`
 
 Returns predictions made by the authenticated user, newest first.
-Results are limited to the first page (up to 100 predictions) because Replicate's full-URL pagination is not supported. To filter predictions upstream, use `created_after`, `created_before`, or `source` filters.
+Results are limited to the first page (up to 100 predictions) because Replicate's full-URL pagination is not supported. To filter predictions upstream, use `created_after` or `created_before` filters.
 
 Key columns:
 
@@ -46,14 +46,14 @@ Key columns:
 | `created_at` | `Timestamp` | When the prediction was created |
 | `started_at` | `Timestamp` | When the model began processing |
 | `completed_at` | `Timestamp` | When the prediction finished |
-| `source` | `Utf8` | How the prediction was created — `"api"` or `"web"`. (Note: Replicate's API only supports upstream pushdown for `source = 'web'`. Other values are filtered locally). |
+| `source` | `Utf8` | How the prediction was created — `"api"` or `"web"`. Response column only; filter locally with `WHERE source = 'api'`. |
 | `input` | `Json` | Model-specific input parameters |
 | `output` | `Json` | Model-specific output (URL, string, or object) |
 | `error` | `Utf8` | Error message when `status = 'failed'` |
 | `metrics__total_time` | `Float64` | Total wall-clock duration in seconds |
 | `data_removed` | `Boolean` | True when output data has been deleted by retention policy |
-| `created_after` | `Utf8` (Virtual) | Filter predictions created after this ISO 8601 timestamp (pushdown) |
-| `created_before` | `Utf8` (Virtual) | Filter predictions created before this ISO 8601 timestamp (pushdown) |
+| `created_after` | `Utf8` (Virtual) | Filter predictions created after this ISO 8601 timestamp — pushed upstream |
+| `created_before` | `Utf8` (Virtual) | Filter predictions created before this ISO 8601 timestamp — pushed upstream |
 
 ### `replicate.models`
 
@@ -120,7 +120,7 @@ ORDER BY created_at DESC
 LIMIT 50;
 ```
 
-### Filter predictions by source and date range (upstream pushdown)
+### Filter predictions by date range (upstream pushdown)
 
 ```sql
 SELECT
@@ -129,9 +129,22 @@ SELECT
   status,
   created_at
 FROM replicate.predictions
-WHERE source = 'web'
-  AND created_after = '2026-05-01T00:00:00Z'
+WHERE created_after = '2026-05-01T00:00:00Z'
   AND created_before = '2026-05-20T23:59:59Z'
+ORDER BY created_at DESC;
+```
+
+### Filter predictions by source (local filtering)
+
+```sql
+SELECT
+  id,
+  model,
+  status,
+  source,
+  created_at
+FROM replicate.predictions
+WHERE source = 'api'
 ORDER BY created_at DESC;
 ```
 

--- a/sources/community/replicate/manifest.yaml
+++ b/sources/community/replicate/manifest.yaml
@@ -61,12 +61,15 @@ tables:
       `data_removed` is true when Replicate has deleted the prediction output.
       Predictions are returned newest-first. Note that query results are
       limited to the first page (max 100 predictions). To filter predictions
-      upstream, use the `created_after` or `created_before` filters
-      (e.g., `WHERE created_after = '2026-05-01T00:00:00Z'`).
+      upstream, use the `created_after`, `created_before`, or `source` filters
+      (e.g., `WHERE source = 'web' AND created_after = '2026-05-01T00:00:00Z'`).
+      Note: Replicate's API only supports upstream pushdown for `source = 'web'`.
     filters:
       - name: created_after
         required: false
       - name: created_before
+        required: false
+      - name: source
         required: false
     request:
       method: GET
@@ -78,6 +81,9 @@ tables:
         - name: created_before
           from: filter
           key: created_before
+        - name: source
+          from: filter
+          key: source
     response:
       rows_path:
         - results

--- a/sources/community/replicate/manifest.yaml
+++ b/sources/community/replicate/manifest.yaml
@@ -15,7 +15,9 @@ inputs:
     hint: |
       Your Replicate API token. Generate one at:
       https://replicate.com/account/api-tokens → New API token.
-      A read-only token is sufficient for all tables in this source.
+      This source only performs read-only GET requests. Any Replicate API
+      token is sufficient — Replicate does not provide scoped or read-only
+      token variants.
       Docs: https://replicate.com/docs/reference/http
 
 auth:
@@ -37,7 +39,8 @@ tables:
   # replicate.predictions — AI inference history for the authenticated user
   # GET /v1/predictions
   # Response: {next, previous, results: [...]}
-  # Pagination: cursor_query — next field contains a full URL with ?cursor=
+  # Pagination: none — limited to first page (max 100 results) because Replicate
+  # returns full URLs for pagination, which is not yet supported by Coral.
   # Scoped to the authenticated user automatically; no filter required.
   # ────────────────────────────────────────────────────────────────────────
   - name: predictions
@@ -45,7 +48,9 @@ tables:
       All predictions (inference runs) made by the authenticated Replicate user.
       Each row is one model invocation. Includes model identifier, status,
       timing, input and output payloads (as JSON), logs, and error details.
-      Scoped to the authenticated account — no filter required.
+      Scoped to the authenticated account. Results are limited to the first
+      page (up to 100 items) because Replicate's full-URL pagination is not
+      yet supported.
     guide: |
       Start with `SELECT id, model, status, created_at FROM replicate.predictions LIMIT 10`.
       `status` is one of: starting, processing, succeeded, failed, canceled, aborted.
@@ -54,19 +59,36 @@ tables:
       `input` and `output` are JSON — their shape varies per model.
       `metrics__total_time` is the total wall-clock time in seconds.
       `data_removed` is true when Replicate has deleted the prediction output.
-      Predictions are returned newest-first.
+      Predictions are returned newest-first. Note that query results are
+      limited to the first page (max 100 predictions). To filter predictions
+      upstream, use the `created_after`, `created_before`, or `source` filters
+      (e.g., `WHERE source = 'api' AND created_after = '2026-05-01T00:00:00Z'`).
+    filters:
+      - name: created_after
+        required: false
+      - name: created_before
+        required: false
+      - name: source
+        required: false
     request:
       method: GET
       path: /predictions
+      query:
+        - name: created_after
+          from: filter
+          key: created_after
+        - name: created_before
+          from: filter
+          key: created_before
+        - name: source
+          from: filter
+          key: source
     response:
       rows_path:
         - results
       row_strategy: direct
     pagination:
-      mode: cursor_query
-      cursor_param: cursor
-      response_cursor_path:
-        - next
+      mode: none
       page_size:
         default: 100
         max: 100
@@ -256,11 +278,34 @@ tables:
             - urls
             - cancel
 
+      - name: created_after
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Filter predictions created after this ISO 8601 timestamp (e.g. '2026-05-01T00:00:00Z').
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: created_after
+
+      - name: created_before
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Filter predictions created before this ISO 8601 timestamp (e.g. '2026-05-31T23:59:59Z').
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: created_before
+
   # ────────────────────────────────────────────────────────────────────────
   # replicate.models — global public ML model catalog
   # GET /v1/models
   # Response: {next, previous, results: [...]}
-  # Pagination: cursor_query — same next-URL pattern as predictions
+  # Pagination: none — limited to first page (max 100 results) because Replicate
+  # returns full URLs for pagination, which is not yet supported by Coral.
   # Global public catalog — no filter required. Optional sort filters.
   # ────────────────────────────────────────────────────────────────────────
   - name: models
@@ -269,6 +314,8 @@ tables:
       Includes owner, name, description, visibility, run count, and URLs.
       Use `is_official = true` to find Replicate-maintained models.
       Use optional `sort_by` and `sort_direction` filters to control ordering.
+      Results are limited to the first page (up to 100 items) because Replicate's
+      full-URL pagination is not yet supported.
     guide: |
       Start with `SELECT owner, name, run_count, description FROM replicate.models LIMIT 20`.
       `visibility` is "public" or "private". Only public models appear here.
@@ -299,10 +346,7 @@ tables:
         - results
       row_strategy: direct
     pagination:
-      mode: cursor_query
-      cursor_param: cursor
-      response_cursor_path:
-        - next
+      mode: none
       page_size:
         default: 100
         max: 100
@@ -459,7 +503,8 @@ tables:
   # replicate.deployments — account-scoped model deployments
   # GET /v1/deployments
   # Response: {next, previous, results: [...]}
-  # Pagination: cursor_query — same next-URL pattern as predictions
+  # Pagination: none — limited to first page (max 100 results) because Replicate
+  # returns full URLs for pagination, which is not yet supported by Coral.
   # Scoped to the authenticated account; no filter required.
   # current_release nested fields are flattened with double-underscore prefix.
   # ────────────────────────────────────────────────────────────────────────
@@ -468,7 +513,9 @@ tables:
       Model deployments configured for the authenticated Replicate account.
       Each row is one deployment and includes its current release configuration:
       the model, version, hardware SKU, and auto-scaling settings. Scoped to
-      the authenticated account — no filter required.
+      the authenticated account — no filter required. Results are limited to the
+      first page (up to 100 items) because Replicate's full-URL pagination is not
+      yet supported.
     guide: |
       Start with `SELECT owner, name, release_model, release_hardware FROM replicate.deployments`.
       `release_hardware` is a hardware SKU string (e.g. gpu-t4, gpu-a40-small).
@@ -485,10 +532,7 @@ tables:
         - results
       row_strategy: direct
     pagination:
-      mode: cursor_query
-      cursor_param: cursor
-      response_cursor_path:
-        - next
+      mode: none
       page_size:
         default: 100
         max: 100
@@ -623,7 +667,8 @@ tables:
   # replicate.collections — curated model groups (global, public)
   # GET /v1/collections
   # Response: {next, previous, results: [...]}
-  # Pagination: cursor_query — same next-URL pattern as predictions
+  # Pagination: none — limited to first page (max 100 results) because Replicate
+  # returns full URLs for pagination, which is not yet supported by Coral.
   # Global public catalog; no filter required.
   # ────────────────────────────────────────────────────────────────────────
   - name: collections
@@ -631,6 +676,8 @@ tables:
       Curated collections of models on Replicate. Each collection groups related
       models under a theme (e.g. "super-resolution", "text-to-image").
       Use `slug` to reference a collection in the Replicate UI or API.
+      Results are limited to the first page (up to 100 items) because Replicate's
+      full-URL pagination is not yet supported.
     guide: |
       Start with `SELECT name, slug, description FROM replicate.collections`.
       Collections are maintained by Replicate to group models by task or theme.
@@ -644,10 +691,7 @@ tables:
         - results
       row_strategy: direct
     pagination:
-      mode: cursor_query
-      cursor_param: cursor
-      response_cursor_path:
-        - next
+      mode: none
       page_size:
         default: 100
         max: 100

--- a/sources/community/replicate/manifest.yaml
+++ b/sources/community/replicate/manifest.yaml
@@ -61,14 +61,12 @@ tables:
       `data_removed` is true when Replicate has deleted the prediction output.
       Predictions are returned newest-first. Note that query results are
       limited to the first page (max 100 predictions). To filter predictions
-      upstream, use the `created_after`, `created_before`, or `source` filters
-      (e.g., `WHERE source = 'api' AND created_after = '2026-05-01T00:00:00Z'`).
+      upstream, use the `created_after` or `created_before` filters
+      (e.g., `WHERE created_after = '2026-05-01T00:00:00Z'`).
     filters:
       - name: created_after
         required: false
       - name: created_before
-        required: false
-      - name: source
         required: false
     request:
       method: GET
@@ -80,19 +78,12 @@ tables:
         - name: created_before
           from: filter
           key: created_before
-        - name: source
-          from: filter
-          key: source
     response:
       rows_path:
         - results
       row_strategy: direct
     pagination:
       mode: none
-      page_size:
-        default: 100
-        max: 100
-        query_param: limit
     columns:
       - name: id
         type: Utf8
@@ -347,10 +338,6 @@ tables:
       row_strategy: direct
     pagination:
       mode: none
-      page_size:
-        default: 100
-        max: 100
-        query_param: limit
     columns:
       - name: owner
         type: Utf8
@@ -533,10 +520,6 @@ tables:
       row_strategy: direct
     pagination:
       mode: none
-      page_size:
-        default: 100
-        max: 100
-        query_param: limit
     columns:
       - name: owner
         type: Utf8
@@ -692,10 +675,6 @@ tables:
       row_strategy: direct
     pagination:
       mode: none
-      page_size:
-        default: 100
-        max: 100
-        query_param: limit
     columns:
       - name: name
         type: Utf8

--- a/sources/community/replicate/manifest.yaml
+++ b/sources/community/replicate/manifest.yaml
@@ -1,0 +1,729 @@
+dsl_version: 3
+name: replicate
+version: 0.1.0
+backend: http
+description: >-
+  Query predictions, models, deployments, and collections from Replicate.
+  Covers your AI inference history, the global public model catalog,
+  account-scoped deployments, curated model collections, and available
+  GPU/CPU hardware options.
+base_url: https://api.replicate.com/v1
+
+inputs:
+  REPLICATE_API_TOKEN:
+    kind: secret
+    hint: |
+      Your Replicate API token. Generate one at:
+      https://replicate.com/account/api-tokens → New API token.
+      A read-only token is sufficient for all tables in this source.
+      Docs: https://replicate.com/docs/reference/http
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.REPLICATE_API_TOKEN}}
+
+test_queries:
+  - SELECT * FROM replicate.hardware LIMIT 10
+  - SELECT * FROM replicate.collections LIMIT 5
+  - SELECT id, model, status, created_at FROM replicate.predictions LIMIT 5
+  - SELECT owner, name, run_count, visibility FROM replicate.models LIMIT 5
+  - SELECT owner, name, release_hardware FROM replicate.deployments LIMIT 5
+
+tables:
+  # ────────────────────────────────────────────────────────────────────────
+  # replicate.predictions — AI inference history for the authenticated user
+  # GET /v1/predictions
+  # Response: {next, previous, results: [...]}
+  # Pagination: cursor_query — next field contains a full URL with ?cursor=
+  # Scoped to the authenticated user automatically; no filter required.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: predictions
+    description: >-
+      All predictions (inference runs) made by the authenticated Replicate user.
+      Each row is one model invocation. Includes model identifier, status,
+      timing, input and output payloads (as JSON), logs, and error details.
+      Scoped to the authenticated account — no filter required.
+    guide: |
+      Start with `SELECT id, model, status, created_at FROM replicate.predictions LIMIT 10`.
+      `status` is one of: starting, processing, succeeded, failed, canceled, aborted.
+      `model` is in "owner/name" format (e.g. stability-ai/sdxl).
+      `version` is the 64-char model version ID, or "hidden" for official models.
+      `input` and `output` are JSON — their shape varies per model.
+      `metrics__total_time` is the total wall-clock time in seconds.
+      `data_removed` is true when Replicate has deleted the prediction output.
+      Predictions are returned newest-first.
+    request:
+      method: GET
+      path: /predictions
+    response:
+      rows_path:
+        - results
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique prediction ID.
+        expr:
+          kind: path
+          path:
+            - id
+
+      - name: model
+        type: Utf8
+        nullable: false
+        description: >-
+          Model identifier in "owner/name" format (e.g. stability-ai/sdxl).
+          Use this to filter predictions for a specific model.
+        expr:
+          kind: path
+          path:
+            - model
+
+      - name: version
+        type: Utf8
+        nullable: true
+        description: >-
+          64-character model version ID used for this prediction.
+          "hidden" for official models that do not expose version IDs.
+        expr:
+          kind: path
+          path:
+            - version
+
+      - name: status
+        type: Utf8
+        nullable: false
+        description: >-
+          Prediction lifecycle status: starting, processing, succeeded, failed,
+          canceled, or aborted. Use `WHERE status = 'failed'` to find errors.
+        expr:
+          kind: path
+          path:
+            - status
+
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: ISO 8601 timestamp when the prediction was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when the model began processing the prediction.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - started_at
+
+      - name: completed_at
+        type: Timestamp
+        nullable: true
+        description: >-
+          ISO 8601 timestamp when the prediction completed and all outputs
+          were uploaded. Null for in-progress or failed predictions.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - completed_at
+
+      - name: source
+        type: Utf8
+        nullable: true
+        description: How the prediction was created — "api" or "web".
+        expr:
+          kind: path
+          path:
+            - source
+
+      - name: deployment
+        type: Utf8
+        nullable: true
+        description: >-
+          Name of the deployment that created this prediction, if it was run
+          via a deployment. Null for predictions run directly against a model.
+        expr:
+          kind: path
+          path:
+            - deployment
+
+      - name: data_removed
+        type: Boolean
+        nullable: false
+        description: >-
+          True when Replicate has deleted the prediction input and output data
+          (per data retention policy). Input and output will be null in this case.
+        expr:
+          kind: path
+          path:
+            - data_removed
+
+      - name: error
+        type: Utf8
+        nullable: true
+        description: Error message if status is "failed". Null on success.
+        expr:
+          kind: path
+          path:
+            - error
+
+      - name: logs
+        type: Utf8
+        nullable: true
+        description: Log output emitted by the model during this prediction run.
+        expr:
+          kind: path
+          path:
+            - logs
+
+      - name: input
+        type: Json
+        nullable: true
+        description: >-
+          Prediction input as a JSON object. Shape is model-specific.
+          Use SQL JSON functions to extract fields (e.g. json_get(input, 'prompt')).
+        expr:
+          kind: path
+          path:
+            - input
+
+      - name: output
+        type: Json
+        nullable: true
+        description: >-
+          Prediction output as a JSON value. Shape is model-specific —
+          can be a string, array of URLs, or a structured object.
+          Null if the prediction has not completed or data was removed.
+        expr:
+          kind: path
+          path:
+            - output
+
+      - name: metrics__total_time
+        type: Float64
+        nullable: true
+        description: >-
+          Total wall-clock time in seconds that the prediction took to complete,
+          including queue wait time.
+        expr:
+          kind: path
+          path:
+            - metrics
+            - total_time
+
+      - name: url_get
+        type: Utf8
+        nullable: true
+        description: API URL to retrieve the latest state of this prediction.
+        expr:
+          kind: path
+          path:
+            - urls
+            - get
+
+      - name: url_cancel
+        type: Utf8
+        nullable: true
+        description: API URL to cancel this prediction if it is still running.
+        expr:
+          kind: path
+          path:
+            - urls
+            - cancel
+
+  # ────────────────────────────────────────────────────────────────────────
+  # replicate.models — global public ML model catalog
+  # GET /v1/models
+  # Response: {next, previous, results: [...]}
+  # Pagination: cursor_query — same next-URL pattern as predictions
+  # Global public catalog — no filter required. Optional sort filters.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: models
+    description: >-
+      All public models available on Replicate. Each row is one model.
+      Includes owner, name, description, visibility, run count, and URLs.
+      Use `is_official = true` to find Replicate-maintained models.
+      Use optional `sort_by` and `sort_direction` filters to control ordering.
+    guide: |
+      Start with `SELECT owner, name, run_count, description FROM replicate.models LIMIT 20`.
+      `visibility` is "public" or "private". Only public models appear here.
+      `is_official` marks models officially maintained by Replicate (always-on,
+      stable API, predictable pricing).
+      `run_count` is the total all-time inference count across all users.
+      `latest_version` and `default_example` are JSON objects — shape varies
+      per model. Use SQL JSON functions to inspect them.
+      Use `WHERE sort_by = 'model_created_at' AND sort_direction = 'desc'`
+      to browse newest models first.
+    filters:
+      - name: sort_by
+        required: false
+      - name: sort_direction
+        required: false
+    request:
+      method: GET
+      path: /models
+      query:
+        - name: sort_by
+          from: filter
+          key: sort_by
+        - name: sort_direction
+          from: filter
+          key: sort_direction
+    response:
+      rows_path:
+        - results
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: owner
+        type: Utf8
+        nullable: false
+        description: Username or organization that owns the model (e.g. stability-ai).
+        expr:
+          kind: path
+          path:
+            - owner
+
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Model name within the owner's namespace (e.g. sdxl).
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Short description of what the model does.
+        expr:
+          kind: path
+          path:
+            - description
+
+      - name: visibility
+        type: Utf8
+        nullable: false
+        description: Whether the model is "public" or "private".
+        expr:
+          kind: path
+          path:
+            - visibility
+
+      - name: is_official
+        type: Boolean
+        nullable: false
+        description: >-
+          True for models officially maintained by Replicate. Official models
+          are always-on, have stable API interfaces, and predictable pricing.
+        expr:
+          kind: path
+          path:
+            - is_official
+
+      - name: run_count
+        type: Int64
+        nullable: false
+        description: Total number of times this model has been run across all users.
+        expr:
+          kind: path
+          path:
+            - run_count
+
+      - name: url
+        type: Utf8
+        nullable: false
+        description: URL of the model page on replicate.com.
+        expr:
+          kind: path
+          path:
+            - url
+
+      - name: cover_image_url
+        type: Utf8
+        nullable: true
+        description: URL of the model's cover image.
+        expr:
+          kind: path
+          path:
+            - cover_image_url
+
+      - name: github_url
+        type: Utf8
+        nullable: true
+        description: URL of the model's source code repository on GitHub.
+        expr:
+          kind: path
+          path:
+            - github_url
+
+      - name: paper_url
+        type: Utf8
+        nullable: true
+        description: URL of the research paper associated with this model.
+        expr:
+          kind: path
+          path:
+            - paper_url
+
+      - name: license_url
+        type: Utf8
+        nullable: true
+        description: URL of the model's license.
+        expr:
+          kind: path
+          path:
+            - license_url
+
+      - name: latest_version
+        type: Json
+        nullable: true
+        description: >-
+          JSON object describing the model's latest version. Contains the version
+          ID, creation timestamp, Cog version, and OpenAPI schema for the model's
+          inputs and outputs. Use SQL JSON functions to inspect.
+        expr:
+          kind: path
+          path:
+            - latest_version
+
+      - name: default_example
+        type: Json
+        nullable: true
+        description: >-
+          JSON object for the model's default example prediction, showing
+          typical inputs and expected outputs. Shape varies per model.
+        expr:
+          kind: path
+          path:
+            - default_example
+
+      - name: sort_by
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Sort field for results. Accepted values: model_created_at,
+          latest_version_created_at. Default: latest_version_created_at.
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: sort_by
+
+      - name: sort_direction
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Sort direction: asc or desc (default). Applied as a query parameter
+          — not returned in the response.
+        expr:
+          kind: from_filter
+          key: sort_direction
+
+  # ────────────────────────────────────────────────────────────────────────
+  # replicate.deployments — account-scoped model deployments
+  # GET /v1/deployments
+  # Response: {next, previous, results: [...]}
+  # Pagination: cursor_query — same next-URL pattern as predictions
+  # Scoped to the authenticated account; no filter required.
+  # current_release nested fields are flattened with double-underscore prefix.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: deployments
+    description: >-
+      Model deployments configured for the authenticated Replicate account.
+      Each row is one deployment and includes its current release configuration:
+      the model, version, hardware SKU, and auto-scaling settings. Scoped to
+      the authenticated account — no filter required.
+    guide: |
+      Start with `SELECT owner, name, release_model, release_hardware FROM replicate.deployments`.
+      `release_hardware` is a hardware SKU string (e.g. gpu-t4, gpu-a40-small).
+      Join against `replicate.hardware` on `sku = release_hardware` to get the
+      human-readable hardware name.
+      `release_min_instances` = 0 means the deployment can scale to zero.
+      `release_model` is in "owner/name" format.
+      Deployments list is empty if the account has no configured deployments.
+    request:
+      method: GET
+      path: /deployments
+    response:
+      rows_path:
+        - results
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: owner
+        type: Utf8
+        nullable: false
+        description: Account username or organization that owns the deployment.
+        expr:
+          kind: path
+          path:
+            - owner
+
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Deployment name (unique within the owner's account).
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: release_number
+        type: Int64
+        nullable: true
+        description: >-
+          Monotonically increasing release number. Increments each time the
+          deployment configuration is updated.
+        expr:
+          kind: path
+          path:
+            - current_release
+            - number
+
+      - name: release_model
+        type: Utf8
+        nullable: true
+        description: >-
+          Model identifier in "owner/name" format used in the current release
+          (e.g. stability-ai/sdxl).
+        expr:
+          kind: path
+          path:
+            - current_release
+            - model
+
+      - name: release_version
+        type: Utf8
+        nullable: true
+        description: 64-character model version ID deployed in the current release.
+        expr:
+          kind: path
+          path:
+            - current_release
+            - version
+
+      - name: release_created_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when the current release was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - current_release
+              - created_at
+
+      - name: release_hardware
+        type: Utf8
+        nullable: true
+        description: >-
+          Hardware SKU for the current release (e.g. cpu, gpu-t4, gpu-a40-small,
+          gpu-a40-large). Join against replicate.hardware on sku to get the
+          full display name.
+        expr:
+          kind: path
+          path:
+            - current_release
+            - configuration
+            - hardware
+
+      - name: release_min_instances
+        type: Int64
+        nullable: true
+        description: >-
+          Minimum number of instances kept warm. 0 means the deployment
+          can scale to zero when idle.
+        expr:
+          kind: path
+          path:
+            - current_release
+            - configuration
+            - min_instances
+
+      - name: release_max_instances
+        type: Int64
+        nullable: true
+        description: Maximum number of instances the deployment can scale up to.
+        expr:
+          kind: path
+          path:
+            - current_release
+            - configuration
+            - max_instances
+
+      - name: release_creator_type
+        type: Utf8
+        nullable: true
+        description: Account type of the creator of this release — "user" or "organization".
+        expr:
+          kind: path
+          path:
+            - current_release
+            - created_by
+            - type
+
+      - name: release_creator_username
+        type: Utf8
+        nullable: true
+        description: Username of the account that created this release.
+        expr:
+          kind: path
+          path:
+            - current_release
+            - created_by
+            - username
+
+  # ────────────────────────────────────────────────────────────────────────
+  # replicate.collections — curated model groups (global, public)
+  # GET /v1/collections
+  # Response: {next, previous, results: [...]}
+  # Pagination: cursor_query — same next-URL pattern as predictions
+  # Global public catalog; no filter required.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: collections
+    description: >-
+      Curated collections of models on Replicate. Each collection groups related
+      models under a theme (e.g. "super-resolution", "text-to-image").
+      Use `slug` to reference a collection in the Replicate UI or API.
+    guide: |
+      Start with `SELECT name, slug, description FROM replicate.collections`.
+      Collections are maintained by Replicate to group models by task or theme.
+      Only the name, slug, and description are returned by this list endpoint —
+      for the full list of models in a collection visit replicate.com/collections/<slug>.
+    request:
+      method: GET
+      path: /collections
+    response:
+      rows_path:
+        - results
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - next
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the collection (e.g. "Super resolution").
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: >-
+          URL-safe slug for the collection in lowercase-with-dashes format
+          (e.g. "super-resolution"). Use this to browse the collection at
+          replicate.com/collections/<slug>.
+        expr:
+          kind: path
+          path:
+            - slug
+
+      - name: description
+        type: Utf8
+        nullable: false
+        description: Short description of the collection's theme or use case.
+        expr:
+          kind: path
+          path:
+            - description
+
+  # ────────────────────────────────────────────────────────────────────────
+  # replicate.hardware — available GPU and CPU hardware options
+  # GET /v1/hardware
+  # Response: root JSON array — no pagination wrapper
+  # No pagination — small static list (< 20 entries).
+  # ────────────────────────────────────────────────────────────────────────
+  - name: hardware
+    description: >-
+      Available hardware options for running models and configuring deployments
+      on Replicate. Each row is one hardware tier with its display name and SKU.
+      Use `sku` values when creating or updating deployments.
+    guide: |
+      Start with `SELECT name, sku FROM replicate.hardware`.
+      `sku` is the identifier used in `replicate.deployments.release_hardware`.
+      Join `replicate.deployments` on `sku = release_hardware` to display
+      human-readable hardware names alongside deployment configurations.
+      This list is small (typically < 20 entries) and returned in a single call.
+    request:
+      method: GET
+      path: /hardware
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Human-readable hardware name (e.g. "Nvidia T4 GPU", "CPU").
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: sku
+        type: Utf8
+        nullable: false
+        description: >-
+          Hardware SKU identifier (e.g. cpu, gpu-t4, gpu-a40-small, gpu-a40-large).
+          Use this value in deployment configuration and to join against
+          replicate.deployments.release_hardware.
+        expr:
+          kind: path
+          path:
+            - sku

--- a/sources/community/replicate/manifest.yaml
+++ b/sources/community/replicate/manifest.yaml
@@ -61,15 +61,14 @@ tables:
       `data_removed` is true when Replicate has deleted the prediction output.
       Predictions are returned newest-first. Note that query results are
       limited to the first page (max 100 predictions). To filter predictions
-      upstream, use the `created_after`, `created_before`, or `source` filters
-      (e.g., `WHERE source = 'web' AND created_after = '2026-05-01T00:00:00Z'`).
-      Note: Replicate's API only supports upstream pushdown for `source = 'web'`.
+      upstream, use the `created_after` or `created_before` filters
+      (e.g., `WHERE created_after = '2026-05-01T00:00:00Z'`).
+      The `source` column is available in query results but is not a pushdown
+      filter — use `WHERE source = 'api'` for local filtering after fetch.
     filters:
       - name: created_after
         required: false
       - name: created_before
-        required: false
-      - name: source
         required: false
     request:
       method: GET
@@ -81,9 +80,6 @@ tables:
         - name: created_before
           from: filter
           key: created_before
-        - name: source
-          from: filter
-          key: source
     response:
       rows_path:
         - results
@@ -174,7 +170,11 @@ tables:
       - name: source
         type: Utf8
         nullable: true
-        description: How the prediction was created — "api" or "web".
+        description: >-
+          How the prediction was created — "api" (via API) or "web" (via
+          the Replicate website playground). This is a response column only;
+          use local SQL filtering (e.g. WHERE source = 'api') rather than
+          a pushdown filter.
         expr:
           kind: path
           path:


### PR DESCRIPTION
## Summary

Fixes #563

Add a new Replicate community source that lets Coral query Replicate
AI inference data through SQL. This makes predictions, public models,
deployments, collections, and hardware options queryable via standard
SQL — enabling AI usage auditing, model discovery, deployment
inspection, and cross-source joins with tools like GitHub, Linear,
or LangSmith directly from Coral.

This change is manifest-only and uses Coral's existing HTTP source-spec
model. It adds read-only Replicate API visibility without changing CLI,
MCP, config, runtime, or bundled-source contracts.

## What changed

Added:

- `sources/community/replicate/manifest.yaml`
- `sources/community/replicate/README.md`

## Source scope

**Inputs:**

- `REPLICATE_API_TOKEN` — static Bearer token (`secret`), generated from
  Replicate dashboard → [Account → API tokens](https://replicate.com/account/api-tokens)

**Tables:**

- **`replicate.predictions`**
  - `GET /v1/predictions`
  - lists all predictions made by the authenticated user, newest-first
  - no filter required — scoped to the authenticated account automatically
  - exposes model, version, status, timestamps, input/output (Json),
    logs, error, metrics, and cancellation URL
  - `input` and `output` kept as `Json` — shape is model-specific

- **`replicate.models`**
  - `GET /v1/models`
  - lists all public models in the global Replicate model catalog
  - optional filters: `sort_by` (`model_created_at`,
    `latest_version_created_at`) and `sort_direction` (`asc`, `desc`)
  - `sort_by` and `sort_direction` are `virtual: true` — query params
    only, no response body equivalent
  - `latest_version` and `default_example` kept as `Json` —
    deeply polymorphic nested objects with model-specific schemas

- **`replicate.deployments`**
  - `GET /v1/deployments`
  - lists all deployments for the authenticated account
  - no filter required — scoped to the authenticated account automatically
  - `current_release` nested object flattened with `release_` prefix
    using multi-level `path` expressions (hardware, scaling config,
    creator info)

- **`replicate.collections`**
  - `GET /v1/collections`
  - lists all curated model collections on Replicate
  - no filter required — global public catalog
  - three fields only: `name`, `slug`, `description`

- **`replicate.hardware`**
  - `GET /v1/hardware`
  - lists all available GPU/CPU hardware tiers and their SKU identifiers
  - no pagination — root JSON array, `mode: none`
  - joinable with `replicate.deployments` on `sku = release_hardware`

## Implementation notes

- uses Replicate API v1 Bearer auth
  (`Authorization: Bearer {{input.REPLICATE_API_TOKEN}}`)
- keeps v1 intentionally read-only
- all four paginated endpoints (predictions, models, deployments,
collections) use pagination.mode: none — results are limited to the
first page (up to 100 items) because Replicate returns full next-page
URLs which are not yet supported by Coral's cursor pagination
- `hardware` returns a root JSON array with no pagination wrapper —
  uses `response: {}` with `mode: none`
- all timestamps are ISO 8601 strings — uses `input: iso8601` throughout
- `virtual: true` used for `models.sort_by` and `models.sort_direction`
  — server-side sort params with no response body equivalent
- `input` and `output` on `predictions` kept as `Json` — completely
  variable shape per model, cannot be statically typed
- `latest_version` and `default_example` on `models` kept as `Json` —
  polymorphic nested objects with per-model OpenAPI schemas
- no OAuth — Replicate uses only static API tokens; confirmed safe
  per Coral maintainer policy

## Validation

Local validation completed:
<img width="1381" height="541" alt="image" src="https://github.com/user-attachments/assets/2aa03818-814d-41ba-8319-48e5a92c618d" />


## Out of scope

Not included in v1:

- creating predictions or running models
- creating or updating deployments
- creating, updating, or deleting collections
- model version management
- training jobs (`/v1/trainings`)
- file uploads (`/v1/files`)
- write operations of any kind



