### PR TITLE
chore(sources/community): assign community source code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@ AGENTS.md @withcoral/core-maintainers
 /crates/coral-mcp/ @withcoral/mcp
 /crates/coral-spec/ @withcoral/sources
 
-# Bundled sources.
+# Sources
 /sources/ @withcoral/sources
 /sources/community/ @jsummerfield
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@ AGENTS.md @withcoral/core-maintainers
 
 # Bundled sources.
 /sources/ @withcoral/sources
+/sources/community/ @jsummerfield
 
 # UI
 /ui/ @withcoral/ui


### PR DESCRIPTION
## Summary

- Route PRs touching `sources/community/` to `@jsummerfield` with a specific CODEOWNERS override.
- Keep the broader `/sources/ @withcoral/sources` rule in place for the rest of bundled sources.

## Validation

- `git diff --check HEAD~1..HEAD`
- CODEOWNERS order check: `/sources/community/` appears after `/sources/` and resolves to `@jsummerfield`.
