### PR TITLE
feat(ui): port custom icons from monorepo

### DIFF
--- a/ui/src/wax/components/icon.tsx
+++ b/ui/src/wax/components/icon.tsx
@@ -1,11 +1,11 @@
 import classnames from 'classnames'
-import { Activity, ArrowDown, ArrowUp, ChevronDown, ChevronRight, CircleAlert, Columns3, Database, Loader, PanelLeft, Play, Plus, RefreshCw, Search, Table2, X } from 'lucide-react'
+import { Activity, Loader } from 'lucide-react'
 
-import { CoralIcon } from '@/wax/components/icon/custom-icons/coral'
+import { customIcons, isCustomIcon } from '@/wax/components/icon/custom-icons/custom-icons'
 import { iconContainer } from '@/wax/components/icon.css'
 
 export type IconColor = 'disabled' | 'error' | 'info' | 'inherit' | 'orange' | 'placeholder' | 'primary' | 'secondary' | 'success' | 'tertiary' | 'warning'
-export type IconName = 'Coral' | 'PanelLeft' | 'Database' | 'Search' | 'X' | 'ChevronDown' | 'ChevronRight' | 'ArrowUp' | 'ArrowDown' | 'Table2' | 'Columns3' | 'Plus' | 'Play' | 'Loader' | 'RefreshCw' | 'CircleAlert' | 'Activity'
+export type IconName = 'Activity' | 'ArrowDown' | 'ArrowUp' | 'ChevronDown' | 'ChevronRight' | 'CircleAlert' | 'Coral' | 'Loader' | 'Search' | 'X'
 export interface IconProps {
   className?: string
   color?: IconColor
@@ -14,27 +14,13 @@ export interface IconProps {
 }
 export type IconSize = '14' | '16' | '18' | '20' | '24' | '30'
 
-const iconMap = {
+const lucideIcons = {
   Activity,
-  PanelLeft,
-  Database,
-  Search,
-  X,
-  ChevronDown,
-  ChevronRight,
-  ArrowUp,
-  ArrowDown,
-  Table2,
-  Columns3,
-  Plus,
-  Play,
   Loader,
-  RefreshCw,
-  CircleAlert,
 } as const
 
 export function Icon({ className, color = 'primary', name, size = '20' }: IconProps) {
-  const IconComponent = name === 'Coral' ? CoralIcon : iconMap[name]
+  const IconComponent = isCustomIcon(name) ? customIcons[name] : lucideIcons[name]
   return (
     <span className={classnames(iconContainer({ color, size: normalizeSize(size) }), className)}>
       <IconComponent color="currentColor" size={Number(size)} />

--- a/ui/src/wax/components/icon/custom-icons/arrow-down.tsx
+++ b/ui/src/wax/components/icon/custom-icons/arrow-down.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+
+export function ArrowDownIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
+  return (
+    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M9 3.75V14.25M9 14.25L3.75 9M9 14.25L14.25 9" />
+    </svg>
+  )
+}

--- a/ui/src/wax/components/icon/custom-icons/arrow-up.tsx
+++ b/ui/src/wax/components/icon/custom-icons/arrow-up.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+
+export function ArrowUpIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
+  return (
+    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M9 14.25V3.75M9 3.75L3.75 9M9 3.75L14.25 9" />
+    </svg>
+  )
+}

--- a/ui/src/wax/components/icon/custom-icons/chevron-down.tsx
+++ b/ui/src/wax/components/icon/custom-icons/chevron-down.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+
+export function ChevronDownIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
+  return (
+    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M4.5 6.75L9 11.25L13.5 6.75" />
+    </svg>
+  )
+}

--- a/ui/src/wax/components/icon/custom-icons/chevron-right.tsx
+++ b/ui/src/wax/components/icon/custom-icons/chevron-right.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+
+export function ChevronRightIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
+  return (
+    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M6.75 4.5L11.25 9L6.75 13.5" />
+    </svg>
+  )
+}

--- a/ui/src/wax/components/icon/custom-icons/circle-alert.tsx
+++ b/ui/src/wax/components/icon/custom-icons/circle-alert.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+
+export function CircleAlertIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
+  return (
+    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M9 6V9M9 12H9.008M16.5 9C16.5 13.142 13.142 16.5 9 16.5C4.858 16.5 1.5 13.142 1.5 9C1.5 4.858 4.858 1.5 9 1.5C13.142 1.5 16.5 4.858 16.5 9Z" />
+    </svg>
+  )
+}

--- a/ui/src/wax/components/icon/custom-icons/custom-icons.ts
+++ b/ui/src/wax/components/icon/custom-icons/custom-icons.ts
@@ -1,0 +1,35 @@
+import { ArrowDownIcon } from '@/wax/components/icon/custom-icons/arrow-down'
+import { ArrowUpIcon } from '@/wax/components/icon/custom-icons/arrow-up'
+import { ChevronDownIcon } from '@/wax/components/icon/custom-icons/chevron-down'
+import { ChevronRightIcon } from '@/wax/components/icon/custom-icons/chevron-right'
+import { CircleAlertIcon } from '@/wax/components/icon/custom-icons/circle-alert'
+import { CoralIcon } from '@/wax/components/icon/custom-icons/coral'
+import { SearchIcon } from '@/wax/components/icon/custom-icons/search'
+import { XIcon } from '@/wax/components/icon/custom-icons/x'
+import { IconName } from '@/wax/components/icon'
+
+/**
+ * How to add a custom icon:
+ * - Go to Figma, copy the 24px icon. Lucide icon is based on 24px, so it MUST be that size.
+ * - If it's not, Claude Code will be able to fix it later.
+ * - Paste it into https://studio.lucide.dev/, click "Share > Copy React Code" from the topbar.
+ * - Create new file, paste that, fix it up.
+ */
+export const customIcons = {
+  ArrowDown: ArrowDownIcon,
+  ArrowUp: ArrowUpIcon,
+  ChevronDown: ChevronDownIcon,
+  ChevronRight: ChevronRightIcon,
+  CircleAlert: CircleAlertIcon,
+  Coral: CoralIcon,
+  Search: SearchIcon,
+  X: XIcon,
+} as const
+
+export type CustomIconName = keyof typeof customIcons
+
+// Assuming we won't have name clashes. Can revisit in the future if that'll be the case
+// E.g. if we'll need our own custom "Menu" icon, which clashes with the existing Lucide "Menu" icon
+export function isCustomIcon(name: IconName): name is CustomIconName {
+  return name in customIcons
+}

--- a/ui/src/wax/components/icon/custom-icons/search.tsx
+++ b/ui/src/wax/components/icon/custom-icons/search.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+
+export function SearchIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
+  return (
+    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M16.5 16.5L12.875 12.875M14.5 8C14.5 11.5899 11.5899 14.5 8 14.5C4.41015 14.5 1.5 11.5899 1.5 8C1.5 4.41015 4.41015 1.5 8 1.5C11.5899 1.5 14.5 4.41015 14.5 8Z" />
+    </svg>
+  )
+}

--- a/ui/src/wax/components/icon/custom-icons/x.tsx
+++ b/ui/src/wax/components/icon/custom-icons/x.tsx
@@ -1,0 +1,9 @@
+import type { LucideProps } from 'lucide-react'
+
+export function XIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
+  return (
+    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+      <path d="M13.5 4.5L4.5 13.5M4.5 4.5L13.5 13.5" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary

We use transparent colours, which break lucide icons (when two segments overlap, their colours blend). The solution we had was to use custom icons (which are the same lucide icons, but rewritten to only have 1 segment, hence no overlaps possible).


## Test plan

| Before | After |
| ------ | ------ |
|  <img width="92" height="94" alt="image" src="https://github.com/user-attachments/assets/9fec5d9f-0d01-4588-b639-5c74cc2eaef5" /> | <img width="81" height="94" alt="image" src="https://github.com/user-attachments/assets/579be34a-e2e3-4545-b8b8-3d63c2586846" /> |
