### PR TITLE
chore(ui): standardize linting/formatting with oxlint + oxfmt

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -172,6 +172,9 @@ jobs:
       - name: Install UI dependencies
         run: npm ci --prefix ui
 
+      - name: Lint and format check
+        run: npm run check --prefix ui
+
       - name: Build UI
         run: npm run build --prefix ui
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,1 @@
+{ "recommendations": ["oxc.oxc-vscode"] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnSaveMode": "file",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.oxc": "always"
+  },
+  "[typescript]":      { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[typescriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[javascript]":      { "editor.defaultFormatter": "oxc.oxc-vscode" },
+  "[javascriptreact]": { "editor.defaultFormatter": "oxc.oxc-vscode" }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 ## Rules
 
 - Run `make rust-checks` before submitting PRs that include changes to Rust code.
+- UI changes must pass `npm run check --prefix ui` (oxfmt + oxlint) before submitting.
 - `make rust-checks` is the Rust-only local gate and should keep using
   `--all-features`; the embedded UI feature is a normal CLI build surface.
 - The built UI artifact is produced by repo/CI orchestration (`make ui-build`

--- a/ui/.oxfmtrc.json
+++ b/ui/.oxfmtrc.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "useTabs": false,
+  "tabWidth": 2,
+  "printWidth": 100,
+  "endOfLine": "lf",
+  "singleQuote": true,
+  "jsxSingleQuote": false,
+  "semi": false,
+  "trailingComma": "all",
+  "arrowParens": "always",
+  "sortPackageJson": false,
+  "ignorePatterns": [
+    "dist/**",
+    "build/**",
+    "coverage/**",
+    "node_modules/**",
+    "src/generated/**",
+    "test-results/**",
+    "playwright-report/**"
+  ]
+}

--- a/ui/.oxlintrc.json
+++ b/ui/.oxlintrc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["eslint", "typescript", "unicorn", "oxc", "react"],
+  "categories": { "correctness": "error", "suspicious": "error" },
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  },
+  "ignorePatterns": [
+    "dist/**",
+    "build/**",
+    "coverage/**",
+    "node_modules/**",
+    "src/generated/**",
+    "test-results/**",
+    "playwright-report/**"
+  ]
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -30,6 +30,8 @@
         "@vitejs/plugin-react": "^5.1.1",
         "concurrently": "^9.2.1",
         "msw": "^2.14.6",
+        "oxfmt": "^0.51.0",
+        "oxlint": "^1.66.0",
         "typescript": "^5.6.2",
         "vite": "^5.4.10"
       }
@@ -65,6 +67,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -555,7 +558,8 @@
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@bufbuild/protoc-gen-es": {
       "version": "2.12.0",
@@ -613,6 +617,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -634,6 +639,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -646,6 +652,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -668,9 +675,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
       "cpu": [
         "ppc64"
       ],
@@ -681,13 +688,13 @@
         "aix"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
       "cpu": [
         "arm"
       ],
@@ -698,13 +705,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
       "cpu": [
         "arm64"
       ],
@@ -715,13 +722,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
       "cpu": [
         "x64"
       ],
@@ -732,13 +739,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
       "cpu": [
         "arm64"
       ],
@@ -749,13 +756,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
       "cpu": [
         "x64"
       ],
@@ -766,13 +773,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
       "cpu": [
         "arm64"
       ],
@@ -783,13 +790,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
       "cpu": [
         "x64"
       ],
@@ -800,13 +807,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
       "cpu": [
         "arm"
       ],
@@ -817,13 +824,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
       "cpu": [
         "arm64"
       ],
@@ -834,13 +841,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
       "cpu": [
         "ia32"
       ],
@@ -851,13 +858,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
       "cpu": [
         "loong64"
       ],
@@ -868,13 +875,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
       "cpu": [
         "mips64el"
       ],
@@ -885,13 +892,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
       "cpu": [
         "ppc64"
       ],
@@ -902,13 +909,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
       "cpu": [
         "riscv64"
       ],
@@ -919,13 +926,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
       "cpu": [
         "s390x"
       ],
@@ -936,13 +943,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
       "cpu": [
         "x64"
       ],
@@ -953,7 +960,7 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
@@ -969,15 +976,14 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
       "cpu": [
         "x64"
       ],
@@ -988,7 +994,7 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
@@ -1004,15 +1010,14 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
       "cpu": [
         "x64"
       ],
@@ -1023,7 +1028,7 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
@@ -1039,15 +1044,14 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
       "cpu": [
         "x64"
       ],
@@ -1058,13 +1062,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
       "cpu": [
         "arm64"
       ],
@@ -1075,13 +1079,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
       "cpu": [
         "ia32"
       ],
@@ -1092,13 +1096,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
       "cpu": [
         "x64"
       ],
@@ -1109,7 +1113,7 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -1370,13 +1374,659 @@
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.128.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.128.0.tgz",
-      "integrity": "sha512-huv1Y/LzBJkBVHt3OlC7u0zHBW9qXf1FdD7sGmc1rXc2P1mTwHssYv7jyGx5KAACSCH+9B3Bhn6Z9luHRvf7pQ==",
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm-eabi": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.51.0.tgz",
+      "integrity": "sha512-Ni0sCqg5CIHaLIYFGj+ncbcumylvNC6FE4rfD0KfdmnWHbPJ+zev0qZCXKxy2hFVa0fYRK0yPzf5nzPbkZou7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-android-arm64": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.51.0.tgz",
+      "integrity": "sha512-eu5lAZjuo0KAkp+M24EhDqfOwA8owQ8d7wyBlOUUGRbDLHpU3IRlDHp8Dif+YqGlxs6jra7yS6WQu/NkPhAxeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-arm64": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.51.0.tgz",
+      "integrity": "sha512-6LsUNIdURhhcIfIn8+xsOb61mSTa9msAHTeSGx9Jf4rsP/gN8PGCF+SKWPAQZbND2w/WBkqQ6303jqEEIXzMdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-darwin-x64": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.51.0.tgz",
+      "integrity": "sha512-9aUMGmVxdHjYMsEAW1tNRoieTJXlVNDFkRvIR1J7LttJXWjVYCu2ekclLij2KJtxBxSQOYSHd12ME/adVGVbZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-freebsd-x64": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.51.0.tgz",
+      "integrity": "sha512-mkY1nhZTqYb+NHaAWxOCKISN6FwdrwMNsu17vTUA3wzUV2VJ+Paq15ZokRcsMU/2PUdHO73prxyeJpjXQ3MPpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-gnueabihf": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.51.0.tgz",
+      "integrity": "sha512-wtFwNwE4+YCNuPaWoGDZeGsKvD6D1YSUNBJNn/rJBh7CrDBThFE+TBI5kY7vRW9rIOQRsbW2IpyyL3Du4Zqwiw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm-musleabihf": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.51.0.tgz",
+      "integrity": "sha512-rnOaNx86G7iRKM6lsCIQMux0SMGNC/TEbFR+r7lpruJ12bnrIWgxd5w1PLqOvgR9r8ZJbpK/zfRKctJnh8/Jfg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-gnu": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.51.0.tgz",
+      "integrity": "sha512-jOgDzSqWcICGRjsp4mc08FxKMN8vzP2Kgs4E0d2HUP99F+nJDQKklRV4Zuj+0gcBgjrzx2CbpqaIdUVPepCojA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-arm64-musl": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.51.0.tgz",
+      "integrity": "sha512-KBUCdrH5bwVrAvI9gU/1S55oH6fzXjr++J/oVocdu7bYTks1l7DNNT+rLd/1TDdAEjObGwmfWamn7LC1m8A0DQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-ppc64-gnu": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.51.0.tgz",
+      "integrity": "sha512-NapfjYsABFqTJ1Dn9Efq6sN5esaHconVKwVLbDGNQLrwpOx/g17mkwErHzU72PutL67nf3wNAkbq122H+zLxag==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-gnu": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.51.0.tgz",
+      "integrity": "sha512-5dlDt1dUZCVi6elIhiK1PWg9wpTzTcIuj0IZnSurvIoMrhOWqqTcc1dSTxcSkNaBZhfsNqRZdINI1zAgbKkJNQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-riscv64-musl": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.51.0.tgz",
+      "integrity": "sha512-pgdWUJn0S5nulyiVdlFV8DzCUnGXkU99W5PSkkmbaZW+LrZBPxpezun4G0DDHbQaVYuJeCuKsXsGKGo77CkUTQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-s390x-gnu": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.51.0.tgz",
+      "integrity": "sha512-2XTFUe97CbDGAI8vjwDfZ1HdakO0XIADyJ24idEg64SC4/K4in/OisXVnrW4NMK7I6TgC7EqRhC0Ln/nKhAemA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-gnu": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.51.0.tgz",
+      "integrity": "sha512-kQ1OuCqqt/yyf0ZN9VFxW1/JnlgJgii3Dr7pWf9vNBvrX1hv6g39/+mc5oGRHRGJFZtl3zsGDWR9c5N2B/gwBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-linux-x64-musl": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.51.0.tgz",
+      "integrity": "sha512-ARTYqxHF475o96Gbn41hvSWSSRygPlRDXZZgZ9I2scU1y0qiWpCQyZCoefaQa0mwv+wwtZ+luS4YOzsRzM/izg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-openharmony-arm64": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.51.0.tgz",
+      "integrity": "sha512-QiC1XrCl6a6BmqMzduO8hdIRMf1m44hCkt2Q68KWkTvUB/E7fd2iomyNh6KnnRca5w6eBrRAAtLFqTh+xjsjJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-arm64-msvc": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.51.0.tgz",
+      "integrity": "sha512-NC/hJb9dtU23Zf8L7IVK95xnFjiQ7AfcLO2l5pb69TDEr958qxrtnB2CveeeNSCBFNIkgaTCfd/vHNSoG78l9g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-ia32-msvc": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.51.0.tgz",
+      "integrity": "sha512-2C45za4Rj36n8YIbhRL1PQbxmXJYf81WEcAgvj5I4ptRROG+A+81hREEN5bmCHADE1UfYaN312U6tkILoZZy6w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxfmt/binding-win32-x64-msvc": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.51.0.tgz",
+      "integrity": "sha512-73RqdAuVKQTkjZIDw08JaDHUM4lav5Qu+CaPwg4QbbA7k8o7LEW0p3UsfZ/F8dsO/pwVYh3RzFcanwLRTTahbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.66.0.tgz",
+      "integrity": "sha512-f7kq8N51T4phpzqfBpA2qaVTI/KrkCmNwaj3t/97I/WLTDI+UhlP5GL9eER+zVxBhtlx5rKXWByJU1/zDAvyaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.66.0.tgz",
+      "integrity": "sha512-xu6QO71tdDS9mjmLZ3AqhtaVHBvdmsOKkYnReNNDgh+XiwnsipeQOIxbiYOOO0iAXycJ+GK0wdMSZP/2j/AmSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.66.0.tgz",
+      "integrity": "sha512-HZ24VimSOC7mxuEA99e0H2FS0C1yO3+iW13jPRAk+e2njsUs3QeAXsafCDyaIrV/MirdOVez+etQNQsJE43zNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.66.0.tgz",
+      "integrity": "sha512-awhj8ZvJrrRSnXj7V++rpZvTmnl99L6mi0B7gg7Cp7BN6cKpzuI481bHNLvXGA9GB1/oEgA3ponuyoAc6Md12A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.66.0.tgz",
+      "integrity": "sha512-KQF0oVV21/FjIqkRuL8Q1vh8ECsE5+ocdH5tcqTQ4ZnYuDVoYibQUNfqBjQaUsP6UIIda5Y75Wpm5p4RgQWiWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.66.0.tgz",
+      "integrity": "sha512-9u1rgwZSEXWb30vbFZzQ78HVXBo0WCKNwJ3a2InRUTNMRng+PUDIoSFmA+m4HdUfBaIqftShq8J8qHc+eE/Vig==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.66.0.tgz",
+      "integrity": "sha512-Ynot2HR1bHxUaNWoC280MVTDfZuaWuP3XfSMRDhyuZrVjhzoaBCVFlw8h8qeZjWKVUBhPWFIxB7AQTlK8Z2WWg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.66.0.tgz",
+      "integrity": "sha512-xCbgzciGgo+A4aQZEknsNrNiIwY7sU5SfRuMmRjPIvZAgdF34cIHiKvwOsS5XRLjlTVSFwitmq6YclTtHTfU+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.66.0.tgz",
+      "integrity": "sha512-hmo+ZB/lHkR1HdDmnziNpzSLmulnUSu10VEqX2Yex7OwvoBAbjJQLvy4gIBRV3AAwWnCvAxKp5Nv1GE6LU1QMg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.66.0.tgz",
+      "integrity": "sha512-2Invd4Uyy81mVooQC5FBtfxSNrvcX1OxbMlVQ6M2erRrNI2awFYF26YNW2yFxdVFZ4ffNOWKghtMjhnUPsXsVA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.66.0.tgz",
+      "integrity": "sha512-s0iXPDQVdgayE3RGa/N2DZF7tjgg0TwEtD1sGoDxqPDGrIXgo45H0yHknT0f9A0yteASsweYZtDyTuVlM4aSag==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.66.0.tgz",
+      "integrity": "sha512-OekL4XFiu7RPK0JIZi8VeHgtIXPREf42t8Cy/rKEsC+P3gcqDgNAAGiyuUOpdbG4wwbfue1q4CHcCO7spSve6w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.66.0.tgz",
+      "integrity": "sha512-Ga1D0kj1SFslm34ThA/BdkUlyAYEnTsXyRC4pF0C5agZSwtGdHYWMTQWemUfBGp4RCG4QWXgdO+HmmmKqOtlBg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.66.0.tgz",
+      "integrity": "sha512-p5jfP1wUZe/IC3qpQO84n9DRnf9g3lKRtLBlQq23ykyrDglHcVx7sWmVTlPuU6SBw8mNnPzyOn022G3XZHnlww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.66.0.tgz",
+      "integrity": "sha512-vUB/sYlYZorDL1ZD+o9mRv7zbsykrrFRtmgS6R8musZqLtrPRQn1gc1eGpuX+sfdccz42STl/AqldY6XRb2upQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.66.0.tgz",
+      "integrity": "sha512-yde+6p/F59xRkGR9H1HfngWRif1QRJjynZK349l+UI0H6w9hL3G8/AVaTHFyTtLVQ56qtNbX2/5Dc77n1ovnOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.66.0.tgz",
+      "integrity": "sha512-O9GLucgoTdmOrbBX+EjzNe7o/Ze5TFOvXcib6bzUOtBOmj6cV+zw18NgB+cGKAkDw1Pdqs8vGkfHbbsLuDtXWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.66.0.tgz",
+      "integrity": "sha512-m3Pjwc2MfTcom4E4gOv7DyuGyt7OfGNCbmqDHd+N7EzXmP+ppHuudm2NjcA3AjV5TSeGxaguVF4SbTKHe1USYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.66.0.tgz",
+      "integrity": "sha512-/DbBvw8UFBhja6PqudUjV4UtfsJr0Oa7jUjWVKB0g86lj/VwnPrkngn0sFql3c9RDA0O16dh7ozsXb6GjNAzBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -1396,9 +2046,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
       "cpu": [
         "arm64"
       ],
@@ -1413,9 +2063,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-apJq2ktnGp27nSInMR5Vcj8kY6xJzDAvfdIFlpDcAK/w4cDO58qVoi1YQsES/SKiFNge/6e4CUzgjfHduYqWpQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
       "cpu": [
         "arm64"
       ],
@@ -1430,9 +2080,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-5Ofot8xbs+pxRHJqm9/9N/4sTQOvdrwEsmPE9pdLEEoAbdZtG6F2LMDfO1sp6ZAtXJuJV/21ew2srq3W8NXB5g==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
       "cpu": [
         "x64"
       ],
@@ -1447,9 +2097,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7h8eeOTT1eyqJyx64BFCnWZpNm486hGWt2sqeLLgDxA0xI1oGZ9H7gK1S85uNGmBhkdPwa/6reTxfFFKvIsebw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
       "cpu": [
         "x64"
       ],
@@ -1464,9 +2114,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.18.tgz",
-      "integrity": "sha512-eRcm/HVt9U/JFu5RKAEKwGQYtDCKWLiaH6wOnsSEp6NMBb/3Os8LgHZlNyzMpFVNmiiMFlfb2zEnebfzJrHFmg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
       "cpu": [
         "arm"
       ],
@@ -1481,9 +2131,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-SOrT/cT4ukTmgnrEz/Hg3m7LBnuCLW9psDeMKrimRWY4I8DmnO7Lco8W2vtqPmMkbVu8iJ+g4GFLVLLOVjJ9DQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
       "cpu": [
         "arm64"
       ],
@@ -1498,9 +2148,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-QWjdxN1HJCpBTAcZ5N5F7wju3gVPzRzSpmGzx7na0c/1qpN9CFil+xt+l9lV/1M6/gqHSNXCiqPfwhVJPeLnug==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
       "cpu": [
         "arm64"
       ],
@@ -1515,9 +2165,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-ugCOyj7a4d9h3q9B+wXmf6g3a68UsjGh6dob5DHevHGMwDUbhsYNbSPxJsENcIttJZ9jv7qGM2UesLw5jqIhdg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
       "cpu": [
         "ppc64"
       ],
@@ -1532,9 +2182,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-kKWRhbsotpXkGbcd5dllUWg5gEXcDAa8u5YnP9AV5DYNbvJHGzzuwv7dpmhc8NqKMJldl0a+x76IHbspEpEmdA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
       "cpu": [
         "s390x"
       ],
@@ -1549,9 +2199,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.18.tgz",
-      "integrity": "sha512-uCo8ElcCIAMyYAZyuIZ81oFkhTSIllNvUCHCAlbhlN4ji3uC28h7IIdlXyIvGO7HsuqnV9p3rD/bpH7XhIyhRw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
       "cpu": [
         "x64"
       ],
@@ -1566,9 +2216,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.18.tgz",
-      "integrity": "sha512-XNOQZtuE6yUIvx4rwGemwh8kpL1xvU41FXy/s9K7T/3JVcqGzo3NfKM2HrbrGgfPYGFW42f07Wk++aOC6B9NWA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
       "cpu": [
         "x64"
       ],
@@ -1583,9 +2233,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.18.tgz",
-      "integrity": "sha512-tSn/kzrfa7tNOXr7sEacDBN4YsIqTyLqh45IO0nHDwtpKIDNDJr+VFojt+4klSpChxB29JLyduSsE0MKEwa65A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
       "cpu": [
         "arm64"
       ],
@@ -1600,9 +2250,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.18.tgz",
-      "integrity": "sha512-+J9YGmc+czgqlhYmwun3S3O0FIZhsH8ep2456xwjAdIOmuJxM7xz4P4PtrxU+Bz17a/5bqPA8o3HAAoX0teUdg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
       "cpu": [
         "wasm32"
       ],
@@ -1619,9 +2269,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-zsu47DgU0FQzSwi6sU9dZoEdUv7pc1AptSEz/Z8HBg54sV0Pbs3N0+CrIbTsgiu6EyoaNN9CHboqbLaz9lhOyQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
       "cpu": [
         "arm64"
       ],
@@ -1636,9 +2286,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.18.tgz",
-      "integrity": "sha512-7H+3yqGgmnlDTRRhw/xpYY9J1kf4GC681nVc4GqKhExZTDrVVrV2tsOR9kso0fvgBdcTCcQShx4SLLoHgaLwhg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
       "cpu": [
         "x64"
       ],
@@ -1660,9 +2310,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
       "cpu": [
         "arm"
       ],
@@ -1674,9 +2324,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
       "cpu": [
         "arm64"
       ],
@@ -1688,9 +2338,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
       "cpu": [
         "arm64"
       ],
@@ -1702,9 +2352,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
       "cpu": [
         "x64"
       ],
@@ -1716,9 +2366,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
       "cpu": [
         "arm64"
       ],
@@ -1730,9 +2380,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
       "cpu": [
         "x64"
       ],
@@ -1744,9 +2394,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
       "cpu": [
         "arm"
       ],
@@ -1758,9 +2408,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
       ],
@@ -1772,9 +2422,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
       "cpu": [
         "arm64"
       ],
@@ -1786,9 +2436,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
       ],
@@ -1800,9 +2450,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
       "cpu": [
         "loong64"
       ],
@@ -1814,9 +2464,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
       ],
@@ -1828,9 +2478,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
       "cpu": [
         "ppc64"
       ],
@@ -1842,9 +2492,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
       ],
@@ -1856,9 +2506,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
       "cpu": [
         "riscv64"
       ],
@@ -1870,9 +2520,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
       ],
@@ -1884,9 +2534,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
       "cpu": [
         "s390x"
       ],
@@ -1898,9 +2548,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
       "cpu": [
         "x64"
       ],
@@ -1912,9 +2562,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
       ],
@@ -1926,9 +2576,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
       "cpu": [
         "x64"
       ],
@@ -1940,9 +2590,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
       "cpu": [
         "arm64"
       ],
@@ -1954,9 +2604,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
       "cpu": [
         "arm64"
       ],
@@ -1968,9 +2618,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
       "cpu": [
         "ia32"
       ],
@@ -1982,9 +2632,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
       "cpu": [
         "x64"
       ],
@@ -1996,9 +2646,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
       "cpu": [
         "x64"
       ],
@@ -2073,21 +2723,23 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2160,6 +2812,7 @@
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.20.1.tgz",
       "integrity": "sha512-5I9RNo5uZW9tsBnqrWzJqELegOqTHBrZyDFnES0gR9gJJHBB9dom1N0bwITM9tKwBcfKrTX4a6DHVeQdJ2ubQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.9",
@@ -2283,9 +2936,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.10.31",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+      "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2315,6 +2968,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2340,9 +2994,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001792",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-      "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -2570,9 +3224,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.352",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
-      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2591,42 +3245,46 @@
       "license": "MIT"
     },
     "node_modules/esbuild": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.21.5",
-        "@esbuild/android-arm": "0.21.5",
-        "@esbuild/android-arm64": "0.21.5",
-        "@esbuild/android-x64": "0.21.5",
-        "@esbuild/darwin-arm64": "0.21.5",
-        "@esbuild/darwin-x64": "0.21.5",
-        "@esbuild/freebsd-arm64": "0.21.5",
-        "@esbuild/freebsd-x64": "0.21.5",
-        "@esbuild/linux-arm": "0.21.5",
-        "@esbuild/linux-arm64": "0.21.5",
-        "@esbuild/linux-ia32": "0.21.5",
-        "@esbuild/linux-loong64": "0.21.5",
-        "@esbuild/linux-mips64el": "0.21.5",
-        "@esbuild/linux-ppc64": "0.21.5",
-        "@esbuild/linux-riscv64": "0.21.5",
-        "@esbuild/linux-s390x": "0.21.5",
-        "@esbuild/linux-x64": "0.21.5",
-        "@esbuild/netbsd-x64": "0.21.5",
-        "@esbuild/openbsd-x64": "0.21.5",
-        "@esbuild/sunos-x64": "0.21.5",
-        "@esbuild/win32-arm64": "0.21.5",
-        "@esbuild/win32-ia32": "0.21.5",
-        "@esbuild/win32-x64": "0.21.5"
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/escalade": {
@@ -2670,9 +3328,9 @@
       }
     },
     "node_modules/fast-wrap-ansi": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+      "integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2715,9 +3373,9 @@
       }
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3171,6 +3829,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^6.0.11",
         "@mswjs/interceptors": "^0.41.3",
@@ -3227,9 +3886,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -3246,11 +3905,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.1",
@@ -3269,6 +3931,99 @@
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/oxfmt": {
+      "version": "0.51.0",
+      "resolved": "https://registry.npmjs.org/oxfmt/-/oxfmt-0.51.0.tgz",
+      "integrity": "sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinypool": "2.1.0"
+      },
+      "bin": {
+        "oxfmt": "bin/oxfmt"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxfmt/binding-android-arm-eabi": "0.51.0",
+        "@oxfmt/binding-android-arm64": "0.51.0",
+        "@oxfmt/binding-darwin-arm64": "0.51.0",
+        "@oxfmt/binding-darwin-x64": "0.51.0",
+        "@oxfmt/binding-freebsd-x64": "0.51.0",
+        "@oxfmt/binding-linux-arm-gnueabihf": "0.51.0",
+        "@oxfmt/binding-linux-arm-musleabihf": "0.51.0",
+        "@oxfmt/binding-linux-arm64-gnu": "0.51.0",
+        "@oxfmt/binding-linux-arm64-musl": "0.51.0",
+        "@oxfmt/binding-linux-ppc64-gnu": "0.51.0",
+        "@oxfmt/binding-linux-riscv64-gnu": "0.51.0",
+        "@oxfmt/binding-linux-riscv64-musl": "0.51.0",
+        "@oxfmt/binding-linux-s390x-gnu": "0.51.0",
+        "@oxfmt/binding-linux-x64-gnu": "0.51.0",
+        "@oxfmt/binding-linux-x64-musl": "0.51.0",
+        "@oxfmt/binding-openharmony-arm64": "0.51.0",
+        "@oxfmt/binding-win32-arm64-msvc": "0.51.0",
+        "@oxfmt/binding-win32-ia32-msvc": "0.51.0",
+        "@oxfmt/binding-win32-x64-msvc": "0.51.0"
+      },
+      "peerDependencies": {
+        "svelte": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "svelte": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.66.0.tgz",
+      "integrity": "sha512-N4LLxYLd94KEBqXDMDM5f+2PUpItTjDLreXe2Gn5KhjhCK4Qp2YUXaBi8Yu325ryOgKwt22m45fpD7nPOn69Yw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.66.0",
+        "@oxlint/binding-android-arm64": "1.66.0",
+        "@oxlint/binding-darwin-arm64": "1.66.0",
+        "@oxlint/binding-darwin-x64": "1.66.0",
+        "@oxlint/binding-freebsd-x64": "1.66.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.66.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.66.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.66.0",
+        "@oxlint/binding-linux-arm64-musl": "1.66.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.66.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.66.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.66.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.66.0",
+        "@oxlint/binding-linux-x64-gnu": "1.66.0",
+        "@oxlint/binding-linux-x64-musl": "1.66.0",
+        "@oxlint/binding-openharmony-arm64": "1.66.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.66.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.66.0",
+        "@oxlint/binding-win32-x64-msvc": "1.66.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.22.1"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        }
+      }
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -3338,6 +4093,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3389,25 +4145,10 @@
         "node": ">=18"
       }
     },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3425,7 +4166,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3438,6 +4179,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3447,6 +4189,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3484,9 +4227,9 @@
       }
     },
     "node_modules/reselect": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
       "license": "MIT"
     },
     "node_modules/rettime": {
@@ -3497,14 +4240,14 @@
       "license": "MIT"
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.18.tgz",
-      "integrity": "sha512-phmyKBpuBdRYDf4hgyynGAYn/rDDe+iZXKVJ7WX5b1zQzpLkP5oJRPGsfJuHdzPMlyyEO/4sPW6yfSx2gf7lVg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.128.0",
-        "@rolldown/pluginutils": "1.0.0-rc.18"
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3513,34 +4256,34 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.18",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.18",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.18",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.18",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.18",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.18",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.18"
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.18.tgz",
-      "integrity": "sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3554,31 +4297,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -3748,6 +4491,16 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
     "node_modules/tldts": {
       "version": "7.0.30",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
@@ -3820,6 +4573,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3836,9 +4590,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3898,6 +4652,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3975,475 +4730,32 @@
         "url": "https://opencollective.com/antfu"
       }
     },
-    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vite-node/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+    "node_modules/vite-node/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "8.0.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.11.tgz",
-      "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.14",
-        "rolldown": "1.0.0-rc.18",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
         "tinyglobby": "^0.2.16"
       },
       "bin": {
@@ -4509,6 +4821,451 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,7 +16,12 @@
     "test:ui:debug": "playwright test --debug",
     "test:ui:screencast": "PW_UI_SCREENCAST=1 PW_UI_REVIEW_PAUSE_MS=1200 playwright test --headed --workers=1",
     "test:ui:screencast:headless": "PW_UI_SCREENCAST=1 PW_UI_REVIEW_PAUSE_MS=1200 playwright test --workers=1",
-    "test:ui:type-check": "npm run proto:gen && tsc -p tsconfig.tests.json"
+    "test:ui:type-check": "npm run proto:gen && tsc -p tsconfig.tests.json",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check",
+    "check": "oxfmt --check && oxlint --deny-warnings"
   },
   "dependencies": {
     "@base-ui-components/react": "^1.0.0-rc.0",
@@ -41,6 +46,8 @@
     "@vitejs/plugin-react": "^5.1.1",
     "concurrently": "^9.2.1",
     "msw": "^2.14.6",
+    "oxfmt": "^0.51.0",
+    "oxlint": "^1.66.0",
     "typescript": "^5.6.2",
     "vite": "^5.4.10"
   }

--- a/ui/src/components/navbar/navbar.tsx
+++ b/ui/src/components/navbar/navbar.tsx
@@ -16,7 +16,15 @@ export function Navbar() {
       </div>
       <div className={styles.nav} aria-label="Primary navigation">
         {NAV_ITEMS.map((item) => (
-          <button aria-current={item.active ? 'page' : undefined} aria-label={item.label} className={styles.navButton} data-active={item.active ? 'true' : 'false'} disabled={item.active} key={item.label} type="button">
+          <button
+            aria-current={item.active ? 'page' : undefined}
+            aria-label={item.label}
+            className={styles.navButton}
+            data-active={item.active ? 'true' : 'false'}
+            disabled={item.active}
+            key={item.label}
+            type="button"
+          >
             <Icon name={item.icon} size="20" color="inherit" />
           </button>
         ))}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -4,24 +4,33 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-400-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-400-latin.woff2')
+    format('woff2');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: 'Encode Sans Semi Expanded';
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-500-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-500-latin.woff2')
+    format('woff2');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: 'Encode Sans Semi Expanded';
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-700-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-700-latin.woff2')
+    format('woff2');
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* Encode Sans Semi Expanded — latin-ext */
@@ -30,24 +39,36 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-400-latin-ext.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-400-latin-ext.woff2')
+    format('woff2');
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
 }
 @font-face {
   font-family: 'Encode Sans Semi Expanded';
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-500-latin-ext.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-500-latin-ext.woff2')
+    format('woff2');
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
 }
 @font-face {
   font-family: 'Encode Sans Semi Expanded';
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-700-latin-ext.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: url('/fonts/encode-sans-semi-expanded/EncodeSansSemiExpanded-700-latin-ext.woff2')
+    format('woff2');
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
 }
 
 /* DM Mono — latin */
@@ -57,7 +78,9 @@
   font-weight: 400;
   font-display: swap;
   src: url('/fonts/dm-mono/DMMono-400-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
   font-family: 'DM Mono';
@@ -65,7 +88,9 @@
   font-weight: 500;
   font-display: swap;
   src: url('/fonts/dm-mono/DMMono-500-latin.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  unicode-range:
+    U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+    U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 /* DM Mono — latin-ext */
@@ -75,7 +100,10 @@
   font-weight: 400;
   font-display: swap;
   src: url('/fonts/dm-mono/DMMono-400-latin-ext.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
 }
 @font-face {
   font-family: 'DM Mono';
@@ -83,7 +111,10 @@
   font-weight: 500;
   font-display: swap;
   src: url('/fonts/dm-mono/DMMono-500-latin-ext.woff2') format('woff2');
-  unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  unicode-range:
+    U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+    U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+    U+A720-A7FF;
 }
 
 *,

--- a/ui/src/lib/sql-highlight.ts
+++ b/ui/src/lib/sql-highlight.ts
@@ -1,34 +1,120 @@
 const SQL_KEYWORDS = new Set([
-  'SELECT', 'FROM', 'WHERE', 'AND', 'OR', 'NOT', 'IN', 'LIKE', 'BETWEEN',
-  'JOIN', 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'FULL', 'CROSS', 'ON',
-  'GROUP', 'BY', 'ORDER', 'ASC', 'DESC', 'HAVING', 'LIMIT', 'OFFSET',
-  'INSERT', 'INTO', 'VALUES', 'UPDATE', 'SET', 'DELETE', 'CREATE', 'DROP',
-  'ALTER', 'TABLE', 'INDEX', 'AS', 'DISTINCT',
-  'NULL', 'IS', 'TRUE', 'FALSE', 'CASE', 'WHEN', 'THEN',
-  'ELSE', 'END', 'UNION', 'ALL', 'EXISTS', 'WITH', 'RECURSIVE',
-  'PRIMARY', 'KEY', 'FOREIGN', 'REFERENCES', 'DEFAULT', 'CONSTRAINT',
+  'SELECT',
+  'FROM',
+  'WHERE',
+  'AND',
+  'OR',
+  'NOT',
+  'IN',
+  'LIKE',
+  'BETWEEN',
+  'JOIN',
+  'LEFT',
+  'RIGHT',
+  'INNER',
+  'OUTER',
+  'FULL',
+  'CROSS',
+  'ON',
+  'GROUP',
+  'BY',
+  'ORDER',
+  'ASC',
+  'DESC',
+  'HAVING',
+  'LIMIT',
+  'OFFSET',
+  'INSERT',
+  'INTO',
+  'VALUES',
+  'UPDATE',
+  'SET',
+  'DELETE',
+  'CREATE',
+  'DROP',
+  'ALTER',
+  'TABLE',
+  'INDEX',
+  'AS',
+  'DISTINCT',
+  'NULL',
+  'IS',
+  'TRUE',
+  'FALSE',
+  'CASE',
+  'WHEN',
+  'THEN',
+  'ELSE',
+  'END',
+  'UNION',
+  'ALL',
+  'EXISTS',
+  'WITH',
+  'RECURSIVE',
+  'PRIMARY',
+  'KEY',
+  'FOREIGN',
+  'REFERENCES',
+  'DEFAULT',
+  'CONSTRAINT',
 ])
 
 const SQL_FUNCTIONS = new Set([
-  'COUNT', 'SUM', 'AVG', 'MIN', 'MAX', 'COALESCE', 'CAST',
-  'UPPER', 'LOWER', 'TRIM', 'LENGTH', 'SUBSTRING', 'REPLACE',
-  'NOW', 'DATE', 'EXTRACT', 'ROUND', 'ABS', 'FLOOR', 'CEIL',
-  'ROW_NUMBER', 'RANK', 'DENSE_RANK', 'LAG', 'LEAD',
-  'INT', 'INTEGER', 'BIGINT', 'SMALLINT', 'FLOAT', 'DOUBLE', 'REAL',
-  'VARCHAR', 'CHAR', 'TEXT', 'BOOLEAN', 'BOOL',
-  'DECIMAL', 'NUMERIC', 'TIMESTAMP', 'TIME', 'INTERVAL',
-  'SERIAL', 'UUID', 'JSON', 'JSONB', 'ARRAY',
+  'COUNT',
+  'SUM',
+  'AVG',
+  'MIN',
+  'MAX',
+  'COALESCE',
+  'CAST',
+  'UPPER',
+  'LOWER',
+  'TRIM',
+  'LENGTH',
+  'SUBSTRING',
+  'REPLACE',
+  'NOW',
+  'DATE',
+  'EXTRACT',
+  'ROUND',
+  'ABS',
+  'FLOOR',
+  'CEIL',
+  'ROW_NUMBER',
+  'RANK',
+  'DENSE_RANK',
+  'LAG',
+  'LEAD',
+  'INT',
+  'INTEGER',
+  'BIGINT',
+  'SMALLINT',
+  'FLOAT',
+  'DOUBLE',
+  'REAL',
+  'VARCHAR',
+  'CHAR',
+  'TEXT',
+  'BOOLEAN',
+  'BOOL',
+  'DECIMAL',
+  'NUMERIC',
+  'TIMESTAMP',
+  'TIME',
+  'INTERVAL',
+  'SERIAL',
+  'UUID',
+  'JSON',
+  'JSONB',
+  'ARRAY',
 ])
 
-const BREAK_BEFORE = /\b(SELECT|FROM|WHERE|AND|OR|JOIN|LEFT JOIN|RIGHT JOIN|INNER JOIN|FULL JOIN|CROSS JOIN|GROUP BY|ORDER BY|HAVING|LIMIT|OFFSET|UNION ALL|UNION|WITH|INSERT INTO|VALUES|UPDATE|SET|DELETE FROM)\b/gi
+const BREAK_BEFORE =
+  /\b(SELECT|FROM|WHERE|AND|OR|JOIN|LEFT JOIN|RIGHT JOIN|INNER JOIN|FULL JOIN|CROSS JOIN|GROUP BY|ORDER BY|HAVING|LIMIT|OFFSET|UNION ALL|UNION|WITH|INSERT INTO|VALUES|UPDATE|SET|DELETE FROM)\b/gi
 
 export function formatSQL(sql: string): string {
   if (sql.includes('\n')) return sql
-  return sql
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(BREAK_BEFORE, '\n$1')
-    .trim()
+  return sql.replace(/\s+/g, ' ').trim().replace(BREAK_BEFORE, '\n$1').trim()
 }
 
 function escapeHtml(value: string): string {
@@ -41,13 +127,18 @@ function escapeHtml(value: string): string {
 }
 
 export function highlightSQL(sql: string): string {
-  return escapeHtml(sql).replace(/(--[^\n]*)|(&#39;[^&]*(?:&(?!#39;)[^&]*)*&#39;)|(&quot;[\w]+&quot;)|(\b[A-Za-z_]\w*\b)|(\d+(?:\.\d+)?)/g, (match, comment, str, quoted, word, num) => {
-    if (comment) return `<span class="sql-comment">${match}</span>`
-    if (str) return `<span class="sql-string">${match}</span>`
-    if (quoted) return `<span class="sql-identifier">${match}</span>`
-    if (word && SQL_KEYWORDS.has(word.toUpperCase())) return `<span class="sql-keyword">${word}</span>`
-    if (word && SQL_FUNCTIONS.has(word.toUpperCase())) return `<span class="sql-function">${word}</span>`
-    if (num) return `<span class="sql-number">${match}</span>`
-    return match
-  })
+  return escapeHtml(sql).replace(
+    /(--[^\n]*)|(&#39;[^&]*(?:&(?!#39;)[^&]*)*&#39;)|(&quot;[\w]+&quot;)|(\b[A-Za-z_]\w*\b)|(\d+(?:\.\d+)?)/g,
+    (match, comment, str, quoted, word, num) => {
+      if (comment) return `<span class="sql-comment">${match}</span>`
+      if (str) return `<span class="sql-string">${match}</span>`
+      if (quoted) return `<span class="sql-identifier">${match}</span>`
+      if (word && SQL_KEYWORDS.has(word.toUpperCase()))
+        return `<span class="sql-keyword">${word}</span>`
+      if (word && SQL_FUNCTIONS.has(word.toUpperCase()))
+        return `<span class="sql-function">${word}</span>`
+      if (num) return `<span class="sql-number">${match}</span>`
+      return match
+    },
+  )
 }

--- a/ui/src/utils/compose-refs.ts
+++ b/ui/src/utils/compose-refs.ts
@@ -55,7 +55,7 @@ function setRef<T>(ref: PossibleRef<T>, value: T) {
  * Accepts callback refs and RefObject(s)
  */
 function useComposedRefs<T>(...refs: PossibleRef<T>[]): React.RefCallback<T> {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // oxlint-disable-next-line react-hooks/exhaustive-deps
   return React.useCallback(composeRefs(...refs), refs)
 }
 

--- a/ui/src/utils/use-truncation-detection.ts
+++ b/ui/src/utils/use-truncation-detection.ts
@@ -8,7 +8,10 @@ import { useEffect, useState } from 'react'
  * @param enabled - Whether to enable truncation detection (default: true)
  * @returns true if the element's content is truncated, false otherwise
  */
-export function useTruncationDetection(elementRef: React.RefObject<HTMLElement | null>, enabled = true): boolean {
+export function useTruncationDetection(
+  elementRef: React.RefObject<HTMLElement | null>,
+  enabled = true,
+): boolean {
   const [isTruncated, setIsTruncated] = useState(false)
 
   useEffect(() => {

--- a/ui/src/views/TracesPage.tsx
+++ b/ui/src/views/TracesPage.tsx
@@ -35,7 +35,11 @@ function useTraceList(enabled: boolean) {
       const queryTraces: TraceSummary[] = []
       let pageToken = ''
 
-      for (let page = 0; page < MAX_TRACE_LIST_PAGES && queryTraces.length < MAX_QUERY_TRACES; page += 1) {
+      for (
+        let page = 0;
+        page < MAX_TRACE_LIST_PAGES && queryTraces.length < MAX_QUERY_TRACES;
+        page += 1
+      ) {
         const response = await listTraces(TRACE_LIST_PAGE_SIZE, pageToken)
         queryTraces.push(...response.traces.filter(isQueryTrace))
         pageToken = response.nextPageToken
@@ -62,7 +66,13 @@ function useTraceList(enabled: boolean) {
   return { error, loading, traces }
 }
 
-function HeaderActions({ searchOpen, searchText, searchVisible, setSearchOpen, setSearchText }: {
+function HeaderActions({
+  searchOpen,
+  searchText,
+  searchVisible,
+  setSearchOpen,
+  setSearchText,
+}: {
   searchOpen: boolean
   searchText: string
   searchVisible: boolean
@@ -87,14 +97,26 @@ function HeaderActions({ searchOpen, searchText, searchVisible, setSearchOpen, s
       />
       <div className={s.inlineSearch} data-searching={searchVisible ? 'true' : undefined}>
         <div className={s.searchTrigger}>
-          <Button.IconButton name="Search" onClick={() => setSearchOpen(true)} size="32" tooltipText="Search" variant="bare" />
+          <Button.IconButton
+            name="Search"
+            onClick={() => setSearchOpen(true)}
+            size="32"
+            tooltipText="Search"
+            variant="bare"
+          />
         </div>
         <div className={s.searchField}>
           <TextInput
             icon="Search"
             onBlur={() => setSearchOpen(false)}
             onChange={setSearchText}
-            onKeyDown={(e) => { if (e.key === 'Escape') { setSearchText(''); setSearchOpen(false); inputRef.current?.blur() } }}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setSearchText('')
+                setSearchOpen(false)
+                inputRef.current?.blur()
+              }
+            }}
             placeholder="Search queries..."
             ref={inputRef}
             value={searchText}
@@ -106,7 +128,11 @@ function HeaderActions({ searchOpen, searchText, searchVisible, setSearchOpen, s
 }
 
 function DisconnectedBanner({ message }: { message: string }) {
-  return <div className={s.disconnectedBanner}><Typography.Body as="span">{message}</Typography.Body></div>
+  return (
+    <div className={s.disconnectedBanner}>
+      <Typography.Body as="span">{message}</Typography.Body>
+    </div>
+  )
 }
 
 export function TracesPage() {
@@ -125,7 +151,10 @@ export function TracesPage() {
   if (selectedTraceId) {
     const selectedIndex = filtered.findIndex((trace) => trace.traceId === selectedTraceId)
     const newerTraceId = selectedIndex > 0 ? filtered[selectedIndex - 1].traceId : null
-    const olderTraceId = selectedIndex >= 0 && selectedIndex < filtered.length - 1 ? filtered[selectedIndex + 1].traceId : null
+    const olderTraceId =
+      selectedIndex >= 0 && selectedIndex < filtered.length - 1
+        ? filtered[selectedIndex + 1].traceId
+        : null
 
     return (
       <TraceDetail
@@ -152,7 +181,10 @@ export function TracesPage() {
       </PageHeader>
       {error && <DisconnectedBanner message={error} />}
       {loading && traces.length === 0 ? (
-        <div className={s.loadingState}><Icon name="Loader" className={s.spinner} color="tertiary" /><Typography.Body>Loading traces…</Typography.Body></div>
+        <div className={s.loadingState}>
+          <Icon name="Loader" className={s.spinner} color="tertiary" />
+          <Typography.Body>Loading traces…</Typography.Body>
+        </div>
       ) : filtered.length === 0 ? (
         searchText.trim() ? (
           <EmptyState
@@ -163,7 +195,9 @@ export function TracesPage() {
           <EmptyState error={error && traces.length === 0 ? error : null} />
         )
       ) : (
-        <div className={s.queryScroll}><TraceList traces={filtered} onSelect={setSelectedTraceId} /></div>
+        <div className={s.queryScroll}>
+          <TraceList traces={filtered} onSelect={setSelectedTraceId} />
+        </div>
       )}
       <StatusBar connected={connected} count={filtered.length} totalCount={traces.length} />
     </section>

--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -7,7 +7,12 @@ import { lightTheme } from '@/wax/theme/theme-light.css'
 import { theme } from '@/wax/theme/theme.css'
 
 const spin = keyframes({ to: { transform: 'rotate(360deg)' } })
-export const root = style({ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 })
+export const root = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 0,
+})
 
 export const header = style({
   alignItems: 'center',
@@ -98,7 +103,13 @@ export const disconnectedBanner = style({
   textAlign: 'center',
 })
 
-export const queryScroll = style({ flex: 1, minHeight: 0, overflowX: 'hidden', overflowY: 'auto', paddingBlockEnd: 32 })
+export const queryScroll = style({
+  flex: 1,
+  minHeight: 0,
+  overflowX: 'hidden',
+  overflowY: 'auto',
+  paddingBlockEnd: 32,
+})
 export const traceList = style({ display: 'flex', flexDirection: 'column' })
 
 export const fullRow = style({
@@ -114,12 +125,24 @@ export const fullRow = style({
   width: '100%',
   selectors: { '&:hover': { backgroundColor: theme.surface.onMainContentSubtle } },
 })
-export const statusDot = style({ borderRadius: '50%', flexShrink: 0, height: 8, marginInline: 8, width: 8, selectors: {
-  '&[data-tone="ok"]': { backgroundColor: theme.pill.green.color },
-  '&[data-tone="error"]': { backgroundColor: theme.pill.red.color },
-  '&[data-tone="running"]': { backgroundColor: theme.pill.blue.color },
-}})
-export const cell = style({ flexShrink: 0, paddingBlock: 10, paddingInline: 8, whiteSpace: 'nowrap' })
+export const statusDot = style({
+  borderRadius: '50%',
+  flexShrink: 0,
+  height: 8,
+  marginInline: 8,
+  width: 8,
+  selectors: {
+    '&[data-tone="ok"]': { backgroundColor: theme.pill.green.color },
+    '&[data-tone="error"]': { backgroundColor: theme.pill.red.color },
+    '&[data-tone="running"]': { backgroundColor: theme.pill.blue.color },
+  },
+})
+export const cell = style({
+  flexShrink: 0,
+  paddingBlock: 10,
+  paddingInline: 8,
+  whiteSpace: 'nowrap',
+})
 export const cellTimestamp = style({ minWidth: 80 })
 export const sqlPreview = style({
   color: utils.opacify(theme.content.primary, 85),
@@ -161,11 +184,22 @@ export const statusBar = style({
 })
 export const statusLeft = style({ alignItems: 'center', display: 'flex', gap: 6 })
 export const statusRight = style({ alignItems: 'center', display: 'flex', gap: 6 })
-export const statusBarDot = style({ borderRadius: '50%', flexShrink: 0, height: 6, width: 6, selectors: {
-  '&[data-state="connected"]': { backgroundColor: theme.pill.green.color },
-  '&[data-state="disconnected"]': { backgroundColor: theme.pill.red.color },
-}})
-export const statusSep = style({ backgroundColor: theme.stroke.primary, flexShrink: 0, height: 10, width: 1 })
+export const statusBarDot = style({
+  borderRadius: '50%',
+  flexShrink: 0,
+  height: 6,
+  width: 6,
+  selectors: {
+    '&[data-state="connected"]': { backgroundColor: theme.pill.green.color },
+    '&[data-state="disconnected"]': { backgroundColor: theme.pill.red.color },
+  },
+})
+export const statusSep = style({
+  backgroundColor: theme.stroke.primary,
+  flexShrink: 0,
+  height: 10,
+  width: 1,
+})
 
 export const emptyState = style({
   alignItems: 'center',
@@ -178,22 +212,102 @@ export const emptyState = style({
   padding: 32,
   textAlign: 'center',
 })
-export const emptyStateText = style({ alignItems: 'center', display: 'flex', flexDirection: 'column', gap: 4, maxWidth: 440 })
-export const loadingState = style({ alignItems: 'center', display: 'flex', flex: 1, gap: 8, justifyContent: 'center' })
+export const emptyStateText = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  maxWidth: 440,
+})
+export const loadingState = style({
+  alignItems: 'center',
+  display: 'flex',
+  flex: 1,
+  gap: 8,
+  justifyContent: 'center',
+})
 export const spinner = style({ animation: `${spin} 1s linear infinite` })
 
-export const detailRoot = style({ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 })
-export const detailEmpty = style({ alignItems: 'center', display: 'flex', flex: 1, flexDirection: 'column', gap: 8, justifyContent: 'center', padding: 32, textAlign: 'center' })
-export const detailHeaderActions = style({ alignItems: 'center', display: 'flex', flexShrink: 0, gap: 4 })
+export const detailRoot = style({
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  minHeight: 0,
+})
+export const detailEmpty = style({
+  alignItems: 'center',
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: 8,
+  justifyContent: 'center',
+  padding: 32,
+  textAlign: 'center',
+})
+export const detailHeaderActions = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
+  gap: 4,
+})
 export const scrollBody = style({ display: 'flex', flex: 1, minHeight: 0, overflow: 'auto' })
-export const content = style({ display: 'flex', flex: 1, flexDirection: 'column', gap: 16, minHeight: '100%', padding: 16 })
-export const sqlBlock = style({ backgroundColor: theme.surface.main, border: `1px solid ${theme.stroke.primary}`, borderRadius: 8, overflow: 'hidden', position: 'relative' })
+export const content = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: 16,
+  minHeight: '100%',
+  padding: 16,
+})
+export const sqlBlock = style({
+  backgroundColor: theme.surface.main,
+  border: `1px solid ${theme.stroke.primary}`,
+  borderRadius: 8,
+  overflow: 'hidden',
+  position: 'relative',
+})
 export const statGrid = style({ display: 'flex', flexWrap: 'wrap', gap: 12 })
-export const statCard = style({ backgroundColor: theme.surface.onMainContent, border: `1px solid ${theme.stroke.secondary}`, borderRadius: 12, display: 'flex', flexDirection: 'column', flexShrink: 0, minWidth: 100, paddingBlock: 12, paddingInline: 16 })
-export const tabList = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, display: 'flex', gap: 4 })
-export const tabTrigger = style({ background: 'none', border: 'none', borderBlockEnd: '2px solid transparent', color: theme.content.tertiary, cursor: 'pointer', fontSize: 14, fontWeight: 500, lineHeight: 1.65, marginBlockEnd: -1, paddingBlock: 8, paddingInline: 12 })
-export const tabTriggerActive = style({ borderBlockEndColor: theme.pill.green.color, color: theme.content.primary })
-export const tabContent = style({ display: 'flex', flex: '1 1 280px', flexDirection: 'column', minHeight: 280, overflow: 'hidden', paddingBlockStart: 16 })
+export const statCard = style({
+  backgroundColor: theme.surface.onMainContent,
+  border: `1px solid ${theme.stroke.secondary}`,
+  borderRadius: 12,
+  display: 'flex',
+  flexDirection: 'column',
+  flexShrink: 0,
+  minWidth: 100,
+  paddingBlock: 12,
+  paddingInline: 16,
+})
+export const tabList = style({
+  borderBlockEnd: `1px solid ${theme.stroke.primary}`,
+  display: 'flex',
+  gap: 4,
+})
+export const tabTrigger = style({
+  background: 'none',
+  border: 'none',
+  borderBlockEnd: '2px solid transparent',
+  color: theme.content.tertiary,
+  cursor: 'pointer',
+  fontSize: 14,
+  fontWeight: 500,
+  lineHeight: 1.65,
+  marginBlockEnd: -1,
+  paddingBlock: 8,
+  paddingInline: 12,
+})
+export const tabTriggerActive = style({
+  borderBlockEndColor: theme.pill.green.color,
+  color: theme.content.primary,
+})
+export const tabContent = style({
+  display: 'flex',
+  flex: '1 1 280px',
+  flexDirection: 'column',
+  minHeight: 280,
+  overflow: 'hidden',
+  paddingBlockStart: 16,
+})
 
 export const waterfallRoot = style({
   alignItems: 'stretch',
@@ -221,8 +335,22 @@ export const waterfallTickRow = style({
   gridTemplateColumns: '320px minmax(0, 1fr)',
 })
 export const waterfallLabel = style({ height: 24, minWidth: 0, paddingBlockEnd: 4 })
-export const waterfallTimeline = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, height: 24, minWidth: 0, overflow: 'hidden', paddingBlockEnd: 4, position: 'relative' })
-export const waterfallTick = style({ color: theme.content.tertiary, fontFamily: fontFamily.dmMono, fontSize: 12, lineHeight: '16px', position: 'absolute', whiteSpace: 'nowrap' })
+export const waterfallTimeline = style({
+  borderBlockEnd: `1px solid ${theme.stroke.primary}`,
+  height: 24,
+  minWidth: 0,
+  overflow: 'hidden',
+  paddingBlockEnd: 4,
+  position: 'relative',
+})
+export const waterfallTick = style({
+  color: theme.content.tertiary,
+  fontFamily: fontFamily.dmMono,
+  fontSize: 12,
+  lineHeight: '16px',
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+})
 export const waterfallResizeHandle = style({
   alignSelf: 'stretch',
   backgroundColor: theme.stroke.primary,
@@ -266,7 +394,12 @@ export const waterfallRowsGrid = style({
   gridTemplateColumns: '320px minmax(0, 1fr)',
   minWidth: 0,
 })
-export const waterfallLabelsColumn = style({ display: 'flex', flexDirection: 'column', gap: 10, minWidth: 0 })
+export const waterfallLabelsColumn = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+  minWidth: 0,
+})
 export const waterfallTimelineBody = style({
   alignSelf: 'stretch',
   display: 'flex',
@@ -275,7 +408,14 @@ export const waterfallTimelineBody = style({
   minHeight: 0,
   minWidth: 0,
 })
-export const waterfallRowShell = style({ borderRadius: 8, borderBottomRightRadius: 0, borderTopRightRadius: 0, minWidth: 0, overflow: 'hidden', position: 'relative' })
+export const waterfallRowShell = style({
+  borderRadius: 8,
+  borderBottomRightRadius: 0,
+  borderTopRightRadius: 0,
+  minWidth: 0,
+  overflow: 'hidden',
+  position: 'relative',
+})
 export const waterfallRowButton = style({
   alignItems: 'center',
   background: 'none',
@@ -295,7 +435,10 @@ export const waterfallRowButton = style({
   },
 })
 export const waterfallRowHover = style({ backgroundColor: theme.surface.onMainContentSubtle })
-export const waterfallRowActive = style({ backgroundColor: theme.pill.blue.background, color: theme.content.primary })
+export const waterfallRowActive = style({
+  backgroundColor: theme.pill.blue.background,
+  color: theme.content.primary,
+})
 export const waterfallSpanLabel = style({
   alignItems: 'center',
   alignSelf: 'stretch',
@@ -309,7 +452,14 @@ export const waterfallSpanLabel = style({
 export const waterfallSpanLabelActive = style({
   color: theme.content.primary,
 })
-export const waterfallTreeGuide = style({ borderBlockEnd: `1px solid ${theme.stroke.primary}`, borderInlineStart: `1px solid ${theme.stroke.primary}`, flexShrink: 0, height: 18, marginInlineEnd: 6, width: 10 })
+export const waterfallTreeGuide = style({
+  borderBlockEnd: `1px solid ${theme.stroke.primary}`,
+  borderInlineStart: `1px solid ${theme.stroke.primary}`,
+  flexShrink: 0,
+  height: 18,
+  marginInlineEnd: 6,
+  width: 10,
+})
 export const waterfallTreeToggle = style({
   alignItems: 'center',
   background: 'none',
@@ -323,9 +473,15 @@ export const waterfallTreeToggle = style({
   marginInlineEnd: 3,
   padding: 0,
   paddingInlineEnd: 2,
-  selectors: { '&:hover': { backgroundColor: theme.button.bare.hover, color: theme.content.primary } },
+  selectors: {
+    '&:hover': { backgroundColor: theme.button.bare.hover, color: theme.content.primary },
+  },
 })
-export const waterfallTreeTogglePlaceholder = style({ flexShrink: 0, marginInlineEnd: 3, width: 38 })
+export const waterfallTreeTogglePlaceholder = style({
+  flexShrink: 0,
+  marginInlineEnd: 3,
+  width: 38,
+})
 export const waterfallChildCountChip = style({
   alignItems: 'center',
   backgroundColor: theme.pill.gray.background,
@@ -341,13 +497,27 @@ export const waterfallChildCountChip = style({
   minWidth: 16,
   paddingInline: 4,
 })
-export const waterfallPluginPill = style({ alignItems: 'center', display: 'inline-flex', gap: 6, maxWidth: '100%', minWidth: 0, overflow: 'hidden', whiteSpace: 'nowrap' })
-export const waterfallPluginDot = style({ borderRadius: '50%', flexShrink: 0, height: 8, width: 8, selectors: {
-  '&[data-tone="query"]': { backgroundColor: theme.pill.purple.color },
-  '&[data-tone="http"]': { backgroundColor: theme.pill.blue.color },
-  '&[data-tone="span"]': { backgroundColor: theme.pill.green.color },
-  '&[data-tone="error"]': { backgroundColor: theme.pill.red.color },
-}})
+export const waterfallPluginPill = style({
+  alignItems: 'center',
+  display: 'inline-flex',
+  gap: 6,
+  maxWidth: '100%',
+  minWidth: 0,
+  overflow: 'hidden',
+  whiteSpace: 'nowrap',
+})
+export const waterfallPluginDot = style({
+  borderRadius: '50%',
+  flexShrink: 0,
+  height: 8,
+  width: 8,
+  selectors: {
+    '&[data-tone="query"]': { backgroundColor: theme.pill.purple.color },
+    '&[data-tone="http"]': { backgroundColor: theme.pill.blue.color },
+    '&[data-tone="span"]': { backgroundColor: theme.pill.green.color },
+    '&[data-tone="error"]': { backgroundColor: theme.pill.red.color },
+  },
+})
 export const waterfallLabelText = style({ display: 'flex', flexDirection: 'column', minWidth: 0 })
 export const waterfallBarSlot = style({
   alignItems: 'center',
@@ -366,14 +536,52 @@ export const waterfallBarSlotActive = style({
   backgroundColor: theme.pill.blue.background,
   color: theme.content.primary,
 })
-export const waterfallBarArea = style({ height: 24, minWidth: 0, overflow: 'hidden', position: 'relative', width: '100%' })
-export const waterfallBar = style({ alignItems: 'center', borderRadius: 6, display: 'flex', height: 20, insetBlockStart: 2, minWidth: 2, overflow: 'hidden', paddingInline: 8, position: 'absolute', whiteSpace: 'nowrap', selectors: {
-  '&[data-tone="query"]': { backgroundColor: theme.pill.purple.background, border: `1px solid ${theme.pill.purple.stroke}`, color: theme.pill.purple.color },
-  '&[data-tone="http"]': { backgroundColor: theme.pill.blue.background, border: `1px solid ${theme.pill.blue.stroke}`, color: theme.pill.blue.color },
-  '&[data-tone="span"]': { backgroundColor: theme.pill.green.background, border: `1px solid ${theme.pill.green.stroke}`, color: theme.pill.green.color },
-  '&[data-tone="error"]': { backgroundColor: theme.pill.red.background, border: `1px solid ${theme.pill.red.stroke}`, color: theme.pill.red.color },
-}})
-export const waterfallBarLabel = style({ fontFamily: fontFamily.dmMono, fontSize: 12, lineHeight: '16px' })
+export const waterfallBarArea = style({
+  height: 24,
+  minWidth: 0,
+  overflow: 'hidden',
+  position: 'relative',
+  width: '100%',
+})
+export const waterfallBar = style({
+  alignItems: 'center',
+  borderRadius: 6,
+  display: 'flex',
+  height: 20,
+  insetBlockStart: 2,
+  minWidth: 2,
+  overflow: 'hidden',
+  paddingInline: 8,
+  position: 'absolute',
+  whiteSpace: 'nowrap',
+  selectors: {
+    '&[data-tone="query"]': {
+      backgroundColor: theme.pill.purple.background,
+      border: `1px solid ${theme.pill.purple.stroke}`,
+      color: theme.pill.purple.color,
+    },
+    '&[data-tone="http"]': {
+      backgroundColor: theme.pill.blue.background,
+      border: `1px solid ${theme.pill.blue.stroke}`,
+      color: theme.pill.blue.color,
+    },
+    '&[data-tone="span"]': {
+      backgroundColor: theme.pill.green.background,
+      border: `1px solid ${theme.pill.green.stroke}`,
+      color: theme.pill.green.color,
+    },
+    '&[data-tone="error"]': {
+      backgroundColor: theme.pill.red.background,
+      border: `1px solid ${theme.pill.red.stroke}`,
+      color: theme.pill.red.color,
+    },
+  },
+})
+export const waterfallBarLabel = style({
+  fontFamily: fontFamily.dmMono,
+  fontSize: 12,
+  lineHeight: '16px',
+})
 export const waterfallBarLabelOutside = style({
   color: theme.content.secondary,
   fontFamily: fontFamily.dmMono,
@@ -424,9 +632,28 @@ export const waterfallHttpDetailHeaderActions = style({
   flexShrink: 0,
   gap: 2,
 })
-export const waterfallHttpDetailScroll = style({ flex: 1, minHeight: 0, minWidth: 0, overflow: 'hidden' })
-export const waterfallHttpDetailContent = style({ display: 'flex', flexDirection: 'column', gap: 10, minHeight: 0, minWidth: 0, paddingBlockEnd: 10, paddingInline: 12 })
-export const waterfallHttpTabRow = style({ alignItems: 'center', display: 'flex', gap: 12, justifyContent: 'space-between', minWidth: 0 })
+export const waterfallHttpDetailScroll = style({
+  flex: 1,
+  minHeight: 0,
+  minWidth: 0,
+  overflow: 'hidden',
+})
+export const waterfallHttpDetailContent = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 10,
+  minHeight: 0,
+  minWidth: 0,
+  paddingBlockEnd: 10,
+  paddingInline: 12,
+})
+export const waterfallHttpTabRow = style({
+  alignItems: 'center',
+  display: 'flex',
+  gap: 12,
+  justifyContent: 'space-between',
+  minWidth: 0,
+})
 export const httpMetaRow = style({ display: 'flex', flexWrap: 'wrap', gap: 6 })
 export const httpMetaChip = style({
   alignItems: 'center',
@@ -439,32 +666,125 @@ export const httpMetaChip = style({
   paddingBlock: 2,
   paddingInline: 8,
 })
-export const copyButtonGroup = style({ alignItems: 'center', display: 'flex', flexShrink: 0, gap: 6 })
-export const waterfallHttpDetailSection = style({ display: 'flex', flex: 1, flexDirection: 'column', gap: 4, minHeight: 0, minWidth: 0 })
-export const bodyViewer = style({ display: 'flex', flexDirection: 'column', gap: 8, minHeight: 0, minWidth: 0 })
+export const copyButtonGroup = style({
+  alignItems: 'center',
+  display: 'flex',
+  flexShrink: 0,
+  gap: 6,
+})
+export const waterfallHttpDetailSection = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  gap: 4,
+  minHeight: 0,
+  minWidth: 0,
+})
+export const bodyViewer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  minHeight: 0,
+  minWidth: 0,
+})
 export const bodyViewerHeader = style({ display: 'flex', flexDirection: 'column', gap: 6 })
 export const bodyMetaRow = style({ display: 'flex', flexWrap: 'wrap', gap: 6 })
-export const bodyViewerSection = style({ display: 'flex', flexDirection: 'column', gap: 4, minHeight: 0, minWidth: 0 })
+export const bodyViewerSection = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 4,
+  minHeight: 0,
+  minWidth: 0,
+})
 export const bodyViewerSectionLabel = style({ color: theme.content.tertiary })
 export const bodyViewerRawDetails = style({ display: 'flex', flexDirection: 'column', gap: 4 })
 
-export const statusBadge = style({ borderRadius: 999, display: 'inline-flex', fontSize: 12, paddingBlock: 2, paddingInline: 8, selectors: {
-  '&[data-tone="ok"]': { backgroundColor: theme.pill.green.background, color: theme.pill.green.color },
-  '&[data-tone="error"]': { backgroundColor: theme.pill.red.background, color: theme.pill.red.color },
-  '&[data-tone="running"]': { backgroundColor: theme.pill.blue.background, color: theme.pill.blue.color },
-}})
-export const emptyPanel = style({ alignItems: 'center', border: `1px dashed ${theme.stroke.primary}`, borderRadius: 8, display: 'flex', justifyContent: 'center', minHeight: 140, padding: 24, textAlign: 'center' })
+export const statusBadge = style({
+  borderRadius: 999,
+  display: 'inline-flex',
+  fontSize: 12,
+  paddingBlock: 2,
+  paddingInline: 8,
+  selectors: {
+    '&[data-tone="ok"]': {
+      backgroundColor: theme.pill.green.background,
+      color: theme.pill.green.color,
+    },
+    '&[data-tone="error"]': {
+      backgroundColor: theme.pill.red.background,
+      color: theme.pill.red.color,
+    },
+    '&[data-tone="running"]': {
+      backgroundColor: theme.pill.blue.background,
+      color: theme.pill.blue.color,
+    },
+  },
+})
+export const emptyPanel = style({
+  alignItems: 'center',
+  border: `1px dashed ${theme.stroke.primary}`,
+  borderRadius: 8,
+  display: 'flex',
+  justifyContent: 'center',
+  minHeight: 140,
+  padding: 24,
+  textAlign: 'center',
+})
 export const externalCallsList = style({ display: 'flex', flexDirection: 'column', gap: 8 })
-export const apiCallsSummary = style({ color: theme.content.tertiary, fontSize: 14, lineHeight: 1.65, paddingBlock: 8, paddingInline: 4 })
-export const externalCallCard = style({ border: `1px solid ${theme.stroke.primary}`, borderRadius: 8, overflow: 'hidden' })
-export const externalCallButton = style({ alignItems: 'center', background: 'none', border: 'none', color: theme.content.primary, cursor: 'pointer', display: 'flex', gap: 8, lineHeight: 1.65, paddingBlock: 8, paddingInline: 12, textAlign: 'left', width: '100%', selectors: { '&:hover': { backgroundColor: theme.surface.onMainContentSubtle } } })
+export const apiCallsSummary = style({
+  color: theme.content.tertiary,
+  fontSize: 14,
+  lineHeight: 1.65,
+  paddingBlock: 8,
+  paddingInline: 4,
+})
+export const externalCallCard = style({
+  border: `1px solid ${theme.stroke.primary}`,
+  borderRadius: 8,
+  overflow: 'hidden',
+})
+export const externalCallButton = style({
+  alignItems: 'center',
+  background: 'none',
+  border: 'none',
+  color: theme.content.primary,
+  cursor: 'pointer',
+  display: 'flex',
+  gap: 8,
+  lineHeight: 1.65,
+  paddingBlock: 8,
+  paddingInline: 12,
+  textAlign: 'left',
+  width: '100%',
+  selectors: { '&:hover': { backgroundColor: theme.surface.onMainContentSubtle } },
+})
 export const externalCallTableName = style({ fontWeight: 500 })
-export const externalCallUrl = style({ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })
+export const externalCallUrl = style({
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
 export const externalCallMeta = style({ flexShrink: 0 })
-export const externalCallExpanded = style({ backgroundColor: theme.surface.onMainContentSubtle, borderBlockStart: `1px solid ${theme.stroke.primary}`, display: 'flex', flexDirection: 'column', gap: 8, paddingBlock: 8, paddingInline: 12 })
+export const externalCallExpanded = style({
+  backgroundColor: theme.surface.onMainContentSubtle,
+  borderBlockStart: `1px solid ${theme.stroke.primary}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 8,
+  paddingBlock: 8,
+  paddingInline: 12,
+})
 export const requestUrlRow = style({ alignItems: 'center', display: 'flex', gap: 8 })
 export const methodBadge = style({ flexShrink: 0 })
-export const requestUrl = style({ flex: 1, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' })
+export const requestUrl = style({
+  flex: 1,
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+})
 export const detailsSummary = style({ color: theme.content.tertiary, cursor: 'pointer' })
 export const detailsPre = style({
   backgroundColor: theme.surface.main,
@@ -494,4 +814,14 @@ globalStyle('.sql-comment', { color: '#6A9955', fontStyle: 'italic' })
 globalStyle(`body.${lightTheme} .sql-comment`, { color: '#008000' })
 globalStyle('.sql-identifier', { color: '#9CDCFE' })
 globalStyle(`body.${lightTheme} .sql-identifier`, { color: '#001080' })
-globalStyle(`${sqlBlock} pre`, { color: theme.content.primary, fontFamily: fontFamily.dmMono, fontSize: 14, lineHeight: 1.65, margin: 0, overflowX: 'auto', padding: 12, whiteSpace: 'pre-wrap', wordBreak: 'break-all' })
+globalStyle(`${sqlBlock} pre`, {
+  color: theme.content.primary,
+  fontFamily: fontFamily.dmMono,
+  fontSize: 14,
+  lineHeight: 1.65,
+  margin: 0,
+  overflowX: 'auto',
+  padding: 12,
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+})

--- a/ui/src/views/traces/empty-state.tsx
+++ b/ui/src/views/traces/empty-state.tsx
@@ -14,11 +14,20 @@ export function EmptyState({
 }) {
   return (
     <div className={s.emptyState}>
-      <Icon name={error ? 'CircleAlert' : 'Activity'} size="30" color={error ? 'error' : 'tertiary'} />
+      <Icon
+        name={error ? 'CircleAlert' : 'Activity'}
+        size="30"
+        color={error ? 'error' : 'tertiary'}
+      />
       <div className={s.emptyStateText}>
-        <Typography.BodyLargeStrong>{error ? 'Tracing unavailable' : title ?? 'No queries yet'}</Typography.BodyLargeStrong>
+        <Typography.BodyLargeStrong>
+          {error ? 'Tracing unavailable' : (title ?? 'No queries yet')}
+        </Typography.BodyLargeStrong>
         <Typography.Body variant="tertiary">
-          {error ? error : details ?? 'Make sure tracing is enabled, then run a SQL query to see it here in real-time.'}
+          {error
+            ? error
+            : (details ??
+              'Make sure tracing is enabled, then run a SQL query to see it here in real-time.')}
         </Typography.Body>
       </div>
     </div>

--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -7,7 +7,13 @@ import { Typography } from '@/wax/components/typography'
 import type { TraceSpan } from '@/generated/coral/v1/traces_pb'
 
 import * as s from '../traces-page.css'
-import { formatDuration, formatDurationFromNanos, parseJsonObject, spanOperation, spanUrl } from './trace-utils'
+import {
+  formatDuration,
+  formatDurationFromNanos,
+  parseJsonObject,
+  spanOperation,
+  spanUrl,
+} from './trace-utils'
 
 type JsonValue = Record<string, unknown> | unknown[] | string | number | boolean | null
 type HttpDetailTab = 'params' | 'request' | 'response'
@@ -21,10 +27,7 @@ const REQUEST_BODY_PRESENT_ATTR = 'http.request.body.present'
 const RESPONSE_BODY_PRESENT_ATTR = 'http.response.body.present'
 const REQUEST_BODY_SIZE_ATTR = 'http.request.body.size'
 const RESPONSE_BODY_SIZE_ATTR = 'http.response.body.size'
-const BODY_ATTRIBUTE_KEYS = new Set([
-  REQUEST_BODY_ATTR,
-  RESPONSE_BODY_ATTR,
-])
+const BODY_ATTRIBUTE_KEYS = new Set([REQUEST_BODY_ATTR, RESPONSE_BODY_ATTR])
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
@@ -32,7 +35,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function looksLikeJson(value: string) {
   const trimmed = value.trim()
-  return (trimmed.startsWith('{') && trimmed.endsWith('}')) || (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  return (
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+  )
 }
 
 function parseMaybeJson(value: unknown): JsonValue {
@@ -162,7 +168,9 @@ function bodyPreview(kind: BodyKind, value: unknown, rawValue: unknown): BodyPre
 function BodySection({ children, label }: { children: React.ReactNode; label: string }) {
   return (
     <section className={s.bodyViewerSection}>
-      <Typography.BodySmallStrong as="span" className={s.bodyViewerSectionLabel}>{label}</Typography.BodySmallStrong>
+      <Typography.BodySmallStrong as="span" className={s.bodyViewerSectionLabel}>
+        {label}
+      </Typography.BodySmallStrong>
       {children}
     </section>
   )
@@ -185,12 +193,17 @@ function BodyViewer({
     return <Typography.BodySmall variant="tertiary">{emptyText}</Typography.BodySmall>
   }
 
-  const rawBodyDetails = preview.rawText !== preview.formattedText ? (
-    <details className={s.bodyViewerRawDetails}>
-      <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Raw body</Typography.Body></summary>
-      <pre className={s.detailsPre}>{preview.rawText}</pre>
-    </details>
-  ) : null
+  const rawBodyDetails =
+    preview.rawText !== preview.formattedText ? (
+      <details className={s.bodyViewerRawDetails}>
+        <summary className={s.detailsSummary}>
+          <Typography.Body as="span" variant="tertiary">
+            Raw body
+          </Typography.Body>
+        </summary>
+        <pre className={s.detailsPre}>{preview.rawText}</pre>
+      </details>
+    ) : null
 
   if (!preview.graphql) {
     return (
@@ -206,19 +219,43 @@ function BodyViewer({
   return (
     <div className={s.bodyViewer}>
       <div className={s.bodyViewerHeader}>
-        <Typography.BodySmallStrong as="span">{bodyKind === 'request' ? 'GraphQL request' : 'GraphQL response'}</Typography.BodySmallStrong>
+        <Typography.BodySmallStrong as="span">
+          {bodyKind === 'request' ? 'GraphQL request' : 'GraphQL response'}
+        </Typography.BodySmallStrong>
         <div className={s.bodyMetaRow}>
           {operationName && metaChip('Operation', operationName)}
           {operationType && metaChip('Type', operationType)}
-          {variables !== undefined && metaChip('Variables', Array.isArray(variables) ? `${variables.length}` : 'present')}
-          {Array.isArray(errors) ? metaChip('Errors', `${errors.length}`) : errors !== undefined ? metaChip('Errors', 'present') : null}
-          {data !== undefined && metaChip('Data', Array.isArray(data) ? `${data.length}` : 'present')}
+          {variables !== undefined &&
+            metaChip('Variables', Array.isArray(variables) ? `${variables.length}` : 'present')}
+          {Array.isArray(errors)
+            ? metaChip('Errors', `${errors.length}`)
+            : errors !== undefined
+              ? metaChip('Errors', 'present')
+              : null}
+          {data !== undefined &&
+            metaChip('Data', Array.isArray(data) ? `${data.length}` : 'present')}
         </div>
       </div>
-      {query !== undefined && <BodySection label="Query"><pre className={s.detailsPre}>{query}</pre></BodySection>}
-      {variables !== undefined && <BodySection label="Variables"><pre className={s.detailsPre}>{formatDetailValue(variables)}</pre></BodySection>}
-      {data !== undefined && <BodySection label="Data"><pre className={s.detailsPre}>{formatDetailValue(data)}</pre></BodySection>}
-      {errors !== undefined && <BodySection label="Errors"><pre className={s.detailsPre}>{formatDetailValue(errors)}</pre></BodySection>}
+      {query !== undefined && (
+        <BodySection label="Query">
+          <pre className={s.detailsPre}>{query}</pre>
+        </BodySection>
+      )}
+      {variables !== undefined && (
+        <BodySection label="Variables">
+          <pre className={s.detailsPre}>{formatDetailValue(variables)}</pre>
+        </BodySection>
+      )}
+      {data !== undefined && (
+        <BodySection label="Data">
+          <pre className={s.detailsPre}>{formatDetailValue(data)}</pre>
+        </BodySection>
+      )}
+      {errors !== undefined && (
+        <BodySection label="Errors">
+          <pre className={s.detailsPre}>{formatDetailValue(errors)}</pre>
+        </BodySection>
+      )}
       {rawBodyDetails}
     </div>
   )
@@ -286,22 +323,33 @@ function formatBytes(value: unknown): string | undefined {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }
 
-function bodyEmptyText(kind: 'request' | 'response', attrs: Record<string, unknown>, truncated: boolean) {
+function bodyEmptyText(
+  kind: 'request' | 'response',
+  attrs: Record<string, unknown>,
+  truncated: boolean,
+) {
   const label = kind === 'request' ? 'Request body' : 'Response body'
-  const size = formatBytes(attrs[kind === 'request' ? REQUEST_BODY_SIZE_ATTR : RESPONSE_BODY_SIZE_ATTR])
-  const present = kind === 'request'
-    ? attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
-    : attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size)
+  const size = formatBytes(
+    attrs[kind === 'request' ? REQUEST_BODY_SIZE_ATTR : RESPONSE_BODY_SIZE_ATTR],
+  )
+  const present =
+    kind === 'request'
+      ? attrBool(attrs[REQUEST_BODY_PRESENT_ATTR])
+      : attrBool(attrs[RESPONSE_BODY_PRESENT_ATTR]) || Boolean(size)
 
-  if (truncated) return `${label} was truncated${size ? ` (${size})` : ''}, but no preview was recorded.`
-  if (present) return `${label} was present${size ? ` (${size})` : ''}, but content was not captured.`
+  if (truncated)
+    return `${label} was truncated${size ? ` (${size})` : ''}, but no preview was recorded.`
+  if (present)
+    return `${label} was present${size ? ` (${size})` : ''}, but content was not captured.`
   return `No ${kind} body was recorded for this request.`
 }
 
 function metaChip(label: string, value: React.ReactNode) {
   return (
     <span className={s.httpMetaChip} key={label}>
-      <Typography.BodySmall as="span" variant="tertiary">{label}</Typography.BodySmall>
+      <Typography.BodySmall as="span" variant="tertiary">
+        {label}
+      </Typography.BodySmall>
       <Typography.BodySmallStrong as="span">{value}</Typography.BodySmallStrong>
     </span>
   )
@@ -336,7 +384,13 @@ export function HttpSpanDetail({
   const requestBodyTruncated = attrBool(attrs[REQUEST_BODY_TRUNCATED_ATTR])
   const responseBodyTruncated = attrBool(attrs[RESPONSE_BODY_TRUNCATED_ATTR])
   const paramsValue = Object.keys(params).length ? params : undefined
-  const preferredTab: HttpDetailTab = responseBody ? 'response' : requestBody ? 'request' : paramsValue ? 'params' : 'response'
+  const preferredTab: HttpDetailTab = responseBody
+    ? 'response'
+    : requestBody
+      ? 'request'
+      : paramsValue
+        ? 'params'
+        : 'response'
   const tabs: Array<{ id: HttpDetailTab; label: string }> = [
     { id: 'params', label: 'Params' },
     { id: 'request', label: `Request body${requestBodyTruncated ? ' (truncated)' : ''}` },
@@ -356,8 +410,13 @@ export function HttpSpanDetail({
   const copyValue = formatDetailValue(activeBody.value)
   const rawCopyValue = formatRawValue(activeBody.rawValue, copyValue)
   const hasSeparateRawCopy = Boolean(rawCopyValue && rawCopyValue !== copyValue)
-  const visibleAttrs = Object.fromEntries(Object.entries(attrs).filter(([key]) => !BODY_ATTRIBUTE_KEYS.has(key)))
-  const offsetMs = Math.max(0, Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n))
+  const visibleAttrs = Object.fromEntries(
+    Object.entries(attrs).filter(([key]) => !BODY_ATTRIBUTE_KEYS.has(key)),
+  )
+  const offsetMs = Math.max(
+    0,
+    Number((BigInt(span.startTimeUnixNanos || 0) - traceStart) / 1_000_000n),
+  )
   const statusCode = attrText(attrs['http.response.status_code'])
   const requestId = attrText(attrs['coral.http.request_id'])
   const attempt = attrText(attrs['coral.http.attempt'])
@@ -383,11 +442,17 @@ export function HttpSpanDetail({
   }
 
   return (
-    <div className={s.waterfallHttpDetail} data-span-inspector="true" onClick={(event) => event.stopPropagation()}>
+    <div
+      className={s.waterfallHttpDetail}
+      data-span-inspector="true"
+      onClick={(event) => event.stopPropagation()}
+    >
       <div className={s.waterfallHttpDetailHeader}>
         <div className={s.waterfallHttpDetailTitle}>
           <Typography.BodySmallStrong as="span">Span details</Typography.BodySmallStrong>
-          <Typography.BodySmall as="span" variant="tertiary" truncate>{spanOperation(span)}</Typography.BodySmall>
+          <Typography.BodySmall as="span" variant="tertiary" truncate>
+            {spanOperation(span)}
+          </Typography.BodySmall>
         </div>
         <div className={s.waterfallHttpDetailHeaderActions}>
           <Button.IconButton
@@ -415,11 +480,20 @@ export function HttpSpanDetail({
           />
         </div>
       </div>
-      <ScrollArea.Container className={s.waterfallHttpDetailScroll} constrainWidth fade="bottom" height="100%">
+      <ScrollArea.Container
+        className={s.waterfallHttpDetailScroll}
+        constrainWidth
+        fade="bottom"
+        height="100%"
+      >
         <div className={s.waterfallHttpDetailContent}>
           <div className={s.requestUrlRow}>
-            <Typography.CodeSmallInline as="span" className={s.methodBadge}>{spanOperation(span)}</Typography.CodeSmallInline>
-            <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>{url || 'No URL recorded'}</Typography.Body>
+            <Typography.CodeSmallInline as="span" className={s.methodBadge}>
+              {spanOperation(span)}
+            </Typography.CodeSmallInline>
+            <Typography.Body as="span" variant="tertiary" className={s.requestUrl}>
+              {url || 'No URL recorded'}
+            </Typography.Body>
           </div>
           <div className={s.httpMetaRow}>
             {statusCode && metaChip('Status', statusCode)}
@@ -435,7 +509,9 @@ export function HttpSpanDetail({
                 <button
                   aria-controls={`http-detail-${span.spanId}-${tab.id}`}
                   aria-selected={activeTab === tab.id}
-                  className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
+                  className={classNames(s.tabTrigger, {
+                    [s.tabTriggerActive]: activeTab === tab.id,
+                  })}
                   id={`http-detail-tab-${span.spanId}-${tab.id}`}
                   key={tab.id}
                   onClick={() => setActiveTab(tab.id)}
@@ -448,12 +524,26 @@ export function HttpSpanDetail({
             </div>
             <div className={s.copyButtonGroup}>
               {hasSeparateRawCopy && (
-                <Button.TextButton disabled={!rawCopyValue} onClick={() => copyValueToClipboard(rawCopyValue, 'raw')} size="22" variant="secondary">
+                <Button.TextButton
+                  disabled={!rawCopyValue}
+                  onClick={() => copyValueToClipboard(rawCopyValue, 'raw')}
+                  size="22"
+                  variant="secondary"
+                >
                   {copyState === 'raw' ? 'Raw copied' : 'Copy raw'}
                 </Button.TextButton>
               )}
-              <Button.TextButton disabled={!copyValue} onClick={() => copyValueToClipboard(copyValue, 'formatted')} size="22" variant="secondary">
-                {copyState === 'formatted' ? 'Copied' : copyState === 'failed' ? 'Copy failed' : 'Copy formatted'}
+              <Button.TextButton
+                disabled={!copyValue}
+                onClick={() => copyValueToClipboard(copyValue, 'formatted')}
+                size="22"
+                variant="secondary"
+              >
+                {copyState === 'formatted'
+                  ? 'Copied'
+                  : copyState === 'failed'
+                    ? 'Copy failed'
+                    : 'Copy formatted'}
               </Button.TextButton>
             </div>
           </div>
@@ -463,10 +553,19 @@ export function HttpSpanDetail({
             id={`http-detail-${span.spanId}-${activeTab}`}
             role="tabpanel"
           >
-            <BodyViewer emptyText={activeBody.emptyText} kind={activeBody.kind} rawValue={activeBody.rawValue} value={activeBody.value} />
+            <BodyViewer
+              emptyText={activeBody.emptyText}
+              kind={activeBody.kind}
+              rawValue={activeBody.rawValue}
+              value={activeBody.value}
+            />
           </section>
           <details>
-            <summary className={s.detailsSummary}><Typography.Body as="span" variant="tertiary">Span attributes</Typography.Body></summary>
+            <summary className={s.detailsSummary}>
+              <Typography.Body as="span" variant="tertiary">
+                Span attributes
+              </Typography.Body>
+            </summary>
             <pre className={s.detailsPre}>{JSON.stringify(visibleAttrs, null, 2)}</pre>
           </details>
         </div>

--- a/ui/src/views/traces/page-header.tsx
+++ b/ui/src/views/traces/page-header.tsx
@@ -2,10 +2,26 @@ import { Typography } from '@/wax/components/typography'
 
 import * as s from '../traces-page.css'
 
-export function PageHeader({ children, isSearching, title }: { children?: React.ReactNode; isSearching?: boolean; title: React.ReactNode }) {
+export function PageHeader({
+  children,
+  isSearching,
+  title,
+}: {
+  children?: React.ReactNode
+  isSearching?: boolean
+  title: React.ReactNode
+}) {
   return (
     <header className={s.header} data-searching={isSearching ? 'true' : undefined}>
-      <div className={s.headerTitle}>{typeof title === 'string' ? <Typography.BodyStrong as="span" variant="secondary">{title}</Typography.BodyStrong> : title}</div>
+      <div className={s.headerTitle}>
+        {typeof title === 'string' ? (
+          <Typography.BodyStrong as="span" variant="secondary">
+            {title}
+          </Typography.BodyStrong>
+        ) : (
+          title
+        )}
+      </div>
       {children}
     </header>
   )

--- a/ui/src/views/traces/status-bar.tsx
+++ b/ui/src/views/traces/status-bar.tsx
@@ -2,20 +2,38 @@ import { Typography } from '@/wax/components/typography'
 
 import * as s from '../traces-page.css'
 
-export function StatusBar({ connected, count, totalCount = count }: { connected: boolean; count: number; totalCount?: number }) {
+export function StatusBar({
+  connected,
+  count,
+  totalCount = count,
+}: {
+  connected: boolean
+  count: number
+  totalCount?: number
+}) {
   const endpoint = typeof window === 'undefined' ? 'TraceService' : window.location.host
   return (
     <div className={s.statusBar}>
       <div className={s.statusLeft}>
         <span className={s.statusBarDot} data-state={connected ? 'connected' : 'disconnected'} />
-        <Typography.BodySmall as="span" variant="tertiary">{connected ? 'Connected' : 'Disconnected'}</Typography.BodySmall>
+        <Typography.BodySmall as="span" variant="tertiary">
+          {connected ? 'Connected' : 'Disconnected'}
+        </Typography.BodySmall>
         <span className={s.statusSep} />
-        <Typography.BodySmall as="span" variant="tertiary">{endpoint}</Typography.BodySmall>
+        <Typography.BodySmall as="span" variant="tertiary">
+          {endpoint}
+        </Typography.BodySmall>
       </div>
       <div className={s.statusRight}>
-        <Typography.BodySmall as="span" variant="tertiary">{count === totalCount ? `${count} ${count === 1 ? 'query' : 'queries'}` : `${count} of ${totalCount} queries`}</Typography.BodySmall>
+        <Typography.BodySmall as="span" variant="tertiary">
+          {count === totalCount
+            ? `${count} ${count === 1 ? 'query' : 'queries'}`
+            : `${count} of ${totalCount} queries`}
+        </Typography.BodySmall>
         <span className={s.statusSep} />
-        <Typography.BodySmall as="span" variant="tertiary">Coral</Typography.BodySmall>
+        <Typography.BodySmall as="span" variant="tertiary">
+          Coral
+        </Typography.BodySmall>
       </div>
     </div>
   )

--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -398,7 +398,7 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
     }
     // Keep the animation target stable during a single open/close transition.
     // Drag resizing updates both detailPanelRatio and animatedDetailPanelRatio directly.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedHttpSpanId])
   useEffect(() => {
     onNavigableSpanIdsChange(rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId))

--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -67,10 +67,18 @@ function useTraceDetail(traceId: string | null) {
     setLoading(true)
     setError(null)
     getTrace(traceId)
-      .then((response) => { if (!stale) setDetail(response) })
-      .catch((err) => { if (!stale) setError(formatTraceError(err instanceof Error ? err.message : String(err))) })
-      .finally(() => { if (!stale) setLoading(false) })
-    return () => { stale = true }
+      .then((response) => {
+        if (!stale) setDetail(response)
+      })
+      .catch((err) => {
+        if (!stale) setError(formatTraceError(err instanceof Error ? err.message : String(err)))
+      })
+      .finally(() => {
+        if (!stale) setLoading(false)
+      })
+    return () => {
+      stale = true
+    }
   }, [traceId])
 
   return { detail, error, loading }
@@ -102,21 +110,44 @@ function StatCard({ label, value }: { label: string; value: React.ReactNode }) {
   )
 }
 
-function WaterfallBar({ left, tone, width, label }: { left: number; tone: WaterfallTone; width: number; label: string }) {
+function WaterfallBar({
+  left,
+  tone,
+  width,
+  label,
+}: {
+  left: number
+  tone: WaterfallTone
+  width: number
+  label: string
+}) {
   const clampedLeft = Math.max(0, Math.min(100, left))
   const clampedWidth = Math.max(0.5, Math.min(100 - clampedLeft, width))
   const narrow = clampedWidth < 6
   const outsideLabelLeft = clampedLeft + clampedWidth + 0.5
-  const outsideLabelStyle = outsideLabelLeft > 86
-    ? { right: `${Math.max(0, 100 - clampedLeft)}%` }
-    : { left: `${outsideLabelLeft}%` }
+  const outsideLabelStyle =
+    outsideLabelLeft > 86
+      ? { right: `${Math.max(0, 100 - clampedLeft)}%` }
+      : { left: `${outsideLabelLeft}%` }
 
   return (
     <div className={s.waterfallBarArea}>
-      <div className={s.waterfallBar} data-tone={tone} style={{ left: `${clampedLeft}%`, width: `${clampedWidth}%` }}>
+      <div
+        className={s.waterfallBar}
+        data-tone={tone}
+        style={{ left: `${clampedLeft}%`, width: `${clampedWidth}%` }}
+      >
         {!narrow && <span className={s.waterfallBarLabel}>{label}</span>}
       </div>
-      {narrow && <span className={s.waterfallBarLabelOutside} data-align={outsideLabelLeft > 86 ? 'end' : 'start'} style={outsideLabelStyle}>{label}</span>}
+      {narrow && (
+        <span
+          className={s.waterfallBarLabelOutside}
+          data-align={outsideLabelLeft > 86 ? 'end' : 'start'}
+          style={outsideLabelStyle}
+        >
+          {label}
+        </span>
+      )}
     </div>
   )
 }
@@ -129,7 +160,15 @@ function spanTiming(span: TraceSpan, traceStart: bigint, durationMs: number) {
   }
 }
 
-function SpanTimingBar({ durationMs, span, traceStart }: { durationMs: number; span: TraceSpan; traceStart: bigint }) {
+function SpanTimingBar({
+  durationMs,
+  span,
+  traceStart,
+}: {
+  durationMs: number
+  span: TraceSpan
+  traceStart: bigint
+}) {
   const timing = spanTiming(span, traceStart, durationMs)
   return (
     <WaterfallBar
@@ -142,7 +181,10 @@ function SpanTimingBar({ durationMs, span, traceStart }: { durationMs: number; s
 }
 
 function WaterfallTickRow({ durationMs }: { durationMs: number }) {
-  const ticks = useMemo(() => Array.from({ length: 5 }, (_, index) => (index / 4) * durationMs), [durationMs])
+  const ticks = useMemo(
+    () => Array.from({ length: 5 }, (_, index) => (index / 4) * durationMs),
+    [durationMs],
+  )
 
   return (
     <div className={s.waterfallTickRow} role="presentation">
@@ -150,8 +192,17 @@ function WaterfallTickRow({ durationMs }: { durationMs: number }) {
       <div className={s.waterfallTimeline}>
         {ticks.map((tick, index) => {
           const pct = (tick / durationMs) * 100
-          const style = index === 0 ? { left: 0 } : index === ticks.length - 1 ? { right: 0 } : { left: `${pct}%`, transform: 'translateX(-50%)' }
-          return <span className={s.waterfallTick} key={`${tick}-${index}`} style={style}>{formatDuration(tick)}</span>
+          const style =
+            index === 0
+              ? { left: 0 }
+              : index === ticks.length - 1
+                ? { right: 0 }
+                : { left: `${pct}%`, transform: 'translateX(-50%)' }
+          return (
+            <span className={s.waterfallTick} key={`${tick}-${index}`} style={style}>
+              {formatDuration(tick)}
+            </span>
+          )
         })}
       </div>
     </div>
@@ -189,7 +240,10 @@ function WaterfallSpanLabel({
   tone: WaterfallTone
 }) {
   return (
-    <div className={classNames(s.waterfallSpanLabel, { [s.waterfallSpanLabelActive]: active })} style={{ paddingInlineStart: WATERFALL_LABEL_PADDING_INLINE_PX + depth * INDENT_PX }}>
+    <div
+      className={classNames(s.waterfallSpanLabel, { [s.waterfallSpanLabelActive]: active })}
+      style={{ paddingInlineStart: WATERFALL_LABEL_PADDING_INLINE_PX + depth * INDENT_PX }}
+    >
       {depth > 0 && <span className={s.waterfallTreeGuide} aria-hidden />}
       {childCount > 0 ? (
         <button
@@ -211,8 +265,14 @@ function WaterfallSpanLabel({
       <span className={s.waterfallPluginPill}>
         <span className={s.waterfallPluginDot} data-tone={tone} />
         <span className={s.waterfallLabelText}>
-          <Typography.BodySmallStrong as="span" truncate>{label}</Typography.BodySmallStrong>
-          {meta && <Typography.BodySmall as="span" variant="tertiary" truncate>{meta}</Typography.BodySmall>}
+          <Typography.BodySmallStrong as="span" truncate>
+            {label}
+          </Typography.BodySmallStrong>
+          {meta && (
+            <Typography.BodySmall as="span" variant="tertiary" truncate>
+              {meta}
+            </Typography.BodySmall>
+          )}
         </span>
       </span>
     </div>
@@ -241,7 +301,10 @@ function WaterfallBarSlot({
 
   return (
     <div
-      className={classNames(s.waterfallBarSlot, { [s.waterfallRowHover]: hovered, [s.waterfallBarSlotActive]: active })}
+      className={classNames(s.waterfallBarSlot, {
+        [s.waterfallRowHover]: hovered,
+        [s.waterfallBarSlotActive]: active,
+      })}
       onMouseEnter={() => onHover(span.spanId)}
       onMouseLeave={() => onHover(null)}
       onClick={() => canExpandHttp && onToggleExpanded(span.spanId)}
@@ -281,7 +344,10 @@ function WaterfallRow({
   const tone = spanTone(span)
   const label = spanDisplayLabel(span)
   const meta = spanDisplayMeta(span, label)
-  const isNoisyInternalSpan = tone === 'span' && span.kind === 'internal' && nanosToMs(span.durationNanos) <= NOISY_INTERNAL_SPAN_MAX_MS
+  const isNoisyInternalSpan =
+    tone === 'span' &&
+    span.kind === 'internal' &&
+    nanosToMs(span.durationNanos) <= NOISY_INTERNAL_SPAN_MAX_MS
   const canExpandHttp = isHttpSpan(span)
 
   return (
@@ -294,7 +360,10 @@ function WaterfallRow({
     >
       <div
         aria-expanded={canExpandHttp ? expanded : undefined}
-        className={classNames(s.waterfallRowButton, { [s.waterfallRowHover]: hovered, [s.waterfallRowActive]: expanded })}
+        className={classNames(s.waterfallRowButton, {
+          [s.waterfallRowHover]: hovered,
+          [s.waterfallRowActive]: expanded,
+        })}
         data-noisy={isNoisyInternalSpan || undefined}
         onMouseEnter={() => onHover(span.spanId)}
         onMouseLeave={() => onHover(null)}
@@ -324,22 +393,39 @@ function WaterfallRow({
   )
 }
 
-function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onNavigableSpanIdsChange, spans, summary }: {
+function TimelineWaterfall({
+  expandedHttpSpanId,
+  onExpandedHttpSpanIdChange,
+  onNavigableSpanIdsChange,
+  spans,
+  summary,
+}: {
   expandedHttpSpanId: string | null
-  onExpandedHttpSpanIdChange: (spanId: string | null | ((current: string | null) => string | null)) => void
+  onExpandedHttpSpanIdChange: (
+    spanId: string | null | ((current: string | null) => string | null),
+  ) => void
   onNavigableSpanIdsChange: (spanIds: string[]) => void
   spans: TraceSpan[]
   summary?: GetTraceResponse['summary']
 }) {
   const proMode = useProMode()
-  const timelineSpans = useMemo(() => proMode ? spans : spans.filter(isHttpSpan), [proMode, spans])
-  const { collapsedSpanIds, rows, toggleSpan } = useTimelineTree(timelineSpans, summary?.rootSpanId, summary?.traceId)
+  const timelineSpans = useMemo(
+    () => (proMode ? spans : spans.filter(isHttpSpan)),
+    [proMode, spans],
+  )
+  const { collapsedSpanIds, rows, toggleSpan } = useTimelineTree(
+    timelineSpans,
+    summary?.rootSpanId,
+    summary?.traceId,
+  )
   const hasRenderedDetailPanel = useRef(false)
   const panelAnimationFrame = useRef<number | null>(null)
   const rootRef = useRef<HTMLDivElement>(null)
   const [hoveredSpanId, setHoveredSpanId] = useState<string | null>(null)
   const [detailPanelRatio, setDetailPanelRatio] = useState(DETAIL_PANEL_DEFAULT_RATIO)
-  const [animatedDetailPanelRatio, setAnimatedDetailPanelRatio] = useState(expandedHttpSpanId ? DETAIL_PANEL_DEFAULT_RATIO : 0)
+  const [animatedDetailPanelRatio, setAnimatedDetailPanelRatio] = useState(
+    expandedHttpSpanId ? DETAIL_PANEL_DEFAULT_RATIO : 0,
+  )
   const [isResizingDetailPanel, setIsResizingDetailPanel] = useState(false)
   const [renderedHttpSpanId, setRenderedHttpSpanId] = useState<string | null>(expandedHttpSpanId)
   const [detailPanelVisible, setDetailPanelVisible] = useState(Boolean(expandedHttpSpanId))
@@ -385,7 +471,8 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
       setDetailPanelSettled(false)
       animatePanelRatio(0, detailPanelRatio, () => setDetailPanelSettled(true))
       return () => {
-        if (panelAnimationFrame.current !== null) window.cancelAnimationFrame(panelAnimationFrame.current)
+        if (panelAnimationFrame.current !== null)
+          window.cancelAnimationFrame(panelAnimationFrame.current)
       }
     }
 
@@ -394,32 +481,45 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
     setDetailPanelSettled(false)
     animatePanelRatio(animatedDetailPanelRatio, 0, () => setRenderedHttpSpanId(null))
     return () => {
-      if (panelAnimationFrame.current !== null) window.cancelAnimationFrame(panelAnimationFrame.current)
+      if (panelAnimationFrame.current !== null)
+        window.cancelAnimationFrame(panelAnimationFrame.current)
     }
     // Keep the animation target stable during a single open/close transition.
     // Drag resizing updates both detailPanelRatio and animatedDetailPanelRatio directly.
     // oxlint-disable-next-line react-hooks/exhaustive-deps
   }, [expandedHttpSpanId])
   useEffect(() => {
-    onNavigableSpanIdsChange(rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId))
+    onNavigableSpanIdsChange(
+      rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId),
+    )
   }, [onNavigableSpanIdsChange, rows])
   const traceStart = BigInt(summary?.startTimeUnixNanos || rows[0]?.span.startTimeUnixNanos || 0)
   const durationMs = Math.max(nanosToMs(summary?.durationNanos || '0'), 1)
-  const navigableSpanIds = useMemo(() => rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId), [rows])
-  const renderedHttpSpanIndex = renderedHttpSpanId ? navigableSpanIds.indexOf(renderedHttpSpanId) : -1
+  const navigableSpanIds = useMemo(
+    () => rows.filter((row) => isHttpSpan(row.span)).map((row) => row.span.spanId),
+    [rows],
+  )
+  const renderedHttpSpanIndex = renderedHttpSpanId
+    ? navigableSpanIds.indexOf(renderedHttpSpanId)
+    : -1
   const renderedHttpRow = rows.find((row) => row.span.spanId === renderedHttpSpanId)
   const renderedHttpSpan = renderedHttpRow?.span
 
-  const selectAdjacentSpan = useCallback((direction: -1 | 1) => {
-    if (renderedHttpSpanIndex < 0) return
-    const nextSpanId = navigableSpanIds[renderedHttpSpanIndex + direction]
-    if (!nextSpanId) return
-    onExpandedHttpSpanIdChange(nextSpanId)
-    window.requestAnimationFrame(() => {
-      const escapedSpanId = nextSpanId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-      document.querySelector(`[data-span-row-id="${escapedSpanId}"]`)?.scrollIntoView({ block: 'nearest' })
-    })
-  }, [renderedHttpSpanIndex, navigableSpanIds, onExpandedHttpSpanIdChange])
+  const selectAdjacentSpan = useCallback(
+    (direction: -1 | 1) => {
+      if (renderedHttpSpanIndex < 0) return
+      const nextSpanId = navigableSpanIds[renderedHttpSpanIndex + direction]
+      if (!nextSpanId) return
+      onExpandedHttpSpanIdChange(nextSpanId)
+      window.requestAnimationFrame(() => {
+        const escapedSpanId = nextSpanId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+        document
+          .querySelector(`[data-span-row-id="${escapedSpanId}"]`)
+          ?.scrollIntoView({ block: 'nearest' })
+      })
+    },
+    [renderedHttpSpanIndex, navigableSpanIds, onExpandedHttpSpanIdChange],
+  )
 
   const resizeDetailPanel = useCallback((clientX: number) => {
     const root = rootRef.current
@@ -431,21 +531,27 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
     setAnimatedDetailPanelRatio(nextRatio)
   }, [])
 
-  const handleResizePointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    setIsResizingDetailPanel(true)
-    event.currentTarget.setPointerCapture(event.pointerId)
-    resizeDetailPanel(event.clientX)
-  }, [resizeDetailPanel])
+  const handleResizePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      setIsResizingDetailPanel(true)
+      event.currentTarget.setPointerCapture(event.pointerId)
+      resizeDetailPanel(event.clientX)
+    },
+    [resizeDetailPanel],
+  )
 
   const handleResizePointerEnd = useCallback(() => {
     setIsResizingDetailPanel(false)
   }, [])
 
-  const handleResizePointerMove = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
-    if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
-    resizeDetailPanel(event.clientX)
-  }, [resizeDetailPanel])
+  const handleResizePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (!event.currentTarget.hasPointerCapture(event.pointerId)) return
+      resizeDetailPanel(event.clientX)
+    },
+    [resizeDetailPanel],
+  )
 
   const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'ArrowLeft') {
@@ -487,7 +593,9 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
                   key={row.span.spanId}
                   onHover={setHoveredSpanId}
                   onToggle={toggleSpan}
-                  onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
+                  onToggleExpanded={(spanId) =>
+                    onExpandedHttpSpanIdChange((current) => (current === spanId ? null : spanId))
+                  }
                   reserveToggleSpace={proMode}
                   row={row}
                 />
@@ -501,7 +609,9 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
                   hovered={hoveredSpanId === row.span.spanId}
                   key={row.span.spanId}
                   onHover={setHoveredSpanId}
-                  onToggleExpanded={(spanId) => onExpandedHttpSpanIdChange((current) => current === spanId ? null : spanId)}
+                  onToggleExpanded={(spanId) =>
+                    onExpandedHttpSpanIdChange((current) => (current === spanId ? null : spanId))
+                  }
                   row={row}
                   traceStart={traceStart}
                 />
@@ -554,18 +664,33 @@ function TimelineWaterfall({ expandedHttpSpanId, onExpandedHttpSpanIdChange, onN
   )
 }
 
-function DetailTabs({ activeTab, extraTabs, onTab }: { activeTab: string; extraTabs?: ExtraDetailTab[]; onTab: (tab: string) => void }) {
+function DetailTabs({
+  activeTab,
+  extraTabs,
+  onTab,
+}: {
+  activeTab: string
+  extraTabs?: ExtraDetailTab[]
+  onTab: (tab: string) => void
+}) {
   const tabs = [
     { id: 'timeline', label: 'Trace', show: true },
     ...(extraTabs ?? []).map((tab) => ({ id: tab.id, label: tab.label, show: tab.show ?? true })),
   ]
   return (
     <div className={s.tabList}>
-      {tabs.filter((tab) => tab.show).map((tab) => (
-        <button className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })} key={tab.id} onClick={() => onTab(tab.id)} type="button">
-          <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
-        </button>
-      ))}
+      {tabs
+        .filter((tab) => tab.show)
+        .map((tab) => (
+          <button
+            className={classNames(s.tabTrigger, { [s.tabTriggerActive]: activeTab === tab.id })}
+            key={tab.id}
+            onClick={() => onTab(tab.id)}
+            type="button"
+          >
+            <Typography.BodySmallStrong as="span">{tab.label}</Typography.BodySmallStrong>
+          </button>
+        ))}
     </div>
   )
 }
@@ -591,47 +716,83 @@ export function TraceDetail({
   const [navigableSpanIds, setNavigableSpanIds] = useState<string[]>([])
   useEffect(() => setActiveTab('timeline'), [traceId])
 
-  const selectAdjacentSpan = useCallback((direction: -1 | 1) => {
-    if (!expandedHttpSpanId) return
-    const currentIndex = navigableSpanIds.indexOf(expandedHttpSpanId)
-    const nextSpanId = currentIndex >= 0 ? navigableSpanIds[currentIndex + direction] : null
-    if (!nextSpanId) return
-    setExpandedHttpSpanId(nextSpanId)
-    window.requestAnimationFrame(() => {
-      const escapedSpanId = nextSpanId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-      document.querySelector(`[data-span-row-id="${escapedSpanId}"]`)?.scrollIntoView({ block: 'nearest' })
-    })
-  }, [expandedHttpSpanId, navigableSpanIds])
+  const selectAdjacentSpan = useCallback(
+    (direction: -1 | 1) => {
+      if (!expandedHttpSpanId) return
+      const currentIndex = navigableSpanIds.indexOf(expandedHttpSpanId)
+      const nextSpanId = currentIndex >= 0 ? navigableSpanIds[currentIndex + direction] : null
+      if (!nextSpanId) return
+      setExpandedHttpSpanId(nextSpanId)
+      window.requestAnimationFrame(() => {
+        const escapedSpanId = nextSpanId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+        document
+          .querySelector(`[data-span-row-id="${escapedSpanId}"]`)
+          ?.scrollIntoView({ block: 'nearest' })
+      })
+    },
+    [expandedHttpSpanId, navigableSpanIds],
+  )
 
-  const handleEscapeShortcut = useCallback((event: KeyboardEvent) => {
-    if (expandedHttpSpanId) {
+  const handleEscapeShortcut = useCallback(
+    (event: KeyboardEvent) => {
+      if (expandedHttpSpanId) {
+        event.preventDefault()
+        setExpandedHttpSpanId(null)
+        return
+      }
+      onClose()
+    },
+    [expandedHttpSpanId, onClose],
+  )
+
+  const handlePreviousSpanShortcut = useCallback(
+    (event: KeyboardEvent) => {
+      if (!expandedHttpSpanId) return
+      if (
+        event.target instanceof HTMLElement &&
+        event.target.closest('[data-span-inspector="true"]')
+      )
+        return
       event.preventDefault()
-      setExpandedHttpSpanId(null)
-      return
-    }
-    onClose()
-  }, [expandedHttpSpanId, onClose])
+      selectAdjacentSpan(-1)
+    },
+    [expandedHttpSpanId, selectAdjacentSpan],
+  )
 
-  const handlePreviousSpanShortcut = useCallback((event: KeyboardEvent) => {
-    if (!expandedHttpSpanId) return
-    if (event.target instanceof HTMLElement && event.target.closest('[data-span-inspector="true"]')) return
-    event.preventDefault()
-    selectAdjacentSpan(-1)
-  }, [expandedHttpSpanId, selectAdjacentSpan])
-
-  const handleNextSpanShortcut = useCallback((event: KeyboardEvent) => {
-    if (!expandedHttpSpanId) return
-    if (event.target instanceof HTMLElement && event.target.closest('[data-span-inspector="true"]')) return
-    event.preventDefault()
-    selectAdjacentSpan(1)
-  }, [expandedHttpSpanId, selectAdjacentSpan])
+  const handleNextSpanShortcut = useCallback(
+    (event: KeyboardEvent) => {
+      if (!expandedHttpSpanId) return
+      if (
+        event.target instanceof HTMLElement &&
+        event.target.closest('[data-span-inspector="true"]')
+      )
+        return
+      event.preventDefault()
+      selectAdjacentSpan(1)
+    },
+    [expandedHttpSpanId, selectAdjacentSpan],
+  )
   const summary = detail?.summary
   const httpSpans = useMemo(() => detail?.spans.filter(isHttpSpan) ?? [], [detail?.spans])
   const sources = useMemo(() => sourceNames(detail?.spans ?? []), [detail?.spans])
-  const resolvedExtraTabs = useMemo(() => (detail ? extraTabs?.(detail) ?? [] : []), [detail, extraTabs])
+  const resolvedExtraTabs = useMemo(
+    () => (detail ? (extraTabs?.(detail) ?? []) : []),
+    [detail, extraTabs],
+  )
 
-  if (loading && !detail) return <div className={s.detailEmpty}><Icon name="Loader" className={s.spinner} color="tertiary" /><Typography.Body>Loading trace…</Typography.Body></div>
-  if (error) return <div className={s.detailEmpty}><EmptyState error={error} /></div>
+  if (loading && !detail)
+    return (
+      <div className={s.detailEmpty}>
+        <Icon name="Loader" className={s.spinner} color="tertiary" />
+        <Typography.Body>Loading trace…</Typography.Body>
+      </div>
+    )
+  if (error)
+    return (
+      <div className={s.detailEmpty}>
+        <EmptyState error={error} />
+      </div>
+    )
   if (!detail || !summary) {
     return (
       <div className={s.detailEmpty}>
@@ -649,24 +810,66 @@ export function TraceDetail({
     <div className={s.detailRoot}>
       <KeyboardShortcut handler={handlePreviousSpanShortcut} shortcut="ArrowUp" />
       <KeyboardShortcut handler={handleNextSpanShortcut} shortcut="ArrowDown" />
-      <PageHeader title={<><Button.TextButton onClick={onClose} size="22" variant="linkSubtle"><Typography.BodyStrong as="span" variant="tertiary">Query stream</Typography.BodyStrong></Button.TextButton><Typography.BodyStrong as="span" variant="tertiary">/</Typography.BodyStrong><Typography.BodyStrong as="span" variant="secondary">Query details</Typography.BodyStrong></>}>
+      <PageHeader
+        title={
+          <>
+            <Button.TextButton onClick={onClose} size="22" variant="linkSubtle">
+              <Typography.BodyStrong as="span" variant="tertiary">
+                Query stream
+              </Typography.BodyStrong>
+            </Button.TextButton>
+            <Typography.BodyStrong as="span" variant="tertiary">
+              /
+            </Typography.BodyStrong>
+            <Typography.BodyStrong as="span" variant="secondary">
+              Query details
+            </Typography.BodyStrong>
+          </>
+        }
+      >
         <div className={s.detailHeaderActions}>
-          <span className={s.statusBadge} data-tone={statusTone(summary.status)}>{statusLabel(summary.status)}</span>
-          <Button.IconButton disabled={!newerTraceId} name="ArrowUp" onClick={() => newerTraceId && onSelectTrace?.(newerTraceId)} size="32" tooltipText="Newer query" variant="bare" />
-          <Button.IconButton disabled={!olderTraceId} name="ArrowDown" onClick={() => olderTraceId && onSelectTrace?.(olderTraceId)} size="32" tooltipText="Older query" variant="bare" />
+          <span className={s.statusBadge} data-tone={statusTone(summary.status)}>
+            {statusLabel(summary.status)}
+          </span>
+          <Button.IconButton
+            disabled={!newerTraceId}
+            name="ArrowUp"
+            onClick={() => newerTraceId && onSelectTrace?.(newerTraceId)}
+            size="32"
+            tooltipText="Newer query"
+            variant="bare"
+          />
+          <Button.IconButton
+            disabled={!olderTraceId}
+            name="ArrowDown"
+            onClick={() => olderTraceId && onSelectTrace?.(olderTraceId)}
+            size="32"
+            tooltipText="Older query"
+            variant="bare"
+          />
           <KeyboardShortcut
             handler={handleEscapeShortcut}
             shortcut="Escape"
             tooltipContent={expandedHttpSpanId ? 'Close span inspector' : 'Close query details'}
             tooltipSide="bottom"
           >
-            <Button.IconButton ariaLabel="Close query details" name="X" onClick={onClose} size="32" variant="bare" />
+            <Button.IconButton
+              ariaLabel="Close query details"
+              name="X"
+              onClick={onClose}
+              size="32"
+              variant="bare"
+            />
           </KeyboardShortcut>
         </div>
       </PageHeader>
       <div className={s.scrollBody}>
         <div className={s.content}>
-          <div className={s.sqlBlock}><pre><SqlCode sql={summary.query || 'No SQL recorded for this trace.'} /></pre></div>
+          <div className={s.sqlBlock}>
+            <pre>
+              <SqlCode sql={summary.query || 'No SQL recorded for this trace.'} />
+            </pre>
+          </div>
           <div className={s.statGrid}>
             <StatCard label="Duration" value={formatDurationFromNanos(summary.durationNanos)} />
             <StatCard label="Rows" value={formatRows(summary)} />

--- a/ui/src/views/traces/trace-list.tsx
+++ b/ui/src/views/traces/trace-list.tsx
@@ -6,7 +6,14 @@ import type { TraceSummary } from '@/generated/coral/v1/traces_pb'
 
 import * as s from '../traces-page.css'
 import { SqlCode } from './sql-code'
-import { durationClass, formatDurationFromNanos, formatTimestamp, startMs, statusTone, timeAgo } from './trace-utils'
+import {
+  durationClass,
+  formatDurationFromNanos,
+  formatTimestamp,
+  startMs,
+  statusTone,
+  timeAgo,
+} from './trace-utils'
 
 function TraceRow({ onSelect, trace }: { onSelect: () => void; trace: TraceSummary }) {
   return (
@@ -14,17 +21,39 @@ function TraceRow({ onSelect, trace }: { onSelect: () => void; trace: TraceSumma
       <span className={s.statusDot} data-tone={statusTone(trace.status)} />
       <div className={classNames(s.cell, s.cellTimestamp)}>
         <Tooltip content={formatTimestamp(startMs(trace))} side="right">
-          <Typography.Body as="span" variant="tertiary">{timeAgo(startMs(trace))}</Typography.Body>
+          <Typography.Body as="span" variant="tertiary">
+            {timeAgo(startMs(trace))}
+          </Typography.Body>
         </Tooltip>
       </div>
-      <div className={s.sqlPreview}><SqlCode inline sql={trace.query || trace.name || trace.traceId} /></div>
-      <div className={classNames(s.cell, s.cellDuration, durationClass(trace.durationNanos, s.durationWarning, s.durationDefault))}>
+      <div className={s.sqlPreview}>
+        <SqlCode inline sql={trace.query || trace.name || trace.traceId} />
+      </div>
+      <div
+        className={classNames(
+          s.cell,
+          s.cellDuration,
+          durationClass(trace.durationNanos, s.durationWarning, s.durationDefault),
+        )}
+      >
         <Typography.Body as="span">{formatDurationFromNanos(trace.durationNanos)}</Typography.Body>
       </div>
     </button>
   )
 }
 
-export function TraceList({ traces, onSelect }: { traces: TraceSummary[]; onSelect: (traceId: string) => void }) {
-  return <div className={s.traceList}>{traces.map((trace) => <TraceRow key={trace.traceId} onSelect={() => onSelect(trace.traceId)} trace={trace} />)}</div>
+export function TraceList({
+  traces,
+  onSelect,
+}: {
+  traces: TraceSummary[]
+  onSelect: (traceId: string) => void
+}) {
+  return (
+    <div className={s.traceList}>
+      {traces.map((trace) => (
+        <TraceRow key={trace.traceId} onSelect={() => onSelect(trace.traceId)} trace={trace} />
+      ))}
+    </div>
+  )
 }

--- a/ui/src/views/traces/trace-utils.ts
+++ b/ui/src/views/traces/trace-utils.ts
@@ -87,7 +87,9 @@ export function attr(span: TraceSpan, name: string): string | undefined {
 
 export function spanSource(span: TraceSpan): string {
   const attrs = parseJsonObject(span.attributesJson)
-  return attrFrom(attrs, 'coral.source') ?? attrFrom(attrs, 'db.system') ?? span.scopeName ?? 'coral'
+  return (
+    attrFrom(attrs, 'coral.source') ?? attrFrom(attrs, 'db.system') ?? span.scopeName ?? 'coral'
+  )
 }
 
 function endpointPath(url: string): string {
@@ -144,7 +146,10 @@ export function spanUrl(span: TraceSpan): string {
 }
 
 export function spanStatusCode(span: TraceSpan): string {
-  return attrFrom(parseJsonObject(span.attributesJson), 'http.response.status_code') ?? statusLabel(span.status)
+  return (
+    attrFrom(parseJsonObject(span.attributesJson), 'http.response.status_code') ??
+    statusLabel(span.status)
+  )
 }
 
 export function isHttpSpan(span: TraceSpan): boolean {
@@ -153,7 +158,7 @@ export function isHttpSpan(span: TraceSpan): boolean {
 }
 
 export function sortedSpans(spans: TraceSpan[]): TraceSpan[] {
-  return [...spans].sort((a, b) => {
+  return [...spans].toSorted((a, b) => {
     const aStart = BigInt(a.startTimeUnixNanos || 0)
     const bStart = BigInt(b.startTimeUnixNanos || 0)
     if (aStart < bStart) return -1

--- a/ui/src/views/traces/use-timeline-tree.ts
+++ b/ui/src/views/traces/use-timeline-tree.ts
@@ -46,12 +46,18 @@ export function buildTimelineTree(spans: TraceSpan[], rootSpanId?: string): Time
   for (const node of nodesById.values()) node.children.sort(compareTimelineNodes)
 
   const rootNode = rootSpanId ? nodesById.get(rootSpanId) : undefined
-  if (!rootNode) return roots.sort(compareTimelineNodes)
+  if (!rootNode) return roots.toSorted(compareTimelineNodes)
 
-  return [rootNode, ...roots.filter((node) => node.span.spanId !== rootSpanId).sort(compareTimelineNodes)]
+  return [
+    rootNode,
+    ...roots.filter((node) => node.span.spanId !== rootSpanId).toSorted(compareTimelineNodes),
+  ]
 }
 
-export function flattenVisibleTimelineTree(nodes: TimelineNode[], collapsedSpanIds: Set<string>): TimelineRow[] {
+export function flattenVisibleTimelineTree(
+  nodes: TimelineNode[],
+  collapsedSpanIds: Set<string>,
+): TimelineRow[] {
   const rows: TimelineRow[] = []
   const visited = new Set<string>()
 
@@ -82,7 +88,10 @@ export function useTimelineTree(spans: TraceSpan[], rootSpanId?: string, traceId
   }, [])
 
   const tree = useMemo(() => buildTimelineTree(spans, rootSpanId), [rootSpanId, spans])
-  const rows = useMemo(() => flattenVisibleTimelineTree(tree, collapsedSpanIds), [collapsedSpanIds, tree])
+  const rows = useMemo(
+    () => flattenVisibleTimelineTree(tree, collapsedSpanIds),
+    [collapsedSpanIds, tree],
+  )
 
   return { collapsedSpanIds, rows, toggleSpan, tree }
 }

--- a/ui/src/wax/base/palette/types.ts
+++ b/ui/src/wax/base/palette/types.ts
@@ -20,4 +20,16 @@ export interface PaletteValues {
   RedAlpha: ColorScale
 }
 
-export type Scale = '01' | '02' | '03' | '04' | '05' | '06' | '07' | '08' | '09' | '10' | '11' | '12'
+export type Scale =
+  | '01'
+  | '02'
+  | '03'
+  | '04'
+  | '05'
+  | '06'
+  | '07'
+  | '08'
+  | '09'
+  | '10'
+  | '11'
+  | '12'

--- a/ui/src/wax/components/button/container.tsx
+++ b/ui/src/wax/components/button/container.tsx
@@ -30,7 +30,9 @@ interface ButtonBaseProps {
   variant?: ButtonVariant
 }
 
-export function Container<T extends ElementType = 'button'>(props: ButtonProps<T> & { ref?: React.Ref<HTMLElement> }) {
+export function Container<T extends ElementType = 'button'>(
+  props: ButtonProps<T> & { ref?: React.Ref<HTMLElement> },
+) {
   const {
     ariaLabel,
     as,
@@ -69,7 +71,12 @@ export function Container<T extends ElementType = 'button'>(props: ButtonProps<T
             isSymbolOnly = true
 
             return [
-              <LonelyIconImplementation key={childElement.key} name={iconProps.name} size={size} variant={variant} />,
+              <LonelyIconImplementation
+                key={childElement.key}
+                name={iconProps.name}
+                size={size}
+                variant={variant}
+              />,
             ]
           }
 
@@ -79,19 +86,31 @@ export function Container<T extends ElementType = 'button'>(props: ButtonProps<T
             hasSuffix = true
           }
 
-          return [<IconImplementation key={childElement.key} name={iconProps.name} size={size} variant={variant} />]
+          return [
+            <IconImplementation
+              key={childElement.key}
+              name={iconProps.name}
+              size={size}
+              variant={variant}
+            />,
+          ]
         }
 
         case Text: {
           return [
-            <TextImplementation buttonVariant={variant} key={child.key} size={size} {...childElement.props} />,
+            <TextImplementation
+              buttonVariant={variant}
+              key={child.key}
+              size={size}
+              {...childElement.props}
+            />,
           ]
         }
 
         default:
           return [child]
       }
-    }
+    },
   )
 
   const componentProps = {
@@ -108,7 +127,7 @@ export function Container<T extends ElementType = 'button'>(props: ButtonProps<T
         variant,
       }),
       { [disabledClass]: disabled },
-      className
+      className,
     ),
     ref,
     ...rest,

--- a/ui/src/wax/components/button/icon-button.tsx
+++ b/ui/src/wax/components/button/icon-button.tsx
@@ -39,7 +39,14 @@ interface IconButtonWithTooltip extends IconButtonPropsBase {
 /**
  * Convenience component for a button containing only an icon.
  */
-export function IconButton({ ariaLabel, name, ref, tooltipSide, tooltipText, ...rest }: IconButtonProps) {
+export function IconButton({
+  ariaLabel,
+  name,
+  ref,
+  tooltipSide,
+  tooltipText,
+  ...rest
+}: IconButtonProps) {
   const button = (
     <Container ariaLabel={ariaLabel ?? tooltipText} ref={ref} {...rest}>
       <Icon name={name} />

--- a/ui/src/wax/components/icon.tsx
+++ b/ui/src/wax/components/icon.tsx
@@ -4,8 +4,29 @@ import { Activity, Loader } from 'lucide-react'
 import { customIcons, isCustomIcon } from '@/wax/components/icon/custom-icons/custom-icons'
 import { iconContainer } from '@/wax/components/icon.css'
 
-export type IconColor = 'disabled' | 'error' | 'info' | 'inherit' | 'orange' | 'placeholder' | 'primary' | 'secondary' | 'success' | 'tertiary' | 'warning'
-export type IconName = 'Activity' | 'ArrowDown' | 'ArrowUp' | 'ChevronDown' | 'ChevronRight' | 'CircleAlert' | 'Coral' | 'Loader' | 'Search' | 'X'
+export type IconColor =
+  | 'disabled'
+  | 'error'
+  | 'info'
+  | 'inherit'
+  | 'orange'
+  | 'placeholder'
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'tertiary'
+  | 'warning'
+export type IconName =
+  | 'Activity'
+  | 'ArrowDown'
+  | 'ArrowUp'
+  | 'ChevronDown'
+  | 'ChevronRight'
+  | 'CircleAlert'
+  | 'Coral'
+  | 'Loader'
+  | 'Search'
+  | 'X'
 export interface IconProps {
   className?: string
   color?: IconColor

--- a/ui/src/wax/components/icon/custom-icons/arrow-down.tsx
+++ b/ui/src/wax/components/icon/custom-icons/arrow-down.tsx
@@ -2,7 +2,18 @@ import type { LucideProps } from 'lucide-react'
 
 export function ArrowDownIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
   return (
-    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      fill="none"
+      height={size}
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      viewBox="0 0 18 18"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M9 3.75V14.25M9 14.25L3.75 9M9 14.25L14.25 9" />
     </svg>
   )

--- a/ui/src/wax/components/icon/custom-icons/arrow-up.tsx
+++ b/ui/src/wax/components/icon/custom-icons/arrow-up.tsx
@@ -2,7 +2,18 @@ import type { LucideProps } from 'lucide-react'
 
 export function ArrowUpIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
   return (
-    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      fill="none"
+      height={size}
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      viewBox="0 0 18 18"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M9 14.25V3.75M9 3.75L3.75 9M9 3.75L14.25 9" />
     </svg>
   )

--- a/ui/src/wax/components/icon/custom-icons/chevron-down.tsx
+++ b/ui/src/wax/components/icon/custom-icons/chevron-down.tsx
@@ -2,7 +2,18 @@ import type { LucideProps } from 'lucide-react'
 
 export function ChevronDownIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
   return (
-    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      fill="none"
+      height={size}
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      viewBox="0 0 18 18"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M4.5 6.75L9 11.25L13.5 6.75" />
     </svg>
   )

--- a/ui/src/wax/components/icon/custom-icons/chevron-right.tsx
+++ b/ui/src/wax/components/icon/custom-icons/chevron-right.tsx
@@ -2,7 +2,18 @@ import type { LucideProps } from 'lucide-react'
 
 export function ChevronRightIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
   return (
-    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      fill="none"
+      height={size}
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      viewBox="0 0 18 18"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M6.75 4.5L11.25 9L6.75 13.5" />
     </svg>
   )

--- a/ui/src/wax/components/icon/custom-icons/circle-alert.tsx
+++ b/ui/src/wax/components/icon/custom-icons/circle-alert.tsx
@@ -2,7 +2,18 @@ import type { LucideProps } from 'lucide-react'
 
 export function CircleAlertIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
   return (
-    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      fill="none"
+      height={size}
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      viewBox="0 0 18 18"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M9 6V9M9 12H9.008M16.5 9C16.5 13.142 13.142 16.5 9 16.5C4.858 16.5 1.5 13.142 1.5 9C1.5 4.858 4.858 1.5 9 1.5C13.142 1.5 16.5 4.858 16.5 9Z" />
     </svg>
   )

--- a/ui/src/wax/components/icon/custom-icons/search.tsx
+++ b/ui/src/wax/components/icon/custom-icons/search.tsx
@@ -2,7 +2,18 @@ import type { LucideProps } from 'lucide-react'
 
 export function SearchIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
   return (
-    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      fill="none"
+      height={size}
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      viewBox="0 0 18 18"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M16.5 16.5L12.875 12.875M14.5 8C14.5 11.5899 11.5899 14.5 8 14.5C4.41015 14.5 1.5 11.5899 1.5 8C1.5 4.41015 4.41015 1.5 8 1.5C11.5899 1.5 14.5 4.41015 14.5 8Z" />
     </svg>
   )

--- a/ui/src/wax/components/icon/custom-icons/x.tsx
+++ b/ui/src/wax/components/icon/custom-icons/x.tsx
@@ -2,7 +2,18 @@ import type { LucideProps } from 'lucide-react'
 
 export function XIcon({ color = 'currentColor', size = 24, ...props }: LucideProps) {
   return (
-    <svg fill="none" height={size} stroke={color} strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.25" viewBox="0 0 18 18" width={size} xmlns="http://www.w3.org/2000/svg" {...props}>
+    <svg
+      fill="none"
+      height={size}
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.25"
+      viewBox="0 0 18 18"
+      width={size}
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
       <path d="M13.5 4.5L4.5 13.5M4.5 4.5L13.5 13.5" />
     </svg>
   )

--- a/ui/src/wax/components/inputs/text/text-input.tsx
+++ b/ui/src/wax/components/inputs/text/text-input.tsx
@@ -42,7 +42,12 @@ export function TextInput({
     <Field.Root disabled={disabled}>
       <div className={styles.container}>
         {icon && (
-          <Icon className={styles.iconWrapper} color={disabled ? 'disabled' : 'placeholder'} name={icon} size="20" />
+          <Icon
+            className={styles.iconWrapper}
+            color={disabled ? 'disabled' : 'placeholder'}
+            name={icon}
+            size="20"
+          />
         )}
         <Field.Control
           autoFocus={autoFocus}

--- a/ui/src/wax/components/keyboard-hint/utils.ts
+++ b/ui/src/wax/components/keyboard-hint/utils.ts
@@ -1,6 +1,7 @@
 const isMacOs =
   typeof navigator !== 'undefined' &&
-  ((navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData?.platform === 'macOS' ||
+  ((navigator as Navigator & { userAgentData?: { platform: string } }).userAgentData?.platform ===
+    'macOS' ||
     /mac/i.test(navigator.platform))
 
 const prettyKeyboardKey: Record<string, string> = {

--- a/ui/src/wax/components/keyboard-shortcut/keyboard-shortcut.tsx
+++ b/ui/src/wax/components/keyboard-shortcut/keyboard-shortcut.tsx
@@ -6,7 +6,9 @@ import { Tooltip } from '@/wax/components/tooltip'
 
 import { parseShortcut } from '../keyboard-hint'
 
-export type KeyboardShortcutProps = KeyboardShortcutWithoutTooltipProps | KeyboardShortcutWithTooltipProps
+export type KeyboardShortcutProps =
+  | KeyboardShortcutWithoutTooltipProps
+  | KeyboardShortcutWithTooltipProps
 
 interface KeyboardShortcutBaseProps {
   handler: (event: KeyboardEvent) => void
@@ -51,10 +53,12 @@ function shortcutMatches(event: KeyboardEvent, shortcut: string) {
   const wantsMeta = keys.includes('meta') || keys.includes('$mod')
   const wantsShift = keys.includes('shift')
 
-  return event.altKey === wantsAlt &&
+  return (
+    event.altKey === wantsAlt &&
     event.ctrlKey === wantsControl &&
     event.metaKey === wantsMeta &&
     event.shiftKey === wantsShift
+  )
 }
 
 export function KeyboardShortcut({

--- a/ui/src/wax/components/scroll-area/scroll-area.tsx
+++ b/ui/src/wax/components/scroll-area/scroll-area.tsx
@@ -67,8 +67,14 @@ export function Container({
       style={{ height: maxHeight ? undefined : height, maxHeight, width, ...style }}
       {...rest}
     >
-      <BaseScrollArea.Viewport className={classNames(styles.viewport, styles.viewportFade[fade])} ref={viewportRef}>
-        <BaseScrollArea.Content className={styles.content} style={constrainWidth ? { minWidth: 0 } : undefined}>
+      <BaseScrollArea.Viewport
+        className={classNames(styles.viewport, styles.viewportFade[fade])}
+        ref={viewportRef}
+      >
+        <BaseScrollArea.Content
+          className={styles.content}
+          style={constrainWidth ? { minWidth: 0 } : undefined}
+        >
           {children}
         </BaseScrollArea.Content>
       </BaseScrollArea.Viewport>

--- a/ui/src/wax/components/sidebar-button/sidebar-button.tsx
+++ b/ui/src/wax/components/sidebar-button/sidebar-button.tsx
@@ -4,7 +4,13 @@ import React, { ElementType, MouseEvent } from 'react'
 import { Icon } from '@/wax/components/icon'
 import type { IconName } from '@/wax/components/icon'
 
-import { activeClass, disabledClass, iconStyles, sidebarButton, textStyles } from './sidebar-button.css'
+import {
+  activeClass,
+  disabledClass,
+  iconStyles,
+  sidebarButton,
+  textStyles,
+} from './sidebar-button.css'
 
 function handleDisabledClick(event: MouseEvent<HTMLElement>) {
   event.preventDefault()
@@ -24,9 +30,15 @@ export interface SidebarButtonProps<T extends ElementType = 'button'> {
 
 export type SidebarButtonVariant = 'accent' | 'default'
 
-type PolymorphicProps<T extends ElementType> = Omit<React.ComponentPropsWithoutRef<T>, keyof SidebarButtonProps<T>> & SidebarButtonProps<T>
+type PolymorphicProps<T extends ElementType> = Omit<
+  React.ComponentPropsWithoutRef<T>,
+  keyof SidebarButtonProps<T>
+> &
+  SidebarButtonProps<T>
 
-export function SidebarButton<T extends ElementType = 'button'>(props: PolymorphicProps<T> & { ref?: React.Ref<HTMLElement> }) {
+export function SidebarButton<T extends ElementType = 'button'>(
+  props: PolymorphicProps<T> & { ref?: React.Ref<HTMLElement> },
+) {
   const {
     as,
     children,
@@ -48,7 +60,7 @@ export function SidebarButton<T extends ElementType = 'button'>(props: Polymorph
     className: classNames(
       sidebarButton({ disabled, isActive, isMinimized, variant }),
       { [activeClass]: isActive, [disabledClass]: disabled },
-      className
+      className,
     ),
     ref,
     ...rest,

--- a/ui/src/wax/components/tooltip/tooltip.tsx
+++ b/ui/src/wax/components/tooltip/tooltip.tsx
@@ -36,16 +36,22 @@ export function Tooltip({
 
   const composedRef = useComposedRefs(
     triggerRef,
-    (children as React.ReactElement<{ ref?: React.Ref<HTMLElement> }>).props?.ref
+    (children as React.ReactElement<{ ref?: React.Ref<HTMLElement> }>).props?.ref,
   )
 
   return (
     <BaseTooltip.Provider delay={delay}>
       <BaseTooltip.Root disabled={disabled}>
-        <BaseTooltip.Trigger ref={composedRef} render={children as React.ReactElement<Record<string, unknown>>} />
+        <BaseTooltip.Trigger
+          ref={composedRef}
+          render={children as React.ReactElement<Record<string, unknown>>}
+        />
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner className={styles.positioner} side={side} sideOffset={sideOffset}>
-            <BaseTooltip.Popup className={classNames(styles.popup, className)} style={{ maxWidth: maxWidth }}>
+            <BaseTooltip.Popup
+              className={classNames(styles.popup, className)}
+              style={{ maxWidth: maxWidth }}
+            >
               <BaseTooltip.Arrow className={styles.arrow} />
               {content}
             </BaseTooltip.Popup>

--- a/ui/src/wax/components/typography/typography.tsx
+++ b/ui/src/wax/components/typography/typography.tsx
@@ -6,7 +6,10 @@ import type { ColorVariants } from './typography.css'
 import { typography } from './typography.css'
 import * as styles from './typography.css'
 
-type TypographyProps<T extends ElementType = 'span'> = Omit<React.ComponentPropsWithoutRef<T>, 'as'> & {
+type TypographyProps<T extends ElementType = 'span'> = Omit<
+  React.ComponentPropsWithoutRef<T>,
+  'as'
+> & {
   as?: T
   size?: CSSProperties['fontSize']
   truncate?: boolean
@@ -47,7 +50,7 @@ function createTypographyComponent({
         className={classNames(
           typography({ color: resolvedColor, variant: typographyVariant }),
           { [styles.truncate]: truncate },
-          className
+          className,
         )}
         style={inlineStyle}
         {...rest}
@@ -59,7 +62,10 @@ function createTypographyComponent({
 }
 
 export const Typography = {
-  Body: createTypographyComponent({ defaultVariant: 'secondary', typographyVariant: TypographyVariant.BODY }),
+  Body: createTypographyComponent({
+    defaultVariant: 'secondary',
+    typographyVariant: TypographyVariant.BODY,
+  }),
   BodyLarge: createTypographyComponent({
     defaultVariant: 'secondary',
     typographyVariant: TypographyVariant.BODY_LARGE,
@@ -84,13 +90,22 @@ export const Typography = {
     defaultVariant: 'primary',
     typographyVariant: TypographyVariant.BUTTON_STRONG,
   }),
-  Code: createTypographyComponent({ defaultVariant: 'code', typographyVariant: TypographyVariant.CODE }),
-  CodeInline: createTypographyComponent({ defaultVariant: 'code', typographyVariant: TypographyVariant.CODE_INLINE }),
+  Code: createTypographyComponent({
+    defaultVariant: 'code',
+    typographyVariant: TypographyVariant.CODE,
+  }),
+  CodeInline: createTypographyComponent({
+    defaultVariant: 'code',
+    typographyVariant: TypographyVariant.CODE_INLINE,
+  }),
   CodeInlineStrong: createTypographyComponent({
     defaultVariant: 'code',
     typographyVariant: TypographyVariant.CODE_INLINE_STRONG,
   }),
-  CodeLarge: createTypographyComponent({ defaultVariant: 'code', typographyVariant: TypographyVariant.CODE_LARGE }),
+  CodeLarge: createTypographyComponent({
+    defaultVariant: 'code',
+    typographyVariant: TypographyVariant.CODE_LARGE,
+  }),
   CodeSmallInline: createTypographyComponent({
     defaultVariant: 'code',
     typographyVariant: TypographyVariant.CODE_SMALL_INLINE,

--- a/ui/src/wax/theme/font.css.ts
+++ b/ui/src/wax/theme/font.css.ts
@@ -1,6 +1,7 @@
 const ENCODE_SANS_FONT_FAMILY =
   '"Encode Sans Semi Expanded", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
-const DM_MONO_FONT_FAMILY = '"DM Mono", "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace'
+const DM_MONO_FONT_FAMILY =
+  '"DM Mono", "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace'
 
 export const fontFamily = {
   encodeSans: ENCODE_SANS_FONT_FAMILY,

--- a/ui/src/wax/theme/theme-provider.ts
+++ b/ui/src/wax/theme/theme-provider.ts
@@ -22,7 +22,12 @@ export function useTheme() {
     window.dispatchEvent(new StorageEvent('storage', { key: STORAGE_KEY, newValue: nextTheme }))
   }
 
-  return { setTheme, theme: resolvedTheme, themeClass: getThemeClass(resolvedTheme), themePreference }
+  return {
+    setTheme,
+    theme: resolvedTheme,
+    themeClass: getThemeClass(resolvedTheme),
+    themePreference,
+  }
 }
 
 export function useThemeClassOnBody() {

--- a/ui/tests/ui/AGENTS.md
+++ b/ui/tests/ui/AGENTS.md
@@ -91,6 +91,7 @@ await review.pause()
 ```
 
 Guidelines:
+
 - Add chapters before important user-visible transitions.
 - Use concise chapter titles; explain intent in the optional description.
 - Use `review.pause()` after major assertions or visual states so the recording

--- a/ui/tests/ui/playwright.setup.ts
+++ b/ui/tests/ui/playwright.setup.ts
@@ -18,7 +18,13 @@ const reviewMode = process.env.PW_UI_SCREENCAST === '1'
 const reviewPauseMs = Number(process.env.PW_UI_REVIEW_PAUSE_MS ?? 900)
 
 function safeArtifactName(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 80) || 'test'
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 80) || 'test'
+  )
 }
 
 export const test = base.extend<NetworkFixtures>({

--- a/ui/tests/ui/support/grpc-web.ts
+++ b/ui/tests/ui/support/grpc-web.ts
@@ -38,10 +38,7 @@ export function grpcWebResponse<Desc extends DescMessage>(
   init?: HttpResponseInit,
 ) {
   const data = toBinary(schema, message)
-  const body = concat([
-    frame(DATA_FRAME, data),
-    frame(TRAILER_FRAME, trailers(0)),
-  ])
+  const body = concat([frame(DATA_FRAME, data), frame(TRAILER_FRAME, trailers(0))])
 
   return HttpResponse.arrayBuffer(body, {
     status: 200,

--- a/ui/tests/ui/support/trace-fixtures.ts
+++ b/ui/tests/ui/support/trace-fixtures.ts
@@ -44,61 +44,71 @@ interface SpanFixture {
 const traceFixtures: TraceFixture[] = [
   {
     source: 'github',
-    query: "SELECT number, title, state FROM github.pull_requests WHERE repository = 'coral' AND state = 'open' ORDER BY updated_at DESC LIMIT 25",
+    query:
+      "SELECT number, title, state FROM github.pull_requests WHERE repository = 'coral' AND state = 'open' ORDER BY updated_at DESC LIMIT 25",
     durationMs: 384,
     rows: 12,
   },
   {
     source: 'slack',
-    query: "SELECT channel_name, user_name, text FROM slack.messages WHERE channel_name = 'eng-coral' AND text ILIKE '%release%' ORDER BY ts DESC LIMIT 50",
+    query:
+      "SELECT channel_name, user_name, text FROM slack.messages WHERE channel_name = 'eng-coral' AND text ILIKE '%release%' ORDER BY ts DESC LIMIT 50",
     durationMs: 512,
     rows: 31,
   },
   {
     source: 'linear',
-    query: "SELECT identifier, title, state_name, assignee_name FROM linear.issues WHERE team_key = 'CORAL' AND state_type != 'completed' ORDER BY updated_at DESC LIMIT 40",
+    query:
+      "SELECT identifier, title, state_name, assignee_name FROM linear.issues WHERE team_key = 'CORAL' AND state_type != 'completed' ORDER BY updated_at DESC LIMIT 40",
     durationMs: 438,
     rows: 18,
   },
   {
     source: 'github',
-    query: "SELECT login, merged_pull_requests FROM github.contributors WHERE repository = 'coral' ORDER BY merged_pull_requests DESC LIMIT 10",
+    query:
+      "SELECT login, merged_pull_requests FROM github.contributors WHERE repository = 'coral' ORDER BY merged_pull_requests DESC LIMIT 10",
     durationMs: 295,
     rows: 10,
   },
   {
     source: 'slack',
-    query: "SELECT channel_name, count(*) AS messages FROM slack.messages WHERE ts > now() - interval '7 days' GROUP BY channel_name ORDER BY messages DESC",
+    query:
+      "SELECT channel_name, count(*) AS messages FROM slack.messages WHERE ts > now() - interval '7 days' GROUP BY channel_name ORDER BY messages DESC",
     durationMs: 620,
     rows: 8,
   },
   {
     source: 'github',
-    query: "SELECT workflow_name, conclusion, run_started_at FROM github.actions_runs WHERE repository = 'coral' ORDER BY run_started_at DESC LIMIT 20",
+    query:
+      "SELECT workflow_name, conclusion, run_started_at FROM github.actions_runs WHERE repository = 'coral' ORDER BY run_started_at DESC LIMIT 20",
     durationMs: 466,
     rows: 20,
   },
   {
     source: 'linear',
-    query: "SELECT identifier, title, priority_label FROM linear.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%' ORDER BY updated_at DESC LIMIT 10",
+    query:
+      "SELECT identifier, title, priority_label FROM linear.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%' ORDER BY updated_at DESC LIMIT 10",
     durationMs: 735,
     rows: 4,
   },
   {
     source: 'slack',
-    query: "SELECT user_name, reaction, item_text FROM slack.reactions WHERE channel_name = 'eng-coral' AND reaction IN ('eyes', 'shipit') ORDER BY ts DESC LIMIT 25",
+    query:
+      "SELECT user_name, reaction, item_text FROM slack.reactions WHERE channel_name = 'eng-coral' AND reaction IN ('eyes', 'shipit') ORDER BY ts DESC LIMIT 25",
     durationMs: 341,
     rows: 16,
   },
   {
     source: 'github',
-    query: "SELECT number, title, author_login FROM github.issues WHERE repository = 'coral' AND labels @> ARRAY['bug'] ORDER BY created_at DESC LIMIT 15",
+    query:
+      "SELECT number, title, author_login FROM github.issues WHERE repository = 'coral' AND labels @> ARRAY['bug'] ORDER BY created_at DESC LIMIT 15",
     durationMs: 419,
     rows: 7,
   },
   {
     source: 'linear',
-    query: "SELECT project_name, count(*) AS open_issues FROM linear.issues WHERE state_type != 'completed' GROUP BY project_name ORDER BY open_issues DESC",
+    query:
+      "SELECT project_name, count(*) AS open_issues FROM linear.issues WHERE state_type != 'completed' GROUP BY project_name ORDER BY open_issues DESC",
     durationMs: 548,
     rows: 6,
   },
@@ -130,8 +140,16 @@ const detailSpans: SpanFixture[] = [
       data: {
         issues: {
           nodes: [
-            { identifier: 'CORAL-128', title: 'Add Playwright coverage for trace stream', priorityLabel: 'High' },
-            { identifier: 'CORAL-134', title: 'Record UI review flows with screencast chapters', priorityLabel: 'Medium' },
+            {
+              identifier: 'CORAL-128',
+              title: 'Add Playwright coverage for trace stream',
+              priorityLabel: 'High',
+            },
+            {
+              identifier: 'CORAL-134',
+              title: 'Record UI review flows with screencast chapters',
+              priorityLabel: 'Medium',
+            },
           ],
         },
       },
@@ -167,8 +185,18 @@ const detailSpans: SpanFixture[] = [
     path: '/repos/oxide/coral/pulls?state=open&per_page=25',
     durationMs: 113,
     responseBody: [
-      { number: 417, title: 'Add MSW Playwright trace fixtures', user: { login: 'ludo' }, state: 'open' },
-      { number: 412, title: 'Tighten Coral UI trace detail layout', user: { login: 'maia' }, state: 'open' },
+      {
+        number: 417,
+        title: 'Add MSW Playwright trace fixtures',
+        user: { login: 'ludo' },
+        state: 'open',
+      },
+      {
+        number: 412,
+        title: 'Tighten Coral UI trace detail layout',
+        user: { login: 'maia' },
+        state: 'open',
+      },
     ],
   },
   {
@@ -204,8 +232,16 @@ const detailSpans: SpanFixture[] = [
     responseBody: {
       ok: true,
       messages: [
-        { user: 'U01ALICE', text: 'Playwright trace review is ready for feedback', ts: '1763999999.000100' },
-        { user: 'U02BOB', text: 'Can we include Linear and GitHub spans?', ts: '1763999988.000200' },
+        {
+          user: 'U01ALICE',
+          text: 'Playwright trace review is ready for feedback',
+          ts: '1763999999.000100',
+        },
+        {
+          user: 'U02BOB',
+          text: 'Can we include Linear and GitHub spans?',
+          ts: '1763999988.000200',
+        },
       ],
     },
   },
@@ -248,7 +284,15 @@ const detailSpans: SpanFixture[] = [
     method: 'GET',
     path: '/api/reactions.get?channel=C08CORAL&timestamp=1763999999.000100',
     durationMs: 44,
-    responseBody: { ok: true, message: { reactions: [{ name: 'eyes', count: 3 }, { name: 'shipit', count: 1 }] } },
+    responseBody: {
+      ok: true,
+      message: {
+        reactions: [
+          { name: 'eyes', count: 3 },
+          { name: 'shipit', count: 1 },
+        ],
+      },
+    },
   },
   {
     source: 'linear',
@@ -267,7 +311,9 @@ const detailSpans: SpanFixture[] = [
 }`,
       variables: { includeArchived: false },
     },
-    responseBody: { data: { projects: { nodes: [{ name: 'Coral UI' }, { name: 'Source Runtime' }] } } },
+    responseBody: {
+      data: { projects: { nodes: [{ name: 'Coral UI' }, { name: 'Source Runtime' }] } },
+    },
   },
   {
     source: 'github',
@@ -322,7 +368,19 @@ const detailSpans: SpanFixture[] = [
     durationMs: 52,
     requestBodyPresent: true,
     requestBodySize: 2048,
-    responseBody: { data: { issues: { nodes: [{ identifier: 'CORAL-201', title: 'Request body present fallback', priorityLabel: 'Low' }] } } },
+    responseBody: {
+      data: {
+        issues: {
+          nodes: [
+            {
+              identifier: 'CORAL-201',
+              title: 'Request body present fallback',
+              priorityLabel: 'Low',
+            },
+          ],
+        },
+      },
+    },
   },
 ]
 
@@ -415,7 +473,9 @@ function httpSpan(traceId: string, fixture: SpanFixture, index: number): TraceSp
   })
 }
 
-export const tenTraceList: TraceSummary[] = traceFixtures.map((fixture, index) => traceSummary(index, fixture))
+export const tenTraceList: TraceSummary[] = traceFixtures.map((fixture, index) =>
+  traceSummary(index, fixture),
+)
 export const selectedTrace = tenTraceList[selectedTraceIndex]
 
 export const traceListResponse: ListTracesResponse = create(ListTracesResponseSchema, {

--- a/ui/tests/ui/support/trace-handlers.ts
+++ b/ui/tests/ui/support/trace-handlers.ts
@@ -16,13 +16,15 @@ const getTraceUrl = '*/coral.v1.TraceService/GetTrace'
 
 export const traceHandlers = {
   empty: [
-    http.post(listTracesUrl, () => grpcWebResponse(ListTracesResponseSchema, emptyTraceListResponse)),
+    http.post(listTracesUrl, () =>
+      grpcWebResponse(ListTracesResponseSchema, emptyTraceListResponse),
+    ),
   ],
-  unavailable: [
-    http.post(listTracesUrl, () => grpcWebError(12, 'Trace storage is not enabled')),
-  ],
+  unavailable: [http.post(listTracesUrl, () => grpcWebError(12, 'Trace storage is not enabled'))],
   tenTraceDetailFlow: [
     http.post(listTracesUrl, () => grpcWebResponse(ListTracesResponseSchema, traceListResponse)),
-    http.post(getTraceUrl, () => grpcWebResponse(GetTraceResponseSchema, selectedTraceDetailResponse)),
+    http.post(getTraceUrl, () =>
+      grpcWebResponse(GetTraceResponseSchema, selectedTraceDetailResponse),
+    ),
   ],
 }

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -1,7 +1,11 @@
 import { traceHandlers } from './support/trace-handlers'
 import { expect, test } from './playwright.setup'
 
-test('shows an empty trace stream without contacting a Coral server', async ({ network, page, review }) => {
+test('shows an empty trace stream without contacting a Coral server', async ({
+  network,
+  page,
+  review,
+}) => {
   network.use(...traceHandlers.empty)
 
   await review.chapter('Test 1: empty trace stream', 'Mock ListTraces with zero traces')
@@ -14,10 +18,17 @@ test('shows an empty trace stream without contacting a Coral server', async ({ n
   await review.pause()
 })
 
-test('lists 10 traces, searches one, opens its details, and opens a span inspector', async ({ network, page, review }) => {
+test('lists 10 traces, searches one, opens its details, and opens a span inspector', async ({
+  network,
+  page,
+  review,
+}) => {
   network.use(...traceHandlers.tenTraceDetailFlow)
 
-  await review.chapter('Test 2: ten traces and span details', 'Mock list and detail gRPC-Web responses')
+  await review.chapter(
+    'Test 2: ten traces and span details',
+    'Mock list and detail gRPC-Web responses',
+  )
   await page.goto('/')
   await review.pause()
 
@@ -27,44 +38,68 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
   await expect(page.getByText(/linear\.issues/).first()).toBeVisible()
   await review.pause()
 
-  await review.chapter('Search for one trace', 'Filter ten traces down to the Playwright Linear query')
+  await review.chapter(
+    'Search for one trace',
+    'Filter ten traces down to the Playwright Linear query',
+  )
   await page.getByPlaceholder('Search queries...').fill('playwright')
 
-  await expect(page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)).toBeVisible()
+  await expect(
+    page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/),
+  ).toBeVisible()
   await expect(page.getByText('1 of 10 queries')).toBeVisible()
   await review.pause()
 
   await review.chapter('Open query details', 'Load the selected trace with ten mocked spans')
-  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
+  await page
+    .getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)
+    .click()
 
   await expect(page.getByText('Query details')).toBeVisible()
-  await expect(page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)).toBeVisible()
+  await expect(
+    page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/),
+  ).toBeVisible()
   await expect(page.getByText('API requests')).toBeVisible()
   await expect(page.getByRole('treeitem')).toHaveCount(14)
   await review.pause()
 
-  await review.chapter('Open a span inspector', 'Expand one HTTP span and inspect the captured response body')
+  await review.chapter(
+    'Open a span inspector',
+    'Expand one HTTP span and inspect the captured response body',
+  )
   await page.getByRole('button', { name: /GET github\.pull_requests/ }).click()
 
   await expect(page.getByText('Span details')).toBeVisible()
   await expect(page.getByText('GET github.pull_requests')).toBeVisible()
   await expect(page.getByText('Response body')).toBeVisible()
-  await expect(page.getByText('\"title\": \"Add MSW Playwright trace fixtures\"')).toBeVisible()
+  await expect(page.getByText('"title": "Add MSW Playwright trace fixtures"')).toBeVisible()
   await review.pause()
 })
 
-test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({ network, page, review }) => {
+test('renders trace request and response bodies with JSON, GraphQL, and fallback states', async ({
+  network,
+  page,
+  review,
+}) => {
   network.use(...traceHandlers.tenTraceDetailFlow)
 
-  await review.chapter('Open the trace with span details', 'Load the selected trace so the body viewer states can be inspected')
+  await review.chapter(
+    'Open the trace with span details',
+    'Load the selected trace so the body viewer states can be inspected',
+  )
   await page.goto('/')
   await page.getByPlaceholder('Search queries...').fill('playwright')
-  await page.getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/).click()
+  await page
+    .getByText(/linear\.issues WHERE team_key = 'CORAL' AND title ILIKE '%playwright%'/)
+    .click()
   await review.pause()
 
   await expect(page.getByRole('treeitem')).toHaveCount(14)
 
-  await review.chapter('Inspect pretty JSON', 'Open a structured response body and confirm it is pretty printed')
+  await review.chapter(
+    'Inspect pretty JSON',
+    'Open a structured response body and confirm it is pretty printed',
+  )
   await page.getByRole('button', { name: /GET slack\.conversations/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
@@ -72,14 +107,20 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
   await expect(page.getByText('"name": "eng-coral"')).toBeVisible()
   await review.pause()
 
-  await review.chapter('Inspect malformed JSON fallback', 'Verify raw text stays readable when parsing fails')
+  await review.chapter(
+    'Inspect malformed JSON fallback',
+    'Verify raw text stays readable when parsing fails',
+  )
   await page.getByRole('button', { name: /GET github\.issue_previews/ }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('{"oops":')).toBeVisible()
   await review.pause()
 
-  await review.chapter('Inspect GraphQL bodies', 'Check request metadata, variables, and response data for GraphQL traffic')
+  await review.chapter(
+    'Inspect GraphQL bodies',
+    'Check request metadata, variables, and response data for GraphQL traffic',
+  )
   await page.getByRole('button', { name: /POST linear\.issues\b/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
   const requestPanel = page.getByRole('tabpanel', { name: 'Request body' })
@@ -98,10 +139,15 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
 
   await expect(responsePanel.getByText('GraphQL response')).toBeVisible()
   await expect(responsePanel.getByText('Data', { exact: true }).first()).toBeVisible()
-  await expect(responsePanel.getByText('"title": "Add Playwright coverage for trace stream"')).toBeVisible()
+  await expect(
+    responsePanel.getByText('"title": "Add Playwright coverage for trace stream"'),
+  ).toBeVisible()
   await review.pause()
 
-  await review.chapter('Inspect GraphQL detection without /graphql', 'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears')
+  await review.chapter(
+    'Inspect GraphQL detection without /graphql',
+    'Open a GraphQL-shaped body on a non-GraphQL path and confirm the richer rendering still appears',
+  )
   await page.getByRole('button', { name: /POST github\.repository_search/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
   const githubRequestPanel = page.getByRole('tabpanel', { name: 'Request body' })
@@ -114,30 +160,52 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
 
   await expect(githubResponsePanel.getByText('GraphQL response')).toBeVisible()
   await expect(githubResponsePanel.getByText('Errors', { exact: true }).first()).toBeVisible()
-  await expect(githubResponsePanel.getByText('"message": "GraphQL warnings should still be visible"')).toBeVisible()
+  await expect(
+    githubResponsePanel.getByText('"message": "GraphQL warnings should still be visible"'),
+  ).toBeVisible()
   await review.pause()
 
-  await review.chapter('Inspect missing and truncated bodies', 'Confirm the viewer still explains empty and truncated body states')
+  await review.chapter(
+    'Inspect missing and truncated bodies',
+    'Confirm the viewer still explains empty and truncated body states',
+  )
   await page.getByRole('button', { name: /POST linear\.issue_request_preview/ }).click()
   await page.getByRole('tab', { name: 'Request body' }).click()
 
-  await expect(page.getByText('Request body was present (2.0 KB), but content was not captured.')).toBeVisible()
+  await expect(
+    page.getByText('Request body was present (2.0 KB), but content was not captured.'),
+  ).toBeVisible()
   await page.getByRole('button', { name: /GET github\.pull_request_archive/ }).click()
   await page.getByRole('tab', { name: 'Response body (truncated)' }).click()
 
-  await expect(page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.')).toBeVisible()
+  await expect(
+    page.getByText('Response body was truncated (4.0 KB), but no preview was recorded.'),
+  ).toBeVisible()
   await review.pause()
 })
 
-test('shows trace storage unavailable errors from TraceService', async ({ network, page, review }) => {
+test('shows trace storage unavailable errors from TraceService', async ({
+  network,
+  page,
+  review,
+}) => {
   network.use(...traceHandlers.unavailable)
 
-  await review.chapter('Test 3: TraceService unavailable', 'Mock a gRPC-Web unimplemented response from TraceService')
+  await review.chapter(
+    'Test 3: TraceService unavailable',
+    'Mock a gRPC-Web unimplemented response from TraceService',
+  )
   await page.goto('/')
   await review.pause()
 
   await expect(page.getByText('Tracing unavailable')).toBeVisible()
-  await expect(page.getByText('Trace storage is not enabled for this Coral server. Enable [local_traces].enabled = true, restart the Coral server, then run a query.').first()).toBeVisible()
+  await expect(
+    page
+      .getByText(
+        'Trace storage is not enabled for this Coral server. Enable [local_traces].enabled = true, restart the Coral server, then run a query.',
+      )
+      .first(),
+  ).toBeVisible()
   await expect(page.getByText('Disconnected')).toBeVisible()
   await expect(page.getByText('0 queries')).toBeVisible()
   await review.pause()

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
## Summary
- Add oxlint + oxfmt as the shared UI linter/formatter, wired into npm scripts, CI (`ui-build`), AGENTS.md, and root `.vscode/` (default formatter + recommended extension).
- Apply the oxc baseline reformat across `ui/src` and `ui/tests`. Three `[...arr].sort(...)` call sites were autofixed to `arr.toSorted(...)` by `unicorn/no-array-sort` (semantically equivalent — the originals already copied). Bumped `ui/tsconfig.json` target/lib `ES2022` → `ES2023` so `toSorted` resolves.
- `react/react-in-jsx-scope` disabled in `.oxlintrc.json` (obsolete under React 19's automatic JSX runtime).

## Test plan

`npm run dev:local`

<img width="2507" height="1141" alt="image" src="https://github.com/user-attachments/assets/a2aa847a-7105-45e5-b63b-e73b1c77bab3" />
