### PR TITLE
feat(sources/community/semaphore_ci): add Semaphore CI community source

### DIFF
--- a/sources/community/semaphore_ci/README.md
+++ b/sources/community/semaphore_ci/README.md
@@ -80,7 +80,9 @@ tag, pull request, or manual rerun.
 ### pipelines
 
 Pipelines for a project or workflow. Each row is one pipeline execution
-within a workflow. Requires `project_id`; optionally pass `wf_id` to
+within a workflow. This Coral source requires `project_id` for a safe
+default query path; Semaphore's API also accepts `wf_id` alone, but
+this source always requires `project_id`. Optionally pass `wf_id` to
 narrow to a single workflow.
 
 > **Important:** The pipeline list endpoint does **not** return `ppl_id`.
@@ -99,7 +101,8 @@ narrow to a single workflow.
 | `branch_name` | Utf8 | Git branch name |
 | `created_at` | Timestamp | Pipeline creation time (UTC) |
 
-**Required filter:** `project_id`
+**Required filter:** `project_id` (Coral source restriction — Semaphore's
+API also accepts `wf_id` alone)
 **Optional filters:** `wf_id`, `branch_name`, `yml_file_path`,
 `created_after`, `created_before`, `done_after`, `done_before`
 **Pagination:** Link header
@@ -129,7 +132,8 @@ Promotions triggered from a pipeline (e.g. deploy to staging/production).
 
 > **Note:** The promotions list endpoint only returns `name`, `status`,
 > and `triggered_by`. Timestamp and auto-promotion metadata are not
-> exposed by this endpoint.
+> exposed by this endpoint. Semaphore returns a server error (500) for
+> pipelines with no promotions configured rather than an empty array.
 
 ---
 
@@ -204,6 +208,11 @@ WHERE pipeline_id = 'initial-ppl-id-from-workflows';
 - **Case inconsistency**: The `state` and `result` fields may use different
   casing between API responses (e.g. `DONE` vs `done`, `FAILED` vs
   `failed`). Use `LOWER(result)` or `UPPER(state)` for reliable filtering.
-- **Pipelines require `project_id`**: The pipelines table requires
-  `project_id`. Optionally add `wf_id` to narrow to a specific workflow.
+- **Pipelines require `project_id`**: This is a Coral source restriction
+  for a safe first-query experience. Semaphore's API contract accepts
+  either `project_id` or `wf_id` (or both); this source always requires
+  `project_id` and treats `wf_id` as an optional narrowing filter.
+- **Promotions 500 on no-promotion pipelines**: Semaphore returns a
+  server error (500) for pipelines that have no promotions configured.
+  This is an upstream API behavior, not a source bug.
 - **API docs**: https://docs.semaphoreci.com/reference/api

--- a/sources/community/semaphore_ci/README.md
+++ b/sources/community/semaphore_ci/README.md
@@ -60,7 +60,7 @@ tag, pull request, or manual rerun.
 | `requester_id` | Utf8 | User or system that requested this workflow |
 | `repository_id` | Utf8 | Repository UUID |
 | `organization_id` | Utf8 | Organization UUID |
-| `initial_ppl_id` | Utf8 | Initial pipeline UUID |
+| `initial_ppl_id` | Utf8 | Initial pipeline UUID — use this for promotions |
 | `hook_id` | Utf8 | Webhook event UUID |
 | `branch_name` | Utf8 | Git branch name |
 | `branch_id` | Utf8 | Semaphore branch UUID |
@@ -81,30 +81,33 @@ Pipelines for a project or workflow. Each row is one pipeline execution
 within a workflow. Pass `project_id` or `wf_id` (or both) — the API
 requires at least one.
 
+> **Important:** The pipeline list endpoint does **not** return `ppl_id`.
+> To get a pipeline ID for the promotions table, use `initial_ppl_id`
+> from `semaphore_ci.workflows`.
+
 | Column | Type | Description |
 |---|---|---|
 | `project_id` | Utf8 | Project ID (echoed when provided) |
-| `ppl_id` | Utf8 | Pipeline UUID (may be absent in list) |
 | `name` | Utf8 | Pipeline name from YAML config |
 | `yaml_file_name` | Utf8 | YAML file defining this pipeline |
 | `working_directory` | Utf8 | Pipeline working directory |
 | `wf_id` | Utf8 | Parent workflow UUID |
 | `state` | Utf8 | State (pending, queuing, running, stopping, done) |
 | `result` | Utf8 | Result (passed, failed, stopped, canceled) |
-| `result_reason` | Utf8 | Reason for the result (e.g. test, malformed_yaml) |
-| `error_description` | Utf8 | Error details for config/system failures |
 | `branch_name` | Utf8 | Git branch name |
 | `created_at` | Timestamp | Pipeline creation time (UTC) |
-| `pending_at` | Timestamp | Time entered pending state (UTC) |
-| `queuing_at` | Timestamp | Time entered queuing state (UTC) |
-| `running_at` | Timestamp | Time pipeline started running (UTC) |
-| `stopping_at` | Timestamp | Time pipeline began stopping (UTC) |
-| `done_at` | Timestamp | Time pipeline finished (UTC) |
 
 **Required filter:** at least one of `project_id` or `wf_id`
 **Optional filters:** `branch_name`, `yml_file_path`, `created_after`,
 `created_before`, `done_after`, `done_before`
 **Pagination:** Link header
+
+> **Note:** Richer fields like `result_reason`, `error_description`,
+> `pending_at`, `running_at`, `done_at`, etc. are only available via
+> the describe endpoint (`GET /pipelines/:pipeline_id`), which is not
+> covered by this list table. Those timestamps also use a custom string
+> format (`YYYY-MM-DD HH:MM:SS.ffffffZ`), not the `{seconds, nanos}`
+> object used by the list endpoint.
 
 ---
 
@@ -130,18 +133,19 @@ Promotions triggered from a pipeline (e.g. deploy to staging/production).
 
 ## Typical Query Flow
 
-Since there is no projects list endpoint, the typical workflow is:
+Since there is no projects list endpoint and the pipeline list does not
+return `ppl_id`, the typical workflow is:
 
 1. **Get your project ID** from the Semaphore UI or CLI
-2. **Query workflows** for that project
+2. **Query workflows** for that project — this gives you `initial_ppl_id`
 3. **Drill into pipelines** using the project ID or a specific workflow ID
-4. **Check promotions** for a specific pipeline
+4. **Check promotions** using `initial_ppl_id` from step 2 as `pipeline_id`
 
 ## Example Queries
 
 ```sql
 -- List recent workflows for a project
-SELECT wf_id, branch_name, commit_sha, created_at
+SELECT wf_id, branch_name, commit_sha, initial_ppl_id, created_at
 FROM semaphore_ci.workflows
 WHERE project_id = 'your-project-uuid'
 LIMIT 10;
@@ -163,10 +167,10 @@ FROM semaphore_ci.pipelines
 WHERE project_id = 'your-project-uuid'
   AND branch_name = 'main';
 
--- List promotions for a pipeline
+-- List promotions using initial_ppl_id from workflows
 SELECT name, status, triggered_by
 FROM semaphore_ci.promotions
-WHERE pipeline_id = 'your-pipeline-uuid';
+WHERE pipeline_id = 'initial-ppl-id-from-workflows';
 ```
 
 ## Pagination
@@ -182,15 +186,18 @@ WHERE pipeline_id = 'your-pipeline-uuid';
 - **No projects endpoint**: The Semaphore v1alpha API does not provide a
   `GET /projects` endpoint. Obtain your `project_id` from the Semaphore
   dashboard (Project Settings) or CLI (`sem get project`).
+- **No `ppl_id` in pipeline list**: The pipeline list endpoint does not
+  return pipeline IDs. Use `initial_ppl_id` from the workflows table to
+  obtain the initial pipeline ID for promotions queries.
 - **Cloud-only**: The `base_url` assumes `*.semaphoreci.com`. Semaphore
   Enterprise users on a custom domain would need to fork and adjust.
 - **Read-only**: This source only uses GET endpoints. No create, update,
   or delete operations.
-- **Timestamps**: The API returns timestamps as protobuf-style
-  `{seconds, nanos}` objects. This source extracts the `seconds` field
-  and exposes each as a UTC `Timestamp` column. The pipelines table
-  exposes `created_at`, `pending_at`, `queuing_at`, `running_at`,
-  `stopping_at`, and `done_at` for build-duration analysis.
+- **Timestamps**: The pipeline list endpoint returns `created_at` as a
+  protobuf-style `{seconds, nanos}` object. The describe endpoint
+  (`GET /pipelines/:pipeline_id`) uses a different custom string format
+  (`YYYY-MM-DD HH:MM:SS.ffffffZ`). This source only covers the list
+  endpoint.
 - **Case inconsistency**: The `state` and `result` fields may use different
   casing between API responses (e.g. `DONE` vs `done`, `FAILED` vs
   `failed`). Use `LOWER(result)` or `UPPER(state)` for reliable filtering.

--- a/sources/community/semaphore_ci/README.md
+++ b/sources/community/semaphore_ci/README.md
@@ -40,6 +40,8 @@ coral source add --file sources/community/semaphore_ci/manifest.yaml
 | `SEMAPHORE_ORG_SLUG` | Variable | Organization slug (subdomain) |
 
 Auth uses `Authorization: Token <TOKEN>` per the Semaphore v1alpha API spec.
+The documented `User-Agent: SemaphoreCI v2.0 Client` header is sent
+automatically via `request_headers`.
 
 ## Tables
 
@@ -78,8 +80,8 @@ tag, pull request, or manual rerun.
 ### pipelines
 
 Pipelines for a project or workflow. Each row is one pipeline execution
-within a workflow. Pass `project_id` or `wf_id` (or both) — the API
-requires at least one.
+within a workflow. Requires `project_id`; optionally pass `wf_id` to
+narrow to a single workflow.
 
 > **Important:** The pipeline list endpoint does **not** return `ppl_id`.
 > To get a pipeline ID for the promotions table, use `initial_ppl_id`
@@ -87,7 +89,7 @@ requires at least one.
 
 | Column | Type | Description |
 |---|---|---|
-| `project_id` | Utf8 | Project ID (echoed when provided) |
+| `project_id` | Utf8 | Project ID (required filter) |
 | `name` | Utf8 | Pipeline name from YAML config |
 | `yaml_file_name` | Utf8 | YAML file defining this pipeline |
 | `working_directory` | Utf8 | Pipeline working directory |
@@ -97,9 +99,9 @@ requires at least one.
 | `branch_name` | Utf8 | Git branch name |
 | `created_at` | Timestamp | Pipeline creation time (UTC) |
 
-**Required filter:** at least one of `project_id` or `wf_id`
-**Optional filters:** `branch_name`, `yml_file_path`, `created_after`,
-`created_before`, `done_after`, `done_before`
+**Required filter:** `project_id`
+**Optional filters:** `wf_id`, `branch_name`, `yml_file_path`,
+`created_after`, `created_before`, `done_after`, `done_before`
 **Pagination:** Link header
 
 > **Note:** Richer fields like `result_reason`, `error_description`,
@@ -159,7 +161,8 @@ WHERE project_id = 'your-project-uuid'
 -- Filter pipelines by workflow ID
 SELECT name, state, result, yaml_file_name
 FROM semaphore_ci.pipelines
-WHERE wf_id = 'your-workflow-uuid';
+WHERE project_id = 'your-project-uuid'
+  AND wf_id = 'your-workflow-uuid';
 
 -- Find pipelines by branch name
 SELECT name, state, result, created_at
@@ -201,7 +204,6 @@ WHERE pipeline_id = 'initial-ppl-id-from-workflows';
 - **Case inconsistency**: The `state` and `result` fields may use different
   casing between API responses (e.g. `DONE` vs `done`, `FAILED` vs
   `failed`). Use `LOWER(result)` or `UPPER(state)` for reliable filtering.
-- **Pipelines require at least one filter**: The Semaphore API requires
-  either `project_id` or `wf_id` (or both) on the pipelines endpoint.
-  Queries without either will fail at the API level.
+- **Pipelines require `project_id`**: The pipelines table requires
+  `project_id`. Optionally add `wf_id` to narrow to a specific workflow.
 - **API docs**: https://docs.semaphoreci.com/reference/api

--- a/sources/community/semaphore_ci/README.md
+++ b/sources/community/semaphore_ci/README.md
@@ -1,8 +1,12 @@
 # Semaphore CI Source
 
 Query CI/CD data from [Semaphore CI](https://semaphoreci.com) — workflows,
-pipelines, and promotions for your projects. Read-only; uses the
-[v1alpha REST API](https://docs.semaphoreci.com/reference/api).
+pipelines, and promotions for your projects. All tables require a
+`project_id` or `pipeline_id` filter — Semaphore's v1alpha API does not
+expose a list-projects endpoint, so obtain IDs from the Semaphore
+dashboard or `sem` CLI. Read-only; cloud-only (assumes `*.semaphoreci.com`).
+
+API docs: https://docs.semaphoreci.com/reference/api
 
 ## Setup
 
@@ -61,36 +65,45 @@ tag, pull request, or manual rerun.
 | `branch_name` | Utf8 | Git branch name |
 | `branch_id` | Utf8 | Semaphore branch UUID |
 | `commit_sha` | Utf8 | Git commit SHA |
-| `triggered_by` | Utf8 | Trigger source (integer enum or string) |
+| `triggered_by` | Int64 | Trigger source (integer enum, e.g. 1 = hook) |
 | `rerun_of` | Utf8 | Original workflow UUID if rerun |
 | `created_at` | Timestamp | Workflow creation time (UTC) |
 
 **Required filter:** `project_id`
-**Optional filter:** `branch_name`
+**Optional filters:** `branch_name`, `created_after`, `created_before`
 **Pagination:** Link header
 
 ---
 
 ### pipelines
 
-Pipelines for a project. Each row is one pipeline execution within a
-workflow.
+Pipelines for a project or workflow. Each row is one pipeline execution
+within a workflow. Pass `project_id` or `wf_id` (or both) — the API
+requires at least one.
 
 | Column | Type | Description |
 |---|---|---|
-| `project_id` | Utf8 | Project ID (required filter) |
+| `project_id` | Utf8 | Project ID (echoed when provided) |
 | `ppl_id` | Utf8 | Pipeline UUID (may be absent in list) |
 | `name` | Utf8 | Pipeline name from YAML config |
 | `yaml_file_name` | Utf8 | YAML file defining this pipeline |
 | `working_directory` | Utf8 | Pipeline working directory |
 | `wf_id` | Utf8 | Parent workflow UUID |
-| `state` | Utf8 | State (running, done, stopping) |
+| `state` | Utf8 | State (pending, queuing, running, stopping, done) |
 | `result` | Utf8 | Result (passed, failed, stopped, canceled) |
+| `result_reason` | Utf8 | Reason for the result (e.g. test, malformed_yaml) |
+| `error_description` | Utf8 | Error details for config/system failures |
 | `branch_name` | Utf8 | Git branch name |
 | `created_at` | Timestamp | Pipeline creation time (UTC) |
+| `pending_at` | Timestamp | Time entered pending state (UTC) |
+| `queuing_at` | Timestamp | Time entered queuing state (UTC) |
+| `running_at` | Timestamp | Time pipeline started running (UTC) |
+| `stopping_at` | Timestamp | Time pipeline began stopping (UTC) |
+| `done_at` | Timestamp | Time pipeline finished (UTC) |
 
-**Required filter:** `project_id`
-**Optional filters:** `wf_id`, `branch_name`
+**Required filter:** at least one of `project_id` or `wf_id`
+**Optional filters:** `branch_name`, `yml_file_path`, `created_after`,
+`created_before`, `done_after`, `done_before`
 **Pagination:** Link header
 
 ---
@@ -108,6 +121,10 @@ Promotions triggered from a pipeline (e.g. deploy to staging/production).
 
 **Required filter:** `pipeline_id`
 **Pagination:** None
+
+> **Note:** The promotions list endpoint only returns `name`, `status`,
+> and `triggered_by`. Timestamp and auto-promotion metadata are not
+> exposed by this endpoint.
 
 ---
 
@@ -129,17 +146,16 @@ FROM semaphore_ci.workflows
 WHERE project_id = 'your-project-uuid'
 LIMIT 10;
 
--- Find failed pipelines
+-- Find failed pipelines (use LOWER for case-safe comparison)
 SELECT name, state, result, branch_name, created_at
 FROM semaphore_ci.pipelines
 WHERE project_id = 'your-project-uuid'
-  AND result = 'FAILED';
+  AND LOWER(result) = 'failed';
 
 -- Filter pipelines by workflow ID
 SELECT name, state, result, yaml_file_name
 FROM semaphore_ci.pipelines
-WHERE project_id = 'your-project-uuid'
-  AND wf_id = 'your-workflow-uuid';
+WHERE wf_id = 'your-workflow-uuid';
 
 -- Find pipelines by branch name
 SELECT name, state, result, created_at
@@ -166,12 +182,19 @@ WHERE pipeline_id = 'your-pipeline-uuid';
 - **No projects endpoint**: The Semaphore v1alpha API does not provide a
   `GET /projects` endpoint. Obtain your `project_id` from the Semaphore
   dashboard (Project Settings) or CLI (`sem get project`).
+- **Cloud-only**: The `base_url` assumes `*.semaphoreci.com`. Semaphore
+  Enterprise users on a custom domain would need to fork and adjust.
 - **Read-only**: This source only uses GET endpoints. No create, update,
   or delete operations.
-- **Timestamps**: The API returns `created_at` as a protobuf-style
-  `{seconds, nanos}` object. This source extracts the `seconds` field
-  and exposes it as a UTC `Timestamp` column.
+- **Timestamps**: The API returns timestamps as protobuf-style
+  `{seconds, nanos}` objects. This source extracts the `seconds` field
+  and exposes each as a UTC `Timestamp` column. The pipelines table
+  exposes `created_at`, `pending_at`, `queuing_at`, `running_at`,
+  `stopping_at`, and `done_at` for build-duration analysis.
 - **Case inconsistency**: The `state` and `result` fields may use different
-  casing between list and describe responses (e.g. `DONE` vs `done`,
-  `FAILED` vs `failed`). Use case-insensitive comparisons when filtering.
+  casing between API responses (e.g. `DONE` vs `done`, `FAILED` vs
+  `failed`). Use `LOWER(result)` or `UPPER(state)` for reliable filtering.
+- **Pipelines require at least one filter**: The Semaphore API requires
+  either `project_id` or `wf_id` (or both) on the pipelines endpoint.
+  Queries without either will fail at the API level.
 - **API docs**: https://docs.semaphoreci.com/reference/api

--- a/sources/community/semaphore_ci/README.md
+++ b/sources/community/semaphore_ci/README.md
@@ -1,0 +1,177 @@
+# Semaphore CI Source
+
+Query CI/CD data from [Semaphore CI](https://semaphoreci.com) — workflows,
+pipelines, and promotions for your projects. Read-only; uses the
+[v1alpha REST API](https://docs.semaphoreci.com/reference/api).
+
+## Setup
+
+### 1. Get your API token
+
+Generate an API token from your Semaphore account:
+[Account Settings → API Tokens](https://me.semaphoreci.com/account).
+
+### 2. Configure environment variables
+
+```bash
+export SEMAPHORE_API_TOKEN="your-semaphore-api-token"
+export SEMAPHORE_ORG_SLUG="mycompany"
+```
+
+The org slug is the subdomain part of your Semaphore dashboard URL.
+For example, if your URL is `https://mycompany.semaphoreci.com`, your slug
+is `mycompany`.
+
+### 3. Add the source
+
+```bash
+coral source add --file sources/community/semaphore_ci/manifest.yaml
+```
+
+## Authentication
+
+| Input | Kind | Description |
+|---|---|---|
+| `SEMAPHORE_API_TOKEN` | Secret | Semaphore CI API token |
+| `SEMAPHORE_ORG_SLUG` | Variable | Organization slug (subdomain) |
+
+Auth uses `Authorization: Token <TOKEN>` per the Semaphore v1alpha API spec.
+
+## Tables
+
+> **Note:** The Semaphore v1alpha API does not expose a list-projects
+> endpoint. To get your `project_id`, use the Semaphore dashboard URL
+> (visible in project settings) or the CLI: `sem get project <name>`.
+> All tables below require a `project_id` or `pipeline_id` filter.
+
+### workflows
+
+Workflow runs for a project. Each row is one workflow triggered by a push,
+tag, pull request, or manual rerun.
+
+| Column | Type | Description |
+|---|---|---|
+| `project_id` | Utf8 | Project ID (required filter) |
+| `wf_id` | Utf8 | Workflow UUID |
+| `requester_id` | Utf8 | User or system that requested this workflow |
+| `repository_id` | Utf8 | Repository UUID |
+| `organization_id` | Utf8 | Organization UUID |
+| `initial_ppl_id` | Utf8 | Initial pipeline UUID |
+| `hook_id` | Utf8 | Webhook event UUID |
+| `branch_name` | Utf8 | Git branch name |
+| `branch_id` | Utf8 | Semaphore branch UUID |
+| `commit_sha` | Utf8 | Git commit SHA |
+| `triggered_by` | Utf8 | Trigger source (integer enum or string) |
+| `rerun_of` | Utf8 | Original workflow UUID if rerun |
+| `created_at` | Timestamp | Workflow creation time (UTC) |
+
+**Required filter:** `project_id`
+**Optional filter:** `branch_name`
+**Pagination:** Link header
+
+---
+
+### pipelines
+
+Pipelines for a project. Each row is one pipeline execution within a
+workflow.
+
+| Column | Type | Description |
+|---|---|---|
+| `project_id` | Utf8 | Project ID (required filter) |
+| `ppl_id` | Utf8 | Pipeline UUID (may be absent in list) |
+| `name` | Utf8 | Pipeline name from YAML config |
+| `yaml_file_name` | Utf8 | YAML file defining this pipeline |
+| `working_directory` | Utf8 | Pipeline working directory |
+| `wf_id` | Utf8 | Parent workflow UUID |
+| `state` | Utf8 | State (running, done, stopping) |
+| `result` | Utf8 | Result (passed, failed, stopped, canceled) |
+| `branch_name` | Utf8 | Git branch name |
+| `created_at` | Timestamp | Pipeline creation time (UTC) |
+
+**Required filter:** `project_id`
+**Optional filters:** `wf_id`, `branch_name`
+**Pagination:** Link header
+
+---
+
+### promotions
+
+Promotions triggered from a pipeline (e.g. deploy to staging/production).
+
+| Column | Type | Description |
+|---|---|---|
+| `pipeline_id` | Utf8 | Pipeline ID (required filter) |
+| `name` | Utf8 | Promotion name (e.g. production) |
+| `status` | Utf8 | Promotion status (passed, failed) |
+| `triggered_by` | Utf8 | What triggered the promotion |
+
+**Required filter:** `pipeline_id`
+**Pagination:** None
+
+---
+
+## Typical Query Flow
+
+Since there is no projects list endpoint, the typical workflow is:
+
+1. **Get your project ID** from the Semaphore UI or CLI
+2. **Query workflows** for that project
+3. **Drill into pipelines** using the project ID or a specific workflow ID
+4. **Check promotions** for a specific pipeline
+
+## Example Queries
+
+```sql
+-- List recent workflows for a project
+SELECT wf_id, branch_name, commit_sha, created_at
+FROM semaphore_ci.workflows
+WHERE project_id = 'your-project-uuid'
+LIMIT 10;
+
+-- Find failed pipelines
+SELECT name, state, result, branch_name, created_at
+FROM semaphore_ci.pipelines
+WHERE project_id = 'your-project-uuid'
+  AND result = 'FAILED';
+
+-- Filter pipelines by workflow ID
+SELECT name, state, result, yaml_file_name
+FROM semaphore_ci.pipelines
+WHERE project_id = 'your-project-uuid'
+  AND wf_id = 'your-workflow-uuid';
+
+-- Find pipelines by branch name
+SELECT name, state, result, created_at
+FROM semaphore_ci.pipelines
+WHERE project_id = 'your-project-uuid'
+  AND branch_name = 'main';
+
+-- List promotions for a pipeline
+SELECT name, status, triggered_by
+FROM semaphore_ci.promotions
+WHERE pipeline_id = 'your-pipeline-uuid';
+```
+
+## Pagination
+
+| Table | Mode | Default Page Size |
+|---|---|---|
+| `workflows` | Link header | 30 |
+| `pipelines` | Link header | 30 |
+| `promotions` | None | — |
+
+## Notes
+
+- **No projects endpoint**: The Semaphore v1alpha API does not provide a
+  `GET /projects` endpoint. Obtain your `project_id` from the Semaphore
+  dashboard (Project Settings) or CLI (`sem get project`).
+- **Read-only**: This source only uses GET endpoints. No create, update,
+  or delete operations.
+- **Timestamps**: The API returns `created_at` as a protobuf-style
+  `{seconds, nanos}` object. This source extracts the `seconds` field
+  and exposes it as a UTC `Timestamp` column.
+- **Case inconsistency**: The `state` and `result` fields may use different
+  casing between list and describe responses (e.g. `DONE` vs `done`,
+  `FAILED` vs `failed`). Use case-insensitive comparisons when filtering.
+- **API docs**: https://docs.semaphoreci.com/reference/api

--- a/sources/community/semaphore_ci/manifest.yaml
+++ b/sources/community/semaphore_ci/manifest.yaml
@@ -1,0 +1,390 @@
+name: semaphore_ci
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query workflows, pipelines, and promotions from Semaphore CI.
+  Covers workflow runs, pipeline state and results, and promotion
+  status for a given project. Read-only; uses the v1alpha REST API.
+base_url: "https://{{input.SEMAPHORE_ORG_SLUG}}.semaphoreci.com/api/v1alpha"
+
+inputs:
+  SEMAPHORE_API_TOKEN:
+    kind: secret
+    hint: |
+      Your Semaphore CI API token. Generate one from
+      Account Settings → API Tokens.
+      See https://docs.semaphoreci.com/reference/api
+  SEMAPHORE_ORG_SLUG:
+    kind: variable
+    hint: |
+      Your Semaphore organization slug — the subdomain part of your
+      Semaphore URL. For example, if your dashboard URL is
+      https://mycompany.semaphoreci.com, enter: mycompany
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Token {{input.SEMAPHORE_API_TOKEN}}
+
+test_queries:
+  - >-
+    SELECT wf_id, branch_name, commit_sha
+    FROM semaphore_ci.workflows
+    WHERE project_id = 'your-project-uuid'
+    LIMIT 5
+  - >-
+    SELECT name, state, result, branch_name
+    FROM semaphore_ci.pipelines
+    WHERE project_id = 'your-project-uuid'
+    LIMIT 5
+  - >-
+    SELECT wf_id, branch_name, created_at
+    FROM semaphore_ci.workflows
+    WHERE project_id = 'your-project-uuid'
+    LIMIT 5
+  - >-
+    SELECT name, status, triggered_by
+    FROM semaphore_ci.promotions
+    WHERE pipeline_id = 'your-pipeline-uuid'
+    LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # workflows — list workflows for a project
+  # GET /api/v1alpha/plumber-workflows?project_id=<id>
+  # Pagination: HTTP Link header (default 30 per page).
+  # Response: root-level JSON array (no wrapper key).
+  # ──────────────────────────────────────────────────────────────────────
+  - name: workflows
+    description: >-
+      Workflow runs for a Semaphore CI project. Each row is one workflow
+      execution triggered by a push, tag, PR, or manual rerun. Requires
+      `project_id` filter — obtain from Semaphore UI or CLI.
+    guide: |
+      Requires `project_id` — find it in the Semaphore dashboard URL or
+      via `sem get project <name>`. Use `wf_id` from here as a filter on
+      `semaphore_ci.pipelines` to drill into a specific workflow.
+      Optional filters: `branch_name` to scope by branch.
+      `created_at` is a UTC timestamp derived from the API's protobuf
+      `{seconds, nanos}` object.
+    filters:
+      - name: project_id
+        required: true
+      - name: branch_name
+        required: false
+    request:
+      method: GET
+      path: /plumber-workflows
+      query:
+        - name: project_id
+          from: filter
+          key: project_id
+        - name: branch_name
+          from: filter
+          key: branch_name
+    response: {}
+    pagination:
+      mode: link_header
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Project ID (echoes the required filter).
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: wf_id
+        type: Utf8
+        nullable: false
+        description: Workflow UUID.
+        expr:
+          kind: path
+          path:
+            - wf_id
+      - name: requester_id
+        type: Utf8
+        nullable: true
+        description: UUID of the user or system that requested this workflow.
+        expr:
+          kind: path
+          path:
+            - requester_id
+      - name: repository_id
+        type: Utf8
+        nullable: true
+        description: Repository UUID associated with this workflow.
+        expr:
+          kind: path
+          path:
+            - repository_id
+      - name: organization_id
+        type: Utf8
+        nullable: true
+        description: Organization UUID.
+        expr:
+          kind: path
+          path:
+            - organization_id
+      - name: initial_ppl_id
+        type: Utf8
+        nullable: true
+        description: UUID of the initial pipeline created by this workflow.
+        expr:
+          kind: path
+          path:
+            - initial_ppl_id
+      - name: hook_id
+        type: Utf8
+        nullable: true
+        description: UUID of the webhook event that triggered this workflow.
+        expr:
+          kind: path
+          path:
+            - hook_id
+      - name: branch_name
+        type: Utf8
+        nullable: true
+        description: Git branch name for this workflow run.
+        expr:
+          kind: path
+          path:
+            - branch_name
+      - name: branch_id
+        type: Utf8
+        nullable: true
+        description: Semaphore branch UUID.
+        expr:
+          kind: path
+          path:
+            - branch_id
+      - name: commit_sha
+        type: Utf8
+        nullable: true
+        description: Git commit SHA that triggered this workflow.
+        expr:
+          kind: path
+          path:
+            - commit_sha
+      - name: triggered_by
+        type: Utf8
+        nullable: true
+        description: >-
+          How the workflow was triggered. May be an integer enum (1 = hook)
+          in list responses or a string (HOOK) in describe responses.
+        expr:
+          kind: path
+          path:
+            - triggered_by
+      - name: rerun_of
+        type: Utf8
+        nullable: true
+        description: UUID of the original workflow if this is a rerun, empty string otherwise.
+        expr:
+          kind: path
+          path:
+            - rerun_of
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: >-
+          Workflow creation time (UTC). Extracted from the API's protobuf
+          {seconds, nanos} object — nanos are truncated.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - created_at
+              - seconds
+
+  # ──────────────────────────────────────────────────────────────────────
+  # pipelines — list pipelines for a project or workflow
+  # GET /api/v1alpha/pipelines?project_id=<id>[&wf_id=<id>]
+  # Pagination: HTTP Link header (default 30 per page).
+  # Response: root-level JSON array (no wrapper key).
+  # ──────────────────────────────────────────────────────────────────────
+  - name: pipelines
+    description: >-
+      Pipelines for a Semaphore CI project. Each row is one pipeline
+      execution within a workflow. Requires `project_id` filter.
+      Optionally filter by `wf_id` to see pipelines for a single workflow.
+    guide: |
+      Requires `project_id`. Optionally pass `wf_id` (from
+      `semaphore_ci.workflows`) to scope to a single workflow's pipelines.
+      Use `ppl_id` from the list response (when present) or the pipeline
+      name to identify pipelines. `state` values: running, done, stopping.
+      `result` values: passed, failed, stopped, canceled.
+    filters:
+      - name: project_id
+        required: true
+      - name: wf_id
+        required: false
+      - name: branch_name
+        required: false
+    request:
+      method: GET
+      path: /pipelines
+      query:
+        - name: project_id
+          from: filter
+          key: project_id
+        - name: wf_id
+          from: filter
+          key: wf_id
+        - name: branch_name
+          from: filter
+          key: branch_name
+    response: {}
+    pagination:
+      mode: link_header
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        description: Project ID (echoes the required filter).
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: ppl_id
+        type: Utf8
+        nullable: true
+        description: Pipeline UUID. May be absent in list responses.
+        expr:
+          kind: path
+          path:
+            - ppl_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Pipeline name as defined in the YAML config.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: yaml_file_name
+        type: Utf8
+        nullable: true
+        description: YAML file that defines this pipeline (e.g. semaphore.yml).
+        expr:
+          kind: path
+          path:
+            - yaml_file_name
+      - name: working_directory
+        type: Utf8
+        nullable: true
+        description: Working directory for the pipeline (e.g. .semaphore).
+        expr:
+          kind: path
+          path:
+            - working_directory
+      - name: wf_id
+        type: Utf8
+        nullable: true
+        description: Parent workflow UUID.
+        expr:
+          kind: path
+          path:
+            - wf_id
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Pipeline state (running, done, stopping).
+        expr:
+          kind: path
+          path:
+            - state
+      - name: result
+        type: Utf8
+        nullable: true
+        description: Pipeline result (passed, failed, stopped, canceled).
+        expr:
+          kind: path
+          path:
+            - result
+      - name: branch_name
+        type: Utf8
+        nullable: true
+        description: Git branch name.
+        expr:
+          kind: path
+          path:
+            - branch_name
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: >-
+          Pipeline creation time (UTC). Extracted from the API's protobuf
+          {seconds, nanos} object — nanos are truncated.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - created_at
+              - seconds
+
+  # ──────────────────────────────────────────────────────────────────────
+  # promotions — list promotions for a pipeline
+  # GET /api/v1alpha/promotions?pipeline_id=<id>
+  # Pagination: none (small result sets per pipeline).
+  # Response: root-level JSON array (no wrapper key).
+  # ──────────────────────────────────────────────────────────────────────
+  - name: promotions
+    description: >-
+      Promotions triggered from a Semaphore CI pipeline. Each row is one
+      promotion (e.g. deploy to production). Requires `pipeline_id` filter.
+    guide: |
+      Requires `pipeline_id` — obtain from `semaphore_ci.pipelines`. A
+      promotion represents a triggered deployment or downstream pipeline.
+      `status` values: passed, failed. `triggered_by` describes what
+      triggered the promotion (e.g. "Pipeline Done request").
+    filters:
+      - name: pipeline_id
+        required: true
+    request:
+      method: GET
+      path: /promotions
+      query:
+        - name: pipeline_id
+          from: filter
+          key: pipeline_id
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: pipeline_id
+        type: Utf8
+        nullable: false
+        description: Pipeline ID (echoes the required filter).
+        expr:
+          kind: from_filter
+          key: pipeline_id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Promotion name (e.g. production, staging).
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Promotion status (passed, failed).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: triggered_by
+        type: Utf8
+        nullable: true
+        description: What triggered the promotion (e.g. Pipeline Done request).
+        expr:
+          kind: path
+          path:
+            - triggered_by

--- a/sources/community/semaphore_ci/manifest.yaml
+++ b/sources/community/semaphore_ci/manifest.yaml
@@ -230,14 +230,18 @@ tables:
   - name: pipelines
     description: >-
       Pipelines for a Semaphore CI project. Each row is one pipeline
-      execution within a workflow. Requires `project_id`; optionally pass
+      execution within a workflow. This Coral source requires `project_id`
+      for a safe default query path; Semaphore's API also accepts `wf_id`
+      alone, but this source always requires `project_id`. Optionally pass
       `wf_id` to narrow to a single workflow. Note: the list endpoint
       does not return `ppl_id`; use `initial_ppl_id` from
       `semaphore_ci.workflows` to obtain the initial pipeline ID for
       promotions.
     guide: |
-      Requires `project_id`. Optionally add `wf_id` to narrow to a
-      specific workflow's pipelines.
+      This source requires `project_id` as a Coral-side restriction for a
+      safe first-query experience. Semaphore's API contract accepts either
+      `project_id` or `wf_id` (or both); this source always requires
+      `project_id` and treats `wf_id` as an optional narrowing filter.
       The list endpoint does NOT return `ppl_id` — to get a pipeline ID
       for the promotions table, use `initial_ppl_id` from
       `semaphore_ci.workflows` (which gives the first pipeline for each
@@ -393,6 +397,10 @@ tables:
       triggered the promotion (e.g. "Pipeline Done request"). The API
       response only includes name, status, and triggered_by; timestamp
       and auto-promotion metadata are not exposed by this endpoint.
+      Known limitation: Semaphore returns a server error (500) for
+      pipelines that have no promotions configured. An empty result
+      set is the expected outcome for pipelines without promotions,
+      but the upstream API does not return one.
     filters:
       - name: pipeline_id
         required: true

--- a/sources/community/semaphore_ci/manifest.yaml
+++ b/sources/community/semaphore_ci/manifest.yaml
@@ -33,7 +33,7 @@ auth:
 
 test_queries:
   - >-
-    SELECT wf_id, branch_name, commit_sha
+    SELECT wf_id, branch_name, commit_sha, initial_ppl_id
     FROM semaphore_ci.workflows
     WHERE project_id = 'your-project-uuid'
     LIMIT 5
@@ -50,7 +50,7 @@ test_queries:
   - >-
     SELECT name, status, triggered_by
     FROM semaphore_ci.promotions
-    WHERE pipeline_id = 'your-pipeline-uuid'
+    WHERE pipeline_id = 'initial-ppl-id-from-workflows'
     LIMIT 5
 
 tables:
@@ -227,12 +227,16 @@ tables:
     description: >-
       Pipelines for a Semaphore CI project. Each row is one pipeline
       execution within a workflow. Pass `project_id` or `wf_id` (or both)
-      — the API requires at least one.
+      — the API requires at least one. Note: the list endpoint does not
+      return `ppl_id`; use `initial_ppl_id` from `semaphore_ci.workflows`
+      to obtain the initial pipeline ID for promotions.
     guide: |
       Pass at least one of `project_id` or `wf_id`. The Semaphore API
       requires one to be present; providing both narrows results further.
-      Use `ppl_id` from the list response (when present) or the pipeline
-      name to identify pipelines.
+      The list endpoint does NOT return `ppl_id` — to get a pipeline ID
+      for the promotions table, use `initial_ppl_id` from
+      `semaphore_ci.workflows` (which gives the first pipeline for each
+      workflow).
       `state` values: pending, queuing, running, done, stopping.
       `result` values: passed, failed, stopped, canceled.
       Time-window filters `created_after`, `created_before`, `done_after`,
@@ -293,14 +297,6 @@ tables:
         expr:
           kind: from_filter
           key: project_id
-      - name: ppl_id
-        type: Utf8
-        nullable: true
-        description: Pipeline UUID. May be absent in list responses.
-        expr:
-          kind: path
-          path:
-            - ppl_id
       - name: name
         type: Utf8
         nullable: true
@@ -351,22 +347,6 @@ tables:
           kind: path
           path:
             - result
-      - name: result_reason
-        type: Utf8
-        nullable: true
-        description: Reason for the pipeline result (e.g. test, malformed_yaml).
-        expr:
-          kind: path
-          path:
-            - result_reason
-      - name: error_description
-        type: Utf8
-        nullable: true
-        description: Error details when a pipeline fails due to config or system errors.
-        expr:
-          kind: path
-          path:
-            - error_description
       - name: branch_name
         type: Utf8
         nullable: true
@@ -389,66 +369,6 @@ tables:
             path:
               - created_at
               - seconds
-      - name: pending_at
-        type: Timestamp
-        nullable: true
-        description: Time the pipeline entered the pending state (UTC).
-        expr:
-          kind: format_timestamp
-          input: seconds
-          expr:
-            kind: path
-            path:
-              - pending_at
-              - seconds
-      - name: queuing_at
-        type: Timestamp
-        nullable: true
-        description: Time the pipeline entered the queuing state (UTC).
-        expr:
-          kind: format_timestamp
-          input: seconds
-          expr:
-            kind: path
-            path:
-              - queuing_at
-              - seconds
-      - name: running_at
-        type: Timestamp
-        nullable: true
-        description: Time the pipeline started running (UTC).
-        expr:
-          kind: format_timestamp
-          input: seconds
-          expr:
-            kind: path
-            path:
-              - running_at
-              - seconds
-      - name: stopping_at
-        type: Timestamp
-        nullable: true
-        description: Time the pipeline began stopping (UTC).
-        expr:
-          kind: format_timestamp
-          input: seconds
-          expr:
-            kind: path
-            path:
-              - stopping_at
-              - seconds
-      - name: done_at
-        type: Timestamp
-        nullable: true
-        description: Time the pipeline finished (UTC). Use done_at - created_at for build duration.
-        expr:
-          kind: format_timestamp
-          input: seconds
-          expr:
-            kind: path
-            path:
-              - done_at
-              - seconds
 
   # ──────────────────────────────────────────────────────────────────────
   # promotions — list promotions for a pipeline
@@ -461,8 +381,9 @@ tables:
       Promotions triggered from a Semaphore CI pipeline. Each row is one
       promotion (e.g. deploy to production). Requires `pipeline_id` filter.
     guide: |
-      Requires `pipeline_id` — obtain from `semaphore_ci.pipelines`. A
-      promotion represents a triggered deployment or downstream pipeline.
+      Requires `pipeline_id` — obtain via `initial_ppl_id` from
+      `semaphore_ci.workflows`. A promotion represents a triggered
+      deployment or downstream pipeline.
       `status` values: passed, failed. `triggered_by` describes what
       triggered the promotion (e.g. "Pipeline Done request"). The API
       response only includes name, status, and triggered_by; timestamp

--- a/sources/community/semaphore_ci/manifest.yaml
+++ b/sources/community/semaphore_ci/manifest.yaml
@@ -30,6 +30,10 @@ auth:
     - name: Authorization
       from: template
       template: Token {{input.SEMAPHORE_API_TOKEN}}
+request_headers:
+  - name: User-Agent
+    from: literal
+    value: SemaphoreCI v2.0 Client
 
 test_queries:
   - >-
@@ -226,13 +230,14 @@ tables:
   - name: pipelines
     description: >-
       Pipelines for a Semaphore CI project. Each row is one pipeline
-      execution within a workflow. Pass `project_id` or `wf_id` (or both)
-      — the API requires at least one. Note: the list endpoint does not
-      return `ppl_id`; use `initial_ppl_id` from `semaphore_ci.workflows`
-      to obtain the initial pipeline ID for promotions.
+      execution within a workflow. Requires `project_id`; optionally pass
+      `wf_id` to narrow to a single workflow. Note: the list endpoint
+      does not return `ppl_id`; use `initial_ppl_id` from
+      `semaphore_ci.workflows` to obtain the initial pipeline ID for
+      promotions.
     guide: |
-      Pass at least one of `project_id` or `wf_id`. The Semaphore API
-      requires one to be present; providing both narrows results further.
+      Requires `project_id`. Optionally add `wf_id` to narrow to a
+      specific workflow's pipelines.
       The list endpoint does NOT return `ppl_id` — to get a pipeline ID
       for the promotions table, use `initial_ppl_id` from
       `semaphore_ci.workflows` (which gives the first pipeline for each
@@ -243,7 +248,7 @@ tables:
       `done_before` accept Unix timestamps for server-side pushdown.
     filters:
       - name: project_id
-        required: false
+        required: true
       - name: wf_id
         required: false
       - name: branch_name
@@ -292,8 +297,8 @@ tables:
     columns:
       - name: project_id
         type: Utf8
-        nullable: true
-        description: Project ID (echoes filter when provided).
+        nullable: false
+        description: Project ID (required filter).
         expr:
           kind: from_filter
           key: project_id

--- a/sources/community/semaphore_ci/manifest.yaml
+++ b/sources/community/semaphore_ci/manifest.yaml
@@ -3,9 +3,11 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query workflows, pipelines, and promotions from Semaphore CI.
-  Covers workflow runs, pipeline state and results, and promotion
-  status for a given project. Read-only; uses the v1alpha REST API.
+  Query workflows, pipelines, and promotions for a Semaphore CI
+  project. All tables require a project_id or pipeline_id filter —
+  Semaphore's v1alpha API does not expose a list-projects endpoint,
+  so obtain IDs from the Semaphore dashboard or `sem` CLI.
+  Read-only; cloud-only (assumes *.semaphoreci.com).
 base_url: "https://{{input.SEMAPHORE_ORG_SLUG}}.semaphoreci.com/api/v1alpha"
 
 inputs:
@@ -67,13 +69,19 @@ tables:
       Requires `project_id` — find it in the Semaphore dashboard URL or
       via `sem get project <name>`. Use `wf_id` from here as a filter on
       `semaphore_ci.pipelines` to drill into a specific workflow.
-      Optional filters: `branch_name` to scope by branch.
+      Optional filters: `branch_name` to scope by branch,
+      `created_after` / `created_before` (Unix timestamps) for time-window
+      queries like "workflows in the last 24 h".
       `created_at` is a UTC timestamp derived from the API's protobuf
       `{seconds, nanos}` object.
     filters:
       - name: project_id
         required: true
       - name: branch_name
+        required: false
+      - name: created_after
+        required: false
+      - name: created_before
         required: false
     request:
       method: GET
@@ -85,6 +93,12 @@ tables:
         - name: branch_name
           from: filter
           key: branch_name
+        - name: created_after
+          from: filter
+          key: created_after
+        - name: created_before
+          from: filter
+          key: created_before
     response: {}
     pagination:
       mode: link_header
@@ -169,11 +183,13 @@ tables:
           path:
             - commit_sha
       - name: triggered_by
-        type: Utf8
+        type: Int64
         nullable: true
         description: >-
-          How the workflow was triggered. May be an integer enum (1 = hook)
-          in list responses or a string (HOOK) in describe responses.
+          How the workflow was triggered. Integer enum from the list
+          endpoint (e.g. 0 = unknown, 1 = hook/push). The describe
+          endpoint returns a string instead, but this table uses the
+          list endpoint which always returns an integer.
         expr:
           kind: path
           path:
@@ -210,20 +226,33 @@ tables:
   - name: pipelines
     description: >-
       Pipelines for a Semaphore CI project. Each row is one pipeline
-      execution within a workflow. Requires `project_id` filter.
-      Optionally filter by `wf_id` to see pipelines for a single workflow.
+      execution within a workflow. Pass `project_id` or `wf_id` (or both)
+      — the API requires at least one.
     guide: |
-      Requires `project_id`. Optionally pass `wf_id` (from
-      `semaphore_ci.workflows`) to scope to a single workflow's pipelines.
+      Pass at least one of `project_id` or `wf_id`. The Semaphore API
+      requires one to be present; providing both narrows results further.
       Use `ppl_id` from the list response (when present) or the pipeline
-      name to identify pipelines. `state` values: running, done, stopping.
+      name to identify pipelines.
+      `state` values: pending, queuing, running, done, stopping.
       `result` values: passed, failed, stopped, canceled.
+      Time-window filters `created_after`, `created_before`, `done_after`,
+      `done_before` accept Unix timestamps for server-side pushdown.
     filters:
       - name: project_id
-        required: true
+        required: false
       - name: wf_id
         required: false
       - name: branch_name
+        required: false
+      - name: yml_file_path
+        required: false
+      - name: created_after
+        required: false
+      - name: created_before
+        required: false
+      - name: done_after
+        required: false
+      - name: done_before
         required: false
     request:
       method: GET
@@ -238,14 +267,29 @@ tables:
         - name: branch_name
           from: filter
           key: branch_name
+        - name: yml_file_path
+          from: filter
+          key: yml_file_path
+        - name: created_after
+          from: filter
+          key: created_after
+        - name: created_before
+          from: filter
+          key: created_before
+        - name: done_after
+          from: filter
+          key: done_after
+        - name: done_before
+          from: filter
+          key: done_before
     response: {}
     pagination:
       mode: link_header
     columns:
       - name: project_id
         type: Utf8
-        nullable: false
-        description: Project ID (echoes the required filter).
+        nullable: true
+        description: Project ID (echoes filter when provided).
         expr:
           kind: from_filter
           key: project_id
@@ -292,7 +336,9 @@ tables:
       - name: state
         type: Utf8
         nullable: true
-        description: Pipeline state (running, done, stopping).
+        description: >-
+          Pipeline state (pending, queuing, running, stopping, done).
+          Transient states pending/queuing appear during initialization.
         expr:
           kind: path
           path:
@@ -305,6 +351,22 @@ tables:
           kind: path
           path:
             - result
+      - name: result_reason
+        type: Utf8
+        nullable: true
+        description: Reason for the pipeline result (e.g. test, malformed_yaml).
+        expr:
+          kind: path
+          path:
+            - result_reason
+      - name: error_description
+        type: Utf8
+        nullable: true
+        description: Error details when a pipeline fails due to config or system errors.
+        expr:
+          kind: path
+          path:
+            - error_description
       - name: branch_name
         type: Utf8
         nullable: true
@@ -327,6 +389,66 @@ tables:
             path:
               - created_at
               - seconds
+      - name: pending_at
+        type: Timestamp
+        nullable: true
+        description: Time the pipeline entered the pending state (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - pending_at
+              - seconds
+      - name: queuing_at
+        type: Timestamp
+        nullable: true
+        description: Time the pipeline entered the queuing state (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - queuing_at
+              - seconds
+      - name: running_at
+        type: Timestamp
+        nullable: true
+        description: Time the pipeline started running (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - running_at
+              - seconds
+      - name: stopping_at
+        type: Timestamp
+        nullable: true
+        description: Time the pipeline began stopping (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - stopping_at
+              - seconds
+      - name: done_at
+        type: Timestamp
+        nullable: true
+        description: Time the pipeline finished (UTC). Use done_at - created_at for build duration.
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr:
+            kind: path
+            path:
+              - done_at
+              - seconds
 
   # ──────────────────────────────────────────────────────────────────────
   # promotions — list promotions for a pipeline
@@ -342,7 +464,9 @@ tables:
       Requires `pipeline_id` — obtain from `semaphore_ci.pipelines`. A
       promotion represents a triggered deployment or downstream pipeline.
       `status` values: passed, failed. `triggered_by` describes what
-      triggered the promotion (e.g. "Pipeline Done request").
+      triggered the promotion (e.g. "Pipeline Done request"). The API
+      response only includes name, status, and triggered_by; timestamp
+      and auto-promotion metadata are not exposed by this endpoint.
     filters:
       - name: pipeline_id
         required: true


### PR DESCRIPTION
## Summary

Fixes #634

Add a new `semaphore_ci` community source that lets Coral query
Semaphore CI pipelines and workflows through SQL — enabling build
audits, failure analysis, and CI/CD joins with GitHub pull requests.

This change is manifest-only and uses Coral's existing HTTP source-spec
model. Read-only. No CLI, MCP, config, or runtime changes.

## What changed

Added:
- `sources/community/semaphore_ci/manifest.yaml`
- `sources/community/semaphore_ci/README.md`

## Source scope

Inputs:
- `SEMAPHORE_API_TOKEN` — static API token (secret)
- `SEMAPHORE_ORG_SLUG` — org subdomain (variable), used to build
  `https://{{input.SEMAPHORE_ORG_SLUG}}.semaphoreci.com/api/v1alpha`

Tables:
- `semaphore_ci.workflows`
  - `GET /plumber-workflows`
  - requires `project_id` filter
  - optional `branch_name` filter
  - `link_header` pagination
  - 13 columns including `wf_id`, `state`, `result`, `commit_sha`,
    `branch_name`, `created_at`

- `semaphore_ci.pipelines`
  - `GET /pipelines`
  - requires `project_id` filter
  - optional `wf_id` filter
  - `link_header` pagination
  - 10 columns including `ppl_id`, `state`, `result`,
    `result_reason`, `error_description`, and 5 timestamp columns

- `semaphore_ci.promotions`
  - `GET /promotions`
  - requires `pipeline_id` filter
  - `mode: none` — small result set per pipeline
  - 4 columns

## Implementation notes

- auth: `Authorization: Token` (not Bearer) via `HeaderAuth`
  `from: template`
- `projects` table excluded — `GET /projects` endpoint does not
  exist in Semaphore v1alpha API
- `created_at` and other timestamps are protobuf
  `{seconds, nanos}` objects — extracted via
  `format_timestamp input: seconds` with path `[created_at, seconds]`
- all responses are root JSON arrays — uses `response: {}`
- no `User-Agent` header declared — Coral sets this automatically

## Validation Screenshot 
<img width="914" height="534" alt="image" src="https://github.com/user-attachments/assets/2f971c0a-a90e-4aff-b084-c00d4d0319c5" />


## Out of scope

Not included in v1:
- jobs endpoint (high data volume, complex nesting)
- write or trigger operations