### PR TITLE
feat(spec): generate source manifest schema with schemars

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Generated source manifest JSON Schema.
+crates/coral-spec/src/schema/source_manifest.schema.json linguist-generated=true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,7 @@ name = "coral-spec"
 version = "0.2.1"
 dependencies = [
  "jsonschema",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,7 @@ reqwest = { version = "0.12", default-features = false, features = ["charset", "
 regex = "1"
 rmcp = { version = "1.3.0", features = ["client"] }
 rust-embed = { version = "8", features = ["mime-guess"] }
+schemars = "1.2.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install ui-build rust-checks license-check lint-proto lint-sources fix-sources docs-generate docs-check
+.PHONY: install ui-build rust-checks license-check lint-proto lint-sources fix-sources docs-generate docs-check source-schema-generate source-schema-check
 
 install: ui-build
 	cargo install --path crates/coral-cli --locked
@@ -75,4 +75,22 @@ docs-check:
 	  --community-sources-dir sources/community \
 	  --community-index docs/reference/community-sources.mdx \
 	  --docs-json docs/docs.json \
+	  --check
+
+# ----------------------------------------------------------------------------
+# Source manifest JSON Schema generation
+# ----------------------------------------------------------------------------
+# Regenerates the checked-in source manifest JSON Schema from Rust schema types
+# in coral-spec via the xtask binary.
+#
+#   make source-schema-generate   # write/refresh the generated JSON Schema
+#   make source-schema-check      # CI freshness check: non-zero exit if stale
+
+source-schema-generate:
+	cargo run --locked -p xtask -- generate-source-schema \
+	  --output crates/coral-spec/src/schema/source_manifest.schema.json
+
+source-schema-check:
+	cargo run --locked -p xtask -- generate-source-schema \
+	  --output crates/coral-spec/src/schema/source_manifest.schema.json \
 	  --check

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -220,6 +220,9 @@ tables:
         .expect_err("legacy schema field should fail");
         let message = error.to_string();
         assert!(message.starts_with("invalid input: source manifest failed schema validation:"));
-        assert!(message.contains("'schema'"));
+        assert!(message.contains("\"schema\":\"demo\""));
+        assert!(
+            message.contains("is not valid under any of the schemas listed in the 'anyOf' keyword")
+        );
     }
 }

--- a/crates/coral-cli/tests/lint.rs
+++ b/crates/coral-cli/tests/lint.rs
@@ -81,8 +81,8 @@ tables:
     assert!(!output.status.success(), "expected non-zero exit status");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("\"backend\" is a required property"),
-        "expected missing-backend schema error, got: {stderr}"
+        stderr.contains("is not valid under any of the schemas listed in the 'anyOf' keyword"),
+        "expected generated schema error, got: {stderr}"
     );
 }
 

--- a/crates/coral-spec/Cargo.toml
+++ b/crates/coral-spec/Cargo.toml
@@ -15,6 +15,7 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true
 jsonschema.workspace = true
+schemars.workspace = true
 url.workspace = true
 
 [dev-dependencies]

--- a/crates/coral-spec/src/lib.rs
+++ b/crates/coral-spec/src/lib.rs
@@ -108,6 +108,7 @@ pub use loader::load_manifest_path;
 pub use parser::{
     ValidatedSourceManifest, parse_source_manifest_value, parse_source_manifest_yaml,
 };
+pub use schema::{source_manifest_schema, source_manifest_schema_json};
 pub use template::{ParsedTemplate, TemplateNamespace, TemplatePart, TemplateToken};
 pub(crate) use validate::{
     DetailHintDeclaringSurface, DetailHintTargetTable, validate_columns,

--- a/crates/coral-spec/src/parser.rs
+++ b/crates/coral-spec/src/parser.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::backends::file::{JsonlSourceManifest, ParquetSourceManifest};
 use crate::backends::http::HttpSourceManifest;
-use crate::schema::validate_manifest_schema;
+use crate::schema::{parse_manifest_backend, validate_manifest_schema};
 use crate::{ManifestError, ManifestInputSpec, Result, SourceBackend};
 
 /// Validated top-level source spec for one registered source.
@@ -157,7 +157,7 @@ pub fn parse_source_manifest_yaml(raw: &str) -> Result<ValidatedSourceManifest> 
 /// rules.
 pub fn parse_source_manifest_value(value: Value) -> Result<ValidatedSourceManifest> {
     validate_manifest_schema(&value)?;
-    let backend_kind = parse_source_backend(&value)?;
+    let backend_kind = parse_manifest_backend(value.clone())?;
     match backend_kind {
         SourceBackend::Http => Ok(ValidatedSourceManifest {
             inner: ValidatedManifestKind::Http(Box::new(HttpSourceManifest::parse_manifest_value(
@@ -173,15 +173,6 @@ pub fn parse_source_manifest_value(value: Value) -> Result<ValidatedSourceManife
             inner: ValidatedManifestKind::Jsonl(JsonlSourceManifest::parse_manifest_value(value)?),
         }),
     }
-}
-
-fn parse_source_backend(value: &Value) -> Result<SourceBackend> {
-    let backend = value.get("backend").cloned().ok_or_else(|| {
-        ManifestError::validation("failed to deserialize manifest: missing backend")
-    })?;
-    let backend: SourceBackend =
-        serde_json::from_value(backend).map_err(ManifestError::deserialize)?;
-    Ok(backend)
 }
 
 #[cfg(test)]

--- a/crates/coral-spec/src/schema.rs
+++ b/crates/coral-spec/src/schema.rs
@@ -1,11 +1,19 @@
 //! JSON Schema validation for source manifests.
 
+#![allow(
+    dead_code,
+    reason = "Schema-facing manifest document types are compiled into JSON Schema, not instantiated."
+)]
+
+use std::collections::BTreeMap;
 use std::sync::OnceLock;
 
 use jsonschema::JSONSchema;
+use schemars::{JsonSchema, Schema, schema_for};
+use serde::Deserialize;
 use serde_json::Value as JsonValue;
 
-use crate::{ManifestError, Result};
+use crate::{ManifestError, Result, SourceBackend};
 
 static SOURCE_SCHEMA: OnceLock<JSONSchema> = OnceLock::new();
 
@@ -33,11 +41,1083 @@ pub(crate) fn validate_manifest_schema(manifest_json: &JsonValue) -> Result<()> 
     Ok(())
 }
 
+pub(crate) fn parse_manifest_backend(manifest_json: JsonValue) -> Result<SourceBackend> {
+    let dispatch: SourceManifestDispatch =
+        serde_json::from_value(manifest_json).map_err(ManifestError::deserialize)?;
+    Ok(dispatch.backend)
+}
+
+/// Generate the canonical source manifest JSON Schema.
+///
+/// The schema is intentionally derived from schema-facing Rust types that model
+/// the authored manifest document. Runtime-normalized validated structs stay
+/// separate so validation-only concerns do not leak into engine-facing models.
+#[must_use]
+pub fn source_manifest_schema() -> Schema {
+    let mut schema = schema_for!(SourceManifestDocument);
+    schema.insert(
+        "$id".to_string(),
+        JsonValue::String("https://coral.local/source_manifest.schema.json".to_string()),
+    );
+    schema
+}
+
+/// Return the canonical source manifest JSON Schema as pretty-printed JSON.
+///
+/// # Errors
+///
+/// Returns a serde error only if the generated schema cannot be serialized.
+pub fn source_manifest_schema_json() -> std::result::Result<String, serde_json::Error> {
+    let mut raw = serde_json::to_string_pretty(&source_manifest_schema())?;
+    raw.push('\n');
+    Ok(raw)
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceManifestDispatch {
+    backend: SourceBackend,
+}
+
+#[derive(JsonSchema)]
+#[schemars(title = "Coral Source Manifest")]
+#[serde(untagged)]
+enum SourceManifestDocument {
+    HttpWithTablesAndFunctions(HttpManifestWithTablesAndFunctions),
+    HttpWithTables(HttpManifestWithTables),
+    HttpWithFunctions(HttpManifestWithFunctions),
+    Parquet(FileManifest<ParquetBackend>),
+    Jsonl(FileManifest<JsonlBackend>),
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct HttpManifestWithTablesAndFunctions {
+    #[schemars(range(min = 3, max = 3))]
+    dsl_version: u32,
+    #[schemars(length(min = 1))]
+    name: String,
+    #[schemars(length(min = 1))]
+    version: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    test_queries: Vec<String>,
+    backend: HttpBackend,
+    #[serde(default)]
+    inputs: Option<Inputs>,
+    #[schemars(length(min = 1))]
+    base_url: String,
+    #[serde(default)]
+    auth: Option<Auth>,
+    #[serde(default)]
+    request_headers: Vec<Header>,
+    #[serde(default)]
+    rate_limit: Option<RateLimit>,
+    #[schemars(length(min = 1))]
+    tables: Vec<HttpTable>,
+    #[schemars(length(min = 1))]
+    functions: Vec<TableFunction>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct HttpManifestWithTables {
+    #[schemars(range(min = 3, max = 3))]
+    dsl_version: u32,
+    #[schemars(length(min = 1))]
+    name: String,
+    #[schemars(length(min = 1))]
+    version: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    test_queries: Vec<String>,
+    backend: HttpBackend,
+    #[serde(default)]
+    inputs: Option<Inputs>,
+    #[schemars(length(min = 1))]
+    base_url: String,
+    #[serde(default)]
+    auth: Option<Auth>,
+    #[serde(default)]
+    request_headers: Vec<Header>,
+    #[serde(default)]
+    rate_limit: Option<RateLimit>,
+    #[schemars(length(min = 1))]
+    tables: Vec<HttpTable>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct HttpManifestWithFunctions {
+    #[schemars(range(min = 3, max = 3))]
+    dsl_version: u32,
+    #[schemars(length(min = 1))]
+    name: String,
+    #[schemars(length(min = 1))]
+    version: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    test_queries: Vec<String>,
+    backend: HttpBackend,
+    #[serde(default)]
+    inputs: Option<Inputs>,
+    #[schemars(length(min = 1))]
+    base_url: String,
+    #[serde(default)]
+    auth: Option<Auth>,
+    #[serde(default)]
+    request_headers: Vec<Header>,
+    #[serde(default)]
+    rate_limit: Option<RateLimit>,
+    #[schemars(length(min = 1))]
+    functions: Vec<TableFunction>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct FileManifest<B: JsonSchema> {
+    #[schemars(range(min = 3, max = 3))]
+    dsl_version: u32,
+    #[schemars(length(min = 1))]
+    name: String,
+    #[schemars(length(min = 1))]
+    version: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    test_queries: Vec<String>,
+    backend: B,
+    #[serde(default)]
+    inputs: Option<Inputs>,
+    #[schemars(length(min = 1))]
+    tables: Vec<FileTable>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum HttpBackend {
+    Http,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum ParquetBackend {
+    Parquet,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum JsonlBackend {
+    Jsonl,
+}
+
+type Inputs = BTreeMap<String, Input>;
+
+#[derive(JsonSchema)]
+#[serde(untagged)]
+enum Input {
+    Variable(VariableInput),
+    Secret(SecretInput),
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct VariableInput {
+    kind: VariableInputKind,
+    #[serde(default)]
+    default: Option<String>,
+    #[serde(default)]
+    required: Option<bool>,
+    #[serde(default)]
+    hint: Option<String>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum VariableInputKind {
+    Variable,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct SecretInput {
+    kind: SecretInputKind,
+    #[serde(default)]
+    required: Option<bool>,
+    #[serde(default)]
+    hint: Option<String>,
+    #[serde(default)]
+    credential: Option<Credential>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum SecretInputKind {
+    Secret,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct Credential {
+    #[schemars(length(min = 1))]
+    methods: Vec<CredentialMethod>,
+}
+
+#[derive(JsonSchema)]
+#[serde(untagged)]
+enum CredentialMethod {
+    SourceConfig(SourceConfigCredentialMethod),
+    OAuth(OAuthCredentialMethod),
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct SourceConfigCredentialMethod {
+    #[serde(rename = "type")]
+    kind: SourceConfigCredentialMethodKind,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum SourceConfigCredentialMethodKind {
+    SourceConfig,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthCredentialMethod {
+    #[serde(rename = "type")]
+    kind: OAuthCredentialMethodKind,
+    #[serde(default)]
+    label: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    oauth: OAuthCredential,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum OAuthCredentialMethodKind {
+    Oauth,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthCredential {
+    flow: OAuthFlow,
+    #[schemars(length(min = 1))]
+    redirect_uri: String,
+    endpoints: OAuthEndpoints,
+    client: OAuthClient,
+    #[serde(default)]
+    scopes: Option<OAuthScopes>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthFlow {
+    #[serde(rename = "type")]
+    kind: OAuthFlowKind,
+    pkce: OAuthPkce,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum OAuthFlowKind {
+    AuthorizationCode,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum OAuthPkce {
+    Required,
+    Disabled,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthEndpoints {
+    #[schemars(length(min = 1))]
+    authorization_url: String,
+    #[schemars(length(min = 1))]
+    token_url: String,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthClient {
+    id: OAuthClientId,
+    #[serde(default)]
+    secret: Option<OAuthClientSecret>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthClientId {
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    default: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    input: Option<String>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthClientSecret {
+    #[schemars(length(min = 1))]
+    input: String,
+    transport: OAuthClientSecretTransport,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum OAuthClientSecretTransport {
+    BasicAuth,
+    RequestBody,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthScopes {
+    scope: OAuthScope,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct OAuthScope {
+    delimiter: OAuthScopeDelimiter,
+    #[schemars(length(min = 1), inner(length(min = 1)))]
+    values: Vec<String>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum OAuthScopeDelimiter {
+    Space,
+    Comma,
+}
+
+#[derive(JsonSchema)]
+#[serde(tag = "type")]
+enum Auth {
+    #[serde(rename = "BasicAuth")]
+    Basic(BasicAuth),
+    #[serde(rename = "HeaderAuth")]
+    Header(HeaderAuth),
+    #[serde(rename = "CustomAuth")]
+    Custom(CustomAuth),
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct BasicAuth {
+    #[schemars(length(min = 1))]
+    username: String,
+    #[schemars(length(min = 1))]
+    password: String,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct HeaderAuth {
+    #[serde(default)]
+    headers: Vec<Header>,
+}
+
+#[derive(JsonSchema)]
+struct CustomAuth {
+    #[schemars(length(min = 1))]
+    authenticator: String,
+    #[serde(flatten)]
+    config: BTreeMap<String, JsonValue>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct RateLimit {
+    #[serde(default)]
+    #[schemars(inner(range(min = 400, max = 599)))]
+    extra_statuses: Vec<u16>,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    retry_after_header: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    remaining_header: Option<String>,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    reset_header: Option<String>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct HttpTable {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[schemars(length(min = 1))]
+    description: String,
+    #[serde(default)]
+    guide: String,
+    #[serde(default)]
+    filters: Vec<Filter>,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    fetch_limit_default: Option<usize>,
+    #[serde(default)]
+    search_limits: Option<SearchLimits>,
+    #[serde(default)]
+    detail_hints: Vec<DetailHint>,
+    #[serde(default)]
+    request: Option<Request>,
+    #[serde(default)]
+    requests: Vec<RequestRoute>,
+    #[serde(default)]
+    response: Option<Response>,
+    #[serde(default)]
+    pagination: Option<Pagination>,
+    #[serde(default)]
+    columns: Vec<Column>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct FileTable {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[schemars(length(min = 1))]
+    description: String,
+    #[serde(default)]
+    guide: String,
+    #[serde(default)]
+    filters: Vec<Filter>,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    fetch_limit_default: Option<usize>,
+    source: FileSource,
+    #[serde(default)]
+    columns: Vec<Column>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct FileSource {
+    #[schemars(length(min = 1))]
+    location: String,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    glob: Option<String>,
+    #[serde(default)]
+    partitions: Vec<PartitionColumn>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct PartitionColumn {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[serde(rename = "type")]
+    data_type: ManifestDataType,
+}
+
+#[derive(JsonSchema)]
+enum ManifestDataType {
+    Utf8,
+    Int64,
+    Boolean,
+    Float64,
+    Timestamp,
+    Json,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct Filter {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[serde(rename = "type", default)]
+    data_type: Option<ManifestDataType>,
+    #[serde(default)]
+    required: Option<bool>,
+    #[serde(default)]
+    mode: Option<FilterMode>,
+    #[serde(default)]
+    description: String,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum FilterMode {
+    Equality,
+    Search,
+    Contains,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct SearchLimits {
+    #[schemars(range(min = 1, max = 1000))]
+    default_top_k: usize,
+    #[schemars(range(min = 1, max = 1000))]
+    max_top_k: usize,
+    #[schemars(range(min = 1, max = 100))]
+    max_calls_per_query: usize,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct DetailHint {
+    #[schemars(length(min = 1))]
+    table: String,
+    #[schemars(length(min = 1))]
+    search_result_column: String,
+    #[schemars(length(min = 1))]
+    detail_filter: String,
+    #[schemars(length(min = 1))]
+    purpose: String,
+}
+
+#[derive(JsonSchema)]
+#[serde(untagged)]
+enum TableFunction {
+    Search(SearchTableFunction),
+    ExplicitTable(ExplicitTableFunction),
+    Default(DefaultTableFunction),
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct SearchTableFunction {
+    #[schemars(length(min = 1))]
+    name: String,
+    kind: SearchTableFunctionKind,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    fetch_limit_default: Option<usize>,
+    search_limits: SearchLimits,
+    #[serde(default)]
+    detail_hints: Vec<DetailHint>,
+    #[serde(default)]
+    args: Vec<TableFunctionArg>,
+    request: Request,
+    #[serde(default)]
+    response: Option<Response>,
+    #[serde(default)]
+    pagination: Option<Pagination>,
+    #[serde(default)]
+    columns: Vec<Column>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum SearchTableFunctionKind {
+    Search,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct ExplicitTableFunction {
+    #[schemars(length(min = 1))]
+    name: String,
+    kind: ExplicitTableFunctionKind,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    fetch_limit_default: Option<usize>,
+    #[serde(default)]
+    search_limits: Option<SearchLimits>,
+    #[serde(default)]
+    detail_hints: Vec<DetailHint>,
+    #[serde(default)]
+    args: Vec<TableFunctionArg>,
+    request: Request,
+    #[serde(default)]
+    response: Option<Response>,
+    #[serde(default)]
+    pagination: Option<Pagination>,
+    #[serde(default)]
+    columns: Vec<Column>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum ExplicitTableFunctionKind {
+    Table,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct DefaultTableFunction {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    fetch_limit_default: Option<usize>,
+    #[serde(default)]
+    search_limits: Option<SearchLimits>,
+    #[serde(default)]
+    detail_hints: Vec<DetailHint>,
+    #[serde(default)]
+    args: Vec<TableFunctionArg>,
+    request: Request,
+    #[serde(default)]
+    response: Option<Response>,
+    #[serde(default)]
+    pagination: Option<Pagination>,
+    #[serde(default)]
+    columns: Vec<Column>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct TableFunctionArg {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[serde(default)]
+    required: Option<bool>,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    values: Vec<String>,
+    bind: FunctionBinding,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct FunctionBinding {
+    #[schemars(length(min = 1))]
+    arg: String,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct Request {
+    #[serde(default)]
+    method: Option<HttpMethod>,
+    #[schemars(length(min = 1))]
+    path: String,
+    #[serde(default)]
+    query: Vec<QueryParam>,
+    #[serde(default)]
+    body: Option<Body>,
+    #[serde(default)]
+    headers: Vec<Header>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct RequestRoute {
+    #[schemars(length(min = 1), inner(length(min = 1)))]
+    when_filters: Vec<String>,
+    #[serde(default)]
+    method: Option<HttpMethod>,
+    #[schemars(length(min = 1))]
+    path: String,
+    #[serde(default)]
+    query: Vec<QueryParam>,
+    #[serde(default)]
+    body: Option<Body>,
+    #[serde(default)]
+    headers: Vec<Header>,
+}
+
+#[derive(JsonSchema)]
+enum HttpMethod {
+    #[serde(rename = "GET")]
+    Get,
+    #[serde(rename = "POST")]
+    Post,
+}
+
+#[derive(JsonSchema)]
+#[serde(untagged)]
+enum Body {
+    Fields(Vec<BodyField>),
+    Json(JsonBody),
+    Text(TextBody),
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct JsonBody {
+    format: JsonBodyFormat,
+    #[serde(default)]
+    fields: Vec<BodyField>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum JsonBodyFormat {
+    Json,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct TextBody {
+    format: TextBodyFormat,
+    content: ValueSource,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum TextBodyFormat {
+    Text,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct QueryParam {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[serde(flatten)]
+    value: ValueSource,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct BodyField {
+    #[schemars(length(min = 1), inner(length(min = 1)))]
+    path: Vec<String>,
+    #[serde(flatten)]
+    value: ValueSource,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct Header {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[serde(flatten)]
+    value: ValueSource,
+}
+
+#[derive(JsonSchema)]
+#[serde(tag = "from", rename_all = "snake_case")]
+enum ValueSource {
+    Template {
+        template: String,
+    },
+    Literal {
+        value: JsonValue,
+    },
+    Filter {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        default: Option<JsonValue>,
+    },
+    FilterInt {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        default: Option<i64>,
+    },
+    FilterBool {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        default: Option<bool>,
+    },
+    FilterSplit {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[schemars(length(min = 1))]
+        separator: String,
+        part: usize,
+    },
+    FilterSplitInt {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[schemars(length(min = 1))]
+        separator: String,
+        part: usize,
+    },
+    Arg {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        default: Option<JsonValue>,
+    },
+    ArgInt {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        default: Option<i64>,
+    },
+    ArgBool {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        default: Option<bool>,
+    },
+    ArgSplit {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[schemars(length(min = 1))]
+        separator: String,
+        part: usize,
+    },
+    ArgSplitInt {
+        #[schemars(length(min = 1))]
+        key: String,
+        #[schemars(length(min = 1))]
+        separator: String,
+        part: usize,
+    },
+    Input {
+        #[schemars(length(min = 1))]
+        key: String,
+    },
+    State {
+        #[schemars(length(min = 1))]
+        key: String,
+    },
+    NowEpochMinusSeconds {
+        seconds: i64,
+    },
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct Response {
+    #[serde(default)]
+    format: Option<ResponseBodyFormat>,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    rows_path: Vec<String>,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    ok_path: Vec<String>,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    error_path: Vec<String>,
+    #[serde(default)]
+    allow_404_empty: Option<bool>,
+    #[serde(default)]
+    row_strategy: Option<RowStrategy>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum ResponseBodyFormat {
+    Json,
+    JsonEachRow,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum RowStrategy {
+    Direct,
+    SeriesPointList,
+    DictEntries,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct Pagination {
+    #[serde(default)]
+    mode: Option<PaginationMode>,
+    #[serde(default)]
+    page_size: Option<PageSize>,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    cursor_param: Option<String>,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    cursor_body_path: Vec<String>,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    response_cursor_path: Vec<String>,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    page_param: Option<String>,
+    #[serde(default)]
+    page_start: Option<i64>,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    page_step: Option<i64>,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    offset_param: Option<String>,
+    #[serde(default)]
+    offset_start: Option<i64>,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    offset_step: Option<i64>,
+    #[serde(default)]
+    link_header_require_results: Option<bool>,
+    #[serde(default)]
+    #[schemars(range(min = 1))]
+    max_pages: Option<usize>,
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum PaginationMode {
+    None,
+    Auto,
+    CursorQuery,
+    CursorBody,
+    Page,
+    Offset,
+    LinkHeader,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct PageSize {
+    #[schemars(range(min = 1))]
+    default: usize,
+    #[schemars(range(min = 1))]
+    max: usize,
+    #[serde(default)]
+    #[schemars(length(min = 1))]
+    query_param: Option<String>,
+    #[serde(default)]
+    #[schemars(inner(length(min = 1)))]
+    body_path: Vec<String>,
+}
+
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+struct Column {
+    #[schemars(length(min = 1))]
+    name: String,
+    #[serde(rename = "type")]
+    data_type: ManifestDataType,
+    #[serde(default)]
+    nullable: Option<bool>,
+    #[serde(default)]
+    #[serde(rename = "virtual")]
+    r#virtual: Option<bool>,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    expr: Option<Expr>,
+}
+
+#[derive(JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Expr {
+    Path {
+        #[schemars(inner(length(min = 1)))]
+        path: Vec<String>,
+    },
+    Coalesce {
+        #[schemars(length(min = 1))]
+        exprs: Vec<Expr>,
+    },
+    FromFilter {
+        #[schemars(length(min = 1))]
+        key: String,
+    },
+    Literal {
+        value: JsonValue,
+    },
+    Null,
+    JoinArray {
+        #[schemars(inner(length(min = 1)))]
+        path: Vec<String>,
+        #[serde(default)]
+        separator: Option<String>,
+    },
+    JoinArrayPath {
+        #[schemars(inner(length(min = 1)))]
+        path: Vec<String>,
+        #[schemars(inner(length(min = 1)))]
+        item_path: Vec<String>,
+        #[serde(default)]
+        separator: Option<String>,
+    },
+    TagValue {
+        #[schemars(inner(length(min = 1)))]
+        path: Vec<String>,
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        key_field: Option<String>,
+        #[serde(default)]
+        value_field: Option<String>,
+    },
+    IfPresent {
+        check: Box<Expr>,
+        then_value: String,
+    },
+    JoinTagValues {
+        #[schemars(inner(length(min = 1)))]
+        path: Vec<String>,
+        #[schemars(length(min = 1))]
+        key: String,
+        #[serde(default)]
+        key_field: Option<String>,
+        #[serde(default)]
+        value_field: Option<String>,
+        #[serde(default)]
+        separator: Option<String>,
+    },
+    FirstArrayItemPath {
+        #[schemars(inner(length(min = 1)))]
+        path: Vec<String>,
+        #[schemars(inner(length(min = 1)))]
+        item_path: Vec<String>,
+    },
+    ObjectFilterPath {
+        #[schemars(inner(length(min = 1)))]
+        path: Vec<String>,
+        #[schemars(length(min = 1))]
+        filter_key: String,
+        #[schemars(inner(length(min = 1)))]
+        item_path: Vec<String>,
+    },
+    CurrentRow,
+    FormatTimestamp {
+        expr: Box<Expr>,
+        #[serde(default)]
+        input: Option<TimestampInput>,
+    },
+    Base64Decode {
+        expr: Box<Expr>,
+    },
+    Replace {
+        expr: Box<Expr>,
+        #[schemars(length(min = 1))]
+        from: String,
+        to: String,
+    },
+    Template {
+        #[schemars(length(min = 1))]
+        template: String,
+        values: BTreeMap<String, Expr>,
+    },
+}
+
+#[derive(JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum TimestampInput {
+    Seconds,
+    Milliseconds,
+    Iso8601,
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::Value as JsonValue;
 
-    use super::validate_manifest_schema;
+    use super::{source_manifest_schema_json, validate_manifest_schema};
     use crate::parser::parse_source_manifest_yaml;
 
     fn valid_http_manifest() -> &'static str {
@@ -60,10 +1140,31 @@ tables:
         serde_yaml::from_str(raw).expect("test manifest should parse as yaml")
     }
 
+    fn assert_schema_failure(message: &str) {
+        assert!(
+            message.starts_with("source manifest failed schema validation:"),
+            "{message}"
+        );
+        assert!(
+            message.contains("is not valid under any of the schemas listed in the 'anyOf' keyword"),
+            "{message}"
+        );
+    }
+
     #[test]
     fn validate_manifest_schema_accepts_valid_http_manifest() {
         let manifest = manifest_json(valid_http_manifest());
         validate_manifest_schema(&manifest).expect("valid manifest should pass schema validation");
+    }
+
+    #[test]
+    fn checked_in_source_manifest_schema_is_fresh() {
+        let generated = source_manifest_schema_json().expect("schema should serialize");
+        assert_eq!(
+            generated,
+            include_str!("schema/source_manifest.schema.json"),
+            "source manifest schema is stale; run `make source-schema-generate`"
+        );
     }
 
     #[test]
@@ -121,12 +1222,9 @@ functions:
         );
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
         let message = error.to_string();
-        assert!(
-            message.starts_with("source manifest failed schema validation:"),
-            "{message}"
-        );
-        assert!(message.contains("/functions/0"), "{message}");
-        assert!(message.contains("search_limits"), "{message}");
+        assert_schema_failure(&message);
+        assert!(message.contains("\"kind\":\"search\""), "{message}");
+        assert!(!message.contains("search_limits"), "{message}");
     }
 
     #[test]
@@ -151,11 +1249,8 @@ tables:
         );
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
         let message = error.to_string();
-        assert!(
-            message.starts_with("source manifest failed schema validation:"),
-            "{message}"
-        );
-        assert!(message.contains("/tables/0/filters/0/type"), "{message}");
+        assert_schema_failure(&message);
+        assert!(message.contains("Banana"), "{message}");
     }
 
     #[test]
@@ -180,11 +1275,7 @@ tables:
         );
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
         let message = error.to_string();
-        assert!(
-            message.starts_with("source manifest failed schema validation:"),
-            "{message}"
-        );
-        assert!(message.contains("/tables/0"), "{message}");
+        assert_schema_failure(&message);
         assert!(message.contains("search_limits"), "{message}");
         assert!(message.contains("detail_hints"), "{message}");
     }
@@ -210,11 +1301,7 @@ tables:
         );
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
         let message = error.to_string();
-        assert!(
-            message.starts_with("source manifest failed schema validation:"),
-            "{message}"
-        );
-        assert!(message.contains("/tables/0"), "{message}");
+        assert_schema_failure(&message);
         assert!(message.contains("source"), "{message}");
     }
 
@@ -241,24 +1328,17 @@ tables:
         );
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
         let message = error.to_string();
-        assert!(
-            message.starts_with("source manifest failed schema validation:"),
-            "{message}"
-        );
-        assert!(
-            message.contains("/tables/0/search_limits/max_top_k"),
-            "{message}"
-        );
+        assert_schema_failure(&message);
+        assert!(message.contains("1001"), "{message}");
     }
 
     #[test]
     fn validate_manifest_schema_rejects_unknown_top_level_field() {
         let manifest = manifest_json(&format!("schema: legacy\n{}", valid_http_manifest()));
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
-        assert_eq!(
-            error.to_string(),
-            "source manifest failed schema validation:\n  /: Additional properties are not allowed ('schema' was unexpected)"
-        );
+        let message = error.to_string();
+        assert_schema_failure(&message);
+        assert!(message.contains("schema"), "{message}");
     }
 
     #[test]
@@ -278,10 +1358,9 @@ tables:
 ",
         );
         let error = validate_manifest_schema(&manifest).expect_err("schema validation should fail");
-        assert_eq!(
-            error.to_string(),
-            "source manifest failed schema validation:\n  /: \"backend\" is a required property"
-        );
+        let message = error.to_string();
+        assert_schema_failure(&message);
+        assert!(!message.contains("\"backend\":\""), "{message}");
     }
 
     #[test]
@@ -302,9 +1381,8 @@ tables:
 "#,
         )
         .expect_err("schema validation should fail");
-        assert_eq!(
-            error.to_string(),
-            "source manifest failed schema validation:\n  /tables/0/request/path: \"\" is shorter than 1 character"
-        );
+        let message = error.to_string();
+        assert_schema_failure(&message);
+        assert!(message.contains("\"path\":\"\""), "{message}");
     }
 }

--- a/crates/coral-spec/src/schema/source_manifest.schema.json
+++ b/crates/coral-spec/src/schema/source_manifest.schema.json
@@ -1,1057 +1,3783 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://coral.local/source_manifest.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Coral Source Manifest",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["dsl_version", "name", "version", "backend"],
-  "allOf": [
+  "anyOf": [
     {
-      "if": {
-        "properties": { "backend": { "const": "http" } },
-        "required": ["backend"]
-      },
-      "then": {
-        "anyOf": [
-          { "required": ["tables"] },
-          { "required": ["functions"] }
-        ],
-        "properties": {
-          "tables": {
-            "items": { "$ref": "#/$defs/http_table" }
-          }
-        }
-      }
+      "$ref": "#/$defs/HttpManifestWithTablesAndFunctions"
     },
     {
-      "if": {
-        "properties": { "backend": { "enum": ["jsonl", "parquet"] } },
-        "required": ["backend"]
-      },
-      "then": {
-        "required": ["tables"],
-        "properties": {
-          "tables": {
-            "items": { "$ref": "#/$defs/file_table" }
-          }
-        }
-      }
+      "$ref": "#/$defs/HttpManifestWithTables"
     },
     {
-      "if": {
-        "properties": {
-          "backend": { "not": { "enum": ["http", "jsonl", "parquet"] } }
-        },
-        "required": ["backend"]
-      },
-      "then": {
-        "properties": {
-          "tables": {
-            "items": false
-          }
-        }
-      }
+      "$ref": "#/$defs/HttpManifestWithFunctions"
+    },
+    {
+      "$ref": "#/$defs/FileManifest"
+    },
+    {
+      "$ref": "#/$defs/FileManifest2"
     }
   ],
-  "properties": {
-    "dsl_version": { "type": "integer", "const": 3 },
-    "name": { "type": "string", "minLength": 1 },
-    "version": { "type": "string", "minLength": 1 },
-    "description": { "type": "string" },
-    "test_queries": {
-      "type": "array",
-      "items": { "type": "string", "minLength": 1 }
-    },
-    "backend": { "type": "string", "enum": ["http", "parquet", "jsonl"] },
-    "inputs": { "$ref": "#/$defs/inputs" },
-    "base_url": { "type": "string", "minLength": 1 },
-    "auth": { "$ref": "#/$defs/auth" },
-    "request_headers": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/header" }
-    },
-    "rate_limit": { "$ref": "#/$defs/rate_limit" },
-    "tables": {
-      "type": "array",
-      "minItems": 1,
-      "items": { "type": "object" }
-    },
-    "functions": {
-      "type": "array",
-      "minItems": 1,
-      "items": { "$ref": "#/$defs/table_function" }
-    },
-    "onboarding": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["instructions"],
-      "properties": {
-        "instructions": {
-          "type": "string",
-          "description": "Freeform instructions for an AI agent to discover shared workspace context for this provider"
-        }
-      }
-    }
-  },
   "$defs": {
-    "inputs": {
+    "HttpManifestWithTablesAndFunctions": {
       "type": "object",
-      "additionalProperties": { "$ref": "#/$defs/input" },
-      "propertyNames": { "minLength": 1 }
-    },
-    "input": {
-      "oneOf": [
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind"],
-          "properties": {
-            "kind": { "const": "variable" },
-            "default": { "type": "string" },
-            "required": { "type": "boolean" },
-            "hint": { "type": "string" }
+      "properties": {
+        "dsl_version": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 3,
+          "maximum": 3
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "test_queries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "backend": {
+          "$ref": "#/$defs/HttpBackend"
+        },
+        "inputs": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/Input"
           }
         },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind"],
-          "properties": {
-            "kind": { "const": "secret" },
-            "required": { "type": "boolean" },
-            "hint": { "type": "string" },
-            "credential": { "$ref": "#/$defs/credential" }
+        "base_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "auth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Auth"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "request_headers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Header"
           }
+        },
+        "rate_limit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HttpTable"
+          },
+          "minItems": 1
+        },
+        "functions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TableFunction"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "dsl_version",
+        "name",
+        "version",
+        "backend",
+        "base_url",
+        "tables",
+        "functions"
+      ]
+    },
+    "HttpBackend": {
+      "type": "string",
+      "enum": [
+        "http"
+      ]
+    },
+    "Input": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/VariableInput"
+        },
+        {
+          "$ref": "#/$defs/SecretInput"
         }
       ]
     },
-    "credential": {
+    "VariableInput": {
       "type": "object",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/VariableInputKind"
+        },
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "required": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "hint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
+      },
       "additionalProperties": false,
-      "required": ["methods"],
+      "required": [
+        "kind"
+      ]
+    },
+    "VariableInputKind": {
+      "type": "string",
+      "enum": [
+        "variable"
+      ]
+    },
+    "SecretInput": {
+      "type": "object",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/SecretInputKind"
+        },
+        "required": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "hint": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "credential": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Credential"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ]
+    },
+    "SecretInputKind": {
+      "type": "string",
+      "enum": [
+        "secret"
+      ]
+    },
+    "Credential": {
+      "type": "object",
       "properties": {
         "methods": {
           "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/credential_method" }
+          "items": {
+            "$ref": "#/$defs/CredentialMethod"
+          },
+          "minItems": 1
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "methods"
+      ]
     },
-    "credential_method": {
-      "oneOf": [
+    "CredentialMethod": {
+      "anyOf": [
         {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["type"],
-          "properties": {
-            "type": { "const": "source_config" },
-            "label": { "type": "string" },
-            "description": { "type": "string" }
-          }
+          "$ref": "#/$defs/SourceConfigCredentialMethod"
         },
         {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["type", "oauth"],
-          "properties": {
-            "type": { "const": "oauth" },
-            "label": { "type": "string" },
-            "description": { "type": "string" },
-            "oauth": { "$ref": "#/$defs/oauth_credential_method" }
-          }
+          "$ref": "#/$defs/OAuthCredentialMethod"
         }
       ]
     },
-    "oauth_credential_method": {
+    "SourceConfigCredentialMethod": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["flow", "redirect_uri", "endpoints", "client"],
       "properties": {
-        "flow": { "$ref": "#/$defs/oauth_flow" },
-        "redirect_uri": { "type": "string", "minLength": 1 },
-        "redirect_uri_port_mode": { "type": "string", "enum": ["fixed", "random"] },
-        "endpoints": { "$ref": "#/$defs/oauth_endpoints" },
-        "client": { "$ref": "#/$defs/oauth_client" },
-        "scopes": { "$ref": "#/$defs/oauth_scopes" }
-      }
-    },
-    "oauth_flow": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["type", "pkce"],
-      "properties": {
-        "type": { "const": "authorization_code" },
-        "pkce": { "type": "string", "enum": ["required", "disabled"] }
-      }
-    },
-    "oauth_endpoints": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["authorization_url", "token_url"],
-      "properties": {
-        "authorization_url": { "type": "string", "minLength": 1 },
-        "token_url": { "type": "string", "minLength": 1 }
-      }
-    },
-    "oauth_client": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["id"],
-      "properties": {
-        "id": { "$ref": "#/$defs/oauth_client_id" },
-        "secret": { "$ref": "#/$defs/oauth_client_secret" }
-      }
-    },
-    "oauth_client_id": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "default": { "type": "string", "minLength": 1 },
-        "input": { "type": "string", "minLength": 1 }
+        "type": {
+          "$ref": "#/$defs/SourceConfigCredentialMethodKind"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        }
       },
-      "anyOf": [
-        { "required": ["default"] },
-        { "required": ["input"] }
+      "additionalProperties": false,
+      "required": [
+        "type"
       ]
     },
-    "oauth_client_secret": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["input", "transport"],
-      "properties": {
-        "input": { "type": "string", "minLength": 1 },
-        "transport": { "type": "string", "enum": ["basic_auth", "request_body"] }
-      }
+    "SourceConfigCredentialMethodKind": {
+      "type": "string",
+      "enum": [
+        "source_config"
+      ]
     },
-    "oauth_scopes": {
+    "OAuthCredentialMethod": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["scope"],
       "properties": {
-        "scope": { "$ref": "#/$defs/oauth_scope" }
-      }
+        "type": {
+          "$ref": "#/$defs/OAuthCredentialMethodKind"
+        },
+        "label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "description": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "oauth": {
+          "$ref": "#/$defs/OAuthCredential"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "oauth"
+      ]
     },
-    "oauth_scope": {
+    "OAuthCredentialMethodKind": {
+      "type": "string",
+      "enum": [
+        "oauth"
+      ]
+    },
+    "OAuthCredential": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["delimiter", "values"],
       "properties": {
-        "delimiter": { "type": "string", "enum": ["space", "comma"] },
+        "flow": {
+          "$ref": "#/$defs/OAuthFlow"
+        },
+        "redirect_uri": {
+          "type": "string",
+          "minLength": 1
+        },
+        "endpoints": {
+          "$ref": "#/$defs/OAuthEndpoints"
+        },
+        "client": {
+          "$ref": "#/$defs/OAuthClient"
+        },
+        "scopes": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OAuthScopes"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "flow",
+        "redirect_uri",
+        "endpoints",
+        "client"
+      ]
+    },
+    "OAuthFlow": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/OAuthFlowKind"
+        },
+        "pkce": {
+          "$ref": "#/$defs/OAuthPkce"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "pkce"
+      ]
+    },
+    "OAuthFlowKind": {
+      "type": "string",
+      "enum": [
+        "authorization_code"
+      ]
+    },
+    "OAuthPkce": {
+      "type": "string",
+      "enum": [
+        "required",
+        "disabled"
+      ]
+    },
+    "OAuthEndpoints": {
+      "type": "object",
+      "properties": {
+        "authorization_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "token_url": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "authorization_url",
+        "token_url"
+      ]
+    },
+    "OAuthClient": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/OAuthClientId"
+        },
+        "secret": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OAuthClientSecret"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id"
+      ]
+    },
+    "OAuthClientId": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "input": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "OAuthClientSecret": {
+      "type": "object",
+      "properties": {
+        "input": {
+          "type": "string",
+          "minLength": 1
+        },
+        "transport": {
+          "$ref": "#/$defs/OAuthClientSecretTransport"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "input",
+        "transport"
+      ]
+    },
+    "OAuthClientSecretTransport": {
+      "type": "string",
+      "enum": [
+        "basic_auth",
+        "request_body"
+      ]
+    },
+    "OAuthScopes": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "$ref": "#/$defs/OAuthScope"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "scope"
+      ]
+    },
+    "OAuthScope": {
+      "type": "object",
+      "properties": {
+        "delimiter": {
+          "$ref": "#/$defs/OAuthScopeDelimiter"
+        },
         "values": {
           "type": "array",
-          "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "delimiter",
+        "values"
+      ]
     },
-    "auth": {
+    "OAuthScopeDelimiter": {
+      "type": "string",
+      "enum": [
+        "space",
+        "comma"
+      ]
+    },
+    "Auth": {
       "oneOf": [
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["type", "username", "password"],
           "properties": {
-            "type": { "const": "BasicAuth" },
-            "username": { "type": "string", "minLength": 1 },
-            "password": { "type": "string", "minLength": 1 }
-          }
+            "username": {
+              "type": "string",
+              "minLength": 1
+            },
+            "password": {
+              "type": "string",
+              "minLength": 1
+            },
+            "type": {
+              "type": "string",
+              "const": "BasicAuth"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "type",
+            "username",
+            "password"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["type"],
           "properties": {
-            "type": { "const": "HeaderAuth" },
             "headers": {
               "type": "array",
-              "items": { "$ref": "#/$defs/header" }
+              "items": {
+                "$ref": "#/$defs/Header"
+              }
+            },
+            "type": {
+              "type": "string",
+              "const": "HeaderAuth"
             }
-          }
+          },
+          "additionalProperties": false,
+          "required": [
+            "type"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": true,
-          "required": ["type", "authenticator"],
           "properties": {
-            "type": { "const": "CustomAuth" },
-            "authenticator": { "type": "string", "minLength": 1 }
-          }
+            "type": {
+              "type": "string",
+              "const": "CustomAuth"
+            }
+          },
+          "$ref": "#/$defs/CustomAuth",
+          "required": [
+            "type"
+          ]
         }
       ]
     },
-    "rate_limit": {
+    "Header": {
       "type": "object",
-      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "unevaluatedProperties": false,
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string"
+            },
+            "from": {
+              "type": "string",
+              "const": "template"
+            }
+          },
+          "required": [
+            "from",
+            "template"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": true,
+            "from": {
+              "type": "string",
+              "const": "literal"
+            }
+          },
+          "required": [
+            "from",
+            "value"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_int"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_bool"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split_int"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_int"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_bool"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split_int"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "input"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "state"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "seconds": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "from": {
+              "type": "string",
+              "const": "now_epoch_minus_seconds"
+            }
+          },
+          "required": [
+            "from",
+            "seconds"
+          ]
+        }
+      ]
+    },
+    "CustomAuth": {
+      "type": "object",
+      "properties": {
+        "authenticator": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "authenticator"
+      ],
+      "additionalProperties": true
+    },
+    "RateLimit": {
+      "type": "object",
       "properties": {
         "extra_statuses": {
           "type": "array",
-          "items": { "type": "integer", "minimum": 400, "maximum": 599 },
-          "uniqueItems": true
+          "items": {
+            "type": "integer",
+            "format": "uint16",
+            "minimum": 400,
+            "maximum": 599
+          },
+          "default": []
         },
-        "retry_after_header": { "type": "string", "minLength": 1 },
-        "remaining_header": { "type": "string", "minLength": 1 },
-        "reset_header": { "type": "string", "minLength": 1 }
-      }
+        "retry_after_header": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "remaining_header": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "reset_header": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        }
+      },
+      "additionalProperties": false
     },
-    "http_table": {
+    "HttpTable": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "description"],
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "description": { "type": "string", "minLength": 1 },
-        "guide": { "type": "string" },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "guide": {
+          "type": "string",
+          "default": ""
+        },
         "filters": {
           "type": "array",
-          "items": { "$ref": "#/$defs/filter" }
+          "items": {
+            "$ref": "#/$defs/Filter"
+          }
         },
-        "fetch_limit_default": { "type": "integer", "minimum": 1 },
-        "search_limits": { "$ref": "#/$defs/search_limits" },
+        "fetch_limit_default": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1,
+          "default": null
+        },
+        "search_limits": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SearchLimits"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "detail_hints": {
           "type": "array",
-          "items": { "$ref": "#/$defs/detail_hint" }
+          "items": {
+            "$ref": "#/$defs/DetailHint"
+          }
         },
-        "request": { "$ref": "#/$defs/request" },
+        "request": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Request"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "requests": {
           "type": "array",
           "items": {
-            "type": "object",
-            "additionalProperties": false,
-            "required": ["when_filters"],
-            "properties": {
-              "when_filters": {
-                "type": "array",
-                "items": { "type": "string", "minLength": 1 },
-                "minItems": 1
-              },
-              "method": { "type": "string", "enum": ["GET", "POST"] },
-              "path": { "type": "string", "minLength": 1 },
-              "query": {
-                "type": "array",
-                "items": { "$ref": "#/$defs/query_param" }
-              },
-              "body": { "$ref": "#/$defs/body" },
-              "headers": {
-                "type": "array",
-                "items": { "$ref": "#/$defs/header" }
-              }
-            }
+            "$ref": "#/$defs/RequestRoute"
           }
         },
-        "response": { "$ref": "#/$defs/response" },
-        "pagination": { "$ref": "#/$defs/pagination" },
-        "columns": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/column" }
-        }
-      }
-    },
-    "file_table": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "description", "source"],
-      "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "description": { "type": "string", "minLength": 1 },
-        "guide": { "type": "string" },
-        "filters": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/filter" }
-        },
-        "fetch_limit_default": { "type": "integer", "minimum": 1 },
-        "source": { "$ref": "#/$defs/source" },
-        "columns": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/column" }
-        }
-      }
-    },
-    "source": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["location"],
-      "properties": {
-        "location": { "type": "string", "minLength": 1 },
-        "glob": { "type": "string", "minLength": 1 },
-        "partitions": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/partition_column" }
-        }
-      }
-    },
-    "partition_column": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "type"],
-      "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "type": { "type": "string", "minLength": 1 }
-      }
-    },
-    "manifest_data_type": {
-      "type": "string",
-      "enum": ["Utf8", "Int64", "Boolean", "Float64", "Timestamp", "Json"]
-    },
-    "filter": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name"],
-      "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "type": { "$ref": "#/$defs/manifest_data_type" },
-        "required": { "type": "boolean" },
-        "mode": {
-          "oneOf": [
-            { "const": "equality" },
+        "response": {
+          "anyOf": [
             {
-              "const": "search",
-              "deprecated": true,
-              "description": "Compatibility-only virtual-filter marker. New provider-native search surfaces should use kind: search table functions."
+              "$ref": "#/$defs/Response"
             },
-            { "const": "contains" }
+            {
+              "type": "null"
+            }
           ]
         },
-        "description": { "type": "string" }
-      }
-    },
-    "search_limits": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["default_top_k", "max_top_k", "max_calls_per_query"],
-      "properties": {
-        "default_top_k": { "type": "integer", "minimum": 1, "maximum": 1000 },
-        "max_top_k": { "type": "integer", "minimum": 1, "maximum": 1000 },
-        "max_calls_per_query": { "type": "integer", "minimum": 1, "maximum": 100 }
-      }
-    },
-    "detail_hint": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["table", "search_result_column", "detail_filter", "purpose"],
-      "properties": {
-        "table": { "type": "string", "minLength": 1 },
-        "search_result_column": { "type": "string", "minLength": 1 },
-        "detail_filter": { "type": "string", "minLength": 1 },
-        "purpose": { "type": "string", "minLength": 1 }
-      }
-    },
-    "table_function": {
-      "type": "object",
-      "additionalProperties": false,
-      "allOf": [
-        {
-          "if": {
-            "properties": { "kind": { "const": "search" } },
-            "required": ["kind"]
-          },
-          "then": { "required": ["search_limits"] }
-        }
-      ],
-      "required": ["name", "request"],
-      "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "kind": { "type": "string", "enum": ["table", "search"] },
-        "description": { "type": "string" },
-        "fetch_limit_default": { "type": "integer", "minimum": 1 },
-        "search_limits": { "$ref": "#/$defs/search_limits" },
-        "detail_hints": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/detail_hint" }
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Pagination"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
-        "args": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/table_function_arg" }
-        },
-        "request": { "$ref": "#/$defs/request" },
-        "response": { "$ref": "#/$defs/response" },
-        "pagination": { "$ref": "#/$defs/pagination" },
         "columns": {
           "type": "array",
-          "items": { "$ref": "#/$defs/column" }
+          "items": {
+            "$ref": "#/$defs/Column"
+          }
         }
-      }
-    },
-    "table_function_arg": {
-      "type": "object",
+      },
       "additionalProperties": false,
-      "required": ["name", "bind"],
+      "required": [
+        "name",
+        "description"
+      ]
+    },
+    "Filter": {
+      "type": "object",
       "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "required": { "type": "boolean" },
-        "values": {
-          "type": "array",
-          "items": { "type": "string", "minLength": 1 },
-          "uniqueItems": true
+        "name": {
+          "type": "string",
+          "minLength": 1
         },
-        "bind": { "$ref": "#/$defs/function_binding" }
-      }
-    },
-    "function_binding": {
-      "type": "object",
+        "type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ManifestDataType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "required": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FilterMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        }
+      },
       "additionalProperties": false,
-      "required": ["arg"],
-      "properties": {
-        "arg": { "type": "string", "minLength": 1 }
-      }
+      "required": [
+        "name"
+      ]
     },
-    "request": {
+    "ManifestDataType": {
+      "type": "string",
+      "enum": [
+        "Utf8",
+        "Int64",
+        "Boolean",
+        "Float64",
+        "Timestamp",
+        "Json"
+      ]
+    },
+    "FilterMode": {
+      "type": "string",
+      "enum": [
+        "equality",
+        "search",
+        "contains"
+      ]
+    },
+    "SearchLimits": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["path"],
       "properties": {
-        "method": { "type": "string", "enum": ["GET", "POST"] },
-        "path": { "type": "string", "minLength": 1 },
+        "default_top_k": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "max_top_k": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "max_calls_per_query": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "default_top_k",
+        "max_top_k",
+        "max_calls_per_query"
+      ]
+    },
+    "DetailHint": {
+      "type": "object",
+      "properties": {
+        "table": {
+          "type": "string",
+          "minLength": 1
+        },
+        "search_result_column": {
+          "type": "string",
+          "minLength": 1
+        },
+        "detail_filter": {
+          "type": "string",
+          "minLength": 1
+        },
+        "purpose": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "table",
+        "search_result_column",
+        "detail_filter",
+        "purpose"
+      ]
+    },
+    "Request": {
+      "type": "object",
+      "properties": {
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
         "query": {
           "type": "array",
-          "items": { "$ref": "#/$defs/query_param" }
+          "items": {
+            "$ref": "#/$defs/QueryParam"
+          }
         },
-        "body": { "$ref": "#/$defs/body" },
+        "body": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Body"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "headers": {
           "type": "array",
-          "items": { "$ref": "#/$defs/header" }
+          "items": {
+            "$ref": "#/$defs/Header"
+          }
         }
-      }
+      },
+      "additionalProperties": false,
+      "required": [
+        "path"
+      ]
     },
-    "body": {
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "GET",
+        "POST"
+      ]
+    },
+    "QueryParam": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "unevaluatedProperties": false,
       "oneOf": [
         {
-          "type": "array",
-          "items": { "$ref": "#/$defs/body_field" }
-        },
-        {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "fields"],
           "properties": {
-            "format": { "const": "json" },
-            "fields": {
-              "type": "array",
-              "items": { "$ref": "#/$defs/body_field" }
+            "template": {
+              "type": "string"
+            },
+            "from": {
+              "type": "string",
+              "const": "template"
             }
-          }
+          },
+          "required": [
+            "from",
+            "template"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["format", "content"],
           "properties": {
-            "format": { "const": "text" },
-            "content": { "$ref": "#/$defs/body_text_content" }
-          }
+            "value": true,
+            "from": {
+              "type": "string",
+              "const": "literal"
+            }
+          },
+          "required": [
+            "from",
+            "value"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_int"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_bool"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split_int"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_int"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_bool"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split_int"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "input"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "state"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "seconds": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "from": {
+              "type": "string",
+              "const": "now_epoch_minus_seconds"
+            }
+          },
+          "required": [
+            "from",
+            "seconds"
+          ]
         }
       ]
     },
-    "body_text_content": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["from"],
-      "properties": {
-        "from": { "type": "string" },
-        "template": { "type": "string" },
-        "value": {},
-        "key": { "type": "string", "minLength": 1 },
-        "keys": {
+    "Body": {
+      "anyOf": [
+        {
           "type": "array",
-          "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "$ref": "#/$defs/BodyField"
+          }
         },
-        "default": {},
-        "seconds": { "type": "integer" },
-        "separator": { "type": "string", "minLength": 1 },
-        "part": { "type": "integer", "minimum": 0 }
-      },
-      "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
-    },
-    "query_param": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "from"],
-      "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "explode": { "type": "boolean" },
-        "from": { "type": "string" },
-        "template": { "type": "string" },
-        "value": {},
-        "key": { "type": "string", "minLength": 1 },
-        "keys": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
+        {
+          "$ref": "#/$defs/JsonBody"
         },
-        "default": {},
-        "seconds": { "type": "integer" },
-        "separator": { "type": "string", "minLength": 1 },
-        "part": { "type": "integer", "minimum": 0 }
-      },
-      "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
+        {
+          "$ref": "#/$defs/TextBody"
+        }
+      ]
     },
-    "body_field": {
+    "BodyField": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["path", "from"],
       "properties": {
         "path": {
           "type": "array",
-          "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "from": { "type": "string" },
-        "template": { "type": "string" },
-        "value": {},
-        "key": { "type": "string", "minLength": 1 },
-        "keys": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "default": {},
-        "seconds": { "type": "integer" },
-        "separator": { "type": "string", "minLength": 1 },
-        "part": { "type": "integer", "minimum": 0 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
       },
-      "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
-    },
-    "header": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "from"],
-      "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "from": { "type": "string" },
-        "template": { "type": "string" },
-        "value": {},
-        "key": { "type": "string", "minLength": 1 },
-        "keys": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "default": {},
-        "seconds": { "type": "integer" },
-        "separator": { "type": "string", "minLength": 1 },
-        "part": { "type": "integer", "minimum": 0 }
-      },
-      "allOf": [{ "$ref": "#/$defs/value_source_switch" }]
-    },
-    "value_source_switch": {
+      "required": [
+        "path"
+      ],
+      "unevaluatedProperties": false,
       "oneOf": [
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "template" },
-            "template": { "type": "string" }
+            "template": {
+              "type": "string"
+            },
+            "from": {
+              "type": "string",
+              "const": "template"
+            }
           },
-          "required": ["template"]
+          "required": [
+            "from",
+            "template"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "literal" },
-            "value": {}
+            "value": true,
+            "from": {
+              "type": "string",
+              "const": "literal"
+            }
           },
-          "required": ["value"]
+          "required": [
+            "from",
+            "value"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "filter" },
-            "key": { "type": "string", "minLength": 1 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "filter_int" },
-            "key": { "type": "string", "minLength": 1 },
-            "default": { "type": "integer" }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_int"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "filter_bool" },
-            "key": { "type": "string", "minLength": 1 },
-            "default": { "type": "boolean" }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_bool"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "filter_split" },
-            "key": { "type": "string", "minLength": 1 },
-            "separator": { "type": "string", "minLength": 1 },
-            "part": { "type": "integer", "minimum": 0 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split"
+            }
           },
-          "required": ["key", "separator", "part"]
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "filter_split_int" },
-            "key": { "type": "string", "minLength": 1 },
-            "separator": { "type": "string", "minLength": 1 },
-            "part": { "type": "integer", "minimum": 0 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split_int"
+            }
           },
-          "required": ["key", "separator", "part"]
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "arg" },
-            "key": { "type": "string", "minLength": 1 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "arg_int" },
-            "key": { "type": "string", "minLength": 1 },
-            "default": { "type": "integer" }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_int"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "arg_bool" },
-            "key": { "type": "string", "minLength": 1 },
-            "default": { "type": "boolean" }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_bool"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "arg_split" },
-            "key": { "type": "string", "minLength": 1 },
-            "separator": { "type": "string", "minLength": 1 },
-            "part": { "type": "integer", "minimum": 0 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split"
+            }
           },
-          "required": ["key", "separator", "part"]
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "arg_split_int" },
-            "key": { "type": "string", "minLength": 1 },
-            "separator": { "type": "string", "minLength": 1 },
-            "part": { "type": "integer", "minimum": 0 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split_int"
+            }
           },
-          "required": ["key", "separator", "part"]
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "input" },
-            "key": { "type": "string", "minLength": 1 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "input"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "state" },
-            "key": { "type": "string", "minLength": 1 }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "state"
+            }
           },
-          "required": ["key"]
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
+          "type": "object",
           "properties": {
-            "from": { "const": "now_epoch_minus_seconds" },
-            "seconds": { "type": "integer" }
+            "seconds": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "from": {
+              "type": "string",
+              "const": "now_epoch_minus_seconds"
+            }
           },
-          "required": ["seconds"]
+          "required": [
+            "from",
+            "seconds"
+          ]
         }
       ]
     },
-    "response": {
+    "JsonBody": {
       "type": "object",
-      "additionalProperties": false,
       "properties": {
         "format": {
-          "type": "string",
-          "enum": ["json", "json_each_row"]
+          "$ref": "#/$defs/JsonBodyFormat"
         },
-        "rows_path": {
+        "fields": {
           "type": "array",
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "ok_path": {
-          "type": "array",
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "error_path": {
-          "type": "array",
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "allow_404_empty": { "type": "boolean" },
-        "row_strategy": {
-          "type": "string",
-          "enum": ["direct", "series_point_list", "dict_entries"]
+          "items": {
+            "$ref": "#/$defs/BodyField"
+          }
         }
-      }
-    },
-    "pagination": {
-      "type": "object",
+      },
       "additionalProperties": false,
-      "properties": {
-        "mode": {
-          "type": "string",
-          "enum": [
-            "none",
-            "auto",
-            "cursor_query",
-            "cursor_body",
-            "page",
-            "offset",
-            "link_header"
-          ]
-        },
-        "page_size": { "$ref": "#/$defs/page_size" },
-        "cursor_param": { "type": "string", "minLength": 1 },
-        "cursor_body_path": {
-          "type": "array",
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "response_cursor_path": {
-          "type": "array",
-          "items": { "type": "string", "minLength": 1 }
-        },
-        "page_param": { "type": "string", "minLength": 1 },
-        "page_start": { "type": "integer" },
-        "page_step": { "type": "integer", "minimum": 1 },
-        "offset_param": { "type": "string", "minLength": 1 },
-        "offset_start": { "type": "integer" },
-        "offset_step": { "type": "integer", "minimum": 1 },
-        "link_header_require_results": { "type": "boolean" },
-        "max_pages": { "type": "integer", "minimum": 1 }
-      }
+      "required": [
+        "format"
+      ]
     },
-    "page_size": {
+    "JsonBodyFormat": {
+      "type": "string",
+      "enum": [
+        "json"
+      ]
+    },
+    "TextBody": {
       "type": "object",
-      "additionalProperties": false,
-      "required": ["default", "max"],
       "properties": {
-        "default": { "type": "integer", "minimum": 1 },
-        "max": { "type": "integer", "minimum": 1 },
-        "query_param": { "type": "string", "minLength": 1 },
-        "body_path": {
-          "type": "array",
-          "items": { "type": "string", "minLength": 1 }
+        "format": {
+          "$ref": "#/$defs/TextBodyFormat"
+        },
+        "content": {
+          "$ref": "#/$defs/ValueSource"
         }
-      }
-    },
-    "column": {
-      "type": "object",
+      },
       "additionalProperties": false,
-      "required": ["name", "type"],
-      "properties": {
-        "name": { "type": "string", "minLength": 1 },
-        "type": { "$ref": "#/$defs/manifest_data_type" },
-        "nullable": { "type": "boolean" },
-        "virtual": { "type": "boolean" },
-        "description": { "type": "string" },
-        "expr": { "$ref": "#/$defs/expr" }
-      }
+      "required": [
+        "format",
+        "content"
+      ]
     },
-    "expr": {
+    "TextBodyFormat": {
+      "type": "string",
+      "enum": [
+        "text"
+      ]
+    },
+    "ValueSource": {
       "oneOf": [
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "path"],
           "properties": {
-            "kind": { "const": "path" },
-            "path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+            "template": {
+              "type": "string"
+            },
+            "from": {
+              "type": "string",
+              "const": "template"
             }
-          }
+          },
+          "required": [
+            "from",
+            "template"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "exprs"],
           "properties": {
-            "kind": { "const": "coalesce" },
-            "exprs": {
-              "type": "array",
-              "minItems": 1,
-              "items": { "$ref": "#/$defs/expr" }
+            "value": true,
+            "from": {
+              "type": "string",
+              "const": "literal"
             }
-          }
+          },
+          "required": [
+            "from",
+            "value"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "key"],
           "properties": {
-            "kind": { "const": "from_filter" },
-            "key": { "type": "string", "minLength": 1 }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "value"],
-          "properties": {
-            "kind": { "const": "literal" },
-            "value": {}
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind"],
-          "properties": {
-            "kind": { "const": "null" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "path"],
-          "properties": {
-            "kind": { "const": "join_array" },
-            "path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+            "key": {
+              "type": "string",
+              "minLength": 1
             },
-            "separator": { "type": "string" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "path", "item_path"],
-          "properties": {
-            "kind": { "const": "join_array_path" },
-            "path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+            "default": {
+              "default": null
             },
-            "item_path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
-            },
-            "separator": { "type": "string" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "path", "key"],
-          "properties": {
-            "kind": { "const": "tag_value" },
-            "path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
-            },
-            "key": { "type": "string", "minLength": 1 },
-            "key_field": { "type": "string" },
-            "value_field": { "type": "string" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "check", "then_value"],
-          "properties": {
-            "kind": { "const": "if_present" },
-            "check": { "$ref": "#/$defs/expr" },
-            "then_value": { "type": "string" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "path", "key"],
-          "properties": {
-            "kind": { "const": "join_tag_values" },
-            "path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
-            },
-            "key": { "type": "string", "minLength": 1 },
-            "key_field": { "type": "string" },
-            "value_field": { "type": "string" },
-            "separator": { "type": "string" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "path", "item_path"],
-          "properties": {
-            "kind": { "const": "first_array_item_path" },
-            "path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
-            },
-            "item_path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+            "from": {
+              "type": "string",
+              "const": "filter"
             }
-          }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "path", "filter_key", "item_path"],
           "properties": {
-            "kind": { "const": "object_filter_path" },
-            "path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+            "key": {
+              "type": "string",
+              "minLength": 1
             },
-            "filter_key": { "type": "string", "minLength": 1 },
-            "item_path": {
-              "type": "array",
-              "items": { "type": "string", "minLength": 1 }
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_int"
             }
-          }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
         },
         {
           "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "expr", "from", "to"],
           "properties": {
-            "kind": { "const": "replace" },
-            "expr": { "$ref": "#/$defs/expr" },
-            "from": { "type": "string", "minLength": 1 },
-            "to": { "type": "string" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind"],
-          "properties": {
-            "kind": { "const": "current_row" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "expr"],
-          "properties": {
-            "kind": { "const": "format_timestamp" },
-            "expr": { "$ref": "#/$defs/expr" },
-            "input": { "type": "string", "enum": ["seconds", "milliseconds", "iso8601"] }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "expr"],
-          "properties": {
-            "kind": { "const": "base64_decode" },
-            "expr": { "$ref": "#/$defs/expr" }
-          }
-        },
-        {
-          "type": "object",
-          "additionalProperties": false,
-          "required": ["kind", "template", "values"],
-          "properties": {
-            "kind": { "const": "template" },
-            "template": { "type": "string", "minLength": 1 },
-            "values": {
-              "type": "object",
-              "additionalProperties": { "$ref": "#/$defs/expr" }
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_bool"
             }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "filter_split_int"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_int"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "default": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "default": null
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_bool"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "separator": {
+              "type": "string",
+              "minLength": 1
+            },
+            "part": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0
+            },
+            "from": {
+              "type": "string",
+              "const": "arg_split_int"
+            }
+          },
+          "required": [
+            "from",
+            "key",
+            "separator",
+            "part"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "input"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "from": {
+              "type": "string",
+              "const": "state"
+            }
+          },
+          "required": [
+            "from",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "seconds": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "from": {
+              "type": "string",
+              "const": "now_epoch_minus_seconds"
+            }
+          },
+          "required": [
+            "from",
+            "seconds"
+          ]
+        }
+      ]
+    },
+    "RequestRoute": {
+      "type": "object",
+      "properties": {
+        "when_filters": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        },
+        "method": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HttpMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "query": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/QueryParam"
+          }
+        },
+        "body": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Body"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "headers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Header"
           }
         }
+      },
+      "additionalProperties": false,
+      "required": [
+        "when_filters",
+        "path"
+      ]
+    },
+    "Response": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ResponseBodyFormat"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "rows_path": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "ok_path": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "error_path": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "allow_404_empty": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "row_strategy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RowStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "ResponseBodyFormat": {
+      "type": "string",
+      "enum": [
+        "json",
+        "json_each_row"
+      ]
+    },
+    "RowStrategy": {
+      "type": "string",
+      "enum": [
+        "direct",
+        "series_point_list",
+        "dict_entries"
+      ]
+    },
+    "Pagination": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PaginationMode"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "page_size": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PageSize"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "cursor_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "cursor_body_path": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "response_cursor_path": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "page_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "page_start": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "default": null
+        },
+        "page_step": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "minimum": 1,
+          "default": null
+        },
+        "offset_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "offset_start": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "default": null
+        },
+        "offset_step": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "int64",
+          "minimum": 1,
+          "default": null
+        },
+        "link_header_require_results": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "max_pages": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1,
+          "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "PaginationMode": {
+      "type": "string",
+      "enum": [
+        "none",
+        "auto",
+        "cursor_query",
+        "cursor_body",
+        "page",
+        "offset",
+        "link_header"
+      ]
+    },
+    "PageSize": {
+      "type": "object",
+      "properties": {
+        "default": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1
+        },
+        "max": {
+          "type": "integer",
+          "format": "uint",
+          "minimum": 1
+        },
+        "query_param": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "body_path": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "default",
+        "max"
+      ]
+    },
+    "Column": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "$ref": "#/$defs/ManifestDataType"
+        },
+        "nullable": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "virtual": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "expr": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Expr"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "Expr": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "path"
+            }
+          },
+          "required": [
+            "kind",
+            "path"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "exprs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/Expr"
+              },
+              "minItems": 1
+            },
+            "kind": {
+              "type": "string",
+              "const": "coalesce"
+            }
+          },
+          "required": [
+            "kind",
+            "exprs"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "kind": {
+              "type": "string",
+              "const": "from_filter"
+            }
+          },
+          "required": [
+            "kind",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": true,
+            "kind": {
+              "type": "string",
+              "const": "literal"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "null"
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "separator": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "kind": {
+              "type": "string",
+              "const": "join_array"
+            }
+          },
+          "required": [
+            "kind",
+            "path"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "item_path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "separator": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "kind": {
+              "type": "string",
+              "const": "join_array_path"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "item_path"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "key_field": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "value_field": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "kind": {
+              "type": "string",
+              "const": "tag_value"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "check": {
+              "$ref": "#/$defs/Expr"
+            },
+            "then_value": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "if_present"
+            }
+          },
+          "required": [
+            "kind",
+            "check",
+            "then_value"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "key_field": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "value_field": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "separator": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "default": null
+            },
+            "kind": {
+              "type": "string",
+              "const": "join_tag_values"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "key"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "item_path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "first_array_item_path"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "item_path"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "filter_key": {
+              "type": "string",
+              "minLength": 1
+            },
+            "item_path": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "object_filter_path"
+            }
+          },
+          "required": [
+            "kind",
+            "path",
+            "filter_key",
+            "item_path"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "type": "string",
+              "const": "current_row"
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/Expr"
+            },
+            "input": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/TimestampInput"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "kind": {
+              "type": "string",
+              "const": "format_timestamp"
+            }
+          },
+          "required": [
+            "kind",
+            "expr"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/Expr"
+            },
+            "kind": {
+              "type": "string",
+              "const": "base64_decode"
+            }
+          },
+          "required": [
+            "kind",
+            "expr"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/Expr"
+            },
+            "from": {
+              "type": "string",
+              "minLength": 1
+            },
+            "to": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string",
+              "const": "replace"
+            }
+          },
+          "required": [
+            "kind",
+            "expr",
+            "from",
+            "to"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string",
+              "minLength": 1
+            },
+            "values": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/$defs/Expr"
+              }
+            },
+            "kind": {
+              "type": "string",
+              "const": "template"
+            }
+          },
+          "required": [
+            "kind",
+            "template",
+            "values"
+          ]
+        }
+      ]
+    },
+    "TimestampInput": {
+      "type": "string",
+      "enum": [
+        "seconds",
+        "milliseconds",
+        "iso8601"
+      ]
+    },
+    "TableFunction": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/SearchTableFunction"
+        },
+        {
+          "$ref": "#/$defs/ExplicitTableFunction"
+        },
+        {
+          "$ref": "#/$defs/DefaultTableFunction"
+        }
+      ]
+    },
+    "SearchTableFunction": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "$ref": "#/$defs/SearchTableFunctionKind"
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "fetch_limit_default": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1,
+          "default": null
+        },
+        "search_limits": {
+          "$ref": "#/$defs/SearchLimits"
+        },
+        "detail_hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DetailHint"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TableFunctionArg"
+          }
+        },
+        "request": {
+          "$ref": "#/$defs/Request"
+        },
+        "response": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Response"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Pagination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Column"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "kind",
+        "search_limits",
+        "request"
+      ]
+    },
+    "SearchTableFunctionKind": {
+      "type": "string",
+      "enum": [
+        "search"
+      ]
+    },
+    "TableFunctionArg": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "required": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "bind": {
+          "$ref": "#/$defs/FunctionBinding"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "bind"
+      ]
+    },
+    "FunctionBinding": {
+      "type": "object",
+      "properties": {
+        "arg": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "arg"
+      ]
+    },
+    "ExplicitTableFunction": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "$ref": "#/$defs/ExplicitTableFunctionKind"
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "fetch_limit_default": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1,
+          "default": null
+        },
+        "search_limits": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SearchLimits"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "detail_hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DetailHint"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TableFunctionArg"
+          }
+        },
+        "request": {
+          "$ref": "#/$defs/Request"
+        },
+        "response": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Response"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Pagination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Column"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "kind",
+        "request"
+      ]
+    },
+    "ExplicitTableFunctionKind": {
+      "type": "string",
+      "enum": [
+        "table"
+      ]
+    },
+    "DefaultTableFunction": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "fetch_limit_default": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1,
+          "default": null
+        },
+        "search_limits": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SearchLimits"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "detail_hints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/DetailHint"
+          }
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TableFunctionArg"
+          }
+        },
+        "request": {
+          "$ref": "#/$defs/Request"
+        },
+        "response": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Response"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "pagination": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Pagination"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Column"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "request"
+      ]
+    },
+    "HttpManifestWithTables": {
+      "type": "object",
+      "properties": {
+        "dsl_version": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 3,
+          "maximum": 3
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "test_queries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "backend": {
+          "$ref": "#/$defs/HttpBackend"
+        },
+        "inputs": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/Input"
+          }
+        },
+        "base_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "auth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Auth"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "request_headers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Header"
+          }
+        },
+        "rate_limit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "tables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HttpTable"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "dsl_version",
+        "name",
+        "version",
+        "backend",
+        "base_url",
+        "tables"
+      ]
+    },
+    "HttpManifestWithFunctions": {
+      "type": "object",
+      "properties": {
+        "dsl_version": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 3,
+          "maximum": 3
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "test_queries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "backend": {
+          "$ref": "#/$defs/HttpBackend"
+        },
+        "inputs": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/Input"
+          }
+        },
+        "base_url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "auth": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Auth"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "request_headers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Header"
+          }
+        },
+        "rate_limit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RateLimit"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "functions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TableFunction"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "dsl_version",
+        "name",
+        "version",
+        "backend",
+        "base_url",
+        "functions"
+      ]
+    },
+    "FileManifest": {
+      "type": "object",
+      "properties": {
+        "dsl_version": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 3,
+          "maximum": 3
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "test_queries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "backend": {
+          "$ref": "#/$defs/ParquetBackend"
+        },
+        "inputs": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/Input"
+          }
+        },
+        "tables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FileTable"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "dsl_version",
+        "name",
+        "version",
+        "backend",
+        "tables"
+      ]
+    },
+    "ParquetBackend": {
+      "type": "string",
+      "enum": [
+        "parquet"
+      ]
+    },
+    "FileTable": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "guide": {
+          "type": "string",
+          "default": ""
+        },
+        "filters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Filter"
+          }
+        },
+        "fetch_limit_default": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 1,
+          "default": null
+        },
+        "source": {
+          "$ref": "#/$defs/FileSource"
+        },
+        "columns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Column"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "description",
+        "source"
+      ]
+    },
+    "FileSource": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "minLength": 1
+        },
+        "glob": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1,
+          "default": null
+        },
+        "partitions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/PartitionColumn"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "location"
+      ]
+    },
+    "PartitionColumn": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "$ref": "#/$defs/ManifestDataType"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "FileManifest2": {
+      "type": "object",
+      "properties": {
+        "dsl_version": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 3,
+          "maximum": 3
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
+        "test_queries": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "default": []
+        },
+        "backend": {
+          "$ref": "#/$defs/JsonlBackend"
+        },
+        "inputs": {
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/Input"
+          }
+        },
+        "tables": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/FileTable"
+          },
+          "minItems": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "dsl_version",
+        "name",
+        "version",
+        "backend",
+        "tables"
+      ]
+    },
+    "JsonlBackend": {
+      "type": "string",
+      "enum": [
+        "jsonl"
       ]
     }
   }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,6 +8,7 @@
 //!     (the regression gate for the SOURCE-465 manifest cleanup).
 //!   - `export-skills` exports installable agent skills from the canonical
 //!     plugin tree into a distribution checkout.
+//!   - `generate-source-schema` regenerates the source manifest JSON Schema.
 
 #![allow(
     clippy::print_stderr,
@@ -21,7 +22,9 @@ use std::process::ExitCode;
 
 use anyhow::{Context, Result, bail};
 use clap::{Parser, Subcommand};
-use coral_spec::{ValidatedSourceManifest, parse_source_manifest_yaml};
+use coral_spec::{
+    ValidatedSourceManifest, parse_source_manifest_yaml, source_manifest_schema_json,
+};
 
 mod detect;
 mod nav;
@@ -43,6 +46,8 @@ enum Command {
     DetectTruncations(DetectArgs),
     /// Export installable skills from plugins/coral/skills.
     ExportSkills(ExportSkillsArgs),
+    /// Regenerate the source manifest JSON Schema from Rust schema types.
+    GenerateSourceSchema(GenerateSourceSchemaArgs),
 }
 
 #[derive(Debug, clap::Args)]
@@ -109,6 +114,21 @@ struct ExportSkillsArgs {
     dest: PathBuf,
 }
 
+#[derive(Debug, clap::Args)]
+struct GenerateSourceSchemaArgs {
+    /// Path to the checked-in source manifest JSON Schema.
+    #[arg(
+        long,
+        default_value = "crates/coral-spec/src/schema/source_manifest.schema.json"
+    )]
+    output: PathBuf,
+
+    /// Render in memory and diff against disk instead of writing.
+    /// Exits non-zero if the generated schema differs from its on-disk copy.
+    #[arg(long)]
+    check: bool,
+}
+
 fn main() -> ExitCode {
     let cli = Cli::parse();
     match run(&cli.command) {
@@ -135,6 +155,22 @@ fn run(command: &Command) -> Result<bool> {
             detect::run(&paths, args.verbose)
         }
         Command::ExportSkills(args) => skills::export(&args.dest),
+        Command::GenerateSourceSchema(args) => generate_source_schema(args),
+    }
+}
+
+fn generate_source_schema(args: &GenerateSourceSchemaArgs) -> Result<bool> {
+    let schema = source_manifest_schema_json().context("serializing source manifest schema")?;
+    let output = GeneratedFile {
+        path: args.output.clone(),
+        body: schema,
+    };
+
+    if args.check {
+        Ok(check_mode(&[output]))
+    } else {
+        write_mode(&[output])?;
+        Ok(true)
     }
 }
 


### PR DESCRIPTION
## What changed

- Replaced the hand-maintained source manifest JSON Schema with a schema generated from Rust schema-facing manifest document types in `coral-spec` using `schemars`.
- Added `source_manifest_schema()` / `source_manifest_schema_json()` and a stale-schema unit test so the checked-in schema must match generated output.
- Added `xtask generate-source-schema` plus `make source-schema-generate` and `make source-schema-check` for regeneration and CI freshness checks.
- Replaced parser backend dispatch from manual `value.get("backend")` extraction with typed deserialization through a small dispatch struct.
- Updated schema-dependent downstream assertions for the generated schema's top-level union error shape.

## Why

The checked-in manifest schema was manually authored and easy to drift from the Rust parser contract. Modeling the authored manifest document in Rust makes the schema deterministic and keeps the source of truth inside `coral-spec`.

## Behavior and contributor impact

Manifest validation behavior is preserved. Where diagnostics changed, the generated schema now rejects invalid backend-specific shapes through the generated top-level union rather than the previous hand-written conditional schema paths.

Contributor behavior changed: source manifest schema edits should now go through the Rust schema-facing types and `make source-schema-generate`, with `make source-schema-check`/unit tests catching stale checked-in JSON.

## Validation

- `env RUSTC_WRAPPER= make source-schema-check`
- `env RUSTC_WRAPPER= make rust-checks`

`RUSTC_WRAPPER=` was used because local `sccache` returned `Operation not permitted` under the sandbox; the checks ran directly through rustc.