### PR TITLE
feat(sources/community/monday): add monday.com community source

### DIFF
--- a/sources/community/monday/README.md
+++ b/sources/community/monday/README.md
@@ -1,0 +1,165 @@
+# monday.com (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (monday.com GraphQL API v2)
+**Tables:** 2 · **Functions:** 2
+**Base URL:** `https://api.monday.com`
+
+Query monday.com boards, items, columns, and users via the GraphQL API v2.
+Join with GitHub PRs, Linear issues, and PagerDuty incidents for cross-source
+project management and engineering intelligence.
+
+## Install
+
+```bash
+coral source add --file sources/community/monday/manifest.yaml
+```
+
+## Authentication and setup
+
+Requires a monday.com personal API token.
+
+1. In monday.com, go to **your avatar → Developers → My Access Tokens**.
+2. Copy the token value.
+
+```bash
+export MONDAY_API_TOKEN=eyJhbGciOiJIUzI1NiJ9...
+coral source add --file sources/community/monday/manifest.yaml
+```
+
+The token is passed directly as the `Authorization` header value — no `Bearer`
+prefix.
+
+## Tables and functions
+
+### Tables
+
+| Table | Description |
+| --- | --- |
+| `boards` | All active boards with ID, name, kind, state, and workspace |
+| `users` | All non-guest account users with email, title, and role flags |
+
+### Table functions
+
+| Function | Required args | Description |
+| --- | --- | --- |
+| `board_items(board_id)` | `board_id` | Items (rows/tasks) for one board, up to 500 |
+| `board_columns(board_id)` | `board_id` | Column definitions for one board |
+
+Obtain `board_id` values from `monday.boards`.
+
+## Example queries
+
+### List all active boards
+
+```sql
+SELECT id, name, board_kind, workspace_name
+FROM monday.boards
+ORDER BY name
+LIMIT 20;
+```
+
+### Items in a board
+
+```sql
+SELECT id, name, state, group_title, created_at
+FROM monday.board_items('1234567890')
+WHERE state = 'active'
+ORDER BY created_at DESC
+LIMIT 50;
+```
+
+### Column definitions for a board
+
+```sql
+SELECT id, title, type
+FROM monday.board_columns('1234567890')
+ORDER BY title;
+```
+
+### All users
+
+```sql
+SELECT id, name, email, title, is_admin, time_zone
+FROM monday.users
+ORDER BY name;
+```
+
+## Cross-source examples
+
+### Engineers with open GitHub PRs and active monday.com items
+
+```sql
+SELECT u.name, u.email,
+       COUNT(DISTINCT pr.id) AS open_prs,
+       COUNT(DISTINCT mi.id) AS active_items
+FROM monday.users u
+LEFT JOIN github.pull_requests pr
+  ON LOWER(pr.author_login) = LOWER(SPLIT_PART(u.email, '@', 1))
+  AND pr.state = 'open'
+LEFT JOIN monday.board_items('BOARD_ID') mi
+  ON mi.state = 'active'
+GROUP BY u.name, u.email
+ORDER BY open_prs DESC
+LIMIT 20;
+```
+
+### monday.com active items matched against Linear issues
+
+```sql
+SELECT mi.name AS monday_item, li.title AS linear_issue, li.state_type
+FROM monday.board_items('BOARD_ID') mi
+JOIN linear.issues li
+  ON LOWER(li.title) LIKE '%' || LOWER(mi.name) || '%'
+WHERE mi.state = 'active'
+  AND li.state_type != 'completed'
+LIMIT 20;
+```
+
+### PagerDuty incidents versus board item creation on the same day
+
+```sql
+SELECT pd.title AS incident, pd.created_at,
+       COUNT(mi.id) AS items_created_same_day
+FROM pagerduty.incidents pd
+LEFT JOIN monday.board_items('BOARD_ID') mi
+  ON SUBSTR(mi.created_at, 1, 10) = SUBSTR(pd.created_at, 1, 10)
+WHERE pd.status = 'triggered'
+GROUP BY pd.title, pd.created_at
+ORDER BY pd.created_at DESC
+LIMIT 10;
+```
+
+## Validation
+
+```bash
+make lint-sources
+coral source lint sources/community/monday/manifest.yaml
+coral source add --file sources/community/monday/manifest.yaml
+coral source test monday
+```
+
+## Limitations
+
+- **GraphQL POST only** — all requests are POST to `https://api.monday.com/v2`;
+  monday.com has no REST API.
+- **500-item cap per call** — `board_items` returns at most 500 items; boards
+  larger than 500 items require cursor-based follow-up calls, which are not
+  exposed in v1.
+- **No column values** — item column values (status labels, dates, assignees)
+  are not decoded in v1; use the `raw` column and DataFusion JSON functions to
+  extract them.
+- **Active boards only** — the `boards` table returns `state: active` boards
+  by default; archived boards are excluded.
+- **Rate limits** — monday.com enforces complexity-based rate limits; avoid
+  scanning large boards in tight loops.
+- **API-Version header** — pinned to `2026-04`; update when a new stable
+  version is released.
+- Community sources are maintained separately from bundled core sources.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the linked issue
+first, sign the CLA if this is your first contribution, run `make lint-sources`,
+and open a focused PR titled
+`feat(sources/community/monday): add monday.com community source`.

--- a/sources/community/monday/README.md
+++ b/sources/community/monday/README.md
@@ -87,18 +87,14 @@ ORDER BY name;
 
 ## Cross-source examples
 
-### Engineers with open GitHub PRs and active monday.com items
+### Engineers with open GitHub PRs
 
 ```sql
-SELECT u.name, u.email,
-       COUNT(DISTINCT pr.id) AS open_prs,
-       COUNT(DISTINCT mi.id) AS active_items
+SELECT u.name, u.email, COUNT(DISTINCT pr.id) AS open_prs
 FROM monday.users u
 LEFT JOIN github.pull_requests pr
   ON LOWER(pr.author_login) = LOWER(SPLIT_PART(u.email, '@', 1))
   AND pr.state = 'open'
-LEFT JOIN monday.board_items('BOARD_ID') mi
-  ON mi.state = 'active'
 GROUP BY u.name, u.email
 ORDER BY open_prs DESC
 LIMIT 20;

--- a/sources/community/monday/README.md
+++ b/sources/community/monday/README.md
@@ -43,7 +43,7 @@ prefix.
 
 | Function | Required args | Description |
 | --- | --- | --- |
-| `board_items(board_id)` | `board_id` | Items (rows/tasks) for one board, up to 500 |
+| `board_items(board_id)` | `board_id` | Items (rows/tasks) for one board, cursor-paginated across all pages |
 | `board_columns(board_id)` | `board_id` | Column definitions for one board |
 
 Obtain `board_id` values from `monday.boards`.
@@ -90,15 +90,21 @@ ORDER BY name;
 ### Engineers with open GitHub PRs
 
 ```sql
-SELECT u.name, u.email, COUNT(DISTINCT pr.id) AS open_prs
+WITH open_prs AS (
+  SELECT user__login, number
+  FROM github.pulls
+  WHERE owner = 'your-org' AND repo = 'your-repo' AND state = 'open'
+)
+SELECT u.name, u.email, COUNT(DISTINCT pr.number) AS open_prs
 FROM monday.users u
-LEFT JOIN github.pull_requests pr
-  ON LOWER(pr.author_login) = LOWER(SPLIT_PART(u.email, '@', 1))
-  AND pr.state = 'open'
+LEFT JOIN open_prs pr
+  ON LOWER(pr.user__login) = LOWER(SPLIT_PART(u.email, '@', 1))
 GROUP BY u.name, u.email
 ORDER BY open_prs DESC
 LIMIT 20;
 ```
+
+The bundled GitHub source exposes `github.pulls` (requires `owner` and `repo` filters) and the author column `user__login`.
 
 ### monday.com active items matched against Linear issues
 
@@ -126,22 +132,33 @@ ORDER BY pd.created_at DESC
 LIMIT 10;
 ```
 
-## Validation
+## Verify your install
 
 ```bash
-make lint-sources
 coral source lint sources/community/monday/manifest.yaml
-coral source add --file sources/community/monday/manifest.yaml
+MONDAY_API_TOKEN=eyJhbGciOiJIUzI1NiJ9... \
+  coral source add --file sources/community/monday/manifest.yaml
 coral source test monday
+```
+
+A successful `coral source test monday` lists the `boards` and `users` tables
+and passes the declared test queries. To exercise every surface against your
+own account:
+
+```bash
+coral sql "SELECT id, name, board_kind, workspace_name FROM monday.boards LIMIT 5"
+coral sql "SELECT id, name, email, is_admin FROM monday.users LIMIT 5"
+coral sql "SELECT id, title, type FROM monday.board_columns('<board_id>') LIMIT 10"
+coral sql "SELECT id, name, state, group_title FROM monday.board_items('<board_id>') LIMIT 10"
 ```
 
 ## Limitations
 
 - **GraphQL POST only** — all requests are POST to `https://api.monday.com/v2`;
   monday.com has no REST API.
-- **500-item cap per call** — `board_items` returns at most 500 items; boards
-  larger than 500 items require cursor-based follow-up calls, which are not
-  exposed in v1.
+- **Page size** — `board_items` fetches 100 items per request by default (max
+  500) and follows monday's `items_page` cursor automatically, so all items on
+  a board are returned across pages.
 - **No column values** — item column values (status labels, dates, assignees)
   are not decoded in v1; use the `raw` column and DataFusion JSON functions to
   extract them.

--- a/sources/community/monday/README.md
+++ b/sources/community/monday/README.md
@@ -6,8 +6,7 @@
 **Base URL:** `https://api.monday.com`
 
 Query monday.com boards, items, columns, and users via the GraphQL API v2.
-Join with GitHub PRs, Linear issues, and PagerDuty incidents for cross-source
-project management and engineering intelligence.
+Use them for project management and cross-source engineering analysis.
 
 ## Install
 
@@ -36,8 +35,8 @@ prefix.
 
 | Table | Description |
 | --- | --- |
-| `boards` | All active boards with ID, name, kind, state, and workspace |
-| `users` | All non-guest account users with email, title, and role flags |
+| `boards` | Up to 500 accessible active boards with ID, name, kind, state, and workspace |
+| `users` | Up to 500 non-guest account users with email, title, and role flags |
 
 ### Table functions
 
@@ -50,7 +49,7 @@ Obtain `board_id` values from `monday.boards`.
 
 ## Example queries
 
-### List all active boards
+### List active boards
 
 ```sql
 SELECT id, name, board_kind, workspace_name
@@ -77,7 +76,7 @@ FROM monday.board_columns('1234567890')
 ORDER BY title;
 ```
 
-### All users
+### List users
 
 ```sql
 SELECT id, name, email, title, is_admin, time_zone
@@ -87,7 +86,7 @@ ORDER BY name;
 
 ## Cross-source examples
 
-### Engineers with open GitHub PRs
+### Engineers with open GitHub PRs by matching login
 
 ```sql
 WITH open_prs AS (
@@ -104,7 +103,10 @@ ORDER BY open_prs DESC
 LIMIT 20;
 ```
 
-The bundled GitHub source exposes `github.pulls` (requires `owner` and `repo` filters) and the author column `user__login`.
+The bundled GitHub source exposes `github.pulls` (requires `owner` and `repo`
+filters) and the author column `user__login`. This example assumes each GitHub
+login matches the local part of the engineer's monday.com email address; adjust
+the join when your organization uses a different identity mapping.
 
 ### monday.com active items matched against Linear issues
 
@@ -156,12 +158,15 @@ coral sql "SELECT id, name, state, group_title FROM monday.board_items('<board_i
 
 - **GraphQL POST only** — all requests are POST to `https://api.monday.com/v2`;
   monday.com has no REST API.
+- **Account-wide table limit** — `boards` and `users` return up to 500 records.
+  Coral's HTTP source DSL cannot currently inject monday.com's page number into
+  a GraphQL JSON body.
 - **Page size** — `board_items` fetches 100 items per request by default (max
   500) and follows monday's `items_page` cursor automatically, so all items on
   a board are returned across pages.
-- **No column values** — item column values (status labels, dates, assignees)
-  are not decoded in v1; use the `raw` column and DataFusion JSON functions to
-  extract them.
+- **Raw column values** — item column values are fetched but not decoded into
+  typed columns in v1. Use the `raw` column and DataFusion JSON functions to
+  extract the `column_values` entries.
 - **Active boards only** — the `boards` table returns `state: active` boards
   by default; archived boards are excluded.
 - **Rate limits** — monday.com enforces complexity-based rate limits; avoid
@@ -169,6 +174,14 @@ coral sql "SELECT id, name, state, group_title FROM monday.board_items('<board_i
 - **API-Version header** — pinned to `2026-04`; update when a new stable
   version is released.
 - Community sources are maintained separately from bundled core sources.
+
+## API references
+
+- [Authentication](https://developer.monday.com/api-reference/docs/authentication)
+- [API versioning](https://developer.monday.com/api-reference/docs/api-versioning)
+- [Boards](https://developer.monday.com/api-reference/reference/boards)
+- [Users](https://developer.monday.com/api-reference/reference/users)
+- [Items page](https://developer.monday.com/api-reference/reference/items-page)
 
 ## Contributing
 

--- a/sources/community/monday/manifest.yaml
+++ b/sources/community/monday/manifest.yaml
@@ -45,7 +45,7 @@ test_queries:
 tables:
   - name: boards
     description: >-
-      Lists all active monday.com boards accessible to the authenticated token.
+      Active monday.com boards accessible to the authenticated token, up to 500.
       Returns board ID, name, description, kind (public/private/share), state,
       and workspace metadata.
     guide: |
@@ -152,7 +152,7 @@ tables:
 
   - name: users
     description: >-
-      Lists all non-guest users in the monday.com account. Returns user ID,
+      Non-guest users in the monday.com account, up to 500. Returns user ID,
       name, email, title, role flags, time zone, and creation timestamp.
     guide: |
       Use `email` to join with GitHub PR authors, Linear assignees, and
@@ -205,7 +205,7 @@ tables:
           path:
             - title
       - name: is_admin
-        type: Json
+        type: Boolean
         nullable: true
         description: True when the user has account admin permissions.
         expr:
@@ -213,7 +213,7 @@ tables:
           path:
             - is_admin
       - name: is_guest
-        type: Json
+        type: Boolean
         nullable: true
         description: True when the user is a guest account.
         expr:
@@ -221,7 +221,7 @@ tables:
           path:
             - is_guest
       - name: enabled
-        type: Json
+        type: Boolean
         nullable: true
         description: True when the user account is active and not deactivated.
         expr:
@@ -276,7 +276,8 @@ functions:
       body:
         query: >-
           { boards(ids: [{{arg.board_id}}]) { items_page(limit: 500) { items
-          { id name state created_at updated_at group { id title } } } } }
+          { id name state created_at updated_at group { id title }
+          column_values { id text value } } } } }
     response:
       rows_path:
         - data
@@ -348,7 +349,10 @@ functions:
       - name: raw
         type: Json
         nullable: true
-        description: Raw item object including all column values.
+        description: >-
+          Raw item object including column_values array with id, text, and
+          value for each column. Use DataFusion JSON functions to extract
+          specific column values.
         expr:
           kind: current_row
 

--- a/sources/community/monday/manifest.yaml
+++ b/sources/community/monday/manifest.yaml
@@ -1,0 +1,424 @@
+name: monday
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query monday.com boards, items, columns, and users via the monday.com
+  GraphQL API v2. Join with GitHub PRs, Linear issues, and PagerDuty incidents
+  for cross-source project management and engineering intelligence.
+base_url: https://api.monday.com
+
+inputs:
+  MONDAY_API_TOKEN:
+    kind: secret
+    hint: |
+      A monday.com personal API token. Generate one in your monday.com account
+      under Developers → My Access Tokens. Pass the token value directly —
+      no Bearer prefix is used.
+
+      See https://developer.monday.com/api-reference/docs/authentication
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: input
+      key: MONDAY_API_TOKEN
+
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/json
+  - name: API-Version
+    from: literal
+    value: "2026-04"
+
+rate_limit:
+  extra_statuses:
+    - 429
+
+test_queries:
+  - SELECT id, name, board_kind FROM monday.boards LIMIT 5
+  - SELECT id, name, email FROM monday.users LIMIT 5
+  - SELECT function_name FROM coral.table_functions WHERE schema_name = 'monday' ORDER BY function_name LIMIT 1
+
+tables:
+  - name: boards
+    description: >-
+      Lists all active monday.com boards accessible to the authenticated token.
+      Returns board ID, name, description, kind (public/private/share), state,
+      and workspace metadata.
+    guide: |
+      Start here to discover board IDs for use with the `board_items` and
+      `board_columns` table functions. Use board `id` as the `board_id`
+      argument. To include archived or deleted boards, modify the `state`
+      filter in the query.
+    request:
+      method: POST
+      path: /v2
+      body:
+        query: >-
+          { boards(limit: 500, state: active) { id name description board_kind
+          state created_at updated_at workspace { id name } } }
+    response:
+      rows_path:
+        - data
+        - boards
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: >-
+          Board ID; use as the `board_id` argument for `board_items` and
+          `board_columns` table functions.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Board display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Board description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: board_kind
+        type: Utf8
+        nullable: true
+        description: Board visibility (public, private, or share).
+        expr:
+          kind: path
+          path:
+            - board_kind
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Board state (active, archived, or deleted).
+        expr:
+          kind: path
+          path:
+            - state
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 creation timestamp.
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 last-updated timestamp.
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: ID of the workspace this board belongs to.
+        expr:
+          kind: path
+          path:
+            - workspace
+            - id
+      - name: workspace_name
+        type: Utf8
+        nullable: true
+        description: Display name of the workspace this board belongs to.
+        expr:
+          kind: path
+          path:
+            - workspace
+            - name
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw board object.
+        expr:
+          kind: current_row
+
+  - name: users
+    description: >-
+      Lists all non-guest users in the monday.com account. Returns user ID,
+      name, email, title, role flags, time zone, and creation timestamp.
+    guide: |
+      Use `email` to join with GitHub PR authors, Linear assignees, and
+      PagerDuty users for cross-source engineer identity resolution. Filter by
+      `is_admin = 'true'` to scope results to admins only.
+    request:
+      method: POST
+      path: /v2
+      body:
+        query: >-
+          { users(limit: 500, kind: non_guests) { id name email title is_admin
+          is_guest enabled created_at time_zone_identifier location } }
+    response:
+      rows_path:
+        - data
+        - users
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique user ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: User display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address; join key with GitHub, Linear, and PagerDuty.
+        expr:
+          kind: path
+          path:
+            - email
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Job title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: is_admin
+        type: Json
+        nullable: true
+        description: True when the user has account admin permissions.
+        expr:
+          kind: path
+          path:
+            - is_admin
+      - name: is_guest
+        type: Json
+        nullable: true
+        description: True when the user is a guest account.
+        expr:
+          kind: path
+          path:
+            - is_guest
+      - name: enabled
+        type: Json
+        nullable: true
+        description: True when the user account is active and not deactivated.
+        expr:
+          kind: path
+          path:
+            - enabled
+      - name: time_zone
+        type: Utf8
+        nullable: true
+        description: User time zone identifier, for example America/New_York.
+        expr:
+          kind: path
+          path:
+            - time_zone_identifier
+      - name: location
+        type: Utf8
+        nullable: true
+        description: User location string.
+        expr:
+          kind: path
+          path:
+            - location
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 account creation timestamp.
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw user object.
+        expr:
+          kind: current_row
+
+functions:
+  - name: board_items
+    description: >-
+      Fetch items (rows/tasks) for a specific monday.com board by board ID.
+      Returns up to 500 items including ID, name, state, group, and timestamps.
+      Obtain board IDs from `monday.boards`.
+    args:
+      - name: board_id
+        required: true
+        bind:
+          arg: board_id
+    request:
+      method: POST
+      path: /v2
+      body:
+        query: >-
+          { boards(ids: [{{arg.board_id}}]) { items_page(limit: 500) { items
+          { id name state created_at updated_at group { id title } } } } }
+    response:
+      rows_path:
+        - data
+        - boards
+        - "0"
+        - items_page
+        - items
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Item ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Item name (the row title in the board).
+        expr:
+          kind: path
+          path:
+            - name
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Item state (active, archived, or deleted).
+        expr:
+          kind: path
+          path:
+            - state
+      - name: group_id
+        type: Utf8
+        nullable: true
+        description: ID of the group (section) this item belongs to.
+        expr:
+          kind: path
+          path:
+            - group
+            - id
+      - name: group_title
+        type: Utf8
+        nullable: true
+        description: Title of the group (section) this item belongs to.
+        expr:
+          kind: path
+          path:
+            - group
+            - title
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 creation timestamp.
+        expr:
+          kind: path
+          path:
+            - created_at
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: ISO 8601 last-updated timestamp.
+        expr:
+          kind: path
+          path:
+            - updated_at
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw item object including all column values.
+        expr:
+          kind: current_row
+
+  - name: board_columns
+    description: >-
+      Fetch the column definitions for a specific monday.com board. Returns
+      column ID, title, type, and settings. Use column titles to interpret the
+      column values in items returned by `board_items`.
+    args:
+      - name: board_id
+        required: true
+        bind:
+          arg: board_id
+    request:
+      method: POST
+      path: /v2
+      body:
+        query: >-
+          { boards(ids: [{{arg.board_id}}]) { columns { id title type
+          description settings_str } } }
+    response:
+      rows_path:
+        - data
+        - boards
+        - "0"
+        - columns
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Column ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Column display name (the header shown in the board).
+        expr:
+          kind: path
+          path:
+            - title
+      - name: type
+        type: Utf8
+        nullable: true
+        description: >-
+          Column type (for example status, text, date, numeric, people,
+          timeline, or checkbox).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Column description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: settings_str
+        type: Utf8
+        nullable: true
+        description: >-
+          JSON-encoded column settings; for status columns this contains the
+          label-to-color mapping.
+        expr:
+          kind: path
+          path:
+            - settings_str

--- a/sources/community/monday/manifest.yaml
+++ b/sources/community/monday/manifest.yaml
@@ -157,7 +157,7 @@ tables:
     guide: |
       Use `email` to join with GitHub PR authors, Linear assignees, and
       PagerDuty users for cross-source engineer identity resolution. Filter by
-      `is_admin = 'true'` to scope results to admins only.
+      `is_admin = true` to scope results to admins only.
     request:
       method: POST
       path: /v2

--- a/sources/community/monday/manifest.yaml
+++ b/sources/community/monday/manifest.yaml
@@ -4,8 +4,7 @@ dsl_version: 3
 backend: http
 description: >-
   Query monday.com boards, items, columns, and users via the monday.com
-  GraphQL API v2. Join with GitHub PRs, Linear issues, and PagerDuty incidents
-  for cross-source project management and engineering intelligence.
+  GraphQL API v2 for project management and engineering analysis.
 base_url: https://api.monday.com
 
 inputs:
@@ -45,7 +44,7 @@ test_queries:
 tables:
   - name: boards
     description: >-
-      Active monday.com boards accessible to the authenticated token, up to 500.
+      Up to 500 active monday.com boards accessible to the authenticated token.
       Returns board ID, name, description, kind (public/private/share), state,
       and workspace metadata.
     guide: |
@@ -166,12 +165,13 @@ tables:
 
   - name: users
     description: >-
-      Non-guest users in the monday.com account, up to 500. Returns user ID,
+      Up to 500 non-guest users in the monday.com account. Returns user ID,
       name, email, title, role flags, time zone, and creation timestamp.
     guide: |
-      Use `email` to join with GitHub PR authors, Linear assignees, and
-      PagerDuty users for cross-source engineer identity resolution. Filter by
-      `is_admin = true` to scope results to admins only.
+      Use `email` to join with other sources that expose user email addresses,
+      such as Linear assignees. GitHub user emails may be absent when users keep
+      their addresses private. Filter by `is_admin = true` to scope results to
+      admins only.
     request:
       method: POST
       path: /v2
@@ -221,7 +221,7 @@ tables:
       - name: email
         type: Utf8
         nullable: true
-        description: User email address; join key with GitHub, Linear, and PagerDuty.
+        description: User email address; useful as a cross-source identity key.
         expr:
           kind: path
           path:

--- a/sources/community/monday/manifest.yaml
+++ b/sources/community/monday/manifest.yaml
@@ -56,10 +56,24 @@ tables:
     request:
       method: POST
       path: /v2
+      query: []
       body:
-        query: >-
-          { boards(limit: 500, state: active) { id name description board_kind
-          state created_at updated_at workspace { id name } } }
+        - path:
+            - query
+          from: literal
+          value: |
+            query {
+              boards(limit: 500, state: active) {
+                id
+                name
+                description
+                board_kind
+                state
+                created_at
+                updated_at
+                workspace { id name }
+              }
+            }
     response:
       rows_path:
         - data
@@ -161,10 +175,26 @@ tables:
     request:
       method: POST
       path: /v2
+      query: []
       body:
-        query: >-
-          { users(limit: 500, kind: non_guests) { id name email title is_admin
-          is_guest enabled created_at time_zone_identifier location } }
+        - path:
+            - query
+          from: literal
+          value: |
+            query {
+              users(limit: 500, kind: non_guests) {
+                id
+                name
+                email
+                title
+                is_admin
+                is_guest
+                enabled
+                created_at
+                time_zone_identifier
+                location
+              }
+            }
     response:
       rows_path:
         - data
@@ -263,8 +293,9 @@ functions:
   - name: board_items
     description: >-
       Fetch items (rows/tasks) for a specific monday.com board by board ID.
-      Returns up to 500 items including ID, name, state, group, and timestamps.
-      Obtain board IDs from `monday.boards`.
+      Returns ID, name, state, group, and timestamps. Cursor-paginated, so all
+      items on the board are returned across pages. Obtain board IDs from
+      `monday.boards`.
     args:
       - name: board_id
         required: true
@@ -273,11 +304,38 @@ functions:
     request:
       method: POST
       path: /v2
+      query: []
       body:
-        query: >-
-          { boards(ids: [{{arg.board_id}}]) { items_page(limit: 500) { items
-          { id name state created_at updated_at group { id title }
-          column_values { id text value } } } } }
+        - path:
+            - query
+          from: literal
+          value: |
+            query BoardItems($boardId: ID!, $limit: Int!, $cursor: String) {
+              boards(ids: [$boardId]) {
+                items_page(limit: $limit, cursor: $cursor) {
+                  cursor
+                  items {
+                    id
+                    name
+                    state
+                    created_at
+                    updated_at
+                    group { id title }
+                    column_values { id text value }
+                  }
+                }
+              }
+            }
+        - path:
+            - variables
+            - boardId
+          from: arg
+          key: board_id
+        - path:
+            - variables
+            - limit
+          from: literal
+          value: 100
     response:
       rows_path:
         - data
@@ -286,7 +344,22 @@ functions:
         - items_page
         - items
     pagination:
-      mode: none
+      mode: cursor_body
+      cursor_body_path:
+        - variables
+        - cursor
+      response_cursor_path:
+        - data
+        - boards
+        - "0"
+        - items_page
+        - cursor
+      page_size:
+        default: 100
+        max: 500
+        body_path:
+          - variables
+          - limit
     columns:
       - name: id
         type: Utf8
@@ -369,10 +442,22 @@ functions:
     request:
       method: POST
       path: /v2
+      query: []
       body:
-        query: >-
-          { boards(ids: [{{arg.board_id}}]) { columns { id title type
-          description settings_str } } }
+        - path:
+            - query
+          from: literal
+          value: |
+            query BoardColumns($boardId: ID!) {
+              boards(ids: [$boardId]) {
+                columns { id title type description settings_str }
+              }
+            }
+        - path:
+            - variables
+            - boardId
+          from: arg
+          key: board_id
     response:
       rows_path:
         - data


### PR DESCRIPTION
### What changed

Adds the `monday` community source for monday.com's GraphQL API v2.

- `boards`: up to 500 accessible active boards, including workspace metadata
- `users`: up to 500 non-guest account users, including email and role flags
- `board_items(board_id)`: all items for one board using cursor pagination; raw item data includes `column_values`
- `board_columns(board_id)`: column definitions for one board

Requests use GraphQL variables for board IDs, path-addressed JSON request bodies, and the current stable monday.com API version (`2026-04`).

### Why

This makes monday.com project data queryable alongside Coral's other engineering sources without ETL. The README includes standalone queries and clearly labels the heuristic used by the GitHub login-matching example.

### Limitations

- `boards` and `users` are capped at 500 records because monday.com's page number must be sent inside the GraphQL JSON body, which Coral's current HTTP source DSL cannot paginate.
- Item column values are available in `raw.column_values` but are not decoded into typed columns.
- Only active boards and non-guest users are returned.
- A monday.com token was not available in this environment, so live account output could not be captured. The manifest was checked against monday.com's current provider documentation.

### Validation

- `coral source lint sources/community/monday/manifest.yaml`
- `ryl -c .yamllint.yaml --stdin-filename sources/community/monday/manifest.yaml -` (normalized input)
- `git diff --check`
- `git merge-tree --write-tree HEAD upstream/main`

### Provider references

- https://developer.monday.com/api-reference/docs/authentication
- https://developer.monday.com/api-reference/docs/api-versioning
- https://developer.monday.com/api-reference/reference/boards
- https://developer.monday.com/api-reference/reference/users
- https://developer.monday.com/api-reference/reference/items-page