### PR TITLE
feat(sources/n8n): add n8n community source spec

### DIFF
--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -1,0 +1,239 @@
+# n8n Community Source
+
+Query n8n workflows, executions, credentials, tags, and variables through Coral
+SQL using the [n8n Public REST API](https://docs.n8n.io/api/).
+
+## Setup
+
+### 1. Create an n8n API key
+
+In your n8n instance:
+
+1. Go to **Settings** > **API**
+2. Click **Generate API Key**
+3. Copy the key
+
+For n8n Cloud, your API base URL is `https://<account>.n8n.cloud/api/v1`.
+For self-hosted, it is `http://localhost:5678/api/v1` (or your custom domain).
+
+> **Note:** The n8n API is not available during the free trial. You need a
+> paid or self-hosted instance.
+
+### 2. Add the source
+
+```bash
+export N8N_BASE_URL="https://<your-instance>.n8n.cloud/api/v1"
+export N8N_API_KEY="<your-api-key>"
+coral source add --file sources/community/n8n/manifest.yaml
+```
+
+Or use interactive mode:
+
+```bash
+coral source add --interactive --file sources/community/n8n/manifest.yaml
+```
+
+### 3. Verify
+
+```bash
+coral source test n8n
+```
+
+## Tables
+
+### `n8n.workflows`
+
+List automation workflows.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Workflow ID |
+| `name` | Utf8 | Workflow name |
+| `active` | Boolean | Whether the workflow is published/active |
+| `version_id` | Utf8 | Current version ID |
+| `node_count` | Int64 | Number of nodes in the workflow |
+| `tag_names` | Utf8 | Comma-separated tag names |
+| `project_id` | Utf8 | Owning project ID |
+| `project_name` | Utf8 | Owning project name |
+| `created_at` | Timestamp | Creation time |
+| `updated_at` | Timestamp | Last update time |
+| `settings` | Json | Workflow settings object |
+
+**Optional filters:** `active`, `tags`, `name`, `project_id`
+
+### `n8n.executions`
+
+List workflow execution runs.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Execution ID |
+| `finished` | Boolean | Whether the execution finished |
+| `mode` | Utf8 | Execution mode (trigger, manual, integrated) |
+| `status` | Utf8 | Status (success, error, running, waiting, canceled, crashed, new, unknown) |
+| `workflow_id` | Utf8 | Executed workflow ID |
+| `workflow_name` | Utf8 | Workflow name at runtime |
+| `started_at` | Timestamp | Start time |
+| `stopped_at` | Timestamp | Stop time (NULL if running) |
+| `last_node_executed` | Utf8 | Last executed node name |
+| `execution_error_message` | Utf8 | Error message if failed |
+| `execution_error_node` | Utf8 | Node that caused the error |
+| `retry_of` | Utf8 | Original execution ID if this is a retry |
+| `retry_success_id` | Utf8 | Successful retry execution ID |
+
+**Optional filters:** `status`, `workflow_id`, `project_id`
+
+### `n8n.credentials`
+
+List credential definitions (secrets are never exposed).
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Credential ID |
+| `name` | Utf8 | Credential display name |
+| `type` | Utf8 | Credential type (e.g. slackApi, githubApi) |
+| `is_managed` | Boolean | Whether managed (enterprise) |
+| `scoped` | Boolean | Whether project-scoped |
+| `created_at` | Timestamp | Creation time |
+| `updated_at` | Timestamp | Last update time |
+
+### `n8n.tags`
+
+List workflow tags.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Tag ID |
+| `name` | Utf8 | Tag name |
+| `created_at` | Timestamp | Creation time |
+| `updated_at` | Timestamp | Last update time |
+
+### `n8n.variables`
+
+List instance variables.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Variable ID |
+| `key` | Utf8 | Variable key/name |
+| `value` | Utf8 | Variable value |
+| `type` | Utf8 | Data type (string, number, boolean) |
+
+**Optional filter:** `project_id`
+
+## Functions
+
+### `n8n.executions_by_workflow`
+
+Search executions for a specific workflow.
+
+```sql
+SELECT id, status, started_at
+FROM n8n.executions_by_workflow(
+  workflow_id => 'abc123',
+  status => 'error'
+)
+LIMIT 10;
+```
+
+## Example queries
+
+```sql
+-- List active workflows with their tags
+SELECT name, tag_names, node_count, updated_at
+FROM n8n.workflows
+WHERE active = true
+ORDER BY updated_at DESC;
+
+-- Find failed executions in the last 24 hours
+SELECT id, workflow_name, status, started_at, execution_error_message
+FROM n8n.executions
+WHERE status = 'error'
+  AND started_at > NOW() - INTERVAL '24 hours'
+ORDER BY started_at DESC;
+
+-- Join executions to workflows for full context
+SELECT
+  w.name AS workflow_name,
+  w.active AS workflow_active,
+  e.status,
+  e.started_at,
+  e.execution_error_message
+FROM n8n.workflows w
+JOIN n8n.executions e ON w.id = e.workflow_id
+WHERE e.status = 'error'
+  AND e.started_at > NOW() - INTERVAL '7 days'
+ORDER BY e.started_at DESC
+LIMIT 20;
+
+-- Count executions by status per workflow
+SELECT
+  workflow_name,
+  status,
+  COUNT(*) AS execution_count
+FROM n8n.executions
+WHERE started_at > NOW() - INTERVAL '30 days'
+GROUP BY workflow_name, status
+ORDER BY execution_count DESC;
+
+-- Audit credentials by type
+SELECT type, COUNT(*) AS count
+FROM n8n.credentials
+GROUP BY type
+ORDER BY count DESC;
+
+-- Find workflows using a specific tag
+SELECT name, tag_names, active
+FROM n8n.workflows
+WHERE tag_names ILIKE '%production%';
+
+-- Cross-source join: correlate n8n failures with PagerDuty incidents
+SELECT
+  e.workflow_name,
+  e.started_at,
+  e.execution_error_message,
+  p.title AS incident_title,
+  p.status AS incident_status
+FROM n8n.executions e
+LEFT JOIN pagerduty.incidents p
+  ON p.created_at BETWEEN e.started_at AND e.started_at + INTERVAL '5 minutes'
+WHERE e.status = 'error'
+  AND e.started_at > NOW() - INTERVAL '24 hours';
+```
+
+## Validation
+
+```bash
+export N8N_BASE_URL="https://<your-instance>.n8n.cloud/api/v1"
+export N8N_API_KEY="<your-api-key>"
+coral source lint sources/community/n8n/manifest.yaml
+coral source add --file sources/community/n8n/manifest.yaml
+coral source test n8n
+coral sql "SELECT * FROM coral.tables WHERE schema_name = 'n8n'"
+coral sql "SELECT * FROM coral.columns WHERE schema_name = 'n8n'"
+coral sql "SELECT id, name, active FROM n8n.workflows LIMIT 5"
+```
+
+## Limitations
+
+- **Read-only.** This source does not create, update, activate, deactivate,
+  or delete any n8n resources.
+- **No execution data.** The `includeData` parameter is always set to `false`
+  to avoid extremely large responses. Execution metadata (status, timing,
+  errors) is available.
+- **API availability.** The n8n Public API requires a paid or self-hosted
+  instance. It is not available during the n8n Cloud free trial.
+- **Credential secrets.** The n8n API never returns credential secrets;
+  only metadata (name, type, dates) is exposed.
+
+## Out of scope for v1
+
+- Workflow create/update/delete operations
+- Execution retry or stop operations
+- Credential create/update/delete operations
+- Tag management
+- Variable create/update/delete operations
+- Source control operations
+- Data table operations
+- User management
+- Audit log generation

--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -49,11 +49,11 @@ List automation workflows.
 |---|---|---|
 | `id` | Utf8 | Workflow ID |
 | `name` | Utf8 | Workflow name |
-| `description` | Utf8 | Workflow description |
 | `active` | Boolean | Whether the workflow is published/active |
-| `is_archived` | Boolean | Whether the workflow is archived |
 | `version_id` | Utf8 | Current version ID |
 | `trigger_count` | Int64 | Number of active trigger nodes |
+| `description` | Utf8 | Workflow description |
+| `is_archived` | Boolean | Whether the workflow is archived |
 | `tag_names` | Utf8 | Comma-separated tag names |
 | `project_id` | Utf8 | Owning project ID |
 | `project_name` | Utf8 | Owning project name |
@@ -63,22 +63,26 @@ List automation workflows.
 
 **Optional filters:** `active`, `tags`, `name`, `project_id`
 
+> **Note:** `tags` is a server-side request filter (efficient), while `tag_names`
+> is a response column containing comma-separated names. Use `WHERE tags = 'x'`
+> for exact tag filtering; use `tag_names ILIKE '%x%'` for substring matching.
+
 ### `n8n.executions`
 
 List workflow execution runs.
 
 | Column | Type | Description |
 |---|---|---|
-| `id` | Int64 | Execution ID |
+| `id` | Utf8 | Execution ID |
 | `finished` | Boolean | Whether the execution finished |
 | `mode` | Utf8 | Execution mode (cli, error, integrated, internal, manual, retry, trigger, webhook, evaluation, chat) |
 | `status` | Utf8 | Status (canceled, crashed, error, new, running, success, unknown, waiting) |
-| `workflow_id` | Int64 | Executed workflow ID |
+| `workflow_id` | Utf8 | Executed workflow ID |
 | `started_at` | Timestamp | Start time |
 | `stopped_at` | Timestamp | Stop time (NULL if running) |
 | `wait_till` | Timestamp | When a waiting execution should resume |
-| `retry_of` | Int64 | Original execution ID if this is a retry |
-| `retry_success_id` | Int64 | Successful retry execution ID |
+| `retry_of` | Utf8 | Original execution ID if this is a retry |
+| `retry_success_id` | Utf8 | Successful retry execution ID |
 
 **Optional filters:** `status`, `workflow_id`, `project_id`
 

--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -49,9 +49,11 @@ List automation workflows.
 |---|---|---|
 | `id` | Utf8 | Workflow ID |
 | `name` | Utf8 | Workflow name |
+| `description` | Utf8 | Workflow description |
 | `active` | Boolean | Whether the workflow is published/active |
+| `is_archived` | Boolean | Whether the workflow is archived |
 | `version_id` | Utf8 | Current version ID |
-| `node_count` | Int64 | Number of nodes in the workflow |
+| `trigger_count` | Int64 | Number of active trigger nodes |
 | `tag_names` | Utf8 | Comma-separated tag names |
 | `project_id` | Utf8 | Owning project ID |
 | `project_name` | Utf8 | Owning project name |
@@ -69,7 +71,8 @@ List workflow execution runs.
 |---|---|---|
 | `id` | Utf8 | Execution ID |
 | `finished` | Boolean | Whether the execution finished |
-| `mode` | Utf8 | Execution mode (trigger, manual, integrated) |
+| `mode` | Utf8 | Execution mode (cli, error, integrated, internal, manual, retry, trigger, webhook, evaluation, chat) |
+| `status` | Utf8 | Status (canceled, crashed, error, new, running, success, unknown, waiting) |
 | `workflow_id` | Utf8 | Executed workflow ID |
 | `started_at` | Timestamp | Start time |
 | `stopped_at` | Timestamp | Stop time (NULL if running) |
@@ -124,7 +127,7 @@ LIMIT 10;
 
 ```sql
 -- List active workflows with their tags
-SELECT name, tag_names, node_count, updated_at
+SELECT name, tag_names, trigger_count, updated_at
 FROM n8n.workflows
 WHERE active = true
 ORDER BY updated_at DESC;
@@ -164,7 +167,7 @@ ORDER BY execution_count DESC;
 -- Find workflows using a specific tag
 SELECT name, tag_names, active
 FROM n8n.workflows
-WHERE tag_names ILIKE '%production%';
+WHERE tags = 'production';
 
 -- Cross-source join: correlate n8n failures with PagerDuty incidents
 SELECT

--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -122,10 +122,10 @@ FROM n8n.workflows
 WHERE active = true
 ORDER BY updated_at DESC;
 
--- Find executions that did not finish in the last 24 hours
-SELECT id, workflow_id, mode, started_at
+-- Find failed executions in the last 24 hours
+SELECT id, workflow_id, mode, status, started_at
 FROM n8n.executions
-WHERE finished = false
+WHERE status = 'error'
   AND started_at > NOW() - INTERVAL '24 hours'
 ORDER BY started_at DESC;
 
@@ -133,25 +133,25 @@ ORDER BY started_at DESC;
 SELECT
   w.name AS workflow_name,
   w.active AS workflow_active,
-  e.finished,
+  e.status,
   e.mode,
   e.started_at
 FROM n8n.workflows w
 JOIN n8n.executions e ON w.id = e.workflow_id
-WHERE e.finished = false
+WHERE e.status = 'error'
   AND e.started_at > NOW() - INTERVAL '7 days'
 ORDER BY e.started_at DESC
 LIMIT 20;
 
--- Count executions by finished state per workflow
+-- Count executions by status per workflow
 SELECT
   w.name AS workflow_name,
-  e.finished,
+  e.status,
   COUNT(*) AS execution_count
 FROM n8n.workflows w
 JOIN n8n.executions e ON w.id = e.workflow_id
 WHERE e.started_at > NOW() - INTERVAL '30 days'
-GROUP BY w.name, e.finished
+GROUP BY w.name, e.status
 ORDER BY execution_count DESC;
 
 -- Find workflows using a specific tag
@@ -162,13 +162,14 @@ WHERE tags = 'production';
 -- Cross-source join: correlate n8n failures with PagerDuty incidents
 SELECT
   w.name AS workflow_name,
+  e.status,
   e.started_at,
   e.mode
 FROM n8n.workflows w
 JOIN n8n.executions e ON w.id = e.workflow_id
 LEFT JOIN pagerduty.incidents p
   ON p.created_at BETWEEN e.started_at AND e.started_at + INTERVAL '5 minutes'
-WHERE e.finished = false
+WHERE e.status = 'error'
   AND e.started_at > NOW() - INTERVAL '24 hours';
 ```
 

--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -69,16 +69,16 @@ List workflow execution runs.
 
 | Column | Type | Description |
 |---|---|---|
-| `id` | Utf8 | Execution ID |
+| `id` | Int64 | Execution ID |
 | `finished` | Boolean | Whether the execution finished |
 | `mode` | Utf8 | Execution mode (cli, error, integrated, internal, manual, retry, trigger, webhook, evaluation, chat) |
 | `status` | Utf8 | Status (canceled, crashed, error, new, running, success, unknown, waiting) |
-| `workflow_id` | Utf8 | Executed workflow ID |
+| `workflow_id` | Int64 | Executed workflow ID |
 | `started_at` | Timestamp | Start time |
 | `stopped_at` | Timestamp | Stop time (NULL if running) |
 | `wait_till` | Timestamp | When a waiting execution should resume |
-| `retry_of` | Utf8 | Original execution ID if this is a retry |
-| `retry_success_id` | Utf8 | Successful retry execution ID |
+| `retry_of` | Int64 | Original execution ID if this is a retry |
+| `retry_success_id` | Int64 | Successful retry execution ID |
 
 **Optional filters:** `status`, `workflow_id`, `project_id`
 
@@ -108,20 +108,6 @@ List instance variables.
 
 > **Note:** Variables require a paid n8n license. Self-hosted free instances
 > will return a `403` error for this table.
-
-## Functions
-
-### `n8n.executions_by_workflow`
-
-Search executions for a specific workflow.
-
-```sql
-SELECT id, finished, mode, started_at
-FROM n8n.executions_by_workflow(
-  workflow_id => 'YOUR_WORKFLOW_ID_HERE'
-)
-LIMIT 10;
-```
 
 ## Example queries
 

--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -1,6 +1,6 @@
 # n8n Community Source
 
-Query n8n workflows, executions, credentials, tags, and variables through Coral
+Query n8n workflows, executions, tags, and variables through Coral
 SQL using the [n8n Public REST API](https://docs.n8n.io/api/).
 
 ## Setup
@@ -83,20 +83,6 @@ List workflow execution runs.
 
 **Optional filters:** `status`, `workflow_id`, `project_id`
 
-### `n8n.credentials`
-
-List credential definitions (secrets are never exposed).
-
-| Column | Type | Description |
-|---|---|---|
-| `id` | Utf8 | Credential ID |
-| `name` | Utf8 | Credential display name |
-| `type` | Utf8 | Credential type (e.g. slackApi, githubApi) |
-| `is_managed` | Boolean | Whether managed (enterprise) |
-| `scoped` | Boolean | Whether project-scoped |
-| `created_at` | Timestamp | Creation time |
-| `updated_at` | Timestamp | Last update time |
-
 ### `n8n.tags`
 
 List workflow tags.
@@ -176,12 +162,6 @@ WHERE started_at > NOW() - INTERVAL '30 days'
 GROUP BY workflow_name, status
 ORDER BY execution_count DESC;
 
--- Audit credentials by type
-SELECT type, COUNT(*) AS count
-FROM n8n.credentials
-GROUP BY type
-ORDER BY count DESC;
-
 -- Find workflows using a specific tag
 SELECT name, tag_names, active
 FROM n8n.workflows
@@ -210,7 +190,7 @@ coral source lint sources/community/n8n/manifest.yaml
 coral source add --file sources/community/n8n/manifest.yaml
 coral source test n8n
 coral sql "SELECT * FROM coral.tables WHERE schema_name = 'n8n'"
-coral sql "SELECT * FROM coral.columns WHERE schema_name = 'n8n'"
+coral sql "SELECT column_name, data_type FROM coral.columns WHERE schema_name = 'n8n' AND table_name = 'workflows'"
 coral sql "SELECT id, name, active FROM n8n.workflows LIMIT 5"
 ```
 
@@ -223,14 +203,15 @@ coral sql "SELECT id, name, active FROM n8n.workflows LIMIT 5"
   errors) is available.
 - **API availability.** The n8n Public API requires a paid or self-hosted
   instance. It is not available during the n8n Cloud free trial.
-- **Credential secrets.** The n8n API never returns credential secrets;
-  only metadata (name, type, dates) is exposed.
+- **Credentials endpoint.** The `/credentials` endpoint is not included because
+  it returns `405 Method Not Allowed` on standard n8n self-hosted instances.
+  Credential metadata may be added in a future version if the API behavior
+  changes.
 
 ## Out of scope for v1
 
 - Workflow create/update/delete operations
 - Execution retry or stop operations
-- Credential create/update/delete operations
 - Tag management
 - Variable create/update/delete operations
 - Source control operations

--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -70,14 +70,10 @@ List workflow execution runs.
 | `id` | Utf8 | Execution ID |
 | `finished` | Boolean | Whether the execution finished |
 | `mode` | Utf8 | Execution mode (trigger, manual, integrated) |
-| `status` | Utf8 | Status (success, error, running, waiting, canceled, crashed, new, unknown) |
 | `workflow_id` | Utf8 | Executed workflow ID |
-| `workflow_name` | Utf8 | Workflow name at runtime |
 | `started_at` | Timestamp | Start time |
 | `stopped_at` | Timestamp | Stop time (NULL if running) |
-| `last_node_executed` | Utf8 | Last executed node name |
-| `execution_error_message` | Utf8 | Error message if failed |
-| `execution_error_node` | Utf8 | Node that caused the error |
+| `wait_till` | Timestamp | When a waiting execution should resume |
 | `retry_of` | Utf8 | Original execution ID if this is a retry |
 | `retry_success_id` | Utf8 | Successful retry execution ID |
 
@@ -114,10 +110,9 @@ List instance variables.
 Search executions for a specific workflow.
 
 ```sql
-SELECT id, status, started_at
+SELECT id, finished, mode, started_at
 FROM n8n.executions_by_workflow(
-  workflow_id => 'abc123',
-  status => 'error'
+  workflow_id => 'YOUR_WORKFLOW_ID_HERE'
 )
 LIMIT 10;
 ```
@@ -131,10 +126,10 @@ FROM n8n.workflows
 WHERE active = true
 ORDER BY updated_at DESC;
 
--- Find failed executions in the last 24 hours
-SELECT id, workflow_name, status, started_at, execution_error_message
+-- Find executions that did not finish in the last 24 hours
+SELECT id, workflow_id, mode, started_at
 FROM n8n.executions
-WHERE status = 'error'
+WHERE finished = false
   AND started_at > NOW() - INTERVAL '24 hours'
 ORDER BY started_at DESC;
 
@@ -142,24 +137,25 @@ ORDER BY started_at DESC;
 SELECT
   w.name AS workflow_name,
   w.active AS workflow_active,
-  e.status,
-  e.started_at,
-  e.execution_error_message
+  e.finished,
+  e.mode,
+  e.started_at
 FROM n8n.workflows w
 JOIN n8n.executions e ON w.id = e.workflow_id
-WHERE e.status = 'error'
+WHERE e.finished = false
   AND e.started_at > NOW() - INTERVAL '7 days'
 ORDER BY e.started_at DESC
 LIMIT 20;
 
--- Count executions by status per workflow
+-- Count executions by finished state per workflow
 SELECT
-  workflow_name,
-  status,
+  w.name AS workflow_name,
+  e.finished,
   COUNT(*) AS execution_count
-FROM n8n.executions
-WHERE started_at > NOW() - INTERVAL '30 days'
-GROUP BY workflow_name, status
+FROM n8n.workflows w
+JOIN n8n.executions e ON w.id = e.workflow_id
+WHERE e.started_at > NOW() - INTERVAL '30 days'
+GROUP BY w.name, e.finished
 ORDER BY execution_count DESC;
 
 -- Find workflows using a specific tag
@@ -169,15 +165,14 @@ WHERE tag_names ILIKE '%production%';
 
 -- Cross-source join: correlate n8n failures with PagerDuty incidents
 SELECT
-  e.workflow_name,
+  w.name AS workflow_name,
   e.started_at,
-  e.execution_error_message,
-  p.title AS incident_title,
-  p.status AS incident_status
-FROM n8n.executions e
+  e.mode
+FROM n8n.workflows w
+JOIN n8n.executions e ON w.id = e.workflow_id
 LEFT JOIN pagerduty.incidents p
   ON p.created_at BETWEEN e.started_at AND e.started_at + INTERVAL '5 minutes'
-WHERE e.status = 'error'
+WHERE e.finished = false
   AND e.started_at > NOW() - INTERVAL '24 hours';
 ```
 

--- a/sources/community/n8n/README.md
+++ b/sources/community/n8n/README.md
@@ -103,6 +103,9 @@ List instance variables.
 
 **Optional filter:** `project_id`
 
+> **Note:** Variables require a paid n8n license. Self-hosted free instances
+> will return a `403` error for this table.
+
 ## Functions
 
 ### `n8n.executions_by_workflow`
@@ -198,10 +201,12 @@ coral sql "SELECT id, name, active FROM n8n.workflows LIMIT 5"
   errors) is available.
 - **API availability.** The n8n Public API requires a paid or self-hosted
   instance. It is not available during the n8n Cloud free trial.
-- **Credentials endpoint.** The `/credentials` endpoint is not included because
-  it returns `405 Method Not Allowed` on standard n8n self-hosted instances.
+- **Credentials endpoint.** The `/credentials` endpoint returns
+  `405 Method Not Allowed` on standard n8n self-hosted instances.
   Credential metadata may be added in a future version if the API behavior
   changes.
+- **Variables require paid license.** The `/variables` endpoint returns `403`
+  on free self-hosted instances. This table works for paid n8n users.
 
 ## Out of scope for v1
 

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -38,7 +38,7 @@ request_headers:
 
 test_queries:
   - SELECT id, name, active FROM n8n.workflows LIMIT 5
-  - SELECT id, status, workflow_id, started_at FROM n8n.executions LIMIT 5
+  - SELECT id, finished, workflow_id, started_at FROM n8n.executions LIMIT 5
   - SELECT id, name FROM n8n.tags LIMIT 5
 
 tables:
@@ -193,8 +193,9 @@ tables:
   - name: executions
     description: |
       List n8n workflow execution runs. Filter by `status`, `workflow_id`,
-      or `project_id`. Join `workflow_id` to `n8n.workflows.id` for workflow
-      metadata. Use `started_at` for time-based analysis.
+      or `project_id`. The `status` filter is accepted by the API but the
+      status value is not included in list responses; use `finished` to
+      determine completion state. Join `workflow_id` to `n8n.workflows.id`.
     filters:
       - name: status
       - name: workflow_id
@@ -253,14 +254,6 @@ tables:
           kind: path
           path:
             - mode
-      - name: status
-        type: Utf8
-        nullable: true
-        description: Execution status (success, error, running, waiting, canceled, crashed, new, unknown).
-        expr:
-          kind: path
-          path:
-            - status
       - name: workflow_id
         type: Utf8
         nullable: true
@@ -269,14 +262,6 @@ tables:
           kind: path
           path:
             - workflowId
-      - name: workflow_name
-        type: Utf8
-        nullable: true
-        description: Name of the executed workflow at runtime.
-        expr:
-          kind: path
-          path:
-            - workflowName
       - name: started_at
         type: Timestamp
         nullable: true
@@ -299,33 +284,17 @@ tables:
             kind: path
             path:
               - stoppedAt
-      - name: last_node_executed
-        type: Utf8
+      - name: wait_till
+        type: Timestamp
         nullable: true
-        description: Name of the last node that executed.
+        description: When a waiting execution should resume.
         expr:
-          kind: path
-          path:
-            - lastNodeExecuted
-      - name: execution_error_message
-        type: Utf8
-        nullable: true
-        description: Error message if the execution failed.
-        expr:
-          kind: path
-          path:
-            - executionError
-            - message
-      - name: execution_error_node
-        type: Utf8
-        nullable: true
-        description: Name of the node that caused the error.
-        expr:
-          kind: path
-          path:
-            - executionError
-            - node
-            - name
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - waitTill
       - name: retry_of
         type: Utf8
         nullable: true
@@ -522,14 +491,22 @@ functions:
           kind: path
           path:
             - id
-      - name: status
-        type: Utf8
+      - name: finished
+        type: Boolean
         nullable: true
-        description: Execution status.
+        description: Whether the execution finished.
         expr:
           kind: path
           path:
-            - status
+            - finished
+      - name: mode
+        type: Utf8
+        nullable: true
+        description: Execution mode.
+        expr:
+          kind: path
+          path:
+            - mode
       - name: workflow_id
         type: Utf8
         nullable: true
@@ -538,14 +515,6 @@ functions:
           kind: path
           path:
             - workflowId
-      - name: workflow_name
-        type: Utf8
-        nullable: true
-        description: Workflow name.
-        expr:
-          kind: path
-          path:
-            - workflowName
       - name: started_at
         type: Timestamp
         nullable: true
@@ -568,12 +537,14 @@ functions:
             kind: path
             path:
               - stoppedAt
-      - name: execution_error_message
-        type: Utf8
+      - name: wait_till
+        type: Timestamp
         nullable: true
-        description: Error message if failed.
+        description: When a waiting execution should resume.
         expr:
-          kind: path
-          path:
-            - executionError
-            - message
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - waitTill

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -46,6 +46,13 @@ tables:
       List n8n automation workflows. Use `active` filter to scope by
       published status. Use `name` for partial matching. Discover workflow
       IDs to filter executions.
+    guide: |
+      Each row is one workflow. `id` is the stable identifier used to
+      join to `n8n.executions.workflow_id`. `tag_names` is a
+      comma-separated string built from the `tags` array — use substring
+      matching (e.g. `tag_names ILIKE '%prod%'`) rather than equality.
+      The `tags` filter sends a server-side request and is more efficient
+      than filtering on `tag_names`.
     filters:
       - name: active
       - name: tags
@@ -206,6 +213,13 @@ tables:
       List n8n workflow execution runs. Filter by `status`, `workflow_id`,
       or `project_id`. Valid status values: canceled, crashed, error, new,
       running, success, unknown, waiting. Join `workflow_id` to `n8n.workflows.id`.
+    guide: |
+      Each row is one execution run. `status` is one of: canceled,
+      crashed, error, new, running, success, unknown, waiting. Use
+      `status = 'error'` to find failures — not `finished = false`,
+      which also matches running executions. `mode` describes how the
+      execution was triggered (e.g. trigger, webhook, manual).
+      `workflow_id` joins to `n8n.workflows.id`.
     filters:
       - name: status
       - name: workflow_id
@@ -241,7 +255,7 @@ tables:
         query_param: limit
     columns:
       - name: id
-        type: Int64
+        type: Utf8
         nullable: false
         description: Execution ID.
         expr:
@@ -273,7 +287,7 @@ tables:
           path:
             - status
       - name: workflow_id
-        type: Int64
+        type: Utf8
         nullable: true
         description: ID of the executed workflow. Join to `n8n.workflows.id`.
         expr:
@@ -314,7 +328,7 @@ tables:
             path:
               - waitTill
       - name: retry_of
-        type: Int64
+        type: Utf8
         nullable: true
         description: ID of the original execution if this is a retry.
         expr:
@@ -322,7 +336,7 @@ tables:
           path:
             - retryOf
       - name: retry_success_id
-        type: Int64
+        type: Utf8
         nullable: true
         description: ID of the successful retry execution.
         expr:

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -472,4 +472,3 @@ tables:
           kind: path
           path:
             - type
-

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -1,0 +1,673 @@
+name: n8n
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query n8n workflows, executions, credentials, tags, and variables through
+  Coral SQL using the n8n Public REST API.
+
+inputs:
+  N8N_BASE_URL:
+    kind: variable
+    default: https://<your-n8n-instance>.n8n.cloud/api/v1
+    hint: >-
+      Base URL for your n8n instance API. For n8n Cloud use
+      https://<account>.n8n.cloud/api/v1. For self-hosted use
+      http://localhost:5678/api/v1 (or your custom domain).
+  N8N_API_KEY:
+    kind: secret
+    required: true
+    hint: >-
+      n8n API key. Create one in your n8n instance under
+      Settings > API > Generate API Key. Requires read scopes for
+      workflows, executions, credentials, tags, and variables.
+
+base_url: "{{input.N8N_BASE_URL}}"
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: X-N8N-API-KEY
+      from: template
+      template: "{{input.N8N_API_KEY}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name, active FROM n8n.workflows LIMIT 5
+  - SELECT id, status, workflow_id, started_at FROM n8n.executions LIMIT 5
+  - SELECT id, name FROM n8n.tags LIMIT 5
+
+tables:
+  # ------------------------------------------------------------------
+  # n8n.workflows — list automation workflows
+  # GET /workflows
+  # ------------------------------------------------------------------
+  - name: workflows
+    description: |
+      List n8n automation workflows. Use `active` filter to scope by
+      published status. Use `name` for partial matching. Discover workflow
+      IDs to filter executions.
+    filters:
+      - name: active
+      - name: tags
+      - name: name
+      - name: project_id
+    request:
+      method: GET
+      path: /workflows
+      query:
+        - name: active
+          from: filter_bool
+          key: active
+        - name: tags
+          from: filter
+          key: tags
+        - name: name
+          from: filter
+          key: name
+        - name: projectId
+          from: filter
+          key: project_id
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - nextCursor
+      page_size:
+        default: 100
+        max: 250
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Workflow ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Workflow name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the workflow is published/active.
+        expr:
+          kind: path
+          path:
+            - active
+      - name: version_id
+        type: Utf8
+        nullable: true
+        description: Current version ID of the workflow.
+        expr:
+          kind: path
+          path:
+            - versionId
+      - name: node_count
+        type: Int64
+        nullable: true
+        description: Number of nodes in the workflow.
+        expr:
+          kind: path
+          path:
+            - nodes
+      - name: tag_names
+        type: Utf8
+        nullable: true
+        description: Comma-separated tag names attached to the workflow.
+        expr:
+          kind: join_array_path
+          path:
+            - tags
+          item_path:
+            - name
+          separator: ","
+      - name: project_id
+        type: Utf8
+        nullable: true
+        description: ID of the project owning the workflow.
+        expr:
+          kind: path
+          path:
+            - homeProject
+            - id
+      - name: project_name
+        type: Utf8
+        nullable: true
+        description: Name of the project owning the workflow.
+        expr:
+          kind: path
+          path:
+            - homeProject
+            - name
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the workflow was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the workflow was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+      - name: settings
+        type: Json
+        nullable: true
+        description: Workflow settings object (timezone, error workflow, etc.).
+        expr:
+          kind: path
+          path:
+            - settings
+
+  # ------------------------------------------------------------------
+  # n8n.executions — list workflow execution runs
+  # GET /executions
+  # ------------------------------------------------------------------
+  - name: executions
+    description: |
+      List n8n workflow execution runs. Filter by `status`, `workflow_id`,
+      or `project_id`. Join `workflow_id` to `n8n.workflows.id` for workflow
+      metadata. Use `started_at` for time-based analysis.
+    filters:
+      - name: status
+      - name: workflow_id
+      - name: project_id
+    request:
+      method: GET
+      path: /executions
+      query:
+        - name: status
+          from: filter
+          key: status
+        - name: workflowId
+          from: filter
+          key: workflow_id
+        - name: projectId
+          from: filter
+          key: project_id
+        - name: includeData
+          from: literal
+          value: "false"
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - nextCursor
+      page_size:
+        default: 100
+        max: 250
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Execution ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: finished
+        type: Boolean
+        nullable: true
+        description: Whether the execution finished.
+        expr:
+          kind: path
+          path:
+            - finished
+      - name: mode
+        type: Utf8
+        nullable: true
+        description: Execution mode (trigger, manual, integrated).
+        expr:
+          kind: path
+          path:
+            - mode
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Execution status (success, error, running, waiting, canceled, crashed, new, unknown).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: workflow_id
+        type: Utf8
+        nullable: true
+        description: ID of the executed workflow. Join to `n8n.workflows.id`.
+        expr:
+          kind: path
+          path:
+            - workflowId
+      - name: workflow_name
+        type: Utf8
+        nullable: true
+        description: Name of the executed workflow at runtime.
+        expr:
+          kind: path
+          path:
+            - workflowName
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: When the execution started.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - startedAt
+      - name: stopped_at
+        type: Timestamp
+        nullable: true
+        description: When the execution stopped (NULL if still running).
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - stoppedAt
+      - name: last_node_executed
+        type: Utf8
+        nullable: true
+        description: Name of the last node that executed.
+        expr:
+          kind: path
+          path:
+            - lastNodeExecuted
+      - name: execution_error_message
+        type: Utf8
+        nullable: true
+        description: Error message if the execution failed.
+        expr:
+          kind: path
+          path:
+            - executionError
+            - message
+      - name: execution_error_node
+        type: Utf8
+        nullable: true
+        description: Name of the node that caused the error.
+        expr:
+          kind: path
+          path:
+            - executionError
+            - node
+            - name
+      - name: retry_of
+        type: Utf8
+        nullable: true
+        description: ID of the original execution if this is a retry.
+        expr:
+          kind: path
+          path:
+            - retryOf
+      - name: retry_success_id
+        type: Utf8
+        nullable: true
+        description: ID of the successful retry execution.
+        expr:
+          kind: path
+          path:
+            - retrySuccessId
+
+  # ------------------------------------------------------------------
+  # n8n.credentials — list credential definitions (no secrets)
+  # GET /credentials
+  # ------------------------------------------------------------------
+  - name: credentials
+    description: |
+      List n8n credential definitions. Secrets are never returned by the
+      API. Use to audit which integrations are configured. Join `type` to
+      understand which services are connected.
+    request:
+      method: GET
+      path: /credentials
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - nextCursor
+      page_size:
+        default: 100
+        max: 250
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Credential ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Credential display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Credential type (e.g. slackApi, githubApi, openAiApi).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: is_managed
+        type: Boolean
+        nullable: true
+        description: Whether the credential is managed (enterprise feature).
+        expr:
+          kind: path
+          path:
+            - isManaged
+      - name: scoped
+        type: Boolean
+        nullable: true
+        description: Whether the credential is project-scoped.
+        expr:
+          kind: path
+          path:
+            - scoped
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the credential was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the credential was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+
+  # ------------------------------------------------------------------
+  # n8n.tags — list workflow tags
+  # GET /tags
+  # ------------------------------------------------------------------
+  - name: tags
+    description: |
+      List n8n workflow tags. Use to categorize and filter workflows.
+      Join `name` to `n8n.workflows.tag_names` for workflow categorization.
+    request:
+      method: GET
+      path: /tags
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - nextCursor
+      page_size:
+        default: 100
+        max: 250
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tag ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Tag name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: When the tag was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - createdAt
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: When the tag was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updatedAt
+
+  # ------------------------------------------------------------------
+  # n8n.variables — list instance variables
+  # GET /variables
+  # ------------------------------------------------------------------
+  - name: variables
+    description: |
+      List n8n instance variables. Variables store reusable values across
+      workflows. Join `key` to workflow node configurations for dependency
+      tracking.
+    filters:
+      - name: project_id
+    request:
+      method: GET
+      path: /variables
+      query:
+        - name: projectId
+          from: filter
+          key: project_id
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - nextCursor
+      page_size:
+        default: 100
+        max: 250
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Variable ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: key
+        type: Utf8
+        nullable: true
+        description: Variable key/name.
+        expr:
+          kind: path
+          path:
+            - key
+      - name: value
+        type: Utf8
+        nullable: true
+        description: Variable value.
+        expr:
+          kind: path
+          path:
+            - value
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Variable data type (string, number, boolean).
+        expr:
+          kind: path
+          path:
+            - type
+
+functions:
+  # ------------------------------------------------------------------
+  # n8n.executions_by_workflow — search executions for a workflow
+  # GET /executions?workflowId=<id>
+  # ------------------------------------------------------------------
+  - name: executions_by_workflow
+    kind: search
+    description: Search executions for a specific workflow.
+    search_limits:
+      default_top_k: 50
+      max_top_k: 250
+      max_calls_per_query: 1
+    args:
+      - name: workflow_id
+        required: true
+        bind:
+          arg: workflow_id
+      - name: status
+        bind:
+          arg: status
+    request:
+      method: GET
+      path: /executions
+      query:
+        - name: workflowId
+          from: arg
+          key: workflow_id
+        - name: status
+          from: arg
+          key: status
+        - name: includeData
+          from: literal
+          value: "false"
+    response:
+      rows_path:
+        - data
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path:
+        - nextCursor
+      page_size:
+        default: 50
+        max: 250
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Execution ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Execution status.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: workflow_id
+        type: Utf8
+        nullable: true
+        description: Workflow ID.
+        expr:
+          kind: path
+          path:
+            - workflowId
+      - name: workflow_name
+        type: Utf8
+        nullable: true
+        description: Workflow name.
+        expr:
+          kind: path
+          path:
+            - workflowName
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: When the execution started.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - startedAt
+      - name: stopped_at
+        type: Timestamp
+        nullable: true
+        description: When the execution stopped.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - stoppedAt
+      - name: execution_error_message
+        type: Utf8
+        nullable: true
+        description: Error message if failed.
+        expr:
+          kind: path
+          path:
+            - executionError
+            - message

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -21,7 +21,7 @@ inputs:
     hint: >-
       n8n API key. Create one in your n8n instance under
       Settings > API > Generate API Key. Requires read scopes for
-      workflows, executions, credentials, tags, and variables.
+      workflows, executions, tags, and variables.
 
 base_url: "{{input.N8N_BASE_URL}}"
 
@@ -36,6 +36,7 @@ test_queries:
   - SELECT id, name, active FROM n8n.workflows LIMIT 5
   - SELECT id, finished, workflow_id, started_at FROM n8n.executions LIMIT 5
   - SELECT id, name FROM n8n.tags LIMIT 5
+  - SELECT id, status, workflow_id FROM n8n.executions WHERE status = 'error' LIMIT 5
 
 tables:
   # ------------------------------------------------------------------

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -567,12 +567,7 @@ functions:
   # GET /executions?workflowId=<id>
   # ------------------------------------------------------------------
   - name: executions_by_workflow
-    kind: search
     description: Search executions for a specific workflow.
-    search_limits:
-      default_top_k: 50
-      max_top_k: 250
-      max_calls_per_query: 1
     args:
       - name: workflow_id
         required: true

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -241,7 +241,7 @@ tables:
         query_param: limit
     columns:
       - name: id
-        type: Utf8
+        type: Int64
         nullable: false
         description: Execution ID.
         expr:
@@ -273,7 +273,7 @@ tables:
           path:
             - status
       - name: workflow_id
-        type: Utf8
+        type: Int64
         nullable: true
         description: ID of the executed workflow. Join to `n8n.workflows.id`.
         expr:
@@ -314,7 +314,7 @@ tables:
             path:
               - waitTill
       - name: retry_of
-        type: Utf8
+        type: Int64
         nullable: true
         description: ID of the original execution if this is a retry.
         expr:
@@ -322,7 +322,7 @@ tables:
           path:
             - retryOf
       - name: retry_success_id
-        type: Utf8
+        type: Int64
         nullable: true
         description: ID of the successful retry execution.
         expr:
@@ -459,110 +459,3 @@ tables:
           path:
             - type
 
-functions:
-  # ------------------------------------------------------------------
-  # n8n.executions_by_workflow — search executions for a workflow
-  # GET /executions?workflowId=<id>
-  # ------------------------------------------------------------------
-  - name: executions_by_workflow
-    description: Search executions for a specific workflow.
-    args:
-      - name: workflow_id
-        required: true
-        bind:
-          arg: workflow_id
-      - name: status
-        bind:
-          arg: status
-    request:
-      method: GET
-      path: /executions
-      query:
-        - name: workflowId
-          from: arg
-          key: workflow_id
-        - name: status
-          from: arg
-          key: status
-        - name: includeData
-          from: literal
-          value: "false"
-    response:
-      rows_path:
-        - data
-      row_strategy: direct
-    pagination:
-      mode: cursor_query
-      cursor_param: cursor
-      response_cursor_path:
-        - nextCursor
-      page_size:
-        default: 50
-        max: 250
-        query_param: limit
-    columns:
-      - name: id
-        type: Utf8
-        nullable: false
-        description: Execution ID.
-        expr:
-          kind: path
-          path:
-            - id
-      - name: finished
-        type: Boolean
-        nullable: true
-        description: Whether the execution finished.
-        expr:
-          kind: path
-          path:
-            - finished
-      - name: mode
-        type: Utf8
-        nullable: true
-        description: Execution mode.
-        expr:
-          kind: path
-          path:
-            - mode
-      - name: workflow_id
-        type: Utf8
-        nullable: true
-        description: Workflow ID.
-        expr:
-          kind: path
-          path:
-            - workflowId
-      - name: started_at
-        type: Timestamp
-        nullable: true
-        description: When the execution started.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - startedAt
-      - name: stopped_at
-        type: Timestamp
-        nullable: true
-        description: When the execution stopped.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - stoppedAt
-      - name: wait_till
-        type: Timestamp
-        nullable: true
-        description: When a waiting execution should resume.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - waitTill

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -3,7 +3,7 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query n8n workflows, executions, credentials, tags, and variables through
+  Query n8n workflows, executions, tags, and variables through
   Coral SQL using the n8n Public REST API.
 
 inputs:
@@ -342,95 +342,6 @@ tables:
           kind: path
           path:
             - retrySuccessId
-
-  # ------------------------------------------------------------------
-  # n8n.credentials — list credential definitions (no secrets)
-  # GET /credentials
-  # ------------------------------------------------------------------
-  - name: credentials
-    description: |
-      List n8n credential definitions. Secrets are never returned by the
-      API. Use to audit which integrations are configured. Join `type` to
-      understand which services are connected.
-    request:
-      method: GET
-      path: /credentials
-    response:
-      rows_path:
-        - data
-      row_strategy: direct
-    pagination:
-      mode: cursor_query
-      cursor_param: cursor
-      response_cursor_path:
-        - nextCursor
-      page_size:
-        default: 100
-        max: 250
-        query_param: limit
-    columns:
-      - name: id
-        type: Utf8
-        nullable: false
-        description: Credential ID.
-        expr:
-          kind: path
-          path:
-            - id
-      - name: name
-        type: Utf8
-        nullable: true
-        description: Credential display name.
-        expr:
-          kind: path
-          path:
-            - name
-      - name: type
-        type: Utf8
-        nullable: true
-        description: Credential type (e.g. slackApi, githubApi, openAiApi).
-        expr:
-          kind: path
-          path:
-            - type
-      - name: is_managed
-        type: Boolean
-        nullable: true
-        description: Whether the credential is managed (enterprise feature).
-        expr:
-          kind: path
-          path:
-            - isManaged
-      - name: scoped
-        type: Boolean
-        nullable: true
-        description: Whether the credential is project-scoped.
-        expr:
-          kind: path
-          path:
-            - scoped
-      - name: created_at
-        type: Timestamp
-        nullable: true
-        description: When the credential was created.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - createdAt
-      - name: updated_at
-        type: Timestamp
-        nullable: true
-        description: When the credential was last updated.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - updatedAt
 
   # ------------------------------------------------------------------
   # n8n.tags — list workflow tags

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -9,7 +9,7 @@ description: >-
 inputs:
   N8N_BASE_URL:
     kind: variable
-    default: https://<your-n8n-instance>.n8n.cloud/api/v1
+    required: true
     hint: >-
       Base URL for your n8n instance API. For n8n Cloud use
       https://<account>.n8n.cloud/api/v1. For self-hosted use
@@ -30,11 +30,6 @@ auth:
     - name: X-N8N-API-KEY
       from: template
       template: "{{input.N8N_API_KEY}}"
-
-request_headers:
-  - name: Accept
-    from: literal
-    value: application/json
 
 test_queries:
   - SELECT id, name, active FROM n8n.workflows LIMIT 5
@@ -118,14 +113,30 @@ tables:
           kind: path
           path:
             - versionId
-      - name: node_count
+      - name: trigger_count
         type: Int64
         nullable: true
-        description: Number of nodes in the workflow.
+        description: Number of active trigger nodes in the workflow.
         expr:
           kind: path
           path:
-            - nodes
+            - triggerCount
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Workflow description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: is_archived
+        type: Boolean
+        nullable: true
+        description: Whether the workflow is archived.
+        expr:
+          kind: path
+          path:
+            - isArchived
       - name: tag_names
         type: Utf8
         nullable: true
@@ -193,9 +204,8 @@ tables:
   - name: executions
     description: |
       List n8n workflow execution runs. Filter by `status`, `workflow_id`,
-      or `project_id`. The `status` filter is accepted by the API but the
-      status value is not included in list responses; use `finished` to
-      determine completion state. Join `workflow_id` to `n8n.workflows.id`.
+      or `project_id`. Valid status values: canceled, crashed, error, new,
+      running, success, unknown, waiting. Join `workflow_id` to `n8n.workflows.id`.
     filters:
       - name: status
       - name: workflow_id
@@ -249,11 +259,19 @@ tables:
       - name: mode
         type: Utf8
         nullable: true
-        description: Execution mode (trigger, manual, integrated).
+        description: Execution mode (cli, error, integrated, internal, manual, retry, trigger, webhook, evaluation, chat).
         expr:
           kind: path
           path:
             - mode
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Execution status (canceled, crashed, error, new, running, success, unknown, waiting).
+        expr:
+          kind: path
+          path:
+            - status
       - name: workflow_id
         type: Utf8
         nullable: true
@@ -319,7 +337,7 @@ tables:
   - name: tags
     description: |
       List n8n workflow tags. Use to categorize and filter workflows.
-      Join `name` to `n8n.workflows.tag_names` for workflow categorization.
+      Match against `tag_names` using a substring filter (e.g. `tag_names ILIKE '%name%'`).
     request:
       method: GET
       path: /tags

--- a/sources/community/n8n/manifest.yaml
+++ b/sources/community/n8n/manifest.yaml
@@ -1,3 +1,4 @@
+---
 name: n8n
 version: 0.1.0
 dsl_version: 3
@@ -273,7 +274,9 @@ tables:
       - name: mode
         type: Utf8
         nullable: true
-        description: Execution mode (cli, error, integrated, internal, manual, retry, trigger, webhook, evaluation, chat).
+        description: >-
+          Execution mode (cli, error, integrated, internal, manual, retry,
+          trigger, webhook, evaluation, chat).
         expr:
           kind: path
           path:


### PR DESCRIPTION
## Summary
Adds a community source spec for [n8n](https://n8n.io) — the workflow automation platform.

Closes #680

## Tables
- `workflows` — automation workflows with name, description, active/archived status, trigger count, tags, project, settings, and timestamps
- `executions` — execution runs with status, mode, finished flag, timing, and retry metadata
- `tags` — workflow tags with timestamps
- `variables` — instance variables (requires paid n8n license)

## Key design decisions
- **Read-only.** `includeData=false` on executions to keep payloads small.
- **`Utf8` for execution IDs.** The n8n OpenAPI schema declares execution IDs as `type: number`, but we use `Utf8` so `executions.workflow_id` can join cleanly against `workflows.id` (which the API returns as a string). Coral coerces JSON numbers to strings when the column type is `Utf8`.
- **No `executions_by_workflow` function.** Removed per reviewer feedback — `SELECT ... FROM n8n.executions WHERE workflow_id = 'X'` provides the same functionality via the table + filter.
- **`N8N_BASE_URL` is `required: true`** with no default, so users must supply their instance URL explicitly.
- **`N8N_API_KEY` is `kind: secret`** per repo rules for credential inputs.

## Filters
| Table | Filters |
|---|---|
| `workflows` | `active`, `tags`, `name`, `project_id` |
| `executions` | `status`, `workflow_id`, `project_id` |
| `variables` | `project_id` |

## Testing
```bash
export N8N_BASE_URL="http://localhost:5678/api/v1"
export N8N_API_KEY="..."
coral source lint sources/community/n8n/manifest.yaml
coral source add --file sources/community/n8n/manifest.yaml
coral source test n8n
```

## Review feedback addressed
- [x] Surfaced `status` column on executions (was filter-only)
- [x] Replaced broken `node_count` with `trigger_count` (`triggerCount` API field)
- [x] Added `description`, `is_archived` columns to workflows
- [x] Removed `N8N_BASE_URL` placeholder default (angle brackets → DNS failure)
- [x] Expanded `mode` description to all 10 enum values
- [x] Documented valid `status` enum values in table description and guide
- [x] Removed redundant `executions_by_workflow` function
- [x] Fixed README tag example to use server-side `tags` filter
- [x] Reworded tags table description (substring filter, not JOIN)
- [x] Removed unnecessary `Accept: application/json` header
- [x] Added `guide` fields to workflows and executions tables
- [x] Kept execution IDs as `Utf8` to avoid cross-type JOIN mismatch with `workflows.id`