### PR TITLE
feat(sources/community/checkly): add Checkly community source

### DIFF
--- a/sources/community/checkly/README.md
+++ b/sources/community/checkly/README.md
@@ -51,7 +51,7 @@ Key columns:
 |---|---|---|
 | `id` | `Utf8` | Check UUID — use this as `check_id` in `check_results` |
 | `name` | `Utf8` | Check display name |
-| `check_type` | `Utf8` | `API` · `BROWSER` · `HEARTBEAT` · `DNS` · `TCP` |
+| `check_type` | `Utf8` | `API` · `BROWSER` · `HEARTBEAT` · `DNS` · `TCP` · `MULTI_STEP` · `PLAYWRIGHT` · `AGENTIC` · `ICMP` · `URL` |
 | `frequency` | `Int64` | Run interval in minutes |
 | `activated` | `Boolean` | `false` = check is paused |
 | `muted` | `Boolean` | `true` = alerts suppressed |
@@ -73,8 +73,8 @@ Recent run results for one specific check. **`check_id` is required.** Get check
 | `check_id` | ✅ Yes | UUID of the check to fetch results for |
 | `result_type` | No | `FINAL` (completed runs) or `ATTEMPT` (retry attempts) |
 | `has_failures` | No | `true` to return only failing runs |
-| `from` | No | UNIX timestamp in **seconds** — lower time bound |
-| `to` | No | UNIX timestamp in **seconds** — upper time bound |
+| `from` | No | UNIX timestamp in **seconds** — lower time bound. Use quoted SQL: `WHERE "from" = '1716768000'` |
+| `to` | No | UNIX timestamp in **seconds** — upper time bound. Use quoted SQL: `WHERE "to" = '1716854400'` |
 | `location` | No | Filter check results by execution location (e.g. `us-east-1`) |
 | `check_type` | No | Filter check results by check type (e.g. `API` or `BROWSER`) |
 
@@ -91,8 +91,10 @@ Key columns:
 | `started_at` | `Timestamp` | Run start time |
 | `stopped_at` | `Timestamp` | Run completion time |
 | `response_time` | `Int64` | Execution time in ms |
-| `location` | `Utf8` (Virtual) | Filter check results by execution location (pushdown) |
-| `check_type` | `Utf8` (Virtual) | Filter check results by check type (pushdown) |
+| `location` | `Utf8` (Virtual) | Filter check results by execution location — pushed upstream as `location` query param |
+| `check_type` | `Utf8` (Virtual) | Filter check results by check type — pushed upstream as `checkType` query param |
+| `from` | `Utf8` (Virtual) | Lower time bound (UNIX seconds) — pushed upstream. Use quoted SQL: `WHERE "from" = '...'` |
+| `to` | `Utf8` (Virtual) | Upper time bound (UNIX seconds) — pushed upstream. Use quoted SQL: `WHERE "to" = '...'` |
 
 ### `checkly.alert_channels`
 
@@ -242,4 +244,13 @@ This source uses two headers on every request:
 
 Both credentials are required. Requests without the `X-Checkly-Account` header will be rejected by the API regardless of the API key's validity.
 
-See the [Checkly API reference](https://developers.checklyhq.com/reference) for full documentation.
+See the [Checkly API overview and authentication](https://www.checklyhq.com/docs/api-reference/overview/) for full documentation.
+
+### Per-endpoint API references
+
+| Table | Endpoint reference |
+|---|---|
+| `checkly.checks` | [List all checks](https://www.checklyhq.com/docs/api-reference/checks/list-all-checks/) |
+| `checkly.check_results` | [List all check results](https://www.checklyhq.com/docs/api-reference/check-results/lists-all-check-results-1/) |
+| `checkly.alert_channels` | [List all alert channels](https://www.checklyhq.com/docs/api-reference/alert-channels/list-all-alert-channels/) |
+| `checkly.dashboards` | [List all dashboards](https://www.checklyhq.com/docs/api-reference/dashboards/list-all-dashboards/) |

--- a/sources/community/checkly/README.md
+++ b/sources/community/checkly/README.md
@@ -70,8 +70,8 @@ Recent run results for one specific check. **`check_id` is required.** Get check
 | `check_id` | ✅ Yes | UUID of the check to fetch results for |
 | `result_type` | No | `FINAL` (completed runs) or `ATTEMPT` (retry attempts) |
 | `has_failures` | No | `true` to return only failing runs |
-| `from` | No | UNIX millisecond timestamp — lower time bound |
-| `to` | No | UNIX millisecond timestamp — upper time bound |
+| `from` | No | UNIX timestamp in **seconds** — lower time bound |
+| `to` | No | UNIX timestamp in **seconds** — upper time bound |
 
 Key columns:
 
@@ -184,10 +184,10 @@ WHERE is_private = false;
 
 This source uses two headers on every request:
 
-| Header | Value |
-|---|---|
-| `Authorization` | `Bearer <CHECKLY_API_KEY>` |
-| `X-Checkly-Account` | `<CHECKLY_ACCOUNT_ID>` |
+| Header | Value | Input kind |
+|---|---|---|
+| `Authorization` | `Bearer <CHECKLY_API_KEY>` | `secret` |
+| `X-Checkly-Account` | `<CHECKLY_ACCOUNT_ID>` | `variable` |
 
 Both credentials are required. Requests without the `X-Checkly-Account` header will be rejected by the API regardless of the API key's validity.
 

--- a/sources/community/checkly/README.md
+++ b/sources/community/checkly/README.md
@@ -16,7 +16,7 @@ Checkly requires **two credentials** for every API request:
 - **Personal key**: Checkly dashboard → User Settings → [API Keys](https://app.checklyhq.com/settings/user/api-keys) → Create API key
 - **Service key** (recommended for CI/CD): Checkly dashboard → Account Settings → API Keys → Create API key
 
-A read-only key is sufficient for all tables in this source.
+This source only performs read-only GET requests. Any Checkly API key is sufficient — Checkly does not provide scoped or read-only key variants.
 
 ### Step 2 — Get your Account ID
 
@@ -34,16 +34,16 @@ See the [Checkly authentication docs](https://developers.checklyhq.com/docs/auth
 
 ## Tables
 
-| Table | Description | Required filters |
-|---|---|---|
-| `checkly.checks` | All API and browser checks in the account — inventory, type, frequency, locations | — |
-| `checkly.check_results` | Recent run results for a specific check — pass/fail, response time, run location | `check_id` (required) |
-| `checkly.alert_channels` | Notification channels — Slack, Email, PagerDuty, Webhook, etc. — and their routing config | — |
-| `checkly.dashboards` | Public and private status page dashboards with domain and tag configuration | — |
+| Table | Description | Required filters | Optional pushdown filters |
+|---|---|---|---|
+| `checkly.checks` | All API and browser checks in the account — inventory, type, frequency, locations | — | `tag`, `check_type`, `search`, `status` |
+| `checkly.check_results` | Recent run results for a specific check — pass/fail, response time, run location | `check_id` (required) | `result_type`, `has_failures`, `from`, `to`, `location`, `check_type` |
+| `checkly.alert_channels` | Notification channels — Slack, Email, PagerDuty, Webhook, etc. — and their routing config | — | — |
+| `checkly.dashboards` | Public and private status page dashboards with domain and tag configuration | — | — |
 
 ### `checkly.checks`
 
-Lists all synthetic monitoring checks in the account, newest first. No filter required — the `X-Checkly-Account` header scopes results automatically.
+Lists all synthetic monitoring checks in the account, newest first. No filter is required, but you can filter results upstream using `tag`, `check_type`, `search`, or `status` pushdown filters.
 
 Key columns:
 
@@ -60,6 +60,9 @@ Key columns:
 | `degraded_response_time` | `Int64` | Degraded threshold in ms |
 | `max_response_time` | `Int64` | Failure threshold in ms |
 | `created_at` | `Timestamp` | Check creation time |
+| `tag` | `Utf8` (Virtual) | Filter checks by a specific tag (pushdown) |
+| `search` | `Utf8` (Virtual) | Search checks by name or tag (pushdown) |
+| `status` | `Utf8` (Virtual) | Filter checks by their current status (pushdown) |
 
 ### `checkly.check_results`
 
@@ -72,6 +75,8 @@ Recent run results for one specific check. **`check_id` is required.** Get check
 | `has_failures` | No | `true` to return only failing runs |
 | `from` | No | UNIX timestamp in **seconds** — lower time bound |
 | `to` | No | UNIX timestamp in **seconds** — upper time bound |
+| `location` | No | Filter check results by execution location (e.g. `us-east-1`) |
+| `check_type` | No | Filter check results by check type (e.g. `API` or `BROWSER`) |
 
 Key columns:
 
@@ -86,6 +91,8 @@ Key columns:
 | `started_at` | `Timestamp` | Run start time |
 | `stopped_at` | `Timestamp` | Run completion time |
 | `response_time` | `Int64` | Execution time in ms |
+| `location` | `Utf8` (Virtual) | Filter check results by execution location (pushdown) |
+| `check_type` | `Utf8` (Virtual) | Filter check results by check type (pushdown) |
 
 ### `checkly.alert_channels`
 
@@ -152,6 +159,36 @@ WHERE check_id = '<your-check-id>'
 LIMIT 50;
 ```
 
+### Search checks by tag and type (upstream pushdown)
+
+```sql
+SELECT
+  id,
+  name,
+  check_type,
+  frequency
+FROM checkly.checks
+WHERE tag = 'production'
+  AND check_type = 'BROWSER';
+```
+
+### Filter check results by location and type (upstream pushdown)
+
+```sql
+SELECT
+  id,
+  has_failures,
+  run_location,
+  response_time,
+  started_at
+FROM checkly.check_results
+WHERE check_id = '<your-check-id>'
+  AND location = 'us-east-1'
+  AND check_type = 'API'
+  AND result_type = 'FINAL'
+LIMIT 50;
+```
+
 ### Audit alert channel routing
 
 ```sql
@@ -180,6 +217,20 @@ FROM checkly.dashboards
 WHERE is_private = false;
 ```
 
+## Rate Limits and Limitations
+
+### Rate Limits
+Checkly enforces rate limits to ensure API stability:
+* **General API**: 10 requests per second (RPS) or 600 requests per minute (RPM) per account.
+* **Check Results Endpoint**: Stricter limit of 5 requests per 10 seconds.
+
+If these limits are exceeded, Checkly returns an HTTP `429 Too Many Requests` status code. Coral will propagate this error back to your client. 
+
+### Large-Query Guidance
+To avoid triggering the strict check-results rate limits:
+* Always filter check results by a specific time window using the `from` and `to` filters (Unix timestamps in seconds).
+* Avoid executing queries that scan all check results without time constraints.
+
 ## Auth
 
 This source uses two headers on every request:
@@ -187,7 +238,7 @@ This source uses two headers on every request:
 | Header | Value | Input kind |
 |---|---|---|
 | `Authorization` | `Bearer <CHECKLY_API_KEY>` | `secret` |
-| `X-Checkly-Account` | `<CHECKLY_ACCOUNT_ID>` | `variable` |
+| `X-Checkly-Account` | `<CHECKLY_ACCOUNT_ID>` | `secret` |
 
 Both credentials are required. Requests without the `X-Checkly-Account` header will be rejected by the API regardless of the API key's validity.
 

--- a/sources/community/checkly/README.md
+++ b/sources/community/checkly/README.md
@@ -147,7 +147,7 @@ SELECT
   stopped_at
 FROM checkly.check_results
 WHERE check_id = '<your-check-id>'
-  AND has_failures = 'true'
+  AND has_failures = true
   AND result_type = 'FINAL'
 LIMIT 50;
 ```

--- a/sources/community/checkly/README.md
+++ b/sources/community/checkly/README.md
@@ -1,0 +1,194 @@
+# Checkly
+
+Query synthetic monitoring checks, check results, alert channels, and
+dashboards from [Checkly](https://checklyhq.com/) — the synthetic monitoring
+platform for API and browser checks.
+
+## Authentication
+
+Checkly requires **two credentials** for every API request:
+
+1. **API Key** — authenticates the request
+2. **Account ID** — scopes the request to your account
+
+### Step 1 — Get your API key
+
+- **Personal key**: Checkly dashboard → User Settings → [API Keys](https://app.checklyhq.com/settings/user/api-keys) → Create API key
+- **Service key** (recommended for CI/CD): Checkly dashboard → Account Settings → API Keys → Create API key
+
+A read-only key is sufficient for all tables in this source.
+
+### Step 2 — Get your Account ID
+
+Checkly dashboard → Account Settings → General → **Account ID** (shown at the top of the page).
+
+### Step 3 — Add the source
+
+```sh
+export CHECKLY_API_KEY="cu_..."
+export CHECKLY_ACCOUNT_ID="12345678"
+coral source add --file sources/community/checkly/manifest.yaml
+```
+
+See the [Checkly authentication docs](https://developers.checklyhq.com/docs/authentication) for details.
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `checkly.checks` | All API and browser checks in the account — inventory, type, frequency, locations | — |
+| `checkly.check_results` | Recent run results for a specific check — pass/fail, response time, run location | `check_id` (required) |
+| `checkly.alert_channels` | Notification channels — Slack, Email, PagerDuty, Webhook, etc. — and their routing config | — |
+| `checkly.dashboards` | Public and private status page dashboards with domain and tag configuration | — |
+
+### `checkly.checks`
+
+Lists all synthetic monitoring checks in the account, newest first. No filter required — the `X-Checkly-Account` header scopes results automatically.
+
+Key columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `Utf8` | Check UUID — use this as `check_id` in `check_results` |
+| `name` | `Utf8` | Check display name |
+| `check_type` | `Utf8` | `API` · `BROWSER` · `HEARTBEAT` · `DNS` · `TCP` |
+| `frequency` | `Int64` | Run interval in minutes |
+| `activated` | `Boolean` | `false` = check is paused |
+| `muted` | `Boolean` | `true` = alerts suppressed |
+| `locations` | `Json` | Array of AWS region strings |
+| `tags` | `Json` | Array of tag strings |
+| `degraded_response_time` | `Int64` | Degraded threshold in ms |
+| `max_response_time` | `Int64` | Failure threshold in ms |
+| `created_at` | `Timestamp` | Check creation time |
+
+### `checkly.check_results`
+
+Recent run results for one specific check. **`check_id` is required.** Get check IDs from `checkly.checks`. Raw results are retained for **30 days**.
+
+| Filter | Required | Description |
+|---|---|---|
+| `check_id` | ✅ Yes | UUID of the check to fetch results for |
+| `result_type` | No | `FINAL` (completed runs) or `ATTEMPT` (retry attempts) |
+| `has_failures` | No | `true` to return only failing runs |
+| `from` | No | UNIX millisecond timestamp — lower time bound |
+| `to` | No | UNIX millisecond timestamp — upper time bound |
+
+Key columns:
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `Utf8` | Result ID |
+| `check_run_id` | `Int64` | Monotonic run sequence number |
+| `result_type` | `Utf8` | `FINAL` or `ATTEMPT` |
+| `has_failures` | `Boolean` | `true` if assertions failed or timeout occurred |
+| `has_errors` | `Boolean` | `true` if a Checkly platform error occurred |
+| `run_location` | `Utf8` | AWS region where the check ran |
+| `started_at` | `Timestamp` | Run start time |
+| `stopped_at` | `Timestamp` | Run completion time |
+| `response_time` | `Int64` | Execution time in ms |
+
+### `checkly.alert_channels`
+
+All notification channels in the account. `config` is a polymorphic JSON object — its shape depends on `type`.
+
+| `type` | `config` fields |
+|---|---|
+| `EMAIL` | `address` |
+| `SLACK` | `channel`, `url` |
+| `WEBHOOK` | `method`, `url`, `headers`, `template` |
+| `SMS` | `number` |
+| `PAGERDUTY` | `service_key`, `account`, `service_name` |
+| `OPSGENIE` | `api_key`, `name`, `priority`, `region` |
+| `CALL` | `name`, `number` |
+
+### `checkly.dashboards`
+
+Status page dashboards for the account. `tags` controls which checks appear on each dashboard — only checks with matching tags are displayed.
+
+## Example queries
+
+### Inventory all active checks
+
+```sql
+SELECT
+  id,
+  name,
+  check_type,
+  frequency,
+  locations,
+  tags
+FROM checkly.checks
+WHERE activated = true
+ORDER BY name;
+```
+
+### Find paused or muted checks
+
+```sql
+SELECT
+  id,
+  name,
+  check_type,
+  activated,
+  muted
+FROM checkly.checks
+WHERE activated = false OR muted = true;
+```
+
+### Get recent failing results for a specific check
+
+```sql
+SELECT
+  id,
+  has_failures,
+  run_location,
+  response_time,
+  started_at,
+  stopped_at
+FROM checkly.check_results
+WHERE check_id = '<your-check-id>'
+  AND has_failures = 'true'
+  AND result_type = 'FINAL'
+LIMIT 50;
+```
+
+### Audit alert channel routing
+
+```sql
+SELECT
+  id,
+  type,
+  send_failure,
+  send_recovery,
+  send_degraded,
+  ssl_expiry,
+  config
+FROM checkly.alert_channels
+ORDER BY type;
+```
+
+### List public status page dashboards
+
+```sql
+SELECT
+  id,
+  custom_url,
+  custom_domain,
+  is_private,
+  tags
+FROM checkly.dashboards
+WHERE is_private = false;
+```
+
+## Auth
+
+This source uses two headers on every request:
+
+| Header | Value |
+|---|---|
+| `Authorization` | `Bearer <CHECKLY_API_KEY>` |
+| `X-Checkly-Account` | `<CHECKLY_ACCOUNT_ID>` |
+
+Both credentials are required. Requests without the `X-Checkly-Account` header will be rejected by the API regardless of the API key's validity.
+
+See the [Checkly API reference](https://developers.checklyhq.com/reference) for full documentation.

--- a/sources/community/checkly/README.md
+++ b/sources/community/checkly/README.md
@@ -98,17 +98,17 @@ Key columns:
 
 ### `checkly.alert_channels`
 
-All notification channels in the account. `config` is a polymorphic JSON object — its shape depends on `type`.
+All notification channels in the account. Each row has a `type` and the
+corresponding notification routing flags (`send_failure`, `send_recovery`,
+`send_degraded`, `ssl_expiry`).
 
-| `type` | `config` fields |
-|---|---|
-| `EMAIL` | `address` |
-| `SLACK` | `channel`, `url` |
-| `WEBHOOK` | `method`, `url`, `headers`, `template` |
-| `SMS` | `number` |
-| `PAGERDUTY` | `service_key`, `account`, `service_name` |
-| `OPSGENIE` | `api_key`, `name`, `priority`, `region` |
-| `CALL` | `name`, `number` |
+Known `type` values: `EMAIL`, `SLACK`, `SLACK_APP`, `WEBHOOK`, `SMS`,
+`PAGERDUTY`, `OPSGENIE`, `CALL`.
+
+> **Note**: The `config` field (channel-specific JSON configuration) is not
+> exposed by this source. It can contain credential material such as webhook
+> authorization headers, PagerDuty service keys, and OpsGenie API keys.
+> Use the Checkly dashboard to inspect individual channel configuration.
 
 ### `checkly.dashboards`
 
@@ -200,8 +200,7 @@ SELECT
   send_failure,
   send_recovery,
   send_degraded,
-  ssl_expiry,
-  config
+  ssl_expiry
 FROM checkly.alert_channels
 ORDER BY type;
 ```

--- a/sources/community/checkly/manifest.yaml
+++ b/sources/community/checkly/manifest.yaml
@@ -16,10 +16,11 @@ inputs:
       Checkly API key. Generate one from:
         User Settings  → API Keys → Create API key  (personal key)
         Account Settings → API Keys → Create API key (service key for CI/CD)
-      A read-only key is sufficient for all tables in this source.
+      This source only performs read-only GET requests. Any Checkly API key
+      is sufficient — Checkly does not provide scoped or read-only key variants.
       Docs: https://developers.checklyhq.com/docs/authentication
   CHECKLY_ACCOUNT_ID:
-    kind: variable
+    kind: secret
     hint: |
       Checkly Account ID. Find it in:
         Account Settings → General → Account ID
@@ -40,7 +41,6 @@ test_queries:
   - SELECT id, name, check_type, activated FROM checkly.checks LIMIT 5
   - SELECT id, type, send_failure FROM checkly.alert_channels LIMIT 5
   - SELECT id, custom_url, is_private FROM checkly.dashboards LIMIT 5
-  - SELECT id, has_failures, run_location, response_time FROM checkly.check_results WHERE check_id = 'replace-with-check-id' LIMIT 10
 
 tables:
   # ────────────────────────────────────────────────────────────────────────
@@ -66,9 +66,32 @@ tables:
       `locations` is a JSON array of region strings (e.g. ["us-east-1", "eu-central-1"]).
       `tags` is a JSON array of string labels.
       Use `id` values to join against checkly.check_results.check_id.
+      Use pushdown filters (such as `tag`, `check_type`, `search`, and `status`) to filter checks upstream.
+    filters:
+      - name: tag
+        required: false
+      - name: check_type
+        required: false
+      - name: search
+        required: false
+      - name: status
+        required: false
     request:
       method: GET
       path: /v1/checks
+      query:
+        - name: tag
+          from: filter
+          key: tag
+        - name: checkType
+          from: filter
+          key: check_type
+        - name: search
+          from: filter
+          key: search
+        - name: status
+          from: filter
+          key: status
     response:
       rows_path: []
       row_strategy: direct
@@ -266,6 +289,37 @@ tables:
             path:
               - updatedAt
 
+      - name: tag
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Filter checks by a specific tag. Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: tag
+
+      - name: search
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Search checks by name or tag. Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: search
+
+      - name: status
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Filter checks by their current status (e.g. failing, passing).
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: status
+
   # ────────────────────────────────────────────────────────────────────────
   # checkly.check_results — recent run results for a specific check
   # GET /v2/check-results/{checkId}   ← NOTE: v2, not v1 (v1 is deprecated)
@@ -290,6 +344,7 @@ tables:
       Use `WHERE has_failures = true` to filter for only failing runs.
       `response_time` is in milliseconds.
       `from` and `to` filters accept UNIX timestamps in seconds (not milliseconds).
+      Use `location` (e.g., 'us-east-1') and `check_type` (e.g., 'API') pushdown filters to limit response.
       Results older than 30 days are not available.
     filters:
       - name: check_id
@@ -301,6 +356,10 @@ tables:
       - name: from
         required: false
       - name: to
+        required: false
+      - name: location
+        required: false
+      - name: check_type
         required: false
     request:
       method: GET
@@ -485,6 +544,28 @@ tables:
         expr:
           kind: from_filter
           key: to
+
+      - name: location
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Filter check results by execution location (e.g. 'us-east-1').
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: location
+
+      - name: check_type
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Filter check results by check type (e.g. 'API', 'BROWSER').
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: check_type
 
   # ────────────────────────────────────────────────────────────────────────
   # checkly.alert_channels — notification channels for check failures

--- a/sources/community/checkly/manifest.yaml
+++ b/sources/community/checkly/manifest.yaml
@@ -1,0 +1,788 @@
+dsl_version: 3
+name: checkly
+version: 0.1.0
+backend: http
+description: >-
+  Query synthetic monitoring checks, check results, alert channels, and
+  dashboards from Checkly. Covers your full monitoring configuration —
+  API and browser check inventory, recent pass/fail run history,
+  notification routing, and status page dashboards.
+base_url: https://api.checklyhq.com
+
+inputs:
+  CHECKLY_API_KEY:
+    kind: secret
+    hint: |
+      Checkly API key. Generate one from:
+        User Settings  → API Keys → Create API key  (personal key)
+        Account Settings → API Keys → Create API key (service key for CI/CD)
+      A read-only key is sufficient for all tables in this source.
+      Docs: https://developers.checklyhq.com/docs/authentication
+  CHECKLY_ACCOUNT_ID:
+    kind: secret
+    hint: |
+      Checkly Account ID. Find it in:
+        Account Settings → General → Account ID
+      Required by the Checkly API to scope every request to your account.
+      Docs: https://developers.checklyhq.com/docs/authentication
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.CHECKLY_API_KEY}}
+    - name: X-Checkly-Account
+      from: input
+      key: CHECKLY_ACCOUNT_ID
+
+test_queries:
+  - SELECT id, name, check_type, activated FROM checkly.checks LIMIT 5
+  - SELECT id, type, send_failure FROM checkly.alert_channels LIMIT 5
+  - SELECT id, custom_url, is_private FROM checkly.dashboards LIMIT 5
+  - SELECT id, has_failures, run_location, response_time FROM checkly.check_results WHERE check_id = 'replace-with-check-id' LIMIT 10
+
+tables:
+  # ────────────────────────────────────────────────────────────────────────
+  # checkly.checks — all synthetic monitoring checks in the account
+  # GET /v1/checks
+  # Response: root JSON array
+  # Pagination: mode: page, page + limit query params
+  # Scoped to the authenticated account by the X-Checkly-Account header.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: checks
+    description: >-
+      All API and browser synthetic monitoring checks configured in the
+      authenticated Checkly account. Each row is one check. Includes the
+      check type, run frequency, active locations, tags, alert thresholds,
+      and enabled state. Use check IDs from this table to query
+      checkly.check_results for recent run outcomes.
+    guide: |
+      Start with `SELECT id, name, check_type, frequency, activated FROM checkly.checks`.
+      `check_type` is one of: API, BROWSER, HEARTBEAT, DNS, TCP.
+      `frequency` is the run interval in minutes (e.g. 1, 5, 10, 30, 60).
+      `activated = false` means the check is paused and not running.
+      `muted = true` means alerts are suppressed even when the check fails.
+      `locations` is a JSON array of region strings (e.g. ["us-east-1", "eu-central-1"]).
+      `tags` is a JSON array of string labels.
+      Use `id` values to join against checkly.check_results.check_id.
+    request:
+      method: GET
+      path: /v1/checks
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique check UUID.
+        expr:
+          kind: path
+          path:
+            - id
+
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Human-readable check name as configured in the Checkly dashboard.
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: check_type
+        type: Utf8
+        nullable: false
+        description: >-
+          Type of synthetic check: API, BROWSER, HEARTBEAT, DNS, or TCP.
+        expr:
+          kind: path
+          path:
+            - checkType
+
+      - name: frequency
+        type: Int64
+        nullable: true
+        description: >-
+          Check run interval in minutes (e.g. 1, 5, 10, 30, 60).
+          Higher-frequency plans allow sub-minute checks.
+        expr:
+          kind: path
+          path:
+            - frequency
+
+      - name: activated
+        type: Boolean
+        nullable: false
+        description: >-
+          Whether the check is currently active (running on its schedule).
+          False means the check is paused.
+        expr:
+          kind: path
+          path:
+            - activated
+
+      - name: muted
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether alerts are muted for this check. When true, failures do
+          not trigger notifications even though the check still runs.
+        expr:
+          kind: path
+          path:
+            - muted
+
+      - name: should_fail
+        type: Boolean
+        nullable: true
+        description: >-
+          When true, the check is expected to fail (inverted pass/fail).
+          Useful for testing that an endpoint correctly returns an error.
+        expr:
+          kind: path
+          path:
+            - shouldFail
+
+      - name: double_check
+        type: Boolean
+        nullable: true
+        description: >-
+          When true, Checkly retries the check from a second location before
+          triggering an alert, reducing false-positive notifications.
+        expr:
+          kind: path
+          path:
+            - doubleCheck
+
+      - name: ssl_check
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether Checkly monitors the SSL certificate expiry for this check.
+          Alerts when the certificate is close to expiring.
+        expr:
+          kind: path
+          path:
+            - sslCheck
+
+      - name: degraded_response_time
+        type: Int64
+        nullable: true
+        description: >-
+          Response time threshold in milliseconds above which the check is
+          considered degraded (but not failed).
+        expr:
+          kind: path
+          path:
+            - degradedResponseTime
+
+      - name: max_response_time
+        type: Int64
+        nullable: true
+        description: >-
+          Response time threshold in milliseconds above which the check is
+          considered failed regardless of HTTP status code.
+        expr:
+          kind: path
+          path:
+            - maxResponseTime
+
+      - name: group_id
+        type: Int64
+        nullable: true
+        description: >-
+          ID of the check group this check belongs to. Null if the check
+          is not part of a group.
+        expr:
+          kind: path
+          path:
+            - groupId
+
+      - name: runtime_id
+        type: Utf8
+        nullable: true
+        description: >-
+          Identifier of the runtime environment (e.g. Node.js version) used
+          to execute this check.
+        expr:
+          kind: path
+          path:
+            - runtimeId
+
+      - name: locations
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of AWS region identifiers where this check runs
+          (e.g. ["us-east-1", "eu-central-1", "ap-southeast-1"]).
+        expr:
+          kind: path
+          path:
+            - locations
+
+      - name: tags
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of string tags assigned to this check for grouping
+          and filtering in the Checkly dashboard.
+        expr:
+          kind: path
+          path:
+            - tags
+
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this check was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this check was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+
+  # ────────────────────────────────────────────────────────────────────────
+  # checkly.check_results — recent run results for a specific check
+  # GET /v2/check-results/{checkId}   ← NOTE: v2, not v1 (v1 is deprecated)
+  # Response: root JSON array
+  # Pagination: mode: page, page + limit query params
+  # Requires: check_id filter (get IDs from checkly.checks)
+  # Raw results are retained for 30 days.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: check_results
+    description: >-
+      Recent run results for a specific Checkly check. Each row is one
+      check execution: pass or fail, run location, response time, and
+      timestamps. Requires a check_id filter — get check IDs from the
+      checkly.checks table. Raw result data is retained for 30 days.
+    guide: |
+      Always specify check_id: `SELECT * FROM checkly.check_results WHERE check_id = '<id>'`.
+      Get check IDs from `SELECT id, name FROM checkly.checks`.
+      `has_failures = true` means assertions failed or a timeout occurred.
+      `has_errors = true` means a Checkly backend error occurred (not a check failure).
+      `result_type` is FINAL (completed run) or ATTEMPT (intermediate retry).
+      Filter to `WHERE result_type = 'FINAL'` to exclude retry attempts.
+      Use `WHERE has_failures = 'true'` to filter for only failing runs.
+      `response_time` is in milliseconds.
+      Results older than 30 days are not available.
+    filters:
+      - name: check_id
+        required: true
+      - name: result_type
+        required: false
+      - name: has_failures
+        required: false
+      - name: from
+        required: false
+      - name: to
+        required: false
+    request:
+      method: GET
+      path: /v2/check-results/{{filter.check_id}}
+      query:
+        - name: resultType
+          from: filter
+          key: result_type
+        - name: hasFailures
+          from: filter
+          key: has_failures
+        - name: from
+          from: filter
+          key: from
+        - name: to
+          from: filter
+          key: to
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: check_id
+        type: Utf8
+        nullable: false
+        description: >-
+          ID of the check this result belongs to. Echoes the required
+          check_id filter used in the request.
+        expr:
+          kind: path
+          path:
+            - checkId
+
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique result ID for this individual check run.
+        expr:
+          kind: path
+          path:
+            - id
+
+      - name: check_run_id
+        type: Int64
+        nullable: true
+        description: >-
+          Monotonically increasing run ID. Useful for ordering results
+          when timestamps have the same precision.
+        expr:
+          kind: path
+          path:
+            - checkRunId
+
+      - name: result_type
+        type: Utf8
+        nullable: true
+        description: >-
+          Whether this is a FINAL result (the completed run outcome) or
+          an ATTEMPT (an intermediate retry). Filter to FINAL for clean
+          per-run pass/fail counts.
+        expr:
+          kind: path
+          path:
+            - resultType
+
+      - name: has_failures
+        type: Boolean
+        nullable: true
+        description: >-
+          True if any assertion failed, a timeout occurred, or the
+          response did not match the configured expectations.
+        expr:
+          kind: path
+          path:
+            - hasFailures
+
+      - name: has_errors
+        type: Boolean
+        nullable: true
+        description: >-
+          True if a Checkly platform error occurred during execution
+          (distinct from a check assertion failure).
+        expr:
+          kind: path
+          path:
+            - hasErrors
+
+      - name: run_location
+        type: Utf8
+        nullable: true
+        description: >-
+          AWS region where this check run was executed
+          (e.g. us-east-1, eu-west-1, ap-southeast-1).
+        expr:
+          kind: path
+          path:
+            - runLocation
+
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this check run began.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - startedAt
+
+      - name: stopped_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this check run completed.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - stoppedAt
+
+      - name: response_time
+        type: Int64
+        nullable: true
+        description: >-
+          Time in milliseconds it took to execute the check. For API
+          checks this is the HTTP response time. Compare against
+          checkly.checks.max_response_time to see threshold breaches.
+        expr:
+          kind: path
+          path:
+            - responseTime
+
+      - name: result_type_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the result_type filter applied to this query (FINAL or ATTEMPT).
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: result_type
+
+      - name: has_failures_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the has_failures filter applied to this query (true or false).
+          Applied as a query parameter — not returned in the response.
+        expr:
+          kind: from_filter
+          key: has_failures
+
+      - name: from_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the from filter applied to this query (UNIX millisecond timestamp).
+          Lower bound for the time window — applied server-side.
+        expr:
+          kind: from_filter
+          key: from
+
+      - name: to_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the to filter applied to this query (UNIX millisecond timestamp).
+          Upper bound for the time window — applied server-side.
+        expr:
+          kind: from_filter
+          key: to
+
+  # ────────────────────────────────────────────────────────────────────────
+  # checkly.alert_channels — notification channels for check failures
+  # GET /v1/alert-channels
+  # Response: root JSON array
+  # Pagination: mode: page, page + limit query params
+  # Scoped to the authenticated account by the X-Checkly-Account header.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: alert_channels
+    description: >-
+      All alert notification channels configured in the Checkly account.
+      Each row is one channel. Includes the channel type (Slack, Email,
+      PagerDuty, etc.), its routing configuration, and which notification
+      events are enabled. Use this table to audit notification coverage
+      and verify that critical checks route to the right channels.
+    guide: |
+      Start with `SELECT id, type, send_failure, send_recovery FROM checkly.alert_channels`.
+      `type` is one of: EMAIL, SLACK, WEBHOOK, SMS, PAGERDUTY, OPSGENIE, CALL.
+      `send_failure = true` means this channel is notified when a check fails.
+      `send_recovery = true` means this channel is notified when a check recovers.
+      `send_degraded = true` means this channel is notified when response time
+      exceeds the degraded threshold (but the check has not fully failed).
+      `config` is a JSON object — its shape varies per `type`. Use SQL JSON
+      functions to extract fields (e.g. json_get(config, 'channel') for Slack).
+      `id` is an integer (not a UUID) — a signed 64-bit integer.
+    request:
+      method: GET
+      path: /v1/alert-channels
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: >-
+          Unique alert channel ID. Note: this is an integer, not a UUID.
+        expr:
+          kind: path
+          path:
+            - id
+
+      - name: type
+        type: Utf8
+        nullable: false
+        description: >-
+          Alert channel type: EMAIL, SLACK, WEBHOOK, SMS, PAGERDUTY,
+          OPSGENIE, or CALL.
+        expr:
+          kind: path
+          path:
+            - type
+
+      - name: config
+        type: Json
+        nullable: true
+        description: >-
+          Channel-specific configuration as a JSON object. Shape varies
+          by type: EMAIL has address; SLACK has channel and url;
+          WEBHOOK has method, url, and headers; PAGERDUTY has service_key;
+          OPSGENIE has api_key, name, priority, and region.
+          Use SQL JSON functions to extract specific fields.
+        expr:
+          kind: path
+          path:
+            - config
+
+      - name: send_recovery
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether this channel sends a notification when a failing check
+          recovers back to a passing state.
+        expr:
+          kind: path
+          path:
+            - sendRecovery
+
+      - name: send_failure
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether this channel sends a notification when a check fails
+          (assertion failure, timeout, or error).
+        expr:
+          kind: path
+          path:
+            - sendFailure
+
+      - name: send_degraded
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether this channel sends a notification when a check becomes
+          degraded (response time exceeds the degraded threshold but
+          the check has not fully failed).
+        expr:
+          kind: path
+          path:
+            - sendDegraded
+
+      - name: ssl_expiry
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether this channel sends SSL certificate expiry warnings.
+        expr:
+          kind: path
+          path:
+            - sslExpiry
+
+      - name: ssl_expiry_threshold
+        type: Int64
+        nullable: true
+        description: >-
+          Number of days before SSL certificate expiry to send a warning
+          via this channel (e.g. 30 means warn 30 days before expiry).
+        expr:
+          kind: path
+          path:
+            - sslExpiryThreshold
+
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this alert channel was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this alert channel was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+
+  # ────────────────────────────────────────────────────────────────────────
+  # checkly.dashboards — public and private status page dashboards
+  # GET /v1/dashboards
+  # Response: root JSON array
+  # Pagination: mode: page, page + limit query params
+  # Scoped to the authenticated account by the X-Checkly-Account header.
+  # ────────────────────────────────────────────────────────────────────────
+  - name: dashboards
+    description: >-
+      Public and private status page dashboards configured in the Checkly
+      account. Each row is one dashboard. Dashboards display the status of
+      selected checks (filtered by tags) to end users or internal teams.
+      Use this table to inventory your status pages and audit which checks
+      are exposed publicly.
+    guide: |
+      Start with `SELECT id, custom_url, custom_domain, is_private FROM checkly.dashboards`.
+      `custom_url` is the Checkly-hosted subdomain (e.g. mycompany.checklyhq.com).
+      `custom_domain` is the user's CNAME target (e.g. status.mycompany.com).
+      `is_private = true` means the dashboard requires login — Team/Enterprise plans only.
+      `tags` is a JSON array of tag strings used to filter which checks appear
+      on this dashboard. Checks must have matching tags to be shown.
+      `paginate = true` means checks cycle automatically at `pagination_rate` seconds.
+    request:
+      method: GET
+      path: /v1/dashboards
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+      link_header_require_results: false
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique dashboard UUID.
+        expr:
+          kind: path
+          path:
+            - id
+
+      - name: custom_url
+        type: Utf8
+        nullable: true
+        description: >-
+          Checkly-hosted subdomain for this dashboard
+          (e.g. mycompany → https://mycompany.checklyhq.com).
+        expr:
+          kind: path
+          path:
+            - customUrl
+
+      - name: custom_domain
+        type: Utf8
+        nullable: true
+        description: >-
+          Custom user domain pointing to this dashboard via CNAME
+          (e.g. status.mycompany.com). Null if no custom domain is configured.
+        expr:
+          kind: path
+          path:
+            - customDomain
+
+      - name: is_private
+        type: Boolean
+        nullable: false
+        description: >-
+          Whether this dashboard is private (requires authentication to view).
+          Private dashboards are available on Team and Enterprise plans only.
+        expr:
+          kind: path
+          path:
+            - isPrivate
+
+      - name: paginate
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether checks on this dashboard automatically paginate/cycle
+          through pages at the configured pagination_rate interval.
+        expr:
+          kind: path
+          path:
+            - paginate
+
+      - name: pagination_rate
+        type: Int64
+        nullable: true
+        description: >-
+          Seconds between automatic page transitions when paginate is true.
+          Common values: 30, 60, 300.
+        expr:
+          kind: path
+          path:
+            - paginationRate
+
+      - name: checks_per_page
+        type: Int64
+        nullable: true
+        description: >-
+          Number of checks displayed per dashboard page (1–20).
+        expr:
+          kind: path
+          path:
+            - checksPerPage
+
+      - name: tags
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of tag strings used to filter which checks appear on
+          this dashboard. Only checks carrying these tags are shown.
+        expr:
+          kind: path
+          path:
+            - tags
+
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this dashboard was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when this dashboard was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt

--- a/sources/community/checkly/manifest.yaml
+++ b/sources/community/checkly/manifest.yaml
@@ -59,7 +59,7 @@ tables:
       checkly.check_results for recent run outcomes.
     guide: |
       Start with `SELECT id, name, check_type, frequency, activated FROM checkly.checks`.
-      `check_type` is one of: API, BROWSER, HEARTBEAT, DNS, TCP.
+      `check_type` is one of: API, BROWSER, HEARTBEAT, DNS, TCP, MULTI_STEP, PLAYWRIGHT, AGENTIC, ICMP, URL.
       `frequency` is the run interval in minutes (e.g. 1, 5, 10, 30, 60).
       `activated = false` means the check is paused and not running.
       `muted = true` means alerts are suppressed even when the check fails.
@@ -127,7 +127,8 @@ tables:
         type: Utf8
         nullable: false
         description: >-
-          Type of synthetic check: API, BROWSER, HEARTBEAT, DNS, or TCP.
+          Type of synthetic check. Current values: API, BROWSER, HEARTBEAT,
+          DNS, TCP, MULTI_STEP, PLAYWRIGHT, AGENTIC, ICMP, URL.
         expr:
           kind: path
           path:
@@ -377,6 +378,12 @@ tables:
         - name: to
           from: filter
           key: to
+        - name: location
+          from: filter
+          key: location
+        - name: checkType
+          from: filter
+          key: check_type
     response:
       rows_path: [entries]
       row_strategy: direct
@@ -523,24 +530,26 @@ tables:
           kind: from_filter
           key: has_failures
 
-      - name: from_filter
+      - name: from
         type: Utf8
         nullable: true
         virtual: true
         description: >-
-          Echoes the from filter applied to this query (UNIX timestamp in seconds).
-          Lower bound for the time window — applied server-side.
+          Lower time bound for check results (UNIX timestamp in seconds).
+          Applied server-side as the `from` query parameter.
+          Use quoted syntax in SQL: WHERE "from" = '1716768000'.
         expr:
           kind: from_filter
           key: from
 
-      - name: to_filter
+      - name: to
         type: Utf8
         nullable: true
         virtual: true
         description: >-
-          Echoes the to filter applied to this query (UNIX timestamp in seconds).
-          Upper bound for the time window — applied server-side.
+          Upper time bound for check results (UNIX timestamp in seconds).
+          Applied server-side as the `to` query parameter.
+          Use quoted syntax in SQL: WHERE "to" = '1716854400'.
         expr:
           kind: from_filter
           key: to
@@ -551,7 +560,7 @@ tables:
         virtual: true
         description: >-
           Filter check results by execution location (e.g. 'us-east-1').
-          Applied as a query parameter — not returned in the response.
+          Pushed upstream as the `location` query parameter.
         expr:
           kind: from_filter
           key: location
@@ -562,7 +571,7 @@ tables:
         virtual: true
         description: >-
           Filter check results by check type (e.g. 'API', 'BROWSER').
-          Applied as a query parameter — not returned in the response.
+          Pushed upstream as the `checkType` query parameter.
         expr:
           kind: from_filter
           key: check_type

--- a/sources/community/checkly/manifest.yaml
+++ b/sources/community/checkly/manifest.yaml
@@ -592,13 +592,11 @@ tables:
       and verify that critical checks route to the right channels.
     guide: |
       Start with `SELECT id, type, send_failure, send_recovery FROM checkly.alert_channels`.
-      `type` is one of: EMAIL, SLACK, WEBHOOK, SMS, PAGERDUTY, OPSGENIE, CALL.
+      `type` is one of: EMAIL, SLACK, SLACK_APP, WEBHOOK, SMS, PAGERDUTY, OPSGENIE, CALL.
       `send_failure = true` means this channel is notified when a check fails.
       `send_recovery = true` means this channel is notified when a check recovers.
       `send_degraded = true` means this channel is notified when response time
       exceeds the degraded threshold (but the check has not fully failed).
-      `config` is a JSON object — its shape varies per `type`. Use SQL JSON
-      functions to extract fields (e.g. json_get(config, 'channel') for Slack).
       `id` is an integer (not a UUID) — a signed 64-bit integer.
     request:
       method: GET
@@ -630,26 +628,12 @@ tables:
         type: Utf8
         nullable: false
         description: >-
-          Alert channel type: EMAIL, SLACK, WEBHOOK, SMS, PAGERDUTY,
-          OPSGENIE, or CALL.
+          Alert channel type: EMAIL, SLACK, SLACK_APP, WEBHOOK, SMS,
+          PAGERDUTY, OPSGENIE, or CALL.
         expr:
           kind: path
           path:
             - type
-
-      - name: config
-        type: Json
-        nullable: true
-        description: >-
-          Channel-specific configuration as a JSON object. Shape varies
-          by type: EMAIL has address; SLACK has channel and url;
-          WEBHOOK has method, url, and headers; PAGERDUTY has service_key;
-          OPSGENIE has api_key, name, priority, and region.
-          Use SQL JSON functions to extract specific fields.
-        expr:
-          kind: path
-          path:
-            - config
 
       - name: send_recovery
         type: Boolean

--- a/sources/community/checkly/manifest.yaml
+++ b/sources/community/checkly/manifest.yaml
@@ -19,7 +19,7 @@ inputs:
       A read-only key is sufficient for all tables in this source.
       Docs: https://developers.checklyhq.com/docs/authentication
   CHECKLY_ACCOUNT_ID:
-    kind: secret
+    kind: variable
     hint: |
       Checkly Account ID. Find it in:
         Account Settings → General → Account ID
@@ -269,8 +269,8 @@ tables:
   # ────────────────────────────────────────────────────────────────────────
   # checkly.check_results — recent run results for a specific check
   # GET /v2/check-results/{checkId}   ← NOTE: v2, not v1 (v1 is deprecated)
-  # Response: root JSON array
-  # Pagination: mode: page, page + limit query params
+  # Response: { length, entries: [...], nextId } — cursor-based
+  # Pagination: mode: cursor_query, cursor sent via nextId query param
   # Requires: check_id filter (get IDs from checkly.checks)
   # Raw results are retained for 30 days.
   # ────────────────────────────────────────────────────────────────────────
@@ -287,8 +287,9 @@ tables:
       `has_errors = true` means a Checkly backend error occurred (not a check failure).
       `result_type` is FINAL (completed run) or ATTEMPT (intermediate retry).
       Filter to `WHERE result_type = 'FINAL'` to exclude retry attempts.
-      Use `WHERE has_failures = 'true'` to filter for only failing runs.
+      Use `WHERE has_failures = true` to filter for only failing runs.
       `response_time` is in milliseconds.
+      `from` and `to` filters accept UNIX timestamps in seconds (not milliseconds).
       Results older than 30 days are not available.
     filters:
       - name: check_id
@@ -318,17 +319,16 @@ tables:
           from: filter
           key: to
     response:
-      rows_path: []
+      rows_path: [entries]
       row_strategy: direct
     pagination:
-      mode: page
-      page_param: page
-      page_start: 1
+      mode: cursor_query
+      cursor_param: nextId
+      response_cursor_path: [nextId]
       page_size:
         default: 100
         max: 100
         query_param: limit
-      link_header_require_results: false
     columns:
       - name: check_id
         type: Utf8
@@ -469,7 +469,7 @@ tables:
         nullable: true
         virtual: true
         description: >-
-          Echoes the from filter applied to this query (UNIX millisecond timestamp).
+          Echoes the from filter applied to this query (UNIX timestamp in seconds).
           Lower bound for the time window — applied server-side.
         expr:
           kind: from_filter
@@ -480,7 +480,7 @@ tables:
         nullable: true
         virtual: true
         description: >-
-          Echoes the to filter applied to this query (UNIX millisecond timestamp).
+          Echoes the to filter applied to this query (UNIX timestamp in seconds).
           Upper bound for the time window — applied server-side.
         expr:
           kind: from_filter
@@ -626,7 +626,7 @@ tables:
           expr:
             kind: path
             path:
-              - createdAt
+              - created_at
 
       - name: updated_at
         type: Timestamp
@@ -638,7 +638,7 @@ tables:
           expr:
             kind: path
             path:
-              - updatedAt
+              - updated_at
 
   # ────────────────────────────────────────────────────────────────────────
   # checkly.dashboards — public and private status page dashboards
@@ -679,9 +679,10 @@ tables:
       link_header_require_results: false
     columns:
       - name: id
-        type: Utf8
+        type: Int64
         nullable: false
-        description: Unique dashboard UUID.
+        description: >-
+          Unique dashboard ID. Checkly documents this as a numeric identifier.
         expr:
           kind: path
           path:
@@ -773,7 +774,7 @@ tables:
           expr:
             kind: path
             path:
-              - createdAt
+              - created_at
 
       - name: updated_at
         type: Timestamp
@@ -785,4 +786,4 @@ tables:
           expr:
             kind: path
             path:
-              - updatedAt
+              - updated_at


### PR DESCRIPTION
## Summary

Fixes #562

Add a new Checkly community source that lets Coral query synthetic
monitoring data through SQL. This makes checks, recent run results,
alert channel configurations, and status page dashboards queryable via
standard SQL — enabling SRE teams to audit monitoring coverage, triage
recent failures, verify alert routing, and join check outcomes against
deployment events from GitHub or Vercel directly from Coral.

This change is manifest-only and uses Coral's existing HTTP source-spec
model. It adds read-only Checkly API visibility without changing CLI,
MCP, config, runtime, or bundled-source contracts.

## What changed

Added:

- `sources/community/checkly/manifest.yaml`
- `sources/community/checkly/README.md`

## Source scope

**Inputs:**

- `CHECKLY_API_KEY` — static Bearer token (`secret`), generated from
  User Settings → API Keys or Account Settings → API Keys (service key)
- `CHECKLY_ACCOUNT_ID` — account scoping credential (`secret`), found in
  Account Settings → General → Account ID

**Auth:**

Checkly requires two headers on every request:
- `Authorization: Bearer {{input.CHECKLY_API_KEY}}` — via `auth.headers`
- `X-Checkly-Account: {{input.CHECKLY_ACCOUNT_ID}}` — via `auth.headers`
  using `from: input`

Both are placed in `auth.headers` using established DSL patterns
(`from: template` and `from: input`). No OAuth — Checkly uses only
static API keys; confirmed safe per Coral maintainer policy.

**Tables:**

- **`checkly.checks`**
  - `GET /v1/checks`
  - lists all API and browser synthetic monitoring checks in the account
  - no filter required — scoped by `X-Checkly-Account` header automatically
  - exposes check type, frequency, locations, tags, alert thresholds,
    enabled state, and group membership
  - `locations` and `tags` kept as `Json` — variable-length string arrays

- **`checkly.check_results`**
  - `GET /v2/check-results/{{filter.check_id}}` ← v2, NOT v1 (v1 deprecated)
  - lists recent run outcomes for a specific check
  - `check_id` is a required filter — get IDs from `checkly.checks`
  - optional filters: `result_type` (`FINAL`/`ATTEMPT`), `has_failures`
    (`true`/`false`), `from` and `to` (UNIX millisecond timestamps)
  - all optional filters are echoed as `virtual: true` columns
  - raw results retained for 30 days — documented in guide and README

- **`checkly.alert_channels`**
  - `GET /v1/alert-channels`
  - lists all notification channels in the account
  - no filter required — scoped by `X-Checkly-Account` header automatically
  - `id` is `Int64` (not a UUID) — noted in schema and guide
  - `config` kept as `Json` — deeply polymorphic object whose shape
    varies per `type` (EMAIL, SLACK, WEBHOOK, PAGERDUTY, OPSGENIE, etc.)
  - exposes `send_failure`, `send_recovery`, `send_degraded`, `ssl_expiry`
    flags for alert routing audit

- **`checkly.dashboards`**
  - `GET /v1/dashboards`
  - lists all public and private status page dashboards
  - no filter required — scoped by `X-Checkly-Account` header automatically
  - exposes `custom_url`, `custom_domain`, `is_private`, `tags`,
    and pagination display configuration

## Implementation notes

- uses Checkly REST API v1 (v2 for check-results only)
- all four endpoints return root JSON arrays — uses `rows_path: []`
  (no wrapper key like `data`) confirmed from Checkly API docs and curl examples
- all paginated tables use `mode: page` with `page_param: page`,
  `page_start: 1`, `query_param: limit`, and
  `link_header_require_results: false` to stop cleanly on empty pages
- `check_results` uses `GET /v2/check-results/{checkId}` — the issue
  description incorrectly referenced the deprecated v1 endpoint
- `check_id` required filter injects into the URL path via
  `{{filter.check_id}}` (same pattern as `tailscale.device_routes`)
- both `CHECKLY_API_KEY` and `CHECKLY_ACCOUNT_ID` are `kind: secret` —
  `CHECKLY_ACCOUNT_ID` is an access-scoping credential per AGENTS.md rules
- all timestamps are ISO 8601 strings — uses `input: iso8601` throughout
- no OAuth — Checkly uses only static API keys

## Validation

Local validation completed:
<img width="1335" height="529" alt="image" src="https://github.com/user-attachments/assets/a05d55f7-ff2b-416a-a55f-3d258b695837" />


## Out of scope

Not included in v1:

- running checks on demand
- creating or updating checks
- check groups management
- private locations
- Checkly Analytics API (`/v1/analytics`) — returns aggregated stats,
  not tabular row data; rejected for v1
- maintenance windows management
- environment variables management
- write operations of any kind
