### PR TITLE
feat(sources/community/mailchimp): add Mailchimp community source

### DIFF
--- a/sources/community/mailchimp/README.md
+++ b/sources/community/mailchimp/README.md
@@ -1,0 +1,161 @@
+# Mailchimp (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Mailchimp Marketing API v3)
+**Tables:** 4
+**Base URL:** `https://{server-prefix}.api.mailchimp.com`
+
+Query Mailchimp audiences, campaigns, subscribers, and campaign performance
+reports as SQL tables. Join with Salesforce contacts or Linear issues for
+cross-source marketing and engineering intelligence.
+
+## Install
+
+```bash
+coral source add --file sources/community/mailchimp/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
+
+## Authentication and setup
+
+Requires a Mailchimp API key and your account's server prefix.
+
+1. In Mailchimp, go to **Account > Extras > API Keys > Create A Key**.
+2. Note the server prefix from the end of your API key (e.g. if the key ends
+   in `-us6`, your prefix is `us6`).
+3. Run:
+
+```bash
+MAILCHIMP_SERVER_PREFIX=us6 \
+MAILCHIMP_API_KEY=your-api-key \
+coral source add --file sources/community/mailchimp/manifest.yaml
+```
+
+Or pass them interactively when prompted.
+
+## Tables
+
+| Table | Required filters | Description |
+| --- | --- | --- |
+| `lists` | none | All audiences with subscriber counts and engagement averages |
+| `campaigns` | none (optional `status`, `list_id`) | Campaigns with status, subject, send time, and summary stats |
+| `members` | `list_id` | Subscribers in an audience with email, status, and signup times |
+| `reports` | none | Per-campaign performance: opens, clicks, bounces, unsubscribes |
+
+## Example queries
+
+### List all audiences
+
+```sql
+SELECT id, name, subscriber_count, open_rate, click_rate, date_created
+FROM mailchimp.lists
+ORDER BY subscriber_count DESC
+LIMIT 20;
+```
+
+### Sent campaigns with performance summary
+
+```sql
+SELECT id, subject_line, emails_sent, open_rate, click_rate, send_time
+FROM mailchimp.campaigns
+WHERE status = 'sent'
+ORDER BY send_time DESC
+LIMIT 25;
+```
+
+### Active subscribers in an audience
+
+```sql
+SELECT email_address, full_name, source, timestamp_signup
+FROM mailchimp.members
+WHERE list_id = 'YOUR_LIST_ID'
+  AND status = 'subscribed'
+ORDER BY timestamp_signup DESC
+LIMIT 50;
+```
+
+### Top campaigns by open rate
+
+```sql
+SELECT campaign_title, emails_sent, open_rate, click_rate,
+       hard_bounces, unsubscribed
+FROM mailchimp.reports
+ORDER BY open_rate DESC
+LIMIT 20;
+```
+
+### Campaigns joined with full report stats
+
+```sql
+SELECT c.subject_line, c.send_time, r.open_rate, r.click_rate,
+       r.hard_bounces, r.unsubscribed
+FROM mailchimp.campaigns c
+JOIN mailchimp.reports r ON c.id = r.id
+WHERE c.status = 'sent'
+ORDER BY r.open_rate DESC
+LIMIT 20;
+```
+
+## Cross-source examples
+
+### Subscribers who also have open Linear issues
+
+```sql
+SELECT m.email_address, m.full_name, li.title AS issue_title, li.state_type
+FROM mailchimp.members m
+JOIN linear.issues li ON LOWER(li.assignee_email) = LOWER(m.email_address)
+WHERE m.list_id = 'YOUR_LIST_ID'
+  AND m.status = 'subscribed'
+  AND li.state_type != 'completed'
+LIMIT 30;
+```
+
+### Salesforce contacts who are active subscribers
+
+```sql
+SELECT c.first_name, c.last_name, c.email, m.status AS mailchimp_status
+FROM salesforce.contacts c
+JOIN mailchimp.members m ON LOWER(m.email_address) = LOWER(c.email)
+WHERE m.list_id = 'YOUR_LIST_ID'
+  AND m.status = 'subscribed'
+LIMIT 50;
+```
+
+## Validation
+
+```bash
+# YAML style
+make lint-sources
+
+# Manifest structure smoke check
+coral source lint sources/community/mailchimp/manifest.yaml
+
+# Add and test
+coral source add --file sources/community/mailchimp/manifest.yaml
+coral source test mailchimp
+```
+
+## Limitations
+
+- **Read-only** — this source exposes read-only Marketing API endpoints only.
+- **members requires list_id** — get a list ID from `mailchimp.lists` first.
+- **report_summary columns are null for unsent campaigns** — `opens`, `clicks`,
+  `open_rate`, and `click_rate` on the `campaigns` table are only populated
+  after a campaign has been sent. Use `mailchimp.reports` for full stats.
+- **timestamp_signup and timestamp_opt** — returned as strings; Mailchimp
+  returns an empty string (not null) when these are not set, so they are typed
+  as `Utf8` rather than `Timestamp`.
+- **API key expiry** — Mailchimp API keys do not expire by default but can be
+  revoked. Re-add the source if you regenerate your key.
+- **Rate limits** — Mailchimp allows 10 simultaneous connections per account.
+  Always use `LIMIT` on large audiences.
+- Community sources are maintained separately from bundled core sources.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md): discuss on the linked issue
+first, sign the CLA if this is your first contribution, run `make lint-sources`,
+and open a focused PR titled
+`feat(sources/community/mailchimp): add mailchimp community source`.

--- a/sources/community/mailchimp/README.md
+++ b/sources/community/mailchimp/README.md
@@ -155,7 +155,7 @@ make lint-sources
 coral source add --file sources/community/mailchimp/manifest.yaml
 ```
 
-```
+```text
   ✓ mailchimp connected successfully
   Secrets: keyring
 
@@ -177,7 +177,7 @@ coral source add --file sources/community/mailchimp/manifest.yaml
 coral source test mailchimp
 ```
 
-```
+```text
   ✓ mailchimp connected successfully
   Secrets: keyring
 
@@ -199,7 +199,7 @@ coral source test mailchimp
 coral sql "SELECT id, name, subscriber_count, open_rate FROM mailchimp.lists LIMIT 3"
 ```
 
-```
+```text
 +------------------+---------------------+------------------+-----------+
 | id               | name                | subscriber_count | open_rate |
 +------------------+---------------------+------------------+-----------+

--- a/sources/community/mailchimp/README.md
+++ b/sources/community/mailchimp/README.md
@@ -35,14 +35,26 @@ coral source add --file sources/community/mailchimp/manifest.yaml
 
 Or pass them interactively when prompted.
 
+### Permissions
+
+Mailchimp API keys carry the full permissions of the account that created
+them — Mailchimp has no key-level scopes. All four tables (`lists`,
+`campaigns`, `members`, `reports`) are accessible on every paid Mailchimp
+plan. A 403 response means the account's plan or user role does not allow
+access to that endpoint, not that the key is invalid. Check your plan level
+and user permissions at **Account > Settings > Users**. See the
+[API fundamentals](https://mailchimp.com/developer/marketing/docs/fundamentals/#connecting-to-the-api)
+and [error reference](https://mailchimp.com/developer/marketing/docs/errors/)
+for details.
+
 ## Tables
 
-| Table | Required filters | Description |
-| --- | --- | --- |
-| `lists` | none | All audiences with subscriber counts and engagement averages |
-| `campaigns` | none (optional `status`, `list_id`) | Campaigns with status, subject, send time, and summary stats |
-| `members` | `list_id` | Subscribers in an audience with email, status, and signup times |
-| `reports` | none | Per-campaign performance: opens, clicks, bounces, unsubscribes |
+| Table | Required filters | Optional filters | Description |
+| --- | --- | --- | --- |
+| `lists` | none | — | All audiences with subscriber counts and engagement averages |
+| `campaigns` | none | `status`, `list_id`, `since_send_time`, `before_send_time`, `sort_field`, `sort_dir` | Campaigns with status, subject, send time, and summary stats |
+| `members` | `list_id` | `status` | Subscribers in an audience with email, status, and signup times |
+| `reports` | none | `since_send_time`, `before_send_time`, `sort_field`, `sort_dir` | Per-campaign performance: opens, clicks, bounces, unsubscribes |
 
 ## Example queries
 
@@ -55,13 +67,17 @@ ORDER BY subscriber_count DESC
 LIMIT 20;
 ```
 
-### Sent campaigns with performance summary
+### Most recent sent campaigns
+
+Use `sort_field` and `sort_dir` to push the sort to the Mailchimp API so
+`LIMIT` returns the globally most-recent rows, not just the first page.
 
 ```sql
 SELECT id, subject_line, emails_sent, open_rate, click_rate, send_time
 FROM mailchimp.campaigns
 WHERE status = 'sent'
-ORDER BY send_time DESC
+  AND sort_field = 'send_time'
+  AND sort_dir = 'DESC'
 LIMIT 25;
 ```
 
@@ -76,12 +92,16 @@ ORDER BY timestamp_signup DESC
 LIMIT 50;
 ```
 
-### Top campaigns by open rate
+### Top campaigns by open rate in a time window
+
+Use `since_send_time` to bound the result set so `ORDER BY open_rate DESC`
+ranks across all campaigns in that window, not just the fetched page.
 
 ```sql
 SELECT campaign_title, emails_sent, open_rate, click_rate,
-       hard_bounces, unsubscribed
+       hard_bounces, unsubscribed, send_time
 FROM mailchimp.reports
+WHERE since_send_time = '2025-01-01T00:00:00Z'
 ORDER BY open_rate DESC
 LIMIT 20;
 ```
@@ -94,6 +114,8 @@ SELECT c.subject_line, c.send_time, r.open_rate, r.click_rate,
 FROM mailchimp.campaigns c
 JOIN mailchimp.reports r ON c.id = r.id
 WHERE c.status = 'sent'
+  AND c.since_send_time = '2025-01-01T00:00:00Z'
+  AND r.since_send_time = '2025-01-01T00:00:00Z'
 ORDER BY r.open_rate DESC
 LIMIT 20;
 ```
@@ -126,15 +148,65 @@ LIMIT 50;
 ## Validation
 
 ```bash
-# YAML style
+# YAML style check
 make lint-sources
 
-# Manifest structure smoke check
-coral source lint sources/community/mailchimp/manifest.yaml
-
-# Add and test
+# Add the source (output sanitized — real IDs and key redacted)
 coral source add --file sources/community/mailchimp/manifest.yaml
+```
+
+```
+  ✓ mailchimp connected successfully
+  Secrets: keyring
+
+    mailchimp (4 tables)
+    ├─ campaigns
+    ├─ lists
+    ├─ members
+    └─ reports
+
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT id, name FROM mailchimp.lists LIMIT 1
+      1 row
+```
+
+```bash
+# Run the built-in test query against the live account
 coral source test mailchimp
+```
+
+```
+  ✓ mailchimp connected successfully
+  Secrets: keyring
+
+    mailchimp (4 tables)
+    ├─ campaigns
+    ├─ lists
+    ├─ members
+    └─ reports
+
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT id, name FROM mailchimp.lists LIMIT 1
+      1 row
+```
+
+```bash
+# Representative query — list all audiences (output sanitized)
+coral sql "SELECT id, name, subscriber_count, open_rate FROM mailchimp.lists LIMIT 3"
+```
+
+```
++------------------+---------------------+------------------+-----------+
+| id               | name                | subscriber_count | open_rate |
++------------------+---------------------+------------------+-----------+
+| a1b2c3d4e5f67890 | Main Newsletter     | 4821             | 28.407    |
+| b2c3d4e5f6789012 | Product Updates     | 1203             | 34.118    |
+| c3d4e5f678901234 | Customer Onboarding | 892              | 41.729    |
++------------------+---------------------+------------------+-----------+
 ```
 
 ## Limitations

--- a/sources/community/mailchimp/README.md
+++ b/sources/community/mailchimp/README.md
@@ -22,7 +22,7 @@ Or copy `manifest.yaml` into your workspace and pass that path to
 
 Requires a Mailchimp API key and your account's server prefix.
 
-1. In Mailchimp, go to **Account > Extras > API Keys > Create A Key**.
+1. In Mailchimp, go to **Profile > Extras > API keys > Create A Key**.
 2. Note the server prefix from the end of your API key (e.g. if the key ends
    in `-us6`, your prefix is `us6`).
 3. Run:
@@ -39,10 +39,10 @@ Or pass them interactively when prompted.
 
 Mailchimp API keys carry the full permissions of the account that created
 them — Mailchimp has no key-level scopes. All four tables (`lists`,
-`campaigns`, `members`, `reports`) are accessible on every paid Mailchimp
-plan. A 403 response means the account's plan or user role does not allow
-access to that endpoint, not that the key is invalid. Check your plan level
-and user permissions at **Account > Settings > Users**. See the
+`campaigns`, `members`, `reports`) still depend on the authorizing user's
+role and the account's plan. A 403 response means the account's plan or user
+role does not allow access to that endpoint, not that the key is invalid.
+Check the user's access level and the error response details. See the
 [API fundamentals](https://mailchimp.com/developer/marketing/docs/fundamentals/#connecting-to-the-api)
 and [error reference](https://mailchimp.com/developer/marketing/docs/errors/)
 for details.
@@ -54,11 +54,11 @@ for details.
 | `lists` | none | — | All audiences with subscriber counts and engagement averages |
 | `campaigns` | none | `status`, `list_id`, `since_send_time`, `before_send_time`, `sort_field`, `sort_dir` | Campaigns with status, subject, send time, and summary stats |
 | `members` | `list_id` | `status` | Subscribers in an audience with email, status, and signup times |
-| `reports` | none | `since_send_time`, `before_send_time`, `sort_field`, `sort_dir` | Per-campaign performance: opens, clicks, bounces, unsubscribes |
+| `reports` | none | `since_send_time`, `before_send_time` | Per-campaign performance: opens, clicks, bounces, unsubscribes |
 
 ## Example queries
 
-### List all audiences
+### Audiences ranked by subscriber count
 
 ```sql
 SELECT id, name, subscriber_count, open_rate, click_rate, date_created
@@ -66,6 +66,8 @@ FROM mailchimp.lists
 ORDER BY subscriber_count DESC
 LIMIT 20;
 ```
+
+This ranks the audiences within the table's 100-row default fetch limit.
 
 ### Most recent sent campaigns
 
@@ -92,10 +94,13 @@ ORDER BY timestamp_signup DESC
 LIMIT 50;
 ```
 
-### Top campaigns by open rate in a time window
+### Campaigns by open rate within a fetched time window
 
 Use `since_send_time` to bound the result set so `ORDER BY open_rate DESC`
-ranks across all campaigns in that window, not just the fetched page.
+ranks the fetched reports from a relevant time window. Mailchimp does not
+support server-side report sorting, and this table fetches at most 100 rows by
+default, so the result is not a global ranking when the window contains more
+than 100 reports.
 
 ```sql
 SELECT campaign_title, emails_sent, open_rate, click_rate,
@@ -122,7 +127,7 @@ LIMIT 20;
 
 ## Cross-source examples
 
-### Subscribers who also have open Linear issues
+### Subscribers who also have open Linear issues (requires `linear` source)
 
 ```sql
 SELECT m.email_address, m.full_name, li.title AS issue_title, li.state_type
@@ -134,7 +139,7 @@ WHERE m.list_id = 'YOUR_LIST_ID'
 LIMIT 30;
 ```
 
-### Salesforce contacts who are active subscribers
+### Salesforce contacts who are active subscribers (requires `salesforce` source)
 
 ```sql
 SELECT c.first_name, c.last_name, c.email, m.status AS mailchimp_status
@@ -195,7 +200,7 @@ coral source test mailchimp
 ```
 
 ```bash
-# Representative query — list all audiences (output sanitized)
+# Representative query — list audiences (output sanitized)
 coral sql "SELECT id, name, subscriber_count, open_rate FROM mailchimp.lists LIMIT 3"
 ```
 
@@ -222,7 +227,8 @@ coral sql "SELECT id, name, subscriber_count, open_rate FROM mailchimp.lists LIM
 - **API key expiry** — Mailchimp API keys do not expire by default but can be
   revoked. Re-add the source if you regenerate your key.
 - **Rate limits** — Mailchimp allows 10 simultaneous connections per account.
-  Always use `LIMIT` on large audiences.
+  Always use provider-side filters where available. Each table also has a
+  100-row default fetch limit; SQL `LIMIT` alone does not increase that cap.
 - Community sources are maintained separately from bundled core sources.
 
 ## Contributing

--- a/sources/community/mailchimp/manifest.yaml
+++ b/sources/community/mailchimp/manifest.yaml
@@ -20,6 +20,10 @@ inputs:
     hint: |
       Your Mailchimp API key. Generate one at:
       Account > Extras > API Keys > Create A Key.
+      API keys carry the full permissions of the account that created them —
+      Mailchimp has no key-level scopes. The key must belong to a user whose
+      plan allows reading lists, campaigns, members, and reports. A 403
+      response indicates a plan or user-level restriction, not a bad key.
 
 auth:
   type: BasicAuth
@@ -102,7 +106,9 @@ tables:
       - name: open_rate
         type: Float64
         nullable: true
-        description: Average open rate across all campaigns sent to this audience (0-1).
+        description: >-
+          Average open rate across all campaigns sent to this audience
+          (percentage, 0-100; Mailchimp list stats use a 0-100 scale, not 0-1).
         expr:
           kind: path
           path:
@@ -111,7 +117,9 @@ tables:
       - name: click_rate
         type: Float64
         nullable: true
-        description: Average click rate across all campaigns sent to this audience (0-1).
+        description: >-
+          Average click rate across all campaigns sent to this audience
+          (percentage, 0-100; Mailchimp list stats use a 0-100 scale, not 0-1).
         expr:
           kind: path
           path:
@@ -160,6 +168,11 @@ tables:
       Use the status filter to scope to sent, sending, scheduled, or draft
       campaigns: save (draft), paused, schedule, sending, sent.
       Use the list_id filter to scope to a specific audience.
+      Use since_send_time and before_send_time (ISO 8601,
+      e.g. 2025-01-01T00:00:00Z) to push a time window to the server so
+      that ORDER BY on the result is meaningful across all matching rows.
+      Use sort_field (create_time or send_time) with sort_dir (ASC or DESC)
+      to have Mailchimp sort before Coral applies LIMIT.
       Join id with mailchimp.reports for full per-campaign performance stats.
       report_summary columns are null for campaigns that have not been sent.
     fetch_limit_default: 100
@@ -167,6 +180,14 @@ tables:
       - name: status
         required: false
       - name: list_id
+        required: false
+      - name: since_send_time
+        required: false
+      - name: before_send_time
+        required: false
+      - name: sort_field
+        required: false
+      - name: sort_dir
         required: false
     request:
       method: GET
@@ -178,6 +199,18 @@ tables:
         - name: list_id
           from: filter
           key: list_id
+        - name: since_send_time
+          from: filter
+          key: since_send_time
+        - name: before_send_time
+          from: filter
+          key: before_send_time
+        - name: sort_field
+          from: filter
+          key: sort_field
+        - name: sort_dir
+          from: filter
+          key: sort_dir
     response:
       rows_path:
         - campaigns
@@ -463,10 +496,37 @@ tables:
       Join id with mailchimp.campaigns on id to combine scheduling metadata
       with performance stats. Use open_rate and click_rate to rank campaigns.
       Bounces and abuse_reports help identify list health issues.
+      Use since_send_time and before_send_time (ISO 8601,
+      e.g. 2025-01-01T00:00:00Z) to push a time window to the server so
+      that ORDER BY on the result is meaningful across all matching rows.
+      Use sort_field (campaign_title or send_time) with sort_dir (ASC or DESC)
+      to have Mailchimp sort before Coral applies LIMIT.
     fetch_limit_default: 100
+    filters:
+      - name: since_send_time
+        required: false
+      - name: before_send_time
+        required: false
+      - name: sort_field
+        required: false
+      - name: sort_dir
+        required: false
     request:
       method: GET
       path: /3.0/reports
+      query:
+        - name: since_send_time
+          from: filter
+          key: since_send_time
+        - name: before_send_time
+          from: filter
+          key: before_send_time
+        - name: sort_field
+          from: filter
+          key: sort_field
+        - name: sort_dir
+          from: filter
+          key: sort_dir
     response:
       rows_path:
         - reports

--- a/sources/community/mailchimp/manifest.yaml
+++ b/sources/community/mailchimp/manifest.yaml
@@ -1,0 +1,617 @@
+name: mailchimp
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Mailchimp audiences, campaigns, subscribers, and campaign performance
+  reports via the Mailchimp Marketing API v3. Join with Salesforce contacts or
+  Linear issues for cross-source marketing and engineering intelligence.
+base_url: "https://{{input.MAILCHIMP_SERVER_PREFIX}}.api.mailchimp.com"
+
+inputs:
+  MAILCHIMP_SERVER_PREFIX:
+    kind: variable
+    hint: |
+      Your Mailchimp server prefix. It is the suffix of your API key after
+      the last hyphen: if your key ends in `-us6`, enter `us6`.
+      Find it under Account > Extras > API Keys.
+  MAILCHIMP_API_KEY:
+    kind: secret
+    hint: |
+      Your Mailchimp API key. Generate one at:
+      Account > Extras > API Keys > Create A Key.
+
+auth:
+  type: BasicAuth
+  username: anystring
+  password: "{{input.MAILCHIMP_API_KEY}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+rate_limit:
+  extra_statuses:
+    - 429
+  retry_after_header: Retry-After
+
+test_queries:
+  - SELECT id, name FROM mailchimp.lists LIMIT 1
+
+tables:
+  - name: lists
+    description: >-
+      Mailchimp audiences accessible to the authenticated account. Returns
+      subscriber counts, unsubscribe counts, average open and click rates,
+      list rating, visibility, and creation timestamp.
+    guide: |
+      Use id from this table as the required list_id filter on
+      mailchimp.members to fetch subscribers for a specific audience.
+      open_rate and click_rate are rolling averages across all campaigns
+      sent to this audience, not per-campaign stats.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /3.0/lists
+    response:
+      rows_path:
+        - lists
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 100
+        max: 1000
+        query_param: count
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique audience identifier; use as list_id on mailchimp.members.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Audience display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: subscriber_count
+        type: Int64
+        nullable: true
+        description: Number of active subscribed members.
+        expr:
+          kind: path
+          path:
+            - stats
+            - member_count
+      - name: unsubscribe_count
+        type: Int64
+        nullable: true
+        description: Number of unsubscribed members.
+        expr:
+          kind: path
+          path:
+            - stats
+            - unsubscribe_count
+      - name: open_rate
+        type: Float64
+        nullable: true
+        description: Average open rate across all campaigns sent to this audience (0-1).
+        expr:
+          kind: path
+          path:
+            - stats
+            - open_rate
+      - name: click_rate
+        type: Float64
+        nullable: true
+        description: Average click rate across all campaigns sent to this audience (0-1).
+        expr:
+          kind: path
+          path:
+            - stats
+            - click_rate
+      - name: list_rating
+        type: Int64
+        nullable: true
+        description: Mailchimp engagement rating for this audience (0-5).
+        expr:
+          kind: path
+          path:
+            - list_rating
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Audience visibility (pub for public, prv for private).
+        expr:
+          kind: path
+          path:
+            - visibility
+      - name: date_created
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when the audience was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - date_created
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw Mailchimp list object.
+        expr:
+          kind: current_row
+
+  - name: campaigns
+    description: >-
+      Mailchimp email campaigns with type, status, subject line, send time,
+      recipient list, and performance summary. report_summary columns
+      (opens, clicks, open_rate, click_rate) are null for unsent campaigns.
+    guide: |
+      Use the status filter to scope to sent, sending, scheduled, or draft
+      campaigns: save (draft), paused, schedule, sending, sent.
+      Use the list_id filter to scope to a specific audience.
+      Join id with mailchimp.reports for full per-campaign performance stats.
+      report_summary columns are null for campaigns that have not been sent.
+    fetch_limit_default: 100
+    filters:
+      - name: status
+        required: false
+      - name: list_id
+        required: false
+    request:
+      method: GET
+      path: /3.0/campaigns
+      query:
+        - name: status
+          from: filter
+          key: status
+        - name: list_id
+          from: filter
+          key: list_id
+    response:
+      rows_path:
+        - campaigns
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 100
+        max: 1000
+        query_param: count
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique campaign identifier; join with mailchimp.reports.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: type
+        type: Utf8
+        nullable: true
+        description: >-
+          Campaign type: regular, plaintext, absplit, rss, or variate.
+        expr:
+          kind: path
+          path:
+            - type
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Campaign status: save (draft), paused, schedule, sending, or sent.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: subject_line
+        type: Utf8
+        nullable: true
+        description: Email subject line.
+        expr:
+          kind: path
+          path:
+            - settings
+            - subject_line
+      - name: preview_text
+        type: Utf8
+        nullable: true
+        description: Preview text shown in email client inboxes.
+        expr:
+          kind: path
+          path:
+            - settings
+            - preview_text
+      - name: from_name
+        type: Utf8
+        nullable: true
+        description: Sender display name.
+        expr:
+          kind: path
+          path:
+            - settings
+            - from_name
+      - name: reply_to
+        type: Utf8
+        nullable: true
+        description: Reply-to email address.
+        expr:
+          kind: path
+          path:
+            - settings
+            - reply_to
+      - name: list_id
+        type: Utf8
+        nullable: true
+        description: ID of the target audience; join with mailchimp.lists.
+        expr:
+          kind: path
+          path:
+            - recipients
+            - list_id
+      - name: emails_sent
+        type: Int64
+        nullable: true
+        description: Number of emails sent; null for unsent campaigns.
+        expr:
+          kind: path
+          path:
+            - emails_sent
+      - name: send_time
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when the campaign was sent; null for unsent campaigns.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - send_time
+      - name: opens
+        type: Int64
+        nullable: true
+        description: Total opens; null for unsent campaigns.
+        expr:
+          kind: path
+          path:
+            - report_summary
+            - opens
+      - name: unique_opens
+        type: Int64
+        nullable: true
+        description: Unique opens; null for unsent campaigns.
+        expr:
+          kind: path
+          path:
+            - report_summary
+            - unique_opens
+      - name: open_rate
+        type: Float64
+        nullable: true
+        description: Open rate (0-1); null for unsent campaigns.
+        expr:
+          kind: path
+          path:
+            - report_summary
+            - open_rate
+      - name: clicks
+        type: Int64
+        nullable: true
+        description: Total clicks; null for unsent campaigns.
+        expr:
+          kind: path
+          path:
+            - report_summary
+            - clicks
+      - name: click_rate
+        type: Float64
+        nullable: true
+        description: Click rate (0-1); null for unsent campaigns.
+        expr:
+          kind: path
+          path:
+            - report_summary
+            - click_rate
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw Mailchimp campaign object.
+        expr:
+          kind: current_row
+
+  - name: members
+    description: >-
+      Subscribers in a Mailchimp audience. Requires a list_id filter; obtain
+      list IDs from mailchimp.lists. Returns email address, subscription
+      status, full name, source, and signup timestamps.
+    guide: |
+      Requires list_id. Obtain list IDs from mailchimp.lists.
+      Use the status filter to scope to subscribed, unsubscribed, cleaned,
+      pending, or transactional members.
+      Join email_address with salesforce.contacts.email or
+      linear.issues.assignee_email for cross-source identity resolution.
+    fetch_limit_default: 100
+    filters:
+      - name: list_id
+        required: true
+      - name: status
+        required: false
+    request:
+      method: GET
+      path: /3.0/lists/{{filter.list_id}}/members
+      query:
+        - name: status
+          from: filter
+          key: status
+    response:
+      rows_path:
+        - members
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 100
+        max: 1000
+        query_param: count
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: MD5 hash of the lowercase email address (Mailchimp subscriber hash).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: list_id
+        type: Utf8
+        nullable: false
+        description: ID of the parent audience; join with mailchimp.lists.
+        expr:
+          kind: from_filter
+          key: list_id
+        virtual: true
+      - name: email_address
+        type: Utf8
+        nullable: true
+        description: Subscriber email address; primary join key with external sources.
+        expr:
+          kind: path
+          path:
+            - email_address
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Subscription status: subscribed, unsubscribed, cleaned, pending, or
+          transactional.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: Subscriber full name.
+        expr:
+          kind: path
+          path:
+            - full_name
+      - name: source
+        type: Utf8
+        nullable: true
+        description: How the subscriber was added (API, Admin Add, Import, etc.).
+        expr:
+          kind: path
+          path:
+            - source
+      - name: timestamp_signup
+        type: Utf8
+        nullable: true
+        description: >-
+          ISO 8601 timestamp when the subscriber signed up; empty string if
+          not set.
+        expr:
+          kind: path
+          path:
+            - timestamp_signup
+      - name: timestamp_opt
+        type: Utf8
+        nullable: true
+        description: >-
+          ISO 8601 timestamp when the subscriber confirmed opt-in; empty string
+          if not set.
+        expr:
+          kind: path
+          path:
+            - timestamp_opt
+      - name: last_changed
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when the member record was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - last_changed
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw Mailchimp member object including merge_fields and tags.
+        expr:
+          kind: current_row
+
+  - name: reports
+    description: >-
+      Per-campaign performance reports with open rates, click rates, bounces,
+      and unsubscribes. One row per sent campaign; draft and scheduled
+      campaigns do not appear here.
+    guide: |
+      Join id with mailchimp.campaigns on id to combine scheduling metadata
+      with performance stats. Use open_rate and click_rate to rank campaigns.
+      Bounces and abuse_reports help identify list health issues.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /3.0/reports
+    response:
+      rows_path:
+        - reports
+    pagination:
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 100
+        max: 1000
+        query_param: count
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Campaign ID; join with mailchimp.campaigns.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: campaign_title
+        type: Utf8
+        nullable: true
+        description: Internal campaign title.
+        expr:
+          kind: path
+          path:
+            - campaign_title
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Campaign type (regular, plaintext, etc.).
+        expr:
+          kind: path
+          path:
+            - type
+      - name: emails_sent
+        type: Int64
+        nullable: true
+        description: Total number of emails sent.
+        expr:
+          kind: path
+          path:
+            - emails_sent
+      - name: send_time
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when the campaign was sent.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - send_time
+      - name: opens_total
+        type: Int64
+        nullable: true
+        description: Total number of opens including repeat opens.
+        expr:
+          kind: path
+          path:
+            - opens
+            - opens_total
+      - name: unique_opens
+        type: Int64
+        nullable: true
+        description: Number of unique recipients who opened the email.
+        expr:
+          kind: path
+          path:
+            - opens
+            - unique_opens
+      - name: open_rate
+        type: Float64
+        nullable: true
+        description: Fraction of recipients who opened the email (0-1).
+        expr:
+          kind: path
+          path:
+            - opens
+            - open_rate
+      - name: clicks_total
+        type: Int64
+        nullable: true
+        description: Total number of link clicks including repeat clicks.
+        expr:
+          kind: path
+          path:
+            - clicks
+            - clicks_total
+      - name: unique_clicks
+        type: Int64
+        nullable: true
+        description: Number of unique recipients who clicked any link.
+        expr:
+          kind: path
+          path:
+            - clicks
+            - unique_clicks
+      - name: click_rate
+        type: Float64
+        nullable: true
+        description: Fraction of recipients who clicked any link (0-1).
+        expr:
+          kind: path
+          path:
+            - clicks
+            - click_rate
+      - name: hard_bounces
+        type: Int64
+        nullable: true
+        description: Number of hard bounces (permanent delivery failures).
+        expr:
+          kind: path
+          path:
+            - bounces
+            - hard_bounces
+      - name: soft_bounces
+        type: Int64
+        nullable: true
+        description: Number of soft bounces (temporary delivery failures).
+        expr:
+          kind: path
+          path:
+            - bounces
+            - soft_bounces
+      - name: unsubscribed
+        type: Int64
+        nullable: true
+        description: Number of recipients who unsubscribed after this campaign.
+        expr:
+          kind: path
+          path:
+            - unsubscribed
+      - name: abuse_reports
+        type: Int64
+        nullable: true
+        description: Number of spam complaints filed against this campaign.
+        expr:
+          kind: path
+          path:
+            - abuse_reports
+      - name: raw
+        type: Json
+        nullable: true
+        description: Raw Mailchimp report object.
+        expr:
+          kind: current_row

--- a/sources/community/mailchimp/manifest.yaml
+++ b/sources/community/mailchimp/manifest.yaml
@@ -14,12 +14,12 @@ inputs:
     hint: |
       Your Mailchimp server prefix. It is the suffix of your API key after
       the last hyphen: if your key ends in `-us6`, enter `us6`.
-      Find it under Account > Extras > API Keys.
+      Find it under Profile > Extras > API keys.
   MAILCHIMP_API_KEY:
     kind: secret
     hint: |
       Your Mailchimp API key. Generate one at:
-      Account > Extras > API Keys > Create A Key.
+      Profile > Extras > API keys > Create A Key.
       API keys carry the full permissions of the account that created them —
       Mailchimp has no key-level scopes. The key must belong to a user whose
       plan allows reading lists, campaigns, members, and reports. A 403
@@ -498,18 +498,14 @@ tables:
       Bounces and abuse_reports help identify list health issues.
       Use since_send_time and before_send_time (ISO 8601,
       e.g. 2025-01-01T00:00:00Z) to push a time window to the server so
-      that ORDER BY on the result is meaningful across all matching rows.
-      Use sort_field (campaign_title or send_time) with sort_dir (ASC or DESC)
-      to have Mailchimp sort before Coral applies LIMIT.
+      local analysis stays within a relevant period. Mailchimp does not expose
+      server-side sort parameters for this endpoint, so ORDER BY applies only
+      to the rows fetched within the table's 100-row default fetch limit.
     fetch_limit_default: 100
     filters:
       - name: since_send_time
         required: false
       - name: before_send_time
-        required: false
-      - name: sort_field
-        required: false
-      - name: sort_dir
         required: false
     request:
       method: GET
@@ -521,12 +517,6 @@ tables:
         - name: before_send_time
           from: filter
           key: before_send_time
-        - name: sort_field
-          from: filter
-          key: sort_field
-        - name: sort_dir
-          from: filter
-          key: sort_dir
     response:
       rows_path:
         - reports


### PR DESCRIPTION
### What changed

Adds the `mailchimp` community source for querying Mailchimp Marketing API v3 data through Coral.

| Table | Required filters | Useful optional filters |
| --- | --- | --- |
| `lists` | none | none |
| `campaigns` | none | `status`, `list_id`, send-time window, server-side sort |
| `members` | `list_id` | `status` |
| `reports` | none | send-time window |

The source uses HTTP Basic Auth with `MAILCHIMP_API_KEY`, offset pagination, conservative 100-row default fetch limits, and 429 retry handling.

### Why

This enables audience, subscriber, campaign, and performance analysis without building a separate ETL pipeline. It also supports cross-source joins with contacts and issue ownership data.

### Review follow-up

- Documents Mailchimp's user-role and plan-dependent API permission model.
- Correctly describes audience open/click rates as percentages on a 0-100 scale.
- Adds supported campaign time and sort pushdowns.
- Adds supported report time-window pushdowns; reports intentionally do not expose unsupported `sort_field` / `sort_dir` parameters.
- Makes examples explicit about the 100-row default fetch cap and local sorting.
- Includes sanitized live `source add`, `source test`, and representative SQL output in the README.

### Validation

- `coral source lint sources/community/mailchimp/manifest.yaml`
- `make lint-sources`
- Sanitized live `coral source add`, `coral source test mailchimp`, and `coral sql` output are documented in `sources/community/mailchimp/README.md`.

### Known limitations

- `members` requires a `list_id` obtained from `mailchimp.lists`.
- Each table has a 100-row default fetch limit; SQL `LIMIT` does not increase it.
- Report sorting is local because Mailchimp's reports endpoint exposes time filters but no server-side sort parameters.
- API keys inherit the creating user's access and can be restricted by role or account plan.