### PR TITLE
feat(engine): execute source-model REST operations

### DIFF
--- a/crates/coral-engine/src/backends/source_model.rs
+++ b/crates/coral-engine/src/backends/source_model.rs
@@ -1,30 +1,28 @@
-//! Registration-only runtime for DSL v4 source-model projections.
+//! Runtime for DSL v4 source-model projections.
 //!
 //! This backend resolves explicit SQL projections against materialized
-//! importer IR and exposes their schemas to `DataFusion`. REST execution is
-//! implemented in the follow-on source-model runtime step.
+//! importer IR, converts REST operations into the existing HTTP backend shape,
+//! and then delegates execution to the established HTTP machinery.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::catalog::TableFunctionImpl;
-use datafusion::datasource::TableProvider;
-use datafusion::datasource::empty::EmptyTable;
 use datafusion::error::{DataFusionError, Result};
-use datafusion::logical_expr::Expr;
 use datafusion::prelude::SessionContext;
 
-use crate::CoreError;
-use crate::backends::common::RegisteredColumn;
-use crate::backends::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, RegisteredTableFunction, SourceTableFunctions, build_registered_inputs,
-    internal_table_function_name, registered_columns_from_specs, schema_from_columns,
-};
+use crate::backends::http;
+use crate::backends::{BackendCompileRequest, BackendRegistration, CompiledBackendSource};
+use crate::{CoreError, RequestAuthenticator};
+use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 use coral_spec::{
-    OperationInput, ProjectionKind, SourceModelIr, SourceModelOperation, SourceModelProjection,
-    SourceModelSourceManifest,
+    BodySpec, FilterMode, FilterSpec, FunctionArgBinding, HeaderSpec, OperationDetails,
+    OperationInput, OperationResult, PaginationMode, PaginationSpec, ParsedTemplate,
+    ProjectionKind, QueryParamSpec, RequestSpec, ResponseSpec, RestOperationDetails,
+    RestPagination, RestParameterLocation, SourceManifestCommon, SourceModelIr,
+    SourceModelManifestSurface, SourceModelOperation, SourceModelProjection,
+    SourceModelSourceManifest, SourceTableFunctionSpec, TableCommon, TableFunctionArgSpec,
+    ValueSourceSpec,
 };
 
 #[derive(Debug, Clone)]
@@ -33,6 +31,7 @@ struct SourceModelCompiledSource {
     ir: SourceModelIr,
     source_secrets: BTreeMap<String, String>,
     source_variables: BTreeMap<String, String>,
+    request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
 }
 
 pub(crate) fn compile_manifest(
@@ -53,6 +52,7 @@ pub(crate) fn compile_manifest(
         ir,
         source_secrets: request.source_secrets.clone(),
         source_variables: request.source_variables.clone(),
+        request_authenticators: request.request_authenticators.clone(),
     }))
 }
 
@@ -66,12 +66,11 @@ impl CompiledBackendSource for SourceModelCompiledSource {
         &self.manifest.common.name
     }
 
-    async fn register(&self, _ctx: &SessionContext) -> Result<BackendRegistration> {
+    async fn register(&self, ctx: &SessionContext) -> Result<BackendRegistration> {
         let operations = operations_by_ref(&self.ir);
-        let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
-        let mut table_infos = Vec::new();
-        let mut table_functions = SourceTableFunctions::new();
-        let mut table_function_infos = Vec::new();
+        let surface = selected_runtime_surface(self.schema_name(), &self.manifest)?;
+        let mut tables = Vec::new();
+        let mut functions = Vec::new();
 
         for projection in &self.manifest.projections {
             let operation =
@@ -85,57 +84,47 @@ impl CompiledBackendSource for SourceModelCompiledSource {
                         operation,
                         &required_inputs,
                     )?;
-                    let schema = schema_from_columns(
-                        &projection.columns,
-                        self.schema_name(),
-                        &projection.name,
-                    )?;
-                    tables.insert(
-                        projection.name.clone(),
-                        Arc::new(EmptyTable::new(schema)) as Arc<dyn TableProvider>,
-                    );
-                    table_infos.push(registered_table(projection, &required_inputs));
-                }
-                ProjectionKind::Function => {
-                    let schema = schema_from_columns(
-                        &projection.columns,
-                        self.schema_name(),
-                        &projection.name,
-                    )?;
-                    let internal_name =
-                        internal_table_function_name(self.schema_name(), &projection.name);
-                    table_functions.insert(
-                        internal_name.clone(),
-                        Arc::new(SourceModelProjectionTableFunction { schema })
-                            as Arc<dyn TableFunctionImpl>,
-                    );
-                    table_function_infos.push(registered_table_function(
+                    tables.push(rest_projection_table(
                         self.schema_name(),
                         projection,
                         operation,
-                        internal_name,
-                    ));
+                    )?);
+                }
+                ProjectionKind::Function => {
+                    functions.push(rest_projection_function(
+                        self.schema_name(),
+                        projection,
+                        operation,
+                    )?);
                 }
             }
         }
 
-        let secret_keys = self.source_secrets.keys().cloned().collect::<BTreeSet<_>>();
-        let inputs = build_registered_inputs(
-            &self.manifest.declared_inputs,
-            &self.source_variables,
-            &secret_keys,
-        );
-
-        Ok(BackendRegistration {
-            tables,
-            table_functions,
-            source: RegisteredSource {
-                schema_name: self.manifest.common.name.clone(),
-                tables: table_infos,
-                table_functions: table_function_infos,
-                inputs,
+        let http_manifest = HttpSourceManifest {
+            common: SourceManifestCommon {
+                dsl_version: self.manifest.common.dsl_version,
+                name: self.manifest.common.name.clone(),
+                version: self.manifest.common.version.clone(),
+                description: self.manifest.common.description.clone(),
+                test_queries: self.manifest.common.test_queries.clone(),
             },
-        })
+            base_url: surface.base_url.clone(),
+            auth: surface.auth.clone(),
+            request_headers: surface.request_headers.clone(),
+            rate_limit: surface.rate_limit.clone(),
+            tables,
+            functions,
+            declared_inputs: self.manifest.declared_inputs.clone(),
+        };
+
+        http::compile_source(
+            http_manifest,
+            self.source_secrets.clone(),
+            self.source_variables.clone(),
+            self.request_authenticators.clone(),
+        )
+        .register(ctx)
+        .await
     }
 }
 
@@ -166,6 +155,37 @@ fn resolve_projection_operation<'a>(
             DataFusionError::Plan(format!(
                 "source schema '{source_schema}' projection '{}' references missing operation '{}.{}'",
                 projection.name, projection.operation.surface, projection.operation.operation
+            ))
+        })
+}
+
+fn selected_runtime_surface<'a>(
+    source_schema: &str,
+    manifest: &'a SourceModelSourceManifest,
+) -> Result<&'a SourceModelManifestSurface> {
+    let Some(first_projection) = manifest.projections.first() else {
+        return Err(DataFusionError::Plan(format!(
+            "source schema '{source_schema}' has no source-model projections"
+        )));
+    };
+    let surface_id = first_projection.operation.surface.as_str();
+    if let Some(other) = manifest
+        .projections
+        .iter()
+        .find(|projection| projection.operation.surface != surface_id)
+    {
+        return Err(DataFusionError::Plan(format!(
+            "source schema '{source_schema}' references multiple source-model surfaces ('{surface_id}' and '{}'); the first source-model REST runtime supports one surface",
+            other.operation.surface
+        )));
+    }
+    manifest
+        .surfaces
+        .iter()
+        .find(|surface| surface.id == surface_id)
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "source schema '{source_schema}' references unknown source-model surface '{surface_id}'"
             ))
         })
 }
@@ -201,74 +221,209 @@ fn validate_table_projection_inputs(
     Ok(())
 }
 
-fn registered_table(
-    projection: &SourceModelProjection,
-    required_inputs: &[String],
-) -> RegisteredTable {
-    RegisteredTable {
-        table_name: projection.name.clone(),
-        description: String::new(),
-        guide: String::new(),
-        columns: registered_columns_from_specs(&projection.columns, required_inputs),
-        required_filters: required_inputs.to_vec(),
-    }
-}
-
-fn registered_table_function(
-    schema_name: &str,
+fn rest_projection_table(
+    source_schema: &str,
     projection: &SourceModelProjection,
     operation: &SourceModelOperation,
-    internal_name: String,
-) -> RegisteredTableFunction {
-    let arguments = operation
-        .inputs
-        .iter()
-        .map(argument_json)
-        .collect::<Vec<_>>();
-    let result_columns = registered_columns_from_specs(&projection.columns, &[])
-        .into_iter()
-        .map(|column| column_json(&column))
-        .collect::<Vec<_>>();
+) -> Result<HttpTableSpec> {
+    let rest = rest_details(source_schema, projection, operation)?;
+    Ok(HttpTableSpec {
+        common: TableCommon {
+            name: projection.name.clone(),
+            description: operation.description.clone(),
+            guide: String::new(),
+            filters: operation_inputs_as_filters(&operation.inputs),
+            fetch_limit_default: None,
+            columns: projection.columns.clone(),
+        },
+        request: rest_request(
+            source_schema,
+            &projection.name,
+            rest,
+            RequestBinding::Filter,
+        )?,
+        requests: Vec::new(),
+        response: rest_response(&operation.result, rest),
+        pagination: rest_pagination(rest),
+    })
+}
 
-    RegisteredTableFunction {
-        schema_name: schema_name.to_string(),
-        function_name: projection.name.clone(),
-        internal_name,
-        description: String::new(),
-        arguments_json: serde_json::to_string(&arguments).expect("arguments json"),
-        result_columns_json: serde_json::to_string(&result_columns).expect("result columns json"),
-        arg_names: operation
-            .inputs
-            .iter()
-            .map(|input| input.name.clone())
-            .collect(),
+fn rest_projection_function(
+    source_schema: &str,
+    projection: &SourceModelProjection,
+    operation: &SourceModelOperation,
+) -> Result<SourceTableFunctionSpec> {
+    let rest = rest_details(source_schema, projection, operation)?;
+    Ok(SourceTableFunctionSpec {
+        name: projection.name.clone(),
+        description: operation.description.clone(),
+        fetch_limit_default: None,
+        args: operation_inputs_as_args(&operation.inputs),
+        request: rest_request(source_schema, &projection.name, rest, RequestBinding::Arg)?,
+        response: rest_response(&operation.result, rest),
+        pagination: rest_pagination(rest),
+        columns: projection.columns.clone(),
+    })
+}
+
+fn rest_details<'a>(
+    source_schema: &str,
+    projection: &SourceModelProjection,
+    operation: &'a SourceModelOperation,
+) -> Result<&'a RestOperationDetails> {
+    match &operation.details {
+        OperationDetails::Rest { rest } => Ok(rest),
+        OperationDetails::Graphql { .. } => Err(DataFusionError::Plan(format!(
+            "source schema '{source_schema}' projection '{}' references operation '{}.{}', but only REST operations are executable in this source-model runtime",
+            projection.name, operation.surface, operation.id
+        ))),
     }
 }
 
-fn argument_json(input: &OperationInput) -> serde_json::Value {
-    serde_json::json!({
-        "name": input.name,
-        "required": input.required,
-        "values": Vec::<String>::new(),
+fn operation_inputs_as_filters(inputs: &[OperationInput]) -> Vec<FilterSpec> {
+    inputs
+        .iter()
+        .map(|input| FilterSpec {
+            name: input.name.clone(),
+            required: input.required,
+            mode: FilterMode::default(),
+        })
+        .collect()
+}
+
+fn operation_inputs_as_args(inputs: &[OperationInput]) -> Vec<TableFunctionArgSpec> {
+    inputs
+        .iter()
+        .map(|input| TableFunctionArgSpec {
+            name: input.name.clone(),
+            required: input.required,
+            values: Vec::new(),
+            bind: FunctionArgBinding {
+                arg: input.name.clone(),
+            },
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RequestBinding {
+    Filter,
+    Arg,
+}
+
+fn rest_request(
+    source_schema: &str,
+    projection_name: &str,
+    rest: &RestOperationDetails,
+    binding: RequestBinding,
+) -> Result<RequestSpec> {
+    if rest.request_body.is_some() {
+        return Err(DataFusionError::Plan(format!(
+            "source schema '{source_schema}' projection '{projection_name}' references REST operation with a request body; source-model REST execution currently supports path, query, and header parameters"
+        )));
+    }
+
+    let mut path = rest.path.clone();
+    let mut query = Vec::new();
+    let mut headers = Vec::new();
+    for parameter in &rest.parameters {
+        match parameter.location {
+            RestParameterLocation::Path => {
+                let value = template_token(binding, &parameter.input);
+                path = replace_path_parameter(&path, &parameter.name, &value);
+            }
+            RestParameterLocation::Query => {
+                query.push(QueryParamSpec {
+                    name: parameter.name.clone(),
+                    value: bound_value(binding, &parameter.input),
+                });
+            }
+            RestParameterLocation::Header => {
+                headers.push(HeaderSpec {
+                    name: parameter.name.clone(),
+                    value: bound_value(binding, &parameter.input),
+                });
+            }
+            RestParameterLocation::Cookie => {
+                return Err(DataFusionError::Plan(format!(
+                    "source schema '{source_schema}' projection '{projection_name}' references REST cookie parameter '{}', which is not supported by source-model REST execution",
+                    parameter.name
+                )));
+            }
+        }
+    }
+
+    Ok(RequestSpec {
+        method: rest.method,
+        path: ParsedTemplate::parse(path).map_err(|error| {
+            DataFusionError::Plan(format!(
+                "source schema '{source_schema}' projection '{projection_name}' has invalid REST path template: {error}"
+            ))
+        })?,
+        query,
+        body: BodySpec::default(),
+        headers,
     })
 }
 
-fn column_json(column: &RegisteredColumn) -> serde_json::Value {
-    serde_json::json!({
-        "name": column.name,
-        "type": column.data_type,
-        "nullable": column.nullable,
-        "description": column.description,
-    })
+fn replace_path_parameter(path: &str, parameter: &str, value: &str) -> String {
+    path.replace(&format!("{{{parameter}}}"), value)
+        .replace(&format!("{{+{parameter}}}"), value)
 }
 
-#[derive(Debug)]
-struct SourceModelProjectionTableFunction {
-    schema: datafusion::arrow::datatypes::SchemaRef,
+fn template_token(binding: RequestBinding, input: &str) -> String {
+    match binding {
+        RequestBinding::Filter => format!("{{{{filter.{input}}}}}"),
+        RequestBinding::Arg => format!("{{{{arg.{input}}}}}"),
+    }
 }
 
-impl TableFunctionImpl for SourceModelProjectionTableFunction {
-    fn call(&self, _args: &[Expr]) -> Result<Arc<dyn TableProvider>> {
-        Ok(Arc::new(EmptyTable::new(self.schema.clone())))
+fn bound_value(binding: RequestBinding, input: &str) -> ValueSourceSpec {
+    match binding {
+        RequestBinding::Filter => ValueSourceSpec::Filter {
+            key: input.to_string(),
+            default: None,
+        },
+        RequestBinding::Arg => ValueSourceSpec::Arg {
+            key: input.to_string(),
+            default: None,
+        },
+    }
+}
+
+fn rest_response(result: &OperationResult, rest: &RestOperationDetails) -> ResponseSpec {
+    let rows_path = match result {
+        OperationResult::Unit => Vec::new(),
+        OperationResult::Single { .. } | OperationResult::List { .. } => rest
+            .responses
+            .iter()
+            .find(|response| !response.error)
+            .map(|response| response.body_path.clone())
+            .unwrap_or_default(),
+        OperationResult::WrappedList { items_path, .. } => items_path.clone(),
+    };
+
+    ResponseSpec {
+        rows_path,
+        ..ResponseSpec::default()
+    }
+}
+
+fn rest_pagination(rest: &RestOperationDetails) -> PaginationSpec {
+    match &rest.pagination {
+        Some(RestPagination::LinkHeader { .. }) => PaginationSpec {
+            mode: PaginationMode::LinkHeader,
+            ..PaginationSpec::default()
+        },
+        Some(RestPagination::Page {
+            page_input,
+            page_size_input: _,
+        }) => PaginationSpec {
+            mode: PaginationMode::Page,
+            page_param: Some(page_input.clone()),
+            page_start: 1,
+            ..PaginationSpec::default()
+        },
+        None => PaginationSpec::default(),
     }
 }

--- a/crates/coral-engine/tests/engine/source_model_tests.rs
+++ b/crates/coral-engine/tests/engine/source_model_tests.rs
@@ -3,10 +3,13 @@ use std::collections::BTreeMap;
 use coral_engine::{CoralQuery, CoreError, QuerySource, StatusCode};
 use coral_spec::{
     HttpMethod, OperationDetails, OperationInput, OperationResult, RestOperationDetails,
+    RestPagination, RestParameter, RestParameterLocation, RestResponse, RestStatusCode,
     SOURCE_MODEL_IR_VERSION, ScalarType, SourceModelIr, SourceModelOperation, SourceModelSurface,
     SurfaceProtocol, TypeRef, parse_source_manifest_value,
 };
 use serde_json::{Value, json};
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::harness::{execution_to_rows, test_runtime};
 
@@ -92,12 +95,294 @@ async fn source_model_table_projection_error_names_missing_required_operation_in
     );
 }
 
+#[tokio::test]
+async fn source_model_rest_table_executes_path_query_and_list_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/coral/issues"))
+        .and(query_param("state", "open"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "number": 1, "title": "first" },
+            { "number": 2, "title": "second" }
+        ])))
+        .mount(&server)
+        .await;
+
+    let source = source_model_runtime_source(
+        &server.uri(),
+        &[issues_table_projection()],
+        vec![github_issues_operation(
+            OperationResult::List {
+                item: TypeRef::scalar(ScalarType::Json),
+            },
+            None,
+        )],
+    );
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT number, title FROM github.issues \
+             WHERE owner = 'acme' AND repo = 'coral' AND state = 'open' \
+             ORDER BY number",
+        )
+        .await
+        .expect("source-model REST table should query"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({ "number": 1, "title": "first" }),
+            json!({ "number": 2, "title": "second" })
+        ]
+    );
+}
+
+#[tokio::test]
+async fn source_model_rest_function_executes_path_params_and_singleton_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/coral/issues/7"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "number": 7,
+            "title": "single"
+        })))
+        .mount(&server)
+        .await;
+
+    let source = source_model_runtime_source(
+        &server.uri(),
+        &[json!({
+            "name": "get_issue",
+            "kind": "function",
+            "surface": "github-rest",
+            "operation": "issues/get",
+            "columns": [
+                { "name": "number", "type": "Int64" },
+                { "name": "title", "type": "Utf8" }
+            ]
+        })],
+        vec![github_get_issue_operation()],
+    );
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT number, title FROM github.get_issue(owner => 'acme', repo => 'coral', issue_number => 7)",
+        )
+        .await
+        .expect("source-model REST function should query singleton response"),
+    );
+
+    assert_eq!(rows, vec![json!({ "number": 7, "title": "single" })]);
+}
+
+#[tokio::test]
+async fn source_model_rest_function_executes_query_params_and_wrapped_response_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search/issues"))
+        .and(query_param("q", "repo:withcoral/coral label:bug"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total_count": 1,
+            "items": [{ "title": "wrapped" }]
+        })))
+        .mount(&server)
+        .await;
+
+    let source = source_model_runtime_source(
+        &server.uri(),
+        &[json!({
+            "name": "search_issues",
+            "kind": "function",
+            "surface": "github-rest",
+            "operation": "search/issues-and-pull-requests",
+            "columns": [{ "name": "title", "type": "Utf8" }]
+        })],
+        vec![github_search_operation()],
+    );
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT title FROM github.search_issues(q => 'repo:withcoral/coral label:bug')",
+        )
+        .await
+        .expect("source-model REST function should query wrapped response"),
+    );
+
+    assert_eq!(rows, vec![json!({ "title": "wrapped" })]);
+}
+
+#[tokio::test]
+async fn source_model_rest_table_executes_link_header_pagination() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/coral/issues"))
+        .and(query_param_is_missing("page"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .append_header("Link", "</repos/acme/coral/issues?page=2>; rel=\"next\"")
+                .set_body_json(json!([{ "number": 1, "title": "first" }])),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/coral/issues"))
+        .and(query_param("page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "number": 2, "title": "second" }
+        ])))
+        .mount(&server)
+        .await;
+
+    let source = source_model_runtime_source(
+        &server.uri(),
+        &[issues_table_projection()],
+        vec![github_issues_operation(
+            OperationResult::List {
+                item: TypeRef::scalar(ScalarType::Json),
+            },
+            Some(RestPagination::LinkHeader {
+                next_rel: Some("next".to_string()),
+                page_size_input: None,
+            }),
+        )],
+    );
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT number, title FROM github.issues \
+             WHERE owner = 'acme' AND repo = 'coral' \
+             ORDER BY number",
+        )
+        .await
+        .expect("source-model REST table should follow link header pagination"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({ "number": 1, "title": "first" }),
+            json!({ "number": 2, "title": "second" })
+        ]
+    );
+}
+
+#[tokio::test]
+async fn source_model_rest_table_executes_page_and_per_page_pagination() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/coral/issues"))
+        .and(query_param("page", "1"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "number": 1, "title": "first" },
+            { "number": 2, "title": "second" }
+        ])))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/coral/issues"))
+        .and(query_param("page", "2"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            { "number": 3, "title": "third" }
+        ])))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/repos/acme/coral/issues"))
+        .and(query_param("page", "3"))
+        .and(query_param("per_page", "2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .mount(&server)
+        .await;
+
+    let source = source_model_runtime_source(
+        &server.uri(),
+        &[issues_table_projection()],
+        vec![github_issues_operation(
+            OperationResult::List {
+                item: TypeRef::scalar(ScalarType::Json),
+            },
+            Some(RestPagination::Page {
+                page_input: "page".to_string(),
+                page_size_input: Some("per_page".to_string()),
+            }),
+        )],
+    );
+
+    let rows = execution_to_rows(
+        &CoralQuery::execute_sql(
+            &[source],
+            test_runtime(),
+            "SELECT number, title FROM github.issues \
+             WHERE owner = 'acme' AND repo = 'coral' AND per_page = 2 \
+             ORDER BY number",
+        )
+        .await
+        .expect("source-model REST table should page with per_page query param"),
+    );
+
+    assert_eq!(
+        rows,
+        vec![
+            json!({ "number": 1, "title": "first" }),
+            json!({ "number": 2, "title": "second" }),
+            json!({ "number": 3, "title": "third" })
+        ]
+    );
+}
+
 fn source_model_source(include_required_input_columns: bool) -> QuerySource {
     let manifest =
         parse_source_manifest_value(source_model_manifest(include_required_input_columns))
             .expect("source-model manifest should parse");
     QuerySource::new(manifest, BTreeMap::default(), BTreeMap::default())
         .with_source_model_ir(source_model_ir())
+}
+
+fn source_model_runtime_source(
+    base_url: &str,
+    projections: &[Value],
+    operations: Vec<SourceModelOperation>,
+) -> QuerySource {
+    let manifest = parse_source_manifest_value(json!({
+        "name": "github",
+        "version": "1.0.0",
+        "dsl_version": 4,
+        "backend": "source_model",
+        "surfaces": [{
+            "id": "github-rest",
+            "type": "open-api",
+            "url": "https://example.com/openapi.yaml",
+            "sha256": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+            "base_url": base_url
+        }],
+        "projections": projections
+    }))
+    .expect("source-model manifest should parse");
+    QuerySource::new(manifest, BTreeMap::default(), BTreeMap::default()).with_source_model_ir(
+        SourceModelIr {
+            ir_version: SOURCE_MODEL_IR_VERSION,
+            surfaces: vec![SourceModelSurface {
+                id: "github-rest".to_string(),
+                description: String::new(),
+                protocol: SurfaceProtocol::Rest,
+                base_url: Some(base_url.to_string()),
+            }],
+            types: Vec::new(),
+            operations,
+            entities: Vec::new(),
+        },
+    )
 }
 
 fn source_model_manifest(include_required_input_columns: bool) -> Value {
@@ -144,6 +429,23 @@ fn source_model_manifest(include_required_input_columns: bool) -> Value {
     })
 }
 
+fn issues_table_projection() -> Value {
+    json!({
+        "name": "issues",
+        "kind": "table",
+        "surface": "github-rest",
+        "operation": "issues/list-for-repo",
+        "columns": [
+            { "name": "owner", "type": "Utf8", "virtual": true, "expr": { "kind": "from_filter", "key": "owner" } },
+            { "name": "repo", "type": "Utf8", "virtual": true, "expr": { "kind": "from_filter", "key": "repo" } },
+            { "name": "state", "type": "Utf8", "virtual": true, "expr": { "kind": "from_filter", "key": "state" } },
+            { "name": "per_page", "type": "Int64", "virtual": true, "expr": { "kind": "from_filter", "key": "per_page" } },
+            { "name": "number", "type": "Int64" },
+            { "name": "title", "type": "Utf8" }
+        ]
+    })
+}
+
 fn source_model_ir() -> SourceModelIr {
     SourceModelIr {
         ir_version: SOURCE_MODEL_IR_VERSION,
@@ -183,6 +485,72 @@ fn source_model_ir() -> SourceModelIr {
     }
 }
 
+fn github_issues_operation(
+    result: OperationResult,
+    pagination: Option<RestPagination>,
+) -> SourceModelOperation {
+    rest_operation_with(
+        "issues/list-for-repo",
+        vec![
+            required_string_input("owner"),
+            required_string_input("repo"),
+            optional_string_input("state"),
+            optional_integer_input("page"),
+            optional_integer_input("per_page"),
+        ],
+        result,
+        "/repos/{owner}/{repo}/issues",
+        vec![
+            rest_parameter("owner", "owner", RestParameterLocation::Path, true),
+            rest_parameter("repo", "repo", RestParameterLocation::Path, true),
+            rest_parameter("state", "state", RestParameterLocation::Query, false),
+            rest_parameter("per_page", "per_page", RestParameterLocation::Query, false),
+        ],
+        pagination,
+    )
+}
+
+fn github_get_issue_operation() -> SourceModelOperation {
+    rest_operation_with(
+        "issues/get",
+        vec![
+            required_string_input("owner"),
+            required_string_input("repo"),
+            required_integer_input("issue_number"),
+        ],
+        OperationResult::Single {
+            ty: TypeRef::scalar(ScalarType::Json),
+        },
+        "/repos/{owner}/{repo}/issues/{issue_number}",
+        vec![
+            rest_parameter("owner", "owner", RestParameterLocation::Path, true),
+            rest_parameter("repo", "repo", RestParameterLocation::Path, true),
+            rest_parameter(
+                "issue_number",
+                "issue_number",
+                RestParameterLocation::Path,
+                true,
+            ),
+        ],
+        None,
+    )
+}
+
+fn github_search_operation() -> SourceModelOperation {
+    rest_operation_with(
+        "search/issues-and-pull-requests",
+        vec![required_string_input("q")],
+        OperationResult::WrappedList {
+            item: TypeRef::scalar(ScalarType::Json),
+            items_path: vec!["items".to_string()],
+            total_count_path: vec!["total_count".to_string()],
+        },
+        "/search/issues",
+        vec![rest_parameter("q", "q", RestParameterLocation::Query, true)],
+        None,
+    )
+}
+
 fn rest_operation(
     id: &str,
     inputs: Vec<OperationInput>,
@@ -207,10 +575,77 @@ fn rest_operation(
     }
 }
 
+fn rest_operation_with(
+    id: &str,
+    inputs: Vec<OperationInput>,
+    result: OperationResult,
+    path: &str,
+    parameters: Vec<RestParameter>,
+    pagination: Option<RestPagination>,
+) -> SourceModelOperation {
+    SourceModelOperation {
+        id: id.to_string(),
+        surface: "github-rest".to_string(),
+        description: String::new(),
+        inputs,
+        result,
+        details: OperationDetails::Rest {
+            rest: Box::new(RestOperationDetails {
+                method: HttpMethod::GET,
+                path: path.to_string(),
+                parameters,
+                request_body: None,
+                responses: vec![RestResponse {
+                    status: RestStatusCode::Code(200),
+                    content_type: Some("application/json".to_string()),
+                    body: Some(TypeRef::scalar(ScalarType::Json)),
+                    body_path: Vec::new(),
+                    error: false,
+                }],
+                pagination,
+            }),
+        },
+    }
+}
+
+fn rest_parameter(
+    name: &str,
+    input: &str,
+    location: RestParameterLocation,
+    required: bool,
+) -> RestParameter {
+    RestParameter {
+        name: name.to_string(),
+        input: input.to_string(),
+        location,
+        required,
+        style: None,
+        explode: None,
+    }
+}
+
 fn required_string_input(name: &str) -> OperationInput {
     OperationInput {
         name: name.to_string(),
         ty: TypeRef::scalar(ScalarType::String),
+        required: true,
+        description: String::new(),
+    }
+}
+
+fn optional_string_input(name: &str) -> OperationInput {
+    OperationInput {
+        name: name.to_string(),
+        ty: TypeRef::scalar(ScalarType::String),
+        required: false,
+        description: String::new(),
+    }
+}
+
+fn required_integer_input(name: &str) -> OperationInput {
+    OperationInput {
+        name: name.to_string(),
+        ty: TypeRef::scalar(ScalarType::Integer),
         required: true,
         description: String::new(),
     }


### PR DESCRIPTION
Implements step 9 of the [DSL v4 PRD](https://github.com/withcoral/coral/blob/sw/05-19-chore_add_prd/plans/2026-05-19-source-dsl-v4-prd.md): execute source-model REST operations through the existing HTTP backend.

Rather than introduce a parallel HTTP execution stack, `backends/source_model.rs` now translates each resolved `(surface, operation, projection)` triple into the existing `HttpSourceManifest` / `HttpTableSpec` shape and delegates to `backends::http::compile_source`. That means v4 sources reuse:

- the existing HTTP request/response/pagination machinery,
- existing auth, request-header, and rate-limit handling (now read off the selected surface),
- existing JSON fetch and row conversion paths.

Coverage in `tests/engine/source_model_tests.rs` is expanded to exercise path parameters, query parameters, singleton response, list response, wrapped-list response paths, and link-header / `page+per_page` pagination sufficient for the GitHub slice.

The runtime still resolves to a single surface per manifest, per the first-wave scope. Existing v3 HTTP behaviour is untouched.

## Test plan

- [ ] `make rust-checks`
- [ ] `tests/engine/source_model_tests.rs` covers path/query params, singleton/list/wrapped responses, and pagination.