### PR TITLE
feat: Query Result Caching with Source/Query Fingerprints

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -270,12 +270,14 @@ impl ServerBuilder {
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
+        let cache_config = config_store.cache_config()?;
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
             env.query_runtime_context(),
             layout,
             self.config.engine_extensions_providers,
+            cache_config,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
             installed_trace_store.map(|store| TraceService::new(store.dir, store.retention))
@@ -701,12 +703,14 @@ enabled = false
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
+        let cache_config = config_store.cache_config()?;
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            cache_config,
         );
         let trace_service =
             TraceService::new(temp.path().join("trace-store"), Duration::from_mins(1));
@@ -983,6 +987,7 @@ enabled = false
             layout.clone(),
         );
         let feedback_manager = FeedbackManager::new(layout.clone());
+        let cache_config = config_store.cache_config()?;
         let query_manager = QueryManager::new(
             config_store,
             credential_manager,
@@ -991,6 +996,7 @@ enabled = false
             },
             layout,
             vec![Arc::new(NoopEngineExtensionsProvider)],
+            cache_config,
         );
         let running = start_server(
             source_manager,

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -56,3 +56,20 @@ pub use query::extensions::{
 };
 pub use telemetry::{RunContext, RunErrorTelemetry, run_with_context, shutdown_tracing};
 pub use workspaces::DEFAULT_WORKSPACE_ID;
+
+/// Clears the persistent query cache for the current Coral config directory.
+pub fn clear_query_cache(source_name: Option<&str>) -> Result<(), AppError> {
+    let env = bootstrap::env::AppEnvironment::discover();
+    let layout = state::AppStateLayout::discover(env.coral_config_dir_override())?;
+    layout.ensure()?;
+    let config_store = state::ConfigStore::new(layout.clone());
+    let cache = storage::cache::QueryCache::new(
+        layout,
+        storage::cache::cache_settings_from_config(config_store.cache_config()?),
+    );
+    match source_name {
+        Some(source_name) => cache.clear_source(source_name)?,
+        None => cache.clear_all()?,
+    }
+    Ok(())
+}

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,
     QueryRuntimeContext, QuerySource, SourceValidationReport, StatusCode, TableInfo,
+    QueryCacheInput, QueryCacheOperation, query_cache_fingerprint,
 };
 use coral_spec::{ManifestInputKind, ManifestInputSpec};
 use opentelemetry::{KeyValue, trace::Status as OtelStatus};
@@ -20,7 +21,12 @@ use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_p
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
 use crate::sources::model::InstalledSource;
+use crate::state::CacheConfig;
 use crate::state::{AppStateLayout, ConfigStore};
+use crate::storage::cache::{
+    CacheScope, CacheValueKind, QueryCache, cache_fingerprint_digest, cache_scope,
+    cache_settings_from_config,
+};
 use crate::workspaces::WorkspaceName;
 
 #[derive(Debug)]
@@ -41,6 +47,7 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    cache: Arc<QueryCache>,
 }
 
 impl QueryManager {
@@ -50,13 +57,19 @@ impl QueryManager {
         runtime_context: QueryRuntimeContext,
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+        cache_config: CacheConfig,
     ) -> Self {
+        let cache = Arc::new(QueryCache::new(
+            layout.clone(),
+            cache_settings_from_config(cache_config),
+        ));
         Self {
             config_store,
             credential_manager,
             runtime_context,
             layout,
             engine_extensions_providers,
+            cache,
         }
     }
 
@@ -70,9 +83,35 @@ impl QueryManager {
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_config(&sources);
+        let cache_key = self.cache_key_for_list_tables(
+            workspace_name,
+            schema_filter,
+            table_filter,
+            &sources,
+        );
+        if let Some(cached) = self
+            .cache
+            .get_json::<Vec<TableInfo>>(&cache_key, CacheValueKind::TableInfoList)
+            .map_err(QueryManagerError::App)?
+        {
+            record_cache_event("list_tables", true);
+            return Ok(cached);
+        }
+        record_cache_event("list_tables", false);
         CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
             .await
             .map_err(QueryManagerError::Core)
+            .inspect(|result| {
+                let _ = self.cache.put_json(
+                    &cache_key,
+                    cache_scope(
+                        workspace_name.as_str(),
+                        source_names(&sources),
+                    ),
+                    CacheValueKind::TableInfoList,
+                    result,
+                );
+            })
     }
 
     pub(crate) async fn list_catalog(
@@ -84,9 +123,27 @@ impl QueryManager {
             .load_query_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_config(&sources);
+        let cache_key = self.cache_key_for_list_catalog(workspace_name, schema_filter, &sources);
+        if let Some(cached) = self
+            .cache
+            .get_json::<CatalogInfo>(&cache_key, CacheValueKind::CatalogInfo)
+            .map_err(QueryManagerError::App)?
+        {
+            record_cache_event("list_catalog", true);
+            return Ok(cached);
+        }
+        record_cache_event("list_catalog", false);
         CoralQuery::list_catalog(&sources, runtime, schema_filter)
             .await
             .map_err(QueryManagerError::Core)
+            .inspect(|result| {
+                let _ = self.cache.put_json(
+                    &cache_key,
+                    cache_scope(workspace_name.as_str(), source_names(&sources)),
+                    CacheValueKind::CatalogInfo,
+                    result,
+                );
+            })
     }
 
     pub(crate) async fn execute_sql(
@@ -94,6 +151,12 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         sql: &str,
     ) -> Result<QueryExecution, QueryManagerError> {
+        let cache_key = self.cache_key_for_sql(
+            workspace_name,
+            QueryCacheOperation::ExecuteSql,
+            sql,
+            &[],
+        );
         run_query_operation(
             QueryOperation::ExecuteSql,
             workspace_name,
@@ -103,9 +166,25 @@ impl QueryManager {
                     .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self.runtime_config(&sources);
+                if let Some(cached) = self
+                    .cache
+                    .get_query_execution(&cache_key)
+                    .map_err(QueryManagerError::App)?
+                {
+                    record_cache_event("execute_sql", true);
+                    return Ok(cached);
+                }
+                record_cache_event("execute_sql", false);
                 CoralQuery::execute_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
+                    .inspect(|result| {
+                        let _ = self.cache.put_query_execution(
+                            &cache_key,
+                            cache_scope(workspace_name.as_str(), source_names(&sources)),
+                            result,
+                        );
+                    })
             },
             |execution| Some(u64::try_from(execution.row_count()).unwrap_or(u64::MAX)),
         )
@@ -117,6 +196,12 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         sql: &str,
     ) -> Result<QueryPlan, QueryManagerError> {
+        let cache_key = self.cache_key_for_sql(
+            workspace_name,
+            QueryCacheOperation::ExplainSql,
+            sql,
+            &[],
+        );
         run_query_operation(
             QueryOperation::ExplainSql,
             workspace_name,
@@ -126,9 +211,26 @@ impl QueryManager {
                     .load_query_sources(workspace_name)
                     .map_err(QueryManagerError::App)?;
                 let runtime = self.runtime_config(&sources);
+                if let Some(cached) = self
+                    .cache
+                    .get_json::<QueryPlan>(&cache_key, CacheValueKind::QueryPlan)
+                    .map_err(QueryManagerError::App)?
+                {
+                    record_cache_event("explain_sql", true);
+                    return Ok(cached);
+                }
+                record_cache_event("explain_sql", false);
                 CoralQuery::explain_sql(&sources, runtime, sql)
                     .await
                     .map_err(QueryManagerError::Core)
+                    .inspect(|result| {
+                        let _ = self.cache.put_json(
+                            &cache_key,
+                            cache_scope(workspace_name.as_str(), source_names(&sources)),
+                            CacheValueKind::QueryPlan,
+                            result,
+                        );
+                    })
             },
             |_| None,
         )
@@ -148,6 +250,18 @@ impl QueryManager {
             .load_query_source(workspace_name, &source)
             .map_err(QueryManagerError::App)?;
         let runtime = self.runtime_config(std::slice::from_ref(&query_source));
+        let cache_key = self.cache_key_for_validate_source(workspace_name, &source, &query_source);
+        if let Some(cached) = self
+            .cache
+            .get_json::<SourceValidationReport>(&cache_key, CacheValueKind::SourceValidationReport)
+            .map_err(QueryManagerError::App)?
+        {
+            record_cache_event("validate_source", true);
+            let mut source = source;
+            source.version = Some(version);
+            return Ok(ValidatedSource { source, report: cached });
+        }
+        record_cache_event("validate_source", false);
         let report = CoralQuery::validate_source(
             &query_source,
             runtime,
@@ -157,6 +271,13 @@ impl QueryManager {
         .map_err(QueryManagerError::Core)?;
         let mut source = source;
         source.version = Some(version);
+
+        let _ = self.cache.put_json(
+            &cache_key,
+            cache_scope(workspace_name.as_str(), vec![source.name.as_str().to_string()]),
+            CacheValueKind::SourceValidationReport,
+            &report,
+        );
 
         Ok(ValidatedSource { source, report })
     }
@@ -231,6 +352,105 @@ impl QueryManager {
             self.runtime_context.clone(),
             engine_extensions_for_providers(&self.engine_extensions_providers, selected_sources),
         )
+    }
+
+    fn cache_key_for_list_tables(
+        &self,
+        workspace_name: &WorkspaceName,
+        schema_filter: Option<&str>,
+        table_filter: Option<&str>,
+        sources: &[QuerySource],
+    ) -> String {
+        let source_fingerprint = source_fingerprint(sources);
+        query_cache_fingerprint(QueryCacheInput {
+            operation: QueryCacheOperation::ListTables,
+            workspace_name: workspace_name.as_str(),
+            sql: None,
+            source_fingerprint: &source_fingerprint,
+            execution_settings: &[
+                schema_filter.unwrap_or(""),
+                table_filter.unwrap_or(""),
+                self.runtime_context
+                    .home_dir
+                    .as_ref()
+                    .map(|path| path.to_string_lossy())
+                    .as_deref()
+                    .unwrap_or(""),
+            ],
+        })
+    }
+
+    fn cache_key_for_list_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+        schema_filter: Option<&str>,
+        sources: &[QuerySource],
+    ) -> String {
+        let source_fingerprint = source_fingerprint(sources);
+        query_cache_fingerprint(QueryCacheInput {
+            operation: QueryCacheOperation::ListCatalog,
+            workspace_name: workspace_name.as_str(),
+            sql: None,
+            source_fingerprint: &source_fingerprint,
+            execution_settings: &[
+                schema_filter.unwrap_or(""),
+                self.runtime_context
+                    .home_dir
+                    .as_ref()
+                    .map(|path| path.to_string_lossy())
+                    .as_deref()
+                    .unwrap_or(""),
+            ],
+        })
+    }
+
+    fn cache_key_for_sql(
+        &self,
+        workspace_name: &WorkspaceName,
+        operation: QueryCacheOperation,
+        sql: &str,
+        sources: &[QuerySource],
+    ) -> String {
+        let source_fingerprint = source_fingerprint(sources);
+        query_cache_fingerprint(QueryCacheInput {
+            operation,
+            workspace_name: workspace_name.as_str(),
+            sql: Some(sql),
+            source_fingerprint: &source_fingerprint,
+            execution_settings: &[
+                self.runtime_context
+                    .home_dir
+                    .as_ref()
+                    .map(|path| path.to_string_lossy())
+                    .as_deref()
+                    .unwrap_or(""),
+            ],
+        })
+    }
+
+    fn cache_key_for_validate_source(
+        &self,
+        workspace_name: &WorkspaceName,
+        source: &InstalledSource,
+        query_source: &QuerySource,
+    ) -> String {
+        let source_fingerprint = query_source_fingerprint(query_source);
+        query_cache_fingerprint(QueryCacheInput {
+            operation: QueryCacheOperation::ValidateSource,
+            workspace_name: workspace_name.as_str(),
+            sql: None,
+            source_fingerprint: &source_fingerprint,
+            execution_settings: &[
+                source.name.as_str(),
+                query_source.version(),
+                self.runtime_context
+                    .home_dir
+                    .as_ref()
+                    .map(|path| path.to_string_lossy())
+                    .as_deref()
+                    .unwrap_or(""),
+            ],
+        })
     }
 }
 
@@ -394,4 +614,36 @@ fn validate_required_variables(
         )));
     }
     Ok(())
+}
+
+fn source_fingerprint(sources: &[QuerySource]) -> String {
+    let mut parts = Vec::with_capacity(sources.len());
+    for source in sources {
+        parts.push(query_source_fingerprint(source));
+    }
+    parts.sort();
+    parts.join(";")
+}
+
+fn query_source_fingerprint(source: &QuerySource) -> String {
+    let mut fields = Vec::new();
+    fields.push(source.source_name().to_string());
+    fields.push(source.version().to_string());
+    for (key, value) in source.variables() {
+        fields.push(format!("var:{key}={value}"));
+    }
+    for (key, value) in source.secrets() {
+        fields.push(format!("secret:{key}={value}"));
+    }
+    cache_fingerprint_digest(&fields.iter().map(String::as_str).collect::<Vec<_>>())
+}
+
+fn record_cache_event(operation: &str, hit: bool) {
+    let metrics = crate::telemetry::metrics::metrics();
+    let attributes = [KeyValue::new("operation", operation)];
+    if hit {
+        metrics.cache_hits.add(1, &attributes);
+    } else {
+        metrics.cache_misses.add(1, &attributes);
+    }
 }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -16,6 +16,7 @@ use crate::workspaces::WorkspaceName;
 struct AppConfig {
     version: u32,
     catalog: SourceCatalog,
+    cache: CacheConfig,
 }
 
 impl Default for AppConfig {
@@ -23,6 +24,7 @@ impl Default for AppConfig {
         Self {
             version: default_config_version(),
             catalog: SourceCatalog::default(),
+            cache: CacheConfig::default(),
         }
     }
 }
@@ -31,12 +33,63 @@ fn default_config_version() -> u32 {
     1
 }
 
+fn default_cache_max_entries() -> usize {
+    512
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CacheConfig {
+    ttl_seconds: Option<u64>,
+    persistent: bool,
+    max_entries: usize,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        Self {
+            ttl_seconds: None,
+            persistent: false,
+            max_entries: default_cache_max_entries(),
+        }
+    }
+}
+
+impl CacheConfig {
+    pub(crate) fn ttl_seconds(&self) -> Option<u64> {
+        self.ttl_seconds
+    }
+
+    pub(crate) fn persistent(&self) -> bool {
+        self.persistent
+    }
+
+    pub(crate) fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.ttl_seconds.is_some_and(|ttl| ttl > 0)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct PersistedCacheConfig {
+    #[serde(default)]
+    ttl_seconds: Option<u64>,
+    #[serde(default)]
+    persistent: bool,
+    #[serde(default = "default_cache_max_entries")]
+    max_entries: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 struct PersistedAppConfig {
     #[serde(default = "default_config_version")]
     version: u32,
     #[serde(default)]
     workspaces: BTreeMap<String, PersistedWorkspaceConfig>,
+    #[serde(default)]
+    cache: PersistedCacheConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -190,6 +243,11 @@ impl ConfigStore {
         self.load_unlocked().map(|config| config.catalog)
     }
 
+    pub(crate) fn cache_config(&self) -> Result<CacheConfig, AppError> {
+        let _lock = self.lock_shared()?;
+        self.load_unlocked().map(|config| config.cache)
+    }
+
     fn update_catalog<T>(
         &self,
         update: impl FnOnce(&mut SourceCatalog) -> T,
@@ -251,6 +309,7 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
 
     // Remove and fully rebuild the workspaces section so removed sources don't linger.
     doc.remove("workspaces");
+    doc.remove("cache");
 
     for (workspace_name, workspace) in &config.workspaces {
         for (source_name, source) in &workspace.sources {
@@ -275,6 +334,24 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
             source_item["secrets"] = Item::Value(render_string_array(&source.secrets));
             source_item["origin"] = value(source.origin.as_config_value());
         }
+    }
+
+    if config.cache.ttl_seconds.is_some()
+        || config.cache.persistent
+        || config.cache.max_entries != default_cache_max_entries()
+    {
+        ensure_implicit_table(&mut doc["cache"]);
+        if let Some(ttl_seconds) = config.cache.ttl_seconds {
+            doc["cache"]["ttl_seconds"] = value(i64::try_from(ttl_seconds).unwrap_or(i64::MAX));
+        } else {
+            doc["cache"]
+                .as_table_mut()
+                .expect("cache table")
+                .remove("ttl_seconds");
+        }
+        doc["cache"]["persistent"] = value(config.cache.persistent);
+        doc["cache"]["max_entries"] =
+            value(i64::try_from(config.cache.max_entries).unwrap_or(i64::MAX));
     }
 
     doc.to_string()
@@ -304,6 +381,11 @@ impl TryFrom<PersistedAppConfig> for AppConfig {
         Ok(Self {
             version: value.version,
             catalog,
+            cache: CacheConfig {
+                ttl_seconds: value.cache.ttl_seconds,
+                persistent: value.cache.persistent,
+                max_entries: value.cache.max_entries,
+            },
         })
     }
 }
@@ -325,6 +407,11 @@ impl From<&AppConfig> for PersistedAppConfig {
         Self {
             version: value.version,
             workspaces,
+            cache: PersistedCacheConfig {
+                ttl_seconds: value.cache.ttl_seconds,
+                persistent: value.cache.persistent,
+                max_entries: value.cache.max_entries,
+            },
         }
     }
 }

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -62,6 +62,14 @@ impl AppStateLayout {
         self.config_dir.join("telemetry").join("traces")
     }
 
+    pub(crate) fn cache_dir(&self) -> PathBuf {
+        self.config_dir.join("cache")
+    }
+
+    pub(crate) fn cache_entries_dir(&self) -> PathBuf {
+        self.cache_dir().join("entries")
+    }
+
     pub(crate) fn workspaces_root(&self) -> PathBuf {
         self.config_dir.join("workspaces")
     }

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -3,5 +3,5 @@
 mod config;
 mod layout;
 
-pub(crate) use config::ConfigStore;
+pub(crate) use config::{CacheConfig, ConfigStore};
 pub(crate) use layout::AppStateLayout;

--- a/crates/coral-app/src/storage/cache.rs
+++ b/crates/coral-app/src/storage/cache.rs
@@ -241,7 +241,9 @@ impl QueryCache {
             .lock()
             .expect("cache lock poisoned during corruption eviction")
             .remove(key);
-        let _ = self.remove_entry_file(key);
+        if let Err(error) = self.remove_entry_file(key) {
+            tracing::warn!(key, ?error, "failed to remove corrupt cache entry file");
+        }
     }
 
     fn cache_dir(&self) -> PathBuf {

--- a/crates/coral-app/src/storage/cache.rs
+++ b/crates/coral-app/src/storage/cache.rs
@@ -2,10 +2,12 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::fs;
+use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::StreamWriter;
 use arrow::record_batch::RecordBatch;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
@@ -86,13 +88,17 @@ impl QueryCache {
         let Some(entry) = self.lookup_entry(key, CacheValueKind::QueryExecution)? else {
             return Ok(None);
         };
-        let payload = STANDARD.decode(&entry.payload).map_err(|error| {
-            AppError::InvalidInput(format!("cache payload decode failed: {error}"))
-        })?;
-        let execution = QueryExecution::from_arrow_ipc_stream(&payload).map_err(|error| {
-            AppError::InvalidInput(format!("cache query decode failed: {error}"))
-        })?;
-        Ok(Some(execution))
+        match STANDARD
+            .decode(&entry.payload)
+            .ok()
+            .and_then(|payload| decode_query_execution_ipc(&payload).ok())
+        {
+            Some(execution) => Ok(Some(execution)),
+            None => {
+                self.evict_corrupt_entry(key);
+                Ok(None)
+            }
+        }
     }
 
     pub(crate) fn put_query_execution(
@@ -169,11 +175,17 @@ impl QueryCache {
         let Some(entry) = self.lookup_entry(key, kind)? else {
             return Ok(None);
         };
-        let payload = STANDARD.decode(&entry.payload).map_err(|error| {
-            AppError::InvalidInput(format!("cache payload decode failed: {error}"))
-        })?;
-        let value = serde_json::from_slice(&payload).map_err(AppError::from)?;
-        Ok(Some(value))
+        match STANDARD
+            .decode(&entry.payload)
+            .ok()
+            .and_then(|payload| serde_json::from_slice(&payload).ok())
+        {
+            Some(value) => Ok(Some(value)),
+            None => {
+                self.evict_corrupt_entry(key);
+                Ok(None)
+            }
+        }
     }
 
     fn lookup_entry(
@@ -222,6 +234,14 @@ impl QueryCache {
             .expect("cache lock poisoned during disk load")
             .put(entry.clone());
         Ok(Some(entry))
+    }
+
+    fn evict_corrupt_entry(&self, key: &str) {
+        self.memory
+            .lock()
+            .expect("cache lock poisoned during corruption eviction")
+            .remove(key);
+        let _ = self.remove_entry_file(key);
     }
 
     fn cache_dir(&self) -> PathBuf {
@@ -418,6 +438,17 @@ fn current_unix_seconds() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs()
+}
+
+fn decode_query_execution_ipc(bytes: &[u8]) -> Result<QueryExecution, arrow::error::ArrowError> {
+    let cursor = Cursor::new(bytes);
+    let mut reader = StreamReader::try_new(cursor, None)?;
+    let arrow_schema = Arc::new(reader.schema().as_ref().clone());
+    let mut batches = Vec::new();
+    for batch in &mut reader {
+        batches.push(batch?);
+    }
+    Ok(QueryExecution::new(arrow_schema, batches))
 }
 
 pub(crate) fn query_cache_key(prefix: &str, fingerprint: &str) -> String {

--- a/crates/coral-app/src/storage/cache.rs
+++ b/crates/coral-app/src/storage/cache.rs
@@ -1,0 +1,477 @@
+//! Query-result and metadata cache for short-lived and persistent reuse.
+
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use arrow::ipc::writer::StreamWriter;
+use arrow::record_batch::RecordBatch;
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use coral_engine::{CatalogInfo, QueryExecution, QueryPlan, SourceValidationReport};
+use serde::{Serialize, de::DeserializeOwned};
+use sha2::{Digest, Sha256};
+
+use crate::bootstrap::AppError;
+use crate::state::{AppStateLayout, CacheConfig};
+use crate::storage::fs as storage_fs;
+
+#[derive(Debug, Clone)]
+pub(crate) struct CacheSettings {
+    ttl_seconds: Option<u64>,
+    persistent: bool,
+    max_entries: usize,
+}
+
+impl From<CacheConfig> for CacheSettings {
+    fn from(value: CacheConfig) -> Self {
+        Self {
+            ttl_seconds: value.ttl_seconds(),
+            persistent: value.persistent(),
+            max_entries: value.max_entries(),
+        }
+    }
+}
+
+impl CacheSettings {
+    fn is_enabled(&self) -> bool {
+        self.ttl_seconds.is_some_and(|ttl| ttl > 0)
+    }
+
+    fn ttl(&self) -> Duration {
+        Duration::from_secs(self.ttl_seconds.unwrap_or(0))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct QueryCache {
+    layout: AppStateLayout,
+    settings: CacheSettings,
+    memory: Arc<Mutex<MemoryCache>>,
+}
+
+impl QueryCache {
+    pub(crate) fn new(layout: AppStateLayout, settings: CacheSettings) -> Self {
+        let memory = MemoryCache::new(settings.max_entries);
+        Self {
+            layout,
+            settings,
+            memory: Arc::new(Mutex::new(memory)),
+        }
+    }
+
+    pub(crate) fn clear_all(&self) -> Result<(), AppError> {
+        self.memory
+            .lock()
+            .expect("cache lock poisoned during clear")
+            .clear();
+        let dir = self.layout.cache_entries_dir();
+        if dir.exists() {
+            fs::remove_dir_all(dir)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn clear_source(&self, source_name: &str) -> Result<(), AppError> {
+        self.memory
+            .lock()
+            .expect("cache lock poisoned during clear")
+            .retain(|entry| !entry.source_names.iter().any(|name| name == source_name));
+        self.clear_persistent_source(source_name)?;
+        Ok(())
+    }
+
+    pub(crate) fn get_query_execution(&self, key: &str) -> Result<Option<QueryExecution>, AppError> {
+        let Some(entry) = self.lookup_entry(key, CacheValueKind::QueryExecution)? else {
+            return Ok(None);
+        };
+        let payload = STANDARD.decode(&entry.payload).map_err(|error| {
+            AppError::InvalidInput(format!("cache payload decode failed: {error}"))
+        })?;
+        let execution = QueryExecution::from_arrow_ipc_stream(&payload).map_err(|error| {
+            AppError::InvalidInput(format!("cache query decode failed: {error}"))
+        })?;
+        Ok(Some(execution))
+    }
+
+    pub(crate) fn put_query_execution(
+        &self,
+        key: &str,
+        scope: CacheScope,
+        execution: &QueryExecution,
+    ) -> Result<(), AppError> {
+        let mut bytes = Vec::new();
+        {
+            let mut writer = StreamWriter::try_new(&mut bytes, execution.arrow_schema())?;
+            for batch in execution.batches() {
+                writer.write(batch)?;
+            }
+            writer.finish()?;
+        }
+        self.put_raw(
+            key,
+            scope,
+            CacheValueKind::QueryExecution,
+            bytes,
+        )
+    }
+
+    pub(crate) fn get_json<T: DeserializeOwned>(
+        &self,
+        key: &str,
+        kind: CacheValueKind,
+    ) -> Result<Option<T>, AppError> {
+        self.get_typed::<T>(key, kind)
+    }
+
+    pub(crate) fn put_json<T: Serialize>(
+        &self,
+        key: &str,
+        scope: CacheScope,
+        kind: CacheValueKind,
+        value: &T,
+    ) -> Result<(), AppError> {
+        let bytes = serde_json::to_vec(value)?;
+        self.put_raw(key, scope, kind, bytes)
+    }
+
+    fn put_raw(
+        &self,
+        key: &str,
+        scope: CacheScope,
+        kind: CacheValueKind,
+        payload: Vec<u8>,
+    ) -> Result<(), AppError> {
+        if !self.settings.is_enabled() {
+            return Ok(());
+        }
+        let entry = StoredCacheEntry::new(key, scope, kind, payload, self.settings.ttl());
+        self.memory
+            .lock()
+            .expect("cache lock poisoned during put")
+            .put(entry.clone());
+        if self.settings.persistent {
+            self.write_entry(&entry)?;
+        }
+        Ok(())
+    }
+
+    fn get_typed<T: DeserializeOwned>(
+        &self,
+        key: &str,
+        kind: CacheValueKind,
+    ) -> Result<Option<T>, AppError> {
+        if !self.settings.is_enabled() {
+            return Ok(None);
+        }
+
+        let Some(entry) = self.lookup_entry(key, kind)? else {
+            return Ok(None);
+        };
+        let payload = STANDARD.decode(&entry.payload).map_err(|error| {
+            AppError::InvalidInput(format!("cache payload decode failed: {error}"))
+        })?;
+        let value = serde_json::from_slice(&payload).map_err(AppError::from)?;
+        Ok(Some(value))
+    }
+
+    fn lookup_entry(
+        &self,
+        key: &str,
+        kind: CacheValueKind,
+    ) -> Result<Option<StoredCacheEntry>, AppError> {
+        if !self.settings.is_enabled() {
+            return Ok(None);
+        }
+
+        if let Some(entry) = self
+            .memory
+            .lock()
+            .expect("cache lock poisoned during get")
+            .get(key)
+            .filter(|entry| entry.kind == kind)
+            .cloned()
+        {
+            if entry.is_expired() {
+                self.memory
+                    .lock()
+                    .expect("cache lock poisoned during expiry cleanup")
+                    .remove(key);
+                return Ok(None);
+            }
+            return Ok(Some(entry));
+        }
+
+        if !self.settings.persistent {
+            return Ok(None);
+        }
+
+        let Some(entry) = self.read_entry(key)? else {
+            return Ok(None);
+        };
+        if entry.kind != kind {
+            return Ok(None);
+        }
+        if entry.is_expired() {
+            self.remove_entry_file(key)?;
+            return Ok(None);
+        }
+        self.memory
+            .lock()
+            .expect("cache lock poisoned during disk load")
+            .put(entry.clone());
+        Ok(Some(entry))
+    }
+
+    fn cache_dir(&self) -> PathBuf {
+        self.layout.cache_entries_dir()
+    }
+
+    fn entry_path(&self, key: &str) -> PathBuf {
+        self.cache_dir().join(format!("{key}.json"))
+    }
+
+    fn read_entry(&self, key: &str) -> Result<Option<StoredCacheEntry>, AppError> {
+        let path = self.entry_path(key);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = fs::read_to_string(path)?;
+        Ok(Some(serde_json::from_str(&raw)?))
+    }
+
+    fn write_entry(&self, entry: &StoredCacheEntry) -> Result<(), AppError> {
+        let dir = self.cache_dir();
+        storage_fs::ensure_dir(&dir)?;
+        let path = self.entry_path(&entry.key);
+        let raw = serde_json::to_vec_pretty(entry)?;
+        storage_fs::write_atomic(&path, &raw)?;
+        Ok(())
+    }
+
+    fn remove_entry_file(&self, key: &str) -> Result<(), AppError> {
+        let path = self.entry_path(key);
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+        Ok(())
+    }
+
+    fn clear_persistent_source(&self, source_name: &str) -> Result<(), AppError> {
+        let dir = self.cache_dir();
+        if !dir.exists() {
+            return Ok(());
+        }
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            if !entry.file_type()?.is_file() {
+                continue;
+            }
+            let raw = fs::read_to_string(entry.path())?;
+            let stored: StoredCacheEntry = serde_json::from_str(&raw)?;
+            if stored.source_names.iter().any(|name| name == source_name) {
+                fs::remove_file(entry.path())?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CacheScope {
+    workspace_name: String,
+    source_names: Vec<String>,
+}
+
+impl CacheScope {
+    pub(crate) fn new(workspace_name: impl Into<String>, source_names: Vec<String>) -> Self {
+        Self {
+            workspace_name: workspace_name.into(),
+            source_names,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum CacheValueKind {
+    QueryExecution,
+    QueryPlan,
+    CatalogInfo,
+    TableInfoList,
+    SourceValidationReport,
+}
+
+impl CacheValueKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::QueryExecution => "query_execution",
+            Self::QueryPlan => "query_plan",
+            Self::CatalogInfo => "catalog_info",
+            Self::TableInfoList => "table_info_list",
+            Self::SourceValidationReport => "source_validation_report",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredCacheEntry {
+    key: String,
+    kind: CacheValueKind,
+    workspace_name: String,
+    source_names: Vec<String>,
+    created_at_unix_seconds: u64,
+    expires_at_unix_seconds: Option<u64>,
+    payload: String,
+}
+
+impl StoredCacheEntry {
+    fn new(
+        key: &str,
+        scope: CacheScope,
+        kind: CacheValueKind,
+        payload: Vec<u8>,
+        ttl: Duration,
+    ) -> Self {
+        let created_at_unix_seconds = current_unix_seconds();
+        let expires_at_unix_seconds = ttl.as_secs().checked_add(created_at_unix_seconds);
+        Self {
+            key: key.to_string(),
+            kind,
+            workspace_name: scope.workspace_name,
+            source_names: scope.source_names,
+            created_at_unix_seconds,
+            expires_at_unix_seconds,
+            payload: STANDARD.encode(payload),
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.expires_at_unix_seconds
+            .is_some_and(|expires_at| current_unix_seconds() >= expires_at)
+    }
+
+}
+
+#[derive(Debug, Clone)]
+struct MemoryCache {
+    capacity: usize,
+    entries: HashMap<String, StoredCacheEntry>,
+    order: VecDeque<String>,
+}
+
+impl MemoryCache {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+        }
+    }
+
+    fn clear(&mut self) {
+        self.entries.clear();
+        self.order.clear();
+    }
+
+    fn retain(&mut self, mut keep: impl FnMut(&StoredCacheEntry) -> bool) {
+        self.entries.retain(|key, entry| {
+            let retain = keep(entry);
+            if !retain {
+                self.order.retain(|candidate| candidate != key);
+            }
+            retain
+        });
+    }
+
+    fn remove(&mut self, key: &str) {
+        self.entries.remove(key);
+        self.order.retain(|candidate| candidate != key);
+    }
+
+    fn get(&mut self, key: &str) -> Option<&StoredCacheEntry> {
+        if self.entries.contains_key(key) {
+            self.order.retain(|candidate| candidate != key);
+            self.order.push_back(key.to_string());
+        }
+        self.entries.get(key)
+    }
+
+    fn put(&mut self, entry: StoredCacheEntry) {
+        if self.capacity == 0 {
+            return;
+        }
+        self.order.retain(|candidate| candidate != &entry.key);
+        let entry_key = entry.key.clone();
+        self.entries.insert(entry.key.clone(), entry);
+        self.order.push_back(entry_key);
+        while self.entries.len() > self.capacity {
+            if let Some(oldest) = self.order.pop_front() {
+                self.entries.remove(&oldest);
+            }
+        }
+    }
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+pub(crate) fn query_cache_key(prefix: &str, fingerprint: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(prefix.as_bytes());
+    hasher.update(b":");
+    hasher.update(fingerprint.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+pub(crate) fn normalize_cache_key_input(parts: &[&str]) -> String {
+    parts
+        .iter()
+        .map(|part| part.trim())
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("|")
+}
+
+pub(crate) fn encode_query_execution(
+    schema: &arrow::datatypes::SchemaRef,
+    batches: &[RecordBatch],
+) -> Result<Vec<u8>, arrow::error::ArrowError> {
+    let mut bytes = Vec::new();
+    {
+        let mut writer = StreamWriter::try_new(&mut bytes, schema)?;
+        for batch in batches {
+            writer.write(batch)?;
+        }
+        writer.finish()?;
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn cache_settings_from_config(config: CacheConfig) -> CacheSettings {
+    CacheSettings::from(config)
+}
+
+pub(crate) fn cache_scope(workspace_name: impl Into<String>, source_names: Vec<String>) -> CacheScope {
+    CacheScope::new(workspace_name, source_names)
+}
+
+pub(crate) fn cache_fingerprint_digest(parts: &[&str]) -> String {
+    let mut hasher = Sha256::new();
+    for part in parts {
+        hasher.update(part.as_bytes());
+        hasher.update(b"\0");
+    }
+    format!("{:x}", hasher.finalize())
+}
+
+pub(crate) fn cache_value_kind_from_query_operation(_operation: &str) -> CacheValueKind {
+    CacheValueKind::QueryExecution
+}
+
+#[allow(dead_code)]
+fn _keep_contract_types_used(_: (&CatalogInfo, &QueryPlan, &SourceValidationReport)) {}

--- a/crates/coral-app/src/storage/mod.rs
+++ b/crates/coral-app/src/storage/mod.rs
@@ -1,3 +1,4 @@
 //! Shared filesystem helpers for local persistence.
 
+pub(crate) mod cache;
 pub(crate) mod fs;

--- a/crates/coral-app/src/telemetry/metrics.rs
+++ b/crates/coral-app/src/telemetry/metrics.rs
@@ -10,6 +10,8 @@ pub(crate) struct Metrics {
     pub(crate) count: Counter<u64>,
     pub(crate) duration: Histogram<f64>,
     pub(crate) rows: Histogram<u64>,
+    pub(crate) cache_hits: Counter<u64>,
+    pub(crate) cache_misses: Counter<u64>,
 }
 
 pub(crate) fn status_attr(ok: bool) -> KeyValue {
@@ -34,6 +36,16 @@ fn build_metrics(meter: &Meter) -> Metrics {
             .u64_histogram("coral.query.rows")
             .with_unit("{rows}")
             .with_description("Rows returned per query")
+            .build(),
+        cache_hits: meter
+            .u64_counter("coral.query.cache.hit")
+            .with_unit("{events}")
+            .with_description("Query cache hits")
+            .build(),
+        cache_misses: meter
+            .u64_counter("coral.query.cache.miss")
+            .with_unit("{events}")
+            .with_description("Query cache misses")
             .build(),
     }
 }
@@ -217,12 +229,16 @@ mod tests {
         metrics.duration.record(0.5, std::slice::from_ref(&ok));
         metrics.duration.record(0.1, std::slice::from_ref(&err));
         metrics.rows.record(7, std::slice::from_ref(&ok));
+        metrics.cache_hits.add(3, std::slice::from_ref(&ok));
+        metrics.cache_misses.add(2, std::slice::from_ref(&err));
 
         super::test_support::flush_metrics();
         let finished = exporter.get_finished_metrics().expect("finished metrics");
         assert_eq!(counter_total(&finished, "coral.query.count"), 3);
         assert_eq!(histogram_total_count(&finished, "coral.query.duration"), 2);
         assert_eq!(histogram_total_count(&finished, "coral.query.rows"), 1);
+        assert_eq!(counter_total(&finished, "coral.query.cache.hit"), 3);
+        assert_eq!(counter_total(&finished, "coral.query.cache.miss"), 2);
         assert!(histogram_has_status(&finished, "coral.query.rows", "ok"));
     }
 }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -60,6 +60,8 @@ enum Command {
     Sql(SqlArgs),
     /// Manage data sources
     Source(SourceArgs),
+    /// Manage the local query cache
+    Cache(CacheArgs),
     /// Interactive wizard to set up Coral and explore use cases
     Onboard,
     /// Start the MCP server over stdio
@@ -120,6 +122,27 @@ struct McpStdioArgs {
 struct SourceArgs {
     #[command(subcommand)]
     command: SourceCommand,
+}
+
+#[derive(Debug, Args)]
+/// Manage the local query cache
+struct CacheArgs {
+    #[command(subcommand)]
+    command: CacheCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum CacheCommand {
+    /// Clear cached query and metadata results
+    Clear(ClearCacheArgs),
+}
+
+#[derive(Debug, Args)]
+/// Clear cached query and metadata results
+struct ClearCacheArgs {
+    /// Restrict cache invalidation to a single source name.
+    #[arg(long)]
+    source: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -243,7 +266,7 @@ impl Command {
             Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
                 RequiredRuntime::AppClient
             }
-            Command::Completion(_) => RequiredRuntime::None,
+            Command::Cache(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
         }
@@ -412,6 +435,7 @@ async fn run_no_runtime_command(command: Command) -> Result<(), CliError> {
             generate(args.shell, &mut cmd, bin_name, &mut std::io::stdout());
             Ok(())
         }
+        Command::Cache(args) => run_cache(args).await,
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
         Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
@@ -448,6 +472,9 @@ async fn run_app_command(
             print_batches(result.batches(), args.format)?;
         }
         Command::Source(args) => run_source(&app, args).await?,
+        Command::Cache(_) => {
+            unreachable!("no-runtime cache commands are routed without an app client")
+        }
         Command::Onboard => {
             onboard::run(&app).await?;
         }
@@ -555,6 +582,17 @@ fn print_text_table<const COLUMNS: usize>(
     for row in rows {
         println!("{}", format_table_row(row.each_ref(), &widths));
     }
+}
+
+async fn run_cache(args: CacheArgs) -> Result<(), CliError> {
+    match args.command {
+        CacheCommand::Clear(clear_args) => {
+            coral_app::clear_query_cache(clear_args.source.as_deref())
+                .map_err(anyhow::Error::from)?;
+            println!("Query cache cleared");
+        }
+    }
+    Ok(())
 }
 
 fn compute_column_widths<const COLUMNS: usize>(

--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -25,6 +25,7 @@ object_store.workspace = true
 opentelemetry.workspace = true
 parquet.workspace = true
 reqwest.workspace = true
+sha2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strsim.workspace = true

--- a/crates/coral-engine/src/cache.rs
+++ b/crates/coral-engine/src/cache.rs
@@ -1,6 +1,8 @@
 //! Deterministic query cache fingerprinting for app-side result caching.
 
 use sha2::{Digest, Sha256};
+use datafusion::sql::sqlparser::dialect::GenericDialect;
+use datafusion::sql::sqlparser::parser::Parser;
 
 /// Query operation categories that participate in cache fingerprinting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -44,10 +46,23 @@ pub struct QueryCacheInput<'a> {
     pub execution_settings: &'a [&'a str],
 }
 
-/// Normalizes SQL by trimming and collapsing whitespace.
+/// Normalizes SQL without rewriting literal contents.
 #[must_use]
 pub fn normalize_sql(sql: &str) -> String {
-    sql.split_whitespace().collect::<Vec<_>>().join(" ")
+    let trimmed = sql.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let dialect = GenericDialect {};
+    match Parser::parse_sql(&dialect, trimmed) {
+        Ok(statements) => statements
+            .into_iter()
+            .map(|statement| statement.to_string())
+            .collect::<Vec<_>>()
+            .join("; "),
+        Err(_) => trimmed.to_string(),
+    }
 }
 
 /// Builds a deterministic fingerprint for one cacheable query or metadata request.
@@ -69,4 +84,19 @@ pub fn query_cache_fingerprint(input: QueryCacheInput<'_>) -> String {
         hasher.update(b"\0");
     }
     format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_sql;
+
+    #[test]
+    fn normalize_sql_preserves_string_literal_whitespace() {
+        let with_double_space = "select 'a  b' as value";
+        let with_single_space = "select 'a b' as value";
+
+        assert_eq!(normalize_sql(with_double_space), "SELECT 'a  b' AS value");
+        assert_eq!(normalize_sql(with_single_space), "SELECT 'a b' AS value");
+        assert_ne!(normalize_sql(with_double_space), normalize_sql(with_single_space));
+    }
 }

--- a/crates/coral-engine/src/cache.rs
+++ b/crates/coral-engine/src/cache.rs
@@ -108,7 +108,7 @@ pub fn normalize_sql(sql: &str) -> String {
                         normalized.push(' ');
                     }
                     pending_space = false;
-                    normalized.push(ch);
+                    normalized.push(ch.to_ascii_lowercase());
                 }
             },
             Mode::SingleQuote => {
@@ -195,5 +195,14 @@ mod tests {
     fn normalize_sql_collapses_formatting_outside_literals() {
         let sql = "  select   *   from   foo  where  id = 1  -- comment\n";
         assert_eq!(normalize_sql(sql), "select * from foo where id = 1");
+    }
+
+    #[test]
+    fn normalize_sql_canonicalizes_case_outside_literals() {
+        let upper = "SELECT * FROM Foo WHERE id = 1";
+        let lower = "select * from foo where id = 1";
+
+        assert_eq!(normalize_sql(upper), "select * from foo where id = 1");
+        assert_eq!(normalize_sql(upper), normalize_sql(lower));
     }
 }

--- a/crates/coral-engine/src/cache.rs
+++ b/crates/coral-engine/src/cache.rs
@@ -1,0 +1,72 @@
+//! Deterministic query cache fingerprinting for app-side result caching.
+
+use sha2::{Digest, Sha256};
+
+/// Query operation categories that participate in cache fingerprinting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryCacheOperation {
+    /// Materialized query execution.
+    ExecuteSql,
+    /// Logical and physical plan rendering.
+    ExplainSql,
+    /// Workspace catalog discovery.
+    ListTables,
+    /// Workspace catalog discovery with table functions.
+    ListCatalog,
+    /// Source validation and declared test queries.
+    ValidateSource,
+}
+
+impl QueryCacheOperation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ExecuteSql => "execute_sql",
+            Self::ExplainSql => "explain_sql",
+            Self::ListTables => "list_tables",
+            Self::ListCatalog => "list_catalog",
+            Self::ValidateSource => "validate_source",
+        }
+    }
+}
+
+/// Canonical inputs used to derive a query cache fingerprint.
+#[derive(Debug, Clone)]
+pub struct QueryCacheInput<'a> {
+    /// Query or metadata operation being cached.
+    pub operation: QueryCacheOperation,
+    /// Workspace being queried.
+    pub workspace_name: &'a str,
+    /// Normalized SQL text, if the operation is SQL-backed.
+    pub sql: Option<&'a str>,
+    /// Stable source/runtime fingerprint supplied by the app layer.
+    pub source_fingerprint: &'a str,
+    /// Execution settings and request-scoped qualifiers.
+    pub execution_settings: &'a [&'a str],
+}
+
+/// Normalizes SQL by trimming and collapsing whitespace.
+#[must_use]
+pub fn normalize_sql(sql: &str) -> String {
+    sql.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Builds a deterministic fingerprint for one cacheable query or metadata request.
+#[must_use]
+pub fn query_cache_fingerprint(input: QueryCacheInput<'_>) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(input.operation.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(input.workspace_name.as_bytes());
+    hasher.update(b"\0");
+    if let Some(sql) = input.sql {
+        hasher.update(normalize_sql(sql).as_bytes());
+    }
+    hasher.update(b"\0");
+    hasher.update(input.source_fingerprint.as_bytes());
+    hasher.update(b"\0");
+    for setting in input.execution_settings {
+        hasher.update(setting.as_bytes());
+        hasher.update(b"\0");
+    }
+    format!("{:x}", hasher.finalize())
+}

--- a/crates/coral-engine/src/cache.rs
+++ b/crates/coral-engine/src/cache.rs
@@ -1,8 +1,6 @@
 //! Deterministic query cache fingerprinting for app-side result caching.
 
 use sha2::{Digest, Sha256};
-use datafusion::sql::sqlparser::dialect::GenericDialect;
-use datafusion::sql::sqlparser::parser::Parser;
 
 /// Query operation categories that participate in cache fingerprinting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -54,15 +52,108 @@ pub fn normalize_sql(sql: &str) -> String {
         return String::new();
     }
 
-    let dialect = GenericDialect {};
-    match Parser::parse_sql(&dialect, trimmed) {
-        Ok(statements) => statements
-            .into_iter()
-            .map(|statement| statement.to_string())
-            .collect::<Vec<_>>()
-            .join("; "),
-        Err(_) => trimmed.to_string(),
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut chars = trimmed.chars().peekable();
+    let mut pending_space = false;
+    enum Mode {
+        Normal,
+        SingleQuote,
+        DoubleQuote,
+        Backtick,
+        LineComment,
+        BlockComment,
     }
+    let mut mode = Mode::Normal;
+
+    while let Some(ch) = chars.next() {
+        match mode {
+            Mode::Normal => match ch {
+                '\'' => {
+                    if pending_space && !normalized.is_empty() {
+                        normalized.push(' ');
+                    }
+                    pending_space = false;
+                    normalized.push(ch);
+                    mode = Mode::SingleQuote;
+                }
+                '"' => {
+                    if pending_space && !normalized.is_empty() {
+                        normalized.push(' ');
+                    }
+                    pending_space = false;
+                    normalized.push(ch);
+                    mode = Mode::DoubleQuote;
+                }
+                '`' => {
+                    if pending_space && !normalized.is_empty() {
+                        normalized.push(' ');
+                    }
+                    pending_space = false;
+                    normalized.push(ch);
+                    mode = Mode::Backtick;
+                }
+                '-' if chars.peek().is_some_and(|next| *next == '-') => {
+                    chars.next();
+                    mode = Mode::LineComment;
+                }
+                '/' if chars.peek().is_some_and(|next| *next == '*') => {
+                    chars.next();
+                    mode = Mode::BlockComment;
+                }
+                ch if ch.is_whitespace() => {
+                    pending_space = true;
+                }
+                _ => {
+                    if pending_space && !normalized.is_empty() {
+                        normalized.push(' ');
+                    }
+                    pending_space = false;
+                    normalized.push(ch);
+                }
+            },
+            Mode::SingleQuote => {
+                normalized.push(ch);
+                if ch == '\'' {
+                    if chars.peek().is_some_and(|next| *next == '\'') {
+                        normalized.push(chars.next().expect("peeked next char"));
+                    } else {
+                        mode = Mode::Normal;
+                    }
+                }
+            }
+            Mode::DoubleQuote => {
+                normalized.push(ch);
+                if ch == '"' {
+                    if chars.peek().is_some_and(|next| *next == '"') {
+                        normalized.push(chars.next().expect("peeked next char"));
+                    } else {
+                        mode = Mode::Normal;
+                    }
+                }
+            }
+            Mode::Backtick => {
+                normalized.push(ch);
+                if ch == '`' {
+                    mode = Mode::Normal;
+                }
+            }
+            Mode::LineComment => {
+                if ch == '\n' {
+                    pending_space = true;
+                    mode = Mode::Normal;
+                }
+            }
+            Mode::BlockComment => {
+                if ch == '*' && chars.peek().is_some_and(|next| *next == '/') {
+                    chars.next();
+                    pending_space = true;
+                    mode = Mode::Normal;
+                }
+            }
+        }
+    }
+
+    normalized.trim().to_string()
 }
 
 /// Builds a deterministic fingerprint for one cacheable query or metadata request.
@@ -95,8 +186,14 @@ mod tests {
         let with_double_space = "select 'a  b' as value";
         let with_single_space = "select 'a b' as value";
 
-        assert_eq!(normalize_sql(with_double_space), "SELECT 'a  b' AS value");
-        assert_eq!(normalize_sql(with_single_space), "SELECT 'a b' AS value");
+        assert_eq!(normalize_sql(with_double_space), "select 'a  b' as value");
+        assert_eq!(normalize_sql(with_single_space), "select 'a b' as value");
         assert_ne!(normalize_sql(with_double_space), normalize_sql(with_single_space));
+    }
+
+    #[test]
+    fn normalize_sql_collapses_formatting_outside_literals() {
+        let sql = "  select   *   from   foo  where  id = 1  -- comment\n";
+        assert_eq!(normalize_sql(sql), "select * from foo where id = 1");
     }
 }

--- a/crates/coral-engine/src/contracts/catalog.rs
+++ b/crates/coral-engine/src/contracts/catalog.rs
@@ -1,7 +1,7 @@
 //! Typed query-visible catalog metadata.
 
 /// Describes one queryable column.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ColumnInfo {
     /// Column name.
     pub name: String,
@@ -20,7 +20,7 @@ pub struct ColumnInfo {
 }
 
 /// Describes one queryable table.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TableInfo {
     /// `SQL` schema name.
     pub schema_name: String,
@@ -37,7 +37,7 @@ pub struct TableInfo {
 }
 
 /// Describes the queryable catalog exposed by one runtime snapshot.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CatalogInfo {
     /// Queryable tables.
     pub tables: Vec<TableInfo>,
@@ -46,7 +46,7 @@ pub struct CatalogInfo {
 }
 
 /// Describes one argument accepted by a source-scoped table function.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TableFunctionArgumentInfo {
     /// Argument name as used in a named SQL function call.
     pub name: String,
@@ -57,7 +57,7 @@ pub struct TableFunctionArgumentInfo {
 }
 
 /// Describes one result column returned by a source-scoped table function.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TableFunctionResultColumnInfo {
     /// Column name returned by the table function.
     pub name: String,
@@ -70,7 +70,7 @@ pub struct TableFunctionResultColumnInfo {
 }
 
 /// Describes one source-scoped table function.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TableFunctionInfo {
     /// `SQL` schema name.
     pub schema_name: String,

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -67,14 +67,14 @@ impl QuerySource {
 }
 
 /// One source-spec validation query executed during source validation.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct QueryTestResult {
     sql: String,
     result: Result<QueryTestSuccess, QueryTestFailure>,
 }
 
 /// Success metadata for one validation query execution.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct QueryTestSuccess {
     row_count: u64,
 }
@@ -88,7 +88,7 @@ impl QueryTestSuccess {
 }
 
 /// Failure details for one validation query execution.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct QueryTestFailure {
     error_message: String,
 }
@@ -156,7 +156,7 @@ impl QueryTestResult {
 }
 
 /// Structured report for validating one source and its optional test queries.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SourceValidationReport {
     /// Tables exposed by the validated source.
     pub tables: Vec<super::TableInfo>,
@@ -210,7 +210,7 @@ impl QueryRuntimeConfig {
 }
 
 /// Query-engine plan renderings for one `SQL` statement.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct QueryPlan {
     unoptimized_logical: String,
     optimized_logical: String,
@@ -285,6 +285,21 @@ impl QueryExecution {
             batches,
             row_count,
         }
+    }
+
+    #[must_use]
+    /// Rebuilds one fully materialized query result from an `Arrow` IPC stream.
+    pub fn from_arrow_ipc_stream(bytes: &[u8]) -> Result<Self, arrow::error::ArrowError> {
+        use arrow::ipc::reader::StreamReader;
+
+        let cursor = std::io::Cursor::new(bytes);
+        let mut reader = StreamReader::try_new(cursor, None)?;
+        let arrow_schema = Arc::new(reader.schema().as_ref().clone());
+        let mut batches = Vec::new();
+        for batch in &mut reader {
+            batches.push(batch?);
+        }
+        Ok(Self::new(arrow_schema, batches))
     }
 
     #[must_use]

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -288,21 +288,6 @@ impl QueryExecution {
     }
 
     #[must_use]
-    /// Rebuilds one fully materialized query result from an `Arrow` IPC stream.
-    pub fn from_arrow_ipc_stream(bytes: &[u8]) -> Result<Self, arrow::error::ArrowError> {
-        use arrow::ipc::reader::StreamReader;
-
-        let cursor = std::io::Cursor::new(bytes);
-        let mut reader = StreamReader::try_new(cursor, None)?;
-        let arrow_schema = Arc::new(reader.schema().as_ref().clone());
-        let mut batches = Vec::new();
-        for batch in &mut reader {
-            batches.push(batch?);
-        }
-        Ok(Self::new(arrow_schema, batches))
-    }
-
-    #[must_use]
     /// Returns the logical result-set schema.
     pub fn schema(&self) -> &[ColumnInfo] {
         &self.schema

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -56,6 +56,7 @@
 )]
 
 mod backends;
+pub mod cache;
 mod composition;
 pub mod contracts;
 mod runtime;
@@ -65,6 +66,7 @@ pub use composition::{
     RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
     SourceTables,
 };
+pub use cache::{QueryCacheInput, QueryCacheOperation, normalize_sql, query_cache_fingerprint};
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,
     QueryRuntimeContext, QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess,

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -100,8 +100,19 @@ export CORAL_CONFIG_DIR=/path/to/coral-config
 Important files include:
 
 - `config.toml` for installed-source metadata and non-secret variables
+- `cache/` for persistent query-result reuse when cache TTL is enabled
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
+
+To enable query caching, add a `[cache]` section to `config.toml` with a TTL and optional persistent storage toggle, for example:
+
+```toml
+[cache]
+ttl_seconds = 300
+persistent = true
+```
+
+After that, repeated SQL queries and catalog lookups can reuse cached results until the TTL expires.
 
 <Note>
   [Bundled source](/reference/bundled-sources) specs are not copied into the config directory. Coral resolves them from the current binary when you validate or query a bundled source, so upgrades pick up newer bundled manifests without re-adding the source.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -23,21 +23,6 @@ JSON output is an array of row objects. Selected nullable columns are included w
 
 Manage configured sources, either the bundled ones, or your custom source specs.
 
-## `coral cache`
-
-Manage the local query cache.
-
-### `coral cache clear`
-
-Clear cached query results and metadata lookups from the local persistent cache.
-
-```shellscript
-coral cache clear
-coral cache clear --source github
-```
-
-Use `--source` to remove cache entries associated with one source name only.
-
 ### `coral source discover`
 
 List the [bundled sources](/reference/bundled-sources) available in your current Coral build.
@@ -120,6 +105,21 @@ Remove an installed source.
 ```shellscript
 coral source remove github
 ```
+
+## `coral cache`
+
+Manage the local query cache.
+
+### `coral cache clear`
+
+Clear cached query results and metadata lookups from the local persistent cache.
+
+```shellscript
+coral cache clear
+coral cache clear --source github
+```
+
+Use `--source` to remove cache entries associated with one source name only.
 
 ## `coral onboard`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -23,6 +23,21 @@ JSON output is an array of row objects. Selected nullable columns are included w
 
 Manage configured sources, either the bundled ones, or your custom source specs.
 
+## `coral cache`
+
+Manage the local query cache.
+
+### `coral cache clear`
+
+Clear cached query results and metadata lookups from the local persistent cache.
+
+```shellscript
+coral cache clear
+coral cache clear --source github
+```
+
+Use `--source` to remove cache entries associated with one source name only.
+
 ### `coral source discover`
 
 List the [bundled sources](/reference/bundled-sources) available in your current Coral build.


### PR DESCRIPTION
## Description
Implemented the cache layer end to end.

The query manager now fingerprints query inputs, checks a shared cache before executing, stores results for SQL execution, explain plans, catalog discovery, and source validation, and records cache hit/miss telemetry. The engine owns the deterministic fingerprint helper in crates/coral-engine/src/cache.rs, while the app-side store and wiring live in crates/coral-app/src/storage/cache.rs and crates/coral-app/src/query/manager.rs. I also added `coral cache clear` in crates/coral-cli/src/lib.rs, plus cache settings in `config.toml` and telemetry counters in crates/coral-app/src/telemetry/metrics.rs.

Docs are updated in docs/reference/cli-reference.mdx and docs/getting-started/installation.mdx. I couldn’t run cargo in this shell because Cargo is not installed on PATH here, but the editor diagnostics on all touched Rust files are clean.

## Issue 
closes #670