### PR TITLE
feat(sources/community/dub): add Dub.co community source

### DIFF
--- a/sources/community/dub/README.md
+++ b/sources/community/dub/README.md
@@ -1,0 +1,168 @@
+# Dub
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** `https://api.dub.co`
+
+Query links, domains, tags, and workspace metadata from Dub.co — the modern link attribution platform for short links, conversion tracking, and affiliate programs.
+
+## Authentication
+
+Requires a `DUB_API_KEY`. Generate one from:
+**Workspace Settings → API Keys → Create API Key**
+
+Keys start with `dub_` and are scoped to a single workspace — no `workspaceId`
+parameter is needed in queries.
+
+```bash
+coral source add --file sources/community/dub/manifest.yaml
+```
+
+You will be prompted to enter your API key interactively.
+
+API docs: https://dub.co/docs/api-reference/introduction
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `workspaces` | Workspace metadata, plan, and team members | — | — |
+| `links` | Short links with click, lead, and sales analytics | — | `domain`, `search`, `show_archived`, `tag_ids`, `folder_id` |
+| `domains` | Custom domains and their verification status | — | — |
+| `tags` | Tags for organizing and categorizing links | — | `search` |
+
+### Key design notes
+
+- **No workspace scoping filter needed.** Dub API keys are workspace-scoped
+  since July 2024. The API key determines which workspace data is returned.
+- **`links` is the richest table.** It includes `clicks`, `leads`, `sales`,
+  `sale_amount`, and `conversions` directly in the list response.
+- **`workspaces` is the entry point.** Query it first to verify connectivity
+  and discover workspace identity and plan.
+- **`tags` are referenced by `links`.** The `tags` column on links is a JSON
+  array of `{id, name, color}` objects.
+
+```text
+workspaces → workspace metadata, plan, usage
+links      → short links with analytics (filterable by domain, tags)
+domains    → custom domains and DNS verification
+tags       → tag definitions (id, name, color)
+```
+
+### links filter values
+
+| Filter | Description |
+|---|---|
+| `domain` | Filter by domain (e.g. `dub.sh`, `yourdomain.com`) |
+| `search` | Search link slugs and destination URLs |
+| `show_archived` | Set to `true` to include archived links (default: false) |
+| `tag_ids` | Filter by tag ID(s) |
+| `folder_id` | Filter by folder ID |
+
+## Quick start
+
+```bash
+# Step 1 — verify API key and discover workspace info
+coral sql "SELECT id, name, slug, plan FROM dub.workspaces"
+
+# Step 2 — list links with click analytics
+coral sql "
+  SELECT id, domain, key, url, clicks, leads, sales, created_at
+  FROM dub.links
+  ORDER BY clicks DESC
+  LIMIT 20
+"
+
+# Step 3 — list all custom domains
+coral sql "SELECT slug, verified, primary, archived FROM dub.domains"
+
+# Step 4 — list all tags
+coral sql "SELECT id, name, color FROM dub.tags"
+
+# Step 5 — filter links by domain
+coral sql "
+  SELECT id, key, url, clicks
+  FROM dub.links
+  WHERE domain = 'yourdomain.com'
+  LIMIT 20
+"
+```
+
+## Example queries
+
+### All links with click analytics
+
+```sql
+SELECT
+  id,
+  domain,
+  key,
+  url,
+  short_link,
+  clicks,
+  leads,
+  sales,
+  sale_amount,
+  created_at
+FROM dub.links
+ORDER BY clicks DESC
+LIMIT 50;
+```
+
+### Top performing links by clicks
+
+```sql
+SELECT
+  short_link,
+  url,
+  clicks,
+  leads,
+  sales,
+  conversions,
+  last_clicked,
+  created_at
+FROM dub.links
+ORDER BY clicks DESC
+LIMIT 10;
+```
+
+### Filter links by domain
+
+```sql
+SELECT
+  id,
+  key,
+  url,
+  clicks,
+  leads,
+  archived,
+  created_at
+FROM dub.links
+WHERE domain = 'yourdomain.com'
+LIMIT 50;
+```
+
+### List all custom domains
+
+```sql
+SELECT
+  slug,
+  verified,
+  primary,
+  archived,
+  target,
+  type,
+  created_at
+FROM dub.domains;
+```
+
+### List tags and their colors
+
+```sql
+SELECT
+  id,
+  name,
+  color
+FROM dub.tags;
+```

--- a/sources/community/dub/README.md
+++ b/sources/community/dub/README.md
@@ -12,8 +12,13 @@ Query links, domains, and tags from Dub.co — the modern link attribution platf
 Requires a `DUB_API_KEY`. Generate one from:
 **Workspace Settings → API Keys → Create API Key**
 
-Keys start with `dub_` and are scoped to a single workspace — no `workspaceId`
-parameter is needed in queries.
+### Recommended Permissions
+To ensure security, generate a **restricted, server-side secret API key** instead of a publishable key. Ensure the key has at least read-only access for the following scopes:
+- `links.read`
+- `domains.read`
+- `tags.read`
+
+Keys start with `dub_` and are scoped to a single workspace — no `workspaceId` parameter is needed in queries.
 
 ```bash
 coral source add --file sources/community/dub/manifest.yaml
@@ -64,6 +69,11 @@ tags       → tag definitions (id, name, color)
 |---|---|
 | `search` | Search domains by name or slug |
 | `archived` | Set to `true` to include archived domains (default: false) |
+
+### Rate Limits & Fetch Limits
+Dub.co enforces plan-based rate limits on its API. The Free plan is limited to **60 requests/minute**. The API returns a `429 Too Many Requests` status code with rate limit headers indicating when you can retry.
+
+To prevent unbounded queries that could exhaust your rate limit, the high-cardinality `links` table has a default fetch limit of **100 links**. You can override this limit in your SQL query by specifying a `LIMIT` clause (e.g. `LIMIT 500`).
 
 ## Quick start
 

--- a/sources/community/dub/README.md
+++ b/sources/community/dub/README.md
@@ -2,10 +2,10 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP
-**Tables:** 4
+**Tables:** 3
 **Base URL:** `https://api.dub.co`
 
-Query links, domains, tags, and workspace metadata from Dub.co — the modern link attribution platform for short links, conversion tracking, and affiliate programs.
+Query links, domains, and tags from Dub.co — the modern link attribution platform for short links, conversion tracking, and affiliate programs.
 
 ## Authentication
 
@@ -27,9 +27,8 @@ API docs: https://dub.co/docs/api-reference/introduction
 
 | Table | Description | Required filters | Optional filters |
 |---|---|---|---|
-| `workspaces` | Workspace metadata, plan, and team members | — | — |
-| `links` | Short links with click, lead, and sales analytics | — | `domain`, `search`, `show_archived`, `tag_ids`, `folder_id` |
-| `domains` | Custom domains and their verification status | — | — |
+| `links` | Short links with click, lead, and sales analytics | — | `domain`, `search`, `show_archived`, `tag_ids`, `folder_id`, `sort_by`, `sort_order` |
+| `domains` | Custom domains, DNS verification, and deep links | — | `archived`, `search` |
 | `tags` | Tags for organizing and categorizing links | — | `search` |
 
 ### Key design notes
@@ -38,15 +37,12 @@ API docs: https://dub.co/docs/api-reference/introduction
   since July 2024. The API key determines which workspace data is returned.
 - **`links` is the richest table.** It includes `clicks`, `leads`, `sales`,
   `sale_amount`, and `conversions` directly in the list response.
-- **`workspaces` is the entry point.** Query it first to verify connectivity
-  and discover workspace identity and plan.
 - **`tags` are referenced by `links`.** The `tags` column on links is a JSON
   array of `{id, name, color}` objects.
 
 ```text
-workspaces → workspace metadata, plan, usage
 links      → short links with analytics (filterable by domain, tags)
-domains    → custom domains and DNS verification
+domains    → custom domains, DNS verification, and deep links
 tags       → tag definitions (id, name, color)
 ```
 
@@ -59,28 +55,37 @@ tags       → tag definitions (id, name, color)
 | `show_archived` | Set to `true` to include archived links (default: false) |
 | `tag_ids` | Filter by tag ID(s) |
 | `folder_id` | Filter by folder ID |
+| `sort_by` | Sort links by `createdAt`, `clicks`, `saleAmount`, or `lastClicked` |
+| `sort_order` | Sort direction (`asc` or `desc`) |
+
+### domains filter values
+
+| Filter | Description |
+|---|---|
+| `search` | Search domains by name or slug |
+| `archived` | Set to `true` to include archived domains (default: false) |
 
 ## Quick start
 
 ```bash
-# Step 1 — verify API key and discover workspace info
-coral sql "SELECT id, name, slug, plan FROM dub.workspaces"
-
-# Step 2 — list links with click analytics
+# Step 1 — list links with click analytics (pushing sort to API)
 coral sql "
   SELECT id, domain, key, url, clicks, leads, sales, created_at
   FROM dub.links
-  ORDER BY clicks DESC
+  WHERE sort_by = 'clicks' AND sort_order = 'desc'
   LIMIT 20
 "
 
-# Step 3 — list all custom domains
-coral sql "SELECT slug, verified, primary, archived FROM dub.domains"
+# Step 2 — list all custom domains (including deep link settings)
+coral sql "
+  SELECT id, slug, verified, primary, archived, expired_url, not_found_url
+  FROM dub.domains
+"
 
-# Step 4 — list all tags
+# Step 3 — list all tags
 coral sql "SELECT id, name, color FROM dub.tags"
 
-# Step 5 — filter links by domain
+# Step 4 — filter links by domain
 coral sql "
   SELECT id, key, url, clicks
   FROM dub.links
@@ -106,7 +111,7 @@ SELECT
   sale_amount,
   created_at
 FROM dub.links
-ORDER BY clicks DESC
+WHERE sort_by = 'clicks' AND sort_order = 'desc'
 LIMIT 50;
 ```
 
@@ -123,7 +128,7 @@ SELECT
   last_clicked,
   created_at
 FROM dub.links
-ORDER BY clicks DESC
+WHERE sort_by = 'clicks' AND sort_order = 'desc'
 LIMIT 10;
 ```
 
@@ -147,12 +152,14 @@ LIMIT 50;
 
 ```sql
 SELECT
+  id,
   slug,
   verified,
   primary,
   archived,
-  target,
-  type,
+  expired_url,
+  not_found_url,
+  logo,
   created_at
 FROM dub.domains;
 ```

--- a/sources/community/dub/manifest.yaml
+++ b/sources/community/dub/manifest.yaml
@@ -25,105 +25,12 @@ auth:
       template: Bearer {{input.DUB_API_KEY}}
 
 test_queries:
-  - SELECT * FROM dub.workspaces LIMIT 5
   - SELECT id, domain, key, url, clicks, leads, created_at FROM dub.links LIMIT 10
   - SELECT * FROM dub.domains LIMIT 10
   - SELECT * FROM dub.tags LIMIT 10
 
 tables:
-  # ------------------------------------------------------------------
-  # dub.workspaces — workspace metadata
-  # GET /workspaces
-  # Root JSON array. No pagination needed (key is workspace-scoped).
-  # ------------------------------------------------------------------
-  - name: workspaces
-    description: >-
-      Workspace metadata for the workspace associated with the API key.
-      Returns workspace identity, plan, usage stats, and team members.
-      Use this as the entry point to confirm your API key is working and
-      to discover workspace-level metadata.
-    guide: |
-      No filters required — the API key is scoped to a single workspace.
-      Start with `SELECT * FROM dub.workspaces LIMIT 1` to verify
-      connectivity and discover the workspace id, slug, and plan.
-    request:
-      method: GET
-      path: /workspaces
-    response: {}
-    pagination:
-      mode: none
-    columns:
-      - name: id
-        type: Utf8
-        nullable: false
-        description: Workspace ID (prefixed with ws_).
-        expr:
-          kind: path
-          path:
-            - id
-      - name: name
-        type: Utf8
-        nullable: false
-        description: Workspace display name.
-        expr:
-          kind: path
-          path:
-            - name
-      - name: slug
-        type: Utf8
-        nullable: false
-        description: URL-friendly workspace identifier used in dashboard URLs.
-        expr:
-          kind: path
-          path:
-            - slug
-      - name: logo
-        type: Utf8
-        nullable: true
-        description: URL of the workspace logo image.
-        expr:
-          kind: path
-          path:
-            - logo
-      - name: plan
-        type: Utf8
-        nullable: true
-        description: Subscription plan (e.g. free, pro, business, enterprise).
-        expr:
-          kind: path
-          path:
-            - plan
-      - name: usage
-        type: Json
-        nullable: true
-        description: >-
-          Usage statistics for the workspace relative to plan limits.
-          Use SQL JSON functions to inspect.
-        expr:
-          kind: path
-          path:
-            - usage
-      - name: users
-        type: Json
-        nullable: true
-        description: >-
-          Team members associated with the workspace.
-          Use SQL JSON functions to inspect.
-        expr:
-          kind: path
-          path:
-            - users
-      - name: created_at
-        type: Timestamp
-        nullable: true
-        description: When the workspace was created (ISO 8601).
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - createdAt
+
 
   # ------------------------------------------------------------------
   # dub.links — short links with analytics
@@ -148,6 +55,8 @@ tables:
       - name: show_archived
       - name: tag_ids
       - name: folder_id
+      - name: sort_by
+      - name: sort_order
     request:
       method: GET
       path: /links
@@ -167,6 +76,12 @@ tables:
         - name: folderId
           from: filter
           key: folder_id
+        - name: sortBy
+          from: filter
+          key: sort_by
+        - name: sortOrder
+          from: filter
+          key: sort_order
     response: {}
     pagination:
       mode: page
@@ -252,7 +167,7 @@ tables:
             - workspaceId
       - name: user_id
         type: Utf8
-        nullable: false
+        nullable: true
         description: User ID of the link creator.
         expr:
           kind: path
@@ -461,28 +376,68 @@ tables:
             kind: path
             path:
               - updatedAt
+      - name: sort_by
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Field to sort links by (createdAt, clicks, saleAmount, lastClicked).
+        expr:
+          kind: from_filter
+          key: sort_by
+      - name: sort_order
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Sort direction (asc, desc).
+        expr:
+          kind: from_filter
+          key: sort_order
 
   # ------------------------------------------------------------------
   # dub.domains — custom domains
   # GET /domains
-  # Root JSON array. No pagination needed (typically small list).
+  # Root JSON array. Page-based pagination (page + pageSize).
   # ------------------------------------------------------------------
   - name: domains
     description: >-
       Custom domains registered in the workspace. Returns domain name,
-      verification status, and configuration. Useful for auditing domain
-      setup and discovering available domains for link creation.
+      verification status, deep link settings, and configuration.
     guide: |
-      No filters required. Start with `SELECT * FROM dub.domains` to see
-      all domains. The `primary` column indicates the default domain for
-      new links. The `verified` column shows DNS verification status.
+      No required filters. Start with `SELECT * FROM dub.domains` to see
+      all domains. Use `WHERE search = 'yourdomain'` to filter by name.
+      Use `WHERE archived = true` to include archived domains.
+    filters:
+      - name: archived
+      - name: search
     request:
       method: GET
       path: /domains
+      query:
+        - name: archived
+          from: filter_bool
+          key: archived
+        - name: search
+          from: filter
+          key: search
     response: {}
     pagination:
-      mode: none
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
     columns:
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Unique domain identifier.
+        expr:
+          kind: path
+          path:
+            - id
       - name: slug
         type: Utf8
         nullable: false
@@ -515,22 +470,6 @@ tables:
           kind: path
           path:
             - archived
-      - name: target
-        type: Utf8
-        nullable: true
-        description: Root domain redirect URL.
-        expr:
-          kind: path
-          path:
-            - target
-      - name: type
-        type: Utf8
-        nullable: true
-        description: Redirect type for the root domain.
-        expr:
-          kind: path
-          path:
-            - type
       - name: placeholder
         type: Utf8
         nullable: true
@@ -539,6 +478,46 @@ tables:
           kind: path
           path:
             - placeholder
+      - name: expired_url
+        type: Utf8
+        nullable: true
+        description: URL to redirect to after a link on this domain has expired.
+        expr:
+          kind: path
+          path:
+            - expiredUrl
+      - name: not_found_url
+        type: Utf8
+        nullable: true
+        description: URL to redirect to when a link on this domain is not found.
+        expr:
+          kind: path
+          path:
+            - notFoundUrl
+      - name: logo
+        type: Utf8
+        nullable: true
+        description: URL of the domain logo image.
+        expr:
+          kind: path
+          path:
+            - logo
+      - name: asset_links
+        type: Utf8
+        nullable: true
+        description: Android App Links configuration (JSON string).
+        expr:
+          kind: path
+          path:
+            - assetLinks
+      - name: apple_app_site_association
+        type: Utf8
+        nullable: true
+        description: iOS Universal Links configuration (JSON string).
+        expr:
+          kind: path
+          path:
+            - appleAppSiteAssociation
       - name: registered_domain
         type: Json
         nullable: true

--- a/sources/community/dub/manifest.yaml
+++ b/sources/community/dub/manifest.yaml
@@ -1,0 +1,633 @@
+name: dub
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query links, domains, tags, and workspace metadata from Dub.co.
+  Covers link analytics (clicks, leads, sales), custom domains,
+  tag management, and workspace configuration.
+base_url: https://api.dub.co
+
+inputs:
+  DUB_API_KEY:
+    kind: secret
+    hint: |
+      Your Dub.co API key. Generate one from:
+      Workspace Settings → API Keys → Create API Key.
+      Keys start with "dub_" and are scoped to a single workspace.
+      See https://dub.co/docs/api-reference/introduction
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.DUB_API_KEY}}
+
+test_queries:
+  - SELECT * FROM dub.workspaces LIMIT 5
+  - SELECT id, domain, key, url, clicks, leads, created_at FROM dub.links LIMIT 10
+  - SELECT * FROM dub.domains LIMIT 10
+  - SELECT * FROM dub.tags LIMIT 10
+
+tables:
+  # ------------------------------------------------------------------
+  # dub.workspaces — workspace metadata
+  # GET /workspaces
+  # Root JSON array. No pagination needed (key is workspace-scoped).
+  # ------------------------------------------------------------------
+  - name: workspaces
+    description: >-
+      Workspace metadata for the workspace associated with the API key.
+      Returns workspace identity, plan, usage stats, and team members.
+      Use this as the entry point to confirm your API key is working and
+      to discover workspace-level metadata.
+    guide: |
+      No filters required — the API key is scoped to a single workspace.
+      Start with `SELECT * FROM dub.workspaces LIMIT 1` to verify
+      connectivity and discover the workspace id, slug, and plan.
+    request:
+      method: GET
+      path: /workspaces
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Workspace ID (prefixed with ws_).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Workspace display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: URL-friendly workspace identifier used in dashboard URLs.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: logo
+        type: Utf8
+        nullable: true
+        description: URL of the workspace logo image.
+        expr:
+          kind: path
+          path:
+            - logo
+      - name: plan
+        type: Utf8
+        nullable: true
+        description: Subscription plan (e.g. free, pro, business, enterprise).
+        expr:
+          kind: path
+          path:
+            - plan
+      - name: usage
+        type: Json
+        nullable: true
+        description: >-
+          Usage statistics for the workspace relative to plan limits.
+          Use SQL JSON functions to inspect.
+        expr:
+          kind: path
+          path:
+            - usage
+      - name: users
+        type: Json
+        nullable: true
+        description: >-
+          Team members associated with the workspace.
+          Use SQL JSON functions to inspect.
+        expr:
+          kind: path
+          path:
+            - users
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the workspace was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+
+  # ------------------------------------------------------------------
+  # dub.links — short links with analytics
+  # GET /links
+  # Root JSON array. Page-based pagination (page + pageSize).
+  # ------------------------------------------------------------------
+  - name: links
+    description: >-
+      Short links in the workspace with click, lead, and sales analytics.
+      Optionally filter by domain, search term, tag, folder, or archived
+      status. Includes destination URL, metadata, and conversion tracking
+      fields.
+    guide: |
+      No required filters — the API key scopes results to the workspace.
+      Start with `SELECT id, domain, key, url, clicks FROM dub.links LIMIT 10`.
+      Use `WHERE domain = 'yourdomain.com'` to narrow by domain.
+      Use `WHERE show_archived = true` to include archived links.
+      The `tags` column is a JSON array of {id, name, color} objects.
+    filters:
+      - name: domain
+      - name: search
+      - name: show_archived
+      - name: tag_ids
+      - name: folder_id
+    request:
+      method: GET
+      path: /links
+      query:
+        - name: domain
+          from: filter
+          key: domain
+        - name: search
+          from: filter
+          key: search
+        - name: showArchived
+          from: filter_bool
+          key: show_archived
+        - name: tagIds
+          from: filter
+          key: tag_ids
+        - name: folderId
+          from: filter
+          key: folder_id
+    response: {}
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique link identifier (prefixed with link_).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: domain
+        type: Utf8
+        nullable: false
+        description: Domain of the short link (e.g. dub.sh).
+        expr:
+          kind: path
+          path:
+            - domain
+      - name: key
+        type: Utf8
+        nullable: false
+        description: Short link slug (the path portion after the domain).
+        expr:
+          kind: path
+          path:
+            - key
+      - name: url
+        type: Utf8
+        nullable: false
+        description: Destination URL the short link redirects to.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: short_link
+        type: Utf8
+        nullable: false
+        description: Full short link URL (e.g. https://dub.sh/abc123).
+        expr:
+          kind: path
+          path:
+            - shortLink
+      - name: external_id
+        type: Utf8
+        nullable: true
+        description: Custom identifier from your own database.
+        expr:
+          kind: path
+          path:
+            - externalId
+      - name: tenant_id
+        type: Utf8
+        nullable: true
+        description: Tenant identifier for grouping links by customer or team.
+        expr:
+          kind: path
+          path:
+            - tenantId
+      - name: folder_id
+        type: Utf8
+        nullable: true
+        description: Folder ID the link belongs to.
+        expr:
+          kind: path
+          path:
+            - folderId
+      - name: workspace_id
+        type: Utf8
+        nullable: false
+        description: Workspace ID that owns this link.
+        expr:
+          kind: path
+          path:
+            - workspaceId
+      - name: user_id
+        type: Utf8
+        nullable: false
+        description: User ID of the link creator.
+        expr:
+          kind: path
+          path:
+            - userId
+      - name: clicks
+        type: Int64
+        nullable: false
+        description: Total number of clicks on the short link.
+        expr:
+          kind: path
+          path:
+            - clicks
+      - name: leads
+        type: Int64
+        nullable: false
+        description: Total number of leads generated from the link.
+        expr:
+          kind: path
+          path:
+            - leads
+      - name: sales
+        type: Int64
+        nullable: false
+        description: Total number of sales generated from the link.
+        expr:
+          kind: path
+          path:
+            - sales
+      - name: sale_amount
+        type: Int64
+        nullable: false
+        description: Total monetary value of sales from the link (in cents).
+        expr:
+          kind: path
+          path:
+            - saleAmount
+      - name: conversions
+        type: Int64
+        nullable: false
+        description: Number of leads that converted to paying customers.
+        expr:
+          kind: path
+          path:
+            - conversions
+      - name: last_clicked
+        type: Timestamp
+        nullable: true
+        description: When the link was last clicked (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - lastClicked
+      - name: archived
+        type: Boolean
+        nullable: false
+        description: Whether the link is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: proxy
+        type: Boolean
+        nullable: false
+        description: Whether custom link previews (proxy) are enabled.
+        expr:
+          kind: path
+          path:
+            - proxy
+      - name: rewrite
+        type: Boolean
+        nullable: false
+        description: Whether link cloaking (URL rewrite) is enabled.
+        expr:
+          kind: path
+          path:
+            - rewrite
+      - name: track_conversion
+        type: Boolean
+        nullable: false
+        description: Whether conversion tracking is enabled for the link.
+        expr:
+          kind: path
+          path:
+            - trackConversion
+      - name: expires_at
+        type: Timestamp
+        nullable: true
+        description: When the link expires (ISO 8601), or null if no expiry.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - expiresAt
+      - name: expired_url
+        type: Utf8
+        nullable: true
+        description: URL to redirect to after the link has expired.
+        expr:
+          kind: path
+          path:
+            - expiredUrl
+      - name: password
+        type: Utf8
+        nullable: true
+        description: Password required to access the link destination.
+        expr:
+          kind: path
+          path:
+            - password
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Custom OG title for social media previews.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Custom OG description for social media previews.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: image
+        type: Utf8
+        nullable: true
+        description: Custom OG image URL for social media previews.
+        expr:
+          kind: path
+          path:
+            - image
+      - name: video
+        type: Utf8
+        nullable: true
+        description: Custom OG video URL for social media previews.
+        expr:
+          kind: path
+          path:
+            - video
+      - name: tags
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of tag objects assigned to the link. Each object
+          has id, name, and color fields. Use SQL JSON functions to
+          inspect.
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: geo
+        type: Json
+        nullable: true
+        description: >-
+          Geographic targeting configuration for the link.
+          Use SQL JSON functions to inspect.
+        expr:
+          kind: path
+          path:
+            - geo
+      - name: test_variants
+        type: Json
+        nullable: true
+        description: >-
+          A/B test variant URLs and traffic distribution configuration.
+          Use SQL JSON functions to inspect.
+        expr:
+          kind: path
+          path:
+            - testVariants
+      - name: qr_code
+        type: Utf8
+        nullable: false
+        description: URL to the generated QR code image for the link.
+        expr:
+          kind: path
+          path:
+            - qrCode
+      - name: created_at
+        type: Timestamp
+        nullable: false
+        description: When the link was created (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: false
+        description: When the link was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+
+  # ------------------------------------------------------------------
+  # dub.domains — custom domains
+  # GET /domains
+  # Root JSON array. No pagination needed (typically small list).
+  # ------------------------------------------------------------------
+  - name: domains
+    description: >-
+      Custom domains registered in the workspace. Returns domain name,
+      verification status, and configuration. Useful for auditing domain
+      setup and discovering available domains for link creation.
+    guide: |
+      No filters required. Start with `SELECT * FROM dub.domains` to see
+      all domains. The `primary` column indicates the default domain for
+      new links. The `verified` column shows DNS verification status.
+    request:
+      method: GET
+      path: /domains
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: Domain name (e.g. example.com).
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: verified
+        type: Boolean
+        nullable: false
+        description: Whether domain ownership is verified via DNS.
+        expr:
+          kind: path
+          path:
+            - verified
+      - name: primary
+        type: Boolean
+        nullable: false
+        description: Whether this is the default domain for new links.
+        expr:
+          kind: path
+          path:
+            - primary
+      - name: archived
+        type: Boolean
+        nullable: false
+        description: Whether the domain is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: target
+        type: Utf8
+        nullable: true
+        description: Root domain redirect URL.
+        expr:
+          kind: path
+          path:
+            - target
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Redirect type for the root domain.
+        expr:
+          kind: path
+          path:
+            - type
+      - name: placeholder
+        type: Utf8
+        nullable: true
+        description: Placeholder URL shown when the domain root is visited.
+        expr:
+          kind: path
+          path:
+            - placeholder
+      - name: registered_domain
+        type: Json
+        nullable: true
+        description: >-
+          Domain registration metadata. Use SQL JSON functions to inspect.
+        expr:
+          kind: path
+          path:
+            - registeredDomain
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the domain was added (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the domain was last updated (ISO 8601).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+
+  # ------------------------------------------------------------------
+  # dub.tags — link tags
+  # GET /tags
+  # Root JSON array. Page-based pagination (page + pageSize).
+  # ------------------------------------------------------------------
+  - name: tags
+    description: >-
+      Tags used to organize and categorize links in the workspace.
+      Each tag has a name and color. Use tag IDs to filter the links
+      table with the tag_ids filter.
+    guide: |
+      No required filters. Start with `SELECT * FROM dub.tags` to see all
+      tags. Use `WHERE search = 'marketing'` to search by name. Use the
+      `id` column as the `tag_ids` filter on the links table.
+    filters:
+      - name: search
+    request:
+      method: GET
+      path: /tags
+      query:
+        - name: search
+          from: filter
+          key: search
+    response: {}
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique tag identifier.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Tag display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: color
+        type: Utf8
+        nullable: false
+        description: >-
+          Tag color (one of red, yellow, green, blue, purple, brown,
+          gray, pink).
+        expr:
+          kind: path
+          path:
+            - color

--- a/sources/community/dub/manifest.yaml
+++ b/sources/community/dub/manifest.yaml
@@ -12,8 +12,12 @@ inputs:
   DUB_API_KEY:
     kind: secret
     hint: |
-      Your Dub.co API key. Generate one from:
+      Your Dub.co API key. Generate a server-side secret API key from:
       Workspace Settings → API Keys → Create API Key.
+      Ensure the key has restricted permissions with at least:
+      - links.read
+      - domains.read
+      - tags.read
       Keys start with "dub_" and are scoped to a single workspace.
       See https://dub.co/docs/api-reference/introduction
 
@@ -92,6 +96,7 @@ tables:
         default: 100
         max: 100
         query_param: pageSize
+    fetch_limit_default: 100
     columns:
       - name: id
         type: Utf8
@@ -275,14 +280,6 @@ tables:
           kind: path
           path:
             - expiredUrl
-      - name: password
-        type: Utf8
-        nullable: true
-        description: Password required to access the link destination.
-        expr:
-          kind: path
-          path:
-            - password
       - name: title
         type: Utf8
         nullable: true
@@ -426,8 +423,8 @@ tables:
       page_start: 1
       page_step: 1
       page_size:
-        default: 100
-        max: 100
+        default: 50
+        max: 50
         query_param: pageSize
     columns:
       - name: id


### PR DESCRIPTION
## Summary

Fixes #633

Add a new `dub` community source that lets Coral query Dub.co link
management data through SQL. This makes workspaces, links, domains,
and tags queryable via standard SQL — enabling link analytics, campaign
auditing, and cross-source joins with tools like GitHub releases or
Stripe revenue directly from Coral.

This change is manifest-only and uses Coral's existing HTTP source-spec
model. It adds read-only Dub.co visibility without changing CLI, MCP,
config, runtime, or bundled-source contracts.

## What changed

Added:
- `sources/community/dub/manifest.yaml`
- `sources/community/dub/README.md`

## Source scope

Inputs:
- `DUB_API_KEY` — static Bearer token (secret), generated from
  Workspace Settings → API Keys. Keys start with `dub_` and are
  workspace-scoped since July 2024.

Tables:
- `dub.workspaces`
  - `GET /workspaces`
  - lists workspace metadata for the authenticated API key
  - no filter required — API key scopes to workspace automatically
  - `usage` and `users` kept as `Json` (nested objects)
  - mode: none (small dataset per key)

- `dub.links`
  - `GET /links`
  - lists all short links with click, lead, and sales analytics
  - no required filter — workspace scoped by API key
  - optional filters: `domain`, `search`, `show_archived`
    (`filter_bool`), `tag_ids`, `folder_id`
  - page-based pagination (`mode: page`, `pageSize` max 100)
  - `tags`, `geo`, `test_variants` kept as `Json`
  - analytics columns (`clicks`, `leads`, `sales`, `saleAmount`,
    `conversions`) exposed as `Int64` directly from list response
  - camelCase API fields translated to snake_case column names
    throughout (`shortLink` → `short_link`, `createdAt` →
    `created_at`, etc.)

- `dub.domains`
  - `GET /domains`
  - lists custom domains configured in the workspace
  - no filter required
  - `registered_domain` kept as `Json`
  - mode: none (small static list)

- `dub.tags`
  - `GET /tags`
  - lists link tags with name and color
  - optional filter: `search`
  - page-based pagination (`mode: page`, `pageSize` max 100)

## Implementation notes

- uses Dub REST API Bearer auth
  (`Authorization: Bearer {{input.DUB_API_KEY}}`)
- keeps v1 intentionally read-only
- all 4 endpoints return root JSON arrays — uses `response: {}`
  throughout
- no `workspaceId` filter needed on any table — Dub API keys are
  workspace-scoped since July 2024; the key itself determines scope
- `show_archived` uses `filter_bool` to correctly serialize as a
  JSON boolean query param (`showArchived`)
- ISO 8601 timestamps use `format_timestamp: iso8601` throughout
- `password` field on links is kept as `Utf8` — API returns masked
  value, never the real password

## Validation

Local validation completed:

![Validation outpu](https://github.com/user-attachments/assets/7551956b-5097-4547-9dda-7985c6316517)


## Out of scope

Not included in v1:
- `/v1/analytics` time-series endpoints (highly parameterized,
  better suited for a table function in v2)
- link creation or updates
- domain verification or management
- webhook management
- write operations of any kind