### PR TITLE
fix(ui): use explicit presence check for HTTP detail tab selection

### DIFF
--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -1,125 +1,147 @@
-import { useEffect, useState } from 'react'
-import classNames from 'classnames'
+import { useEffect, useState } from "react";
+import classNames from "classnames";
 
-import * as Button from '@/wax/components/button'
-import * as ScrollArea from '@/wax/components/scroll-area'
-import { Typography } from '@/wax/components/typography'
-import type { TraceSpan } from '@/generated/coral/v1/traces_pb'
+import * as Button from "@/wax/components/button";
+import * as ScrollArea from "@/wax/components/scroll-area";
+import { Typography } from "@/wax/components/typography";
+import type { TraceSpan } from "@/generated/coral/v1/traces_pb";
 
-import * as s from '../traces-page.css'
-import { formatDuration, formatDurationFromNanos, parseJsonObject, spanOperation, spanUrl } from './trace-utils'
+import * as s from "../traces-page.css";
+import {
+  formatDuration,
+  formatDurationFromNanos,
+  parseJsonObject,
+  spanOperation,
+  spanUrl,
+} from "./trace-utils";
 
-type JsonValue = Record<string, unknown> | unknown[] | string | number | boolean | null
-type HttpDetailTab = 'params' | 'request' | 'response'
-type CopyKind = 'formatted' | 'raw'
+type JsonValue =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+type HttpDetailTab = "params" | "request" | "response";
+type CopyKind = "formatted" | "raw";
 
-const REQUEST_BODY_ATTR = 'coral.http.request.body'
-const RESPONSE_BODY_ATTR = 'coral.http.response.body'
-const REQUEST_BODY_TRUNCATED_ATTR = 'coral.http.request.body.truncated'
-const RESPONSE_BODY_TRUNCATED_ATTR = 'coral.http.response.body.truncated'
-const REQUEST_BODY_PRESENT_ATTR = 'http.request.body.present'
-const RESPONSE_BODY_PRESENT_ATTR = 'http.response.body.present'
-const REQUEST_BODY_SIZE_ATTR = 'http.request.body.size'
-const RESPONSE_BODY_SIZE_ATTR = 'http.response.body.size'
-const BODY_ATTRIBUTE_KEYS = new Set([
-  REQUEST_BODY_ATTR,
-  RESPONSE_BODY_ATTR,
-])
+const REQUEST_BODY_ATTR = "coral.http.request.body";
+const RESPONSE_BODY_ATTR = "coral.http.response.body";
+const REQUEST_BODY_TRUNCATED_ATTR = "coral.http.request.body.truncated";
+const RESPONSE_BODY_TRUNCATED_ATTR = "coral.http.response.body.truncated";
+const REQUEST_BODY_PRESENT_ATTR = "http.request.body.present";
+const RESPONSE_BODY_PRESENT_ATTR = "http.response.body.present";
+const REQUEST_BODY_SIZE_ATTR = "http.request.body.size";
+const RESPONSE_BODY_SIZE_ATTR = "http.response.body.size";
+const BODY_ATTRIBUTE_KEYS = new Set([REQUEST_BODY_ATTR, RESPONSE_BODY_ATTR]);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function looksLikeJson(value: string) {
-  const trimmed = value.trim()
-  return (trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  const trimmed = value.trim();
+  return (
+    (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+    (trimmed.startsWith("[") && trimmed.endsWith("]"))
+  );
 }
 
 function parseMaybeJson(value: unknown): JsonValue {
-  if (typeof value !== 'string') return value as JsonValue
+  if (typeof value !== "string") return value as JsonValue;
   try {
-    const parsed = JSON.parse(value) as JsonValue
-    if (typeof parsed === 'string' && looksLikeJson(parsed)) {
-      return JSON.parse(parsed) as JsonValue
+    const parsed = JSON.parse(value) as JsonValue;
+    if (typeof parsed === "string" && looksLikeJson(parsed)) {
+      return JSON.parse(parsed) as JsonValue;
     }
-    return parsed
+    return parsed;
   } catch {
-    return value
+    return value;
   }
 }
 
 function formatJsonValue(value: JsonValue): string {
-  return JSON.stringify(value, null, 2)
+  return JSON.stringify(value, null, 2);
 }
 
 function requestParams(url: string): Record<string, string | string[]> {
-  if (!url) return {}
+  if (!url) return {};
   try {
-    const params = new URL(url, 'http://coral.local').searchParams
-    const result: Record<string, string | string[]> = {}
+    const params = new URL(url, "http://coral.local").searchParams;
+    const result: Record<string, string | string[]> = {};
     for (const [key, value] of params.entries()) {
-      const current = result[key]
-      if (current === undefined) result[key] = value
-      else if (Array.isArray(current)) current.push(value)
-      else result[key] = [current, value]
+      const current = result[key];
+      if (current === undefined) result[key] = value;
+      else if (Array.isArray(current)) current.push(value);
+      else result[key] = [current, value];
     }
-    return result
+    return result;
   } catch {
-    return {}
+    return {};
   }
 }
 
 function formatDetailValue(value: JsonValue | undefined): string {
-  if (value === undefined || value === null || value === '') return ''
-  if (typeof value === 'string') {
-    const parsedValue = parseMaybeJson(value)
-    return typeof parsedValue === 'string' ? value : formatJsonValue(parsedValue)
+  if (value === undefined || value === null || value === "") return "";
+  if (typeof value === "string") {
+    const parsedValue = parseMaybeJson(value);
+    return typeof parsedValue === "string"
+      ? value
+      : formatJsonValue(parsedValue);
   }
-  return formatJsonValue(value)
+  return formatJsonValue(value);
 }
 
 function formatRawValue(value: unknown, formatted: string): string {
-  if (value === undefined || value === null || value === '') return ''
-  return typeof value === 'string' ? value : formatted
+  if (value === undefined || value === null || value === "") return "";
+  return typeof value === "string" ? value : formatted;
 }
 
-type BodyKind = 'request' | 'response'
+type BodyKind = "request" | "response";
 
 interface GraphqlBodyPreview {
-  bodyKind: BodyKind
-  operationName?: string
-  operationType?: string
-  query?: string
-  variables?: JsonValue
-  data?: JsonValue
-  errors?: JsonValue
+  bodyKind: BodyKind;
+  operationName?: string;
+  operationType?: string;
+  query?: string;
+  variables?: JsonValue;
+  data?: JsonValue;
+  errors?: JsonValue;
 }
 
 interface BodyPreview {
-  formattedText: string
-  graphql?: GraphqlBodyPreview
-  rawText: string
+  formattedText: string;
+  graphql?: GraphqlBodyPreview;
+  rawText: string;
 }
 
-function inferGraphqlOperationType(query: string | undefined): string | undefined {
-  if (!query) return undefined
-  const match = query.trim().match(/^(query|mutation|subscription)\b/i)
-  return match?.[1]?.toLowerCase() ?? 'query'
+function inferGraphqlOperationType(
+  query: string | undefined,
+): string | undefined {
+  if (!query) return undefined;
+  const match = query.trim().match(/^(query|mutation|subscription)\b/i);
+  return match?.[1]?.toLowerCase() ?? "query";
 }
 
-function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue): GraphqlBodyPreview | undefined {
-  if (!isPlainObject(value)) return undefined
+function detectGraphqlBody(
+  bodyKind: BodyKind,
+  value: JsonValue,
+): GraphqlBodyPreview | undefined {
+  if (!isPlainObject(value)) return undefined;
 
-  const query = typeof value.query === 'string' ? value.query : undefined
-  const operationName = typeof value.operationName === 'string' ? value.operationName : undefined
-  const variables = value.variables as JsonValue | undefined
-  const data = value.data as JsonValue | undefined
-  const errors = value.errors as JsonValue | undefined
-  const hasRequestShape = Boolean(query || operationName || variables !== undefined)
-  const hasResponseShape = Boolean(data !== undefined || errors !== undefined)
+  const query = typeof value.query === "string" ? value.query : undefined;
+  const operationName =
+    typeof value.operationName === "string" ? value.operationName : undefined;
+  const variables = value.variables as JsonValue | undefined;
+  const data = value.data as JsonValue | undefined;
+  const errors = value.errors as JsonValue | undefined;
+  const hasRequestShape = Boolean(
+    query || operationName || variables !== undefined,
+  );
+  const hasResponseShape = Boolean(data !== undefined || errors !== undefined);
 
-  if (bodyKind === 'request' && !hasRequestShape) return undefined
-  if (bodyKind === 'response' && !hasResponseShape) return undefined
+  if (bodyKind === "request" && !hasRequestShape) return undefined;
+  if (bodyKind === "response" && !hasResponseShape) return undefined;
 
   return {
     bodyKind,
@@ -129,43 +151,58 @@ function detectGraphqlBody(bodyKind: BodyKind, value: JsonValue): GraphqlBodyPre
     variables,
     data,
     errors,
-  }
+  };
 }
 
-function bodyPreview(kind: BodyKind, value: unknown, rawValue: unknown): BodyPreview | undefined {
-  if (value === undefined || value === null || value === '') return undefined
+function bodyPreview(
+  kind: BodyKind,
+  value: unknown,
+  rawValue: unknown,
+): BodyPreview | undefined {
+  if (value === undefined || value === null || value === "") return undefined;
 
-  if (typeof value === 'string') {
-    const parsedValue = parseMaybeJson(value)
-    if (typeof parsedValue === 'string') {
+  if (typeof value === "string") {
+    const parsedValue = parseMaybeJson(value);
+    if (typeof parsedValue === "string") {
       return {
         formattedText: value,
-        rawText: typeof rawValue === 'string' ? rawValue : value,
-      }
+        rawText: typeof rawValue === "string" ? rawValue : value,
+      };
     }
-    const formattedText = formatJsonValue(parsedValue)
+    const formattedText = formatJsonValue(parsedValue);
     return {
       formattedText,
       graphql: detectGraphqlBody(kind, parsedValue),
-      rawText: typeof rawValue === 'string' ? rawValue : formattedText,
-    }
+      rawText: typeof rawValue === "string" ? rawValue : formattedText,
+    };
   }
 
-  const formattedText = formatJsonValue(value as JsonValue)
+  const formattedText = formatJsonValue(value as JsonValue);
   return {
     formattedText,
     graphql: detectGraphqlBody(kind, value as JsonValue),
-    rawText: typeof rawValue === 'string' ? rawValue : formattedText,
-  }
+    rawText: typeof rawValue === "string" ? rawValue : formattedText,
+  };
 }
 
-function BodySection({ children, label }: { children: React.ReactNode; label: string }) {
+function BodySection({
+  children,
+  label,
+}: {
+  children: React.ReactNode;
+  label: string;
+}) {
   return (
     <section className={s.bodyViewerSection}>
-      <Typography.BodySmallStrong as="span" className={s.bodyViewerSectionLabel}>{label}</Typography.BodySmallStrong>
+      <Typography.BodySmallStrong
+        as="span"
+        className={s.bodyViewerSectionLabel}
+      >
+        {label}
+      </Typography.BodySmallStrong>
       {children}
     </section>
-  )
+  );
 }
 
 function BodyViewer({
@@ -174,23 +211,32 @@ function BodyViewer({
   rawValue,
   value,
 }: {
-  emptyText: string
-  kind: BodyKind
-  rawValue: unknown
-  value: unknown
+  emptyText: string;
+  kind: BodyKind;
+  rawValue: unknown;
+  value: unknown;
 }) {
-  const preview = bodyPreview(kind, value, rawValue)
+  const preview = bodyPreview(kind, value, rawValue);
 
   if (!preview) {
-    return <Typography.BodySmall variant="tertiary">{emptyText}</Typography.BodySmall>
+    return (
+      <Typography.BodySmall variant="tertiary">
+        {emptyText}
+      </Typography.BodySmall>
+    );
   }
 
-  const rawBodyDetails = preview.rawText !== preview.formattedText ? (
-    <details className={s.bodyViewerRawDetails}>
-      <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Raw body</Typography.Body></summary>
-      <pre className={s.detailsPre}>{preview.rawText}</pre>
-    </details>
-  ) : null
+  const rawBodyDetails =
+    preview.rawText !== preview.formattedText ? (
+      <details className={s.bodyViewerRawDetails}>
+        <summary className={s.detailsSummary}>
+          <Typography.Body as="span" variant="tertiary">
+            Raw body
+          </Typography.Body>
+        </summary>
+        <pre className={s.detailsPre}>{preview.rawText}</pre>
+      </details>
+    ) : null;
 
   if (!preview.graphql) {
     return (
@@ -198,37 +244,75 @@ function BodyViewer({
         <pre className={s.detailsPre}>{preview.formattedText}</pre>
         {rawBodyDetails}
       </div>
-    )
+    );
   }
 
-  const { bodyKind, data, errors, operationName, operationType, query, variables } = preview.graphql
+  const {
+    bodyKind,
+    data,
+    errors,
+    operationName,
+    operationType,
+    query,
+    variables,
+  } = preview.graphql;
 
   return (
     <div className={s.bodyViewer}>
       <div className={s.bodyViewerHeader}>
-        <Typography.BodySmallStrong as="span">{bodyKind === 'request' ? 'GraphQL request' : 'GraphQL response'}</Typography.BodySmallStrong>
+        <Typography.BodySmallStrong as="span">
+          {bodyKind === "request" ? "GraphQL request" : "GraphQL response"}
+        </Typography.BodySmallStrong>
         <div className={s.bodyMetaRow}>
-          {operationName && metaChip('Operation', operationName)}
-          {operationType && metaChip('Type', operationType)}
-          {variables !== undefined && metaChip('Variables', Array.isArray(variables) ? `${variables.length}` : 'present')}
-          {Array.isArray(errors) ? metaChip('Errors', `${errors.length}`) : errors !== undefined ? metaChip('Errors', 'present') : null}
-          {data !== undefined && metaChip('Data', Array.isArray(data) ? `${data.length}` : 'present')}
+          {operationName && metaChip("Operation", operationName)}
+          {operationType && metaChip("Type", operationType)}
+          {variables !== undefined &&
+            metaChip(
+              "Variables",
+              Array.isArray(variables) ? `${variables.length}` : "present",
+            )}
+          {Array.isArray(errors)
+            ? metaChip("Errors", `${errors.length}`)
+            : errors !== undefined
+              ? metaChip("Errors", "present")
+              : null}
+          {data !== undefined &&
+            metaChip(
+              "Data",
+              Array.isArray(data) ? `${data.length}` : "present",
+            )}
         </div>
       </div>
-      {query !== undefined && <BodySection label="Query"><pre className={s.detailsPre}>{query}</pre></BodySection>}
-      {variables !== undefined && <BodySection label="Variables"><pre className={s.detailsPre}>{formatDetailValue(variables)}</pre></BodySection>}
-      {data !== undefined && <BodySection label="Data"><pre className={s.detailsPre}>{formatDetailValue(data)}</pre></BodySection>}
-      {errors !== undefined && <BodySection label="Errors"><pre className={s.detailsPre}>{formatDetailValue(errors)}</pre></BodySection>}
+      {query !== undefined && (
+        <BodySection label="Query">
+          <pre className={s.detailsPre}>{query}</pre>
+        </BodySection>
+      )}
+      {variables !== undefined && (
+        <BodySection label="Variables">
+          <pre className={s.detailsPre}>{formatDetailValue(variables)}</pre>
+        </BodySection>
+      )}
+      {data !== undefined && (
+        <BodySection label="Data">
+          <pre className={s.detailsPre}>{formatDetailValue(data)}</pre>
+        </BodySection>
+      )}
+      {errors !== undefined && (
+        <BodySection label="Errors">
+          <pre className={s.detailsPre}>{formatDetailValue(errors)}</pre>
+        </BodySection>
+      )}
       {rawBodyDetails}
     </div>
-  )
+  );
 }
 
 interface ActiveBodyState {
-  emptyText: string
-  kind: BodyKind
-  rawValue: unknown
-  value: JsonValue | undefined
+  emptyText: string;
+  kind: BodyKind;
+  rawValue: unknown;
+  value: JsonValue | undefined;
 }
 
 function activeBodyState(
@@ -243,68 +327,81 @@ function activeBodyState(
   responseBodyTruncated: boolean,
 ): ActiveBodyState {
   switch (activeTab) {
-    case 'params':
+    case "params":
       return {
-        emptyText: 'No query parameters were recorded for this request.',
-        kind: 'response',
+        emptyText: "No query parameters were recorded for this request.",
+        kind: "response",
         rawValue: paramsValue,
         value: paramsValue,
-      }
-    case 'request':
+      };
+    case "request":
       return {
-        emptyText: bodyEmptyText('request', attrs, requestBodyTruncated),
-        kind: 'request',
+        emptyText: bodyEmptyText("request", attrs, requestBodyTruncated),
+        kind: "request",
         rawValue: rawRequestBody,
         value: requestBody,
-      }
-    case 'response':
+      };
+    case "response":
       return {
-        emptyText: bodyEmptyText('response', attrs, responseBodyTruncated),
-        kind: 'response',
+        emptyText: bodyEmptyText("response", attrs, responseBodyTruncated),
+        kind: "response",
         rawValue: rawResponseBody,
         value: responseBody,
-      }
+      };
   }
 }
 
 function attrBool(value: unknown): boolean {
-  return value === true || value === 'true'
+  return value === true || value === "true";
 }
 
 function attrText(value: unknown): string | undefined {
-  if (value === undefined || value === null || value === '') return undefined
-  return String(value)
+  if (value === undefined || value === null || value === "") return undefined;
+  return String(value);
 }
 
 function formatBytes(value: unknown): string | undefined {
-  const raw = attrText(value)
-  if (!raw) return undefined
-  const bytes = Number(raw)
-  if (!Number.isFinite(bytes)) return raw
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  const raw = attrText(value);
+  if (!raw) return undefined;
+  const bytes = Number(raw);
+  if (!Number.isFinite(bytes)) return raw;
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-function bodyEmptyText(kind: 'request' | 'response', attrs: Record<string, unknown>, truncated: boolean) {
-  const label = kind === 'request' ? 'Request body' : 'Response body'
-  const size = formatBytes(attrs[kind === 'request' ? REQUEST_BODY_SIZE_ATTR : RESPONSE_BODY_SIZE_ATTR])
-  const present = kind === 'request'
-    ? attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
-    : attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size)
+function bodyEmptyText(
+  kind: "request" | "response",
+  attrs: Record<string, unknown>,
+  truncated: boolean,
+) {
+  const label = kind === "request" ? "Request body" : "Response body";
+  const size = formatBytes(
+    attrs[
+      kind === "request" ? REQUEST_BODY_SIZE_ATTR : RESPONSE_BODY_SIZE_ATTR
+    ],
+  );
+  const present =
+    kind === "request"
+      ? attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
+      : attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size);
 
-  if (truncated) return `${label} was truncated${size ? ` (${size})` : ''}, but no preview was recorded.`
-  if (present) return `${label} was present${size ? ` (${size})` : ''}, but content was not captured.`
-  return `No ${kind} body was recorded for this request.`
+  if (truncated)
+    return `${label} was truncated${size ? ` (${size})` : ""}, but no preview was recorded.`;
+  if (present)
+    return `${label} was present${size ? ` (${size})` : ""}, but content was not captured.`;
+  return `No ${kind} body was recorded for this request.`;
 }
 
 function metaChip(label: string, value: React.ReactNode) {
   return (
     <span className={s.httpMetaChip} key={label}>
-      <Typography.BodySmall as="span" variant="tertiary">{label}</Typography.BodySmall>
+      <Typography.BodySmall as="span" variant="tertiary">
+        {label}
+      </Typography.BodySmall>
       <Typography.BodySmallStrong as="span">{value}</Typography.BodySmallStrong>
     </span>
-  )
+  );
 }
 
 export function HttpSpanDetail({
@@ -316,32 +413,47 @@ export function HttpSpanDetail({
   span,
   traceStart,
 }: {
-  canSelectNextSpan: boolean
-  canSelectPreviousSpan: boolean
-  onClose: () => void
-  onSelectNextSpan: () => void
-  onSelectPreviousSpan: () => void
-  span: TraceSpan
-  traceStart: bigint
+  canSelectNextSpan: boolean;
+  canSelectPreviousSpan: boolean;
+  onClose: () => void;
+  onSelectNextSpan: () => void;
+  onSelectPreviousSpan: () => void;
+  span: TraceSpan;
+  traceStart: bigint;
 }) {
-  const [activeTab, setActiveTab] = useState<HttpDetailTab>('response')
-  const [copyState, setCopyState] = useState<CopyKind | 'failed' | 'idle'>('idle')
-  const attrs = parseJsonObject(span.attributesJson)
-  const url = spanUrl(span)
-  const params = requestParams(url)
-  const rawRequestBody = attrs[REQUEST_BODY_ATTR]
-  const rawResponseBody = attrs[RESPONSE_BODY_ATTR]
-  const requestBody = parseMaybeJson(rawRequestBody)
-  const responseBody = parseMaybeJson(rawResponseBody)
-  const requestBodyTruncated = attrBool(attrs[REQUEST_BODY_TRUNCATED_ATTR])
-  const responseBodyTruncated = attrBool(attrs[RESPONSE_BODY_TRUNCATED_ATTR])
-  const paramsValue = Object.keys(params).length ? params : undefined
-  const preferredTab: HttpDetailTab = responseBody ? 'response' : requestBody ? 'request' : paramsValue ? 'params' : 'response'
+  const [activeTab, setActiveTab] = useState<HttpDetailTab>("response");
+  const [copyState, setCopyState] = useState<CopyKind | "failed" | "idle">(
+    "idle",
+  );
+  const attrs = parseJsonObject(span.attributesJson);
+  const url = spanUrl(span);
+  const params = requestParams(url);
+  const rawRequestBody = attrs[REQUEST_BODY_ATTR];
+  const rawResponseBody = attrs[RESPONSE_BODY_ATTR];
+  const requestBody = parseMaybeJson(rawRequestBody);
+  const responseBody = parseMaybeJson(rawResponseBody);
+  const requestBodyTruncated = attrBool(attrs[REQUEST_BODY_TRUNCATED_ATTR]);
+  const responseBodyTruncated = attrBool(attrs[RESPONSE_BODY_TRUNCATED_ATTR]);
+  const paramsValue = Object.keys(params).length ? params : undefined;
+  const preferredTab: HttpDetailTab =
+    responseBody !== undefined && responseBody !== null && responseBody !== ""
+      ? "response"
+      : requestBody !== undefined && requestBody !== null && requestBody !== ""
+        ? "request"
+        : paramsValue
+          ? "params"
+          : "response";
   const tabs: Array<{ id: HttpDetailTab; label: string }> = [
-    { id: 'params', label: 'Params' },
-    { id: 'request', label: `Request body${requestBodyTruncated ? ' (truncated)' : ''}` },
-    { id: 'response', label: `Response body${responseBodyTruncated ? ' (truncated)' : ''}` },
-  ]
+    { id: "params", label: "Params" },
+    {
+      id: "request",
+      label: `Request body${requestBodyTruncated ? " (truncated)" : ""}`,
+    },
+    {
+      id: "response",
+      label: `Response body${responseBodyTruncated ? " (truncated)" : ""}`,
+    },
+  ];
   const activeBody = activeBodyState(
     activeTab,
     attrs,
@@ -352,42 +464,57 @@ export function HttpSpanDetail({
     responseBody,
     rawResponseBody,
     responseBodyTruncated,
-  )
-  const copyValue = formatDetailValue(activeBody.value)
-  const rawCopyValue = formatRawValue(activeBody.rawValue, copyValue)
-  const hasSeparateRawCopy = Boolean(rawCopyValue && rawCopyValue !== copyValue)
-  const visibleAttrs = Object.fromEntries(Object.entries(attrs).filter(([key]) => !BODY_ATTRIBUTE_KEYS.has(key)))
-  const offsetMs = Math.max(0, Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n))
-  const statusCode = attrText(attrs['http.response.status_code'])
-  const requestId = attrText(attrs['coral.http.request_id'])
-  const attempt = attrText(attrs['coral.http.attempt'])
-  const source = attrText(attrs['coral.source'])
-  const table = attrText(attrs['coral.table'])
+  );
+  const copyValue = formatDetailValue(activeBody.value);
+  const rawCopyValue = formatRawValue(activeBody.rawValue, copyValue);
+  const hasSeparateRawCopy = Boolean(
+    rawCopyValue && rawCopyValue !== copyValue,
+  );
+  const visibleAttrs = Object.fromEntries(
+    Object.entries(attrs).filter(([key]) => !BODY_ATTRIBUTE_KEYS.has(key)),
+  );
+  const offsetMs = Math.max(
+    0,
+    Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n),
+  );
+  const statusCode = attrText(attrs["http.response.status_code"]);
+  const requestId = attrText(attrs["coral.http.request_id"]);
+  const attempt = attrText(attrs["coral.http.attempt"]);
+  const source = attrText(attrs["coral.source"]);
+  const table = attrText(attrs["coral.table"]);
 
-  useEffect(() => setActiveTab(preferredTab), [preferredTab, span.spanId])
-  useEffect(() => setCopyState('idle'), [activeTab, span.spanId])
+  useEffect(() => setActiveTab(preferredTab), [preferredTab, span.spanId]);
+  useEffect(() => setCopyState("idle"), [activeTab, span.spanId]);
   useEffect(() => {
-    if (copyState === 'idle') return
-    const timeout = window.setTimeout(() => setCopyState('idle'), 1800)
-    return () => window.clearTimeout(timeout)
-  }, [copyState])
+    if (copyState === "idle") return;
+    const timeout = window.setTimeout(() => setCopyState("idle"), 1800);
+    return () => window.clearTimeout(timeout);
+  }, [copyState]);
 
   async function copyValueToClipboard(value: string, kind: CopyKind) {
-    if (!value) return
+    if (!value) return;
     try {
-      await navigator.clipboard.writeText(value)
-      setCopyState(kind)
+      await navigator.clipboard.writeText(value);
+      setCopyState(kind);
     } catch {
-      setCopyState('failed')
+      setCopyState("failed");
     }
   }
 
   return (
-    <div className={s.waterfallHttpDetail} data-span-inspector="true" onClick={(event) => event.stopPropagation()}>
+    <div
+      className={s.waterfallHttpDetail}
+      data-span-inspector="true"
+      onClick={(event) => event.stopPropagation()}
+    >
       <div className={s.waterfallHttpDetailHeader}>
         <div className={s.waterfallHttpDetailTitle}>
-          <Typography.BodySmallStrong as="span">Span details</Typography.BodySmallStrong>
-          <Typography.BodySmall as="span" variant="tertiary" truncate>{spanOperation(span)}</Typography.BodySmall>
+          <Typography.BodySmallStrong as="span">
+            Span details
+          </Typography.BodySmallStrong>
+          <Typography.BodySmall as="span" variant="tertiary" truncate>
+            {spanOperation(span)}
+          </Typography.BodySmall>
         </div>
         <div className={s.waterfallHttpDetailHeaderActions}>
           <Button.IconButton
@@ -415,45 +542,81 @@ export function HttpSpanDetail({
           />
         </div>
       </div>
-      <ScrollArea.Container className={s.waterfallHttpDetailScroll} constrainWidth fade="bottom" height="100%">
+      <ScrollArea.Container
+        className={s.waterfallHttpDetailScroll}
+        constrainWidth
+        fade="bottom"
+        height="100%"
+      >
         <div className={s.waterfallHttpDetailContent}>
           <div className={s.requestUrlRow}>
-            <Typography.CodeSmallInline as="span" className={s.methodBadge}>{spanOperation(span)}</Typography.CodeSmallInline>
-            <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>{url || 'No URL recorded'}</Typography.Body>
+            <Typography.CodeSmallInline as="span" className={s.methodBadge}>
+              {spanOperation(span)}
+            </Typography.CodeSmallInline>
+            <Typography.Body
+              as="span"
+              variant="tertiary"
+              className={s.requestUrl}
+            >
+              {url || "No URL recorded"}
+            </Typography.Body>
           </div>
           <div className={s.httpMetaRow}>
-            {statusCode && metaChip('Status', statusCode)}
-            {metaChip('Duration', formatDurationFromNanos(span.durationNanos))}
-            {metaChip('Start', `+${formatDuration(offsetMs)}`)}
-            {requestId && metaChip('Request', `#${requestId}`)}
-            {attempt && metaChip('Attempt', attempt)}
-            {source && metaChip('Source', table ? `${source}.${table}` : source)}
+            {statusCode && metaChip("Status", statusCode)}
+            {metaChip("Duration", formatDurationFromNanos(span.durationNanos))}
+            {metaChip("Start", `+${formatDuration(offsetMs)}`)}
+            {requestId && metaChip("Request", `#${requestId}`)}
+            {attempt && metaChip("Attempt", attempt)}
+            {source &&
+              metaChip("Source", table ? `${source}.${table}` : source)}
           </div>
           <div className={s.waterfallHttpTabRow}>
-            <div className={s.tabList} role="tablist" aria-label="HTTP span details">
+            <div
+              className={s.tabList}
+              role="tablist"
+              aria-label="HTTP span details"
+            >
               {tabs.map((tab) => (
                 <button
                   aria-controls={`http-detail-${span.spanId}-${tab.id}`}
                   aria-selected={activeTab === tab.id}
-                  className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
+                  className={classNames(s.tabTrigger, {
+                    [s.tabTriggerActive]: activeTab === tab.id,
+                  })}
                   id={`http-detail-tab-${span.spanId}-${tab.id}`}
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
                   role="tab"
                   type="button"
                 >
-                  <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
+                  <Typography.BodySmallStrong as="span">
+                    {tab.label}
+                  </Typography.BodySmallStrong>
                 </button>
               ))}
             </div>
             <div className={s.copyButtonGroup}>
               {hasSeparateRawCopy && (
-                <Button.TextButton disabled={!rawCopyValue} onClick={() => copyValueToClipboard(rawCopyValue, 'raw')} size="22" variant="secondary">
-                  {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
+                <Button.TextButton
+                  disabled={!rawCopyValue}
+                  onClick={() => copyValueToClipboard(rawCopyValue, "raw")}
+                  size="22"
+                  variant="secondary"
+                >
+                  {copyState === "raw" ? "Raw copied" : "Copy raw"}
                 </Button.TextButton>
               )}
-              <Button.TextButton disabled={!copyValue} onClick={() => copyValueToClipboard(copyValue, 'formatted')} size="22" variant="secondary">
-                {copyState === 'formatted' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy formatted'}
+              <Button.TextButton
+                disabled={!copyValue}
+                onClick={() => copyValueToClipboard(copyValue, "formatted")}
+                size="22"
+                variant="secondary"
+              >
+                {copyState === "formatted"
+                  ? "Copied"
+                  : copyState === "failed"
+                    ? "Copy failed"
+                    : "Copy formatted"}
               </Button.TextButton>
             </div>
           </div>
@@ -463,14 +626,25 @@ export function HttpSpanDetail({
             id={`http-detail-${span.spanId}-${activeTab}`}
             role="tabpanel"
           >
-            <BodyViewer emptyText={activeBody.emptyText} kind={activeBody.kind} rawValue={activeBody.rawValue} value={activeBody.value} />
+            <BodyViewer
+              emptyText={activeBody.emptyText}
+              kind={activeBody.kind}
+              rawValue={activeBody.rawValue}
+              value={activeBody.value}
+            />
           </section>
           <details>
-            <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>
-            <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
+            <summary className={s.detailsSummary}>
+              <Typography.Body as="span" variant="tertiary">
+                Span attributes
+              </Typography.Body>
+            </summary>
+            <pre className={s.detailsPre}>
+              {JSON.stringify(visibleAttrs, null, 2)}
+            </pre>
           </details>
         </div>
       </ScrollArea.Container>
     </div>
-  )
+  );
 }

--- a/ui/tests/ui/support/trace-fixtures.ts
+++ b/ui/tests/ui/support/trace-fixtures.ts
@@ -314,7 +314,7 @@ const detailSpans: SpanFixture[] = [
     responseBodyTruncated: true,
     responseBodySize: 4096,
   },
-  {
+    {
     source: 'linear',
     table: 'issue_request_preview',
     method: 'POST',
@@ -323,6 +323,33 @@ const detailSpans: SpanFixture[] = [
     requestBodyPresent: true,
     requestBodySize: 2048,
     responseBody: { data: { issues: { nodes: [{ identifier: 'CORAL-201', title: 'Request body present fallback', priorityLabel: 'Low' }] } } },
+  },
+
+  // New spans for falsy JSON response body regression test
+    // New spans for falsy JSON response body regression test
+  {
+    source: 'github',
+    table: 'falsy_json_false',
+    method: 'GET',
+    path: '/repos/oxide/coral/falsy-false',
+    durationMs: 33,
+    responseBody: false,
+  },
+  {
+    source: 'github',
+    table: 'falsy_json_zero',
+    method: 'GET',
+    path: '/repos/oxide/coral/falsy-zero',
+    durationMs: 33,
+    responseBody: 0,
+  },
+  {
+    source: 'github',
+    table: 'falsy_json_null',
+    method: 'GET',
+    path: '/repos/oxide/coral/falsy-null',
+    durationMs: 33,
+    responseBody: null,
   },
 ]
 

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -142,3 +142,30 @@ test('shows trace storage unavailable errors from TraceService', async ({ networ
   await expect(page.getByText('0 queries')).toBeVisible()
   await review.pause()
 })
+test('defaults to response tab when response body is a falsy JSON value', async ({ network, page, review }) => {
+  network.use(...traceHandlers.tenTraceDetailFlow)
+
+  await review.chapter('Open the trace with falsy JSON body spans', 'Load the selected trace so falsy body tab selection can be inspected')
+  await page.goto('/')
+  await page.getByPlaceholder('Search queries...').fill('playwright')
+  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
+  await review.pause()
+
+  await review.chapter('Falsy JSON false body defaults to response tab', 'Open a span whose response body is JSON false and confirm response tab is active')
+  await page.getByRole('button', { name: /GET github\.falsy_json_false/ }).click()
+
+  await expect(page.getByText('Span details')).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'Response body' })).toHaveAttribute('aria-selected', 'true')
+  await review.pause()
+
+  await review.chapter('Falsy JSON zero body defaults to response tab', 'Open a span whose response body is JSON 0 and confirm response tab is active')
+  await page.getByRole('button', { name: /GET github\.falsy_json_zero/ }).click()
+
+  await expect(page.getByRole('tab', { name: 'Response body' })).toHaveAttribute('aria-selected', 'true')
+  await review.pause()
+  await review.chapter('Falsy JSON null body defaults to response tab', 'Open a span whose response body is JSON null and confirm response tab is active')
+  await page.getByRole('button', { name: /GET github\.falsy_json_null/ }).click()
+
+  await expect(page.getByRole('tab', { name: 'Response body' })).toHaveAttribute('aria-selected', 'true')
+  await review.pause()
+})


### PR DESCRIPTION
## Problem
`preferredTab` used truthiness to check if a response/request body exists.
`parseMaybeJson()` can return valid falsy JSON values (`false`, `0`, `null`).
If a response body was JSON `false` or `0`, the UI would skip to the next
tab even though a body was present.

## Fix
Replaced truthiness with explicit `!== undefined && !== null && !== ''`
guards, matching the actual sentinel values `bodyPreview` uses for
"no body present".