### PR TITLE
fix(ci): invoke Windows release smoke binary correctly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,8 +137,9 @@ jobs:
         env:
           TARGET: ${{ matrix.target }}
         run: |
-          .\target\$env:TARGET\release\coral.exe --version
-          .\target\$env:TARGET\release\coral.exe source discover
+          $coral = "target\$env:TARGET\release\coral.exe"
+          & $coral --version
+          & $coral source discover
 
       - name: Package Unix
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary

- Fix the Windows release smoke step so PowerShell expands the target-specific binary path before invocation.
- Invoke the computed executable path with PowerShell's call operator.

## Root Cause

The release workflow tried to execute `.\target\$env:TARGET\release\coral.exe` directly. In PowerShell, the environment variable was not expanded inside that command path, so the Windows job looked for a literal path containing `$env:TARGET` and failed before packaging.

## Validation

- `git diff --check`
- `pwsh` path expansion check for `target\$env:TARGET\release\coral.exe`
- `pwsh` parser check for the fixed smoke-step snippet
- Ruby YAML parse of `.github/workflows/release.yml`