### PR TITLE
docs(sources): document search authoring semantics

### DIFF
--- a/docs/guides/write-a-custom-source.mdx
+++ b/docs/guides/write-a-custom-source.mdx
@@ -35,8 +35,24 @@ Source authoring works well as an agent-driven workflow. Point your coding agent
 2. Lints the file with `coral source lint ./my-source.yaml` to catch errors before installing
 3. Adds it with `coral source add --file ./my-source.yaml`
 4. Validates with `coral source test my_source`
-5. Inspects `coral.tables`, `coral.columns` and `coral.inputs` to check the shape
+5. Inspects `coral.tables`, `coral.table_functions`, `coral.columns`, `coral.filters` and `coral.inputs` to check the shape
 6. Refines and repeats until the tables look right
+
+## Search and retrieval endpoints
+
+Model provider-native search as a source-scoped table function, not as a normal table filter. If an API endpoint accepts a query string and returns provider-ranked candidates, declare it under `functions` with `kind: search`, `search_limits`, explicit arguments, and result columns. Search functions are called from SQL with named arguments:
+
+```sql
+SELECT id, title, url
+FROM github.search_issues(q => 'repo:withcoral/coral source functions')
+LIMIT 10
+```
+
+Search functions are retrieval surfaces, not exhaustive tables. They preserve provider ranking and may return only the best candidates for a query. Use result columns such as `id`, `url`, `title`, `score`, `rank`, or provider timestamps so users and agents can decide which candidate to inspect next. If the search row is intentionally thin, expose enough stable identifiers for follow-up queries against ordinary detail tables.
+
+Table functions are more general than search. Use the default table function kind for parameterized non-retrieval operations, such as scoped child collections, time-range logs, metrics queries, or detail operations that do not map cleanly to a stable table.
+
+Use ordinary table filters for exact lookup, required scoping, or provider-side filtering on list endpoints. Use `mode: contains` only when the provider has normal substring matching for a table filter. Provider-ranked retrieval belongs in a `kind: search` function with `search_limits`; table filters are not retrieval surfaces.
 
 ## Column naming for nested fields
 
@@ -201,5 +217,5 @@ For the full set of HTTP response, pagination, auth, and column fields, see [HTT
 
 - **Lint before installing.** `coral source lint ./my-source.yaml` is a fast local precheck because it does not install the source or require credentials.
 - **Start small.** Begin with one table and a few columns. Validate with `coral source test`, check `coral.columns` and `coral.inputs`, then expand.
-- **Use `coral.tables`, `coral.columns`, and `coral.inputs`.** They show you exactly what Coral sees after adding a source — including required filters and column metadata.
+- **Use `coral.tables`, `coral.table_functions`, `coral.columns`, `coral.filters`, and `coral.inputs`.** They show you exactly what Coral sees after adding a source — including required filters, search functions, and column metadata.
 - **Look at bundled sources for patterns.** The bundled source specs in the repo under `sources/core/` are working examples of HTTP pagination, response parsing, auth, and inputs.

--- a/docs/reference/source-spec-reference.mdx
+++ b/docs/reference/source-spec-reference.mdx
@@ -322,10 +322,16 @@ In this minimal example:
 ### HTTP table functions
 
 HTTP sources can declare source-scoped table functions for provider-native
-operations that return rows, such as search endpoints. A function adds
+operations that return rows and need invocation arguments. A function adds
 invocation arguments, but it still owns the same execution shape as an HTTP
 table: request, response mapping, pagination, and result columns. It does not
 need a backing table.
+
+Table functions are not only for search. Use the default `kind: table` for
+parameterized non-retrieval operations, such as scoped child collections,
+time-range log queries, metrics queries, or detail operations that do not map
+cleanly to a stable table. Use `kind: search` only for provider-ranked
+retrieval surfaces.
 
 ```yaml
 functions:
@@ -385,9 +391,10 @@ Use `bind.arg` when a SQL argument should populate a differently named request
 argument. Function request values can then reference those bound arguments with
 `from: arg`.
 
-`kind: search` marks a provider-native retrieval surface. Search functions
-return provider-ranked candidate rows, not exhaustive SQL-filtered tables. Use
-named SQL arguments when calling them:
+`kind: search` marks a provider-ranked retrieval surface. Search functions
+return provider-ranked candidate rows, not exhaustive SQL-filtered tables.
+Other table functions keep the default `kind: table`. Use named SQL arguments
+when calling table functions:
 
 ```sql
 SELECT id, title, html_url
@@ -407,10 +414,9 @@ filters:
     mode: contains
 ```
 
-`mode: search` is still accepted as a legacy compatibility marker for existing
-virtual-filter tables and is exposed through `coral.filters.filter_mode` and
-`coral.columns.filter_mode`. Do not use it for new provider-native retrieval
-surfaces; declare those as `kind: search` functions instead.
+Provider-ranked retrieval surfaces must be declared as `kind: search`
+functions. Table filters are for exact lookup, required scoping, or ordinary
+provider-side filtering on list/detail tables.
 
 `search_limits` values must be positive. `default_top_k` and `max_top_k` are
 capped at 1000, `max_calls_per_query` is capped at 100, and

--- a/plugins/coral/skills/coral-create-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-create-source-spec/SKILL.md
@@ -55,6 +55,7 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
    - auth
    - variables and secrets
    - tables
+   - table functions for source-scoped parameterized endpoints
    - filters
    - response extraction
    - pagination
@@ -67,7 +68,9 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
    - repo sources or already-named sources: `coral source test <name>`
 6. Inspect the exposed shape:
    - inspect `coral.tables` for visible tables, descriptions, guides, and required filters; keep metadata queries bounded with `LIMIT`/`OFFSET`
+   - inspect `coral.table_functions` for source-scoped functions, arguments, result columns, kind, and search limits
    - inspect `coral.columns` for canonical column metadata, including `is_virtual` and `is_required_filter`; filter by one table or page large column sets
+   - inspect `coral.filters` for normalized table filter names, types, modes, required flags, and descriptions
    - inspect `coral.inputs` to verify variables, secrets, defaults, hints, and required flags
 7. Query representative tables with `coral sql`.
 8. If you are relying on `coral source test`, make sure `test_queries` gives you a basic smoke/connection check for the source.
@@ -81,6 +84,10 @@ Only switch to Coral repo layout when the user is explicitly editing the Coral r
 - Use source secrets for credentials.
 - Keep table names stable and SQL-friendly.
 - Mark filters as required only when the API truly requires them.
+- Use default table functions for parameterized non-retrieval operations, such as scoped child collections, time-range logs, metrics queries, or detail operations that do not map cleanly to a stable table.
+- Use `kind: search` table functions for provider endpoints that accept query text and return ranked candidates.
+- Do not model provider search as a table filter. Use `mode: contains` only for ordinary provider-side substring filters. Provider-ranked retrieval belongs in a `kind: search` function.
+- Include `search_limits` on every `kind: search` function and expose stable result identifiers for follow-up detail queries.
 - Prefer explicit pagination when the API shape is known.
 - Verify pagination with actual row fetches, not only `COUNT(*)`.
 - Add or update `test_queries` when you want `coral source test` to perform a basic smoke/connection check.
@@ -140,7 +147,9 @@ coral source lint ./my-source.yaml
 coral source add --file ./my-source.yaml
 coral source test my_source
 coral sql "SELECT schema_name, table_name, description, required_filters FROM coral.tables WHERE schema_name = 'my_source' ORDER BY schema_name, table_name LIMIT 50 OFFSET 0"
-coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, description FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
+coral sql "SELECT function_name, kind, arguments_json, result_columns_json, search_limits_json FROM coral.table_functions WHERE schema_name = 'my_source' ORDER BY function_name LIMIT 50 OFFSET 0"
+coral sql "SELECT table_name, filter_name, filter_mode, is_required, data_type, description FROM coral.filters WHERE schema_name = 'my_source' ORDER BY table_name, filter_name LIMIT 100 OFFSET 0"
+coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, filter_mode, description FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
 coral sql "SELECT key, kind, value, default_value, hint, required, is_set FROM coral.inputs WHERE schema_name = 'my_source' ORDER BY key"
 ```
 
@@ -160,6 +169,7 @@ For HTTP-backed sources:
 - define `base_url`
 - define auth headers
 - define request path, query, and body only where needed
+- define source-scoped table functions for provider-native operations that require invocation arguments
 - define response `rows_path`
 - define pagination explicitly when the provider pattern is known
 - define typed columns

--- a/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
+++ b/plugins/coral/skills/coral-create-source-spec/references/http-source-checklist.md
@@ -53,6 +53,16 @@ Additional hint guidance:
 - Preserve provider semantics when filter behavior matters.
 - Add `test_queries` once you know which simple query or queries should confirm the source basically works.
 
+## Search and Retrieval
+
+- Use default table functions for parameterized non-retrieval operations, such as scoped child collections, time-range logs, metrics queries, or detail operations that do not map cleanly to a stable table.
+- Use `functions` with `kind: search` for provider-native search endpoints that accept query text and return provider-ranked candidates.
+- Add `search_limits` to every `kind: search` function.
+- Keep search function arguments close to the provider API, and use `bind.arg` when the SQL argument name should differ from the request argument name.
+- Search result columns should include stable identifiers and useful candidate metadata such as title, URL, score, rank, or timestamps when the provider returns them.
+- Do not model provider-native search as a table filter. Use `mode: contains` only for ordinary substring filters on normal list/detail tables. Provider-ranked retrieval belongs in a `kind: search` function.
+- If a search result is not a complete entity, make sure the returned identifier can be used with ordinary detail tables or required filters.
+
 ## Response Extraction
 
 - Set `rows_path` to the array Coral should read as rows.
@@ -90,7 +100,9 @@ coral source lint ./my-source.yaml
 coral source add --file ./my-source.yaml
 coral source test my_source
 coral sql "SELECT table_name, description, required_filters FROM coral.tables WHERE schema_name = 'my_source' ORDER BY table_name LIMIT 50 OFFSET 0"
-coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, description FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
+coral sql "SELECT function_name, kind, arguments_json, result_columns_json, search_limits_json FROM coral.table_functions WHERE schema_name = 'my_source' ORDER BY function_name LIMIT 50 OFFSET 0"
+coral sql "SELECT table_name, filter_name, filter_mode, is_required, data_type, description FROM coral.filters WHERE schema_name = 'my_source' ORDER BY table_name, filter_name LIMIT 100 OFFSET 0"
+coral sql "SELECT table_name, column_name, data_type, is_virtual, is_required_filter, filter_mode, description FROM coral.columns WHERE schema_name = 'my_source' ORDER BY table_name, ordinal_position LIMIT 100 OFFSET 0"
 ```
 
 If the source is named or lives in the Coral repo, add representative `test_queries` for a basic smoke/connection check and run:

--- a/plugins/coral/skills/coral-review-source-spec/SKILL.md
+++ b/plugins/coral/skills/coral-review-source-spec/SKILL.md
@@ -50,7 +50,7 @@ These checks should be based on the authoritative API docs for the API the sourc
 - High-cardinality or expensive endpoints require filters or have conservative `fetch_limit_default` values.
 - Required filters are explicit and described in table `description` or `guide`.
 - Guides tell users how to start, which IDs to join through, and any provider-specific timestamp or query syntax traps.
-- Search-like operations use search filters or table functions when that is clearer than pretending the endpoint is a normal list table.
+- Provider endpoints that accept query text and return ranked candidates use `kind: search` table functions with `search_limits`, stable result identifiers, and useful candidate metadata. Non-retrieval table functions keep the default kind for parameterized operations such as scoped child collections, time-range logs, metrics queries, or detail operations. Ordinary table filters are for exact lookup, scoping, or provider-side filtering; `mode: contains` is only substring matching. Flag provider-native search modeled as a filter and require a `kind: search` function.
 - Table and column names are snake_case, stable, and obvious. Avoid leaking odd provider operation names unless the source is intentionally generated.
 
 ### HTTP and API Semantics


### PR DESCRIPTION
## Summary
- Adds source-author guidance for provider endpoints that accept query text and return ranked candidates in the custom source guide and source-spec reference.
- Clarifies that table functions are general source-scoped row-returning operations: default `kind: table` for parameterized non-retrieval operations, `kind: search` only for provider-ranked retrieval with `search_limits`.
- Updates the canonical `coral-create-source-spec` skill, HTTP checklist, and review skill so agents treat `coral.table_functions` as the general function catalog while using `kind: search` for ranked retrieval surfaces.

## Notes
- `withcoral/skills` is not edited directly; these changes are made under `plugins/coral/skills` and will sync through the existing skills distribution workflow after merge.
- This PR is stacked on top of #610 because it documents the source-authoring contract after the `mode: search` migration/removal work.

## Local validation
- `git diff --check`
- `cargo fmt --check`
- `cargo run --locked -p xtask -- generate-docs --check`
- `cargo run --locked -p xtask -- export-skills --dest <tmpdir>`
