### PR TITLE
feat(engine): register source-model projections

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -189,14 +189,16 @@ impl QueryManager {
     ) -> Result<(QuerySource, String), AppError> {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
-        if let Some(source_model) = source_spec.as_source_model() {
-            load_materialized_source_model_manifest(
+        let source_model_ir = if let Some(source_model) = source_spec.as_source_model() {
+            Some(load_materialized_source_model_manifest(
                 &self.layout,
                 workspace_name,
                 &source.name,
                 source_model,
-            )?;
-        }
+            )?)
+        } else {
+            None
+        };
         validate_required_variables(source, source_spec.declared_inputs())?;
         let stored_secrets = self
             .secret_store
@@ -227,10 +229,12 @@ impl QueryManager {
             })?;
             resolved_secrets.insert(secret_name, value);
         }
-        Ok((
-            QuerySource::new(source_spec, source.variables.clone(), resolved_secrets),
-            installed.candidate.version,
-        ))
+        let mut query_source =
+            QuerySource::new(source_spec, source.variables.clone(), resolved_secrets);
+        if let Some(ir) = source_model_ir {
+            query_source = query_source.with_source_model_ir(ir);
+        }
+        Ok((query_source, installed.candidate.version))
     }
 
     fn runtime_config(&self, selected_sources: &[QuerySource]) -> QueryRuntimeConfig {

--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -8,7 +8,7 @@ use crate::{QueryRuntimeContext, RequestAuthenticator};
 use async_trait::async_trait;
 use coral_spec::backends::file::PartitionColumnSpec;
 use coral_spec::{
-    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec,
+    ColumnSpec, FilterSpec, ManifestDataType, ManifestInputKind, ManifestInputSpec, SourceModelIr,
     SourceTableFunctionSpec, TableCommon,
 };
 use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
@@ -118,6 +118,7 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_secrets: BTreeMap<String, String>,
     pub(crate) source_variables: BTreeMap<String, String>,
     pub(crate) request_authenticators: &'a HashMap<String, Arc<dyn RequestAuthenticator>>,
+    pub(crate) source_model_ir: Option<SourceModelIr>,
 }
 
 #[async_trait]

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod http;
 pub(crate) mod jsonl;
 pub(crate) mod parquet;
 pub(crate) mod shared;
+pub(crate) mod source_model;
 
 pub(crate) fn compile_query_source(
     source: &QuerySource,
@@ -32,6 +33,7 @@ pub(crate) fn compile_query_source(
             source_secrets: source.secrets().clone(),
             source_variables: source.variables().clone(),
             request_authenticators,
+            source_model_ir: source.source_model_ir().cloned(),
         },
     )
 }
@@ -51,6 +53,7 @@ pub(crate) fn compile_source_manifest(
             source_secrets,
             source_variables,
             request_authenticators: &request_authenticators,
+            source_model_ir: None,
         },
     )
 }
@@ -67,6 +70,9 @@ pub(crate) fn compile_validated_manifest(
     }
     if let Some(jsonl_manifest) = manifest.as_jsonl() {
         return jsonl::compile_manifest(jsonl_manifest, request);
+    }
+    if let Some(source_model_manifest) = manifest.as_source_model() {
+        return source_model::compile_manifest(source_model_manifest, request);
     }
 
     Err(CoreError::internal(

--- a/crates/coral-engine/src/backends/source_model.rs
+++ b/crates/coral-engine/src/backends/source_model.rs
@@ -1,0 +1,274 @@
+//! Registration-only runtime for DSL v4 source-model projections.
+//!
+//! This backend resolves explicit SQL projections against materialized
+//! importer IR and exposes their schemas to `DataFusion`. REST execution is
+//! implemented in the follow-on source-model runtime step.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::TableFunctionImpl;
+use datafusion::datasource::TableProvider;
+use datafusion::datasource::empty::EmptyTable;
+use datafusion::error::{DataFusionError, Result};
+use datafusion::logical_expr::Expr;
+use datafusion::prelude::SessionContext;
+
+use crate::CoreError;
+use crate::backends::common::RegisteredColumn;
+use crate::backends::{
+    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
+    RegisteredTable, RegisteredTableFunction, SourceTableFunctions, build_registered_inputs,
+    internal_table_function_name, registered_columns_from_specs, schema_from_columns,
+};
+use coral_spec::{
+    OperationInput, ProjectionKind, SourceModelIr, SourceModelOperation, SourceModelProjection,
+    SourceModelSourceManifest,
+};
+
+#[derive(Debug, Clone)]
+struct SourceModelCompiledSource {
+    manifest: SourceModelSourceManifest,
+    ir: SourceModelIr,
+    source_secrets: BTreeMap<String, String>,
+    source_variables: BTreeMap<String, String>,
+}
+
+pub(crate) fn compile_manifest(
+    manifest: &SourceModelSourceManifest,
+    request: &BackendCompileRequest<'_>,
+) -> std::result::Result<Box<dyn CompiledBackendSource>, CoreError> {
+    let Some(ir) = request.source_model_ir.clone() else {
+        return Err(CoreError::FailedPrecondition(format!(
+            "source '{}' uses backend=source_model but has no materialized source-model IR; run `coral source refresh {}` or reinstall the source",
+            manifest.common.name, manifest.common.name
+        )));
+    };
+    ir.validate(&manifest.projection_refs())
+        .map_err(|error| CoreError::InvalidInput(error.to_string()))?;
+
+    Ok(Box::new(SourceModelCompiledSource {
+        manifest: manifest.clone(),
+        ir,
+        source_secrets: request.source_secrets.clone(),
+        source_variables: request.source_variables.clone(),
+    }))
+}
+
+#[async_trait]
+impl CompiledBackendSource for SourceModelCompiledSource {
+    fn schema_name(&self) -> &str {
+        &self.manifest.common.name
+    }
+
+    fn source_name(&self) -> &str {
+        &self.manifest.common.name
+    }
+
+    async fn register(&self, _ctx: &SessionContext) -> Result<BackendRegistration> {
+        let operations = operations_by_ref(&self.ir);
+        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
+        let mut table_infos = Vec::new();
+        let mut table_functions = SourceTableFunctions::new();
+        let mut table_function_infos = Vec::new();
+
+        for projection in &self.manifest.projections {
+            let operation =
+                resolve_projection_operation(self.schema_name(), projection, &operations)?;
+            match projection.kind {
+                ProjectionKind::Table => {
+                    let required_inputs = required_operation_inputs(operation);
+                    validate_table_projection_inputs(
+                        self.schema_name(),
+                        projection,
+                        operation,
+                        &required_inputs,
+                    )?;
+                    let schema = schema_from_columns(
+                        &projection.columns,
+                        self.schema_name(),
+                        &projection.name,
+                    )?;
+                    tables.insert(
+                        projection.name.clone(),
+                        Arc::new(EmptyTable::new(schema)) as Arc<dyn TableProvider>,
+                    );
+                    table_infos.push(registered_table(projection, &required_inputs));
+                }
+                ProjectionKind::Function => {
+                    let schema = schema_from_columns(
+                        &projection.columns,
+                        self.schema_name(),
+                        &projection.name,
+                    )?;
+                    let internal_name =
+                        internal_table_function_name(self.schema_name(), &projection.name);
+                    table_functions.insert(
+                        internal_name.clone(),
+                        Arc::new(SourceModelProjectionTableFunction { schema })
+                            as Arc<dyn TableFunctionImpl>,
+                    );
+                    table_function_infos.push(registered_table_function(
+                        self.schema_name(),
+                        projection,
+                        operation,
+                        internal_name,
+                    ));
+                }
+            }
+        }
+
+        let secret_keys = self.source_secrets.keys().cloned().collect::<BTreeSet<_>>();
+        let inputs = build_registered_inputs(
+            &self.manifest.declared_inputs,
+            &self.source_variables,
+            &secret_keys,
+        );
+
+        Ok(BackendRegistration {
+            tables,
+            table_functions,
+            source: RegisteredSource {
+                schema_name: self.manifest.common.name.clone(),
+                tables: table_infos,
+                table_functions: table_function_infos,
+                inputs,
+            },
+        })
+    }
+}
+
+fn operations_by_ref(ir: &SourceModelIr) -> HashMap<(&str, &str), &SourceModelOperation> {
+    ir.operations
+        .iter()
+        .map(|operation| {
+            (
+                (operation.surface.as_str(), operation.id.as_str()),
+                operation,
+            )
+        })
+        .collect()
+}
+
+fn resolve_projection_operation<'a>(
+    source_schema: &str,
+    projection: &SourceModelProjection,
+    operations: &'a HashMap<(&str, &str), &SourceModelOperation>,
+) -> Result<&'a SourceModelOperation> {
+    operations
+        .get(&(
+            projection.operation.surface.as_str(),
+            projection.operation.operation.as_str(),
+        ))
+        .copied()
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "source schema '{source_schema}' projection '{}' references missing operation '{}.{}'",
+                projection.name, projection.operation.surface, projection.operation.operation
+            ))
+        })
+}
+
+fn required_operation_inputs(operation: &SourceModelOperation) -> Vec<String> {
+    operation
+        .inputs
+        .iter()
+        .filter(|input| input.required)
+        .map(|input| input.name.clone())
+        .collect()
+}
+
+fn validate_table_projection_inputs(
+    source_schema: &str,
+    projection: &SourceModelProjection,
+    operation: &SourceModelOperation,
+    required_inputs: &[String],
+) -> Result<()> {
+    let projected_columns = projection
+        .columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .collect::<HashSet<_>>();
+    for input in required_inputs {
+        if !projected_columns.contains(input.as_str()) {
+            return Err(DataFusionError::Plan(format!(
+                "source schema '{source_schema}' projection/table '{}' references operation '{}.{}' but is missing required operation input '{input}'",
+                projection.name, operation.surface, operation.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn registered_table(
+    projection: &SourceModelProjection,
+    required_inputs: &[String],
+) -> RegisteredTable {
+    RegisteredTable {
+        table_name: projection.name.clone(),
+        description: String::new(),
+        guide: String::new(),
+        columns: registered_columns_from_specs(&projection.columns, required_inputs),
+        required_filters: required_inputs.to_vec(),
+    }
+}
+
+fn registered_table_function(
+    schema_name: &str,
+    projection: &SourceModelProjection,
+    operation: &SourceModelOperation,
+    internal_name: String,
+) -> RegisteredTableFunction {
+    let arguments = operation
+        .inputs
+        .iter()
+        .map(argument_json)
+        .collect::<Vec<_>>();
+    let result_columns = registered_columns_from_specs(&projection.columns, &[])
+        .into_iter()
+        .map(|column| column_json(&column))
+        .collect::<Vec<_>>();
+
+    RegisteredTableFunction {
+        schema_name: schema_name.to_string(),
+        function_name: projection.name.clone(),
+        internal_name,
+        description: String::new(),
+        arguments_json: serde_json::to_string(&arguments).expect("arguments json"),
+        result_columns_json: serde_json::to_string(&result_columns).expect("result columns json"),
+        arg_names: operation
+            .inputs
+            .iter()
+            .map(|input| input.name.clone())
+            .collect(),
+    }
+}
+
+fn argument_json(input: &OperationInput) -> serde_json::Value {
+    serde_json::json!({
+        "name": input.name,
+        "required": input.required,
+        "values": Vec::<String>::new(),
+    })
+}
+
+fn column_json(column: &RegisteredColumn) -> serde_json::Value {
+    serde_json::json!({
+        "name": column.name,
+        "type": column.data_type,
+        "nullable": column.nullable,
+        "description": column.description,
+    })
+}
+
+#[derive(Debug)]
+struct SourceModelProjectionTableFunction {
+    schema: datafusion::arrow::datatypes::SchemaRef,
+}
+
+impl TableFunctionImpl for SourceModelProjectionTableFunction {
+    fn call(&self, _args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
+        Ok(Arc::new(EmptyTable::new(self.schema.clone())))
+    }
+}

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
-use coral_spec::ValidatedSourceManifest;
+use coral_spec::{SourceModelIr, ValidatedSourceManifest};
 
 use super::ColumnInfo;
 use crate::EngineExtensions;
@@ -17,6 +17,7 @@ pub struct QuerySource {
     source_spec: ValidatedSourceManifest,
     variables: BTreeMap<String, String>,
     secrets: BTreeMap<String, String>,
+    source_model_ir: Option<SourceModelIr>,
 }
 
 impl QuerySource {
@@ -32,7 +33,15 @@ impl QuerySource {
             source_spec,
             variables,
             secrets,
+            source_model_ir: None,
         }
+    }
+
+    #[must_use]
+    /// Attaches materialized DSL v4 source-model IR to this selected source.
+    pub fn with_source_model_ir(mut self, source_model_ir: SourceModelIr) -> Self {
+        self.source_model_ir = Some(source_model_ir);
+        self
     }
 
     #[must_use]
@@ -63,6 +72,12 @@ impl QuerySource {
     /// Returns resolved source secrets required by the manifest.
     pub fn secrets(&self) -> &BTreeMap<String, String> {
         &self.secrets
+    }
+
+    #[must_use]
+    /// Returns materialized DSL v4 source-model IR when this source uses it.
+    pub fn source_model_ir(&self) -> Option<&SourceModelIr> {
+        self.source_model_ir.as_ref()
     }
 }
 

--- a/crates/coral-engine/tests/engine.rs
+++ b/crates/coral-engine/tests/engine.rs
@@ -21,6 +21,8 @@ mod parquet_tests;
 mod pattern_error_tests;
 #[path = "engine/query_result_observer_tests.rs"]
 mod query_result_observer_tests;
+#[path = "engine/source_model_tests.rs"]
+mod source_model_tests;
 #[path = "engine/structured_error_tests.rs"]
 mod structured_error_tests;
 #[path = "engine/test_source_tests.rs"]

--- a/crates/coral-engine/tests/engine/source_model_tests.rs
+++ b/crates/coral-engine/tests/engine/source_model_tests.rs
@@ -1,0 +1,226 @@
+use std::collections::BTreeMap;
+
+use coral_engine::{CoralQuery, CoreError, QuerySource, StatusCode};
+use coral_spec::{
+    HttpMethod, OperationDetails, OperationInput, OperationResult, RestOperationDetails,
+    SOURCE_MODEL_IR_VERSION, ScalarType, SourceModelIr, SourceModelOperation, SourceModelSurface,
+    SurfaceProtocol, TypeRef, parse_source_manifest_value,
+};
+use serde_json::{Value, json};
+
+use crate::harness::{execution_to_rows, test_runtime};
+
+#[tokio::test]
+async fn source_model_registers_explicit_table_projection_from_imported_ir() {
+    let source = source_model_source(true);
+
+    let tables = CoralQuery::list_tables(&[source], test_runtime(), Some("github"), None)
+        .await
+        .expect("source-model table projection should register");
+
+    assert_eq!(tables.len(), 1);
+    let table = tables
+        .first()
+        .expect("source-model source should register one table");
+    assert_eq!(table.schema_name, "github");
+    assert_eq!(table.table_name, "issues");
+    assert_eq!(table.required_filters, ["owner", "repo"]);
+    let required_columns = table
+        .columns
+        .iter()
+        .filter(|column| column.is_required_filter)
+        .map(|column| column.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(required_columns, ["owner", "repo"]);
+}
+
+#[tokio::test]
+async fn source_model_registers_explicit_function_projection_metadata() {
+    let source = source_model_source(true);
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT schema_name, function_name, arguments_json, result_columns_json \
+             FROM coral.table_functions WHERE schema_name = 'github'",
+        )
+        .await
+        .expect("source-model function metadata should query"),
+    );
+
+    assert_eq!(rows.len(), 1);
+    let row = rows
+        .first()
+        .expect("source-model source should register one function");
+    assert_eq!(row["schema_name"], "github");
+    assert_eq!(row["function_name"], "search_issues");
+    assert_eq!(
+        serde_json::from_str::<Value>(row["arguments_json"].as_str().unwrap()).unwrap(),
+        json!([
+            { "name": "q", "required": true, "values": [] },
+            { "name": "per_page", "required": false, "values": [] }
+        ])
+    );
+    assert_eq!(
+        serde_json::from_str::<Value>(row["result_columns_json"].as_str().unwrap()).unwrap(),
+        json!([
+            { "name": "title", "type": "Utf8", "nullable": true, "description": "" }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn source_model_table_projection_error_names_missing_required_operation_input() {
+    let source = source_model_source(false);
+
+    let error = CoralQuery::validate_source(&source, test_runtime(), &[])
+        .await
+        .expect_err("table projection missing required operation input should fail");
+
+    assert_eq!(error.status_code(), StatusCode::FailedPrecondition);
+    let CoreError::FailedPrecondition(detail) = error else {
+        panic!("expected failed precondition");
+    };
+    assert!(
+        detail.contains("source schema 'github' projection/table 'issues'"),
+        "error should name source schema and projection/table: {detail}"
+    );
+    assert!(
+        detail.contains("missing required operation input 'owner'"),
+        "error should name missing operation input: {detail}"
+    );
+}
+
+fn source_model_source(include_required_input_columns: bool) -> QuerySource {
+    let manifest =
+        parse_source_manifest_value(source_model_manifest(include_required_input_columns))
+            .expect("source-model manifest should parse");
+    QuerySource::new(manifest, BTreeMap::default(), BTreeMap::default())
+        .with_source_model_ir(source_model_ir())
+}
+
+fn source_model_manifest(include_required_input_columns: bool) -> Value {
+    let mut columns = vec![json!({ "name": "title", "type": "Utf8" })];
+    if include_required_input_columns {
+        columns.insert(
+            0,
+            json!({ "name": "repo", "type": "Utf8", "virtual": true }),
+        );
+        columns.insert(
+            0,
+            json!({ "name": "owner", "type": "Utf8", "virtual": true }),
+        );
+    }
+
+    json!({
+        "name": "github",
+        "version": "1.0.0",
+        "dsl_version": 4,
+        "backend": "source_model",
+        "surfaces": [{
+            "id": "github-rest",
+            "type": "open-api",
+            "url": "https://example.com/openapi.yaml",
+            "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "base_url": "https://api.github.com"
+        }],
+        "projections": [
+            {
+                "name": "issues",
+                "kind": "table",
+                "surface": "github-rest",
+                "operation": "issues/list-for-repo",
+                "columns": columns
+            },
+            {
+                "name": "search_issues",
+                "kind": "function",
+                "surface": "github-rest",
+                "operation": "search/issues-and-pull-requests",
+                "columns": [{ "name": "title", "type": "Utf8" }]
+            }
+        ]
+    })
+}
+
+fn source_model_ir() -> SourceModelIr {
+    SourceModelIr {
+        ir_version: SOURCE_MODEL_IR_VERSION,
+        surfaces: vec![SourceModelSurface {
+            id: "github-rest".to_string(),
+            description: String::new(),
+            protocol: SurfaceProtocol::Rest,
+            base_url: Some("https://api.github.com".to_string()),
+        }],
+        types: Vec::new(),
+        operations: vec![
+            rest_operation(
+                "issues/list-for-repo",
+                vec![
+                    required_string_input("owner"),
+                    required_string_input("repo"),
+                    optional_integer_input("per_page"),
+                ],
+                OperationResult::List {
+                    item: TypeRef::scalar(ScalarType::Json),
+                },
+            ),
+            rest_operation(
+                "search/issues-and-pull-requests",
+                vec![
+                    required_string_input("q"),
+                    optional_integer_input("per_page"),
+                ],
+                OperationResult::WrappedList {
+                    item: TypeRef::scalar(ScalarType::Json),
+                    items_path: vec!["items".to_string()],
+                    total_count_path: vec!["total_count".to_string()],
+                },
+            ),
+        ],
+        entities: Vec::new(),
+    }
+}
+
+fn rest_operation(
+    id: &str,
+    inputs: Vec<OperationInput>,
+    result: OperationResult,
+) -> SourceModelOperation {
+    SourceModelOperation {
+        id: id.to_string(),
+        surface: "github-rest".to_string(),
+        description: String::new(),
+        inputs,
+        result,
+        details: OperationDetails::Rest {
+            rest: Box::new(RestOperationDetails {
+                method: HttpMethod::GET,
+                path: "/unused".to_string(),
+                parameters: Vec::new(),
+                request_body: None,
+                responses: Vec::new(),
+                pagination: None,
+            }),
+        },
+    }
+}
+
+fn required_string_input(name: &str) -> OperationInput {
+    OperationInput {
+        name: name.to_string(),
+        ty: TypeRef::scalar(ScalarType::String),
+        required: true,
+        description: String::new(),
+    }
+}
+
+fn optional_integer_input(name: &str) -> OperationInput {
+    OperationInput {
+        name: name.to_string(),
+        ty: TypeRef::scalar(ScalarType::Integer),
+        required: false,
+        description: String::new(),
+    }
+}

--- a/sources/core/github/manifest.source_model.yaml
+++ b/sources/core/github/manifest.source_model.yaml
@@ -47,6 +47,14 @@ projections:
     surface: github-rest
     operation: issues/list-for-repo
     columns:
+      - name: owner
+        type: Utf8
+        nullable: true
+        virtual: true
+      - name: repo
+        type: Utf8
+        nullable: true
+        virtual: true
       - name: id
         type: Int64
         nullable: true


### PR DESCRIPTION
Implements step 8 of the [DSL v4 PRD](https://github.com/withcoral/coral/blob/sw/05-19-chore_add_prd/plans/2026-05-19-source-dsl-v4-prd.md): source-model projection registration in the engine.

- Adds `crates/coral-engine/src/backends/source_model.rs`, a registration-only backend that resolves each explicit projection against the materialised importer IR and exposes its schema to DataFusion. Tables register as `EmptyTable` placeholders; table functions register through the existing function-spec plumbing.
- Registers `backend: source_model` in `backends/mod.rs` so DSL v4 manifests compile through the new backend, alongside the unchanged v3 HTTP path.
- Threads materialised IR through `query/manager.rs` and `contracts/query.rs` so the engine receives the IR alongside the validated manifest.
- Errors reference the source schema, projection/table name, and any missing required input.
- Existing v3 runtime behaviour is unchanged.

REST execution lands in the next PR; this one only establishes that v4 sources surface the expected tables and function signatures.

## Test plan

- [ ] `make rust-checks`
- [ ] Engine tests in `tests/engine/source_model_tests.rs` cover schema registration, missing-IR diagnostics, and projection/operation reference validation.