### PR TITLE
docs(sources): document source DSL v4

### DIFF
--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -25,6 +25,13 @@ API-backed sources vary in difficulty. The source spec model is designed for API
 - **Structured, accessible documentation** — an OpenAPI spec, GraphQL schema, or clearly organized REST docs that describe endpoints and response shapes
 - **Real data to validate against** — actual records in the account so you can confirm the source is returning the expected results during development
 
+For custom source specs, `dsl_version: 3` is still the broadest authoring path:
+you hand-author tables, functions, HTTP requests, response mapping, pagination,
+and columns. `dsl_version: 4` is available for the source-model path when you
+have a pinned OpenAPI document and want Coral to import operations from that
+document. DSL v4 is OpenAPI-only today; GraphQL importing is planned as a
+fast-follow.
+
 If you are unsure whether your API is a good candidate, ask us in [Discord](https://withcoral.com/discord) before getting started.
 
 ## Agent-driven authoring
@@ -196,6 +203,92 @@ tables:
 When you run `coral source add --file`, Coral reads each declared `input` from an environment variable of the same name, or prompts for them when you pass `--interactive`. `kind: variable` values go to source variables; `kind: secret` values go to the secret store. API keys, bearer tokens, passwords, private keys, and authorization values must be secrets, even when the API key is read-only.
 
 For the full set of HTTP response, pagination, auth, and column fields, see [HTTP-backed tables](/reference/source-spec-reference#http-backed-tables).
+
+## Example: OpenAPI source-model source
+
+Use DSL v4 when you want Coral to import API operations from an OpenAPI
+document, then expose a smaller SQL surface through explicit projections.
+
+This model is intentionally narrower than v3 HTTP authoring:
+
+- The API description must be OpenAPI (`type: open-api`).
+- The surface must include both a retrieval `url` and a pinned `sha256`.
+- `base_url`, `auth`, `request_headers`, and `rate_limit` live under the
+  surface, not at the top level.
+- You declare `projections`, not `tables` or `functions`.
+- You do not hand-author `entities`, `operations`, `bindings`, endpoint paths,
+  HTTP methods, parameter mappings, or response paths in the manifest.
+
+```yaml
+name: github_issues
+version: 0.1.0
+dsl_version: 4
+backend: source_model
+inputs:
+  GITHUB_API_BASE:
+    kind: variable
+    default: https://api.github.com
+    hint: GitHub REST API base URL.
+  GITHUB_TOKEN:
+    kind: secret
+    hint: GitHub personal access token.
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://raw.githubusercontent.com/github/rest-api-description/f5d3342150d3748e7307c81639635706f8338a12/descriptions/api.github.com/api.github.com.yaml
+    sha256: 2d2094fd1bab20958ae7f7b885fe818f19e57deea0bfdcbde7c9db450d5cc5a0
+    base_url: "{{input.GITHUB_API_BASE}}"
+    auth:
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: template
+          template: Bearer {{input.GITHUB_TOKEN}}
+    request_headers:
+      - name: Accept
+        from: literal
+        value: application/vnd.github+json
+      - name: X-GitHub-Api-Version
+        from: literal
+        value: "2022-11-28"
+    rate_limit:
+      extra_statuses: [403]
+      remaining_header: x-ratelimit-remaining
+      reset_header: x-ratelimit-reset
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+    columns:
+      - name: owner
+        type: Utf8
+        virtual: true
+      - name: repo
+        type: Utf8
+        virtual: true
+      - name: number
+        type: Int64
+        expr: {kind: path, path: [number]}
+      - name: title
+        type: Utf8
+        expr: {kind: path, path: [title]}
+```
+
+When you run `coral source add --file ./github-issues.yaml`, Coral fetches or
+reads the pinned OpenAPI document, verifies the hash, imports the source-model
+IR, validates the projections, and stores the materialized IR locally. Later
+queries load that local IR; they do not fetch OpenAPI documents at query time.
+
+Use `coral source refresh github_issues` to refresh materialized IR for an
+installed v4 source. Refresh still checks the manifest `sha256`, so a changed
+upstream document fails clearly instead of silently changing the imported model.
+
+Bundled/core v4 sources should pin provider-owned immutable OpenAPI URLs when
+available. If the provider only publishes mutable OpenAPI artifacts, the bundled
+source should pin a Coral-owned mirrored artifact that lives outside the Coral
+binary. For the full DSL v4 field reference, see [Source-model sources (DSL
+v4)](/reference/source-spec-reference#source-model-sources-dsl-v4).
 
 ## Tips
 

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -23,13 +23,18 @@ test_queries:
   - SELECT * FROM my_source.messages LIMIT 1
 ```
 
-| Field         | Description                                        |
-| ------------- | -------------------------------------------------- |
-| `name`        | Source name, also used as the SQL schema name      |
-| `version`     | Source spec version string                         |
-| `dsl_version` | Coral source spec DSL version (currently `3`)      |
-| `backend`     | How data is fetched: `http`, `jsonl`, or `parquet` |
-| `test_queries` | Optional read-only SQL checks Coral runs during `coral source test` |
+| Field          | Description                             |
+| -------------- | --------------------------------------- |
+| `name`         | Source name and SQL schema name         |
+| `version`      | Source spec version string              |
+| `dsl_version`  | Coral source spec DSL version           |
+| `backend`      | Backend selector                        |
+| `test_queries` | Optional source validation queries      |
+
+Use `dsl_version: 3` with `backend: http`, `jsonl`, or `parquet` for
+hand-authored sources. Use `dsl_version: 4` only with
+`backend: source_model`; v4 imports API operations from a pinned OpenAPI
+document and exposes explicit SQL projections from that imported model.
 
 ## Test queries
 
@@ -509,6 +514,142 @@ rate_limit:
   reset_header: X-RateLimit-Reset
 ```
 
+## Source-model sources (DSL v4)
+
+For `source_model`, the source spec declares which API description Coral should
+import and which SQL projections to expose. The first DSL v4 implementation is
+OpenAPI-only:
+
+- Set `dsl_version: 4` and `backend: source_model`.
+- Declare one or more `surfaces` with `type: open-api`, a retrieval `url`, and
+  a pinned `sha256`.
+- Put runtime API config on each surface: `base_url`, `auth`,
+  `request_headers`, and `rate_limit`.
+- Declare explicit `projections` that map SQL tables or functions to imported
+  `(surface, operation)` pairs.
+- Do not declare `tables`, `functions`, `entities`, `operations`, or
+  `bindings` in a v4 manifest. Operations, entities, and protocol binding
+  details come from the imported OpenAPI document, not from hand-authored YAML.
+
+```yaml
+name: github
+version: 1.1.6-source-model.0
+dsl_version: 4
+backend: source_model
+description: Query GitHub repository issues through the DSL v4 source-model path.
+inputs:
+  GITHUB_API_BASE:
+    kind: variable
+    default: https://api.github.com
+    hint: GitHub REST API base URL.
+  GITHUB_TOKEN:
+    kind: secret
+    hint: GitHub personal access token.
+surfaces:
+  - id: github-rest
+    type: open-api
+    url: https://raw.githubusercontent.com/github/rest-api-description/f5d3342150d3748e7307c81639635706f8338a12/descriptions/api.github.com/api.github.com.yaml
+    sha256: 2d2094fd1bab20958ae7f7b885fe818f19e57deea0bfdcbde7c9db450d5cc5a0
+    base_url: "{{input.GITHUB_API_BASE}}"
+    auth:
+      type: HeaderAuth
+      headers:
+        - name: Authorization
+          from: template
+          template: Bearer {{input.GITHUB_TOKEN}}
+    request_headers:
+      - name: Accept
+        from: literal
+        value: application/vnd.github+json
+      - name: X-GitHub-Api-Version
+        from: literal
+        value: "2022-11-28"
+    rate_limit:
+      extra_statuses: [403]
+      remaining_header: x-ratelimit-remaining
+      reset_header: x-ratelimit-reset
+projections:
+  - name: issues
+    kind: table
+    surface: github-rest
+    operation: issues/list-for-repo
+    columns:
+      - name: owner
+        type: Utf8
+        virtual: true
+      - name: repo
+        type: Utf8
+        virtual: true
+      - name: number
+        type: Int64
+        expr: {kind: path, path: [number]}
+      - name: title
+        type: Utf8
+        expr: {kind: path, path: [title]}
+```
+
+### Surfaces
+
+A v4 surface identifies an upstream API description and the runtime config used
+when Coral calls that API.
+
+| Field             | Type     | Description                           |
+| ----------------- | -------- | ------------------------------------- |
+| `id`              | string   | Manifest-local surface ID             |
+| `type`            | string   | Importer; currently only `open-api`   |
+| `url`             | string   | OpenAPI document URL                  |
+| `sha256`          | string   | SHA-256 hex digest of document bytes  |
+| `base_url`        | template | Runtime API base URL                  |
+| `auth`            | object   | Auth config for this surface          |
+| `request_headers` | list     | Non-auth headers for this surface     |
+| `rate_limit`      | object   | Rate-limit hints for this surface     |
+
+The `url` may use `https://`, `http://`, or a development `file://` URL.
+
+The `sha256` pin is mandatory. If fetched bytes do not match the manifest pin,
+Coral refuses to materialize the source model. For bundled/core sources, prefer
+provider-owned immutable OpenAPI URLs. When the provider does not publish a
+stable historical artifact, bundled/core sources should pin a Coral-owned
+mirrored OpenAPI artifact that lives outside the Coral binary. Community and
+user-installed sources may use mutable provider URLs, but the hash remains the
+reproducibility contract.
+
+### Materialized IR
+
+During `coral source add`, Coral fetches or reads each pinned OpenAPI document,
+verifies `sha256`, imports source-model IR, validates the declared projections,
+and writes the materialized IR to local app state. Normal query-time loads read
+that local IR. They do not re-fetch OpenAPI documents and do not rerun the
+importer.
+
+Use `coral source refresh <NAME>` when you want to refresh materialized IR for
+an installed v4 source. Refresh still verifies the manifest pin. If the remote
+document has changed and no longer matches `sha256`, refresh fails and reports
+the new hash instead of silently importing a different model.
+
+### Projections
+
+Projections are the only place a v4 manifest declares Coral's SQL surface. Each
+projection has:
+
+| Field       | Type   | Description                         |
+| ----------- | ------ | ----------------------------------- |
+| `name`      | string | SQL table or table function name    |
+| `kind`      | string | `table` or `function`               |
+| `surface`   | string | Surface ID for the operation        |
+| `operation` | string | Imported operation ID               |
+| `columns`   | list   | SQL columns exposed from row values |
+
+DSL v4 does not derive projections automatically yet. Authors choose the
+operations and columns to expose explicitly.
+
+### GraphQL fast-follow
+
+The source-model IR is intended to support a later GraphQL importer, but DSL v4
+manifests cannot reference GraphQL schemas yet. Use `type: open-api` today; a
+GraphQL surface type is a planned fast-follow, not part of the current authoring
+contract.
+
 ### HTTP value sources
 
 Request query params, body fields, and headers support these `from` values:
@@ -671,7 +812,10 @@ pagination:
 
 ## Source inputs
 
-HTTP source specs can declare the variables and secrets this source needs under a top-level `inputs` map. At install time, `coral source add` collects each input from an environment variable matching the key, or prompts interactively when you pass `--interactive`.
+HTTP and source-model source specs can declare the variables and secrets this
+source needs under a top-level `inputs` map. At install time,
+`coral source add` collects each input from an environment variable matching the
+key, or prompts interactively when you pass `--interactive`.
 
 - **Variables**: non-secret configuration like base URLs or organization IDs
 - **Secrets**: API keys or bearer tokens


### PR DESCRIPTION
Implements step 11 of the [DSL v4 PRD](https://github.com/withcoral/coral/blob/sw/05-19-chore_add_prd/plans/2026-05-19-source-dsl-v4-prd.md): user-facing docs for DSL v4 authoring.

- `docs/guides/write-a-custom-source.mdx`: notes that v3 is still the broadest authoring path, introduces v4 as the OpenAPI-driven source-model path, and walks through an example v4 manifest (pinned `type: open-api` surface descriptor with `url` + `sha256`, surface-scoped `auth` / `request_headers` / `rate_limit` / `base_url`, and explicit `projections`). Calls out the anti-goal on hand-authored `entities`, `operations`, or `bindings`, and that GraphQL importing is a fast-follow.
- `docs/reference/source-spec-reference.mdx`: documents the v4 manifest envelope (`backend: source_model`, `surfaces`, `projections`), surface-level runtime configuration, the materialisation model, the Coral artifact mirror policy for bundled sources, and the import-timing rule (`source add` materialises IR; no query-time or lazy load-time imports).

Docs only; no code changes.

## Test plan

- [ ] N/A — docs only.