### PR TITLE
ci: use cargo-nextest for Rust checks

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,6 +110,11 @@ jobs:
           cache-on-failure: true
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        with:
+          tool: nextest
+
       - name: Run make rust-checks
         run: make rust-checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ update the relevant docs in the same pull request.
 
 - Rust stable toolchain
 - Git
+- cargo-nextest, installed with `brew install cargo-nextest` or
+  `cargo install cargo-nextest --locked`
 - any source-specific local dependencies needed for the part you are working on
 
 ### Common commands
@@ -70,7 +72,7 @@ If you prefer to run steps individually, the equivalent commands are:
 ```bash
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-cargo test --workspace --all-targets --all-features --locked
+cargo nextest run --workspace --all-targets --all-features --locked --no-fail-fast
 RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
+.PHONY: install rust-checks license-check lint-proto lint-sources fix-sources docs-generate docs-check
+
 install:
 	cargo install --path crates/coral-cli --locked
 
 rust-checks:
 	cargo fmt --all -- --check
 	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
-	cargo test --workspace --all-targets --all-features --locked
+	cargo nextest run --workspace --all-targets --all-features --locked --no-fail-fast
 	RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked
 
 # ----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -246,6 +246,18 @@ upgrades pick up newer bundled manifests without re-adding the source.
 
 ## Development
 
+Install the local test runner once with Homebrew:
+
+```bash
+brew install cargo-nextest
+```
+
+Or install it with Cargo:
+
+```bash
+cargo install cargo-nextest --locked
+```
+
 Run the workspace validation gate from the repository root:
 
 ```bash

--- a/docs/project/architecture.mdx
+++ b/docs/project/architecture.mdx
@@ -42,7 +42,7 @@ The user-facing command-line interface.
 | Output formatting | Table and JSON via `coral-client` helpers |
 
 Intentionally thin at the binary boundary — `main.rs` is a small wrapper, `bootstrap.rs` owns CLI bootstrap, and `lib.rs` owns shared command parsing and dispatch for Coral binaries. Query/result helpers stay in `coral-client`.
-For black-box CLI tests, contributors can enable the `CORAL_ENDPOINT` bootstrap override with `cargo test --locked -p coral-cli --features cli-test-server`.
+For black-box CLI tests, contributors can enable the `CORAL_ENDPOINT` bootstrap override with `cargo nextest run --locked -p coral-cli --features cli-test-server`.
 
 ### `coral-client`
 


### PR DESCRIPTION
## Summary

This switches the Rust validation gate from `cargo test` to `cargo-nextest` so local and CI test runs use the same next-generation test runner. Tests ran 3x faster on my machine.

The change also documents both supported local install paths for contributors and updates the CLI black-box test example to use nextest.

## Validation

- `make rust-checks`
- `make docs-check`
- `make -n rust-checks`
- `git diff --check`