### PR TITLE
feat(sources/community/prometheus): add prometheus community source

### DIFF
--- a/sources/community/prometheus/README.md
+++ b/sources/community/prometheus/README.md
@@ -1,0 +1,151 @@
+# Prometheus Connector (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Prometheus query API)
+**Tables:** 3
+**Default base URL:** `http://127.0.0.1:9090` (override with `PROMETHEUS_BASE_URL`)
+
+Query Prometheus scrape health, firing alerts, and instant PromQL results with SQL.
+Read-only v1 uses unauthenticated HTTP against a base URL that already handles
+auth (typically a local Prometheus server or an authenticating gateway). Pairs
+with the community **k8s** source for alert-to-pod triage when rules expose
+`pod` and `namespace` labels.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Add the manifest from
+this directory:
+
+```bash
+coral source add --file sources/community/prometheus/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
+
+Reference the linked GitHub issue in your PR so maintainers can connect the
+contribution to the prior discussion.
+
+## Authentication and setup
+
+### Local development (recommended for contributors)
+
+A local Prometheus server on port 9090 usually needs no extra Coral auth:
+
+```bash
+export PROMETHEUS_BASE_URL=http://127.0.0.1:9090
+coral source add --file sources/community/prometheus/manifest.yaml
+```
+
+Confirm `http://127.0.0.1:9090/-/healthy` responds before running queries.
+
+### Authenticated gateways (advanced)
+
+v1 does not send `Authorization` headers from Coral. For secured Prometheus,
+point `PROMETHEUS_BASE_URL` at a reverse proxy or gateway that authenticates on
+your behalf. Bearer-token support in the manifest is a potential follow-on.
+
+### Multiple Prometheus instances
+
+Register one Coral source per server (for example `prometheus_dev`,
+`prometheus_prod`), each with its own `PROMETHEUS_BASE_URL`.
+
+## Table categories
+
+### Instant queries
+
+| Table | Description |
+| --- | --- |
+| `query_up` | Scrape health via fixed PromQL `up` |
+| `query_custom` | Arbitrary instant query via required `promql` filter |
+
+### Alerts
+
+| Table | Description |
+| --- | --- |
+| `alerts` | Firing and pending alerts from PromQL `ALERTS` |
+
+## Filters and pagination
+
+`query_custom` requires a `promql` filter with the full PromQL expression.
+`query_up` and `alerts` use fixed queries.
+
+Example:
+
+```sql
+SELECT metric_name, instance, sample_value
+FROM prometheus.query_custom
+WHERE promql = 'kube_pod_status_phase{phase="Pending"}'
+LIMIT 20;
+```
+
+Each table calls `GET /api/v1/query` once. Pagination is `none`; use `LIMIT` and
+aggregations in PromQL to control load.
+
+## Example relationships
+
+| From | To | Join hint |
+| --- | --- | --- |
+| `prometheus.alerts.pod` | `k8s.pods.name` | When alert rules set `pod` |
+| `prometheus.alerts.namespace` | `k8s.pods.namespace` | Scope alerts to a namespace |
+
+## Example queries
+
+### Scrape health (`up`)
+
+```sql
+SELECT metric_name, instance, job, sample_value
+FROM prometheus.query_up
+LIMIT 20;
+```
+
+### Targets not reporting `up`
+
+```sql
+SELECT instance, job, sample_value
+FROM prometheus.query_up
+WHERE sample_value != '1'
+LIMIT 20;
+```
+
+### Firing alerts
+
+```sql
+SELECT alert_name, alert_state, severity, namespace, pod, instance
+FROM prometheus.alerts
+WHERE alert_state = 'firing'
+LIMIT 20;
+```
+
+### Custom PromQL
+
+```sql
+SELECT promql, metric_name, instance, pod, sample_value
+FROM prometheus.query_custom
+WHERE promql = 'sum(rate(container_cpu_usage_seconds_total[5m])) by (pod, namespace)'
+LIMIT 10;
+```
+
+## Validation
+
+```bash
+make lint-sources
+coral source lint sources/community/prometheus/manifest.yaml
+export PROMETHEUS_BASE_URL=http://127.0.0.1:9090
+coral source add --file sources/community/prometheus/manifest.yaml
+coral source test prometheus
+```
+
+## Limitations
+
+- Read-only v1; instant queries (`/api/v1/query`) only, not `query_range`.
+- No bearer-token auth in the manifest; use a local server or authenticated gateway.
+- Sample timestamps and values are strings from Prometheus value tuples.
+- `query_custom` does not validate PromQL; errors surface at query time.
+- High-cardinality PromQL can overload Prometheus; use aggregations and `LIMIT`.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the issue first,
+sign the CLA if this is your first contribution, run `make lint-sources`, and
+open a focused PR titled `feat(sources/community/prometheus): add prometheus community source`.

--- a/sources/community/prometheus/README.md
+++ b/sources/community/prometheus/README.md
@@ -1,6 +1,6 @@
 # Prometheus Connector (Community)
 
-**Version:** 0.1.1
+**Version:** 0.1.2
 **Backend:** HTTP (Prometheus query and alerts APIs)
 **Tables:** 2
 **Default base URL:** `http://127.0.0.1:9090` (override with `PROMETHEUS_BASE_URL`)
@@ -83,6 +83,14 @@ WHERE sample_value < 1
 LIMIT 20;
 ```
 
+> **Caveat:** `query_up` hard-codes Prometheus `limit=500` on `/api/v1/query`,
+> and the SQL `WHERE` filter is applied *after* Coral fetches the response.
+> Prometheus does not guarantee instant-vector ordering, so on a fleet with
+> more than 500 `up` series a down target can be truncated server-side before
+> Coral evaluates `sample_value < 1`. For fleets above ~500 targets, run
+> `up < 1` directly in Prometheus or treat this query as best-effort within
+> the provider-side cap.
+
 ### Firing alerts
 
 ```sql
@@ -91,6 +99,10 @@ FROM prometheus.alerts
 WHERE alert_state = 'firing'
 LIMIT 20;
 ```
+
+> The `/api/v1/alerts` endpoint only returns active alerts, so `alert_state`
+> values are `firing` or `pending`. Inactive alerts are not returned by this
+> API.
 
 ### Optional join to a Kubernetes source
 
@@ -115,6 +127,11 @@ export PROMETHEUS_BASE_URL=http://127.0.0.1:9090
 coral source add --file sources/community/prometheus/manifest.yaml
 coral source test prometheus
 ```
+
+Sanitized output from a real Prometheus instance (`coral source test
+prometheus` plus representative `query_up` and `alerts` queries) is included
+in the pull request description so reviewers can see end-to-end behavior
+without re-running the suite.
 
 ## Limitations
 

--- a/sources/community/prometheus/README.md
+++ b/sources/community/prometheus/README.md
@@ -57,7 +57,7 @@ Register one Coral source per server (for example `prometheus_dev`,
 | Table | Description |
 | --- | --- |
 | `query_up` | Scrape health via fixed PromQL `up` |
-| `query_custom` | Arbitrary instant query via required `promql` filter |
+| `query_custom` | Instant-vector PromQL via required `promql` filter (not scalar/matrix) |
 
 ### Alerts
 
@@ -67,8 +67,11 @@ Register one Coral source per server (for example `prometheus_dev`,
 
 ## Filters and pagination
 
-`query_custom` requires a `promql` filter with the full PromQL expression.
-`query_up` and `alerts` use fixed queries.
+`query_custom` requires a `promql` filter with PromQL that evaluates to an
+instant vector (selectors, `rate(...)`, `sum(...) by (...)`). Scalar literals and
+matrix/range results are not supported in v1. `query_up` and `alerts` use fixed
+queries. Each table has a conservative default fetch cap (`query_up` 500,
+`alerts` 200, `query_custom` 100); use SQL `LIMIT` as well.
 
 Example:
 
@@ -141,8 +144,11 @@ coral source test prometheus
 - Read-only v1; instant queries (`/api/v1/query`) only, not `query_range`.
 - No bearer-token auth in the manifest; use a local server or authenticated gateway.
 - Sample timestamps and values are strings from Prometheus value tuples.
+- `query_custom` supports instant-vector PromQL only; scalar and matrix results
+  return empty or malformed rows.
 - `query_custom` does not validate PromQL; errors surface at query time.
-- High-cardinality PromQL can overload Prometheus; use aggregations and `LIMIT`.
+- Default fetch caps apply per table; high-cardinality PromQL can still overload
+  Prometheus—use aggregations and `LIMIT`.
 
 ## Contributing
 

--- a/sources/community/prometheus/README.md
+++ b/sources/community/prometheus/README.md
@@ -1,15 +1,13 @@
 # Prometheus Connector (Community)
 
-**Version:** 0.1.0
-**Backend:** HTTP (Prometheus query API)
-**Tables:** 3
+**Version:** 0.1.1
+**Backend:** HTTP (Prometheus query and alerts APIs)
+**Tables:** 2
 **Default base URL:** `http://127.0.0.1:9090` (override with `PROMETHEUS_BASE_URL`)
 
-Query Prometheus scrape health, firing alerts, and instant PromQL results with SQL.
-Read-only v1 uses unauthenticated HTTP against a base URL that already handles
-auth (typically a local Prometheus server or an authenticating gateway). Pairs
-with the community **k8s** source for alert-to-pod triage when rules expose
-`pod` and `namespace` labels.
+Query Prometheus scrape health and active alerts with SQL. Read-only v1 uses
+unauthenticated HTTP against a base URL that already handles auth (typically a
+local Prometheus server or an authenticating gateway).
 
 ## Install
 
@@ -50,47 +48,19 @@ your behalf. Bearer-token support in the manifest is a potential follow-on.
 Register one Coral source per server (for example `prometheus_dev`,
 `prometheus_prod`), each with its own `PROMETHEUS_BASE_URL`.
 
-## Table categories
-
-### Instant queries
+## Tables
 
 | Table | Description |
 | --- | --- |
-| `query_up` | Scrape health via fixed PromQL `up` |
-| `query_custom` | Instant-vector PromQL via required `promql` filter (not scalar/matrix) |
+| `query_up` | Scrape health via PromQL `up` (`limit=500` on the query API) |
+| `alerts` | Active alerts from `GET /api/v1/alerts` |
 
-### Alerts
+## Load control
 
-| Table | Description |
-| --- | --- |
-| `alerts` | Firing and pending alerts from PromQL `ALERTS` |
-
-## Filters and pagination
-
-`query_custom` requires a `promql` filter with PromQL that evaluates to an
-instant vector (selectors, `rate(...)`, `sum(...) by (...)`). Scalar literals and
-matrix/range results are not supported in v1. `query_up` and `alerts` use fixed
-queries. Each table has a conservative default fetch cap (`query_up` 500,
-`alerts` 200, `query_custom` 100); use SQL `LIMIT` as well.
-
-Example:
-
-```sql
-SELECT metric_name, instance, sample_value
-FROM prometheus.query_custom
-WHERE promql = 'kube_pod_status_phase{phase="Pending"}'
-LIMIT 20;
-```
-
-Each table calls `GET /api/v1/query` once. Pagination is `none`; use `LIMIT` and
-aggregations in PromQL to control load.
-
-## Example relationships
-
-| From | To | Join hint |
-| --- | --- | --- |
-| `prometheus.alerts.pod` | `k8s.pods.name` | When alert rules set `pod` |
-| `prometheus.alerts.namespace` | `k8s.pods.namespace` | Scope alerts to a namespace |
+Each instant-query table sends Prometheus’s native `limit` query parameter so the
+server does not return unbounded series before Coral applies `fetch_limit_default`
+or SQL `LIMIT`. Treat SQL `LIMIT` as a secondary cap, not a substitute for the
+API `limit`.
 
 ## Example queries
 
@@ -107,26 +77,31 @@ LIMIT 20;
 ```sql
 SELECT instance, job, sample_value
 FROM prometheus.query_up
-WHERE sample_value != '1'
+WHERE sample_value < 1
 LIMIT 20;
 ```
 
 ### Firing alerts
 
 ```sql
-SELECT alert_name, alert_state, severity, namespace, pod, instance
+SELECT alert_name, alert_state, severity, namespace, pod, summary, active_at
 FROM prometheus.alerts
 WHERE alert_state = 'firing'
 LIMIT 20;
 ```
 
-### Custom PromQL
+### Optional join to a Kubernetes source
+
+If you also install a community `k8s` source (not bundled on Coral `main`), you
+can correlate alert labels to pods:
 
 ```sql
-SELECT promql, metric_name, instance, pod, sample_value
-FROM prometheus.query_custom
-WHERE promql = 'sum(rate(container_cpu_usage_seconds_total[5m])) by (pod, namespace)'
-LIMIT 10;
+SELECT a.alert_name, a.pod, a.namespace, p.status
+FROM prometheus.alerts a
+JOIN k8s.pods p
+  ON a.pod = p.name AND a.namespace = p.namespace
+WHERE a.alert_state = 'firing'
+LIMIT 20;
 ```
 
 ## Validation
@@ -141,14 +116,12 @@ coral source test prometheus
 
 ## Limitations
 
-- Read-only v1; instant queries (`/api/v1/query`) only, not `query_range`.
+- Read-only v1; instant queries (`/api/v1/query`) for `query_up` only, not `query_range`.
+- No arbitrary PromQL table in v1 (`query_custom` removed; use Prometheus directly or a follow-on).
+- `alerts` uses `/api/v1/alerts`, not the internal `ALERTS` time series.
+- Native histogram samples populate `sample_histogram`; classic samples use `sample_at` / `sample_value`.
+- `sample_value_raw` preserves the JSON string for special float encodings.
 - No bearer-token auth in the manifest; use a local server or authenticated gateway.
-- Sample timestamps and values are strings from Prometheus value tuples.
-- `query_custom` supports instant-vector PromQL only; scalar and matrix results
-  return empty or malformed rows.
-- `query_custom` does not validate PromQL; errors surface at query time.
-- Default fetch caps apply per table; high-cardinality PromQL can still overload
-  Prometheus—use aggregations and `LIMIT`.
 
 ## Contributing
 

--- a/sources/community/prometheus/README.md
+++ b/sources/community/prometheus/README.md
@@ -53,14 +53,16 @@ Register one Coral source per server (for example `prometheus_dev`,
 | Table | Description |
 | --- | --- |
 | `query_up` | Scrape health via PromQL `up` (`limit=500` on the query API) |
-| `alerts` | Active alerts from `GET /api/v1/alerts` |
+| `alerts` | Active alerts from `GET /api/v1/alerts` (Coral fetch cap only; no API `limit`) |
 
 ## Load control
 
-Each instant-query table sends Prometheus’s native `limit` query parameter so the
-server does not return unbounded series before Coral applies `fetch_limit_default`
-or SQL `LIMIT`. Treat SQL `LIMIT` as a secondary cap, not a substitute for the
-API `limit`.
+`query_up` sends Prometheus’s native `limit=500` query parameter on `/api/v1/query`
+so the server does not return unbounded series before Coral applies
+`fetch_limit_default` or SQL `LIMIT`.
+
+`alerts` uses `GET /api/v1/alerts`, which does not accept a `limit` parameter.
+Coral caps rows at 200 via `fetch_limit_default`; use SQL `LIMIT` on large alert sets.
 
 ## Example queries
 

--- a/sources/community/prometheus/manifest.yaml
+++ b/sources/community/prometheus/manifest.yaml
@@ -4,7 +4,8 @@ dsl_version: 3
 backend: http
 description: >-
   Query Prometheus scrape health and active alerts from Prometheus (self-hosted).
-  Read-only v1 via the HTTP query and alerts APIs with provider-side series limits.
+  Read-only v1 tables: query_up, alerts. Uses /api/v1/query (up) and /api/v1/alerts.
+  No arbitrary PromQL table in v1.
 inputs:
   PROMETHEUS_BASE_URL:
     kind: variable

--- a/sources/community/prometheus/manifest.yaml
+++ b/sources/community/prometheus/manifest.yaml
@@ -21,7 +21,9 @@ tables:
   - name: query_up
     description: Instant vector for the `up` metric (target scrape health).
     guide: |
-      Fixed PromQL `up`. No required filters. Use `LIMIT` on large fleets.
+      Fixed PromQL `up`. No required filters. Coral caps fetched rows at 500;
+      use SQL `LIMIT` on large fleets.
+    fetch_limit_default: 500
     request:
       method: GET
       path: /api/v1/query
@@ -89,7 +91,8 @@ tables:
     description: Firing and pending alert series from the internal `ALERTS` metric.
     guide: |
       Fixed PromQL `ALERTS`. Filter on `alert_state`. Join `pod` and `namespace` to
-      k8s.pods when your rules expose those labels.
+      k8s.pods when your rules expose those labels. Coral caps fetched rows at 200.
+    fetch_limit_default: 200
     request:
       method: GET
       path: /api/v1/query
@@ -176,10 +179,16 @@ tables:
             - metric
 
   - name: query_custom
-    description: Instant query with PromQL supplied through the `promql` filter.
+    description: >-
+      Instant-vector PromQL via the `promql` filter. Scalar and matrix results
+      from `/api/v1/query` are not supported in v1.
     guide: |
-      Required filter: `promql` (full PromQL expression, for example `rate(http_requests_total[5m])`).
-      Prefer aggregations and label filters to limit cardinality.
+      Required filter: `promql` with an expression that returns an instant vector
+      (for example `up`, `rate(http_requests_total[5m])`, or `sum(...) by (pod)`).
+      Scalar literals (for example `42`) and range/matrix selectors are not
+      supported. Prefer aggregations and label filters to limit cardinality.
+      Coral caps fetched rows at 100.
+    fetch_limit_default: 100
     filters:
       - name: promql
         required: true

--- a/sources/community/prometheus/manifest.yaml
+++ b/sources/community/prometheus/manifest.yaml
@@ -1,10 +1,10 @@
 name: prometheus
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-
-  Query Prometheus scrape health, firing alerts, and instant PromQL results from
-  Prometheus (self-hosted). Read-only v1; instant queries via the HTTP query API.
+  Query Prometheus scrape health and active alerts from Prometheus (self-hosted).
+  Read-only v1 via the HTTP query and alerts APIs with provider-side series limits.
 inputs:
   PROMETHEUS_BASE_URL:
     kind: variable
@@ -21,8 +21,9 @@ tables:
   - name: query_up
     description: Instant vector for the `up` metric (target scrape health).
     guide: |
-      Fixed PromQL `up`. No required filters. Coral caps fetched rows at 500;
-      use SQL `LIMIT` on large fleets.
+      Fixed PromQL `up`. Sends Prometheus `limit=500` on the query API. Scalar and
+      matrix results are not returned by this table. Native histogram samples expose
+      `sample_histogram` JSON; classic samples use `sample_at` and `sample_value`.
     fetch_limit_default: 500
     request:
       method: GET
@@ -31,6 +32,9 @@ tables:
         - name: query
           from: literal
           value: "up"
+        - name: limit
+          from: literal
+          value: "500"
     response:
       rows_path:
         - data
@@ -62,24 +66,44 @@ tables:
           path:
             - metric
             - job
-      - name: sample_time_unix
-        type: Utf8
+      - name: sample_at
+        type: Timestamp
         nullable: true
-        description: Sample timestamp from the value tuple (string).
+        description: Sample timestamp (Unix seconds) from the value tuple.
         expr:
-          kind: path
-          path:
-            - value
-            - "0"
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - value
+              - "0"
       - name: sample_value
-        type: Utf8
+        type: Float64
         nullable: true
-        description: Sample value from the value tuple (1 = up).
+        description: Numeric sample value from the value tuple.
         expr:
           kind: path
           path:
             - value
             - "1"
+      - name: sample_value_raw
+        type: Utf8
+        nullable: true
+        description: Raw JSON sample value string (preserves NaN/Inf encoding).
+        expr:
+          kind: path
+          path:
+            - value
+            - "1"
+      - name: sample_histogram
+        type: Json
+        nullable: true
+        description: Native histogram payload when the sample uses `histogram` instead of `value`.
+        expr:
+          kind: path
+          path:
+            - histogram
       - name: metric_labels
         type: Json
         expr:
@@ -88,22 +112,19 @@ tables:
             - metric
 
   - name: alerts
-    description: Firing and pending alert series from the internal `ALERTS` metric.
+    description: Active alerts from the Prometheus alerts API.
     guide: |
-      Fixed PromQL `ALERTS`. Filter on `alert_state`. Join `pod` and `namespace` to
-      k8s.pods when your rules expose those labels. Coral caps fetched rows at 200.
+      Uses `GET /api/v1/alerts` (not the internal `ALERTS` metric). Filter on
+      `alert_state` (`firing`, `pending`, `inactive`). Sends `limit=200` on the API.
+      For custom PromQL, use a follow-on table or query Prometheus directly.
     fetch_limit_default: 200
     request:
       method: GET
-      path: /api/v1/query
-      query:
-        - name: query
-          from: literal
-          value: "ALERTS"
+      path: /api/v1/alerts
     response:
       rows_path:
         - data
-        - result
+        - alerts
     pagination:
       mode: none
     columns:
@@ -113,23 +134,50 @@ tables:
         expr:
           kind: path
           path:
-            - metric
+            - labels
             - alertname
       - name: alert_state
+        type: Utf8
+        nullable: true
+        description: Alert state (`firing`, `pending`, or `inactive`).
+        expr:
+          kind: path
+          path:
+            - state
+      - name: active_at
+        type: Timestamp
+        nullable: true
+        description: When the alert became active.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - activeAt
+      - name: summary
         type: Utf8
         nullable: true
         expr:
           kind: path
           path:
-            - metric
-            - alertstate
+            - annotations
+            - summary
+      - name: description
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - annotations
+            - description
       - name: severity
         type: Utf8
         nullable: true
         expr:
           kind: path
           path:
-            - metric
+            - labels
             - severity
       - name: pod
         type: Utf8
@@ -137,7 +185,7 @@ tables:
         expr:
           kind: path
           path:
-            - metric
+            - labels
             - pod
       - name: namespace
         type: Utf8
@@ -145,7 +193,7 @@ tables:
         expr:
           kind: path
           path:
-            - metric
+            - labels
             - namespace
       - name: instance
         type: Utf8
@@ -153,7 +201,7 @@ tables:
         expr:
           kind: path
           path:
-            - metric
+            - labels
             - instance
       - name: job
         type: Utf8
@@ -161,116 +209,27 @@ tables:
         expr:
           kind: path
           path:
-            - metric
+            - labels
             - job
-      - name: sample_value
-        type: Utf8
+      - name: value
+        type: Float64
         nullable: true
+        description: Alert value when present.
         expr:
           kind: path
           path:
             - value
-            - "1"
-      - name: metric_labels
+      - name: labels
         type: Json
-        expr:
-          kind: path
-          path:
-            - metric
-
-  - name: query_custom
-    description: >-
-      Instant-vector PromQL via the `promql` filter. Scalar and matrix results
-      from `/api/v1/query` are not supported in v1.
-    guide: |
-      Required filter: `promql` with an expression that returns an instant vector
-      (for example `up`, `rate(http_requests_total[5m])`, or `sum(...) by (pod)`).
-      Scalar literals (for example `42`) and range/matrix selectors are not
-      supported. Prefer aggregations and label filters to limit cardinality.
-      Coral caps fetched rows at 100.
-    fetch_limit_default: 100
-    filters:
-      - name: promql
-        required: true
-    request:
-      method: GET
-      path: /api/v1/query
-      query:
-        - name: query
-          from: filter
-          key: promql
-    response:
-      rows_path:
-        - data
-        - result
-    pagination:
-      mode: none
-    columns:
-      - name: promql
-        type: Utf8
-        description: Echoes the promql filter that produced this row.
-        expr:
-          kind: from_filter
-          key: promql
-      - name: metric_name
-        type: Utf8
         nullable: true
         expr:
           kind: path
           path:
-            - metric
-            - "__name__"
-      - name: instance
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - metric
-            - instance
-      - name: pod
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - metric
-            - pod
-      - name: namespace
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - metric
-            - namespace
-      - name: job
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - metric
-            - job
-      - name: sample_time_unix
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - value
-            - "0"
-      - name: sample_value
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - value
-            - "1"
-      - name: metric_labels
+            - labels
+      - name: annotations
         type: Json
+        nullable: true
         expr:
           kind: path
           path:
-            - metric
+            - annotations

--- a/sources/community/prometheus/manifest.yaml
+++ b/sources/community/prometheus/manifest.yaml
@@ -1,0 +1,267 @@
+name: prometheus
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Prometheus scrape health, firing alerts, and instant PromQL results from
+  Prometheus (self-hosted). Read-only v1; instant queries via the HTTP query API.
+inputs:
+  PROMETHEUS_BASE_URL:
+    kind: variable
+    default: http://127.0.0.1:9090
+    hint: |
+      Prometheus server root URL with no trailing slash. Use the default for a local
+      server on port 9090. For secured deployments, point at a reverse proxy or
+      gateway that injects authentication. v1 does not send bearer tokens from Coral.
+base_url: "{{input.PROMETHEUS_BASE_URL}}"
+test_queries:
+  - SELECT metric_name, instance, sample_value FROM prometheus.query_up LIMIT 5
+  - SELECT alert_name, alert_state FROM prometheus.alerts WHERE alert_state = 'firing' LIMIT 10
+tables:
+  - name: query_up
+    description: Instant vector for the `up` metric (target scrape health).
+    guide: |
+      Fixed PromQL `up`. No required filters. Use `LIMIT` on large fleets.
+    request:
+      method: GET
+      path: /api/v1/query
+      query:
+        - name: query
+          from: literal
+          value: "up"
+    response:
+      rows_path:
+        - data
+        - result
+    pagination:
+      mode: none
+    columns:
+      - name: metric_name
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - "__name__"
+      - name: instance
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - instance
+      - name: job
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - job
+      - name: sample_time_unix
+        type: Utf8
+        nullable: true
+        description: Sample timestamp from the value tuple (string).
+        expr:
+          kind: path
+          path:
+            - value
+            - "0"
+      - name: sample_value
+        type: Utf8
+        nullable: true
+        description: Sample value from the value tuple (1 = up).
+        expr:
+          kind: path
+          path:
+            - value
+            - "1"
+      - name: metric_labels
+        type: Json
+        expr:
+          kind: path
+          path:
+            - metric
+
+  - name: alerts
+    description: Firing and pending alert series from the internal `ALERTS` metric.
+    guide: |
+      Fixed PromQL `ALERTS`. Filter on `alert_state`. Join `pod` and `namespace` to
+      k8s.pods when your rules expose those labels.
+    request:
+      method: GET
+      path: /api/v1/query
+      query:
+        - name: query
+          from: literal
+          value: "ALERTS"
+    response:
+      rows_path:
+        - data
+        - result
+    pagination:
+      mode: none
+    columns:
+      - name: alert_name
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - alertname
+      - name: alert_state
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - alertstate
+      - name: severity
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - severity
+      - name: pod
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - pod
+      - name: namespace
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - namespace
+      - name: instance
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - instance
+      - name: job
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - job
+      - name: sample_value
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - value
+            - "1"
+      - name: metric_labels
+        type: Json
+        expr:
+          kind: path
+          path:
+            - metric
+
+  - name: query_custom
+    description: Instant query with PromQL supplied through the `promql` filter.
+    guide: |
+      Required filter: `promql` (full PromQL expression, for example `rate(http_requests_total[5m])`).
+      Prefer aggregations and label filters to limit cardinality.
+    filters:
+      - name: promql
+        required: true
+    request:
+      method: GET
+      path: /api/v1/query
+      query:
+        - name: query
+          from: filter
+          key: promql
+    response:
+      rows_path:
+        - data
+        - result
+    pagination:
+      mode: none
+    columns:
+      - name: promql
+        type: Utf8
+        description: Echoes the promql filter that produced this row.
+        expr:
+          kind: from_filter
+          key: promql
+      - name: metric_name
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - "__name__"
+      - name: instance
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - instance
+      - name: pod
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - pod
+      - name: namespace
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - namespace
+      - name: job
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - metric
+            - job
+      - name: sample_time_unix
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - value
+            - "0"
+      - name: sample_value
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - value
+            - "1"
+      - name: metric_labels
+        type: Json
+        expr:
+          kind: path
+          path:
+            - metric

--- a/sources/community/prometheus/manifest.yaml
+++ b/sources/community/prometheus/manifest.yaml
@@ -115,8 +115,10 @@ tables:
     description: Active alerts from the Prometheus alerts API.
     guide: |
       Uses `GET /api/v1/alerts` (not the internal `ALERTS` metric). Filter on
-      `alert_state` (`firing`, `pending`, `inactive`). Sends `limit=200` on the API.
-      For custom PromQL, use a follow-on table or query Prometheus directly.
+      `alert_state` (`firing`, `pending`, `inactive`). The alerts API has no
+      `limit` parameter; Coral caps fetched rows at 200 via `fetch_limit_default`.
+      Use SQL `LIMIT` on large alert sets. For custom PromQL, use a follow-on table
+      or query Prometheus directly.
     fetch_limit_default: 200
     request:
       method: GET

--- a/sources/community/prometheus/manifest.yaml
+++ b/sources/community/prometheus/manifest.yaml
@@ -1,5 +1,5 @@
 name: prometheus
-version: 0.1.1
+version: 0.1.2
 dsl_version: 3
 backend: http
 description: >-
@@ -115,8 +115,9 @@ tables:
   - name: alerts
     description: Active alerts from the Prometheus alerts API.
     guide: |
-      Uses `GET /api/v1/alerts` (not the internal `ALERTS` metric). Filter on
-      `alert_state` (`firing`, `pending`, `inactive`). The alerts API has no
+      Uses `GET /api/v1/alerts` (not the internal `ALERTS` metric). The endpoint
+      only returns active alerts, so `alert_state` is `firing` or `pending`
+      (inactive alerts are not exposed by this API). The alerts API has no
       `limit` parameter; Coral caps fetched rows at 200 via `fetch_limit_default`.
       Use SQL `LIMIT` on large alert sets. For custom PromQL, use a follow-on table
       or query Prometheus directly.
@@ -142,7 +143,7 @@ tables:
       - name: alert_state
         type: Utf8
         nullable: true
-        description: Alert state (`firing`, `pending`, or `inactive`).
+        description: Alert state from the active alerts endpoint (`firing` or `pending`).
         expr:
           kind: path
           path:


### PR DESCRIPTION
Closes #473

## Summary

Adds a new read-only community Prometheus source under `sources/community/prometheus/`.
Query scrape health via PromQL `up` and active alerts via `GET /api/v1/alerts`.

v1 sends Prometheus’s native `limit` parameter on instant queries, exposes typed
sample values and timestamps, and intentionally excludes an arbitrary-PromQL
table until per-result-type handling is complete.

## Tables

| Table | Description |
| --- | --- |
| `query_up` | Scrape health (PromQL `up`, server-side `limit=500`) |
| `alerts` | Active alerts from `GET /api/v1/alerts` (Coral fetch cap only; the API has no `limit`) |

## Files

- `sources/community/prometheus/manifest.yaml`
- `sources/community/prometheus/README.md`

## Setup

```bash
export PROMETHEUS_BASE_URL=http://127.0.0.1:9090
coral source add --file sources/community/prometheus/manifest.yaml
```

## Auth

Unauthenticated HTTP against `PROMETHEUS_BASE_URL` (local server or an
authenticating gateway). Bearer-token auth is intentionally deferred to a
follow-on.

## Why it changed

Addresses prior maintainer feedback:

- Provider-side `limit=500` on `/api/v1/query` for `query_up` (`fetch_limit_default` is *also* set but cannot replace a server-side cap).
- `/api/v1/alerts` instead of the synthetic `ALERTS` metric, with active-only states documented.
- Typed samples: `sample_at: Timestamp`, `sample_value: Float64`, `sample_value_raw: Utf8` (preserves NaN/Inf), and `sample_histogram: Json` for native histograms.
- `query_custom` removed from v1 (scalar/matrix/histogram result-type handling deferred).
- `inactive` removed from the `alert_state` guide; the active alerts endpoint only returns `firing` or `pending`.
- README adds an explicit Caveat for the `WHERE sample_value < 1` example explaining the server-side `limit=500` truncation risk for fleets above ~500 targets, and pointing users at server-side `up < 1` for high-cardinality deployments.

## Evidence (live run, sanitized)

Local Prometheus 3.11.3 at `http://127.0.0.1:9090`, Coral CLI `0.2.0`.

### `coral source lint`

```text
$ coral source lint sources/community/prometheus/manifest.yaml
Manifest is valid
```

### `coral source add` (test queries run inline)

```text
$ export PROMETHEUS_BASE_URL=http://127.0.0.1:9090
$ coral source add --file sources/community/prometheus/manifest.yaml
Added source prometheus

  ✓ prometheus connected successfully

    prometheus (2 tables)
    ├─ alerts
    └─ query_up
    Query tests
    2 declared · 2 passed · 0 failed

    ✓ SELECT metric_name, instance, sample_value FROM prometheus.query_up LIMIT 5
      1 row

    ✓ SELECT alert_name, alert_state FROM prometheus.alerts WHERE alert_state = 'firing' LIMIT 10
      0 rows
```

### `coral source test prometheus`

```text
$ coral source test prometheus

  ✓ prometheus connected successfully

    prometheus (2 tables)
    ├─ alerts
    └─ query_up
    Query tests
    2 declared · 2 passed · 0 failed

    ✓ SELECT metric_name, instance, sample_value FROM prometheus.query_up LIMIT 5
      1 row

    ✓ SELECT alert_name, alert_state FROM prometheus.alerts WHERE alert_state = 'firing' LIMIT 10
      0 rows
```

### `coral source info prometheus`

```text
$ coral source info prometheus
prometheus
  Status:      installed
  Origin:      imported
  Version:     0.1.2
  Description: Query Prometheus scrape health and active alerts from Prometheus (self-hosted). Read-only v1 tables: query_up, alerts. Uses /api/v1/query (up) and /api/v1/alerts. No arbitrary PromQL table in v1.

  Inputs
    PROMETHEUS_BASE_URL (variable, optional)
      default: http://127.0.0.1:9090
```

### `query_up` — scrape health

```text
$ coral sql "SELECT metric_name, instance, job, sample_value FROM prometheus.query_up LIMIT 20"
+-------------+----------------+------------+--------------+
| metric_name | instance       | job        | sample_value |
+-------------+----------------+------------+--------------+
| up          | localhost:9090 | prometheus | 1.0          |
+-------------+----------------+------------+--------------+
```

### `query_up` — down targets (best-effort within `limit=500`)

```text
$ coral sql "SELECT instance, job, sample_value FROM prometheus.query_up WHERE sample_value < 1 LIMIT 20"
++
++
```

The local single-target server is healthy, so `sample_value < 1` correctly
returns zero rows. For fleets above the provider-side `limit=500` cap, the
README directs users to run `up < 1` directly in Prometheus (see the Caveat
under “Targets not reporting `up`”).

### `alerts` — firing alerts (none configured locally)

```text
$ coral sql "SELECT alert_name, alert_state FROM prometheus.alerts LIMIT 20"
+------------+-------------+
| alert_name | alert_state |
+------------+-------------+
+------------+-------------+

$ coral sql "SELECT alert_name, alert_state, severity, namespace, pod, summary, active_at FROM prometheus.alerts WHERE alert_state = 'firing' LIMIT 20"
++
++
```

Empty result reflects that the local Prometheus has no alerting rules. The
table schema and HTTP path are exercised by `coral source test prometheus`
above.

## Example queries

### Scrape health

```sql
SELECT metric_name, instance, job, sample_value
FROM prometheus.query_up
LIMIT 20;
```

### Targets not reporting `up` (best-effort within `limit=500`)

```sql
SELECT instance, job, sample_value
FROM prometheus.query_up
WHERE sample_value < 1
LIMIT 20;
```

For fleets above ~500 targets, run `up < 1` directly against Prometheus.

### Firing alerts

```sql
SELECT alert_name, alert_state, severity, namespace, pod, summary, active_at
FROM prometheus.alerts
WHERE alert_state = 'firing'
LIMIT 20;
```

`/api/v1/alerts` only returns active alerts, so `alert_state` is `firing` or
`pending`. Inactive alerts are not returned by this API.

## User-visible impact

```bash
export PROMETHEUS_BASE_URL=http://127.0.0.1:9090
coral source add --file sources/community/prometheus/manifest.yaml
coral source test prometheus
coral sql "SELECT metric_name, instance, job, sample_value FROM prometheus.query_up LIMIT 20"
```

## Notes

- `query_custom` is intentionally removed from v1 (scalar/matrix/histogram result-type handling deferred).
- `query_up` exposes `sample_at: Timestamp`, `sample_value: Float64`, `sample_value_raw: Utf8`, and `sample_histogram: Json` (for native histograms).
- The optional `k8s.pods` join example in the README is explicitly marked as depending on an external/community source not bundled on `main`.

## Follow-on

- `query_custom` with per-result-type handling (scalar / matrix / vector / histogram).
- `query_range` for time-series matrices.
- Optional bearer-token auth via secret input.