### PR TITLE
feat(sources/community/google_drive): add Google Drive community source

### DIFF
--- a/sources/community/google_drive/README.md
+++ b/sources/community/google_drive/README.md
@@ -61,14 +61,25 @@ not SQL — for example `mimeType = "application/pdf"` or
 
 ## Example queries
 
-### List recently modified files
+### List recently modified files (all drives)
 
 ```sql
 SELECT id, name, mime_type, modified_time, web_view_link
 FROM google_drive.files
-WHERE q = 'modifiedTime > "2026-05-01T00:00:00"'
+WHERE corpora = 'allDrives'
+  AND q = 'modifiedTime > "2026-05-01T00:00:00"'
 ORDER BY modified_time DESC
 LIMIT 20;
+```
+
+### Files in a specific shared drive
+
+```sql
+SELECT id, name, mime_type, modified_time
+FROM google_drive.files
+WHERE corpora = 'drive'
+  AND drive_id = 'YOUR_SHARED_DRIVE_ID'
+LIMIT 50;
 ```
 
 ### Full metadata for one file

--- a/sources/community/google_drive/README.md
+++ b/sources/community/google_drive/README.md
@@ -67,7 +67,7 @@ not SQL — for example `mimeType = "application/pdf"` or
 SELECT id, name, mime_type, modified_time, web_view_link
 FROM google_drive.files
 WHERE corpora = 'allDrives'
-  AND q = 'modifiedTime > "2026-05-01T00:00:00"'
+  AND q = 'trashed = false and modifiedTime > "2026-05-01T00:00:00"'
 ORDER BY modified_time DESC
 LIMIT 20;
 ```
@@ -114,11 +114,11 @@ LIMIT 30;
 ### Google Docs modified by the same engineer who authored a recent PR
 
 ```sql
-SELECT f.name, f.modified_time, f.web_view_link, pr.merged_by
+SELECT f.name, f.modified_time, f.web_view_link, pr.merged_by__login
 FROM google_drive.files f
-JOIN github.pull_requests pr ON LOWER(f.owner_email) = LOWER(pr.author_email)
-WHERE pr.state = 'closed'
-  AND pr.merged_at >= '2026-05-01T00:00:00Z'
+JOIN github.pulls pr
+  ON SPLIT_PART(f.owner_email, '@', 1) = pr.user__login
+WHERE pr.merged_at >= '2026-05-01T00:00:00Z'
 LIMIT 20;
 ```
 

--- a/sources/community/google_drive/README.md
+++ b/sources/community/google_drive/README.md
@@ -99,16 +99,6 @@ FROM google_drive.shared_drives
 LIMIT 10;
 ```
 
-### Files scoped to a shared drive
-
-```sql
-SELECT id, name, mime_type, modified_time
-FROM google_drive.files
-WHERE drive_id = '<DRIVE_ID>'
-ORDER BY modified_time DESC
-LIMIT 50;
-```
-
 ## Cross-source examples
 
 ### File owners joined with Linear assignees

--- a/sources/community/google_drive/README.md
+++ b/sources/community/google_drive/README.md
@@ -1,0 +1,156 @@
+# Google Drive (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Google Drive API v3)
+**Tables:** 3
+**Base URL:** `https://www.googleapis.com`
+
+Query Google Drive file listings, file metadata, and shared drives via the
+Drive API v3. Authenticates with Google OAuth (authorization_code + PKCE) using
+the same credential pattern as the core Gmail source.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Add the manifest from
+this directory:
+
+```bash
+coral source add --file sources/community/google_drive/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
+
+## Authentication and setup
+
+Requires a Google OAuth client ID and client secret with the
+`https://www.googleapis.com/auth/drive.readonly` scope.
+
+1. In [Google Cloud Console](https://console.cloud.google.com), create an
+   OAuth 2.0 client ID (Desktop app type) under **APIs & Services → Credentials**.
+2. Enable the **Google Drive API** under **APIs & Services → Library**.
+3. Run the interactive setup:
+
+```bash
+coral source add --interactive google_drive \
+  --file sources/community/google_drive/manifest.yaml
+```
+
+Choose **Connect with Google**, then paste your `GOOGLE_OAUTH_CLIENT_ID` and
+`GOOGLE_OAUTH_CLIENT_SECRET` when prompted. Coral completes the PKCE OAuth
+flow locally and stores the access token.
+
+To paste an access token directly instead:
+
+```bash
+export GOOGLE_DRIVE_TOKEN=ya29.a0...
+coral source add --file sources/community/google_drive/manifest.yaml
+```
+
+## Tables
+
+| Table | Required filters | Description |
+| --- | --- | --- |
+| `files` | none (optional `q`, `drive_id`) | Paginated file list across My Drive and shared drives |
+| `file_info` | `file_id` | Full metadata for a single file or folder |
+| `shared_drives` | none | All shared drives accessible to the authenticated user |
+
+The `q` filter on `files` uses [Drive query syntax](https://developers.google.com/drive/api/guides/search-files),
+not SQL — for example `mimeType = "application/pdf"` or
+`modifiedTime > "2026-01-01T00:00:00"`.
+
+## Example queries
+
+### List recently modified files
+
+```sql
+SELECT id, name, mime_type, modified_time, web_view_link
+FROM google_drive.files
+WHERE q = 'modifiedTime > "2026-05-01T00:00:00"'
+ORDER BY modified_time DESC
+LIMIT 20;
+```
+
+### Full metadata for one file
+
+```sql
+SELECT name, mime_type, size, owner_email, last_modifier_email, web_view_link
+FROM google_drive.file_info
+WHERE file_id = '1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms'
+LIMIT 1;
+```
+
+### List shared drives
+
+```sql
+SELECT drive_id, name, created_time
+FROM google_drive.shared_drives
+LIMIT 10;
+```
+
+### Files scoped to a shared drive
+
+```sql
+SELECT id, name, mime_type, modified_time
+FROM google_drive.files
+WHERE drive_id = '<DRIVE_ID>'
+ORDER BY modified_time DESC
+LIMIT 50;
+```
+
+## Cross-source examples
+
+### File owners joined with Linear assignees
+
+```sql
+SELECT f.name, f.owner_email, li.title AS linear_issue
+FROM google_drive.files f
+JOIN linear.issues li ON LOWER(f.owner_email) = LOWER(li.assignee_email)
+WHERE li.state_type != 'completed'
+LIMIT 30;
+```
+
+### Google Docs modified by the same engineer who merged a recent PR
+
+```sql
+SELECT f.name, f.modified_time, f.web_view_link, pr.merged_by
+FROM google_drive.files f
+JOIN github.pull_requests pr ON LOWER(f.owner_email) = LOWER(pr.author_email)
+WHERE pr.state = 'closed'
+  AND pr.merged_at >= '2026-05-01T00:00:00Z'
+LIMIT 20;
+```
+
+## Validation
+
+```bash
+# YAML style
+make lint-sources
+
+# Manifest structure smoke check
+coral source lint sources/community/google_drive/manifest.yaml
+
+# Add and test
+coral source add --file sources/community/google_drive/manifest.yaml
+coral source test google_drive
+```
+
+## Limitations
+
+- **Read-only** — this source exposes read-only Drive API endpoints only.
+- **Drive query syntax** — the `q` filter on `files` uses Drive query syntax,
+  not SQL; unsupported operators cause API errors.
+- **Primary owner only** — only the first owner (index 0) is surfaced as
+  `owner_email`; the `raw` column contains the full owners array.
+- **No file content** — binary or text content download is out of scope for v1.
+- **No permissions table** — per-file ACL listing is a natural follow-on.
+- **Quota** — the Drive API enforces per-user and per-project quotas; always
+  use `LIMIT` on large drives.
+- Community sources are maintained separately from bundled core sources.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the linked issue
+first, sign the CLA if this is your first contribution, run `make lint-sources`,
+and open a focused PR titled
+`feat(sources/community/google_drive): add google drive community source`.

--- a/sources/community/google_drive/README.md
+++ b/sources/community/google_drive/README.md
@@ -110,7 +110,7 @@ WHERE li.state_type != 'completed'
 LIMIT 30;
 ```
 
-### Google Docs modified by the same engineer who merged a recent PR
+### Google Docs modified by the same engineer who authored a recent PR
 
 ```sql
 SELECT f.name, f.modified_time, f.web_view_link, pr.merged_by

--- a/sources/community/google_drive/manifest.yaml
+++ b/sources/community/google_drive/manifest.yaml
@@ -1,0 +1,458 @@
+name: google_drive
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Google Drive file listings, file metadata, and shared drives via the
+  Drive API v3. Authenticates with Google OAuth (authorization_code + PKCE).
+  Join with GitHub, Linear, or Notion sources to correlate document activity
+  with engineering work.
+base_url: https://www.googleapis.com
+
+inputs:
+  GOOGLE_DRIVE_TOKEN:
+    kind: secret
+    hint: |
+      A valid Google OAuth access token with the
+      `https://www.googleapis.com/auth/drive.readonly` scope.
+
+      To connect interactively, choose "Connect with Google" and provide a
+      Google OAuth client ID and client secret when prompted. Access tokens
+      expire; rerun `coral source add --interactive google_drive` when the
+      stored token needs to be replaced.
+
+      To paste a token manually instead, obtain one from your own OAuth flow
+      with the same read-only Drive scope.
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with Google
+          description: Use a Google OAuth client ID and client secret.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://127.0.0.1/oauth/callback
+            redirect_uri_port: random
+            endpoints:
+              authorization_url: https://accounts.google.com/o/oauth2/v2/auth
+              token_url: https://oauth2.googleapis.com/token
+            client:
+              id:
+                input: GOOGLE_OAUTH_CLIENT_ID
+              secret:
+                input: GOOGLE_OAUTH_CLIENT_SECRET
+                transport: request_body
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - https://www.googleapis.com/auth/drive.readonly
+        - type: source_config
+          label: Paste access token
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.GOOGLE_DRIVE_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+rate_limit:
+  extra_statuses:
+    - 429
+  retry_after_header: Retry-After
+
+test_queries:
+  - >-
+    SELECT table_name
+    FROM coral.tables
+    WHERE schema_name = 'google_drive'
+    ORDER BY table_name
+    LIMIT 1
+
+tables:
+  - name: files
+    description: >-
+      Lists files and folders accessible to the authenticated user across My
+      Drive and shared drives. Supports an optional `q` filter using Drive
+      query syntax (for example `mimeType = "application/pdf"` or
+      `modifiedTime > "2026-01-01T00:00:00"`) and an optional `drive_id`
+      filter to scope results to a specific shared drive.
+    guide: |
+      Start here to discover file IDs for use with `file_info`. Always use
+      `LIMIT` on large drives. The `q` filter uses Drive query syntax, not SQL;
+      see https://developers.google.com/drive/api/guides/search-files for
+      supported fields and operators.
+    fetch_limit_default: 100
+    filters:
+      - name: q
+        required: false
+      - name: drive_id
+        required: false
+    request:
+      method: GET
+      path: /drive/v3/files
+      query:
+        - name: fields
+          from: literal
+          value: >-
+            nextPageToken,files(id,name,mimeType,size,createdTime,modifiedTime,
+            owners,shared,webViewLink,parents,trashed,driveId)
+        - name: supportsAllDrives
+          from: literal
+          value: "true"
+        - name: includeItemsFromAllDrives
+          from: literal
+          value: "true"
+        - name: q
+          from: filter
+          key: q
+        - name: driveId
+          from: filter
+          key: drive_id
+        - name: corpora
+          from: literal
+          value: allDrives
+    response:
+      rows_path:
+        - files
+    pagination:
+      mode: cursor_query
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+      page_size:
+        default: 100
+        max: 1000
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique file identifier; use with `file_info` for full metadata.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: File or folder name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: mime_type
+        type: Utf8
+        nullable: true
+        description: >-
+          MIME type (for example application/vnd.google-apps.document for a
+          Google Doc, or application/pdf for a PDF).
+        expr:
+          kind: path
+          path:
+            - mimeType
+      - name: size
+        type: Int64
+        nullable: true
+        description: File size in bytes; null for Google Workspace files.
+        expr:
+          kind: path
+          path:
+            - size
+      - name: created_time
+        type: Utf8
+        nullable: true
+        description: ISO 8601 creation timestamp.
+        expr:
+          kind: path
+          path:
+            - createdTime
+      - name: modified_time
+        type: Utf8
+        nullable: true
+        description: ISO 8601 last-modified timestamp.
+        expr:
+          kind: path
+          path:
+            - modifiedTime
+      - name: owner_email
+        type: Utf8
+        nullable: true
+        description: Email address of the primary owner.
+        expr:
+          kind: path
+          path:
+            - owners
+            - "0"
+            - emailAddress
+      - name: shared
+        type: Utf8
+        nullable: true
+        description: String true when the file is shared with other users.
+        expr:
+          kind: if_present
+          check:
+            kind: path
+            path:
+              - shared
+          then_value: "true"
+      - name: trashed
+        type: Utf8
+        nullable: true
+        description: String true when the file is in the trash.
+        expr:
+          kind: if_present
+          check:
+            kind: path
+            path:
+              - trashed
+          then_value: "true"
+      - name: web_view_link
+        type: Utf8
+        nullable: true
+        description: URL to open the file in a browser.
+        expr:
+          kind: path
+          path:
+            - webViewLink
+      - name: drive_id
+        type: Utf8
+        nullable: true
+        description: Shared drive ID when the file lives in a shared drive; null for My Drive files.
+        expr:
+          kind: path
+          path:
+            - driveId
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw Drive file object.
+        expr:
+          kind: current_row
+
+  - name: file_info
+    description: >-
+      Full metadata for a single Drive file or folder. Returns richer detail
+      than the `files` listing table, including description, version, content
+      hints, and the full owners array.
+    guide: |
+      Requires the `file_id` filter. Obtain file IDs from `google_drive.files`.
+      Returns a single row for the requested file.
+    filters:
+      - name: file_id
+        required: true
+    request:
+      method: GET
+      path: /drive/v3/files/{{filter.file_id}}
+      query:
+        - name: fields
+          from: literal
+          value: >-
+            id,name,mimeType,description,size,version,createdTime,modifiedTime,
+            owners,lastModifyingUser,shared,webViewLink,parents,capabilities,
+            contentHints,trashed,driveId
+        - name: supportsAllDrives
+          from: literal
+          value: "true"
+    response:
+      row_strategy: direct
+      allow_404_empty: true
+    pagination:
+      mode: none
+    columns:
+      - name: file_id
+        type: Utf8
+        nullable: false
+        description: Unique file identifier.
+        expr:
+          kind: from_filter
+          key: file_id
+        virtual: true
+      - name: name
+        type: Utf8
+        nullable: true
+        description: File or folder name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: mime_type
+        type: Utf8
+        nullable: true
+        description: MIME type of the file.
+        expr:
+          kind: path
+          path:
+            - mimeType
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Short description attached to the file.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: size
+        type: Int64
+        nullable: true
+        description: File size in bytes; null for Google Workspace files.
+        expr:
+          kind: path
+          path:
+            - size
+      - name: version
+        type: Int64
+        nullable: true
+        description: Monotonically increasing version number for the file.
+        expr:
+          kind: path
+          path:
+            - version
+      - name: created_time
+        type: Utf8
+        nullable: true
+        description: ISO 8601 creation timestamp.
+        expr:
+          kind: path
+          path:
+            - createdTime
+      - name: modified_time
+        type: Utf8
+        nullable: true
+        description: ISO 8601 last-modified timestamp.
+        expr:
+          kind: path
+          path:
+            - modifiedTime
+      - name: owner_email
+        type: Utf8
+        nullable: true
+        description: Email of the primary owner.
+        expr:
+          kind: path
+          path:
+            - owners
+            - "0"
+            - emailAddress
+      - name: owner_name
+        type: Utf8
+        nullable: true
+        description: Display name of the primary owner.
+        expr:
+          kind: path
+          path:
+            - owners
+            - "0"
+            - displayName
+      - name: last_modifier_email
+        type: Utf8
+        nullable: true
+        description: Email of the user who last modified the file.
+        expr:
+          kind: path
+          path:
+            - lastModifyingUser
+            - emailAddress
+      - name: shared
+        type: Utf8
+        nullable: true
+        description: String true when the file is shared with other users.
+        expr:
+          kind: if_present
+          check:
+            kind: path
+            path:
+              - shared
+          then_value: "true"
+      - name: web_view_link
+        type: Utf8
+        nullable: true
+        description: URL to open the file in a browser.
+        expr:
+          kind: path
+          path:
+            - webViewLink
+      - name: drive_id
+        type: Utf8
+        nullable: true
+        description: Shared drive ID; null for My Drive files.
+        expr:
+          kind: path
+          path:
+            - driveId
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw Drive file metadata object.
+        expr:
+          kind: current_row
+
+  - name: shared_drives
+    description: >-
+      Lists all shared drives (formerly Team Drives) accessible to the
+      authenticated user. Returns drive ID, name, and creation timestamp.
+    guide: |
+      Use `drive_id` from this table as the `drive_id` filter on
+      `google_drive.files` to scope file listings to a specific shared drive.
+    request:
+      method: GET
+      path: /drive/v3/drives
+      query:
+        - name: fields
+          from: literal
+          value: nextPageToken,drives(id,name,createdTime,hidden)
+    response:
+      rows_path:
+        - drives
+    pagination:
+      mode: cursor_query
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+      page_size:
+        default: 100
+        max: 100
+        query_param: pageSize
+    columns:
+      - name: drive_id
+        type: Utf8
+        nullable: false
+        description: Unique shared drive identifier; use as `drive_id` filter on `files`.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Shared drive display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_time
+        type: Utf8
+        nullable: true
+        description: ISO 8601 creation timestamp for the shared drive.
+        expr:
+          kind: path
+          path:
+            - createdTime
+      - name: hidden
+        type: Utf8
+        nullable: true
+        description: String true when the drive is hidden from the default view.
+        expr:
+          kind: if_present
+          check:
+            kind: path
+            path:
+              - hidden
+          then_value: "true"

--- a/sources/community/google_drive/manifest.yaml
+++ b/sources/community/google_drive/manifest.yaml
@@ -33,7 +33,7 @@ inputs:
               type: authorization_code
               pkce: required
             redirect_uri: http://127.0.0.1/oauth/callback
-            redirect_uri_port: random
+            redirect_uri_port_mode: random
             endpoints:
               authorization_url: https://accounts.google.com/o/oauth2/v2/auth
               token_url: https://oauth2.googleapis.com/token
@@ -91,6 +91,13 @@ tables:
         corpora = 'allDrives'         — My Drive + all shared drives (recommended default)
         corpora = 'drive'             — one specific shared drive; requires `drive_id`
 
+      Drive returns trashed files unless you exclude them in `q`:
+        q = 'trashed = false'
+
+      Use `order_by` to sort results at the API level (not just the fetched page).
+      Supported values: modifiedTime, createdTime, name, recency, quotaBytesUsed.
+      Append ' desc' for descending: order_by = 'modifiedTime desc'
+
       The `q` filter uses Drive query syntax, not SQL. See
       https://developers.google.com/drive/api/guides/search-files for
       supported fields and operators. Always use `LIMIT` on large drives.
@@ -101,6 +108,8 @@ tables:
       - name: drive_id
         required: false
       - name: corpora
+        required: false
+      - name: order_by
         required: false
     request:
       method: GET
@@ -126,6 +135,9 @@ tables:
         - name: corpora
           from: filter
           key: corpora
+        - name: orderBy
+          from: filter
+          key: order_by
     response:
       rows_path:
         - files
@@ -136,7 +148,7 @@ tables:
         - nextPageToken
       page_size:
         default: 100
-        max: 1000
+        max: 100
         query_param: pageSize
     columns:
       - name: id
@@ -362,16 +374,13 @@ tables:
             - lastModifyingUser
             - emailAddress
       - name: shared
-        type: Utf8
+        type: Boolean
         nullable: true
-        description: String true when the file is shared with other users.
+        description: True when the file is shared with other users.
         expr:
-          kind: if_present
-          check:
-            kind: path
-            path:
-              - shared
-          then_value: "true"
+          kind: path
+          path:
+            - shared
       - name: web_view_link
         type: Utf8
         nullable: true
@@ -447,13 +456,10 @@ tables:
           path:
             - createdTime
       - name: hidden
-        type: Utf8
+        type: Boolean
         nullable: true
-        description: String true when the drive is hidden from the default view.
+        description: True when the drive is hidden from the default view.
         expr:
-          kind: if_present
-          check:
-            kind: path
-            path:
-              - hidden
-          then_value: "true"
+          kind: path
+          path:
+            - hidden

--- a/sources/community/google_drive/manifest.yaml
+++ b/sources/community/google_drive/manifest.yaml
@@ -79,20 +79,21 @@ test_queries:
 tables:
   - name: files
     description: >-
-      Lists files and folders accessible to the authenticated user across My
-      Drive and shared drives. Supports an optional `q` filter using Drive
-      query syntax (for example `mimeType = "application/pdf"` or
-      `modifiedTime > "2026-01-01T00:00:00"`) and an optional `drive_id`
-      filter to scope results to a specific shared drive.
+      Lists files and folders accessible to the authenticated user. Always set
+      the `corpora` filter to control which drives are searched: use
+      `allDrives` to include My Drive and all shared drives, or `drive` when
+      scoping to a specific shared drive with `drive_id`. Omitting `corpora`
+      causes the Drive API to default to the narrower `user` corpus and may
+      silently exclude shared-drive files. Supports an optional `q` filter
+      using Drive query syntax.
     guide: |
-      Start here to discover file IDs for use with `file_info`. Always use
-      `LIMIT` on large drives. The `q` filter uses Drive query syntax, not SQL;
-      see https://developers.google.com/drive/api/guides/search-files for
-      supported fields and operators.
+      Always set `corpora` explicitly:
+        corpora = 'allDrives'         — My Drive + all shared drives (recommended default)
+        corpora = 'drive'             — one specific shared drive; requires `drive_id`
 
-      To scope results to a specific shared drive, set both `drive_id` and
-      `corpora = 'drive'`. Without `drive_id`, omit `corpora` or set it to
-      `allDrives` to search across My Drive and all shared drives.
+      The `q` filter uses Drive query syntax, not SQL. See
+      https://developers.google.com/drive/api/guides/search-files for
+      supported fields and operators. Always use `LIMIT` on large drives.
     fetch_limit_default: 100
     filters:
       - name: q

--- a/sources/community/google_drive/manifest.yaml
+++ b/sources/community/google_drive/manifest.yaml
@@ -89,11 +89,17 @@ tables:
       `LIMIT` on large drives. The `q` filter uses Drive query syntax, not SQL;
       see https://developers.google.com/drive/api/guides/search-files for
       supported fields and operators.
+
+      To scope results to a specific shared drive, set both `drive_id` and
+      `corpora = 'drive'`. Without `drive_id`, omit `corpora` or set it to
+      `allDrives` to search across My Drive and all shared drives.
     fetch_limit_default: 100
     filters:
       - name: q
         required: false
       - name: drive_id
+        required: false
+      - name: corpora
         required: false
     request:
       method: GET
@@ -117,8 +123,8 @@ tables:
           from: filter
           key: drive_id
         - name: corpora
-          from: literal
-          value: allDrives
+          from: filter
+          key: corpora
     response:
       rows_path:
         - files
@@ -193,27 +199,21 @@ tables:
             - "0"
             - emailAddress
       - name: shared
-        type: Utf8
+        type: Boolean
         nullable: true
-        description: String true when the file is shared with other users.
+        description: True when the file is shared with other users.
         expr:
-          kind: if_present
-          check:
-            kind: path
-            path:
-              - shared
-          then_value: "true"
+          kind: path
+          path:
+            - shared
       - name: trashed
-        type: Utf8
+        type: Boolean
         nullable: true
-        description: String true when the file is in the trash.
+        description: True when the file is in the trash.
         expr:
-          kind: if_present
-          check:
-            kind: path
-            path:
-              - trashed
-          then_value: "true"
+          kind: path
+          path:
+            - trashed
       - name: web_view_link
         type: Utf8
         nullable: true


### PR DESCRIPTION

### What changed

Adds a new community source `google_drive` that exposes Google Drive file
listings, file metadata, and shared drive enumeration via the Drive API v3.

Tables:

- `files` — paginated file list across My Drive and shared drives; supports an
  optional `q` filter for Drive query syntax and `drive_id` for shared drives
- `file_info` — full metadata for a single file (name, MIME type, size, owners,
  permissions summary, web view link)
- `shared_drives` — lists all shared drives accessible to the authenticated user

### Google Drive — Why it changed

Google Drive is the canonical document store for many engineering teams.
Exposing it as a Coral source enables queries such as "which design docs were
modified in the same week as a GitHub deploy?" or joining Drive file ownership
with Linear assignments or GitHub PR authors across a single SQL query.

### Google Drive — User-visible impact

```sql
-- Recent files
SELECT id, name, mime_type, modified_time, web_view_link
FROM google_drive.files
WHERE q = 'modifiedTime > "2026-05-15T00:00:00"'
LIMIT 20;

-- Full metadata for one file
SELECT name, size, owners, web_view_link
FROM google_drive.file_info
WHERE file_id = '<FILE_ID>'
LIMIT 1;

-- Shared drives
SELECT drive_id, name, created_time
FROM google_drive.shared_drives
LIMIT 10;
```

### Google Drive — Limitations and follow-on work

- File content download is out of scope for v1.
- The Drive query (`q` filter) uses Drive's own query syntax, not SQL.
- Per-file permissions are a natural follow-on as a `permissions` table.

### Google Drive — Authentication

Uses Google OAuth (authorization code + PKCE) with the `drive.readonly` scope,
same credential pattern and `GOOGLE_OAUTH_CLIENT_ID` /
`GOOGLE_OAUTH_CLIENT_SECRET` inputs as Gmail and Google Sheets.

---