### PR TITLE
feat(sources/community/gmail): add Gmail community source

### DIFF
--- a/sources/community/gmail/README.md
+++ b/sources/community/gmail/README.md
@@ -1,0 +1,116 @@
+# Gmail
+
+Query Gmail messages, threads, labels, and drafts using SQL via the [Gmail REST API v1](https://developers.google.com/gmail/api/reference/rest).
+
+## Authentication
+
+The source uses OAuth 2.0 Bearer Token authentication. `GMAIL_ACCESS_TOKEN` is required at install time.
+
+To generate an access token:
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
+2. Create a project and enable the **Gmail API**.
+3. Create an **OAuth 2.0 Client ID** credential (Desktop or Web app).
+4. Authorize the scope `https://www.googleapis.com/auth/gmail.readonly`.
+5. Obtain an access token via OAuth 2.0 flow or use the [OAuth 2.0 Playground](https://developers.google.com/oauthplayground/).
+
+## Configuration
+
+| Input | Kind | Required | Default | Description |
+|---|---|---|---|---|
+| `GMAIL_ACCESS_TOKEN` | secret | yes | — | OAuth 2.0 access token with `gmail.readonly` scope. |
+
+## Schema
+
+### `labels`
+
+One row per Gmail label (folder/category). Requires `user_id` filter. Use `'me'` for the authenticated user. Use `label_id` values as filters in the `messages` and `threads` tables.
+
+| Column | Type | Description |
+|---|---|---|
+| `label_id` | text | Unique label ID (e.g. `INBOX`, `SENT`, or a custom ID). |
+| `name` | text | Display name of the label. |
+| `type` | text | `system` for built-in labels, `user` for custom labels. |
+
+### `messages`
+
+One row per Gmail message. Requires `user_id` filter. Optionally filter by `label_id` or Gmail search `q`.
+
+| Column | Type | Description |
+|---|---|---|
+| `message_id` | text | Unique message ID. Use as filter in `message_detail`. |
+| `thread_id` | text | Thread this message belongs to. |
+
+### `message_detail`
+
+Full metadata for a single message. Requires `user_id` and `message_id` filters.
+
+| Column | Type | Description |
+|---|---|---|
+| `message_id` | text | Unique message ID. |
+| `thread_id` | text | Thread ID. |
+| `snippet` | text | Short plain-text preview of the message body. |
+| `history_id` | text | History record ID. |
+| `internal_date` | text | Message timestamp in milliseconds since epoch. |
+| `label_ids` | text | JSON array of label IDs applied to this message. |
+
+### `threads`
+
+One row per conversation thread. Requires `user_id` filter. Optionally filter by `label_id` or `q`.
+
+| Column | Type | Description |
+|---|---|---|
+| `thread_id` | text | Unique thread ID. |
+| `snippet` | text | Preview of the most recent message in the thread. |
+| `history_id` | text | History record ID. |
+
+## Example Queries
+
+```sql
+-- List all labels
+SELECT label_id, name, type
+FROM gmail.labels
+WHERE user_id = 'me';
+
+-- List messages in INBOX
+SELECT message_id, thread_id
+FROM gmail.messages
+WHERE user_id = 'me'
+  AND label_id = 'INBOX';
+
+-- Search for unread messages
+SELECT message_id, thread_id
+FROM gmail.messages
+WHERE user_id = 'me'
+  AND q = 'is:unread';
+
+-- Search for messages from a specific sender
+SELECT message_id, thread_id
+FROM gmail.messages
+WHERE user_id = 'me'
+  AND q = 'from:someone@example.com';
+
+-- Get full details of a specific message
+SELECT message_id, snippet, internal_date, label_ids
+FROM gmail.message_detail
+WHERE user_id = 'me'
+  AND message_id = 'your-message-id';
+
+-- List threads in INBOX
+SELECT thread_id, snippet
+FROM gmail.threads
+WHERE user_id = 'me'
+  AND label_id = 'INBOX';
+```
+
+## Limitations
+
+- **Read-only**: This source only supports `SELECT` operations. Sending or modifying emails is not supported.
+- **Access token expiry**: OAuth 2.0 access tokens expire after 1 hour. Refresh the token and update the secret as needed.
+- **message_detail requires one call per message**: Fetching details for many messages requires repeated queries with different `message_id` filters.
+- **Pagination not yet supported**: Results are limited to the API's default page size (100 messages per request).
+
+## Notes
+
+- Use `'me'` as the `user_id` to query the authenticated user's mailbox.
+- Gmail search syntax is supported in the `q` filter — see [Gmail search operators](https://support.google.com/mail/answer/7190) for the full reference.

--- a/sources/community/gmail/manifest.yaml
+++ b/sources/community/gmail/manifest.yaml
@@ -1,0 +1,204 @@
+name: gmail
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Gmail messages, threads, and labels using the Gmail REST API v1.
+
+inputs:
+  GMAIL_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      OAuth 2.0 access token for the Gmail API.
+      Create credentials at https://console.cloud.google.com/apis/credentials.
+      Enable the Gmail API and generate an OAuth 2.0 token with the scope
+      https://www.googleapis.com/auth/gmail.readonly.
+
+base_url: "https://gmail.googleapis.com"
+
+auth:
+  type: BearerToken
+  token: "{{input.GMAIL_ACCESS_TOKEN}}"
+
+test_queries:
+  - SELECT * FROM gmail.labels WHERE user_id = 'me' LIMIT 5
+
+tables:
+  - name: labels
+    description: Gmail labels (folders and categories) for a user.
+    guide: >
+      Requires user_id filter. Use 'me' for the authenticated user.
+      Returns one row per label. label_id is the stable identifier used
+      as a filter in the messages table. System labels include INBOX,
+      SENT, DRAFT, SPAM, TRASH, UNREAD, STARRED, and IMPORTANT.
+    filters:
+      - name: user_id
+        required: true
+    request:
+      method: GET
+      path: /gmail/v1/users/{{filter.user_id}}/labels
+    response:
+      rows_path: [labels]
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: label_id
+        type: Utf8
+        nullable: false
+        description: >-
+          Unique label ID. Use as the label_id filter in the messages table.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the label (e.g. INBOX, SENT, or a custom name).
+        expr: {kind: path, path: [name]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Label type. system for built-in labels, user for custom labels.
+        expr: {kind: path, path: [type]}
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: User ID (echoes the user_id filter).
+        expr: {kind: from_filter, key: user_id}
+        virtual: true
+
+  - name: messages
+    description: Gmail messages for a user.
+    guide: >
+      Requires user_id filter. Use 'me' for the authenticated user.
+      Optionally filter by label_id (from the labels table) to list messages
+      in a specific label such as INBOX or SENT.
+      Returns one row per message with message_id and thread_id.
+      Use message_id as a filter in the message_detail table to fetch full
+      message content.
+    filters:
+      - name: user_id
+        required: true
+      - name: label_id
+        required: false
+    request:
+      method: GET
+      path: /gmail/v1/users/{{filter.user_id}}/messages?labelIds={{filter.label_id}}
+    response:
+      rows_path: [messages]
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: message_id
+        type: Utf8
+        nullable: false
+        description: >-
+          Unique message ID. Use as the message_id filter in message_detail.
+        expr: {kind: path, path: [id]}
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: Thread ID this message belongs to.
+        expr: {kind: path, path: [threadId]}
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: User ID (echoes the user_id filter).
+        expr: {kind: from_filter, key: user_id}
+        virtual: true
+
+  - name: message_detail
+    description: Full metadata for a single Gmail message.
+    guide: >
+      Requires user_id and message_id filters. Get message_id values from
+      the messages table. Returns one row with the message snippet, thread ID,
+      history ID, and internal date.
+      Use user_id = 'me' for the authenticated user.
+    filters:
+      - name: user_id
+        required: true
+      - name: message_id
+        required: true
+    request:
+      method: GET
+      path: /gmail/v1/users/{{filter.user_id}}/messages/{{filter.message_id}}
+    response:
+      rows_path: []
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: message_id
+        type: Utf8
+        nullable: false
+        description: Unique message ID.
+        expr: {kind: path, path: [id]}
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: Thread ID this message belongs to.
+        expr: {kind: path, path: [threadId]}
+      - name: snippet
+        type: Utf8
+        nullable: true
+        description: Short plain-text preview of the message body.
+        expr: {kind: path, path: [snippet]}
+      - name: history_id
+        type: Utf8
+        nullable: true
+        description: History record ID for this message.
+        expr: {kind: path, path: [historyId]}
+      - name: internal_date
+        type: Utf8
+        nullable: true
+        description: Message timestamp in milliseconds since epoch.
+        expr: {kind: path, path: [internalDate]}
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: User ID (echoes the user_id filter).
+        expr: {kind: from_filter, key: user_id}
+        virtual: true
+
+  - name: threads
+    description: Gmail conversation threads for a user.
+    guide: >
+      Requires user_id filter. Use 'me' for the authenticated user.
+      Optionally filter by label_id to list threads in a specific label.
+      Returns one row per thread. snippet is a preview of the most recent
+      message in the thread.
+    filters:
+      - name: user_id
+        required: true
+      - name: label_id
+        required: false
+    request:
+      method: GET
+      path: /gmail/v1/users/{{filter.user_id}}/threads?labelIds={{filter.label_id}}
+    response:
+      rows_path: [threads]
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: thread_id
+        type: Utf8
+        nullable: false
+        description: Unique thread ID.
+        expr: {kind: path, path: [id]}
+      - name: snippet
+        type: Utf8
+        nullable: true
+        description: Short plain-text preview of the most recent message in the thread.
+        expr: {kind: path, path: [snippet]}
+      - name: history_id
+        type: Utf8
+        nullable: true
+        description: History record ID for the thread.
+        expr: {kind: path, path: [historyId]}
+      - name: user_id
+        type: Utf8
+        nullable: true
+        description: User ID (echoes the user_id filter).
+        expr: {kind: from_filter, key: user_id}
+        virtual: true


### PR DESCRIPTION
## Summary
Adds a new community source for Gmail using the Gmail REST API v1.

## Tables
- `labels` — list all Gmail labels (INBOX, SENT, DRAFT, etc.)
- `messages` — list messages, filterable by label_id
- `message_detail` — full metadata for a single message
- `threads` — list conversation threads, filterable by label_id

## Authentication
OAuth 2.0 Bearer Token with `gmail.readonly` scope.

## Example Queries
```sql
SELECT * FROM gmail.labels WHERE user_id = 'me';
SELECT * FROM gmail.messages WHERE user_id = 'me' AND label_id = 'INBOX';
```

## Notes
- Read-only source
- Follows existing community source patterns