### PR TITLE
fix(ui): improve trace waterfall scanability

### DIFF
--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -169,9 +169,9 @@ export const waterfallTimelinePane = style({
 export const waterfallTickRow = style({
   display: 'grid',
   flexShrink: 0,
-  gridTemplateColumns: '220px minmax(0, 1fr)',
+  gridTemplateColumns: '320px minmax(0, 1fr)',
 })
-export const waterfallLabel = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, height: 24, minWidth: 0, paddingBlockEnd: 4 })
+export const waterfallLabel = style({ height: 24, minWidth: 0, paddingBlockEnd: 4 })
 export const waterfallTimeline = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, height: 24, minWidth: 0, overflow: 'hidden', paddingBlockEnd: 4, position: 'relative' })
 export const waterfallTick = style({ color: theme.content.tertiary, fontFamily: codeFontFamily, fontSize: 12, lineHeight: '16px', position: 'absolute', whiteSpace: 'nowrap' })
 export const waterfallResizeHandle = style({
@@ -214,7 +214,7 @@ export const waterfallRowsViewport = style({
 export const waterfallRowsGrid = style({
   alignItems: 'start',
   display: 'grid',
-  gridTemplateColumns: '220px minmax(0, 1fr)',
+  gridTemplateColumns: '320px minmax(0, 1fr)',
   minWidth: 0,
 })
 export const waterfallLabelsColumn = style({ display: 'flex', flexDirection: 'column', gap: 10, minWidth: 0 })
@@ -226,12 +226,14 @@ export const waterfallTimelineBody = style({
   minHeight: 0,
   minWidth: 0,
 })
-export const waterfallRowShell = style({ borderRadius: 8, minWidth: 0, overflow: 'hidden', position: 'relative' })
+export const waterfallRowShell = style({ borderRadius: 8, borderBottomRightRadius: 0, borderTopRightRadius: 0, minWidth: 0, overflow: 'hidden', position: 'relative' })
 export const waterfallRowButton = style({
   alignItems: 'center',
   background: 'none',
   border: 'none',
   borderRadius: 4,
+  borderBottomRightRadius: 0,
+  borderTopRightRadius: 0,
   color: theme.content.primary,
   display: 'flex',
   minHeight: 38,
@@ -244,6 +246,7 @@ export const waterfallRowButton = style({
   },
 })
 export const waterfallRowHover = style({ backgroundColor: theme.surface.onMainContentSubtle })
+export const waterfallRowActive = style({ backgroundColor: theme.pill.blue.background, color: theme.content.primary })
 export const waterfallSpanLabel = style({
   alignItems: 'center',
   alignSelf: 'stretch',
@@ -252,11 +255,9 @@ export const waterfallSpanLabel = style({
   minHeight: 38,
   minWidth: 0,
   overflow: 'hidden',
-  paddingInlineEnd: 10,
+  paddingInline: 10,
 })
 export const waterfallSpanLabelActive = style({
-  backgroundColor: theme.pill.blue.background,
-  boxShadow: `inset 3px 0 0 ${theme.pill.blue.color}`,
   color: theme.content.primary,
 })
 export const waterfallTreeGuide = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, borderInlineStart: `1px solid ${theme.stroke.primary}`, flexShrink: 0, height: 18, marginInlineEnd: 6, width: 10 })
@@ -302,6 +303,8 @@ export const waterfallLabelText = style({ display: 'flex', flexDirection: 'colum
 export const waterfallBarSlot = style({
   alignItems: 'center',
   borderRadius: 4,
+  borderBottomLeftRadius: 0,
+  borderTopLeftRadius: 0,
   display: 'flex',
   flexShrink: 0,
   minHeight: 38,
@@ -311,7 +314,8 @@ export const waterfallBarSlot = style({
   },
 })
 export const waterfallBarSlotActive = style({
-  boxShadow: `inset 0 0 0 1px ${theme.pill.blue.stroke}`,
+  backgroundColor: theme.pill.blue.background,
+  color: theme.content.primary,
 })
 export const waterfallBarArea = style({ height: 24, minWidth: 0, overflow: 'hidden', position: 'relative', width: '100%' })
 export const waterfallBar = style({ alignItems: 'center', borderRadius: 6, display: 'flex', height: 20, insetBlockStart: 2, minWidth: 2, overflow: 'hidden', paddingInline: 8, position: 'absolute', whiteSpace: 'nowrap', selectors: {

--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -31,6 +31,7 @@ import {
 export type DetailTab = 'timeline' | 'api'
 type WaterfallTone = 'query' | 'http' | 'span' | 'error'
 
+const WATERFALL_LABEL_PADDING_INLINE_PX = 10
 const INDENT_PX = 14
 const DETAIL_PANEL_DEFAULT_RATIO = 0.4
 const DETAIL_PANEL_MIN_RATIO = 0.28
@@ -172,6 +173,7 @@ function WaterfallSpanLabel({
   label,
   meta,
   onToggle,
+  reserveToggleSpace,
   spanId,
   tone,
 }: {
@@ -182,11 +184,12 @@ function WaterfallSpanLabel({
   label: string
   meta: string
   onToggle: (spanId: string) => void
+  reserveToggleSpace: boolean
   spanId: string
   tone: WaterfallTone
 }) {
   return (
-    <div className={classNames(s.waterfallSpanLabel, { [s.waterfallSpanLabelActive]: active })} style={{ paddingInlineStart: depth * INDENT_PX }}>
+    <div className={classNames(s.waterfallSpanLabel, { [s.waterfallSpanLabelActive]: active })} style={{ paddingInlineStart: WATERFALL_LABEL_PADDING_INLINE_PX + depth * INDENT_PX }}>
       {depth > 0 && <span className={s.waterfallTreeGuide} aria-hidden />}
       {childCount > 0 ? (
         <button
@@ -202,9 +205,9 @@ function WaterfallSpanLabel({
           <Icon name={collapsed ? 'ChevronRight' : 'ChevronDown'} size="14" color="secondary" />
           <span className={s.waterfallChildCountChip}>{childCount}</span>
         </button>
-      ) : (
-        <span className={s.waterfallTreeTogglePlaceholder} />
-      )}
+      ) : reserveToggleSpace ? (
+        <span aria-hidden className={s.waterfallTreeTogglePlaceholder} />
+      ) : null}
       <span className={s.waterfallPluginPill}>
         <span className={s.waterfallPluginDot} data-tone={tone} />
         <span className={s.waterfallLabelText}>
@@ -262,6 +265,7 @@ function WaterfallRow({
   onToggle,
   onToggleExpanded,
   onHover,
+  reserveToggleSpace,
   row,
 }: {
   collapsed: boolean
@@ -270,6 +274,7 @@ function WaterfallRow({
   onToggle: (spanId: string) => void
   onToggleExpanded: (spanId: string) => void
   onHover: (spanId: string | null) => void
+  reserveToggleSpace: boolean
   row: TimelineRow
 }) {
   const { childCount, depth, span } = row
@@ -289,7 +294,7 @@ function WaterfallRow({
     >
       <div
         aria-expanded={canExpandHttp ? expanded : undefined}
-        className={classNames(s.waterfallRowButton, { [s.waterfallRowHover]: hovered })}
+        className={classNames(s.waterfallRowButton, { [s.waterfallRowHover]: hovered, [s.waterfallRowActive]: expanded })}
         data-noisy={isNoisyInternalSpan || undefined}
         onMouseEnter={() => onHover(span.spanId)}
         onMouseLeave={() => onHover(null)}
@@ -310,6 +315,7 @@ function WaterfallRow({
           label={label}
           meta={meta}
           onToggle={onToggle}
+          reserveToggleSpace={reserveToggleSpace}
           spanId={span.spanId}
           tone={tone}
         />
@@ -482,6 +488,7 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
                   onHover={setHoveredSpanId}
                   onToggle={toggleSpan}
                   onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
+                  reserveToggleSpace={proMode}
                   row={row}
                 />
               ))}


### PR DESCRIPTION
Remove extra space before the label, give more space for the label, fix ugly hover glitch

| before | after |
| --- | --- |
| ![CleanShot 2026-05-20 at 14.23.33@2x.png](https://app.graphite.com/user-attachments/assets/12cef5c1-34a9-4e81-885b-de6b30d20353.png) | ![image.png](https://app.graphite.com/user-attachments/assets/e4e4242f-abab-4f1d-b26d-23339e78747b.png) |

