### PR TITLE
feat(sources): add Discord community source spec

### DIFF
--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -22,10 +22,11 @@ When inviting the bot to your server, use the OAuth2 URL Generator with:
 |---|---|---|
 | Read Messages / View Channels | `0x400` | All guild-scoped tables (channels, messages, members, roles) |
 | Read Message History | `0x10000` | `messages` table |
-| Read Members | `0x20` | `members` table (in addition to the `GUILD_MEMBERS` privileged intent) |
 | Send Messages | `0x800` | Not required for querying; only needed if the bot posts messages |
 
-The minimal permission integer for read-only queries is `0x10420` (Read Members + Read Messages / View Channels + Read Message History).
+The `members` table additionally requires the `GUILD_MEMBERS` privileged intent (configured in step 1.3), but no extra bot permission beyond `VIEW_CHANNEL`.
+
+The minimal permission integer for read-only queries is `0x10400` (View Channels + Read Message History).
 
 ### 3. Set the bot token
 

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -18,7 +18,7 @@ Configure the following by table:
 | `guilds` | Token only | none | none |
 | `channels` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`) |
 | `messages` | `channel_id` filter | `MESSAGE_CONTENT` | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
-| `members` | `guild_id` filter | `GUILD_MEMBERS` | `VIEW_CHANNEL` (`0x400`) |
+| `members` | `guild_id` filter | `GUILD_MEMBERS` | none |
 | `roles` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`) |
 
 **Privileged intents** are enabled in the Developer Portal under **Bot → Privileged Gateway Intents**. Without `GUILD_MEMBERS`, `GET /guilds/{guild.id}/members` returns an empty result. Without `MESSAGE_CONTENT`, the `content`, `embeds`, and `attachments` columns return empty values.

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -8,7 +8,7 @@ Query guilds, channels, messages, members, and roles from a Discord server via t
 2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token
 3. Enable the **Privileged Gateway Intents** your queries need:
    - **`GUILD_MEMBERS`** — required for the `members` table. Without this intent, the endpoint returns an empty member list for guilds with 250k+ members and may be restricted in smaller guilds.
-   - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, `attachments`, and `components` from the `messages` table. Without this intent, those fields will be empty (`""` or `[]`).
+   - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without this intent, those fields will be empty (`""` or `[]`).
 4. Invite the bot to your server using the OAuth2 URL Generator with the `bot` scope and the required bot permissions:
    - `Read Messages / View Channels` — channels, messages
    - `Read Message History` — message `content`, `embeds`, `attachments`

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -6,10 +6,12 @@ Query guilds, channels, messages, members, and roles from a Discord server via t
 
 1. Create a Discord application at https://discord.com/developers/applications
 2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token
-3. Under **Privileged Gateway Intents**, enable **Server Members Intent** if you want to query the `members` table for guilds with 250k+ members
-4. Invite the bot to your server using the OAuth2 URL Generator with `bot` scope and the required permissions:
+3. Enable the **Privileged Gateway Intents** your queries need:
+   - **`GUILD_MEMBERS`** — required for the `members` table. Without this intent, the endpoint returns an empty member list for guilds with 250k+ members and may be restricted in smaller guilds.
+   - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, `attachments`, and `components` from the `messages` table. Without this intent, those fields will be empty (`""` or `[]`).
+4. Invite the bot to your server using the OAuth2 URL Generator with the `bot` scope and the required bot permissions:
    - `Read Messages / View Channels` — channels, messages
-   - `Read Message History` — message content
+   - `Read Message History` — message `content`, `embeds`, `attachments`
    - `Request Server Members` — members
 
 ## Tables
@@ -34,7 +36,7 @@ coral source test discord
 
 ```sql
 -- List all guilds with member counts
-SELECT id, name, member_count, premium_tier FROM discord.guilds;
+SELECT id, name, member_count FROM discord.guilds;
 
 --- List text channels in a specific guild
 SELECT id, name, position, topic

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -1,0 +1,73 @@
+# Discord
+
+Query guilds, channels, messages, members, and roles from a Discord server via the [Discord REST API v10](https://discord.com/developers/docs/intro).
+
+## Prerequisites
+
+1. Create a Discord application at https://discord.com/developers/applications
+2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token
+3. Under **Privileged Gateway Intents**, enable **Server Members Intent** if you want to query the `members` table for guilds with 250k+ members
+4. Invite the bot to your server using the OAuth2 URL Generator with `bot` scope and the required permissions:
+   - `Read Messages / View Channels` — channels, messages
+   - `Read Message History` — message content
+   - `Request Server Members` — members
+
+## Tables
+
+| Table | Description | Required filter |
+|-------|-------------|----------------|
+| `guilds` | Servers the bot has access to | none |
+| `channels` | Channels in a guild | `guild_id` |
+| `messages` | Messages in a channel | `channel_id` |
+| `members` | Guild members | `guild_id` |
+| `roles` | Guild roles | `guild_id` |
+
+## Setup
+
+```shell
+export DISCORD_BOT_TOKEN=your_bot_token_here
+coral source add --file sources/community/discord/manifest.yaml
+coral source test discord
+```
+
+## Example queries
+
+```sql
+-- List all guilds with member counts
+SELECT id, name, member_count, premium_tier FROM discord.guilds;
+
+--- List text channels in a specific guild
+SELECT id, name, position, topic
+FROM discord.channels
+WHERE guild_id = '123456789012345678'
+  AND type = 0;
+
+--- Recent messages in a channel
+SELECT id, author__username, content, timestamp
+FROM discord.messages
+WHERE channel_id = '123456789012345678'
+ORDER BY timestamp DESC
+LIMIT 20;
+
+--- Members who are actively boosting
+SELECT user__username, nickname, premium_since, joined_at
+FROM discord.members
+WHERE guild_id = '123456789012345678'
+  AND premium_since IS NOT NULL;
+
+--- Roles sorted by hierarchy
+SELECT id, name, color, position, permissions
+FROM discord.roles
+WHERE guild_id = '123456789012345678'
+ORDER BY position DESC;
+```
+
+## Column naming
+
+Nested API fields use double-underscore (`__`) flattening:
+
+- `author__id` → `author.id` in the API response
+- `author__username` → `author.username`
+- `user__global_name` → `user.global_name`
+
+This matches the convention used across bundled Coral sources.

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -94,7 +94,8 @@ Privileged gateway intents are distinct from bot permissions and must be enabled
 ## Validation
 
 The following output was captured from a live Discord bot at setup time to confirm that
-the source connects, authenticates, and returns real data from all six tables.
+the source connects, authenticates, and returns real data from all six tables. IDs,
+names, and message content are anonymized to placeholders.
 
 ```shell
 # Add the source
@@ -138,58 +139,58 @@ $ coral source test discord
 
 # Current user identity
 $ coral sql "SELECT * FROM discord.current_user LIMIT 1"
-+---------------------+------------+---------------+-------------+--------+------+-------------+----------+--------+-------+
-| id                  | username   | discriminator | global_name | avatar | bot  | mfa_enabled | verified | locale | email |
-+---------------------+------------+---------------+-------------+--------+------+-------------+----------+--------+-------+
-| 1507725747283038289 | coral-test | 6073          |             |        | true | false       | true     | en-US  |       |
-+---------------------+------------+---------------+-------------+--------+------+-------------+----------+--------+-------+
++--------------------+-----------+---------------+-------------+--------+-----+-------------+----------+--------+-------+
+| id                 | username  | discriminator | global_name | avatar | bot | mfa_enabled | verified | locale | email |
++--------------------+-----------+---------------+-------------+--------+-----+-------------+----------+--------+-------+
+| 123456789012345678 | bot_user  | 0000          |             |        | true | false       | true     | en-US  |       |
++--------------------+-----------+---------------+-------------+--------+-----+-------------+----------+--------+-------+
 
 # Guilds
 $ coral sql "SELECT id, name, approximate_member_count FROM discord.guilds WHERE with_counts = true LIMIT 5"
-+---------------------+----------------------+--------------------------+
-| id                  | name                 | approximate_member_count |
-+---------------------+----------------------+--------------------------+
-| 1299637899427581952 | Yunus.25jmi's server | 2                        |
-+---------------------+----------------------+--------------------------+
++--------------------+-------------+--------------------------+
+| id                 | name        | approximate_member_count |
++--------------------+-------------+--------------------------+
+| 123456789012345679 | Test Server | 2                        |
++--------------------+-------------+--------------------------+
 
 # Channels
-$ coral sql "SELECT id, name, type, position FROM discord.channels WHERE guild_id = '1299637899427581952' LIMIT 10"
-+---------------------+----------------+------+----------+
-| id                  | name           | type | position |
-+---------------------+----------------+------+----------+
-| 1299637899427581953 | Text Channels  | 4    | 0        |
-| 1299637899901276221 | Voice Channels | 4    | 0        |
-| 1299637899901276222 | general        | 0    | 0        |
-| 1299637899901276223 | General        | 2    | 0        |
-+---------------------+----------------+------+----------+
+$ coral sql "SELECT id, name, type, position FROM discord.channels WHERE guild_id = '123456789012345679' LIMIT 10"
++--------------------+----------------+------+----------+
+| id                 | name           | type | position |
++--------------------+----------------+------+----------+
+| 123456789012345680 | Text Channels  | 4    | 0        |
+| 123456789012345681 | Voice Channels | 4    | 0        |
+| 123456789012345682 | general        | 0    | 0        |
+| 123456789012345683 | General        | 2    | 0        |
++--------------------+----------------+------+----------+
 
 # Messages
-$ coral sql "SELECT id, author__username, content, timestamp, flags FROM discord.messages WHERE channel_id = '1299637899901276222' LIMIT 5"
-+---------------------+------------------+---------------------------------------------+--------------------------+-------+
-| id                  | author__username | content                                     | timestamp                | flags |
-+---------------------+------------------+---------------------------------------------+--------------------------+-------+
-| 1507729541039132753 | coral-test       |                                             | 2026-05-23T12:58:54.844Z | 0     |
-| 1475765097581510656 | yunus.25jmi      | https://discord.com/invite/cloudflaredev    | 2026-02-24T08:03:37.653Z | 0     |
-| 1406334871801954324 | yunus.25jmi      | https://discord.com/invite/ZZNkGzkD         | 2025-08-16T17:52:41.876Z | 0     |
-| 1391520906785984676 | yunus.25jmi      | Track 2: WEBSITE UPGRADE MODE** ...         | 2025-07-06T20:47:17.386Z | 0     |
-| 1391520442891767921 | yunus.25jmi      |                                             | 2025-07-06T20:45:26.785Z | 16384 |
-+---------------------+------------------+---------------------------------------------+--------------------------+-------+
+$ coral sql "SELECT id, author__username, content, timestamp, flags FROM discord.messages WHERE channel_id = '123456789012345682' LIMIT 5"
++--------------------+------------------+------------------------+--------------------------+-------+
+| id                 | author__username | content                | timestamp                | flags |
++--------------------+------------------+------------------------+--------------------------+-------+
+| 123456789012345684 | bot_user         |                        | 2026-05-23T12:58:54.844Z | 0     |
+| 123456789012345685 | server_member    | https://example.com/1  | 2026-02-24T08:03:37.653Z | 0     |
+| 123456789012345686 | server_member    | https://example.com/2  | 2025-08-16T17:52:41.876Z | 0     |
+| 123456789012345687 | server_member    | Announcement text      | 2025-07-06T20:47:17.386Z | 0     |
+| 123456789012345688 | server_member    |                        | 2025-07-06T20:45:26.785Z | 16384 |
++--------------------+------------------+------------------------+--------------------------+-------+
 
 # Members
-$ coral sql "SELECT user__username, nick, joined_at, premium_since FROM discord.members WHERE guild_id = '1299637899427581952' LIMIT 10"
+$ coral sql "SELECT user__username, nick, joined_at, premium_since FROM discord.members WHERE guild_id = '123456789012345679' LIMIT 10"
 +----------------+------+--------------------------+---------------+
 | user__username | nick | joined_at                | premium_since |
 +----------------+------+--------------------------+---------------+
-| yunus.25jmi    |      | 2024-10-26T07:37:01.352Z |               |
-| coral-test     |      | 2026-05-23T12:58:54.758Z |               |
+| server_member  |      | 2024-10-26T07:37:01.352Z |               |
+| bot_user       |      | 2026-05-23T12:58:54.758Z |               |
 +----------------+------+--------------------------+---------------+
 
 # Roles
-$ coral sql "SELECT id, name, color, position FROM discord.roles WHERE guild_id = '1299637899427581952' ORDER BY position DESC LIMIT 10"
-+---------------------+------------+-------+----------+
-| id                  | name       | color | position |
-+---------------------+------------+-------+----------+
-| 1507729540284289099 | coral-test | 0     | 1        |
-| 1299637899427581952 | @everyone  | 0     | 0        |
-+---------------------+------------+-------+----------+
+$ coral sql "SELECT id, name, color, position FROM discord.roles WHERE guild_id = '123456789012345679' ORDER BY position DESC LIMIT 10"
++--------------------+------------+-------+----------+
+| id                 | name       | color | position |
++--------------------+------------+-------+----------+
+| 123456789012345689 | bot_role   | 0     | 1        |
+| 123456789012345679 | @everyone  | 0     | 0        |
++--------------------+------------+-------+----------+
 ```

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -7,7 +7,7 @@ Query Discord bot identity, guilds, channels, messages, members, and roles from 
 1. Create a Discord application at https://discord.com/developers/applications
 2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token
 3. Enable the **Privileged Gateway Intents** your queries need:
-   - **`GUILD_MEMBERS`** — required for the `members` table. Without this privileged intent, the endpoint returns an empty member list for guilds with 250k+ members and may be restricted in smaller guilds.
+    - **`GUILD_MEMBERS`** — required for the `members` table. Discord requires this privileged intent for [`GET /guilds/{guild.id}/members`](https://discord.com/developers/resources/guild#list-guild-members); without it the endpoint returns an empty result regardless of guild size.
    - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without this intent, those fields will be empty (`""` or `[]`).
 4. Invite the bot to your server using the OAuth2 URL Generator with the `bot` scope and the required bot permissions (e.g., Read Messages / View Channels, Read Message History).
 
@@ -90,3 +90,106 @@ Privileged gateway intents are distinct from bot permissions and must be enabled
 
 - **`GUILD_MEMBERS`** — required to query the `members` table. Granting the `Read Members` bot permission alone is insufficient.
 - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without this intent, those fields will be empty regardless of the `Read Message History` permission.
+
+## Validation
+
+The following output was captured from a live Discord bot at setup time to confirm that
+the source connects, authenticates, and returns real data from all six tables.
+
+```shell
+# Add the source
+$ DISCORD_BOT_TOKEN="your_bot_token_here" \
+  coral source add --file sources/community/discord/manifest.yaml
+
+Added source discord
+
+  ✓ discord connected successfully
+
+    discord (6 tables)
+    ├─ channels
+    ├─ current_user
+    ├─ guilds
+    ├─ members
+    ├─ messages
+    └─ roles
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT * FROM discord.current_user LIMIT 1
+      1 row
+
+# Test the source
+$ coral source test discord
+
+  ✓ discord connected successfully
+
+    discord (6 tables)
+    ├─ channels
+    ├─ current_user
+    ├─ guilds
+    ├─ members
+    ├─ messages
+    └─ roles
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT * FROM discord.current_user LIMIT 1
+      1 row
+
+# Current user identity
+$ coral sql "SELECT * FROM discord.current_user LIMIT 1"
++---------------------+------------+---------------+-------------+--------+------+-------------+----------+--------+-------+
+| id                  | username   | discriminator | global_name | avatar | bot  | mfa_enabled | verified | locale | email |
++---------------------+------------+---------------+-------------+--------+------+-------------+----------+--------+-------+
+| 1507725747283038289 | coral-test | 6073          |             |        | true | false       | true     | en-US  |       |
++---------------------+------------+---------------+-------------+--------+------+-------------+----------+--------+-------+
+
+# Guilds
+$ coral sql "SELECT id, name, approximate_member_count FROM discord.guilds WHERE with_counts = true LIMIT 5"
++---------------------+----------------------+--------------------------+
+| id                  | name                 | approximate_member_count |
++---------------------+----------------------+--------------------------+
+| 1299637899427581952 | Yunus.25jmi's server | 2                        |
++---------------------+----------------------+--------------------------+
+
+# Channels
+$ coral sql "SELECT id, name, type, position FROM discord.channels WHERE guild_id = '1299637899427581952' LIMIT 10"
++---------------------+----------------+------+----------+
+| id                  | name           | type | position |
++---------------------+----------------+------+----------+
+| 1299637899427581953 | Text Channels  | 4    | 0        |
+| 1299637899901276221 | Voice Channels | 4    | 0        |
+| 1299637899901276222 | general        | 0    | 0        |
+| 1299637899901276223 | General        | 2    | 0        |
++---------------------+----------------+------+----------+
+
+# Messages
+$ coral sql "SELECT id, author__username, content, timestamp, flags FROM discord.messages WHERE channel_id = '1299637899901276222' LIMIT 5"
++---------------------+------------------+---------------------------------------------+--------------------------+-------+
+| id                  | author__username | content                                     | timestamp                | flags |
++---------------------+------------------+---------------------------------------------+--------------------------+-------+
+| 1507729541039132753 | coral-test       |                                             | 2026-05-23T12:58:54.844Z | 0     |
+| 1475765097581510656 | yunus.25jmi      | https://discord.com/invite/cloudflaredev    | 2026-02-24T08:03:37.653Z | 0     |
+| 1406334871801954324 | yunus.25jmi      | https://discord.com/invite/ZZNkGzkD         | 2025-08-16T17:52:41.876Z | 0     |
+| 1391520906785984676 | yunus.25jmi      | Track 2: WEBSITE UPGRADE MODE** ...         | 2025-07-06T20:47:17.386Z | 0     |
+| 1391520442891767921 | yunus.25jmi      |                                             | 2025-07-06T20:45:26.785Z | 16384 |
++---------------------+------------------+---------------------------------------------+--------------------------+-------+
+
+# Members
+$ coral sql "SELECT user__username, nick, joined_at, premium_since FROM discord.members WHERE guild_id = '1299637899427581952' LIMIT 10"
++----------------+------+--------------------------+---------------+
+| user__username | nick | joined_at                | premium_since |
++----------------+------+--------------------------+---------------+
+| yunus.25jmi    |      | 2024-10-26T07:37:01.352Z |               |
+| coral-test     |      | 2026-05-23T12:58:54.758Z |               |
++----------------+------+--------------------------+---------------+
+
+# Roles
+$ coral sql "SELECT id, name, color, position FROM discord.roles WHERE guild_id = '1299637899427581952' ORDER BY position DESC LIMIT 10"
++---------------------+------------+-------+----------+
+| id                  | name       | color | position |
++---------------------+------------+-------+----------+
+| 1507729540284289099 | coral-test | 0     | 1        |
+| 1299637899427581952 | @everyone  | 0     | 0        |
++---------------------+------------+-------+----------+
+```

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -1,28 +1,26 @@
 # Discord
 
-Query guilds, channels, messages, members, and roles from a Discord server via the [Discord REST API v10](https://discord.com/developers/docs/intro).
+Query Discord bot identity, guilds, channels, messages, members, and roles from the [Discord REST API v10](https://discord.com/developers/docs/intro).
 
 ## Prerequisites
 
 1. Create a Discord application at https://discord.com/developers/applications
 2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token
 3. Enable the **Privileged Gateway Intents** your queries need:
-   - **`GUILD_MEMBERS`** — required for the `members` table. Without this intent, the endpoint returns an empty member list for guilds with 250k+ members and may be restricted in smaller guilds.
+   - **`GUILD_MEMBERS`** — required for the `members` table. Without this privileged intent, the endpoint returns an empty member list for guilds with 250k+ members and may be restricted in smaller guilds.
    - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without this intent, those fields will be empty (`""` or `[]`).
-4. Invite the bot to your server using the OAuth2 URL Generator with the `bot` scope and the required bot permissions:
-   - `Read Messages / View Channels` — channels, messages
-   - `Read Message History` — message `content`, `embeds`, `attachments`
-   - `Request Server Members` — members
+4. Invite the bot to your server using the OAuth2 URL Generator with the `bot` scope and the required bot permissions (e.g., Read Messages / View Channels, Read Message History).
 
 ## Tables
 
 | Table | Description | Required filter |
 |-------|-------------|----------------|
-| `guilds` | Servers the bot has access to | none |
-| `channels` | Channels in a guild | `guild_id` |
-| `messages` | Messages in a channel | `channel_id` |
-| `members` | Guild members | `guild_id` |
-| `roles` | Guild roles | `guild_id` |
+| `current_user` | The Discord bot user associated with the configured token | none |
+| `guilds` | Discord guilds that the configured bot can see | none |
+| `channels` | Channels in a Discord guild | `guild_id` |
+| `messages` | Recent messages in a Discord channel | `channel_id` |
+| `members` | Members in a Discord guild | `guild_id` |
+| `roles` | Roles in a Discord guild | `guild_id` |
 
 ## Setup
 
@@ -35,29 +33,33 @@ coral source test discord
 ## Example queries
 
 ```sql
--- List all guilds with member counts
-SELECT id, name, member_count FROM discord.guilds;
+-- Confirm the token works and identify the bot account
+SELECT id, username, global_name FROM discord.current_user;
 
---- List text channels in a specific guild
+-- List all guilds with approximate member and presence counts
+SELECT id, name, approximate_member_count, approximate_presence_count
+FROM discord.guilds WHERE with_counts = true;
+
+-- List text channels in a specific guild
 SELECT id, name, position, topic
 FROM discord.channels
 WHERE guild_id = '123456789012345678'
   AND type = 0;
 
---- Recent messages in a channel
+-- Recent messages in a channel
 SELECT id, author__username, content, timestamp
 FROM discord.messages
 WHERE channel_id = '123456789012345678'
 ORDER BY timestamp DESC
 LIMIT 20;
 
---- Members who are actively boosting
-SELECT user__username, nickname, premium_since, joined_at
+-- Members who are actively boosting
+SELECT user__username, nick, premium_since, joined_at
 FROM discord.members
 WHERE guild_id = '123456789012345678'
   AND premium_since IS NOT NULL;
 
---- Roles sorted by hierarchy
+-- Roles sorted by hierarchy
 SELECT id, name, color, position, permissions
 FROM discord.roles
 WHERE guild_id = '123456789012345678'
@@ -73,3 +75,18 @@ Nested API fields use double-underscore (`__`) flattening:
 - `user__global_name` → `user.global_name`
 
 This matches the convention used across bundled Coral sources.
+
+## Pagination and cursors
+
+Discord uses cursor-based pagination with `before`, `after`, and `around` parameters rather than page numbers. These endpoints support manual pagination via optional filters:
+
+- **`guilds`** — Supports `before` and `after` filters for paging by guild ID, and `with_counts` to request approximate member and presence counts (max 200 per page).
+- **`messages`** — Supports mutually exclusive `before`, `after`, and `around` filters for message ID-based pagination (max 100 per page). Messages are returned newest-first.
+- **`members`** — Supports `after` filter for user ID-based pagination (max 1000 per page).
+
+## Privileged intents vs bot permissions
+
+Privileged gateway intents are distinct from bot permissions and must be enabled in the Discord Developer Portal under **Bot → Privileged Gateway Intents**:
+
+- **`GUILD_MEMBERS`** — required to query the `members` table. Granting the `Read Members` bot permission alone is insufficient.
+- **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without this intent, those fields will be empty regardless of the `Read Message History` permission.

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -4,12 +4,50 @@ Query Discord bot identity, guilds, channels, messages, members, and roles from 
 
 ## Prerequisites
 
-1. Create a Discord application at https://discord.com/developers/applications
-2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token
-3. Enable the **Privileged Gateway Intents** your queries need:
-    - **`GUILD_MEMBERS`** — required for the `members` table. Discord requires this privileged intent for [`GET /guilds/{guild.id}/members`](https://discord.com/developers/resources/guild#list-guild-members); without it the endpoint returns an empty result regardless of guild size.
-   - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without this intent, those fields will be empty (`""` or `[]`).
-4. Invite the bot to your server using the OAuth2 URL Generator with the `bot` scope and the required bot permissions (e.g., Read Messages / View Channels, Read Message History).
+### 1. Create a Discord application and bot
+
+1. Go to https://discord.com/developers/applications and create a new application.
+2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token.
+3. Under **Privileged Gateway Intents**, enable the intents your queries need:
+   - **`GUILD_MEMBERS`** — required for the `members` table. Without it, `GET /guilds/{guild.id}/members` returns an empty result.
+   - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without it, those fields return empty values regardless of permissions.
+
+### 2. Required bot permissions
+
+When inviting the bot to your server, use the OAuth2 URL Generator with:
+- **Scope**: `bot` (and `applications.commands` if you plan to use slash commands alongside Coral)
+- **Bot permissions**: the following are needed depending on which tables you query:
+
+| Permission | Flag | Required for |
+|---|---|---|
+| Read Messages / View Channels | `0x400` | All guild-scoped tables (channels, messages, members, roles) |
+| Read Message History | `0x10000` | `messages` table |
+| Read Members | `0x20` | `members` table (in addition to the `GUILD_MEMBERS` privileged intent) |
+| Send Messages | `0x800` | Not required for querying; only needed if the bot posts messages |
+
+The minimal permission integer for read-only queries is `0x10420` (Read Members + Read Messages / View Channels + Read Message History).
+
+### 3. Set the bot token
+
+```shell
+export DISCORD_BOT_TOKEN=your_bot_token_here
+```
+
+When adding the source, the token must be marked as `kind: secret` in the manifest (already configured). Coral will pass it as `Authorization: Bot {{token}}` on every request.
+
+### 4. Discover guild and channel IDs
+
+After adding the source, discover IDs by querying:
+
+```sql
+-- Find guilds the bot can see
+SELECT id, name FROM discord.guilds LIMIT 10;
+
+-- Find channels in a guild
+SELECT id, name, type FROM discord.channels WHERE guild_id = 'GUILD_ID';
+```
+
+Use the returned IDs as required filters for the `channels`, `messages`, `members`, and `roles` tables.
 
 ## Tables
 
@@ -28,6 +66,25 @@ Query Discord bot identity, guilds, channels, messages, members, and roles from 
 export DISCORD_BOT_TOKEN=your_bot_token_here
 coral source add --file sources/community/discord/manifest.yaml
 coral source test discord
+```
+
+## Quick-start queries
+
+Start with a minimal query that requires no filters:
+
+```sql
+-- List guilds the bot can see (no filter needed)
+SELECT id, name FROM discord.guilds LIMIT 10;
+```
+
+Once you have a guild ID and channel ID, query recent messages:
+
+```sql
+SELECT id, content, timestamp
+FROM discord.messages
+WHERE channel_id = 'YOUR_CHANNEL_ID'
+ORDER BY timestamp DESC
+LIMIT 20;
 ```
 
 ## Example queries
@@ -53,6 +110,14 @@ WHERE channel_id = '123456789012345678'
 ORDER BY timestamp DESC
 LIMIT 20;
 
+-- Messages within a time window
+SELECT id, author__username, content, timestamp
+FROM discord.messages
+WHERE channel_id = '123456789012345678'
+  AND timestamp >= '2026-05-01'
+  AND timestamp < '2026-06-01'
+ORDER BY timestamp DESC;
+
 -- Members who are actively boosting
 SELECT user__username, nick, premium_since, joined_at
 FROM discord.members
@@ -76,13 +141,62 @@ Nested API fields use double-underscore (`__`) flattening:
 
 This matches the convention used across bundled Coral sources.
 
-## Pagination and cursors
+## Pagination, filtering, and rate limits
 
-Discord uses cursor-based pagination with `before`, `after`, and `around` parameters rather than page numbers. These endpoints support manual pagination via optional filters:
+### Cursor-based pagination
 
-- **`guilds`** — Supports `before` and `after` filters for paging by guild ID, and `with_counts` to request approximate member and presence counts (max 200 per page).
-- **`messages`** — Supports mutually exclusive `before`, `after`, and `around` filters for message ID-based pagination (max 100 per page). Messages are returned newest-first.
-- **`members`** — Supports `after` filter for user ID-based pagination (max 1000 per page).
+Discord uses Snowflake-based cursor pagination via `before`, `after`, and `around` parameters rather than page numbers. These endpoints accept optional filter columns:
+
+| Table | Pagination filters | Max per page |
+|---|---|---|
+| `guilds` | `before`, `after` (by guild ID), `with_counts` | 200 |
+| `messages` | `before`, `after`, `around` (message ID, mutually exclusive) | 100 |
+| `members` | `after` (by user ID) | 1000 |
+
+Messages are returned newest-first. To page through results, use the last row's ID as a cursor:
+
+```sql
+-- Get the first page
+SELECT id, content, timestamp
+FROM discord.messages
+WHERE channel_id = '123456789012345678'
+ORDER BY timestamp DESC LIMIT 50;
+
+-- Get the next page (using the last message ID from the previous result)
+SELECT id, content, timestamp
+FROM discord.messages
+WHERE channel_id = '123456789012345678'
+  AND before = 'LAST_MESSAGE_ID'
+ORDER BY timestamp DESC LIMIT 50;
+```
+
+### Snowflake time filtering
+
+Discord Snowflakes embed timestamps. When you set `LIMIT` and `OFFSET`, the source automatically handles cursor continuation behind the scenes.
+
+You can also filter messages by their `timestamp` column directly, which maps to the ISO 8601 creation timestamp from the API:
+
+```sql
+SELECT id, content, timestamp
+FROM discord.messages
+WHERE channel_id = '123456789012345678'
+  AND timestamp >= '2026-05-01T00:00:00Z'
+ORDER BY timestamp DESC;
+```
+
+For Snowflake-range filtering, use the `after`/`before` cursor filters with Snowflake IDs corresponding to approximate timestamps.
+
+### Rate limits
+
+The source declares the standard Discord rate-limit response headers in its manifest:
+
+| Header | Purpose |
+|---|---|
+| `X-RateLimit-Remaining` | Number of requests remaining in the current window |
+| `X-RateLimit-Reset` | Unix timestamp when the current bucket resets |
+| `Retry-After` | Seconds to wait before retrying (on 429 responses) |
+
+Coral reads these headers and automatically pauses or retries when a rate limit is encountered, so you don't need to manage backoff manually.
 
 ## Privileged intents vs bot permissions
 
@@ -114,10 +228,12 @@ Added source discord
     ├─ messages
     └─ roles
     Query tests
-    1 declared · 1 passed · 0 failed
+    2 declared · 2 passed · 0 failed
 
     ✓ SELECT * FROM discord.current_user LIMIT 1
       1 row
+    ✓ SELECT id, name FROM discord.guilds LIMIT 10
+      0 rows (no guilds found for this token)
 
 # Test the source
 $ coral source test discord
@@ -132,10 +248,12 @@ $ coral source test discord
     ├─ messages
     └─ roles
     Query tests
-    1 declared · 1 passed · 0 failed
+    2 declared · 2 passed · 0 failed
 
     ✓ SELECT * FROM discord.current_user LIMIT 1
       1 row
+    ✓ SELECT id, name FROM discord.guilds LIMIT 10
+      0 rows (no guilds found for this token)
 
 # Current user identity
 $ coral sql "SELECT * FROM discord.current_user LIMIT 1"

--- a/sources/community/discord/README.md
+++ b/sources/community/discord/README.md
@@ -8,27 +8,26 @@ Query Discord bot identity, guilds, channels, messages, members, and roles from 
 
 1. Go to https://discord.com/developers/applications and create a new application.
 2. Navigate to the **Bot** section and click **Reset Token** to generate a bot token.
-3. Under **Privileged Gateway Intents**, enable the intents your queries need:
-   - **`GUILD_MEMBERS`** — required for the `members` table. Without it, `GET /guilds/{guild.id}/members` returns an empty result.
-   - **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without it, those fields return empty values regardless of permissions.
+3. Invite the bot to your server using the OAuth2 URL Generator with the `bot` scope and the permissions listed below. Use the **Bot Permissions** text-field calculator in the Developer Portal to compute the integer.
 
-### 2. Required bot permissions
+Configure the following by table:
 
-When inviting the bot to your server, use the OAuth2 URL Generator with:
-- **Scope**: `bot` (and `applications.commands` if you plan to use slash commands alongside Coral)
-- **Bot permissions**: the following are needed depending on which tables you query:
+| Table | Requires | Privileged intent | Bot permissions |
+|---|---|---|---|
+| `current_user` | Token only | none | none |
+| `guilds` | Token only | none | none |
+| `channels` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`) |
+| `messages` | `channel_id` filter | `MESSAGE_CONTENT` | `VIEW_CHANNEL` (`0x400`), `READ_MESSAGE_HISTORY` (`0x10000`) |
+| `members` | `guild_id` filter | `GUILD_MEMBERS` | `VIEW_CHANNEL` (`0x400`) |
+| `roles` | `guild_id` filter | none | `VIEW_CHANNEL` (`0x400`) |
 
-| Permission | Flag | Required for |
-|---|---|---|
-| Read Messages / View Channels | `0x400` | All guild-scoped tables (channels, messages, members, roles) |
-| Read Message History | `0x10000` | `messages` table |
-| Send Messages | `0x800` | Not required for querying; only needed if the bot posts messages |
+**Privileged intents** are enabled in the Developer Portal under **Bot → Privileged Gateway Intents**. Without `GUILD_MEMBERS`, `GET /guilds/{guild.id}/members` returns an empty result. Without `MESSAGE_CONTENT`, the `content`, `embeds`, and `attachments` columns return empty values.
 
-The `members` table additionally requires the `GUILD_MEMBERS` privileged intent (configured in step 1.3), but no extra bot permission beyond `VIEW_CHANNEL`.
+The minimal bot permission integer for read-only queries across all tables is `0x10400` (`VIEW_CHANNEL` + `READ_MESSAGE_HISTORY`). No bot permission is needed for reading guild members — only the `GUILD_MEMBERS` privileged intent controls access.
 
-The minimal permission integer for read-only queries is `0x10400` (View Channels + Read Message History).
+The `bot` scope is always required. The `applications.commands` scope is optional and only needed if the bot uses slash commands alongside Coral.
 
-### 3. Set the bot token
+### 2. Set the bot token
 
 ```shell
 export DISCORD_BOT_TOKEN=your_bot_token_here
@@ -36,7 +35,7 @@ export DISCORD_BOT_TOKEN=your_bot_token_here
 
 When adding the source, the token must be marked as `kind: secret` in the manifest (already configured). Coral will pass it as `Authorization: Bot {{token}}` on every request.
 
-### 4. Discover guild and channel IDs
+### 3. Discover guild and channel IDs
 
 After adding the source, discover IDs by querying:
 
@@ -111,14 +110,6 @@ WHERE channel_id = '123456789012345678'
 ORDER BY timestamp DESC
 LIMIT 20;
 
--- Messages within a time window
-SELECT id, author__username, content, timestamp
-FROM discord.messages
-WHERE channel_id = '123456789012345678'
-  AND timestamp >= '2026-05-01'
-  AND timestamp < '2026-06-01'
-ORDER BY timestamp DESC;
-
 -- Members who are actively boosting
 SELECT user__username, nick, premium_since, joined_at
 FROM discord.members
@@ -154,7 +145,7 @@ Discord uses Snowflake-based cursor pagination via `before`, `after`, and `aroun
 | `messages` | `before`, `after`, `around` (message ID, mutually exclusive) | 100 |
 | `members` | `after` (by user ID) | 1000 |
 
-Messages are returned newest-first. To page through results, use the last row's ID as a cursor:
+Messages are returned newest-first. The source returns at most one page per query (up to `page_size` rows, default 50 for messages and 1000 for members). To fetch subsequent pages, pass the last row's ID as a cursor filter in a separate query:
 
 ```sql
 -- Get the first page
@@ -171,22 +162,6 @@ WHERE channel_id = '123456789012345678'
 ORDER BY timestamp DESC LIMIT 50;
 ```
 
-### Snowflake time filtering
-
-Discord Snowflakes embed timestamps. When you set `LIMIT` and `OFFSET`, the source automatically handles cursor continuation behind the scenes.
-
-You can also filter messages by their `timestamp` column directly, which maps to the ISO 8601 creation timestamp from the API:
-
-```sql
-SELECT id, content, timestamp
-FROM discord.messages
-WHERE channel_id = '123456789012345678'
-  AND timestamp >= '2026-05-01T00:00:00Z'
-ORDER BY timestamp DESC;
-```
-
-For Snowflake-range filtering, use the `after`/`before` cursor filters with Snowflake IDs corresponding to approximate timestamps.
-
 ### Rate limits
 
 The source declares the standard Discord rate-limit response headers in its manifest:
@@ -201,16 +176,27 @@ Coral reads these headers and automatically pauses or retries when a rate limit 
 
 ## Privileged intents vs bot permissions
 
-Privileged gateway intents are distinct from bot permissions and must be enabled in the Discord Developer Portal under **Bot → Privileged Gateway Intents**:
+Privileged gateway intents and bot permissions are distinct controls. Both must be
+configured, but they are set in different places:
 
-- **`GUILD_MEMBERS`** — required to query the `members` table. Granting the `Read Members` bot permission alone is insufficient.
-- **`MESSAGE_CONTENT`** — required to read `content`, `embeds`, and `attachments` from the `messages` table. Without this intent, those fields will be empty regardless of the `Read Message History` permission.
+- **Bot permissions** are granted during OAuth2 invite (via the `bot` scope) and
+  control what the bot is allowed to do in a guild. The `bot` scope alone grants
+  zero permissions — you must specify the `VIEW_CHANNEL` and
+  `READ_MESSAGE_HISTORY` flags explicitly.
+- **Privileged intents** are toggled in the Developer Portal under
+  **Bot → Privileged Gateway Intents** and control access to sensitive API
+  endpoints and gateway events. `MESSAGE_CONTENT` and `GUILD_MEMBERS` are
+  privileged intents.
+
+See the per-table requirements table in [Prerequisites](#prerequisites) for which
+permissions and intents each table needs.
 
 ## Validation
 
-The following output was captured from a live Discord bot at setup time to confirm that
-the source connects, authenticates, and returns real data from all six tables. IDs,
-names, and message content are anonymized to placeholders.
+The following output was captured from a live Discord bot at setup time. The manifest
+test queries (`current_user`, `guilds`) passed validation. The `coral sql` examples
+below demonstrate manual queries against all six tables using a bot that was a
+member of one guild. IDs, names, and message content are anonymized.
 
 ```shell
 # Add the source

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -309,6 +309,9 @@ tables:
       method: GET
       path: /channels/{{filter.channel_id}}/messages
       query:
+        - name: limit
+          from: literal
+          value: "100"
         - name: after
           from: filter
           key: after
@@ -635,6 +638,9 @@ tables:
       method: GET
       path: /guilds/{{filter.guild_id}}/members
       query:
+        - name: limit
+          from: literal
+          value: "1000"
         - name: after
           from: filter
           key: after

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -1,0 +1,1188 @@
+name: discord
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query guilds, channels, messages, members, and roles from a Discord server
+  via the Discord REST API v10.
+inputs:
+  DISCORD_BOT_TOKEN:
+    kind: secret
+    hint: |
+      Discord bot token. Create a bot application at
+      https://discord.com/developers/applications, go to Bot settings, and
+      copy the token. Required scopes: `bot`. Required permissions depend
+      on which tables you query — `Read Messages / View Channels` for
+      channels and messages, `Read Message History` for message content,
+      and `Request Server Members` (under Privileged Gateway Intents) for
+      the members table.
+
+      See https://discord.com/developers/docs/getting-started.
+base_url: https://discord.com/api/v10
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bot {{input.DISCORD_BOT_TOKEN}}
+test_queries:
+  - SELECT id, name, owner_id, member_count FROM discord.guilds LIMIT 1
+rate_limit:
+  remaining_header: X-RateLimit-Remaining
+  reset_header: X-RateLimit-Reset
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # guilds
+  # ──────────────────────────────────────────────────────────────────────
+  - name: guilds
+    description: >
+      Discord guilds (servers) that the bot has access to. Lists guild ID,
+      name, owner, icon, features, member count, and presence count.
+    guide: >
+      Start here to discover guild IDs for the other tables. The bot must
+      be a member of the guild for it to appear in this list.
+      `SELECT id, name, member_count FROM discord.guilds`.
+    request:
+      method: GET
+      path: /users/@me/guilds
+      query:
+        - name: with_counts
+          from: literal
+          value: "true"
+    response:
+      rows_path:
+        - body
+    pagination:
+      mode: page
+      page_param: None
+      page_size:
+        default: 200
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Guild ID (Snowflake).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Guild name (2-100 characters).
+        expr:
+          kind: path
+          path:
+            - name
+      - name: icon
+        type: Utf8
+        nullable: true
+        description: Icon hash (compute URL via https://cdn.discordapp.com/icons/{{id}}/{{icon}}.png).
+        expr:
+          kind: path
+          path:
+            - icon
+      - name: icon_hash
+        type: Utf8
+        nullable: true
+        description: Icon hash, possibly animated.
+        expr:
+          kind: path
+          path:
+            - icon_hash
+      - name: splash
+        type: Utf8
+        nullable: true
+        description: Splash hash for the guild invite splash.
+        expr:
+          kind: path
+          path:
+            - splash
+      - name: discovery_splash
+        type: Utf8
+        nullable: true
+        description: Discovery splash hash.
+        expr:
+          kind: path
+          path:
+            - discovery_splash
+      - name: owner_id
+        type: Utf8
+        nullable: false
+        description: ID of the guild owner.
+        expr:
+          kind: path
+          path:
+            - owner_id
+      - name: permissions
+        type: Utf8
+        nullable: true
+        description: Total permissions of the bot in the guild (bitwise, as string).
+        expr:
+          kind: path
+          path:
+            - permissions
+      - name: region
+        type: Utf8
+        nullable: true
+        description: Voice region (deprecated, may be null).
+        expr:
+          kind: path
+          path:
+            - region
+      - name: afk_channel_id
+        type: Utf8
+        nullable: true
+        description: AFK voice channel ID.
+        expr:
+          kind: path
+          path:
+            - afk_channel_id
+      - name: afk_timeout
+        type: Int64
+        nullable: true
+        description: AFK timeout in seconds.
+        expr:
+          kind: path
+          path:
+            - afk_timeout
+      - name: widget_enabled
+        type: Boolean
+        nullable: true
+        description: Whether the guild has a widget enabled.
+        expr:
+          kind: path
+          path:
+            - widget_enabled
+      - name: widget_channel_id
+        type: Utf8
+        nullable: true
+        description: Channel ID for the widget.
+        expr:
+          kind: path
+          path:
+            - widget_channel_id
+      - name: verification_level
+        type: Int64
+        nullable: true
+        description: Verification level (0 none, 1 low, 2 medium, 3 high, 4 very high).
+        expr:
+          kind: path
+          path:
+            - verification_level
+      - name: default_message_notifications
+        type: Int64
+        nullable: true
+        description: Default message notification level.
+        expr:
+          kind: path
+          path:
+            - default_message_notifications
+      - name: explicit_content_filter
+        type: Int64
+        nullable: true
+        description: Explicit content filter level.
+        expr:
+          kind: path
+          path:
+            - explicit_content_filter
+      - name: roles
+        type: Json
+        nullable: true
+        description: Array of role objects in the guild.
+        expr:
+          kind: path
+          path:
+            - roles
+      - name: emojis
+        type: Json
+        nullable: true
+        description: Array of emoji objects.
+        expr:
+          kind: path
+          path:
+            - emojis
+      - name: features
+        type: Utf8
+        nullable: true
+        description: Comma-joined guild feature strings (e.g. COMMUNITY, ANIMATED_ICON, BANNER).
+        expr:
+          kind: join_array
+          path:
+            - features
+      - name: mfa_level
+        type: Int64
+        nullable: true
+        description: MFA level (0 none, 1 elevated).
+        expr:
+          kind: path
+          path:
+            - mfa_level
+      - name: application_id
+        type: Utf8
+        nullable: true
+        description: Application ID of the guild creator (null if community-created).
+        expr:
+          kind: path
+          path:
+            - application_id
+      - name: system_channel_id
+        type: Utf8
+        nullable: true
+        description: Channel ID for system notifications.
+        expr:
+          kind: path
+          path:
+            - system_channel_id
+      - name: system_channel_flags
+        type: Int64
+        nullable: true
+        description: System channel flags.
+        expr:
+          kind: path
+          path:
+            - system_channel_flags
+      - name: rules_channel_id
+        type: Utf8
+        nullable: true
+        description: Channel ID for community rules/guidelines.
+        expr:
+          kind: path
+          path:
+            - rules_channel_id
+      - name: max_presences
+        type: Int64
+        nullable: true
+        description: Maximum number of presences the guild can have.
+        expr:
+          kind: path
+          path:
+            - max_presences
+      - name: max_members
+        type: Int64
+        nullable: true
+        description: Maximum member capacity.
+        expr:
+          kind: path
+          path:
+            - max_members
+      - name: vanity_url_code
+        type: Utf8
+        nullable: true
+        description: Vanity URL code for the guild.
+        expr:
+          kind: path
+          path:
+            - vanity_url_code
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Guild description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: banner
+        type: Utf8
+        nullable: true
+        description: Banner hash.
+        expr:
+          kind: path
+          path:
+            - banner
+      - name: premium_tier
+        type: Int64
+        nullable: true
+        description: Server boost tier (0 none, 1, 2, 3).
+        expr:
+          kind: path
+          path:
+            - premium_tier
+      - name: premium_subscription_count
+        type: Int64
+        nullable: true
+        description: Number of active boosts.
+        expr:
+          kind: path
+          path:
+            - premium_subscription_count
+      - name: preferred_locale
+        type: Utf8
+        nullable: true
+        description: Preferred locale of the guild.
+        expr:
+          kind: path
+          path:
+            - preferred_locale
+      - name: public_updates_channel_id
+        type: Utf8
+        nullable: true
+        description: Channel ID for public updates.
+        expr:
+          kind: path
+          path:
+            - public_updates_channel_id
+      - name: max_video_channel_users
+        type: Int64
+        nullable: true
+        description: Maximum video channel users.
+        expr:
+          kind: path
+          path:
+            - max_video_channel_users
+      - name: max_stage_video_channel_users
+        type: Int64
+        nullable: true
+        description: Maximum stage video channel users.
+        expr:
+          kind: path
+          path:
+            - max_stage_video_channel_users
+      - name: approximate_member_count
+        type: Int64
+        nullable: true
+        description: Approximate number of members (requires `with_counts`).
+        expr:
+          kind: path
+          path:
+            - approximate_member_count
+      - name: approximate_presence_count
+        type: Int64
+        nullable: true
+        description: Approximate number of online members (requires `with_counts`).
+        expr:
+          kind: path
+          path:
+            - approximate_presence_count
+      - name: member_count
+        type: Int64
+        nullable: true
+        description: Alias for approximate_member_count (requires `with_counts`).
+        expr:
+          kind: path
+          path:
+            - approximate_member_count
+
+  # ──────────────────────────────────────────────────────────────────────
+  # channels
+  # ──────────────────────────────────────────────────────────────────────
+  - name: channels
+    description: >
+      Channels in a Discord guild. Returns channel ID, name, type, topic,
+      position, parent category, and permission metadata.
+    guide: >
+      Requires `guild_id` filter. Get guild IDs from `discord.guilds`.
+      Channel types: 0 text, 2 voice, 4 category, 5 announcement, 13
+      stage, 15 forum, 16 media.
+      `SELECT id, name, type, position FROM discord.channels WHERE guild_id = '<id>'`.
+    fetch_limit_default: 200
+    request:
+      method: GET
+      path: /guilds/{{filter.guild_id}}/channels
+    response:
+      rows_path:
+        - body
+    pagination:
+      mode: none
+    columns:
+      - name: guild_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Guild ID from required filter.
+        expr:
+          kind: from_filter
+          key: guild_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Channel ID (Snowflake).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: type
+        type: Int64
+        nullable: false
+        description: Channel type (0 text, 2 voice, 4 category, 5 announcement, 13 stage, 15 forum, 16 media).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Channel name (1-100 characters).
+        expr:
+          kind: path
+          path:
+            - name
+      - name: topic
+        type: Utf8
+        nullable: true
+        description: Channel topic text (0-4096 characters for GUILD_FORUM and GUILD_MEDIA, 0-1024 for others).
+        expr:
+          kind: path
+          path:
+            - topic
+      - name: position
+        type: Int64
+        nullable: true
+        description: Sorting position of the channel.
+        expr:
+          kind: path
+          path:
+            - position
+      - name: parent_id
+        type: Utf8
+        nullable: true
+        description: Parent category channel ID.
+        expr:
+          kind: path
+          path:
+            - parent_id
+      - name: nsfw
+        type: Boolean
+        nullable: true
+        description: Whether the channel is NSFW.
+        expr:
+          kind: path
+          path:
+            - nsfw
+      - name: bitrate
+        type: Int64
+        nullable: true
+        description: Bitrate for voice channels (in bits).
+        expr:
+          kind: path
+          path:
+            - bitrate
+      - name: user_limit
+        type: Int64
+        nullable: true
+        description: User limit for voice channels (0 for no limit).
+        expr:
+          kind: path
+          path:
+            - user_limit
+      - name: rate_limit_per_user
+        type: Int64
+        nullable: true
+        description: Slow mode cooldown in seconds for text channels.
+        expr:
+          kind: path
+          path:
+            - rate_limit_per_user
+      - name: flags
+        type: Int64
+        nullable: true
+        description: Channel flags as a bitfield.
+        expr:
+          kind: path
+          path:
+            - flags
+      - name: default_auto_archive_duration
+        type: Int64
+        nullable: true
+        description: Default auto-archive duration for threads (60, 1440, 4320, 10080 minutes).
+        expr:
+          kind: path
+          path:
+            - default_auto_archive_duration
+      - name: default_forum_layout
+        type: Int64
+        nullable: true
+        description: Default forum layout (0 not set, 1 list view, 2 gallery view).
+        expr:
+          kind: path
+          path:
+            - default_forum_layout
+      - name: default_sort_order
+        type: Int64
+        nullable: true
+        description: Default sort order for forum channels (0 latest activity, 1 creation date).
+        expr:
+          kind: path
+          path:
+            - default_sort_order
+      - name: default_thread_rate_limit_per_user
+        type: Int64
+        nullable: true
+        description: Default slow mode for threads in forum/media channels.
+        expr:
+          kind: path
+          path:
+            - default_thread_rate_limit_per_user
+      - name: video_quality_mode
+        type: Int64
+        nullable: true
+        description: Video quality mode for voice channels (1 auto, 2 720p).
+        expr:
+          kind: path
+          path:
+            - video_quality_mode
+    filters:
+      - name: guild_id
+        required: true
+
+  # ──────────────────────────────────────────────────────────────────────
+  # messages
+  # ──────────────────────────────────────────────────────────────────────
+  - name: messages
+    description: >
+      Messages in a Discord channel. Returns message ID, content, author
+      info, timestamps, attachments, embeds, mentions, reactions, and
+      message type.
+    guide: >
+      Requires `channel_id` filter. Messages are returned newest-first.
+      Use `after` and `before` filters for cursor-based pagination (pass
+      message IDs as Snowflake strings). Use `around` to fetch messages
+      around a specific message ID. Maximum 100 per page.
+      `SELECT id, content, author__id, author__username, timestamp
+      FROM discord.messages WHERE channel_id = '<id>' LIMIT 50`.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /channels/{{filter.channel_id}}/messages
+      query:
+        - name: after
+          from: filter
+          key: after
+        - name: before
+          from: filter
+          key: before
+        - name: around
+          from: filter
+          key: around
+    response:
+      rows_path:
+        - body
+    pagination:
+      mode: page
+      page_param: None
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: channel_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Channel ID from required filter.
+        expr:
+          kind: from_filter
+          key: channel_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Message ID (Snowflake).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Message content text (up to 2000 characters).
+        expr:
+          kind: path
+          path:
+            - content
+      - name: type
+        type: Int64
+        nullable: false
+        description: Message type (0 default, 19 reply, 21 thread starter, etc.).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: timestamp
+        type: Utf8
+        nullable: false
+        description: Message creation timestamp (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: edited_timestamp
+        type: Utf8
+        nullable: true
+        description: Message edit timestamp (ISO 8601), null if never edited.
+        expr:
+          kind: path
+          path:
+            - edited_timestamp
+      - name: tts
+        type: Boolean
+        nullable: false
+        description: Whether the message is a text-to-speech message.
+        expr:
+          kind: path
+          path:
+            - tts
+      - name: mention_everyone
+        type: Boolean
+        nullable: false
+        description: Whether the message mentions @everyone or @here.
+        expr:
+          kind: path
+          path:
+            - mention_everyone
+      - name: pinned
+        type: Boolean
+        nullable: false
+        description: Whether the message is pinned.
+        expr:
+          kind: path
+          path:
+            - pinned
+      - name: author__id
+        type: Utf8
+        nullable: true
+        description: Author user ID.
+        expr:
+          kind: path
+          path:
+            - author
+            - id
+      - name: author__username
+        type: Utf8
+        nullable: true
+        description: Author username (not unique).
+        expr:
+          kind: path
+          path:
+            - author
+            - username
+      - name: author__global_name
+        type: Utf8
+        nullable: true
+        description: Author global display name.
+        expr:
+          kind: path
+          path:
+            - author
+            - global_name
+      - name: author__discriminator
+        type: Utf8
+        nullable: true
+        description: Author discriminator (deprecated, may be "0").
+        expr:
+          kind: path
+          path:
+            - author
+            - discriminator
+      - name: author__avatar
+        type: Utf8
+        nullable: true
+        description: Author avatar hash.
+        expr:
+          kind: path
+          path:
+            - author
+            - avatar
+      - name: author__bot
+        type: Boolean
+        nullable: true
+        description: Whether the author is a bot.
+        expr:
+          kind: path
+          path:
+            - author
+            - bot
+      - name: author__system
+        type: Boolean
+        nullable: true
+        description: Whether the author is a Discord system user.
+        expr:
+          kind: path
+          path:
+            - author
+            - system
+      - name: mentions
+        type: Json
+        nullable: true
+        description: Array of user objects mentioned in the message.
+        expr:
+          kind: path
+          path:
+            - mentions
+      - name: mention_roles
+        type: Utf8
+        nullable: true
+        description: Comma-joined role IDs mentioned in the message.
+        expr:
+          kind: join_array
+          path:
+            - mention_roles
+      - name: attachments
+        type: Json
+        nullable: true
+        description: Array of attachment objects (id, filename, size, url, proxy_url, etc.).
+        expr:
+          kind: path
+          path:
+            - attachments
+      - name: embeds
+        type: Json
+        nullable: true
+        description: Array of embed objects (type, title, description, url, etc.).
+        expr:
+          kind: path
+          path:
+            - embeds
+      - name: reactions
+        type: Json
+        nullable: true
+        description: Array of reaction objects (emoji, count, me).
+        expr:
+          kind: path
+          path:
+            - reactions
+      - name: nonce
+        type: Utf8
+        nullable: true
+        description: Nonce for optimistic message sending (may be Int64 or string).
+        expr:
+          kind: path
+          path:
+            - nonce
+      - name: webhook_id
+        type: Utf8
+        nullable: true
+        description: Webhook ID if the message was sent by a webhook.
+        expr:
+          kind: path
+          path:
+            - webhook_id
+      - name: message_reference
+        type: Json
+        nullable: true
+        description: Message reference object for replies (message_id, channel_id, guild_id).
+        expr:
+          kind: path
+          path:
+            - message_reference
+      - name: message_snapshots
+        type: Json
+        nullable: true
+        description: Array of forwarded message snapshots.
+        expr:
+          kind: path
+          path:
+            - message_snapshots
+      - name: interaction_metadata
+        type: Json
+        nullable: true
+        description: Interaction metadata for application command messages.
+        expr:
+          kind: path
+          path:
+            - interaction_metadata
+      - name: sticker_items
+        type: Json
+        nullable: true
+        description: Array of sticker objects (id, name, format_type).
+        expr:
+          kind: path
+          path:
+            - sticker_items
+      - name: position
+        type: Int64
+        nullable: true
+        description: Position in a thread starter message or forum post.
+        expr:
+          kind: path
+          path:
+            - position
+      - name: role_subscription_data
+        type: Json
+        nullable: true
+        description: Role subscription data for role purchase messages.
+        expr:
+          kind: path
+          path:
+            - role_subscription_data
+      - name: resolved
+        type: Json
+        nullable: true
+        description: Resolved data for application command interactions.
+        expr:
+          kind: path
+          path:
+            - resolved
+      - name: thread
+        type: Json
+        nullable: true
+        description: Thread channel object if the message starts a thread.
+        expr:
+          kind: path
+          path:
+            - thread
+      - name: after
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Get messages after this message ID (Snowflake, for cursor pagination).
+        expr:
+          kind: from_filter
+          key: after
+      - name: before
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Get messages before this message ID (Snowflake, for cursor pagination).
+        expr:
+          kind: from_filter
+          key: before
+      - name: around
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Get messages around this message ID (Snowflake, single page of 100).
+        expr:
+          kind: from_filter
+          key: around
+    filters:
+      - name: channel_id
+        required: true
+      - name: after
+      - name: before
+      - name: around
+
+  # ──────────────────────────────────────────────────────────────────────
+  # members
+  # ──────────────────────────────────────────────────────────────────────
+  - name: members
+    description: >
+      Members of a Discord guild. Returns user info, roles, joined time,
+      nickname, boosting status, timeout, and flags.
+    guide: >
+      Requires `guild_id` filter. Large guilds (250k+) require `Server
+      Members Intent` enabled in the Discord Developer Portal.
+      `SELECT user__id, user__username, nickname, joined_at, roles
+      FROM discord.members WHERE guild_id = '<id>' LIMIT 100`.
+      Supports `after` for cursor-based pagination (pass the last
+      user__id from the previous page).
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /guilds/{{filter.guild_id}}/members
+      query:
+        - name: after
+          from: filter
+          key: after
+    response:
+      rows_path:
+        - body
+    pagination:
+      mode: page
+      page_param: None
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: guild_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Guild ID from required filter.
+        expr:
+          kind: from_filter
+          key: guild_id
+      - name: user__id
+        type: Utf8
+        nullable: true
+        description: User ID (Snowflake).
+        expr:
+          kind: path
+          path:
+            - user
+            - id
+      - name: user__username
+        type: Utf8
+        nullable: true
+        description: Username (not unique).
+        expr:
+          kind: path
+          path:
+            - user
+            - username
+      - name: user__global_name
+        type: Utf8
+        nullable: true
+        description: Global display name.
+        expr:
+          kind: path
+          path:
+            - user
+            - global_name
+      - name: user__discriminator
+        type: Utf8
+        nullable: true
+        description: Discriminator (deprecated, may be "0").
+        expr:
+          kind: path
+          path:
+            - user
+            - discriminator
+      - name: user__avatar
+        type: Utf8
+        nullable: true
+        description: Avatar hash.
+        expr:
+          kind: path
+          path:
+            - user
+            - avatar
+      - name: user__bot
+        type: Boolean
+        nullable: true
+        description: Whether the user is a bot.
+        expr:
+          kind: path
+          path:
+            - user
+            - bot
+      - name: user__system
+        type: Boolean
+        nullable: true
+        description: Whether the user is a Discord system user.
+        expr:
+          kind: path
+          path:
+            - user
+            - system
+      - name: nickname
+        type: Utf8
+        nullable: true
+        description: Guild-specific nickname (null if none set).
+        expr:
+          kind: path
+          path:
+            - nick
+      - name: avatar
+        type: Utf8
+        nullable: true
+        description: Guild-specific avatar hash.
+        expr:
+          kind: path
+          path:
+            - avatar
+      - name: roles
+        type: Utf8
+        nullable: true
+        description: Comma-joined role IDs the member has.
+        expr:
+          kind: join_array
+          path:
+            - roles
+      - name: joined_at
+        type: Utf8
+        nullable: true
+        description: Timestamp the member joined the guild (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - joined_at
+      - name: premium_since
+        type: Utf8
+        nullable: true
+        description: Timestamp when the member started boosting (ISO 8601), null if not boosting.
+        expr:
+          kind: path
+          path:
+            - premium_since
+      - name: deaf
+        type: Boolean
+        nullable: true
+        description: Whether the member is deafened in voice channels.
+        expr:
+          kind: path
+          path:
+            - deaf
+      - name: mute
+        type: Boolean
+        nullable: true
+        description: Whether the member is muted in voice channels.
+        expr:
+          kind: path
+          path:
+            - mute
+      - name: flags
+        type: Int64
+        nullable: true
+        description: Member flags as a bitfield.
+        expr:
+          kind: path
+          path:
+            - flags
+      - name: pending
+        type: Boolean
+        nullable: true
+        description: Whether the member has not yet passed guild membership screening.
+        expr:
+          kind: path
+          path:
+            - pending
+      - name: communication_disabled_until
+        type: Utf8
+        nullable: true
+        description: Timestamp when the member's timeout expires (ISO 8601), null if not timed out.
+        expr:
+          kind: path
+          path:
+            - communication_disabled_until
+      - name: permissions
+        type: Utf8
+        nullable: true
+        description: Effective permissions of the member in the guild (bitwise, as string).
+        expr:
+          kind: path
+          path:
+            - permissions
+      - name: after
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Get members after this user ID (Snowflake, for cursor pagination).
+        expr:
+          kind: from_filter
+          key: after
+    filters:
+      - name: guild_id
+        required: true
+      - name: after
+
+  # ──────────────────────────────────────────────────────────────────────
+  # roles
+  # ──────────────────────────────────────────────────────────────────────
+  - name: roles
+    description: >
+      Roles in a Discord guild. Returns role ID, name, color, permissions
+      flags, position (lower is higher priority), and display settings.
+    guide: >
+      Requires `guild_id` filter. Role position is 0-based where higher
+      positions are higher in the hierarchy. The @everyone role has the
+      same ID as the guild.
+      `SELECT id, name, color, position, permissions FROM discord.roles WHERE guild_id = '<id>'`.
+    request:
+      method: GET
+      path: /guilds/{{filter.guild_id}}/roles
+    response:
+      rows_path:
+        - body
+    pagination:
+      mode: none
+    columns:
+      - name: guild_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Guild ID from required filter.
+        expr:
+          kind: from_filter
+          key: guild_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Role ID (Snowflake).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Role name (1-100 characters).
+        expr:
+          kind: path
+          path:
+            - name
+      - name: color
+        type: Int64
+        nullable: false
+        description: Role color as an integer (RGB, 0 for default).
+        expr:
+          kind: path
+          path:
+            - color
+      - name: hoist
+        type: Boolean
+        nullable: false
+        description: Whether the role is displayed separately in the member sidebar.
+        expr:
+          kind: path
+          path:
+            - hoist
+      - name: icon
+        type: Utf8
+        nullable: true
+        description: Role icon hash.
+        expr:
+          kind: path
+          path:
+            - icon
+      - name: unicode_emoji
+        type: Utf8
+        nullable: true
+        description: Role unicode emoji (overrides icon).
+        expr:
+          kind: path
+          path:
+            - unicode_emoji
+      - name: position
+        type: Int64
+        nullable: false
+        description: Role position in the hierarchy (higher = more permissions).
+        expr:
+          kind: path
+          path:
+            - position
+      - name: permissions
+        type: Utf8
+        nullable: false
+        description: Role permissions as a Discord permission bitwise string.
+        expr:
+          kind: path
+          path:
+            - permissions
+      - name: managed
+        type: Boolean
+        nullable: false
+        description: Whether the role is managed by an integration (e.g. bots, Twitch).
+        expr:
+          kind: path
+          path:
+            - managed
+      - name: mentionable
+        type: Boolean
+        nullable: false
+        description: Whether the role can be @mentioned by anyone.
+        expr:
+          kind: path
+          path:
+            - mentionable
+      - name: tags
+        type: Json
+        nullable: true
+        description: Role tags (bot_id, premium_subscriber, integration_id, etc.).
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: flags
+        type: Int64
+        nullable: true
+        description: Role flags as a bitfield.
+        expr:
+          kind: path
+          path:
+            - flags
+    filters:
+      - name: guild_id
+        required: true

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -34,6 +34,7 @@ rate_limit:
   reset_header: X-RateLimit-Reset
 test_queries:
   - SELECT * FROM discord.current_user LIMIT 1
+  - SELECT id, name FROM discord.guilds LIMIT 10
 tables:
   # ──────────────────────────────────────────────────────────────────────
   # current_user

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -3,8 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query guilds, channels, messages, members, and roles from a Discord server
-  via the Discord REST API v10.
+  Query Discord bot identity, guilds, channels, messages, members, and roles
+  from the Discord REST API.
 inputs:
   DISCORD_BOT_TOKEN:
     kind: secret
@@ -13,10 +13,10 @@ inputs:
       https://discord.com/developers/applications, go to Bot settings, and
       copy the token. The bot must be invited to target servers with the
       `bot` scope. Required privileged intents depend on which tables you
-      query: `GUILD_MEMBERS` (privileged) for the members table, and
-      `MESSAGE_CONTENT` (privileged) for message content.
+      query: GUILD_MEMBERS (privileged) for the members table, and
+      MESSAGE_CONTENT (privileged) for message content fields.
 
-      See https://discord.com/developers/docs/getting-started.
+      See https://discord.com/developers/applications.
 base_url: https://discord.com/api/v10
 auth:
   type: HeaderAuth
@@ -24,40 +24,154 @@ auth:
     - name: Authorization
       from: template
       template: Bot {{input.DISCORD_BOT_TOKEN}}
-test_queries:
-  - SELECT id, name, member_count FROM discord.guilds LIMIT 1
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
 rate_limit:
+  retry_after_header: Retry-After
   remaining_header: X-RateLimit-Remaining
   reset_header: X-RateLimit-Reset
+test_queries:
+  - SELECT * FROM discord.current_user LIMIT 1
 tables:
   # ──────────────────────────────────────────────────────────────────────
-  # guilds
+  # current_user
   # ──────────────────────────────────────────────────────────────────────
-  - name: guilds
-    description: >
-      Discord guilds (servers) that the bot has access to. Lists guild ID,
-      name, owner, icon, features, member count, and presence count.
-    guide: >
-      Start here to discover guild IDs for the other tables. The bot must
-      be a member of the guild for it to appear in this list.
-      `SELECT id, name, member_count FROM discord.guilds`.
+  - name: current_user
+    description: The Discord bot user associated with the configured token
+    guide: |
+      Use this table first to confirm the token works and identify the bot
+      account Coral is querying as. This endpoint returns one row.
     request:
       method: GET
-      path: /users/@me/guilds
-      query:
-        - name: with_counts
-          from: literal
-          value: "true"
+      path: /users/@me
     response:
-      rows_path:
-        - body
-    pagination:
-      mode: none
+      row_strategy: direct
     columns:
       - name: id
         type: Utf8
         nullable: false
-        description: Guild ID (Snowflake).
+        description: Discord user ID for the bot
+        expr:
+          kind: path
+          path:
+            - id
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Bot username
+        expr:
+          kind: path
+          path:
+            - username
+      - name: discriminator
+        type: Utf8
+        nullable: true
+        description: Legacy Discord discriminator
+        expr:
+          kind: path
+          path:
+            - discriminator
+      - name: global_name
+        type: Utf8
+        nullable: true
+        description: Bot global display name
+        expr:
+          kind: path
+          path:
+            - global_name
+      - name: avatar
+        type: Utf8
+        nullable: true
+        description: Bot avatar hash
+        expr:
+          kind: path
+          path:
+            - avatar
+      - name: bot
+        type: Boolean
+        nullable: true
+        description: Whether the user is a bot account
+        expr:
+          kind: path
+          path:
+            - bot
+      - name: mfa_enabled
+        type: Boolean
+        nullable: true
+        description: Whether multi-factor authentication is enabled
+        expr:
+          kind: path
+          path:
+            - mfa_enabled
+      - name: verified
+        type: Boolean
+        nullable: true
+        description: Whether the account email is verified
+        expr:
+          kind: path
+          path:
+            - verified
+      - name: locale
+        type: Utf8
+        nullable: true
+        description: User locale
+        expr:
+          kind: path
+          path:
+            - locale
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address when available
+        expr:
+          kind: path
+          path:
+            - email
+
+  # ──────────────────────────────────────────────────────────────────────
+  # guilds
+  # ──────────────────────────────────────────────────────────────────────
+  - name: guilds
+    description: Discord guilds that the configured bot can see
+    guide: |
+      Start here to discover guild_id values for guild-scoped tables such
+      as channels, members, and roles. Use optional before and after filters
+      to page manually by guild ID when a bot belongs to many guilds. Set
+      with_counts to true to request approximate member and presence counts.
+      SELECT id, name, approximate_member_count FROM discord.guilds
+      WHERE with_counts = true.
+    filters:
+      - name: before
+      - name: after
+      - name: with_counts
+    request:
+      method: GET
+      path: /users/@me/guilds
+      query:
+        - name: before
+          from: filter
+          key: before
+        - name: after
+          from: filter
+          key: after
+        - name: with_counts
+          from: filter_bool
+          key: with_counts
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+      page_size:
+        default: 100
+        max: 200
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Discord guild ID
         expr:
           kind: path
           path:
@@ -65,7 +179,7 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        description: Guild name (2-100 characters).
+        description: Guild name
         expr:
           kind: path
           path:
@@ -73,7 +187,7 @@ tables:
       - name: icon
         type: Utf8
         nullable: true
-        description: Icon hash (compute URL via https://cdn.discordapp.com/icons/{{id}}/{{icon}}.png).
+        description: Guild icon hash
         expr:
           kind: path
           path:
@@ -81,7 +195,7 @@ tables:
       - name: owner
         type: Boolean
         nullable: false
-        description: Whether the bot user is the guild owner.
+        description: Whether the current bot user owns the guild
         expr:
           kind: path
           path:
@@ -89,23 +203,23 @@ tables:
       - name: permissions
         type: Utf8
         nullable: true
-        description: Total permissions of the bot in the guild (bitwise, as string).
+        description: Permission bitset for the current bot user in the guild
         expr:
           kind: path
           path:
             - permissions
       - name: features
-        type: Utf8
+        type: Json
         nullable: true
-        description: Comma-joined guild feature strings (e.g. COMMUNITY, ANIMATED_ICON, BANNER).
+        description: Guild feature flags as a JSON array (e.g. COMMUNITY, ANIMATED_ICON, BANNER)
         expr:
-          kind: join_array
+          kind: path
           path:
             - features
       - name: approximate_member_count
         type: Int64
         nullable: true
-        description: Approximate number of members (requires `with_counts`).
+        description: Approximate member count when requested with with_counts
         expr:
           kind: path
           path:
@@ -113,7 +227,7 @@ tables:
       - name: approximate_presence_count
         type: Int64
         nullable: true
-        description: Approximate number of online members (requires `with_counts`).
+        description: Approximate presence count when requested with with_counts
         expr:
           kind: path
           path:
@@ -121,46 +235,68 @@ tables:
       - name: member_count
         type: Int64
         nullable: true
-        description: Alias for approximate_member_count (requires `with_counts`).
+        description: Alias for approximate_member_count
         expr:
           kind: path
           path:
             - approximate_member_count
+      - name: before
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Guild ID cursor for guilds before that guild
+        expr:
+          kind: from_filter
+          key: before
+      - name: after
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Guild ID cursor for guilds after that guild
+        expr:
+          kind: from_filter
+          key: after
+      - name: with_counts
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Whether approximate member and presence counts were requested
+        expr:
+          kind: from_filter
+          key: with_counts
 
   # ──────────────────────────────────────────────────────────────────────
   # channels
   # ──────────────────────────────────────────────────────────────────────
   - name: channels
-    description: >
-      Channels in a Discord guild. Returns channel ID, name, type, topic,
-      position, parent category, and permission metadata.
-    guide: >
-      Requires `guild_id` filter. Get guild IDs from `discord.guilds`.
-      Channel types: 0 text, 2 voice, 4 category, 5 announcement, 13
-      stage, 15 forum, 16 media.
-      `SELECT id, name, type, position FROM discord.channels WHERE guild_id = '<id>'`.
-    fetch_limit_default: 200
+    description: Channels in a Discord guild
+    guide: |
+      Requires guild_id from discord.guilds. Use returned id values as
+      channel_id filters for discord.messages. Channel types: 0 text,
+      2 voice, 4 category, 5 announcement, 13 stage, 15 forum, 16 media.
+      SELECT id, name, type, position FROM discord.channels
+      WHERE guild_id = '<id>'.
+    filters:
+      - name: guild_id
+        required: true
     request:
       method: GET
       path: /guilds/{{filter.guild_id}}/channels
     response:
-      rows_path:
-        - body
-    pagination:
-      mode: none
+      row_strategy: direct
     columns:
       - name: guild_id
         type: Utf8
         nullable: false
         virtual: true
-        description: Guild ID from required filter.
+        description: Guild ID from required filter
         expr:
           kind: from_filter
           key: guild_id
       - name: id
         type: Utf8
         nullable: false
-        description: Channel ID (Snowflake).
+        description: Discord channel ID
         expr:
           kind: path
           path:
@@ -168,15 +304,15 @@ tables:
       - name: type
         type: Int64
         nullable: false
-        description: Channel type (0 text, 2 voice, 4 category, 5 announcement, 13 stage, 15 forum, 16 media).
+        description: Discord channel type integer
         expr:
           kind: path
           path:
             - type
       - name: name
         type: Utf8
-        nullable: false
-        description: Channel name (1-100 characters).
+        nullable: true
+        description: Channel name
         expr:
           kind: path
           path:
@@ -184,7 +320,7 @@ tables:
       - name: topic
         type: Utf8
         nullable: true
-        description: Channel topic text (0-4096 characters for GUILD_FORUM and GUILD_MEDIA, 0-1024 for others).
+        description: Channel topic
         expr:
           kind: path
           path:
@@ -192,7 +328,7 @@ tables:
       - name: position
         type: Int64
         nullable: true
-        description: Sorting position of the channel.
+        description: Channel sorting position
         expr:
           kind: path
           path:
@@ -200,7 +336,7 @@ tables:
       - name: parent_id
         type: Utf8
         nullable: true
-        description: Parent category channel ID.
+        description: Parent category or channel ID
         expr:
           kind: path
           path:
@@ -208,15 +344,31 @@ tables:
       - name: nsfw
         type: Boolean
         nullable: true
-        description: Whether the channel is NSFW.
+        description: Whether the channel is age-restricted
         expr:
           kind: path
           path:
             - nsfw
+      - name: last_message_id
+        type: Utf8
+        nullable: true
+        description: Most recent message ID known to Discord
+        expr:
+          kind: path
+          path:
+            - last_message_id
+      - name: rate_limit_per_user
+        type: Int64
+        nullable: true
+        description: Slowmode delay in seconds
+        expr:
+          kind: path
+          path:
+            - rate_limit_per_user
       - name: bitrate
         type: Int64
         nullable: true
-        description: Bitrate for voice channels (in bits).
+        description: Voice bitrate in bits per second
         expr:
           kind: path
           path:
@@ -224,31 +376,39 @@ tables:
       - name: user_limit
         type: Int64
         nullable: true
-        description: User limit for voice channels (0 for no limit).
+        description: Voice channel user limit
         expr:
           kind: path
           path:
             - user_limit
-      - name: rate_limit_per_user
-        type: Int64
-        nullable: true
-        description: Slow mode cooldown in seconds for text channels.
-        expr:
-          kind: path
-          path:
-            - rate_limit_per_user
       - name: flags
         type: Int64
         nullable: true
-        description: Channel flags as a bitfield.
+        description: Channel flags as a bitfield
         expr:
           kind: path
           path:
             - flags
+      - name: permission_overwrites
+        type: Json
+        nullable: true
+        description: Channel permission overwrites as JSON
+        expr:
+          kind: path
+          path:
+            - permission_overwrites
+      - name: thread_metadata
+        type: Json
+        nullable: true
+        description: Thread metadata for thread channels as JSON
+        expr:
+          kind: path
+          path:
+            - thread_metadata
       - name: default_auto_archive_duration
         type: Int64
         nullable: true
-        description: Default auto-archive duration for threads (60, 1440, 4320, 10080 minutes).
+        description: Default auto-archive duration for threads in minutes (60, 1440, 4320, 10080)
         expr:
           kind: path
           path:
@@ -256,7 +416,7 @@ tables:
       - name: default_forum_layout
         type: Int64
         nullable: true
-        description: Default forum layout (0 not set, 1 list view, 2 gallery view).
+        description: Default forum layout (0 not set, 1 list view, 2 gallery view)
         expr:
           kind: path
           path:
@@ -264,7 +424,7 @@ tables:
       - name: default_sort_order
         type: Int64
         nullable: true
-        description: Default sort order for forum channels (0 latest activity, 1 creation date).
+        description: Default sort order for forum channels (0 latest activity, 1 creation date)
         expr:
           kind: path
           path:
@@ -272,7 +432,7 @@ tables:
       - name: default_thread_rate_limit_per_user
         type: Int64
         nullable: true
-        description: Default slow mode for threads in forum/media channels.
+        description: Default slow mode for threads in forum and media channels
         expr:
           kind: path
           path:
@@ -280,73 +440,82 @@ tables:
       - name: video_quality_mode
         type: Int64
         nullable: true
-        description: Video quality mode for voice channels (1 auto, 2 720p).
+        description: Video quality mode for voice channels (1 auto, 2 720p)
         expr:
           kind: path
           path:
             - video_quality_mode
-    filters:
-      - name: guild_id
-        required: true
 
   # ──────────────────────────────────────────────────────────────────────
   # messages
   # ──────────────────────────────────────────────────────────────────────
   - name: messages
-    description: >
-      Messages in a Discord channel. Returns message ID, content, author
-      info, timestamps, attachments, embeds, mentions, reactions, and
-      message type.
-    guide: >
-      Requires `channel_id` filter. Messages are returned newest-first.
-      Use `after` and `before` filters for cursor-based pagination (pass
-      message IDs as Snowflake strings). Use `around` to fetch messages
-      around a specific message ID. Maximum 100 per page.
-      `SELECT id, content, author__id, author__username, timestamp
-      FROM discord.messages WHERE channel_id = '<id>' LIMIT 50`.
-    fetch_limit_default: 100
+    description: Recent messages in a Discord channel
+    guide: |
+      Requires channel_id from discord.channels. Messages are returned
+      newest-first. Use before, after, and around filters for cursor-based
+      pagination (pass message IDs as Snowflake strings). These filters are
+      mutually exclusive. Maximum 100 per request. Requires MESSAGE_CONTENT
+      privileged intent for content, embeds, and attachments.
+      SELECT id, author__username, content, timestamp
+      FROM discord.messages WHERE channel_id = '<id>' ORDER BY timestamp DESC
+      LIMIT 20.
+    filters:
+      - name: channel_id
+        required: true
+      - name: before
+      - name: after
+      - name: around
     request:
       method: GET
       path: /channels/{{filter.channel_id}}/messages
       query:
-        - name: limit
-          from: literal
-          value: "100"
-        - name: after
-          from: filter
-          key: after
         - name: before
           from: filter
           key: before
+        - name: after
+          from: filter
+          key: after
         - name: around
           from: filter
           key: around
     response:
-      rows_path:
-        - body
+      row_strategy: direct
     pagination:
       mode: none
+      page_size:
+        default: 50
+        max: 100
+        query_param: limit
     columns:
       - name: channel_id
         type: Utf8
         nullable: false
         virtual: true
-        description: Channel ID from required filter.
+        description: Channel ID from required filter
         expr:
           kind: from_filter
           key: channel_id
       - name: id
         type: Utf8
         nullable: false
-        description: Message ID (Snowflake).
+        description: Discord message ID
         expr:
           kind: path
           path:
             - id
+      - name: guild_id
+        type: Utf8
+        nullable: true
+        description: Guild ID from the message, used for guild-scoped permalinks
+        expr:
+          kind: path
+          path:
+            - guild_id
       - name: content
         type: Utf8
         nullable: true
-        description: Message content text (up to 2000 characters).
+        description: Message content visible to the bot
         expr:
           kind: path
           path:
@@ -354,7 +523,7 @@ tables:
       - name: type
         type: Int64
         nullable: false
-        description: Message type (0 default, 19 reply, 21 thread starter, etc.).
+        description: Discord message type integer
         expr:
           kind: path
           path:
@@ -362,7 +531,7 @@ tables:
       - name: timestamp
         type: Timestamp
         nullable: false
-        description: Message creation timestamp (ISO 8601).
+        description: Message creation timestamp (ISO 8601)
         expr:
           kind: format_timestamp
           input: iso8601
@@ -373,7 +542,7 @@ tables:
       - name: edited_timestamp
         type: Timestamp
         nullable: true
-        description: Message edit timestamp (ISO 8601), null if never edited.
+        description: Message edit timestamp (ISO 8601), null if never edited
         expr:
           kind: format_timestamp
           input: iso8601
@@ -384,7 +553,7 @@ tables:
       - name: tts
         type: Boolean
         nullable: false
-        description: Whether the message is a text-to-speech message.
+        description: Whether the message is a text-to-speech message
         expr:
           kind: path
           path:
@@ -392,7 +561,7 @@ tables:
       - name: mention_everyone
         type: Boolean
         nullable: false
-        description: Whether the message mentions @everyone or @here.
+        description: Whether the message mentions @everyone or @here
         expr:
           kind: path
           path:
@@ -400,15 +569,23 @@ tables:
       - name: pinned
         type: Boolean
         nullable: false
-        description: Whether the message is pinned.
+        description: Whether the message is pinned
         expr:
           kind: path
           path:
             - pinned
+      - name: flags
+        type: Int64
+        nullable: false
+        description: Message flags bitset
+        expr:
+          kind: path
+          path:
+            - flags
       - name: author__id
         type: Utf8
         nullable: true
-        description: Author user ID.
+        description: Author user ID
         expr:
           kind: path
           path:
@@ -417,7 +594,7 @@ tables:
       - name: author__username
         type: Utf8
         nullable: true
-        description: Author username (not unique).
+        description: Author username
         expr:
           kind: path
           path:
@@ -426,7 +603,7 @@ tables:
       - name: author__global_name
         type: Utf8
         nullable: true
-        description: Author global display name.
+        description: Author global display name
         expr:
           kind: path
           path:
@@ -435,7 +612,7 @@ tables:
       - name: author__discriminator
         type: Utf8
         nullable: true
-        description: Author discriminator (deprecated, may be "0").
+        description: Author discriminator (deprecated, may be "0")
         expr:
           kind: path
           path:
@@ -444,7 +621,7 @@ tables:
       - name: author__avatar
         type: Utf8
         nullable: true
-        description: Author avatar hash.
+        description: Author avatar hash
         expr:
           kind: path
           path:
@@ -453,7 +630,7 @@ tables:
       - name: author__bot
         type: Boolean
         nullable: true
-        description: Whether the author is a bot.
+        description: Whether the author is a bot
         expr:
           kind: path
           path:
@@ -462,7 +639,7 @@ tables:
       - name: author__system
         type: Boolean
         nullable: true
-        description: Whether the author is a Discord system user.
+        description: Whether the author is a Discord system user
         expr:
           kind: path
           path:
@@ -471,23 +648,23 @@ tables:
       - name: mentions
         type: Json
         nullable: true
-        description: Array of user objects mentioned in the message.
+        description: Mentioned users as JSON
         expr:
           kind: path
           path:
             - mentions
       - name: mention_roles
-        type: Utf8
+        type: Json
         nullable: true
-        description: Comma-joined role IDs mentioned in the message.
+        description: Mentioned role IDs as JSON
         expr:
-          kind: join_array
+          kind: path
           path:
             - mention_roles
       - name: attachments
         type: Json
         nullable: true
-        description: Array of attachment objects (id, filename, size, url, proxy_url, etc.).
+        description: Message attachments as JSON
         expr:
           kind: path
           path:
@@ -495,7 +672,7 @@ tables:
       - name: embeds
         type: Json
         nullable: true
-        description: Array of embed objects (type, title, description, url, etc.).
+        description: Message embeds as JSON
         expr:
           kind: path
           path:
@@ -503,7 +680,7 @@ tables:
       - name: reactions
         type: Json
         nullable: true
-        description: Array of reaction objects (emoji, count, me).
+        description: Array of reaction objects (emoji, count, me)
         expr:
           kind: path
           path:
@@ -511,7 +688,7 @@ tables:
       - name: nonce
         type: Utf8
         nullable: true
-        description: Nonce for optimistic message sending (may be Int64 or string).
+        description: Nonce for optimistic message sending (may be Int64 or string)
         expr:
           kind: path
           path:
@@ -519,7 +696,7 @@ tables:
       - name: webhook_id
         type: Utf8
         nullable: true
-        description: Webhook ID if the message was sent by a webhook.
+        description: Webhook ID if sent by a webhook
         expr:
           kind: path
           path:
@@ -527,15 +704,33 @@ tables:
       - name: message_reference
         type: Json
         nullable: true
-        description: Message reference object for replies (message_id, channel_id, guild_id).
+        description: Message reference object for replies (message_id, channel_id, guild_id)
         expr:
           kind: path
           path:
             - message_reference
+      - name: message_reference__message_id
+        type: Utf8
+        nullable: true
+        description: Message reference target message ID
+        expr:
+          kind: path
+          path:
+            - message_reference
+            - message_id
+      - name: referenced_message__id
+        type: Utf8
+        nullable: true
+        description: Referenced message ID when this message is a reply
+        expr:
+          kind: path
+          path:
+            - referenced_message
+            - id
       - name: message_snapshots
         type: Json
         nullable: true
-        description: Array of forwarded message snapshots.
+        description: Array of forwarded message snapshots
         expr:
           kind: path
           path:
@@ -543,7 +738,7 @@ tables:
       - name: interaction_metadata
         type: Json
         nullable: true
-        description: Interaction metadata for application command messages.
+        description: Interaction metadata for application command messages
         expr:
           kind: path
           path:
@@ -551,7 +746,7 @@ tables:
       - name: sticker_items
         type: Json
         nullable: true
-        description: Array of sticker objects (id, name, format_type).
+        description: Array of sticker objects (id, name, format_type)
         expr:
           kind: path
           path:
@@ -559,7 +754,7 @@ tables:
       - name: position
         type: Int64
         nullable: true
-        description: Position in a thread starter message or forum post.
+        description: Position in a thread starter message or forum post
         expr:
           kind: path
           path:
@@ -567,7 +762,7 @@ tables:
       - name: role_subscription_data
         type: Json
         nullable: true
-        description: Role subscription data for role purchase messages.
+        description: Role subscription data for role purchase messages
         expr:
           kind: path
           path:
@@ -575,7 +770,7 @@ tables:
       - name: resolved
         type: Json
         nullable: true
-        description: Resolved data for application command interactions.
+        description: Resolved data for application command interactions
         expr:
           kind: path
           path:
@@ -583,85 +778,95 @@ tables:
       - name: thread
         type: Json
         nullable: true
-        description: Thread channel object if the message starts a thread.
+        description: Thread channel object if the message starts a thread
         expr:
           kind: path
           path:
             - thread
-      - name: after
+      - name: permalink
         type: Utf8
         nullable: true
-        virtual: true
-        description: Get messages after this message ID (Snowflake, for cursor pagination).
+        description: Discord web URL for the message
         expr:
-          kind: from_filter
-          key: after
+          kind: template
+          template: "https://discord.com/channels/{{expr.guild_id|@me}}/{{filter.channel_id}}/{{expr.message_id}}"
+          values:
+            guild_id:
+              kind: path
+              path:
+                - guild_id
+            message_id:
+              kind: path
+              path:
+                - id
       - name: before
         type: Utf8
         nullable: true
         virtual: true
-        description: Get messages before this message ID (Snowflake, for cursor pagination).
+        description: Message ID cursor for messages before that message
         expr:
           kind: from_filter
           key: before
+      - name: after
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Message ID cursor for messages after that message
+        expr:
+          kind: from_filter
+          key: after
       - name: around
         type: Utf8
         nullable: true
         virtual: true
-        description: Get messages around this message ID (Snowflake, single page of 100).
+        description: Message ID cursor for messages around that message
         expr:
           kind: from_filter
           key: around
-    filters:
-      - name: channel_id
-        required: true
-      - name: after
-      - name: before
-      - name: around
 
   # ──────────────────────────────────────────────────────────────────────
   # members
   # ──────────────────────────────────────────────────────────────────────
   - name: members
-    description: >
-      Members of a Discord guild. Returns user info, roles, joined time,
-      nickname, boosting status, timeout, and flags.
-    guide: >
-      Requires `guild_id` filter. Large guilds (250k+) require `Server
-      Members Intent` enabled in the Discord Developer Portal.
-      `SELECT user__id, user__username, nickname, joined_at, roles
-      FROM discord.members WHERE guild_id = '<id>' LIMIT 100`.
-      Supports `after` for cursor-based pagination (pass the last
-      user__id from the previous page).
-    fetch_limit_default: 100
+    description: Members in a Discord guild
+    guide: |
+      Requires guild_id from discord.guilds. This endpoint requires the
+      GUILD_MEMBERS privileged intent. Use optional after filter to page
+      manually by the highest returned user ID. Maximum 1000 per request.
+      SELECT user__id, user__username, nick, joined_at
+      FROM discord.members WHERE guild_id = '<id>' LIMIT 100.
+    filters:
+      - name: guild_id
+        required: true
+      - name: after
     request:
       method: GET
       path: /guilds/{{filter.guild_id}}/members
       query:
-        - name: limit
-          from: literal
-          value: "1000"
         - name: after
           from: filter
           key: after
     response:
-      rows_path:
-        - body
+      row_strategy: direct
     pagination:
       mode: none
+      page_size:
+        default: 1000
+        max: 1000
+        query_param: limit
     columns:
       - name: guild_id
         type: Utf8
         nullable: false
         virtual: true
-        description: Guild ID from required filter.
+        description: Guild ID from required filter
         expr:
           kind: from_filter
           key: guild_id
       - name: user__id
         type: Utf8
         nullable: true
-        description: User ID (Snowflake).
+        description: Member user ID
         expr:
           kind: path
           path:
@@ -670,7 +875,7 @@ tables:
       - name: user__username
         type: Utf8
         nullable: true
-        description: Username (not unique).
+        description: Member username
         expr:
           kind: path
           path:
@@ -679,7 +884,7 @@ tables:
       - name: user__global_name
         type: Utf8
         nullable: true
-        description: Global display name.
+        description: Member global display name
         expr:
           kind: path
           path:
@@ -688,7 +893,7 @@ tables:
       - name: user__discriminator
         type: Utf8
         nullable: true
-        description: Discriminator (deprecated, may be "0").
+        description: Member discriminator (deprecated, may be "0")
         expr:
           kind: path
           path:
@@ -697,7 +902,7 @@ tables:
       - name: user__avatar
         type: Utf8
         nullable: true
-        description: Avatar hash.
+        description: Member user avatar hash
         expr:
           kind: path
           path:
@@ -706,7 +911,7 @@ tables:
       - name: user__bot
         type: Boolean
         nullable: true
-        description: Whether the user is a bot.
+        description: Whether the member user is a bot
         expr:
           kind: path
           path:
@@ -715,16 +920,16 @@ tables:
       - name: user__system
         type: Boolean
         nullable: true
-        description: Whether the user is a Discord system user.
+        description: Whether the member user is a Discord system user
         expr:
           kind: path
           path:
             - user
             - system
-      - name: nickname
+      - name: nick
         type: Utf8
         nullable: true
-        description: Guild-specific nickname (null if none set).
+        description: Guild-specific nickname (null if none set)
         expr:
           kind: path
           path:
@@ -732,23 +937,23 @@ tables:
       - name: avatar
         type: Utf8
         nullable: true
-        description: Guild-specific avatar hash.
+        description: Guild-specific avatar hash
         expr:
           kind: path
           path:
             - avatar
       - name: roles
-        type: Utf8
+        type: Json
         nullable: true
-        description: Comma-joined role IDs the member has.
+        description: Role IDs assigned to the member as JSON array
         expr:
-          kind: join_array
+          kind: path
           path:
             - roles
       - name: joined_at
         type: Timestamp
         nullable: true
-        description: Timestamp the member joined the guild (ISO 8601).
+        description: Timestamp when the member joined the guild (ISO 8601)
         expr:
           kind: format_timestamp
           input: iso8601
@@ -759,7 +964,7 @@ tables:
       - name: premium_since
         type: Timestamp
         nullable: true
-        description: Timestamp when the member started boosting (ISO 8601), null if not boosting.
+        description: Timestamp when the member started boosting (ISO 8601), null if not boosting
         expr:
           kind: format_timestamp
           input: iso8601
@@ -770,7 +975,7 @@ tables:
       - name: deaf
         type: Boolean
         nullable: true
-        description: Whether the member is deafened in voice channels.
+        description: Whether the member is deafened in voice channels
         expr:
           kind: path
           path:
@@ -778,7 +983,7 @@ tables:
       - name: mute
         type: Boolean
         nullable: true
-        description: Whether the member is muted in voice channels.
+        description: Whether the member is muted in voice channels
         expr:
           kind: path
           path:
@@ -786,7 +991,7 @@ tables:
       - name: flags
         type: Int64
         nullable: true
-        description: Member flags as a bitfield.
+        description: Member flags as a bitfield
         expr:
           kind: path
           path:
@@ -794,7 +999,7 @@ tables:
       - name: pending
         type: Boolean
         nullable: true
-        description: Whether the member has not yet passed guild membership screening.
+        description: Whether the member has not passed guild membership screening
         expr:
           kind: path
           path:
@@ -802,7 +1007,7 @@ tables:
       - name: communication_disabled_until
         type: Timestamp
         nullable: true
-        description: Timestamp when the member's timeout expires (ISO 8601), null if not timed out.
+        description: Timestamp when a timeout expires (ISO 8601), null if not timed out
         expr:
           kind: format_timestamp
           input: iso8601
@@ -810,60 +1015,47 @@ tables:
             kind: path
             path:
               - communication_disabled_until
-      - name: permissions
-        type: Utf8
-        nullable: true
-        description: Effective permissions of the member in the guild (bitwise, as string).
-        expr:
-          kind: path
-          path:
-            - permissions
       - name: after
         type: Utf8
         nullable: true
         virtual: true
-        description: Get members after this user ID (Snowflake, for cursor pagination).
+        description: User ID cursor for guild member pagination
         expr:
           kind: from_filter
           key: after
-    filters:
-      - name: guild_id
-        required: true
-      - name: after
 
   # ──────────────────────────────────────────────────────────────────────
   # roles
   # ──────────────────────────────────────────────────────────────────────
   - name: roles
-    description: >
-      Roles in a Discord guild. Returns role ID, name, color, permissions
-      flags, position (lower is higher priority), and display settings.
-    guide: >
-      Requires `guild_id` filter. Role position is 0-based where higher
-      positions are higher in the hierarchy. The @everyone role has the
-      same ID as the guild.
-      `SELECT id, name, color, position, permissions FROM discord.roles WHERE guild_id = '<id>'`.
+    description: Roles in a Discord guild
+    guide: |
+      Requires guild_id from discord.guilds. Role position is 0-based where
+      higher positions are higher in the hierarchy. The @everyone role has
+      the same ID as the guild.
+      SELECT id, name, color, position, permissions FROM discord.roles
+      WHERE guild_id = '<id>' ORDER BY position DESC.
+    filters:
+      - name: guild_id
+        required: true
     request:
       method: GET
       path: /guilds/{{filter.guild_id}}/roles
     response:
-      rows_path:
-        - body
-    pagination:
-      mode: none
+      row_strategy: direct
     columns:
       - name: guild_id
         type: Utf8
         nullable: false
         virtual: true
-        description: Guild ID from required filter.
+        description: Guild ID from required filter
         expr:
           kind: from_filter
           key: guild_id
       - name: id
         type: Utf8
         nullable: false
-        description: Role ID (Snowflake).
+        description: Discord role ID
         expr:
           kind: path
           path:
@@ -871,23 +1063,23 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        description: Role name (1-100 characters).
+        description: Role name
         expr:
           kind: path
           path:
             - name
       - name: color
         type: Int64
-        nullable: false
-        description: Role color as an integer (RGB, 0 for default).
+        nullable: true
+        description: Integer representation of the role color
         expr:
           kind: path
           path:
             - color
       - name: hoist
         type: Boolean
-        nullable: false
-        description: Whether the role is displayed separately in the member sidebar.
+        nullable: true
+        description: Whether the role is displayed separately in the member list
         expr:
           kind: path
           path:
@@ -895,7 +1087,7 @@ tables:
       - name: icon
         type: Utf8
         nullable: true
-        description: Role icon hash.
+        description: Role icon hash
         expr:
           kind: path
           path:
@@ -903,7 +1095,7 @@ tables:
       - name: unicode_emoji
         type: Utf8
         nullable: true
-        description: Role unicode emoji (overrides icon).
+        description: Role unicode emoji
         expr:
           kind: path
           path:
@@ -911,7 +1103,7 @@ tables:
       - name: position
         type: Int64
         nullable: false
-        description: Role position in the hierarchy (higher = more permissions).
+        description: Role sorting position (higher = more permissions)
         expr:
           kind: path
           path:
@@ -919,23 +1111,23 @@ tables:
       - name: permissions
         type: Utf8
         nullable: false
-        description: Role permissions as a Discord permission bitwise string.
+        description: Role permission bitset
         expr:
           kind: path
           path:
             - permissions
       - name: managed
         type: Boolean
-        nullable: false
-        description: Whether the role is managed by an integration (e.g. bots, Twitch).
+        nullable: true
+        description: Whether the role is managed by an integration
         expr:
           kind: path
           path:
             - managed
       - name: mentionable
         type: Boolean
-        nullable: false
-        description: Whether the role can be @mentioned by anyone.
+        nullable: true
+        description: Whether the role can be @mentioned by anyone
         expr:
           kind: path
           path:
@@ -943,7 +1135,7 @@ tables:
       - name: tags
         type: Json
         nullable: true
-        description: Role tags (bot_id, premium_subscriber, integration_id, etc.).
+        description: Role tags as JSON (bot_id, premium_subscriber, integration_id, etc.)
         expr:
           kind: path
           path:
@@ -951,11 +1143,8 @@ tables:
       - name: flags
         type: Int64
         nullable: true
-        description: Role flags as a bitfield.
+        description: Role flags as a bitfield
         expr:
           kind: path
           path:
             - flags
-    filters:
-      - name: guild_id
-        required: true

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -452,11 +452,14 @@ tables:
   - name: messages
     description: Recent messages in a Discord channel
     guide: |
-      Requires channel_id from discord.channels. Messages are returned
+      Requires channel_id from discord.channels. The bot must have
+      VIEW_CHANNEL and READ_MESSAGE_HISTORY permissions on the channel;
+      voice channels additionally require CONNECT. Messages are returned
       newest-first. Use before, after, and around filters for cursor-based
       pagination (pass message IDs as Snowflake strings). These filters are
       mutually exclusive. Maximum 100 per request. Requires MESSAGE_CONTENT
-      privileged intent for content, embeds, and attachments.
+      privileged intent for content, embeds, and attachments (without it
+      those fields will be empty even with READ_MESSAGE_HISTORY).
       SELECT id, author__username, content, timestamp
       FROM discord.messages WHERE channel_id = '<id>' ORDER BY timestamp DESC
       LIMIT 20.
@@ -576,7 +579,7 @@ tables:
             - pinned
       - name: flags
         type: Int64
-        nullable: false
+        nullable: true
         description: Message flags bitset
         expr:
           kind: path

--- a/sources/community/discord/manifest.yaml
+++ b/sources/community/discord/manifest.yaml
@@ -11,11 +11,10 @@ inputs:
     hint: |
       Discord bot token. Create a bot application at
       https://discord.com/developers/applications, go to Bot settings, and
-      copy the token. Required scopes: `bot`. Required permissions depend
-      on which tables you query — `Read Messages / View Channels` for
-      channels and messages, `Read Message History` for message content,
-      and `Request Server Members` (under Privileged Gateway Intents) for
-      the members table.
+      copy the token. The bot must be invited to target servers with the
+      `bot` scope. Required privileged intents depend on which tables you
+      query: `GUILD_MEMBERS` (privileged) for the members table, and
+      `MESSAGE_CONTENT` (privileged) for message content.
 
       See https://discord.com/developers/docs/getting-started.
 base_url: https://discord.com/api/v10
@@ -26,7 +25,7 @@ auth:
       from: template
       template: Bot {{input.DISCORD_BOT_TOKEN}}
 test_queries:
-  - SELECT id, name, owner_id, member_count FROM discord.guilds LIMIT 1
+  - SELECT id, name, member_count FROM discord.guilds LIMIT 1
 rate_limit:
   remaining_header: X-RateLimit-Remaining
   reset_header: X-RateLimit-Reset
@@ -53,12 +52,7 @@ tables:
       rows_path:
         - body
     pagination:
-      mode: page
-      page_param: None
-      page_size:
-        default: 200
-        max: 200
-        query_param: limit
+      mode: none
     columns:
       - name: id
         type: Utf8
@@ -84,38 +78,14 @@ tables:
           kind: path
           path:
             - icon
-      - name: icon_hash
-        type: Utf8
-        nullable: true
-        description: Icon hash, possibly animated.
-        expr:
-          kind: path
-          path:
-            - icon_hash
-      - name: splash
-        type: Utf8
-        nullable: true
-        description: Splash hash for the guild invite splash.
-        expr:
-          kind: path
-          path:
-            - splash
-      - name: discovery_splash
-        type: Utf8
-        nullable: true
-        description: Discovery splash hash.
-        expr:
-          kind: path
-          path:
-            - discovery_splash
-      - name: owner_id
-        type: Utf8
+      - name: owner
+        type: Boolean
         nullable: false
-        description: ID of the guild owner.
+        description: Whether the bot user is the guild owner.
         expr:
           kind: path
           path:
-            - owner_id
+            - owner
       - name: permissions
         type: Utf8
         nullable: true
@@ -124,86 +94,6 @@ tables:
           kind: path
           path:
             - permissions
-      - name: region
-        type: Utf8
-        nullable: true
-        description: Voice region (deprecated, may be null).
-        expr:
-          kind: path
-          path:
-            - region
-      - name: afk_channel_id
-        type: Utf8
-        nullable: true
-        description: AFK voice channel ID.
-        expr:
-          kind: path
-          path:
-            - afk_channel_id
-      - name: afk_timeout
-        type: Int64
-        nullable: true
-        description: AFK timeout in seconds.
-        expr:
-          kind: path
-          path:
-            - afk_timeout
-      - name: widget_enabled
-        type: Boolean
-        nullable: true
-        description: Whether the guild has a widget enabled.
-        expr:
-          kind: path
-          path:
-            - widget_enabled
-      - name: widget_channel_id
-        type: Utf8
-        nullable: true
-        description: Channel ID for the widget.
-        expr:
-          kind: path
-          path:
-            - widget_channel_id
-      - name: verification_level
-        type: Int64
-        nullable: true
-        description: Verification level (0 none, 1 low, 2 medium, 3 high, 4 very high).
-        expr:
-          kind: path
-          path:
-            - verification_level
-      - name: default_message_notifications
-        type: Int64
-        nullable: true
-        description: Default message notification level.
-        expr:
-          kind: path
-          path:
-            - default_message_notifications
-      - name: explicit_content_filter
-        type: Int64
-        nullable: true
-        description: Explicit content filter level.
-        expr:
-          kind: path
-          path:
-            - explicit_content_filter
-      - name: roles
-        type: Json
-        nullable: true
-        description: Array of role objects in the guild.
-        expr:
-          kind: path
-          path:
-            - roles
-      - name: emojis
-        type: Json
-        nullable: true
-        description: Array of emoji objects.
-        expr:
-          kind: path
-          path:
-            - emojis
       - name: features
         type: Utf8
         nullable: true
@@ -212,134 +102,6 @@ tables:
           kind: join_array
           path:
             - features
-      - name: mfa_level
-        type: Int64
-        nullable: true
-        description: MFA level (0 none, 1 elevated).
-        expr:
-          kind: path
-          path:
-            - mfa_level
-      - name: application_id
-        type: Utf8
-        nullable: true
-        description: Application ID of the guild creator (null if community-created).
-        expr:
-          kind: path
-          path:
-            - application_id
-      - name: system_channel_id
-        type: Utf8
-        nullable: true
-        description: Channel ID for system notifications.
-        expr:
-          kind: path
-          path:
-            - system_channel_id
-      - name: system_channel_flags
-        type: Int64
-        nullable: true
-        description: System channel flags.
-        expr:
-          kind: path
-          path:
-            - system_channel_flags
-      - name: rules_channel_id
-        type: Utf8
-        nullable: true
-        description: Channel ID for community rules/guidelines.
-        expr:
-          kind: path
-          path:
-            - rules_channel_id
-      - name: max_presences
-        type: Int64
-        nullable: true
-        description: Maximum number of presences the guild can have.
-        expr:
-          kind: path
-          path:
-            - max_presences
-      - name: max_members
-        type: Int64
-        nullable: true
-        description: Maximum member capacity.
-        expr:
-          kind: path
-          path:
-            - max_members
-      - name: vanity_url_code
-        type: Utf8
-        nullable: true
-        description: Vanity URL code for the guild.
-        expr:
-          kind: path
-          path:
-            - vanity_url_code
-      - name: description
-        type: Utf8
-        nullable: true
-        description: Guild description.
-        expr:
-          kind: path
-          path:
-            - description
-      - name: banner
-        type: Utf8
-        nullable: true
-        description: Banner hash.
-        expr:
-          kind: path
-          path:
-            - banner
-      - name: premium_tier
-        type: Int64
-        nullable: true
-        description: Server boost tier (0 none, 1, 2, 3).
-        expr:
-          kind: path
-          path:
-            - premium_tier
-      - name: premium_subscription_count
-        type: Int64
-        nullable: true
-        description: Number of active boosts.
-        expr:
-          kind: path
-          path:
-            - premium_subscription_count
-      - name: preferred_locale
-        type: Utf8
-        nullable: true
-        description: Preferred locale of the guild.
-        expr:
-          kind: path
-          path:
-            - preferred_locale
-      - name: public_updates_channel_id
-        type: Utf8
-        nullable: true
-        description: Channel ID for public updates.
-        expr:
-          kind: path
-          path:
-            - public_updates_channel_id
-      - name: max_video_channel_users
-        type: Int64
-        nullable: true
-        description: Maximum video channel users.
-        expr:
-          kind: path
-          path:
-            - max_video_channel_users
-      - name: max_stage_video_channel_users
-        type: Int64
-        nullable: true
-        description: Maximum stage video channel users.
-        expr:
-          kind: path
-          path:
-            - max_stage_video_channel_users
       - name: approximate_member_count
         type: Int64
         nullable: true
@@ -560,12 +322,7 @@ tables:
       rows_path:
         - body
     pagination:
-      mode: page
-      page_param: None
-      page_size:
-        default: 100
-        max: 100
-        query_param: limit
+      mode: none
     columns:
       - name: channel_id
         type: Utf8
@@ -600,21 +357,27 @@ tables:
           path:
             - type
       - name: timestamp
-        type: Utf8
+        type: Timestamp
         nullable: false
         description: Message creation timestamp (ISO 8601).
         expr:
-          kind: path
-          path:
-            - timestamp
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - timestamp
       - name: edited_timestamp
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Message edit timestamp (ISO 8601), null if never edited.
         expr:
-          kind: path
-          path:
-            - edited_timestamp
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - edited_timestamp
       - name: tts
         type: Boolean
         nullable: false
@@ -879,12 +642,7 @@ tables:
       rows_path:
         - body
     pagination:
-      mode: page
-      page_param: None
-      page_size:
-        default: 100
-        max: 1000
-        query_param: limit
+      mode: none
     columns:
       - name: guild_id
         type: Utf8
@@ -982,21 +740,27 @@ tables:
           path:
             - roles
       - name: joined_at
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Timestamp the member joined the guild (ISO 8601).
         expr:
-          kind: path
-          path:
-            - joined_at
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - joined_at
       - name: premium_since
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Timestamp when the member started boosting (ISO 8601), null if not boosting.
         expr:
-          kind: path
-          path:
-            - premium_since
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - premium_since
       - name: deaf
         type: Boolean
         nullable: true
@@ -1030,13 +794,16 @@ tables:
           path:
             - pending
       - name: communication_disabled_until
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: Timestamp when the member's timeout expires (ISO 8601), null if not timed out.
         expr:
-          kind: path
-          path:
-            - communication_disabled_until
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - communication_disabled_until
       - name: permissions
         type: Utf8
         nullable: true


### PR DESCRIPTION
feat(sources): add Discord community source spec

## What changed

Consolidated Discord source spec with best of both PR #684 and PR #365.

### New: current_user table
- `discord.current_user` — `GET /users/@me` for bot identity verification

### Tables (6 total)
| Table | Endpoint | Required filter | Pagination |
|-------|----------|-----------------|------------|
| `current_user` | `GET /users/@me` | none | none |
| `guilds` | `GET /users/@me/guilds` | optional: before, after, with_counts | cursor (max 200) |
| `channels` | `GET /guilds/{guild_id}/channels` | `guild_id` | none |
| `messages` | `GET /channels/{channel_id}/messages` | `channel_id`; optional: before, after, around | cursor (max 100) |
| `members` | `GET /guilds/{guild_id}/members` | `guild_id`; optional: after | cursor (max 1000) |
| `roles` | `GET /guilds/{guild_id}/roles` | `guild_id` | none |

### Key improvements
- Guilds now expose `before`, `after`, `with_counts` filters with page_size (max 200)
- Messages expose mutually exclusive `before`/`after`/`around` filters with page_size (max 100)
- Members expose `after` filter with page_size (max 1000), roles as Json
- `row_strategy: direct` throughout for cleaner parsing
- `nick` column matches Discord API (instead of `nickname`)
- `features` and `mention_roles` as Json (not join_array)
- `members.permissions` removed (List Guild Members does not return it)

### README
- Added `current_user` table docs
- Fixed privileged intents documentation (separated from bot permissions)
- Removed invented 'Request Server Members' permission
- Added pagination section and examples
