### PR TITLE
feat(sources/community/supabase): add supabase community source

### DIFF
--- a/sources/community/supabase/README.md
+++ b/sources/community/supabase/README.md
@@ -1,35 +1,27 @@
-# Supabase Connector (Community)
+# Supabase PostgREST Connector (Community)
 
-**Version:** 0.1.0
-**Backend:** HTTP (PostgREST)
-**Tables:** 2
+**Version:** 0.1.1
+**Backend:** HTTP (PostgREST data API)
+**Tables:** 3
 **Base URL:** `SUPABASE_REST_URL` (for example `https://<project-ref>.supabase.co/rest/v1`)
 
-Query rows from Supabase Postgres tables exposed through the PostgREST API (Supabase
-Cloud). Read-only v1 uses your project REST URL and API key. Join app data with
-HubSpot, GitHub, or other Coral sources on `email`, `user_id`, or fields in the
-`row` JSON column.
+Query rows from a Supabase project through the **PostgREST data API**. This source
+does **not** wrap the Supabase Management API (`api.supabase.com`); see open PR
+[#444](https://github.com/withcoral/coral/pull/444) for platform metadata coverage.
+
+Read-only v1 uses legacy anon/service_role JWT keys and **fixed table paths** (no
+dynamic `/{{table}}` segments) so requests cannot escape `/rest/v1` into other
+API surfaces.
 
 ## Install
-
-Community sources are not bundled with the Coral binary. Add the manifest from
-this directory:
 
 ```bash
 coral source add --file sources/community/supabase/manifest.yaml
 ```
 
-Or copy `manifest.yaml` into your workspace and pass that path to
-`coral source add --file`.
-
-Reference the linked GitHub issue in your PR so maintainers can connect the
-contribution to the prior discussion.
-
 ## Authentication and setup
 
-### API URL and key
-
-From the Supabase dashboard (**Project Settings → API**):
+From **Project Settings → API** in the Supabase dashboard:
 
 ```bash
 export SUPABASE_REST_URL=https://YOUR_PROJECT_REF.supabase.co/rest/v1
@@ -39,74 +31,57 @@ coral source add --file sources/community/supabase/manifest.yaml
 
 | Key | When to use |
 | --- | --- |
-| **anon** | Respects Row Level Security; recommended for read-only app tables exposed to clients |
-| **service_role** | Bypasses RLS; trusted environments only—never commit or expose publicly |
+| **anon (JWT)** | Respects Row Level Security; recommended |
+| **service_role (JWT)** | Bypasses RLS; trusted environments only |
 
-Tables must be exposed to the API (typically `public` schema with grants and RLS
-policies that allow `SELECT` for your key).
+v1 expects legacy JWT-style API keys sent as `apikey` and `Authorization: Bearer`.
+New Supabase publishable/secret keys are not supported in this manifest.
 
-### Multiple projects
-
-Register one Coral source per Supabase project (for example `supabase_prod`,
-`supabase_staging`), each with its own `SUPABASE_REST_URL` and `SUPABASE_API_KEY`.
+`coral source test` uses `rest_openapi` only, so it works even when you do not
+have a `profiles` table.
 
 ## Tables
 
 | Table | Description |
 | --- | --- |
-| `table_rows` | List rows from any PostgREST table (required `table` filter) |
-| `row_by_id` | Single row by `id` (required `table` and `row_id` filters) |
+| `rest_openapi` | `GET /` OpenAPI document (connectivity check) |
+| `profiles` | Example list table at `/profiles` (when exposed) |
+| `profile_by_id` | Example lookup at `/profiles` with `profile_id` filter |
 
-### Filters
-
-**`table_rows`**
-
-- `table` (required) — PostgREST resource name, for example `profiles`, `orders`
-- `select_columns` (optional) — PostgREST `select` list, for example `id,email,created_at`
-
-**`row_by_id`**
-
-- `table` (required)
-- `row_id` (required) — primary key value (uuid or text)
+Add more tables by copying the `profiles` / `profile_by_id` pattern with a fixed
+path for each PostgREST resource you need.
 
 ## Example queries
 
-### List profiles
+### Connectivity check
 
 ```sql
-SELECT table, id, email, created_at
-FROM supabase.table_rows
-WHERE table = 'profiles'
+SELECT openapi FROM supabase.rest_openapi LIMIT 1;
+```
+
+### List profiles (when the table exists)
+
+```sql
+SELECT id, email, created_at
+FROM supabase.profiles
 LIMIT 50;
 ```
 
-### Single row
+### Profile by id
 
 ```sql
-SELECT table, row_id, id, email, row
-FROM supabase.row_by_id
-WHERE table = 'profiles'
-  AND row_id = '550e8400-e29b-41d4-a716-446655440000'
+SELECT profile_id, id, email, row
+FROM supabase.profile_by_id
+WHERE profile_id = '550e8400-e29b-41d4-a716-446655440000'
 LIMIT 1;
-```
-
-### Narrow columns (PostgREST select)
-
-```sql
-SELECT table, id, email
-FROM supabase.table_rows
-WHERE table = 'profiles'
-  AND select_columns = 'id,email,created_at'
-LIMIT 20;
 ```
 
 ### Join with HubSpot (requires HubSpot source)
 
 ```sql
 SELECT p.email, c.firstname, c.lifecyclestage
-FROM supabase.table_rows p
+FROM supabase.profiles p
 JOIN hubspot.contacts c ON LOWER(p.email) = LOWER(c.email)
-WHERE p.table = 'profiles'
 LIMIT 20;
 ```
 
@@ -116,23 +91,18 @@ LIMIT 20;
 make lint-sources
 coral source lint sources/community/supabase/manifest.yaml
 export SUPABASE_REST_URL=https://YOUR_PROJECT_REF.supabase.co/rest/v1
-export SUPABASE_API_KEY=your-anon-or-service-role-key
+export SUPABASE_API_KEY=your-anon-or-service-role-jwt
 coral source add --file sources/community/supabase/manifest.yaml
 coral source test supabase
 ```
 
-Adjust the `table` name in `test_queries` in `manifest.yaml` if your project does
-not expose a `profiles` table.
-
 ## Limitations
 
-- Read-only v1 (`GET` only); no inserts, updates, or RPC
-- Table names and columns depend on your Supabase schema; use `row` JSON for extra fields
-- `auth.users` and other non-exposed schemas are out of scope unless exposed via PostgREST
-- Service role keys bypass RLS—treat them like production secrets
+- PostgREST data API only; not organizations/projects/storage config (Management API).
+- Fixed paths only; no dynamic table name in URLs.
+- Example `profiles` tables require that resource in your project schema.
+- Read-only v1 (`GET` only).
 
 ## Contributing
 
-Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the issue first,
-sign the CLA if this is your first contribution, run `make lint-sources`, and
-open a focused PR titled `feat(sources/community/supabase): add supabase community source`.
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md). Coordinate with [#444](https://github.com/withcoral/coral/pull/444) if adding overlapping Supabase coverage.

--- a/sources/community/supabase/README.md
+++ b/sources/community/supabase/README.md
@@ -1,0 +1,137 @@
+# Supabase Connector (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (PostgREST)
+**Tables:** 2
+**Base URL:** `SUPABASE_REST_URL` (for example `https://<project-ref>.supabase.co/rest/v1`)
+
+Query rows from Supabase Postgres tables exposed through the PostgREST API. Read-only
+v1 uses your project REST URL and API key. Join app data with HubSpot, GitHub, or
+other Coral sources on `email`, `user_id`, or fields in the `row` JSON column.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Add the manifest from
+this directory:
+
+```bash
+coral source add --file sources/community/supabase/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
+
+Reference the linked GitHub issue in your PR so maintainers can connect the
+contribution to the prior discussion.
+
+## Authentication and setup
+
+### API URL and key
+
+From the Supabase dashboard (**Project Settings → API**):
+
+```bash
+export SUPABASE_REST_URL=https://YOUR_PROJECT_REF.supabase.co/rest/v1
+export SUPABASE_API_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+coral source add --file sources/community/supabase/manifest.yaml
+```
+
+| Key | When to use |
+| --- | --- |
+| **anon** | Respects Row Level Security; recommended for read-only app tables exposed to clients |
+| **service_role** | Bypasses RLS; trusted environments only—never commit or expose publicly |
+
+Tables must be exposed to the API (typically `public` schema with grants and RLS
+policies that allow `SELECT` for your key).
+
+### Multiple projects
+
+Register one Coral source per Supabase project (for example `supabase_prod`,
+`supabase_staging`), each with its own `SUPABASE_REST_URL` and `SUPABASE_API_KEY`.
+
+## Tables
+
+| Table | Description |
+| --- | --- |
+| `table_rows` | List rows from any PostgREST table (required `table` filter) |
+| `row_by_id` | Single row by `id` (required `table` and `row_id` filters) |
+
+### Filters
+
+**`table_rows`**
+
+- `table` (required) — PostgREST resource name, for example `profiles`, `orders`
+- `select_columns` (optional) — PostgREST `select` list, for example `id,email,created_at`
+
+**`row_by_id`**
+
+- `table` (required)
+- `row_id` (required) — primary key value (uuid or text)
+
+## Example queries
+
+### List profiles
+
+```sql
+SELECT table, id, email, created_at
+FROM supabase.table_rows
+WHERE table = 'profiles'
+LIMIT 50;
+```
+
+### Single row
+
+```sql
+SELECT table, row_id, id, email, row
+FROM supabase.row_by_id
+WHERE table = 'profiles'
+  AND row_id = '550e8400-e29b-41d4-a716-446655440000'
+LIMIT 1;
+```
+
+### Narrow columns (PostgREST select)
+
+```sql
+SELECT table, id, email
+FROM supabase.table_rows
+WHERE table = 'profiles'
+  AND select_columns = 'id,email,created_at'
+LIMIT 20;
+```
+
+### Join with HubSpot (requires HubSpot source)
+
+```sql
+SELECT p.email, c.firstname, c.lifecyclestage
+FROM supabase.table_rows p
+JOIN hubspot.contacts c ON LOWER(p.email) = LOWER(c.email)
+WHERE p.table = 'profiles'
+LIMIT 20;
+```
+
+## Validation
+
+```bash
+make lint-sources
+coral source lint sources/community/supabase/manifest.yaml
+export SUPABASE_REST_URL=https://YOUR_PROJECT_REF.supabase.co/rest/v1
+export SUPABASE_API_KEY=your-anon-or-service-role-key
+coral source add --file sources/community/supabase/manifest.yaml
+coral source test supabase
+```
+
+Adjust the `table` name in `test_queries` in `manifest.yaml` if your project does
+not expose a `profiles` table.
+
+## Limitations
+
+- Read-only v1 (`GET` only); no inserts, updates, or RPC
+- Table names and columns depend on your Supabase schema; use `row` JSON for extra fields
+- `auth.users` and other non-exposed schemas are out of scope unless exposed via PostgREST
+- Service role keys bypass RLS—treat them like production secrets
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the issue first,
+sign the CLA if this is your first contribution, run `make lint-sources`, and
+open a focused PR titled `feat(sources/community/supabase): add supabase community source`.

--- a/sources/community/supabase/README.md
+++ b/sources/community/supabase/README.md
@@ -5,9 +5,10 @@
 **Tables:** 2
 **Base URL:** `SUPABASE_REST_URL` (for example `https://<project-ref>.supabase.co/rest/v1`)
 
-Query rows from Supabase Postgres tables exposed through the PostgREST API. Read-only
-v1 uses your project REST URL and API key. Join app data with HubSpot, GitHub, or
-other Coral sources on `email`, `user_id`, or fields in the `row` JSON column.
+Query rows from Supabase Postgres tables exposed through the PostgREST API (Supabase
+Cloud). Read-only v1 uses your project REST URL and API key. Join app data with
+HubSpot, GitHub, or other Coral sources on `email`, `user_id`, or fields in the
+`row` JSON column.
 
 ## Install
 

--- a/sources/community/supabase/manifest.yaml
+++ b/sources/community/supabase/manifest.yaml
@@ -3,8 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query rows from Supabase Postgres tables exposed through the PostgREST REST API.
-  Read-only v1; use the table_rows table with a table filter for any public API table.
+  Query rows from Supabase (Cloud) via PostgREST. List any exposed table with
+  table_rows or fetch one row by id with row_by_id. Read-only v1.
 inputs:
   SUPABASE_REST_URL:
     kind: variable

--- a/sources/community/supabase/manifest.yaml
+++ b/sources/community/supabase/manifest.yaml
@@ -1,0 +1,207 @@
+name: supabase
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query rows from Supabase Postgres tables exposed through the PostgREST REST API.
+  Read-only v1; use the table_rows table with a table filter for any public API table.
+inputs:
+  SUPABASE_REST_URL:
+    kind: variable
+    hint: |
+      Supabase PostgREST base URL with no trailing slash, for example
+      `https://abcdefghijklmnop.supabase.co/rest/v1`. Find your project ref and URL
+      under Project Settings > API in the Supabase dashboard.
+  SUPABASE_API_KEY:
+    kind: secret
+    required: true
+    hint: |
+      Supabase anon or service_role API key (Project Settings > API). Prefer the
+      anon key when Row Level Security should apply. The service role bypasses RLS;
+      use only in trusted environments. Sent as `apikey` and Bearer authorization.
+base_url: "{{input.SUPABASE_REST_URL}}"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.SUPABASE_API_KEY}}
+request_headers:
+  - name: apikey
+    from: input
+    key: SUPABASE_API_KEY
+  - name: Accept
+    from: literal
+    value: application/json
+  - name: Prefer
+    from: literal
+    value: count=exact
+test_queries:
+  - SELECT table, id FROM supabase.table_rows WHERE table = 'profiles' LIMIT 1
+tables:
+  - name: table_rows
+    description: Rows from a Supabase table exposed via PostgREST.
+    guide: |
+      Required filter: `table` (PostgREST resource name, for example `profiles` or
+      `orders`). Optional `select_columns` maps to PostgREST `select` (comma-separated
+      columns). For a single row by primary key, use `row_by_id` instead.
+      Expose tables to the API in Supabase (public schema + grants/RLS). Coral caps
+      fetched rows at 100; use SQL `LIMIT` and narrow `select_columns` on wide tables.
+      The `row` column contains the full JSON object when you need fields not listed
+      as top-level columns.
+    fetch_limit_default: 100
+    filters:
+      - name: table
+        required: true
+      - name: select_columns
+    request:
+      method: GET
+      path: /{{filter.table}}
+      query:
+        - name: select
+          from: filter
+          key: select_columns
+    response:
+      rows_path: []
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: table
+        type: Utf8
+        description: PostgREST table name from the required table filter.
+        expr:
+          kind: from_filter
+          key: table
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Primary key when present on the row (uuid or text).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: Created timestamp when the column exists on the table.
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: Updated timestamp when the column exists on the table.
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Email column when present (common on profiles/users tables).
+        expr:
+          kind: path
+          path:
+            - email
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: Foreign key to auth.users when present on the table.
+        expr:
+          kind: path
+          path:
+            - user_id
+      - name: row
+        type: Json
+        nullable: true
+        description: Full PostgREST row object for columns not mapped above.
+        expr:
+          kind: path
+          path: []
+
+  - name: row_by_id
+    description: Single row from a Supabase table by primary key `id`.
+    guide: |
+      Required filters: `table` and `row_id` (uuid or text primary key value).
+      Maps to PostgREST `id=eq.<row_id>`. Use `table_rows` for scans; use this
+      table for point lookups. Coral caps fetched rows at 1.
+    fetch_limit_default: 1
+    filters:
+      - name: table
+        required: true
+      - name: row_id
+        required: true
+    request:
+      method: GET
+      path: /{{filter.table}}
+      query:
+        - name: id
+          from: template
+          template: eq.{{filter.row_id}}
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: table
+        type: Utf8
+        description: PostgREST table name from the table filter.
+        expr:
+          kind: from_filter
+          key: table
+      - name: row_id
+        type: Utf8
+        description: Primary key value from the row_id filter.
+        expr:
+          kind: from_filter
+          key: row_id
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Primary key on the returned row.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: created_at
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: email
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - email
+      - name: user_id
+        type: Utf8
+        nullable: true
+        expr:
+          kind: path
+          path:
+            - user_id
+      - name: row
+        type: Json
+        nullable: true
+        description: Full PostgREST row object.
+        expr:
+          kind: path
+          path: []

--- a/sources/community/supabase/manifest.yaml
+++ b/sources/community/supabase/manifest.yaml
@@ -1,24 +1,26 @@
 name: supabase
-version: 0.1.0
+version: 0.1.1
 dsl_version: 3
 backend: http
 description: >-
-  Query rows from Supabase (Cloud) via PostgREST. List any exposed table with
-  table_rows or fetch one row by id with row_by_id. Read-only v1.
+  Query Supabase project tables through the PostgREST data API (not the Supabase
+  Management API). Read-only v1 with fixed table paths and a connectivity check.
 inputs:
   SUPABASE_REST_URL:
     kind: variable
     hint: |
-      Supabase PostgREST base URL with no trailing slash, for example
-      `https://abcdefghijklmnop.supabase.co/rest/v1`. Find your project ref and URL
-      under Project Settings > API in the Supabase dashboard.
+      PostgREST base URL with no trailing slash, for example
+      `https://abcdefghijklmnop.supabase.co/rest/v1`. Find it under Project
+      Settings > API in the Supabase dashboard.
   SUPABASE_API_KEY:
     kind: secret
     required: true
     hint: |
-      Supabase anon or service_role API key (Project Settings > API). Prefer the
-      anon key when Row Level Security should apply. The service role bypasses RLS;
-      use only in trusted environments. Sent as `apikey` and Bearer authorization.
+      Legacy Supabase **anon** or **service_role** JWT from Project Settings > API.
+      v1 sends the same value as `apikey` and `Authorization: Bearer`. Prefer the
+      anon key when Row Level Security should apply. New publishable/secret keys are
+      not supported in this manifest. The service role bypasses RLS; use only in
+      trusted environments.
 base_url: "{{input.SUPABASE_REST_URL}}"
 auth:
   type: HeaderAuth
@@ -33,30 +35,41 @@ request_headers:
   - name: Accept
     from: literal
     value: application/json
-  - name: Prefer
-    from: literal
-    value: count=exact
 test_queries:
-  - SELECT table, id FROM supabase.table_rows WHERE table = 'profiles' LIMIT 1
+  - SELECT openapi FROM supabase.rest_openapi LIMIT 1
 tables:
-  - name: table_rows
-    description: Rows from a Supabase table exposed via PostgREST.
+  - name: rest_openapi
+    description: PostgREST OpenAPI document (connectivity and schema discovery).
     guide: |
-      Required filter: `table` (PostgREST resource name, for example `profiles` or
-      `orders`). Optional `select_columns` maps to PostgREST `select` (comma-separated
-      columns). For a single row by primary key, use `row_by_id` instead.
-      Expose tables to the API in Supabase (public schema + grants/RLS). Coral caps
-      fetched rows at 100; use SQL `LIMIT` and narrow `select_columns` on wide tables.
-      The `row` column contains the full JSON object when you need fields not listed
-      as top-level columns.
-    fetch_limit_default: 100
-    filters:
-      - name: table
-        required: true
-      - name: select_columns
+      Calls `GET /` on the configured PostgREST base URL. Use this table to verify
+      credentials and discover exposed resources before querying data tables.
+    fetch_limit_default: 1
     request:
       method: GET
-      path: /{{filter.table}}
+      path: /
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: openapi
+        type: Json
+        nullable: true
+        description: OpenAPI schema returned by PostgREST.
+        expr:
+          kind: path
+          path: []
+
+  - name: profiles
+    description: Rows from the `profiles` table when exposed to PostgREST.
+    guide: |
+      Fixed path `/profiles`. Duplicate this table pattern in a fork if your project
+      uses different table names. Sends PostgREST `limit` via pagination (default 100).
+      Requires `SELECT` grants and RLS policies for your API key.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /profiles
       query:
         - name: select
           from: filter
@@ -71,17 +84,12 @@ tables:
         default: 100
         max: 1000
         query_param: limit
+    filters:
+      - name: select_columns
     columns:
-      - name: table
-        type: Utf8
-        description: PostgREST table name from the required table filter.
-        expr:
-          kind: from_filter
-          key: table
       - name: id
         type: Utf8
         nullable: true
-        description: Primary key when present on the row (uuid or text).
         expr:
           kind: path
           path:
@@ -89,7 +97,6 @@ tables:
       - name: created_at
         type: Utf8
         nullable: true
-        description: Created timestamp when the column exists on the table.
         expr:
           kind: path
           path:
@@ -97,7 +104,6 @@ tables:
       - name: updated_at
         type: Utf8
         nullable: true
-        description: Updated timestamp when the column exists on the table.
         expr:
           kind: path
           path:
@@ -105,7 +111,6 @@ tables:
       - name: email
         type: Utf8
         nullable: true
-        description: Email column when present (common on profiles/users tables).
         expr:
           kind: path
           path:
@@ -113,7 +118,6 @@ tables:
       - name: user_id
         type: Utf8
         nullable: true
-        description: Foreign key to auth.users when present on the table.
         expr:
           kind: path
           path:
@@ -121,69 +125,44 @@ tables:
       - name: row
         type: Json
         nullable: true
-        description: Full PostgREST row object for columns not mapped above.
+        description: Full row JSON for columns not mapped above.
         expr:
           kind: path
           path: []
 
-  - name: row_by_id
-    description: Single row from a Supabase table by primary key `id`.
+  - name: profile_by_id
+    description: Single `profiles` row by primary key `id`.
     guide: |
-      Required filters: `table` and `row_id` (uuid or text primary key value).
-      Maps to PostgREST `id=eq.<row_id>`. Use `table_rows` for scans; use this
-      table for point lookups. Coral caps fetched rows at 1.
+      Fixed path `/profiles` with `id=eq.<profile_id>`. Requires `profile_id` filter.
     fetch_limit_default: 1
     filters:
-      - name: table
-        required: true
-      - name: row_id
+      - name: profile_id
         required: true
     request:
       method: GET
-      path: /{{filter.table}}
+      path: /profiles
       query:
         - name: id
           from: template
-          template: eq.{{filter.row_id}}
+          template: eq.{{filter.profile_id}}
     response:
       rows_path: []
     pagination:
       mode: none
     columns:
-      - name: table
+      - name: profile_id
         type: Utf8
-        description: PostgREST table name from the table filter.
+        description: Filter value used for the lookup.
         expr:
           kind: from_filter
-          key: table
-      - name: row_id
-        type: Utf8
-        description: Primary key value from the row_id filter.
-        expr:
-          kind: from_filter
-          key: row_id
+          key: profile_id
       - name: id
         type: Utf8
         nullable: true
-        description: Primary key on the returned row.
         expr:
           kind: path
           path:
             - id
-      - name: created_at
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - created_at
-      - name: updated_at
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - updated_at
       - name: email
         type: Utf8
         nullable: true
@@ -191,17 +170,9 @@ tables:
           kind: path
           path:
             - email
-      - name: user_id
-        type: Utf8
-        nullable: true
-        expr:
-          kind: path
-          path:
-            - user_id
       - name: row
         type: Json
         nullable: true
-        description: Full PostgREST row object.
         expr:
           kind: path
           path: []

--- a/sources/community/supabase/manifest.yaml
+++ b/sources/community/supabase/manifest.yaml
@@ -4,7 +4,8 @@ dsl_version: 3
 backend: http
 description: >-
   Query Supabase project tables through the PostgREST data API (not the Supabase
-  Management API). Read-only v1 with fixed table paths and a connectivity check.
+  Management API). Read-only v1 tables: rest_openapi, profiles, profile_by_id.
+  Fixed paths only; no dynamic table URLs.
 inputs:
   SUPABASE_REST_URL:
     kind: variable


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Closes #666</h1><h1>Summary</h1><p>Adds a new read-only community Supabase PostgREST source under:</p><pre><code class="language-text">sources/community/supabase/
</code></pre><p>This source queries project tables through <code inline="">/rest/v1/</code> with fixed paths and a <code inline="">rest_openapi</code> connectivity check.</p><p>It does not cover the Supabase Management API (see PR #444).</p><hr><h1>Tables</h1>
Table | Description
-- | --
rest_openapi | GET / OpenAPI document used for stable source connectivity testing
profiles | Example list table exposed at fixed /profiles
profile_by_id | Example row lookup using profile_id filter

<hr><h1>Files</h1><pre><code class="language-text">sources/community/supabase/manifest.yaml
sources/community/supabase/README.md
</code></pre><hr><h1>Setup</h1><pre><code class="language-bash">export SUPABASE_REST_URL=https://YOUR_PROJECT_REF.supabase.co/rest/v1
export SUPABASE_API_KEY=your-anon-or-service-role-jwt
</code></pre><hr><h1>Auth</h1><ul><li><p>Legacy <code inline="">anon</code> / <code inline="">service_role</code> JWT keys are sent as:</p><ul><li><p><code inline="">apikey</code></p></li><li><p><code inline="">Authorization: Bearer</code></p></li></ul></li><li><p>Publishable and secret keys are documented as out of scope for v1</p></li></ul><hr><h1>Why it changed</h1><p>Provides safe PostgREST reads without dynamic path segments that could accidentally reach non-PostgREST admin routes.</p><hr><h1>What was tested</h1><ul><li><p><code inline="">coral source lint sources/community/supabase/manifest.yaml</code></p></li><li><p><code inline="">make lint-sources</code></p></li><li><p><code inline="">coral source add --file + coral source test supabase</code> (<code inline="">rest_openapi</code> connectivity validation)</p></li></ul><hr><h1>Example queries</h1><h2>OpenAPI connectivity check</h2><pre><code class="language-sql">SELECT openapi
FROM supabase.rest_openapi
LIMIT 1;
</code></pre><h2>List profiles</h2><pre><code class="language-sql">SELECT id, email
FROM supabase.profiles
LIMIT 50;
</code></pre><hr><h1>User-visible impact</h1><pre><code class="language-bash">export SUPABASE_REST_URL=https://YOUR_PROJECT_REF.supabase.co/rest/v1
export SUPABASE_API_KEY=your-key

coral source add --file sources/community/supabase/manifest.yaml
</code></pre><hr><h1>Notes</h1><ul><li><p>Fixed paths only (addresses path traversal review feedback)</p></li><li><p>No <code inline="">Prefer: count=exact</code> header usage</p></li><li><p>Coexists with Management API work in:</p><ul><li><p><code inline="">feat(sources/community/supabase): add Supabase community source #444</code></p></li></ul></li><li><p>Scoped specifically to the PostgREST data plane</p></li></ul><hr><h1>Follow-on</h1><p>Potential future enhancements:</p><ul><li><p>Additional fixed tables copied from the <code inline="">profiles</code> pattern</p></li><li><p>Management API tables (potential future consolidation with PR #444)</p></li></ul></body></html><!--EndFragment-->
</body>
</html>