### PR TITLE
fix(ui): rework trace span detail layout

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -558,8 +557,7 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.12.0",
@@ -617,7 +615,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -639,7 +636,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -652,7 +648,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2728,7 +2723,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -2739,7 +2733,6 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2812,7 +2805,6 @@
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.20.1.tgz",
       "integrity": "sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -2968,7 +2960,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3251,7 +3242,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3829,7 +3819,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -4093,7 +4082,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4179,7 +4167,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4189,7 +4176,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4573,7 +4559,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4652,7 +4637,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -88,7 +88,10 @@ export const searchField = style({
     [`screen and (max-width: ${breakpoints.mobile})`]: {
       display: 'none',
       selectors: {
-        [`${inlineSearch}[data-searching="true"] &`]: { display: 'block', flex: 1 },
+        [`${inlineSearch}[data-searching="true"] &`]: {
+          display: 'block',
+          flex: 1,
+        },
       },
     },
   },
@@ -123,7 +126,9 @@ export const fullRow = style({
   paddingInline: 24,
   textAlign: 'left',
   width: '100%',
-  selectors: { '&:hover': { backgroundColor: theme.surface.onMainContentSubtle } },
+  selectors: {
+    '&:hover': { backgroundColor: theme.surface.onMainContentSubtle },
+  },
 })
 export const statusDot = style({
   borderRadius: '50%',
@@ -182,8 +187,16 @@ export const statusBar = style({
   justifyContent: 'space-between',
   paddingInline: 12,
 })
-export const statusLeft = style({ alignItems: 'center', display: 'flex', gap: 6 })
-export const statusRight = style({ alignItems: 'center', display: 'flex', gap: 6 })
+export const statusLeft = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 6,
+})
+export const statusRight = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 6,
+})
 export const statusBarDot = style({
   borderRadius: '50%',
   flexShrink: 0,
@@ -250,7 +263,12 @@ export const detailHeaderActions = style({
   flexShrink: 0,
   gap: 4,
 })
-export const scrollBody = style({ display: 'flex', flex: 1, minHeight: 0, overflow: 'auto' })
+export const scrollBody = style({
+  display: 'flex',
+  flex: 1,
+  minHeight: 0,
+  overflow: 'auto',
+})
 export const content = style({
   display: 'flex',
   flex: 1,
@@ -312,8 +330,11 @@ export const tabContent = style({
 export const waterfallRoot = style({
   alignItems: 'stretch',
   display: 'flex',
+  flex: 1,
   gap: 8,
   minHeight: 280,
+  height: '100%',
+  overflow: 'hidden',
   paddingBlock: 8,
   paddingInline: 12,
 })
@@ -331,7 +352,11 @@ export const waterfallTickRow = style({
   flexShrink: 0,
   gridTemplateColumns: '320px minmax(0, 1fr)',
 })
-export const waterfallLabel = style({ height: 24, minWidth: 0, paddingBlockEnd: 4 })
+export const waterfallLabel = style({
+  height: 24,
+  minWidth: 0,
+  paddingBlockEnd: 4,
+})
 export const waterfallTimeline = style({
   borderBlockEnd: `1px solid ${theme.stroke.primary}`,
   height: 24,
@@ -430,7 +455,9 @@ export const waterfallRowButton = style({
     '&[role="button"]': { cursor: 'pointer' },
   },
 })
-export const waterfallRowHover = style({ backgroundColor: theme.surface.onMainContentSubtle })
+export const waterfallRowHover = style({
+  backgroundColor: theme.surface.onMainContentSubtle,
+})
 export const waterfallRowActive = style({
   backgroundColor: theme.pill.blue.background,
   color: theme.content.primary,
@@ -470,7 +497,10 @@ export const waterfallTreeToggle = style({
   padding: 0,
   paddingInlineEnd: 2,
   selectors: {
-    '&:hover': { backgroundColor: theme.button.bare.hover, color: theme.content.primary },
+    '&:hover': {
+      backgroundColor: theme.button.bare.hover,
+      color: theme.content.primary,
+    },
   },
 })
 export const waterfallTreeTogglePlaceholder = style({
@@ -514,7 +544,11 @@ export const waterfallPluginDot = style({
     '&[data-tone="error"]': { backgroundColor: theme.pill.red.color },
   },
 })
-export const waterfallLabelText = style({ display: 'flex', flexDirection: 'column', minWidth: 0 })
+export const waterfallLabelText = style({
+  display: 'flex',
+  flexDirection: 'column',
+  minWidth: 0,
+})
 export const waterfallBarSlot = style({
   alignItems: 'center',
   borderRadius: 4,
@@ -628,6 +662,11 @@ export const waterfallHttpDetailHeaderActions = style({
   flexShrink: 0,
   gap: 2,
 })
+export const waterfallHttpDetailScroll = style({
+  flex: 1,
+  minHeight: 0,
+  minWidth: 0,
+})
 export const waterfallHttpDetailContent = style({
   display: 'flex',
   flexDirection: 'column',
@@ -676,7 +715,11 @@ export const bodyViewer = style({
   minHeight: 0,
   minWidth: 0,
 })
-export const bodyViewerHeader = style({ display: 'flex', flexDirection: 'column', gap: 6 })
+export const bodyViewerHeader = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+})
 export const bodyMetaRow = style({ display: 'flex', flexWrap: 'wrap', gap: 6 })
 export const bodyViewerSection = style({
   display: 'flex',
@@ -686,7 +729,11 @@ export const bodyViewerSection = style({
   minWidth: 0,
 })
 export const bodyViewerSectionLabel = style({ color: theme.content.tertiary })
-export const bodyViewerRawDetails = style({ display: 'flex', flexDirection: 'column', gap: 4 })
+export const bodyViewerRawDetails = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+})
 
 export const statusBadge = style({
   borderRadius: 999,
@@ -719,7 +766,11 @@ export const emptyPanel = style({
   padding: 24,
   textAlign: 'center',
 })
-export const externalCallsList = style({ display: 'flex', flexDirection: 'column', gap: 8 })
+export const externalCallsList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+})
 export const apiCallsSummary = style({
   color: theme.content.tertiary,
   fontSize: 14,
@@ -745,7 +796,9 @@ export const externalCallButton = style({
   paddingInline: 12,
   textAlign: 'left',
   width: '100%',
-  selectors: { '&:hover': { backgroundColor: theme.surface.onMainContentSubtle } },
+  selectors: {
+    '&:hover': { backgroundColor: theme.surface.onMainContentSubtle },
+  },
 })
 export const externalCallTableName = style({ fontWeight: 500 })
 export const externalCallUrl = style({
@@ -756,19 +809,46 @@ export const externalCallUrl = style({
   whiteSpace: 'nowrap',
 })
 export const externalCallMeta = style({ flexShrink: 0 })
-export const externalCallExpanded = style({ backgroundColor: theme.surface.onMainContentSubtle, borderBlockStart: `1px solid ${theme.stroke.primary}`, display: 'flex', flexDirection: 'column', gap: 8, paddingBlock: 8, paddingInline: 12 })
-export const requestLine = style({ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })
-export const detailsSummary = style({ color: theme.content.tertiary, cursor: 'pointer' })
+export const externalCallExpanded = style({
+  backgroundColor: theme.surface.onMainContentSubtle,
+  borderBlockStart: `1px solid ${theme.stroke.primary}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  paddingBlock: 8,
+  paddingInline: 12,
+})
+export const requestLine = style({
+  alignItems: 'baseline',
+  display: 'flex',
+  flex: 1,
+  gap: 6,
+  minWidth: 0,
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+})
+export const methodBadge = style({ flexShrink: 0 })
+export const requestEndpoint = style({
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
+export const detailsSummary = style({
+  color: theme.content.tertiary,
+  cursor: 'pointer',
+})
 export const detailsPre = style({
   backgroundColor: theme.surface.main,
   borderRadius: 6,
+  flex: 1,
   fontFamily: fontFamily.dmMono,
   fontSize: 12,
   lineHeight: '18px',
   margin: 0,
   marginBlockStart: 4,
   minHeight: 0,
-  maxHeight: 240,
   overflow: 'auto',
   padding: 8,
   whiteSpace: 'pre-wrap',

--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -312,11 +312,8 @@ export const tabContent = style({
 export const waterfallRoot = style({
   alignItems: 'stretch',
   display: 'flex',
-  flex: 1,
   gap: 8,
-  height: '100%',
   minHeight: 280,
-  overflow: 'hidden',
   paddingBlock: 8,
   paddingInline: 12,
 })
@@ -374,7 +371,6 @@ export const waterfallSidePanel = style({
   minHeight: 0,
   minWidth: 320,
   opacity: 0,
-  overflow: 'hidden',
   transform: 'translateX(12px)',
   transition: 'opacity 140ms ease, transform 180ms ease',
   selectors: {
@@ -608,7 +604,6 @@ export const waterfallHttpDetail = style({
   gap: 10,
   minHeight: 0,
   minWidth: 0,
-  overflow: 'hidden',
 })
 export const waterfallHttpDetailHeader = style({
   alignItems: 'center',
@@ -632,17 +627,10 @@ export const waterfallHttpDetailHeaderActions = style({
   flexShrink: 0,
   gap: 2,
 })
-export const waterfallHttpDetailScroll = style({
-  flex: 1,
-  minHeight: 0,
-  minWidth: 0,
-  overflow: 'hidden',
-})
 export const waterfallHttpDetailContent = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 10,
-  height: '100%',
   minHeight: 0,
   minWidth: 0,
   paddingBlockEnd: 10,
@@ -675,21 +663,17 @@ export const copyButtonGroup = style({
 })
 export const waterfallHttpDetailSection = style({
   display: 'flex',
-  flex: 1,
   flexDirection: 'column',
   gap: 4,
   minHeight: 0,
   minWidth: 0,
-  overflow: 'hidden',
 })
 export const bodyViewer = style({
   display: 'flex',
-  flex: 1,
   flexDirection: 'column',
   gap: 8,
   minHeight: 0,
   minWidth: 0,
-  overflow: 'hidden',
 })
 export const bodyViewerHeader = style({ display: 'flex', flexDirection: 'column', gap: 6 })
 export const bodyMetaRow = style({ display: 'flex', flexWrap: 'wrap', gap: 6 })
@@ -793,13 +777,13 @@ export const detailsSummary = style({ color: theme.content.tertiary, cursor: 'po
 export const detailsPre = style({
   backgroundColor: theme.surface.main,
   borderRadius: 6,
-  flex: 1,
   fontFamily: fontFamily.dmMono,
   fontSize: 12,
   lineHeight: '18px',
   margin: 0,
   marginBlockStart: 4,
   minHeight: 0,
+  maxHeight: 240,
   overflow: 'auto',
   padding: 8,
   whiteSpace: 'pre-wrap',

--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -756,23 +756,8 @@ export const externalCallUrl = style({
   whiteSpace: 'nowrap',
 })
 export const externalCallMeta = style({ flexShrink: 0 })
-export const externalCallExpanded = style({
-  backgroundColor: theme.surface.onMainContentSubtle,
-  borderBlockStart: `1px solid ${theme.stroke.primary}`,
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 8,
-  paddingBlock: 8,
-  paddingInline: 12,
-})
-export const methodBadge = style({ flexShrink: 0 })
-export const requestUrl = style({
-  flex: 1,
-  minWidth: 0,
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-})
+export const externalCallExpanded = style({ backgroundColor: theme.surface.onMainContentSubtle, borderBlockStart: `1px solid ${theme.stroke.primary}`, display: 'flex', flexDirection: 'column', gap: 8, paddingBlock: 8, paddingInline: 12 })
+export const requestLine = style({ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })
 export const detailsSummary = style({ color: theme.content.tertiary, cursor: 'pointer' })
 export const detailsPre = style({
   backgroundColor: theme.surface.main,

--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -642,6 +642,7 @@ export const waterfallHttpDetailContent = style({
   display: 'flex',
   flexDirection: 'column',
   gap: 10,
+  height: '100%',
   minHeight: 0,
   minWidth: 0,
   paddingBlockEnd: 10,
@@ -679,13 +680,16 @@ export const waterfallHttpDetailSection = style({
   gap: 4,
   minHeight: 0,
   minWidth: 0,
+  overflow: 'hidden',
 })
 export const bodyViewer = style({
   display: 'flex',
+  flex: 1,
   flexDirection: 'column',
   gap: 8,
   minHeight: 0,
   minWidth: 0,
+  overflow: 'hidden',
 })
 export const bodyViewerHeader = style({ display: 'flex', flexDirection: 'column', gap: 6 })
 export const bodyMetaRow = style({ display: 'flex', flexWrap: 'wrap', gap: 6 })

--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -765,7 +765,6 @@ export const externalCallExpanded = style({
   paddingBlock: 8,
   paddingInline: 12,
 })
-export const requestUrlRow = style({ alignItems: 'center', display: 'flex', gap: 8 })
 export const methodBadge = style({ flexShrink: 0 })
 export const requestUrl = style({
   flex: 1,

--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -617,8 +617,9 @@ export const waterfallHttpDetailHeader = style({
   paddingInline: 12,
 })
 export const waterfallHttpDetailTitle = style({
+  alignItems: 'center',
   display: 'flex',
-  flexDirection: 'column',
+  gap: 8,
   minWidth: 0,
 })
 export const waterfallHttpDetailHeaderActions = style({

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -51,7 +51,8 @@ function looksLikeJson(value: string) {
   )
 }
 
-function parseMaybeJson(value: unknown): JsonValue {
+function parseMaybeJson(value: unknown): JsonValue | undefined {
+  if (value === undefined || value === null) return undefined
   if (typeof value !== 'string') return value as JsonValue
   try {
     const parsed = JSON.parse(value) as JsonValue
@@ -285,10 +286,10 @@ function activeBodyState(
   activeTab: HttpDetailTab,
   attrs: Record<string, unknown>,
   paramsValue: Record<string, string | string[]> | undefined,
-  requestBody: JsonValue,
+  requestBody: JsonValue | undefined,
   rawRequestBody: unknown,
   requestBodyTruncated: boolean,
-  responseBody: JsonValue,
+  responseBody: JsonValue | undefined,
   rawResponseBody: unknown,
   responseBodyTruncated: boolean,
 ): ActiveBodyState {
@@ -348,7 +349,11 @@ function bodyEmptyText(kind: BodyKind, attrs: Record<string, unknown>, truncated
   return `No ${kind} body was recorded for this request.`
 }
 
-function preferredHttpDetailTab(responseBody: JsonValue, requestBody: JsonValue, paramsValue: Record<string, string | string[]> | undefined): HttpDetailTab {
+function preferredHttpDetailTab(
+  responseBody: JsonValue | undefined,
+  requestBody: JsonValue | undefined,
+  paramsValue: Record<string, string | string[]> | undefined,
+): HttpDetailTab {
   if (responseBody) return 'response'
   if (requestBody) return 'request'
   if (paramsValue) return 'params'

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -483,9 +483,11 @@ export function HttpSpanDetail({
     >
       <div className={s.waterfallHttpDetailHeader}>
         <div className={s.waterfallHttpDetailTitle}>
-          <Typography.BodySmallStrong as="span">Span details</Typography.BodySmallStrong>
-          <Typography.BodySmall as="span" variant="tertiary" truncate>
+          <Typography.CodeSmallInlineStrong as="span" className={s.methodBadge}>
             {spanOperation(span)}
+          </Typography.CodeSmallInlineStrong>
+          <Typography.BodySmall as="span" className={s.requestUrl} variant="tertiary" truncate>
+            {url || 'No URL recorded'}
           </Typography.BodySmall>
         </div>
         <div className={s.waterfallHttpDetailHeaderActions}>
@@ -515,14 +517,7 @@ export function HttpSpanDetail({
         </div>
       </div>
       <div className={s.waterfallHttpDetailContent}>
-        <div className={s.requestUrlRow}>
-          <Typography.CodeSmallInline as="span" className={s.methodBadge}>
-            {spanOperation(span)}
-          </Typography.CodeSmallInline>
-          <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>
-            {url || 'No URL recorded'}
-          </Typography.Body>
-        </div>
+
         <div className={s.httpMetaRow}>
           {statusCode && metaChip('Status', statusCode)}
           {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -6,13 +6,7 @@ import { Typography } from '@/wax/components/typography'
 import type { TraceSpan } from '@/generated/coral/v1/traces_pb'
 
 import * as s from '../traces-page.css'
-import {
-  formatDuration,
-  formatDurationFromNanos,
-  parseJsonObject,
-  spanOperation,
-  spanUrl,
-} from './trace-utils'
+import { formatDuration, formatDurationFromNanos, parseJsonObject, spanRequestLine, spanUrl } from './trace-utils'
 
 type JsonValue = Record<string, unknown> | unknown[] | string | number | boolean | null
 type BodyKind = 'request' | 'response'
@@ -445,6 +439,7 @@ export function HttpSpanDetail({
   const attempt = attrText(attrs['coral.http.attempt'])
   const source = attrText(attrs['coral.source'])
   const table = attrText(attrs['coral.table'])
+  const requestLine = spanRequestLine(span)
 
   useEffect(() => setActiveTab(preferredTab), [preferredTab, span.spanId])
   useEffect(() => setCopyState('idle'), [activeTab, span.spanId])
@@ -472,12 +467,7 @@ export function HttpSpanDetail({
     >
       <div className={s.waterfallHttpDetailHeader}>
         <div className={s.waterfallHttpDetailTitle}>
-          <Typography.CodeSmallInlineStrong as="span" className={s.methodBadge}>
-            {spanOperation(span)}
-          </Typography.CodeSmallInlineStrong>
-          <Typography.BodySmall as="span" className={s.requestUrl} variant="tertiary" truncate>
-            {url || 'No URL recorded'}
-          </Typography.BodySmall>
+          <Typography.CodeSmallInlineStrong as="span" className={s.requestLine} truncate>{requestLine || 'No URL recorded'}</Typography.CodeSmallInlineStrong>
         </div>
         <div className={s.waterfallHttpDetailHeaderActions}>
           <Button.IconButton

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import classNames from 'classnames'
 
 import * as Button from '@/wax/components/button'
-import * as ScrollArea from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 import type { TraceSpan } from '@/generated/coral/v1/traces_pb'
 
@@ -480,96 +479,64 @@ export function HttpSpanDetail({
           />
         </div>
       </div>
-      <ScrollArea.Container
-        className={s.waterfallHttpDetailScroll}
-        constrainWidth
-        fade="bottom"
-        height="100%"
-      >
-        <div className={s.waterfallHttpDetailContent}>
-          <div className={s.requestUrlRow}>
-            <Typography.CodeSmallInline as="span" className={s.methodBadge}>
-              {spanOperation(span)}
-            </Typography.CodeSmallInline>
-            <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>
-              {url || 'No URL recorded'}
-            </Typography.Body>
-          </div>
-          <div className={s.httpMetaRow}>
-            {statusCode && metaChip('Status', statusCode)}
-            {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}
-            {metaChip('Start', `+${formatDuration(offsetMs)}`)}
-            {requestId && metaChip('Request', `#${requestId}`)}
-            {attempt && metaChip('Attempt', attempt)}
-            {source && metaChip('Source', table ? `${source}.${table}` : source)}
-          </div>
-          <div className={s.waterfallHttpTabRow}>
-            <div className={s.tabList} role="tablist" aria-label="HTTP span details">
-              {tabs.map((tab) => (
-                <button
-                  aria-controls={`http-detail-${span.spanId}-${tab.id}`}
-                  aria-selected={activeTab === tab.id}
-                  className={classNames(s.tabTrigger, {
-                    [s.tabTriggerActive]: activeTab === tab.id,
-                  })}
-                  id={`http-detail-tab-${span.spanId}-${tab.id}`}
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  role="tab"
-                  type="button"
-                >
-                  <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
-                </button>
-              ))}
-            </div>
-            <div className={s.copyButtonGroup}>
-              {hasSeparateRawCopy && (
-                <Button.TextButton
-                  disabled={!rawCopyValue}
-                  onClick={() => copyValueToClipboard(rawCopyValue, 'raw')}
-                  size="22"
-                  variant="secondary"
-                >
-                  {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
-                </Button.TextButton>
-              )}
-              <Button.TextButton
-                disabled={!copyValue}
-                onClick={() => copyValueToClipboard(copyValue, 'formatted')}
-                size="22"
-                variant="secondary"
-              >
-                {copyState === 'formatted'
-                  ? 'Copied'
-                  : copyState === 'failed'
-                    ? 'Copy failed'
-                    : 'Copy formatted'}
-              </Button.TextButton>
-            </div>
-          </div>
-          <section
-            aria-labelledby={`http-detail-tab-${span.spanId}-${activeTab}`}
-            className={s.waterfallHttpDetailSection}
-            id={`http-detail-${span.spanId}-${activeTab}`}
-            role="tabpanel"
-          >
-            <BodyViewer
-              emptyText={activeBody.emptyText}
-              kind={activeBody.kind}
-              rawValue={activeBody.rawValue}
-              value={activeBody.value}
-            />
-          </section>
-          <details>
-            <summary className={s.detailsSummary}>
-              <Typography.Body as="span" variant="tertiary">
-                Span attributes
-              </Typography.Body>
-            </summary>
-            <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
-          </details>
+      <div className={s.waterfallHttpDetailContent}>
+        <div className={s.requestUrlRow}>
+          <Typography.CodeSmallInline as="span" className={s.methodBadge}>
+            {spanOperation(span)}
+          </Typography.CodeSmallInline>
+          <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>
+            {url || 'No URL recorded'}
+          </Typography.Body>
         </div>
-      </ScrollArea.Container>
+        <div className={s.httpMetaRow}>
+          {statusCode && metaChip('Status', statusCode)}
+          {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}
+          {metaChip('Start', `+${formatDuration(offsetMs)}`)}
+          {requestId && metaChip('Request', `#${requestId}`)}
+          {attempt && metaChip('Attempt', attempt)}
+          {source && metaChip('Source', table ? `${source}.${table}` : source)}
+        </div>
+        <div className={s.waterfallHttpTabRow}>
+          <div className={s.tabList} role="tablist" aria-label="HTTP span details">
+            {tabs.map((tab) => (
+              <button
+                aria-controls={`http-detail-${span.spanId}-${tab.id}`}
+                aria-selected={activeTab === tab.id}
+                className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
+                id={`http-detail-tab-${span.spanId}-${tab.id}`}
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                role="tab"
+                type="button"
+              >
+                <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
+              </button>
+            ))}
+          </div>
+          <div className={s.copyButtonGroup}>
+            {hasSeparateRawCopy && (
+              <Button.TextButton disabled={!rawCopyValue} onClick={() => copyValueToClipboard(rawCopyValue, 'raw')} size="22" variant="secondary">
+                {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
+              </Button.TextButton>
+            )}
+            <Button.TextButton disabled={!copyValue} onClick={() => copyValueToClipboard(copyValue, 'formatted')} size="22" variant="secondary">
+              {copyState === 'formatted' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy formatted'}
+            </Button.TextButton>
+          </div>
+        </div>
+        <section
+          aria-labelledby={`http-detail-tab-${span.spanId}-${activeTab}`}
+          className={s.waterfallHttpDetailSection}
+          id={`http-detail-${span.spanId}-${activeTab}`}
+          role="tabpanel"
+        >
+          <BodyViewer emptyText={activeBody.emptyText} kind={activeBody.kind} rawValue={activeBody.rawValue} value={activeBody.value} />
+        </section>
+        <details>
+          <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>
+          <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
+        </details>
+      </div>
     </div>
   )
 }

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -2,11 +2,20 @@ import { useEffect, useState } from 'react'
 import classNames from 'classnames'
 
 import * as Button from '@/wax/components/button'
+import * as ScrollArea from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 import type { TraceSpan } from '@/generated/coral/v1/traces_pb'
 
 import * as s from '../traces-page.css'
-import { formatDuration, formatDurationFromNanos, parseJsonObject, spanRequestLine, spanUrl } from './trace-utils'
+import {
+  formatDuration,
+  formatDurationFromNanos,
+  parseJsonObject,
+  spanRequestEndpoint,
+  spanRequestLine,
+  spanRequestOperation,
+  spanUrl,
+} from './trace-utils'
 
 type JsonValue = Record<string, unknown> | unknown[] | string | number | boolean | null
 type BodyKind = 'request' | 'response'
@@ -22,10 +31,7 @@ const REQUEST_BODY_PRESENT_ATTR = 'http.request.body.present'
 const RESPONSE_BODY_PRESENT_ATTR = 'http.response.body.present'
 const REQUEST_BODY_SIZE_ATTR = 'http.request.body.size'
 const RESPONSE_BODY_SIZE_ATTR = 'http.response.body.size'
-const BODY_ATTRIBUTE_KEYS = new Set([
-  REQUEST_BODY_ATTR,
-  RESPONSE_BODY_ATTR,
-])
+const BODY_ATTRIBUTE_KEYS = new Set([REQUEST_BODY_ATTR, RESPONSE_BODY_ATTR])
 const BODY_DETAILS = {
   request: {
     label: 'Request body',
@@ -90,6 +96,7 @@ function formatDetailValue(value: JsonValue | undefined): string {
   if (value === undefined || value === null || value === '') return ''
   if (typeof value === 'string') {
     const parsedValue = parseMaybeJson(value)
+    if (parsedValue === undefined) return ''
     return typeof parsedValue === 'string' ? value : formatJsonValue(parsedValue)
   }
   return formatJsonValue(value)
@@ -98,6 +105,10 @@ function formatDetailValue(value: JsonValue | undefined): string {
 function formatRawValue(value: unknown, formatted: string): string {
   if (value === undefined || value === null || value === '') return ''
   return typeof value === 'string' ? value : formatted
+}
+
+function hasBodyValue(value: JsonValue | undefined): boolean {
+  return value !== undefined && value !== null && value !== ''
 }
 
 interface GraphqlBodyPreview {
@@ -152,6 +163,7 @@ function bodyPreview(kind: BodyKind, value: unknown, rawValue: unknown): BodyPre
 
   if (typeof value === 'string') {
     const parsedValue = parseMaybeJson(value)
+    if (parsedValue === undefined) return undefined
     if (typeof parsedValue === 'string') {
       return {
         formattedText: value,
@@ -198,7 +210,7 @@ function BodyViewer({
   emptyText: string
   kind: BodyKind
   rawValue: unknown
-  value: unknown
+  value: JsonValue | undefined
 }) {
   const preview = bodyPreview(kind, value, rawValue)
 
@@ -232,7 +244,9 @@ function BodyViewer({
   return (
     <div className={s.bodyViewer}>
       <div className={s.bodyViewerHeader}>
-        <Typography.BodySmallStrong as="span">{graphqlBodyTitle(bodyKind)}</Typography.BodySmallStrong>
+        <Typography.BodySmallStrong as="span">
+          {graphqlBodyTitle(bodyKind)}
+        </Typography.BodySmallStrong>
         <div className={s.bodyMetaRow}>
           {operationName && metaChip('Operation', operationName)}
           {operationType && metaChip('Type', operationType)}
@@ -354,8 +368,8 @@ function preferredHttpDetailTab(
   requestBody: JsonValue | undefined,
   paramsValue: Record<string, string | string[]> | undefined,
 ): HttpDetailTab {
-  if (responseBody) return 'response'
-  if (requestBody) return 'request'
+  if (hasBodyValue(responseBody)) return 'response'
+  if (hasBodyValue(requestBody)) return 'request'
   if (paramsValue) return 'params'
   return 'response'
 }
@@ -445,6 +459,8 @@ export function HttpSpanDetail({
   const source = attrText(attrs['coral.source'])
   const table = attrText(attrs['coral.table'])
   const requestLine = spanRequestLine(span)
+  const requestOperation = spanRequestOperation(span)
+  const requestEndpoint = spanRequestEndpoint(span)
 
   useEffect(() => setActiveTab(preferredTab), [preferredTab, span.spanId])
   useEffect(() => setCopyState('idle'), [activeTab, span.spanId])
@@ -472,7 +488,30 @@ export function HttpSpanDetail({
     >
       <div className={s.waterfallHttpDetailHeader}>
         <div className={s.waterfallHttpDetailTitle}>
-          <Typography.CodeSmallInlineStrong as="span" className={s.requestLine} truncate>{requestLine || 'No URL recorded'}</Typography.CodeSmallInlineStrong>
+          {requestOperation || requestEndpoint ? (
+            <span className={s.requestLine}>
+              {requestOperation && (
+                <Typography.CodeSmallInlineStrong as="span" className={s.methodBadge}>
+                  {requestOperation}
+                </Typography.CodeSmallInlineStrong>
+              )}
+              {requestEndpoint && (
+                <Typography.BodySmall
+                  as="span"
+                  className={s.requestEndpoint}
+                  data-request-endpoint="true"
+                  variant="tertiary"
+                  truncate
+                >
+                  {requestEndpoint}
+                </Typography.BodySmall>
+              )}
+            </span>
+          ) : (
+            <Typography.CodeSmallInlineStrong as="span" className={s.requestLine} truncate>
+              {requestLine || 'No URL recorded'}
+            </Typography.CodeSmallInlineStrong>
+          )}
         </div>
         <div className={s.waterfallHttpDetailHeaderActions}>
           <Button.IconButton
@@ -500,57 +539,84 @@ export function HttpSpanDetail({
           />
         </div>
       </div>
-      <div className={s.waterfallHttpDetailContent}>
-
-        <div className={s.httpMetaRow}>
-          {statusCode && metaChip('Status', statusCode)}
-          {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}
-          {metaChip('Start', `+${formatDuration(offsetMs)}`)}
-          {requestId && metaChip('Request', `#${requestId}`)}
-          {attempt && metaChip('Attempt', attempt)}
-          {source && metaChip('Source', table ? `${source}.${table}` : source)}
-        </div>
-        <div className={s.waterfallHttpTabRow}>
-          <div className={s.tabList} role="tablist" aria-label="HTTP span details">
-            {tabs.map((tab) => (
-              <button
-                aria-controls={`http-detail-${span.spanId}-${tab.id}`}
-                aria-selected={activeTab === tab.id}
-                className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
-                id={`http-detail-tab-${span.spanId}-${tab.id}`}
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                role="tab"
-                type="button"
+      <ScrollArea.Container
+        className={s.waterfallHttpDetailScroll}
+        constrainWidth
+        fade="bottom"
+        height="100%"
+      >
+        <div className={s.waterfallHttpDetailContent}>
+          <div className={s.httpMetaRow}>
+            {statusCode && metaChip('Status', statusCode)}
+            {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}
+            {metaChip('Start', `${formatDuration(offsetMs)}`)}
+            {requestId && metaChip('Request', `#${requestId}`)}
+            {attempt && metaChip('Attempt', attempt)}
+            {source && metaChip('Source', table ? `${source}.${table}` : source)}
+          </div>
+          <div className={s.waterfallHttpTabRow}>
+            <div className={s.tabList} role="tablist" aria-label="HTTP span details">
+              {tabs.map((tab) => (
+                <button
+                  aria-controls={`http-detail-${span.spanId}-${tab.id}`}
+                  aria-selected={activeTab === tab.id}
+                  className={classNames(s.tabTrigger, {
+                    [s.tabTriggerActive]: activeTab === tab.id,
+                  })}
+                  id={`http-detail-tab-${span.spanId}-${tab.id}`}
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  role="tab"
+                  type="button"
+                >
+                  <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
+                </button>
+              ))}
+            </div>
+            <div className={s.copyButtonGroup}>
+              {hasSeparateRawCopy && (
+                <Button.TextButton
+                  disabled={!rawCopyValue}
+                  onClick={() => copyValueToClipboard(rawCopyValue, 'raw')}
+                  size="22"
+                  variant="secondary"
+                >
+                  {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
+                </Button.TextButton>
+              )}
+              <Button.TextButton
+                disabled={!copyValue}
+                onClick={() => copyValueToClipboard(copyValue, 'formatted')}
+                size="22"
+                variant="secondary"
               >
-                <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
-              </button>
-            ))}
-          </div>
-          <div className={s.copyButtonGroup}>
-            {hasSeparateRawCopy && (
-              <Button.TextButton disabled={!rawCopyValue} onClick={() => copyValueToClipboard(rawCopyValue, 'raw')} size="22" variant="secondary">
-                {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
+                {formattedCopyLabel(copyState)}
               </Button.TextButton>
-            )}
-            <Button.TextButton disabled={!copyValue} onClick={() => copyValueToClipboard(copyValue, 'formatted')} size="22" variant="secondary">
-              {formattedCopyLabel(copyState)}
-            </Button.TextButton>
+            </div>
           </div>
+          <section
+            aria-labelledby={`http-detail-tab-${span.spanId}-${activeTab}`}
+            className={s.waterfallHttpDetailSection}
+            id={`http-detail-${span.spanId}-${activeTab}`}
+            role="tabpanel"
+          >
+            <BodyViewer
+              emptyText={activeBody.emptyText}
+              kind={activeBody.kind}
+              rawValue={activeBody.rawValue}
+              value={activeBody.value}
+            />
+          </section>
+          <details>
+            <summary className={s.detailsSummary}>
+              <Typography.Body as="span" variant="tertiary">
+                Span attributes
+              </Typography.Body>
+            </summary>
+            <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
+          </details>
         </div>
-        <section
-          aria-labelledby={`http-detail-tab-${span.spanId}-${activeTab}`}
-          className={s.waterfallHttpDetailSection}
-          id={`http-detail-${span.spanId}-${activeTab}`}
-          role="tabpanel"
-        >
-          <BodyViewer emptyText={activeBody.emptyText} kind={activeBody.kind} rawValue={activeBody.rawValue} value={activeBody.value} />
-        </section>
-        <details>
-          <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>
-          <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
-        </details>
-      </div>
+      </ScrollArea.Container>
     </div>
   )
 }

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -214,25 +214,20 @@ function BodyViewer({
   }
 
   const { bodyKind, data, errors, operationName, operationType, query, variables } = preview.graphql
+  const errorCountLabel = Array.isArray(errors) ? `${errors.length}` : 'present'
+  const dataCountLabel = Array.isArray(data) ? `${data.length}` : 'present'
+  const variablesCountLabel = Array.isArray(variables) ? `${variables.length}` : 'present'
 
   return (
     <div className={s.bodyViewer}>
       <div className={s.bodyViewerHeader}>
-        <Typography.BodySmallStrong as="span">
-          {bodyKind === 'request' ? 'GraphQL request' : 'GraphQL response'}
-        </Typography.BodySmallStrong>
+        <Typography.BodySmallStrong as="span">{graphqlBodyTitle(bodyKind)}</Typography.BodySmallStrong>
         <div className={s.bodyMetaRow}>
           {operationName && metaChip('Operation', operationName)}
           {operationType && metaChip('Type', operationType)}
-          {variables !== undefined &&
-            metaChip('Variables', Array.isArray(variables) ? `${variables.length}` : 'present')}
-          {Array.isArray(errors)
-            ? metaChip('Errors', `${errors.length}`)
-            : errors !== undefined
-              ? metaChip('Errors', 'present')
-              : null}
-          {data !== undefined &&
-            metaChip('Data', Array.isArray(data) ? `${data.length}` : 'present')}
+          {variables !== undefined && metaChip('Variables', variablesCountLabel)}
+          {errors !== undefined && metaChip('Errors', errorCountLabel)}
+          {data !== undefined && metaChip('Data', dataCountLabel)}
         </div>
       </div>
       {query !== undefined && (
@@ -258,6 +253,15 @@ function BodyViewer({
       {rawBodyDetails}
     </div>
   )
+}
+
+function graphqlBodyTitle(kind: BodyKind) {
+  switch (kind) {
+    case 'request':
+      return 'GraphQL request'
+    case 'response':
+      return 'GraphQL response'
+  }
 }
 
 interface ActiveBodyState {
@@ -322,25 +326,62 @@ function formatBytes(value: unknown): string | undefined {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function bodyEmptyText(
-  kind: 'request' | 'response',
-  attrs: Record<string, unknown>,
-  truncated: boolean,
-) {
-  const label = kind === 'request' ? 'Request body' : 'Response body'
-  const size = formatBytes(
-    attrs[kind === 'request' ? REQUEST_BODY_SIZE_ATTR : RESPONSE_BODY_SIZE_ATTR],
-  )
-  const present =
-    kind === 'request'
-      ? attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
-      : attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size)
+function bodyEmptyText(kind: BodyKind, attrs: Record<string, unknown>, truncated: boolean) {
+  const label = bodyLabel(kind)
+  const size = formatBytes(attrs[bodySizeAttr(kind)])
+  const present = bodyPresent(kind, attrs, size)
 
   if (truncated)
     return `${label} was truncated${size ? ` (${size})` : ''}, but no preview was recorded.`
   if (present)
     return `${label} was present${size ? ` (${size})` : ''}, but content was not captured.`
   return `No ${kind} body was recorded for this request.`
+}
+
+function bodyLabel(kind: BodyKind) {
+  switch (kind) {
+    case 'request':
+      return 'Request body'
+    case 'response':
+      return 'Response body'
+  }
+}
+
+function bodySizeAttr(kind: BodyKind) {
+  switch (kind) {
+    case 'request':
+      return REQUEST_BODY_SIZE_ATTR
+    case 'response':
+      return RESPONSE_BODY_SIZE_ATTR
+  }
+}
+
+function bodyPresent(kind: BodyKind, attrs: Record<string, unknown>, size: string | undefined) {
+  switch (kind) {
+    case 'request':
+      return attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
+    case 'response':
+      return attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size)
+  }
+}
+
+function preferredHttpDetailTab(responseBody: JsonValue, requestBody: JsonValue, paramsValue: Record<string, string | string[]> | undefined): HttpDetailTab {
+  if (responseBody) return 'response'
+  if (requestBody) return 'request'
+  if (paramsValue) return 'params'
+  return 'response'
+}
+
+function formattedCopyLabel(copyState: CopyKind | 'failed' | 'idle') {
+  switch (copyState) {
+    case 'formatted':
+      return 'Copied'
+    case 'failed':
+      return 'Copy failed'
+    case 'idle':
+    case 'raw':
+      return 'Copy formatted'
+  }
 }
 
 function metaChip(label: string, value: React.ReactNode) {
@@ -383,13 +424,7 @@ export function HttpSpanDetail({
   const requestBodyTruncated = attrBool(attrs[REQUEST_BODY_TRUNCATED_ATTR])
   const responseBodyTruncated = attrBool(attrs[RESPONSE_BODY_TRUNCATED_ATTR])
   const paramsValue = Object.keys(params).length ? params : undefined
-  const preferredTab: HttpDetailTab = responseBody
-    ? 'response'
-    : requestBody
-      ? 'request'
-      : paramsValue
-        ? 'params'
-        : 'response'
+  const preferredTab = preferredHttpDetailTab(responseBody, requestBody, paramsValue)
   const tabs: Array<{ id: HttpDetailTab; label: string }> = [
     { id: 'params', label: 'Params' },
     { id: 'request', label: `Request body${requestBodyTruncated ? ' (truncated)' : ''}` },
@@ -520,7 +555,7 @@ export function HttpSpanDetail({
               </Button.TextButton>
             )}
             <Button.TextButton disabled={!copyValue} onClick={() => copyValueToClipboard(copyValue, 'formatted')} size="22" variant="secondary">
-              {copyState === 'formatted' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy formatted'}
+              {formattedCopyLabel(copyState)}
             </Button.TextButton>
           </div>
         </div>

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -15,8 +15,10 @@ import {
 } from './trace-utils'
 
 type JsonValue = Record<string, unknown> | unknown[] | string | number | boolean | null
+type BodyKind = 'request' | 'response'
 type HttpDetailTab = 'params' | 'request' | 'response'
 type CopyKind = 'formatted' | 'raw'
+type CopyState = CopyKind | 'failed' | 'idle'
 
 const REQUEST_BODY_ATTR = 'coral.http.request.body'
 const RESPONSE_BODY_ATTR = 'coral.http.response.body'
@@ -26,7 +28,22 @@ const REQUEST_BODY_PRESENT_ATTR = 'http.request.body.present'
 const RESPONSE_BODY_PRESENT_ATTR = 'http.response.body.present'
 const REQUEST_BODY_SIZE_ATTR = 'http.request.body.size'
 const RESPONSE_BODY_SIZE_ATTR = 'http.response.body.size'
-const BODY_ATTRIBUTE_KEYS = new Set([REQUEST_BODY_ATTR, RESPONSE_BODY_ATTR])
+const BODY_ATTRIBUTE_KEYS = new Set([
+  REQUEST_BODY_ATTR,
+  RESPONSE_BODY_ATTR,
+])
+const BODY_DETAILS = {
+  request: {
+    label: 'Request body',
+    presentAttr: REQUEST_BODY_PRESENT_ATTR,
+    sizeAttr: REQUEST_BODY_SIZE_ATTR,
+  },
+  response: {
+    label: 'Response body',
+    presentAttr: RESPONSE_BODY_PRESENT_ATTR,
+    sizeAttr: RESPONSE_BODY_SIZE_ATTR,
+  },
+} satisfies Record<BodyKind, { label: string; presentAttr: string; sizeAttr: string }>
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -87,8 +104,6 @@ function formatRawValue(value: unknown, formatted: string): string {
   if (value === undefined || value === null || value === '') return ''
   return typeof value === 'string' ? value : formatted
 }
-
-type BodyKind = 'request' | 'response'
 
 interface GraphqlBodyPreview {
   bodyKind: BodyKind
@@ -175,6 +190,10 @@ function BodySection({ children, label }: { children: React.ReactNode; label: st
   )
 }
 
+function presenceCountLabel(value: JsonValue) {
+  return Array.isArray(value) ? `${value.length}` : 'present'
+}
+
 function BodyViewer({
   emptyText,
   kind,
@@ -214,9 +233,6 @@ function BodyViewer({
   }
 
   const { bodyKind, data, errors, operationName, operationType, query, variables } = preview.graphql
-  const errorCountLabel = Array.isArray(errors) ? `${errors.length}` : 'present'
-  const dataCountLabel = Array.isArray(data) ? `${data.length}` : 'present'
-  const variablesCountLabel = Array.isArray(variables) ? `${variables.length}` : 'present'
 
   return (
     <div className={s.bodyViewer}>
@@ -225,9 +241,9 @@ function BodyViewer({
         <div className={s.bodyMetaRow}>
           {operationName && metaChip('Operation', operationName)}
           {operationType && metaChip('Type', operationType)}
-          {variables !== undefined && metaChip('Variables', variablesCountLabel)}
-          {errors !== undefined && metaChip('Errors', errorCountLabel)}
-          {data !== undefined && metaChip('Data', dataCountLabel)}
+          {variables !== undefined && metaChip('Variables', presenceCountLabel(variables))}
+          {errors !== undefined && metaChip('Errors', presenceCountLabel(errors))}
+          {data !== undefined && metaChip('Data', presenceCountLabel(data))}
         </div>
       </div>
       {query !== undefined && (
@@ -327,42 +343,15 @@ function formatBytes(value: unknown): string | undefined {
 }
 
 function bodyEmptyText(kind: BodyKind, attrs: Record<string, unknown>, truncated: boolean) {
-  const label = bodyLabel(kind)
-  const size = formatBytes(attrs[bodySizeAttr(kind)])
-  const present = bodyPresent(kind, attrs, size)
+  const bodyDetails = BODY_DETAILS[kind]
+  const size = formatBytes(attrs[bodyDetails.sizeAttr])
+  const present = attrBool(attrs[bodyDetails.presentAttr]) || (kind === 'response' && Boolean(size))
 
   if (truncated)
-    return `${label} was truncated${size ? ` (${size})` : ''}, but no preview was recorded.`
+    return `${bodyDetails.label} was truncated${size ? ` (${size})` : ''}, but no preview was recorded.`
   if (present)
-    return `${label} was present${size ? ` (${size})` : ''}, but content was not captured.`
+    return `${bodyDetails.label} was present${size ? ` (${size})` : ''}, but content was not captured.`
   return `No ${kind} body was recorded for this request.`
-}
-
-function bodyLabel(kind: BodyKind) {
-  switch (kind) {
-    case 'request':
-      return 'Request body'
-    case 'response':
-      return 'Response body'
-  }
-}
-
-function bodySizeAttr(kind: BodyKind) {
-  switch (kind) {
-    case 'request':
-      return REQUEST_BODY_SIZE_ATTR
-    case 'response':
-      return RESPONSE_BODY_SIZE_ATTR
-  }
-}
-
-function bodyPresent(kind: BodyKind, attrs: Record<string, unknown>, size: string | undefined) {
-  switch (kind) {
-    case 'request':
-      return attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
-    case 'response':
-      return attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size)
-  }
 }
 
 function preferredHttpDetailTab(responseBody: JsonValue, requestBody: JsonValue, paramsValue: Record<string, string | string[]> | undefined): HttpDetailTab {
@@ -372,7 +361,7 @@ function preferredHttpDetailTab(responseBody: JsonValue, requestBody: JsonValue,
   return 'response'
 }
 
-function formattedCopyLabel(copyState: CopyKind | 'failed' | 'idle') {
+function formattedCopyLabel(copyState: CopyState) {
   switch (copyState) {
     case 'formatted':
       return 'Copied'
@@ -413,7 +402,7 @@ export function HttpSpanDetail({
   traceStart: bigint
 }) {
   const [activeTab, setActiveTab] = useState<HttpDetailTab>('response')
-  const [copyState, setCopyState] = useState<CopyKind | 'failed' | 'idle'>('idle')
+  const [copyState, setCopyState] = useState<CopyState>('idle')
   const attrs = parseJsonObject(span.attributesJson)
   const url = spanUrl(span)
   const params = requestParams(url)

--- a/ui/src/views/traces/trace-utils.ts
+++ b/ui/src/views/traces/trace-utils.ts
@@ -113,6 +113,13 @@ function endpointLine(url: string): string {
   }
 }
 
+function sourceTableLabel(attrs: JsonObject): string | undefined {
+  const source = attrFrom(attrs, 'coral.source')
+  const table = attrFrom(attrs, 'coral.table')
+  if (source && table) return `${source}.${table}`
+  return table
+}
+
 export function spanOperation(span: TraceSpan): string {
   const attrs = parseJsonObject(span.attributesJson)
   const method = attrFrom(attrs, 'http.request.method')
@@ -123,9 +130,15 @@ export function spanOperation(span: TraceSpan): string {
 }
 
 export function spanRequestLine(span: TraceSpan): string {
-  const operation = spanDisplayLabel(span)
-  const url = spanUrl(span)
+  const attrs = parseJsonObject(span.attributesJson)
+  const method = attrFrom(attrs, 'http.request.method')
+  const url = attrFrom(attrs, 'url.full') ?? attrFrom(attrs, 'http.url') ?? ''
   const endpoint = endpointLine(url)
+  const target = sourceTableLabel(attrs)
+  const operation = method && target ? `${method} ${target}` : method ?? target
+
+  if (!operation && !endpoint) return spanDisplayLabel(span)
+  if (!operation) return endpoint
   if (!endpoint) return operation
   return `${operation} ${endpoint}`
 }
@@ -133,15 +146,12 @@ export function spanRequestLine(span: TraceSpan): string {
 export function spanDisplayLabel(span: TraceSpan): string {
   const attrs = parseJsonObject(span.attributesJson)
   const method = attrFrom(attrs, 'http.request.method')
-  const source = attrFrom(attrs, 'coral.source')
-  const table = attrFrom(attrs, 'coral.table')
+  const target = sourceTableLabel(attrs)
   const url = attrFrom(attrs, 'url.full') ?? attrFrom(attrs, 'http.url') ?? ''
 
-  if (method && source && table) return `${method} ${source}.${table}`
-  if (method && table) return `${method} ${table}`
+  if (method && target) return `${method} ${target}`
   if (method && url) return `${method} ${endpointPath(url)}`
-  if (source && table) return `${source}.${table}`
-  if (table) return table
+  if (target) return target
   if (span.name === 'coral.query') return 'Query'
   return span.name || span.scopeName || 'span'
 }

--- a/ui/src/views/traces/trace-utils.ts
+++ b/ui/src/views/traces/trace-utils.ts
@@ -129,13 +129,22 @@ export function spanOperation(span: TraceSpan): string {
   return table ?? span.name
 }
 
-export function spanRequestLine(span: TraceSpan): string {
+export function spanRequestOperation(span: TraceSpan): string {
   const attrs = parseJsonObject(span.attributesJson)
   const method = attrFrom(attrs, 'http.request.method')
-  const url = attrFrom(attrs, 'url.full') ?? attrFrom(attrs, 'http.url') ?? ''
-  const endpoint = endpointLine(url)
   const target = sourceTableLabel(attrs)
-  const operation = method && target ? `${method} ${target}` : method ?? target
+
+  if (method && target) return `${method} ${target}`
+  return method ?? target ?? ''
+}
+
+export function spanRequestEndpoint(span: TraceSpan): string {
+  return endpointLine(spanUrl(span))
+}
+
+export function spanRequestLine(span: TraceSpan): string {
+  const operation = spanRequestOperation(span)
+  const endpoint = spanRequestEndpoint(span)
 
   if (!operation && !endpoint) return spanDisplayLabel(span)
   if (!operation) return endpoint

--- a/ui/src/views/traces/trace-utils.ts
+++ b/ui/src/views/traces/trace-utils.ts
@@ -103,6 +103,16 @@ function endpointPath(url: string): string {
   }
 }
 
+function endpointLine(url: string): string {
+  if (!url) return ''
+  try {
+    const parsed = new URL(url, 'http://coral.local')
+    return `${parsed.pathname}${parsed.search}`
+  } catch {
+    return endpointPath(url)
+  }
+}
+
 export function spanOperation(span: TraceSpan): string {
   const attrs = parseJsonObject(span.attributesJson)
   const method = attrFrom(attrs, 'http.request.method')
@@ -110,6 +120,14 @@ export function spanOperation(span: TraceSpan): string {
   if (method && table) return `${method} ${table}`
   if (method) return method
   return table ?? span.name
+}
+
+export function spanRequestLine(span: TraceSpan): string {
+  const operation = spanDisplayLabel(span)
+  const url = spanUrl(span)
+  const endpoint = endpointLine(url)
+  if (!endpoint) return operation
+  return `${operation} ${endpoint}`
 }
 
 export function spanDisplayLabel(span: TraceSpan): string {

--- a/ui/src/wax/components/scroll-area/scroll-area.css.ts
+++ b/ui/src/wax/components/scroll-area/scroll-area.css.ts
@@ -68,7 +68,6 @@ export const viewportFade = styleVariants({
 
 export const content = style({
   display: 'block',
-  height: '100%',
 })
 
 export const scrollbar = style({

--- a/ui/src/wax/components/scroll-area/scroll-area.css.ts
+++ b/ui/src/wax/components/scroll-area/scroll-area.css.ts
@@ -68,6 +68,7 @@ export const viewportFade = styleVariants({
 
 export const content = style({
   display: 'block',
+  height: '100%',
 })
 
 export const scrollbar = style({

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -67,7 +67,6 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await page.getByRole('button', { name: /^GET github\.pull_requests\b/ }).click()
 
   await expect(page.getByText('GET github.pull_requests /repos/oxide/coral/pulls?state=open&per_page=25')).toBeVisible()
-  await expect(page.getByText('Span details')).toHaveCount(0)
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
   await expect(page.getByText('Raw body')).toBeVisible()
@@ -76,12 +75,11 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await review.pause()
 })
 
-test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({
-  network,
-  page,
-  review,
-}) => {
-  test.slow()
+test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({ network, page, review }, testInfo) => {
+  if (process.env.PW_UI_SCREENCAST) {
+    testInfo.setTimeout(45_000)
+  }
+
   network.use(...traceHandlers.tenTraceDetailFlow)
 
   await review.chapter(
@@ -90,10 +88,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   )
   await page.goto('/')
   await page.getByPlaceholder('Search queries...').fill('playwright')
-  await page
-    .getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)
-    .click()
-  await review.pause()
+  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
 
   await expect(page.getByRole('treeitem')).toHaveCount(14)
 
@@ -103,14 +98,12 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"channels": [')).toBeVisible()
   await expect(page.getByText('"name": "eng-coral"')).toBeVisible()
-  await review.pause()
 
   await review.chapter('Inspect malformed JSON fallback', 'Verify raw text stays readable when parsing fails')
   await page.getByRole('button', { name: /^GET github\.issue_previews\b/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('{"oops":')).toBeVisible()
-  await review.pause()
 
   await review.chapter('Inspect GraphQL bodies', 'Check request metadata, variables, and response data for GraphQL traffic')
   await page.getByRole('button', { name: /^POST linear\.issues\b/ }).click()
@@ -149,10 +142,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
 
   await expect(githubResponsePanel.getByText('GraphQL response')).toBeVisible()
   await expect(githubResponsePanel.getByText('Errors', { exact: true }).first()).toBeVisible()
-  await expect(
-    githubResponsePanel.getByText('"message": "GraphQL warnings should still be visible"'),
-  ).toBeVisible()
-  await review.pause()
+  await expect(githubResponsePanel.getByText('"message": "GraphQL warnings should still be visible"')).toBeVisible()
 
   await review.chapter('Inspect missing and truncated bodies', 'Confirm the viewer still explains empty and truncated body states')
   await page.getByRole('button', { name: /^POST linear\.issue_request_preview\b/ }).click()
@@ -162,10 +152,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   await page.getByRole('button', { name: /^GET github\.pull_request_archive\b/ }).click()
   await page.getByRole('tab', { name: 'Response body (truncated)' }).click()
 
-  await expect(
-    page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.'),
-  ).toBeVisible()
-  await review.pause()
+  await expect(page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.')).toBeVisible()
 })
 
 test('shows trace storage unavailable errors from TraceService', async ({

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -73,6 +73,9 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByText('GET github.pull_requests')).toBeVisible()
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
+  await page.screenshot({ path: 'test-results/AOL-6-review.png', fullPage: true })
+  await expect(page.getByText('Raw body')).toBeVisible()
+  await expect(page.getByText('Span attributes')).toBeVisible()
   await review.pause()
 })
 

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -67,7 +67,6 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await page.getByRole('button', { name: /^GET github\.pull_requests\b/ }).click()
 
   await expect(page.getByText('GET github.pull_requests /repos/oxide/coral/pulls?state=open&per_page=25')).toBeVisible()
-  await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
   await expect(page.getByText('Raw body')).toBeVisible()
   await expect(page.getByText('Span attributes')).toBeVisible()
@@ -75,11 +74,7 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await review.pause()
 })
 
-test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({ network, page, review }, testInfo) => {
-  if (process.env.PW_UI_SCREENCAST) {
-    testInfo.setTimeout(45_000)
-  }
-
+test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({ network, page, review }) => {
   network.use(...traceHandlers.tenTraceDetailFlow)
 
   await review.chapter(
@@ -128,6 +123,17 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
     responsePanel.getByText('"title": "Add Playwright coverage for trace stream"'),
   ).toBeVisible()
   await review.pause()
+})
+
+test('renders GraphQL detection without /graphql and body absence states', async ({ network, page, review }) => {
+  network.use(...traceHandlers.tenTraceDetailFlow)
+
+  await review.chapter('Open the trace with span details', 'Load the selected trace so the remaining body viewer states can be inspected')
+  await page.goto('/')
+  await page.getByPlaceholder('Search queries...').fill('playwright')
+  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
+
+  await expect(page.getByRole('treeitem')).toHaveCount(14)
 
   await review.chapter('Inspect GraphQL detection without /graphql', 'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears')
   await page.getByRole('button', { name: /^POST github\.repository_search\b/ }).click()
@@ -153,6 +159,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   await page.getByRole('tab', { name: 'Response body (truncated)' }).click()
 
   await expect(page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.')).toBeVisible()
+  await review.pause()
 })
 
 test('shows trace storage unavailable errors from TraceService', async ({

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -63,13 +63,10 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByRole('treeitem')).toHaveCount(14)
   await review.pause()
 
-  await review.chapter(
-    'Open a span inspector',
-    'Expand one HTTP span and inspect the captured response body',
-  )
-  await page.getByRole('button', { name: /GET github\.pull_requests/ }).click()
+  await review.chapter('Open a span inspector', 'Expand one HTTP span and inspect the captured response body')
+  await page.getByRole('button', { name: /^GET github\.pull_requests\b/ }).click()
 
-  await expect(page.getByText('GET github.pull_requests')).toBeVisible()
+  await expect(page.getByText('GET github.pull_requests /repos/oxide/coral/pulls?state=open&per_page=25')).toBeVisible()
   await expect(page.getByText('Span details')).toHaveCount(0)
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
@@ -100,32 +97,23 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
 
   await expect(page.getByRole('treeitem')).toHaveCount(14)
 
-  await review.chapter(
-    'Inspect pretty JSON',
-    'Open a structured response body and confirm it is pretty printed',
-  )
-  await page.getByRole('button', { name: /GET slack\.conversations/ }).click()
+  await review.chapter('Inspect pretty JSON', 'Open a structured response body and confirm it is pretty printed')
+  await page.getByRole('button', { name: /^GET slack\.conversations\b/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"channels": [')).toBeVisible()
   await expect(page.getByText('"name": "eng-coral"')).toBeVisible()
   await review.pause()
 
-  await review.chapter(
-    'Inspect malformed JSON fallback',
-    'Verify raw text stays readable when parsing fails',
-  )
-  await page.getByRole('button', { name: /GET github\.issue_previews/ }).click()
+  await review.chapter('Inspect malformed JSON fallback', 'Verify raw text stays readable when parsing fails')
+  await page.getByRole('button', { name: /^GET github\.issue_previews\b/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('{"oops":')).toBeVisible()
   await review.pause()
 
-  await review.chapter(
-    'Inspect GraphQL bodies',
-    'Check request metadata, variables, and response data for GraphQL traffic',
-  )
-  await page.getByRole('button', { name: /POST linear\.issues\b/ }).click()
+  await review.chapter('Inspect GraphQL bodies', 'Check request metadata, variables, and response data for GraphQL traffic')
+  await page.getByRole('button', { name: /^POST linear\.issues\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
   const requestPanel = page.getByRole('tabpanel', { name: 'Request body' })
   const responsePanel = page.getByRole('tabpanel', { name: 'Response body' })
@@ -148,11 +136,8 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   ).toBeVisible()
   await review.pause()
 
-  await review.chapter(
-    'Inspect GraphQL detection without /graphql',
-    'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears',
-  )
-  await page.getByRole('button', { name: /POST github\.repository_search/ }).click()
+  await review.chapter('Inspect GraphQL detection without /graphql', 'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears')
+  await page.getByRole('button', { name: /^POST github\.repository_search\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
   const githubRequestPanel = page.getByRole('tabpanel', { name: 'Request body' })
   const githubResponsePanel = page.getByRole('tabpanel', { name: 'Response body' })
@@ -169,17 +154,12 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   ).toBeVisible()
   await review.pause()
 
-  await review.chapter(
-    'Inspect missing and truncated bodies',
-    'Confirm the viewer still explains empty and truncated body states',
-  )
-  await page.getByRole('button', { name: /POST linear\.issue_request_preview/ }).click()
+  await review.chapter('Inspect missing and truncated bodies', 'Confirm the viewer still explains empty and truncated body states')
+  await page.getByRole('button', { name: /^POST linear\.issue_request_preview\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
 
-  await expect(
-    page.getByText('Request body was present (2.0 KB), but content was not captured.'),
-  ).toBeVisible()
-  await page.getByRole('button', { name: /GET github\.pull_request_archive/ }).click()
+  await expect(page.getByText('Request body was present (2.0 KB), but content was not captured.')).toBeVisible()
+  await page.getByRole('button', { name: /^GET github\.pull_request_archive\b/ }).click()
   await page.getByRole('tab', { name: 'Response body (truncated)' }).click()
 
   await expect(

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -63,10 +63,19 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByRole('treeitem')).toHaveCount(14)
   await review.pause()
 
-  await review.chapter('Open a span inspector', 'Expand one HTTP span and inspect the captured response body')
+  await review.chapter(
+    'Open a span inspector',
+    'Expand one HTTP span and inspect the captured response body',
+  )
   await page.getByRole('button', { name: /^GET github\.pull_requests\b/ }).click()
 
-  await expect(page.getByText('GET github.pull_requests /repos/oxide/coral/pulls?state=open&per_page=25')).toBeVisible()
+  const spanInspector = page.locator('[data-span-inspector="true"]')
+  await expect(spanInspector.getByText('GET github.pull_requests')).toBeVisible()
+  await expect(
+    spanInspector.locator('[data-request-endpoint="true"]', {
+      hasText: '/repos/oxide/coral/pulls?state=open&per_page=25',
+    }),
+  ).toBeVisible()
   await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
   await expect(page.getByText('Raw body')).toBeVisible()
   await expect(page.getByText('Span attributes')).toBeVisible()
@@ -74,7 +83,11 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await review.pause()
 })
 
-test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({ network, page, review }) => {
+test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({
+  network,
+  page,
+  review,
+}) => {
   network.use(...traceHandlers.tenTraceDetailFlow)
 
   await review.chapter(
@@ -83,24 +96,35 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   )
   await page.goto('/')
   await page.getByPlaceholder('Search queries...').fill('playwright')
-  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
+  await page
+    .getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)
+    .click()
 
   await expect(page.getByRole('treeitem')).toHaveCount(14)
 
-  await review.chapter('Inspect pretty JSON', 'Open a structured response body and confirm it is pretty printed')
+  await review.chapter(
+    'Inspect pretty JSON',
+    'Open a structured response body and confirm it is pretty printed',
+  )
   await page.getByRole('button', { name: /^GET slack\.conversations\b/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"channels": [')).toBeVisible()
   await expect(page.getByText('"name": "eng-coral"')).toBeVisible()
 
-  await review.chapter('Inspect malformed JSON fallback', 'Verify raw text stays readable when parsing fails')
+  await review.chapter(
+    'Inspect malformed JSON fallback',
+    'Verify raw text stays readable when parsing fails',
+  )
   await page.getByRole('button', { name: /^GET github\.issue_previews\b/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('{"oops":')).toBeVisible()
 
-  await review.chapter('Inspect GraphQL bodies', 'Check request metadata, variables, and response data for GraphQL traffic')
+  await review.chapter(
+    'Inspect GraphQL bodies',
+    'Check request metadata, variables, and response data for GraphQL traffic',
+  )
   await page.getByRole('button', { name: /^POST linear\.issues\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
   const requestPanel = page.getByRole('tabpanel', { name: 'Request body' })
@@ -125,17 +149,29 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   await review.pause()
 })
 
-test('renders GraphQL detection without /graphql and body absence states', async ({ network, page, review }) => {
+test('renders GraphQL detection without /graphql and body absence states', async ({
+  network,
+  page,
+  review,
+}) => {
   network.use(...traceHandlers.tenTraceDetailFlow)
 
-  await review.chapter('Open the trace with span details', 'Load the selected trace so the remaining body viewer states can be inspected')
+  await review.chapter(
+    'Open the trace with span details',
+    'Load the selected trace so the remaining body viewer states can be inspected',
+  )
   await page.goto('/')
   await page.getByPlaceholder('Search queries...').fill('playwright')
-  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
+  await page
+    .getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)
+    .click()
 
   await expect(page.getByRole('treeitem')).toHaveCount(14)
 
-  await review.chapter('Inspect GraphQL detection without /graphql', 'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears')
+  await review.chapter(
+    'Inspect GraphQL detection without /graphql',
+    'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears',
+  )
   await page.getByRole('button', { name: /^POST github\.repository_search\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
   const githubRequestPanel = page.getByRole('tabpanel', { name: 'Request body' })
@@ -148,17 +184,26 @@ test('renders GraphQL detection without /graphql and body absence states', async
 
   await expect(githubResponsePanel.getByText('GraphQL response')).toBeVisible()
   await expect(githubResponsePanel.getByText('Errors', { exact: true }).first()).toBeVisible()
-  await expect(githubResponsePanel.getByText('"message": "GraphQL warnings should still be visible"')).toBeVisible()
+  await expect(
+    githubResponsePanel.getByText('"message": "GraphQL warnings should still be visible"'),
+  ).toBeVisible()
 
-  await review.chapter('Inspect missing and truncated bodies', 'Confirm the viewer still explains empty and truncated body states')
+  await review.chapter(
+    'Inspect missing and truncated bodies',
+    'Confirm the viewer still explains empty and truncated body states',
+  )
   await page.getByRole('button', { name: /^POST linear\.issue_request_preview\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
 
-  await expect(page.getByText('Request body was present (2.0 KB), but content was not captured.')).toBeVisible()
+  await expect(
+    page.getByText('Request body was present (2.0 KB), but content was not captured.'),
+  ).toBeVisible()
   await page.getByRole('button', { name: /^GET github\.pull_request_archive\b/ }).click()
   await page.getByRole('tab', { name: 'Response body (truncated)' }).click()
 
-  await expect(page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.')).toBeVisible()
+  await expect(
+    page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.'),
+  ).toBeVisible()
   await review.pause()
 })
 

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -73,9 +73,9 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByText('GET github.pull_requests')).toBeVisible()
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
-  await page.screenshot({ path: 'test-results/AOL-6-review.png', fullPage: true })
   await expect(page.getByText('Raw body')).toBeVisible()
   await expect(page.getByText('Span attributes')).toBeVisible()
+  await page.screenshot({ path: 'test-results/AOL-6-review.png', fullPage: true })
   await review.pause()
 })
 
@@ -84,6 +84,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   page,
   review,
 }) => {
+  test.slow()
   network.use(...traceHandlers.tenTraceDetailFlow)
 
   await review.chapter(

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -69,8 +69,8 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   )
   await page.getByRole('button', { name: /GET github\.pull_requests/ }).click()
 
-  await expect(page.getByText('Span details')).toBeVisible()
   await expect(page.getByText('GET github.pull_requests')).toBeVisible()
+  await expect(page.getByText('Span details')).toHaveCount(0)
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
   await expect(page.getByText('Raw body')).toBeVisible()


### PR DESCRIPTION
## Summary

- Tightened trace span detail review coverage by splitting the long body-viewer flow into two shorter Playwright cases.
- Clarified body presence checks so valid falsy JSON bodies are not confused with missing bodies.
- Kept the reviewer-requested span detail screenshot capture.

| before | after |
| --- | --- |
| ![image.png](https://app.graphite.com/user-attachments/assets/6645e0d0-2b10-4d3a-b5e0-d3076aea5631.png) | <br>![CleanShot 2026-05-25 at 13.14.26@2x.png](https://app.graphite.com/user-attachments/assets/eef2bbc6-17c8-47aa-8d71-8733f76129a8.png)<br> |

|

## Linear

- AOL-6: fix : traces span detail

## Changes

- Removed the unnecessary per-test timeout override from the body-viewer review flow.
- Split JSON/GraphQL/fallback coverage into two focused tests so screencast mode stays within the default Playwright budget.
- Added an explicit body-value presence helper and narrowed the body viewer value type for maintainability.

## Validation

- `npm run test:ui --prefix ui`
- `npm run test:ui:screencast:headless --prefix ui`
- `npm run test:ui:type-check --prefix ui`
- `git diff --check`

## Artifacts

- Screenshot: `ui/test-results/AOL-6-review.png`
- Screencasts:
    - `ui/test-results/traces-lists-10-traces-sea-24a7a--and-opens-a-span-inspector-chromium/lists-10-traces-searches-one-opens-its-details-and-opens-a-span-inspector.webm`
    - `ui/test-results/traces-renders-trace-reque-5a49a-GraphQL-and-fallback-states-chromium/renders-trace-request-and-response-bodies-with-json-graphql-and-fallback-states.webm`
    - `ui/test-results/traces-renders-GraphQL-det-554d2-hql-and-body-absence-states-chromium/renders-graphql-detection-without-graphql-and-body-absence-states.webm`
    - `ui/test-results/traces-shows-an-empty-trac-54b18-t-contacting-a-Coral-server-chromium/shows-an-empty-trace-stream-without-contacting-a-coral-server.webm`
    - `ui/test-results/traces-shows-trace-storage-6cf29-le-errors-from-TraceService-chromium/shows-trace-storage-unavailable-errors-from-traceservice.webm`

## Notes

- UI-only change.
- Dependencies and Chromium were already present during reviewer validation.
- Reviewer refinement committed as `759d2fef` (`refactor(ui): clarify trace body presence checks`).