### PR TITLE
feat(ui): improve trace body viewer

### DIFF
--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -388,6 +388,12 @@ export const httpMetaChip = style({
 })
 export const copyButtonGroup = style({ alignItems: 'center', display: 'flex', flexShrink: 0, gap: 6 })
 export const waterfallHttpDetailSection = style({ display: 'flex', flex: 1, flexDirection: 'column', gap: 4, minHeight: 0, minWidth: 0 })
+export const bodyViewer = style({ display: 'flex', flexDirection: 'column', gap: 8, minHeight: 0, minWidth: 0 })
+export const bodyViewerHeader = style({ display: 'flex', flexDirection: 'column', gap: 6 })
+export const bodyMetaRow = style({ display: 'flex', flexWrap: 'wrap', gap: 6 })
+export const bodyViewerSection = style({ display: 'flex', flexDirection: 'column', gap: 4, minHeight: 0, minWidth: 0 })
+export const bodyViewerSectionLabel = style({ color: theme.content.tertiary })
+export const bodyViewerRawDetails = style({ display: 'flex', flexDirection: 'column', gap: 4 })
 
 export const statusBadge = style({ borderRadius: 999, display: 'inline-flex', fontSize: 12, paddingBlock: 2, paddingInline: 8, selectors: {
   '&[data-tone="ok"]': { backgroundColor: theme.pill.green.background, color: theme.pill.green.color },

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -96,11 +96,8 @@ interface GraphqlBodyPreview {
 }
 
 interface BodyPreview {
-  emptyText?: string
   formattedText: string
   graphql?: GraphqlBodyPreview
-  isText: boolean
-  rawText: string
 }
 
 function inferGraphqlOperationType(query: string | undefined): string | undefined {
@@ -109,17 +106,18 @@ function inferGraphqlOperationType(query: string | undefined): string | undefine
   return match?.[1]?.toLowerCase() ?? 'query'
 }
 
-function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue, url: string): GraphqlBodyPreview | undefined {
+function urlPathname(url: string): string {
+  if (!url) return ''
+  try {
+    return new URL(url, 'http://coral.local').pathname
+  } catch {
+    return ''
+  }
+}
+
+function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue, pathname: string): GraphqlBodyPreview | undefined {
   if (!isPlainObject(value)) return undefined
 
-  const pathname = (() => {
-    if (!url) return ''
-    try {
-      return new URL(url, 'http://coral.local').pathname
-    } catch {
-      return ''
-    }
-  })()
   const query = typeof value.query === 'string' ? value.query : undefined
   const operationName = typeof value.operationName === 'string' ? value.operationName : undefined
   const variables = value.variables as JsonValue | undefined
@@ -143,34 +141,25 @@ function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue, url: string): G
   }
 }
 
-function bodyPreview(kind: BodyKind, value: unknown, rawValue: unknown, url: string): BodyPreview | undefined {
+function bodyPreview(kind: BodyKind, value: unknown, pathname: string): BodyPreview | undefined {
   if (value === undefined || value === null || value === '') return undefined
 
   if (typeof value === 'string') {
     const parsedValue = parseMaybeJson(value)
     if (typeof parsedValue === 'string') {
       return {
-        emptyText: undefined,
         formattedText: value,
-        isText: true,
-        rawText: typeof rawValue === 'string' ? rawValue : value,
       }
     }
     return {
-      emptyText: undefined,
       formattedText: formatJsonValue(parsedValue),
-      graphql: detectGraphqlBody(kind, parsedValue, url),
-      isText: false,
-      rawText: typeof rawValue === 'string' ? rawValue : formatJsonValue(parsedValue),
+      graphql: detectGraphqlBody(kind, parsedValue, pathname),
     }
   }
 
   return {
-    emptyText: undefined,
     formattedText: formatJsonValue(value as JsonValue),
-    graphql: detectGraphqlBody(kind, value as JsonValue, url),
-    isText: false,
-    rawText: typeof rawValue === 'string' ? rawValue : formatJsonValue(value as JsonValue),
+    graphql: detectGraphqlBody(kind, value as JsonValue, pathname),
   }
 }
 
@@ -186,17 +175,15 @@ function BodySection({ children, label }: { children: React.ReactNode; label: st
 function BodyViewer({
   emptyText,
   kind,
-  rawValue,
-  url,
+  pathname,
   value,
 }: {
   emptyText: string
   kind: BodyKind
-  rawValue: unknown
-  url: string
+  pathname: string
   value: unknown
 }) {
-  const preview = bodyPreview(kind, value, rawValue, url)
+  const preview = bodyPreview(kind, value, pathname)
 
   if (!preview) {
     return <Typography.BodySmall variant="tertiary">{emptyText}</Typography.BodySmall>
@@ -230,6 +217,49 @@ function BodyViewer({
       </details>}
     </div>
   )
+}
+
+interface ActiveBodyState {
+  emptyText: string
+  kind: BodyKind
+  rawValue: unknown
+  value: JsonValue | undefined
+}
+
+function activeBodyState(
+  activeTab: HttpDetailTab,
+  attrs: Record<string, unknown>,
+  paramsValue: Record<string, string | string[]> | undefined,
+  requestBody: JsonValue,
+  rawRequestBody: unknown,
+  requestBodyTruncated: boolean,
+  responseBody: JsonValue,
+  rawResponseBody: unknown,
+  responseBodyTruncated: boolean,
+): ActiveBodyState {
+  switch (activeTab) {
+    case 'params':
+      return {
+        emptyText: 'No query parameters were recorded for this request.',
+        kind: 'response',
+        rawValue: paramsValue,
+        value: paramsValue,
+      }
+    case 'request':
+      return {
+        emptyText: bodyEmptyText('request', attrs, requestBodyTruncated),
+        kind: 'request',
+        rawValue: rawRequestBody,
+        value: requestBody,
+      }
+    case 'response':
+      return {
+        emptyText: bodyEmptyText('response', attrs, responseBodyTruncated),
+        kind: 'response',
+        rawValue: rawResponseBody,
+        value: responseBody,
+      }
+  }
 }
 
 function attrBool(value: unknown): boolean {
@@ -307,24 +337,21 @@ export function HttpSpanDetail({
     { id: 'request', label: `Request body${requestBodyTruncated ? ' (truncated)' : ''}` },
     { id: 'response', label: `Response body${responseBodyTruncated ? ' (truncated)' : ''}` },
   ]
-  const activeValue = activeTab === 'params'
-    ? paramsValue
-    : activeTab === 'request'
-      ? requestBody
-      : responseBody
-  const activeRawValue = activeTab === 'params'
-    ? paramsValue
-    : activeTab === 'request'
-      ? rawRequestBody
-      : rawResponseBody
-  const activeEmptyText = activeTab === 'params'
-    ? 'No query parameters were recorded for this request.'
-    : activeTab === 'request'
-      ? bodyEmptyText('request', attrs, requestBodyTruncated)
-      : bodyEmptyText('response', attrs, responseBodyTruncated)
-  const copyValue = formatDetailValue(activeValue)
-  const rawCopyValue = formatRawValue(activeRawValue, copyValue)
+  const activeBody = activeBodyState(
+    activeTab,
+    attrs,
+    paramsValue,
+    requestBody,
+    rawRequestBody,
+    requestBodyTruncated,
+    responseBody,
+    rawResponseBody,
+    responseBodyTruncated,
+  )
+  const copyValue = formatDetailValue(activeBody.value)
+  const rawCopyValue = formatRawValue(activeBody.rawValue, copyValue)
   const hasSeparateRawCopy = Boolean(rawCopyValue && rawCopyValue !== copyValue)
+  const pathname = urlPathname(url)
   const visibleAttrs = Object.fromEntries(Object.entries(attrs).filter(([key]) => !BODY_ATTRIBUTE_KEYS.has(key)))
   const offsetMs = Math.max(0, Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n))
   const statusCode = attrText(attrs['http.response.status_code'])
@@ -432,13 +459,7 @@ export function HttpSpanDetail({
             id={`http-detail-${span.spanId}-${activeTab}`}
             role="tabpanel"
           >
-            {activeTab === 'params' ? (
-              <BodyViewer emptyText={activeEmptyText} kind="response" rawValue={activeRawValue} url={url} value={activeValue} />
-            ) : activeTab === 'request' ? (
-              <BodyViewer emptyText={activeEmptyText} kind="request" rawValue={activeRawValue} url={url} value={activeValue} />
-            ) : (
-              <BodyViewer emptyText={activeEmptyText} kind="response" rawValue={activeRawValue} url={url} value={activeValue} />
-            )}
+            <BodyViewer emptyText={activeBody.emptyText} kind={activeBody.kind} pathname={pathname} value={activeBody.value} />
           </section>
           <details>
             <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -18,12 +18,17 @@ const RESPONSE_BODY_ATTR = 'coral.http.response.body'
 const REQUEST_BODY_TRUNCATED_ATTR = 'coral.http.request.body.truncated'
 const RESPONSE_BODY_TRUNCATED_ATTR = 'coral.http.response.body.truncated'
 const REQUEST_BODY_PRESENT_ATTR = 'http.request.body.present'
+const RESPONSE_BODY_PRESENT_ATTR = 'http.response.body.present'
 const REQUEST_BODY_SIZE_ATTR = 'http.request.body.size'
 const RESPONSE_BODY_SIZE_ATTR = 'http.response.body.size'
 const BODY_ATTRIBUTE_KEYS = new Set([
   REQUEST_BODY_ATTR,
   RESPONSE_BODY_ATTR,
 ])
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
 
 function looksLikeJson(value: string) {
   const trimmed = value.trim()
@@ -41,6 +46,10 @@ function parseMaybeJson(value: unknown): JsonValue {
   } catch {
     return value
   }
+}
+
+function formatJsonValue(value: JsonValue): string {
+  return JSON.stringify(value, null, 2)
 }
 
 function requestParams(url: string): Record<string, string | string[]> {
@@ -64,9 +73,9 @@ function formatDetailValue(value: JsonValue | undefined): string {
   if (value === undefined || value === null || value === '') return ''
   if (typeof value === 'string') {
     const parsedValue = parseMaybeJson(value)
-    return typeof parsedValue === 'string' ? value : JSON.stringify(parsedValue, null, 2)
+    return typeof parsedValue === 'string' ? value : formatJsonValue(parsedValue)
   }
-  return JSON.stringify(value, null, 2)
+  return formatJsonValue(value)
 }
 
 function formatRawValue(value: unknown, formatted: string): string {
@@ -74,11 +83,153 @@ function formatRawValue(value: unknown, formatted: string): string {
   return typeof value === 'string' ? value : formatted
 }
 
-function DetailPre({ emptyText = 'Not recorded', value }: { emptyText?: string; value: JsonValue | undefined }) {
-  if (value === undefined || value === null || value === '') {
+type BodyKind = 'request' | 'response'
+
+interface GraphqlBodyPreview {
+  bodyKind: BodyKind
+  operationName?: string
+  operationType?: string
+  query?: string
+  variables?: JsonValue
+  data?: JsonValue
+  errors?: JsonValue
+}
+
+interface BodyPreview {
+  emptyText?: string
+  formattedText: string
+  graphql?: GraphqlBodyPreview
+  isText: boolean
+  rawText: string
+}
+
+function inferGraphqlOperationType(query: string | undefined): string | undefined {
+  if (!query) return undefined
+  const match = query.trim().match(/^(query|mutation|subscription)\b/i)
+  return match?.[1]?.toLowerCase() ?? 'query'
+}
+
+function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue, url: string): GraphqlBodyPreview | undefined {
+  if (!isPlainObject(value)) return undefined
+
+  const pathname = (() => {
+    if (!url) return ''
+    try {
+      return new URL(url, 'http://coral.local').pathname
+    } catch {
+      return ''
+    }
+  })()
+  const query = typeof value.query === 'string' ? value.query : undefined
+  const operationName = typeof value.operationName === 'string' ? value.operationName : undefined
+  const variables = value.variables as JsonValue | undefined
+  const data = value.data as JsonValue | undefined
+  const errors = value.errors as JsonValue | undefined
+  const hasRequestShape = Boolean(query || operationName || variables !== undefined)
+  const hasResponseShape = Boolean(data !== undefined || errors !== undefined)
+
+  if (pathname !== '/graphql') return undefined
+  if (bodyKind === 'request' && !hasRequestShape) return undefined
+  if (bodyKind === 'response' && !hasResponseShape) return undefined
+
+  return {
+    bodyKind,
+    operationName,
+    operationType: inferGraphqlOperationType(query),
+    query,
+    variables,
+    data,
+    errors,
+  }
+}
+
+function bodyPreview(kind: BodyKind, value: unknown, rawValue: unknown, url: string): BodyPreview | undefined {
+  if (value === undefined || value === null || value === '') return undefined
+
+  if (typeof value === 'string') {
+    const parsedValue = parseMaybeJson(value)
+    if (typeof parsedValue === 'string') {
+      return {
+        emptyText: undefined,
+        formattedText: value,
+        isText: true,
+        rawText: typeof rawValue === 'string' ? rawValue : value,
+      }
+    }
+    return {
+      emptyText: undefined,
+      formattedText: formatJsonValue(parsedValue),
+      graphql: detectGraphqlBody(kind, parsedValue, url),
+      isText: false,
+      rawText: typeof rawValue === 'string' ? rawValue : formatJsonValue(parsedValue),
+    }
+  }
+
+  return {
+    emptyText: undefined,
+    formattedText: formatJsonValue(value as JsonValue),
+    graphql: detectGraphqlBody(kind, value as JsonValue, url),
+    isText: false,
+    rawText: typeof rawValue === 'string' ? rawValue : formatJsonValue(value as JsonValue),
+  }
+}
+
+function BodySection({ children, label }: { children: React.ReactNode; label: string }) {
+  return (
+    <section className={s.bodyViewerSection}>
+      <Typography.BodySmallStrong as="span" className={s.bodyViewerSectionLabel}>{label}</Typography.BodySmallStrong>
+      {children}
+    </section>
+  )
+}
+
+function BodyViewer({
+  emptyText,
+  kind,
+  rawValue,
+  url,
+  value,
+}: {
+  emptyText: string
+  kind: BodyKind
+  rawValue: unknown
+  url: string
+  value: unknown
+}) {
+  const preview = bodyPreview(kind, value, rawValue, url)
+
+  if (!preview) {
     return <Typography.BodySmall variant="tertiary">{emptyText}</Typography.BodySmall>
   }
-  return <pre className={s.detailsPre}>{formatDetailValue(value)}</pre>
+
+  if (!preview.graphql) {
+    return <pre className={s.detailsPre}>{preview.formattedText}</pre>
+  }
+
+  const { bodyKind, data, errors, operationName, operationType, query, variables } = preview.graphql
+
+  return (
+    <div className={s.bodyViewer}>
+      <div className={s.bodyViewerHeader}>
+        <Typography.BodySmallStrong as="span">{bodyKind === 'request' ? 'GraphQL request' : 'GraphQL response'}</Typography.BodySmallStrong>
+        <div className={s.bodyMetaRow}>
+          {operationName && metaChip('Operation', operationName)}
+          {operationType && metaChip('Type', operationType)}
+          {variables !== undefined && metaChip('Variables', Array.isArray(variables) ? `${variables.length}` : 'present')}
+          {Array.isArray(errors) ? metaChip('Errors', `${errors.length}`) : errors !== undefined ? metaChip('Errors', 'present') : null}
+          {data !== undefined && metaChip('Data', Array.isArray(data) ? `${data.length}` : 'present')}
+        </div>
+      </div>
+      {query !== undefined && <BodySection label="Query"><pre className={s.detailsPre}>{query}</pre></BodySection>}
+      {variables !== undefined && <BodySection label="Variables"><pre className={s.detailsPre}>{formatDetailValue(variables)}</pre></BodySection>}
+      {data !== undefined && <BodySection label="Data"><pre className={s.detailsPre}>{formatDetailValue(data)}</pre></BodySection>}
+      {errors !== undefined && <BodySection label="Errors"><pre className={s.detailsPre}>{formatDetailValue(errors)}</pre></BodySection>}
+      {preview.formattedText && <details className={s.bodyViewerRawDetails}>
+        <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Full body JSON</Typography.Body></summary>
+        <pre className={s.detailsPre}>{preview.formattedText}</pre>
+      </details>}
+    </div>
+  )
 }
 
 function attrBool(value: unknown): boolean {
@@ -103,7 +254,9 @@ function formatBytes(value: unknown): string | undefined {
 function bodyEmptyText(kind: 'request' | 'response', attrs: Record<string, unknown>, truncated: boolean) {
   const label = kind === 'request' ? 'Request body' : 'Response body'
   const size = formatBytes(attrs[kind === 'request' ? REQUEST_BODY_SIZE_ATTR : RESPONSE_BODY_SIZE_ATTR])
-  const present = kind === 'request' ? attrBool(attrs[REQUEST_BODY_PRESENT_ATTR]) : Boolean(size)
+  const present = kind === 'request'
+    ? attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
+    : attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size)
 
   if (truncated) return `${label} was truncated${size ? ` (${size})` : ''}, but no preview was recorded.`
   if (present) return `${label} was present${size ? ` (${size})` : ''}, but content was not captured.`
@@ -279,7 +432,13 @@ export function HttpSpanDetail({
             id={`http-detail-${span.spanId}-${activeTab}`}
             role="tabpanel"
           >
-            <DetailPre emptyText={activeEmptyText} value={activeValue} />
+            {activeTab === 'params' ? (
+              <BodyViewer emptyText={activeEmptyText} kind="response" rawValue={activeRawValue} url={url} value={activeValue} />
+            ) : activeTab === 'request' ? (
+              <BodyViewer emptyText={activeEmptyText} kind="request" rawValue={activeRawValue} url={url} value={activeValue} />
+            ) : (
+              <BodyViewer emptyText={activeEmptyText} kind="response" rawValue={activeRawValue} url={url} value={activeValue} />
+            )}
           </section>
           <details>
             <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -98,6 +98,7 @@ interface GraphqlBodyPreview {
 interface BodyPreview {
   formattedText: string
   graphql?: GraphqlBodyPreview
+  rawText: string
 }
 
 function inferGraphqlOperationType(query: string | undefined): string | undefined {
@@ -106,16 +107,7 @@ function inferGraphqlOperationType(query: string | undefined): string | undefine
   return match?.[1]?.toLowerCase() ?? 'query'
 }
 
-function urlPathname(url: string): string {
-  if (!url) return ''
-  try {
-    return new URL(url, 'http://coral.local').pathname
-  } catch {
-    return ''
-  }
-}
-
-function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue, pathname: string): GraphqlBodyPreview | undefined {
+function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue): GraphqlBodyPreview | undefined {
   if (!isPlainObject(value)) return undefined
 
   const query = typeof value.query === 'string' ? value.query : undefined
@@ -126,7 +118,6 @@ function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue, pathname: strin
   const hasRequestShape = Boolean(query || operationName || variables !== undefined)
   const hasResponseShape = Boolean(data !== undefined || errors !== undefined)
 
-  if (pathname !== '/graphql') return undefined
   if (bodyKind === 'request' && !hasRequestShape) return undefined
   if (bodyKind === 'response' && !hasResponseShape) return undefined
 
@@ -141,7 +132,7 @@ function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue, pathname: strin
   }
 }
 
-function bodyPreview(kind: BodyKind, value: unknown, pathname: string): BodyPreview | undefined {
+function bodyPreview(kind: BodyKind, value: unknown, rawValue: unknown): BodyPreview | undefined {
   if (value === undefined || value === null || value === '') return undefined
 
   if (typeof value === 'string') {
@@ -149,17 +140,22 @@ function bodyPreview(kind: BodyKind, value: unknown, pathname: string): BodyPrev
     if (typeof parsedValue === 'string') {
       return {
         formattedText: value,
+        rawText: typeof rawValue === 'string' ? rawValue : value,
       }
     }
+    const formattedText = formatJsonValue(parsedValue)
     return {
-      formattedText: formatJsonValue(parsedValue),
-      graphql: detectGraphqlBody(kind, parsedValue, pathname),
+      formattedText,
+      graphql: detectGraphqlBody(kind, parsedValue),
+      rawText: typeof rawValue === 'string' ? rawValue : formattedText,
     }
   }
 
+  const formattedText = formatJsonValue(value as JsonValue)
   return {
-    formattedText: formatJsonValue(value as JsonValue),
-    graphql: detectGraphqlBody(kind, value as JsonValue, pathname),
+    formattedText,
+    graphql: detectGraphqlBody(kind, value as JsonValue),
+    rawText: typeof rawValue === 'string' ? rawValue : formattedText,
   }
 }
 
@@ -175,22 +171,34 @@ function BodySection({ children, label }: { children: React.ReactNode; label: st
 function BodyViewer({
   emptyText,
   kind,
-  pathname,
+  rawValue,
   value,
 }: {
   emptyText: string
   kind: BodyKind
-  pathname: string
+  rawValue: unknown
   value: unknown
 }) {
-  const preview = bodyPreview(kind, value, pathname)
+  const preview = bodyPreview(kind, value, rawValue)
 
   if (!preview) {
     return <Typography.BodySmall variant="tertiary">{emptyText}</Typography.BodySmall>
   }
 
+  const rawBodyDetails = preview.rawText !== preview.formattedText ? (
+    <details className={s.bodyViewerRawDetails}>
+      <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Raw body</Typography.Body></summary>
+      <pre className={s.detailsPre}>{preview.rawText}</pre>
+    </details>
+  ) : null
+
   if (!preview.graphql) {
-    return <pre className={s.detailsPre}>{preview.formattedText}</pre>
+    return (
+      <div className={s.bodyViewer}>
+        <pre className={s.detailsPre}>{preview.formattedText}</pre>
+        {rawBodyDetails}
+      </div>
+    )
   }
 
   const { bodyKind, data, errors, operationName, operationType, query, variables } = preview.graphql
@@ -211,10 +219,7 @@ function BodyViewer({
       {variables !== undefined && <BodySection label="Variables"><pre className={s.detailsPre}>{formatDetailValue(variables)}</pre></BodySection>}
       {data !== undefined && <BodySection label="Data"><pre className={s.detailsPre}>{formatDetailValue(data)}</pre></BodySection>}
       {errors !== undefined && <BodySection label="Errors"><pre className={s.detailsPre}>{formatDetailValue(errors)}</pre></BodySection>}
-      {preview.formattedText && <details className={s.bodyViewerRawDetails}>
-        <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Full body JSON</Typography.Body></summary>
-        <pre className={s.detailsPre}>{preview.formattedText}</pre>
-      </details>}
+      {rawBodyDetails}
     </div>
   )
 }
@@ -351,7 +356,6 @@ export function HttpSpanDetail({
   const copyValue = formatDetailValue(activeBody.value)
   const rawCopyValue = formatRawValue(activeBody.rawValue, copyValue)
   const hasSeparateRawCopy = Boolean(rawCopyValue && rawCopyValue !== copyValue)
-  const pathname = urlPathname(url)
   const visibleAttrs = Object.fromEntries(Object.entries(attrs).filter(([key]) => !BODY_ATTRIBUTE_KEYS.has(key)))
   const offsetMs = Math.max(0, Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n))
   const statusCode = attrText(attrs['http.response.status_code'])
@@ -459,7 +463,7 @@ export function HttpSpanDetail({
             id={`http-detail-${span.spanId}-${activeTab}`}
             role="tabpanel"
           >
-            <BodyViewer emptyText={activeBody.emptyText} kind={activeBody.kind} pathname={pathname} value={activeBody.value} />
+            <BodyViewer emptyText={activeBody.emptyText} kind={activeBody.kind} rawValue={activeBody.rawValue} value={activeBody.value} />
           </section>
           <details>
             <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>

--- a/ui/tests/ui/support/trace-fixtures.ts
+++ b/ui/tests/ui/support/trace-fixtures.ts
@@ -29,7 +29,13 @@ interface SpanFixture {
   method: 'GET' | 'POST'
   path: string
   requestBody?: unknown
-  responseBody: unknown
+  requestBodyPresent?: boolean
+  requestBodySize?: number
+  requestBodyTruncated?: boolean
+  responseBody?: unknown
+  responseBodyPresent?: boolean
+  responseBodySize?: number
+  responseBodyTruncated?: boolean
   source: SourceName
   statusCode?: number
   table: string
@@ -109,6 +115,15 @@ const detailSpans: SpanFixture[] = [
     durationMs: 84,
     requestBody: {
       operationName: 'IssuesSearch',
+      query: `query IssuesSearch($teamKey: String!, $query: String!, $first: Int!) {
+  issues(teamKey: $teamKey, query: $query, first: $first) {
+    nodes {
+      identifier
+      title
+      priorityLabel
+    }
+  }
+}`,
       variables: { teamKey: 'CORAL', query: 'playwright', first: 10 },
     },
     responseBody: {
@@ -128,8 +143,22 @@ const detailSpans: SpanFixture[] = [
     method: 'POST',
     path: '/graphql',
     durationMs: 57,
-    requestBody: { operationName: 'TeamsByKey', variables: { key: 'CORAL' } },
-    responseBody: { data: { teams: { nodes: [{ key: 'CORAL', name: 'Coral' }] } } },
+    requestBody: {
+      operationName: 'TeamsByKey',
+      query: `query TeamsByKey($key: String!) {
+  teams(key: $key) {
+    nodes {
+      key
+      name
+    }
+  }
+}`,
+      variables: { key: 'CORAL' },
+    },
+    responseBody: {
+      data: { teams: { nodes: [{ key: 'CORAL', name: 'Coral' }] } },
+      errors: [{ message: 'Partial GraphQL error for test coverage', path: ['teams'] }],
+    },
   },
   {
     source: 'github',
@@ -186,7 +215,17 @@ const detailSpans: SpanFixture[] = [
     method: 'POST',
     path: '/graphql',
     durationMs: 49,
-    requestBody: { operationName: 'UsersForAssignees', variables: { first: 25 } },
+    requestBody: {
+      operationName: 'UsersForAssignees',
+      query: `query UsersForAssignees($first: Int!) {
+  users(first: $first) {
+    nodes {
+      name
+    }
+  }
+}`,
+      variables: { first: 25 },
+    },
     responseBody: { data: { users: { nodes: [{ name: 'Avery Chen' }, { name: 'Mina Park' }] } } },
   },
   {
@@ -217,8 +256,45 @@ const detailSpans: SpanFixture[] = [
     method: 'POST',
     path: '/graphql',
     durationMs: 61,
-    requestBody: { operationName: 'OpenProjects', variables: { includeArchived: false } },
+    requestBody: {
+      operationName: 'OpenProjects',
+      query: `query OpenProjects($includeArchived: Boolean!) {
+  projects(includeArchived: $includeArchived) {
+    nodes {
+      name
+    }
+  }
+}`,
+      variables: { includeArchived: false },
+    },
     responseBody: { data: { projects: { nodes: [{ name: 'Coral UI' }, { name: 'Source Runtime' }] } } },
+  },
+  {
+    source: 'github',
+    table: 'issue_previews',
+    method: 'GET',
+    path: '/repos/oxide/coral/issues?labels=bug&per_page=15&preview=malformed',
+    durationMs: 74,
+    responseBody: '{"oops":',
+  },
+  {
+    source: 'github',
+    table: 'pull_request_archive',
+    method: 'GET',
+    path: '/repos/oxide/coral/pulls?state=closed&per_page=20',
+    durationMs: 88,
+    responseBodyTruncated: true,
+    responseBodySize: 4096,
+  },
+  {
+    source: 'linear',
+    table: 'issue_request_preview',
+    method: 'POST',
+    path: '/graphql',
+    durationMs: 52,
+    requestBodyPresent: true,
+    requestBodySize: 2048,
+    responseBody: { data: { issues: { nodes: [{ identifier: 'CORAL-201', title: 'Request body present fallback', priorityLabel: 'Low' }] } } },
   },
 ]
 
@@ -266,12 +342,31 @@ function httpSpan(traceId: string, fixture: SpanFixture, index: number): TraceSp
     'url.full': `https://${sourceHost(fixture.source)}${fixture.path}`,
     'coral.source': fixture.source,
     'coral.table': fixture.table,
-    'coral.http.response.body': JSON.stringify(fixture.responseBody),
   }
 
   if (fixture.requestBody) {
     attrs['http.request.body.present'] = true
     attrs['coral.http.request.body'] = JSON.stringify(fixture.requestBody)
+  } else if (fixture.requestBodyPresent !== undefined) {
+    attrs['http.request.body.present'] = fixture.requestBodyPresent
+  }
+  if (fixture.requestBodySize !== undefined) {
+    attrs['http.request.body.size'] = `${fixture.requestBodySize}`
+  }
+  if (fixture.requestBodyTruncated) {
+    attrs['coral.http.request.body.truncated'] = true
+  }
+  if (fixture.responseBody !== undefined) {
+    attrs['coral.http.response.body'] = JSON.stringify(fixture.responseBody)
+  }
+  if (fixture.responseBodyPresent !== undefined) {
+    attrs['http.response.body.present'] = fixture.responseBodyPresent
+  }
+  if (fixture.responseBodySize !== undefined) {
+    attrs['http.response.body.size'] = `${fixture.responseBodySize}`
+  }
+  if (fixture.responseBodyTruncated) {
+    attrs['coral.http.response.body.truncated'] = true
   }
 
   return create(TraceSpanSchema, {

--- a/ui/tests/ui/support/trace-fixtures.ts
+++ b/ui/tests/ui/support/trace-fixtures.ts
@@ -279,6 +279,34 @@ const detailSpans: SpanFixture[] = [
   },
   {
     source: 'github',
+    table: 'repository_search',
+    method: 'POST',
+    path: '/api/v1/search',
+    durationMs: 66,
+    requestBody: {
+      operationName: 'RepositorySearch',
+      query: `query RepositorySearch($name: String!) {
+  repository(name: $name) {
+    id
+    name
+    isPrivate
+  }
+}`,
+      variables: { name: 'coral' },
+    },
+    responseBody: {
+      data: {
+        repository: {
+          id: 'R_kgDOExample',
+          name: 'coral',
+          isPrivate: false,
+        },
+      },
+      errors: [{ message: 'GraphQL warnings should still be visible', path: ['repository'] }],
+    },
+  },
+  {
+    source: 'github',
     table: 'pull_request_archive',
     method: 'GET',
     path: '/repos/oxide/coral/pulls?state=closed&per_page=20',

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -41,7 +41,7 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByText('Query details')).toBeVisible()
   await expect(page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)).toBeVisible()
   await expect(page.getByText('API requests')).toBeVisible()
-  await expect(page.getByRole('treeitem')).toHaveCount(13)
+  await expect(page.getByRole('treeitem')).toHaveCount(14)
   await review.pause()
 
   await review.chapter('Open a span inspector', 'Expand one HTTP span and inspect the captured response body')
@@ -50,7 +50,7 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByText('Span details')).toBeVisible()
   await expect(page.getByText('GET github.pull_requests')).toBeVisible()
   await expect(page.getByText('Response body')).toBeVisible()
-  await expect(page.getByText('Add MSW Playwright trace fixtures')).toBeVisible()
+  await expect(page.getByText('\"title\": \"Add MSW Playwright trace fixtures\"')).toBeVisible()
   await review.pause()
 })
 
@@ -64,14 +64,14 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
   await review.pause()
 
-  await expect(page.getByRole('treeitem')).toHaveCount(13)
+  await expect(page.getByRole('treeitem')).toHaveCount(14)
 
   await review.chapter('Inspect pretty JSON', 'Open a structured response body and confirm it is pretty printed')
   await page.getByRole('button', { name: /GET slack\.conversations/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"channels": [')).toBeVisible()
-  await expect(page.getByText('"eng-coral"')).toBeVisible()
+  await expect(page.getByText('"name": "eng-coral"')).toBeVisible()
   await review.pause()
 
   await review.chapter('Inspect malformed JSON fallback', 'Verify raw text stays readable when parsing fails')
@@ -82,25 +82,41 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   await review.pause()
 
   await review.chapter('Inspect GraphQL bodies', 'Check request metadata, variables, and response data for GraphQL traffic')
-  await page.getByRole('button', { name: /POST linear\.issues$/ }).click()
+  await page.getByRole('button', { name: /POST linear\.issues\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
   const requestPanel = page.getByRole('tabpanel', { name: 'Request body' })
   const responsePanel = page.getByRole('tabpanel', { name: 'Response body' })
 
   await expect(requestPanel.getByText('GraphQL request')).toBeVisible()
-  await expect(requestPanel.getByText('Operation')).toBeVisible()
-  await expect(requestPanel.getByText('IssuesSearch')).toBeVisible()
-  await expect(requestPanel.getByText('Type')).toBeVisible()
+  await expect(requestPanel.getByText('Operation', { exact: true })).toBeVisible()
+  await expect(requestPanel.getByText('IssuesSearch', { exact: true })).toBeVisible()
+  await expect(requestPanel.getByText('Type', { exact: true })).toBeVisible()
   await expect(requestPanel.getByText('query', { exact: true })).toBeVisible()
-  await expect(requestPanel.getByText('Variables')).toBeVisible()
-  await expect(requestPanel.getByText('playwright')).toBeVisible()
-  await expect(requestPanel.getByText('Query')).toBeVisible()
-  await expect(requestPanel.getByText('issues(teamKey: $teamKey, query: $query, first: $first)')).toBeVisible()
+  await expect(requestPanel.getByText('Variables', { exact: true }).first()).toBeVisible()
+  await expect(requestPanel.getByText('"query": "playwright"')).toBeVisible()
+  await expect(requestPanel.getByText('Query', { exact: true })).toBeVisible()
+  await expect(requestPanel.locator('pre').filter({ hasText: /^query IssuesSearch/ })).toBeVisible()
   await page.getByRole('tab', { name: 'Response body' }).click()
 
   await expect(responsePanel.getByText('GraphQL response')).toBeVisible()
-  await expect(responsePanel.getByText('Data')).toBeVisible()
-  await expect(responsePanel.getByText('Add Playwright coverage for trace stream')).toBeVisible()
+  await expect(responsePanel.getByText('Data', { exact: true }).first()).toBeVisible()
+  await expect(responsePanel.getByText('"title": "Add Playwright coverage for trace stream"')).toBeVisible()
+  await review.pause()
+
+  await review.chapter('Inspect GraphQL detection without /graphql', 'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears')
+  await page.getByRole('button', { name: /POST github\.repository_search/ }).click()
+  await page.getByRole('tab', { name: 'Request body' }).click()
+  const githubRequestPanel = page.getByRole('tabpanel', { name: 'Request body' })
+  const githubResponsePanel = page.getByRole('tabpanel', { name: 'Response body' })
+
+  await expect(githubRequestPanel.getByText('GraphQL request')).toBeVisible()
+  await expect(githubRequestPanel.getByText('RepositorySearch', { exact: true })).toBeVisible()
+  await expect(githubRequestPanel.getByText('Raw body')).toBeVisible()
+  await page.getByRole('tab', { name: 'Response body' }).click()
+
+  await expect(githubResponsePanel.getByText('GraphQL response')).toBeVisible()
+  await expect(githubResponsePanel.getByText('Errors', { exact: true }).first()).toBeVisible()
+  await expect(githubResponsePanel.getByText('"message": "GraphQL warnings should still be visible"')).toBeVisible()
   await review.pause()
 
   await review.chapter('Inspect missing and truncated bodies', 'Confirm the viewer still explains empty and truncated body states')
@@ -109,6 +125,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
 
   await expect(page.getByText('Request body was present (2.0 KB), but content was not captured.')).toBeVisible()
   await page.getByRole('button', { name: /GET github\.pull_request_archive/ }).click()
+  await page.getByRole('tab', { name: 'Response body (truncated)' }).click()
 
   await expect(page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.')).toBeVisible()
   await review.pause()

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -41,7 +41,7 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByText('Query details')).toBeVisible()
   await expect(page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)).toBeVisible()
   await expect(page.getByText('API requests')).toBeVisible()
-  await expect(page.getByRole('treeitem')).toHaveCount(10)
+  await expect(page.getByRole('treeitem')).toHaveCount(13)
   await review.pause()
 
   await review.chapter('Open a span inspector', 'Expand one HTTP span and inspect the captured response body')
@@ -51,6 +51,66 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByText('GET github.pull_requests')).toBeVisible()
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('Add MSW Playwright trace fixtures')).toBeVisible()
+  await review.pause()
+})
+
+test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({ network, page, review }) => {
+  network.use(...traceHandlers.tenTraceDetailFlow)
+
+  await review.chapter('Open the trace with span details', 'Load the selected trace so the body viewer states can be inspected')
+  await page.goto('/')
+  await page.getByRole('button', { name: 'Search queries' }).click()
+  await page.getByPlaceholder('Search queries...').fill('playwright')
+  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
+  await review.pause()
+
+  await expect(page.getByRole('treeitem')).toHaveCount(13)
+
+  await review.chapter('Inspect pretty JSON', 'Open a structured response body and confirm it is pretty printed')
+  await page.getByRole('button', { name: /GET slack\.conversations/ }).click()
+
+  await expect(page.getByText('Response body')).toBeVisible()
+  await expect(page.getByText('"channels": [')).toBeVisible()
+  await expect(page.getByText('"eng-coral"')).toBeVisible()
+  await review.pause()
+
+  await review.chapter('Inspect malformed JSON fallback', 'Verify raw text stays readable when parsing fails')
+  await page.getByRole('button', { name: /GET github\.issue_previews/ }).click()
+
+  await expect(page.getByText('Response body')).toBeVisible()
+  await expect(page.getByText('{"oops":')).toBeVisible()
+  await review.pause()
+
+  await review.chapter('Inspect GraphQL bodies', 'Check request metadata, variables, and response data for GraphQL traffic')
+  await page.getByRole('button', { name: /POST linear\.issues$/ }).click()
+  await page.getByRole('tab', { name: 'Request body' }).click()
+  const requestPanel = page.getByRole('tabpanel', { name: 'Request body' })
+  const responsePanel = page.getByRole('tabpanel', { name: 'Response body' })
+
+  await expect(requestPanel.getByText('GraphQL request')).toBeVisible()
+  await expect(requestPanel.getByText('Operation')).toBeVisible()
+  await expect(requestPanel.getByText('IssuesSearch')).toBeVisible()
+  await expect(requestPanel.getByText('Type')).toBeVisible()
+  await expect(requestPanel.getByText('query', { exact: true })).toBeVisible()
+  await expect(requestPanel.getByText('Variables')).toBeVisible()
+  await expect(requestPanel.getByText('playwright')).toBeVisible()
+  await expect(requestPanel.getByText('Query')).toBeVisible()
+  await expect(requestPanel.getByText('issues(teamKey: $teamKey, query: $query, first: $first)')).toBeVisible()
+  await page.getByRole('tab', { name: 'Response body' }).click()
+
+  await expect(responsePanel.getByText('GraphQL response')).toBeVisible()
+  await expect(responsePanel.getByText('Data')).toBeVisible()
+  await expect(responsePanel.getByText('Add Playwright coverage for trace stream')).toBeVisible()
+  await review.pause()
+
+  await review.chapter('Inspect missing and truncated bodies', 'Confirm the viewer still explains empty and truncated body states')
+  await page.getByRole('button', { name: /POST linear\.issue_request_preview/ }).click()
+  await page.getByRole('tab', { name: 'Request body' }).click()
+
+  await expect(page.getByText('Request body was present (2.0 KB), but content was not captured.')).toBeVisible()
+  await page.getByRole('button', { name: /GET github\.pull_request_archive/ }).click()
+
+  await expect(page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.')).toBeVisible()
   await review.pause()
 })
 


### PR DESCRIPTION
feat(ui): improve trace body viewer

Add GraphQL-aware body rendering and Playwright coverage for JSON, GraphQL, malformed, and truncated span bodies. Verified with npm run type-check --prefix ui and npm run build --prefix ui; Playwright browser runs were blocked by missing host browser libraries in this shell.

[trace-body-viewer-screencast.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/0b282aa4-746b-446f-b8ab-c996fb951e50.mp4" />](https://app.graphite.com/user-attachments/video/0b282aa4-746b-446f-b8ab-c996fb951e50.mp4)  
  
  
  
![image.png](https://app.graphite.com/user-attachments/assets/f790bad0-b8b0-4aae-85b2-8f8903c243c0.png)![image.png](https://app.graphite.com/user-attachments/assets/ef6cd1a3-0909-4ff0-9dfc-929f8f92c104.png)



