### PR TITLE
feat(sources/community/ghost): add ghost cms integration

### DIFF
--- a/sources/community/ghost/README.md
+++ b/sources/community/ghost/README.md
@@ -5,6 +5,13 @@
 **Tables:** 4
 **Base URL:** `{{input.GHOST_SITE_URL}}/ghost/api/content` (default: `https://demo.ghost.io/ghost/api/content`)
 
+> **Note:** `GHOST_SITE_URL` should be the admin/API origin of your Ghost
+> instance — **not** necessarily the public domain. For Ghost(Pro) sites they
+> are usually the same (e.g. `https://demo.ghost.io`). For self-hosted
+> installs, use the origin visible in your Ghost Admin URL bar (e.g.
+> `https://admin.your-site.com`). Do **not** include `/ghost/api/content` or a
+> trailing slash.
+
 Query public posts, pages, tags, and authors from any Ghost CMS site via the Ghost Content API.
 
 ## Authentication
@@ -26,7 +33,7 @@ GHOST_CONTENT_API_KEY=22444f78447824223cefc48062 \
 Run the command from the repository root. Or set `GHOST_SITE_URL` for custom self-hosted sites:
 
 ```bash
-GHOST_SITE_URL=https://your-site.com GHOST_CONTENT_API_KEY=your_key_here \
+GHOST_SITE_URL=https://admin.your-site.com GHOST_CONTENT_API_KEY=your_key_here \
   coral source add --file sources/community/ghost/manifest.yaml
 ```
 
@@ -38,12 +45,16 @@ coral source add --file sources/community/ghost/manifest.yaml --interactive
 
 ## Tables
 
-| Table | Description | Relation data included |
-|---|---|---|
-| `posts` | Public posts from the Ghost site, ordered by publication date. | `tags`, `authors` |
-| `pages` | Public pages from the Ghost site, ordered by publication date. | `tags`, `authors` |
-| `tags` | Public tags defined on the Ghost site. Includes post counts. | — |
-| `authors` | Authors who have published content on the site. Includes post counts. | — |
+| Table | Description | Default ordering | Relation data included |
+|---|---|---|---|
+| `posts` | Public posts from the Ghost site. | `published_at DESC` | `tags`, `authors` |
+| `pages` | Public pages from the Ghost site. | `title ASC` | `tags`, `authors` |
+| `tags` | Public tags (internal tags excluded via `visibility:public`). Includes post counts. | — | — |
+| `authors` | Authors who have published content on the site. Includes post counts. | — | — |
+
+> Ghost NQL `filter` / `order` parameters are **not** passed through to the
+> provider. Use SQL `WHERE` and `ORDER BY` clauses to filter and sort results
+> after fetch (e.g. `WHERE featured = true`, `ORDER BY published_at ASC`).
 
 ## Quick Start
 

--- a/sources/community/ghost/README.md
+++ b/sources/community/ghost/README.md
@@ -47,12 +47,12 @@ coral source add --file sources/community/ghost/manifest.yaml --interactive
 
 | Table | Description | Filters | Default ordering | Relation data included |
 |---|---|---|---|---|
-| `posts` | Public posts from the Ghost site. | `filter`, `order` | `published_at DESC` | `tags`, `authors` |
-| `pages` | Public pages from the Ghost site. | `filter`, `order` | `title ASC` | `tags`, `authors` |
+| `posts` | Public posts from the Ghost site. | `nql_filter`, `nql_order` | `published_at DESC` | `tags`, `authors` |
+| `pages` | Public pages from the Ghost site. | `nql_filter`, `nql_order` | `title ASC` | `tags`, `authors` |
 | `tags` | Public tags with at least one published post. Internal tags excluded. | — | — | — |
 | `authors` | Authors who have published content on the site. | — | — | — |
 
-> **Filters:** `posts` and `pages` support optional `filter` and `order` parameters. These map directly to Ghost's NQL `filter` and `order` API parameters, allowing you to narrow results server-side (e.g., `filter = 'tag:news'`, `order = 'published_at ASC'`).
+> **Filters:** `posts` and `pages` support optional `nql_filter` and `nql_order` parameters. Use `nql_filter` with Ghost NQL syntax to narrow results server-side (e.g., `WHERE nql_filter = 'tag:news'`). Use `nql_order` to change the sort order (e.g., `WHERE nql_order = 'published_at ASC'`). These map to Ghost's `filter` and `order` API query parameters.
 
 ## Quick Start
 
@@ -71,6 +71,24 @@ coral sql "SELECT name, location, post_count FROM ghost.authors ORDER BY post_co
 ```
 
 ## Advanced Queries
+
+### Server-side NQL Filtering
+
+Ghost's Content API supports a powerful NQL (Node Query Language) filter syntax. Coral passes `nql_filter` and `nql_order` values directly to the Ghost API so filtering happens server-side.
+
+```sql
+-- Posts tagged "getting-started"
+coral sql "SELECT title, url FROM ghost.posts WHERE nql_filter = 'tag:getting-started' LIMIT 5"
+
+-- Featured posts only
+coral sql "SELECT title, featured, url FROM ghost.posts WHERE nql_filter = 'featured:true' LIMIT 5"
+
+-- Posts ordered by oldest first
+coral sql "SELECT title, published_at FROM ghost.posts WHERE nql_order = 'published_at ASC' LIMIT 5"
+
+-- Combine filter and order
+coral sql "SELECT title, published_at FROM ghost.posts WHERE nql_filter = 'featured:true' AND nql_order = 'published_at ASC' LIMIT 5"
+```
 
 ### Querying Nested Relations
 

--- a/sources/community/ghost/README.md
+++ b/sources/community/ghost/README.md
@@ -1,0 +1,88 @@
+# Ghost
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** `{{input.GHOST_SITE_URL}}/ghost/api/content` (default: `https://demo.ghost.io/ghost/api/content`)
+
+Query public posts, pages, tags, and authors from any Ghost CMS site via the Ghost Content API.
+
+## Authentication
+
+Requires a Content API key (`GHOST_CONTENT_API_KEY`). You can generate one from your Ghost Admin dashboard:
+1. Go to **Settings → Integrations → Custom Integration**.
+2. Click **Add custom integration**.
+3. Copy the **Content API Key**.
+
+For testing, you can use the public Ghost demo credentials:
+* **GHOST_SITE_URL**: `https://demo.ghost.io`
+* **GHOST_CONTENT_API_KEY**: `22444f78447824223cefc48062`
+
+```bash
+GHOST_CONTENT_API_KEY=22444f78447824223cefc48062 \
+  coral source add --file sources/community/ghost/manifest.yaml
+```
+
+Run the command from the repository root. Or set `GHOST_SITE_URL` for custom self-hosted sites:
+
+```bash
+GHOST_SITE_URL=https://your-site.com GHOST_CONTENT_API_KEY=your_key_here \
+  coral source add --file sources/community/ghost/manifest.yaml
+```
+
+To add it interactively:
+
+```bash
+coral source add --file sources/community/ghost/manifest.yaml --interactive
+```
+
+## Tables
+
+| Table | Description | Relation data included |
+|---|---|---|
+| `posts` | Public posts from the Ghost site, ordered by publication date. | `tags`, `authors` |
+| `pages` | Public pages from the Ghost site, ordered by publication date. | `tags`, `authors` |
+| `tags` | Public tags defined on the Ghost site. Includes post counts. | — |
+| `authors` | Authors who have published content on the site. Includes post counts. | — |
+
+## Quick Start
+
+```sql
+-- Retrieve the latest 5 posts with their publication date
+coral sql "SELECT title, published_at, url FROM ghost.posts ORDER BY published_at DESC LIMIT 5"
+
+-- Retrieve all static pages
+coral sql "SELECT title, url FROM ghost.pages"
+
+-- Find the most popular tags by post count
+coral sql "SELECT name, post_count FROM ghost.tags WHERE post_count > 0 ORDER BY post_count DESC"
+
+-- List all authors and their public post count
+coral sql "SELECT name, location, post_count FROM ghost.authors ORDER BY post_count DESC"
+```
+
+## Advanced Queries
+
+### Querying Nested Relations
+
+Ghost `posts` and `pages` return nested lists of tags and authors as structured JSON. You can query or extract them:
+
+```sql
+-- List posts and extract their first tag name
+coral sql "
+  SELECT 
+    title,
+    json_get_str(tags, 0, 'name') as primary_tag 
+  FROM ghost.posts 
+  LIMIT 5
+"
+```
+
+### Full JSON Raw Payload
+
+Every table includes a `raw` JSON column that contains the complete response payload from the Ghost API, allowing access to any fields not explicitly mapped to top-level columns:
+
+```sql
+-- Access custom fields or other API metadata
+coral sql "SELECT json_get_str(raw, 'comment_id') as comment_id FROM ghost.posts LIMIT 5"
+```

--- a/sources/community/ghost/README.md
+++ b/sources/community/ghost/README.md
@@ -45,16 +45,14 @@ coral source add --file sources/community/ghost/manifest.yaml --interactive
 
 ## Tables
 
-| Table | Description | Default ordering | Relation data included |
-|---|---|---|---|
-| `posts` | Public posts from the Ghost site. | `published_at DESC` | `tags`, `authors` |
-| `pages` | Public pages from the Ghost site. | `title ASC` | `tags`, `authors` |
-| `tags` | Public tags (internal tags excluded via `visibility:public`). Includes post counts. | — | — |
-| `authors` | Authors who have published content on the site. Includes post counts. | — | — |
+| Table | Description | Filters | Default ordering | Relation data included |
+|---|---|---|---|---|
+| `posts` | Public posts from the Ghost site. | `filter`, `order` | `published_at DESC` | `tags`, `authors` |
+| `pages` | Public pages from the Ghost site. | `filter`, `order` | `title ASC` | `tags`, `authors` |
+| `tags` | Public tags with at least one published post. Internal tags excluded. | — | — | — |
+| `authors` | Authors who have published content on the site. | — | — | — |
 
-> Ghost NQL `filter` / `order` parameters are **not** passed through to the
-> provider. Use SQL `WHERE` and `ORDER BY` clauses to filter and sort results
-> after fetch (e.g. `WHERE featured = true`, `ORDER BY published_at ASC`).
+> **Filters:** `posts` and `pages` support optional `filter` and `order` parameters. These map directly to Ghost's NQL `filter` and `order` API parameters, allowing you to narrow results server-side (e.g., `filter = 'tag:news'`, `order = 'published_at ASC'`).
 
 ## Quick Start
 
@@ -66,7 +64,7 @@ coral sql "SELECT title, published_at, url FROM ghost.posts ORDER BY published_a
 coral sql "SELECT title, url FROM ghost.pages"
 
 -- Find the most popular tags by post count
-coral sql "SELECT name, post_count FROM ghost.tags WHERE post_count > 0 ORDER BY post_count DESC"
+coral sql "SELECT name, post_count FROM ghost.tags ORDER BY post_count DESC"
 
 -- List all authors and their public post count
 coral sql "SELECT name, location, post_count FROM ghost.authors ORDER BY post_count DESC"

--- a/sources/community/ghost/manifest.yaml
+++ b/sources/community/ghost/manifest.yaml
@@ -11,7 +11,13 @@ inputs:
     kind: variable
     default: https://demo.ghost.io
     hint: |
-      The full URL of your Ghost site (e.g. `https://demo.ghost.io` or `https://your-site.com`).
+      The admin/API origin of your Ghost instance, without `/ghost/api/content`
+      and without a trailing slash.
+
+      For Ghost(Pro) sites this is usually the same as your public URL
+      (e.g. `https://demo.ghost.io`). For self-hosted installs the API origin
+      may differ from the public domain — use the origin you see in the Ghost
+      Admin URL bar (e.g. `https://admin.your-site.com`).
   GHOST_CONTENT_API_KEY:
     kind: secret
     hint: |
@@ -34,8 +40,11 @@ test_queries:
 tables:
   - name: posts
     description: >-
-      All public posts from the Ghost site, ordered by publication date.
-      Includes tags and authors information by default.
+      All public posts from the Ghost site, ordered by publication date
+      (newest first, `published_at DESC`). Includes tags and authors
+      information by default. Provider-side Ghost NQL filtering is not
+      exposed — use SQL WHERE clauses to filter by tag, author, featured
+      status, etc. after fetch.
     request:
       method: GET
       path: /posts/
@@ -204,8 +213,10 @@ tables:
 
   - name: pages
     description: >-
-      All public static pages from the Ghost site.
-      Includes tags and authors information by default.
+      All public static pages from the Ghost site, ordered by title
+      (ascending, `title ASC`). Includes tags and authors information by
+      default. Provider-side Ghost NQL filtering is not exposed — use SQL
+      WHERE clauses to filter after fetch.
     request:
       method: GET
       path: /pages/
@@ -373,7 +384,11 @@ tables:
           kind: current_row
 
   - name: tags
-    description: All tags defined on the Ghost site, with associated post counts.
+    description: >-
+      Public tags defined on the Ghost site, with associated post counts.
+      Internal tags (names starting with `#`) are excluded via a
+      provider-side `visibility:public` filter. Tags with zero posts are
+      included; filter them with `WHERE post_count > 0` if needed.
     request:
       method: GET
       path: /tags/
@@ -384,6 +399,9 @@ tables:
         - name: include
           from: literal
           value: count.posts
+        - name: filter
+          from: literal
+          value: "visibility:public"
     response:
       rows_path:
         - tags

--- a/sources/community/ghost/manifest.yaml
+++ b/sources/community/ghost/manifest.yaml
@@ -1,0 +1,605 @@
+name: ghost
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query public posts, pages, tags, and authors from a Ghost CMS site via the
+  Ghost Content API.
+base_url: "{{input.GHOST_SITE_URL}}/ghost/api/content"
+inputs:
+  GHOST_SITE_URL:
+    kind: variable
+    default: https://demo.ghost.io
+    hint: |
+      The full URL of your Ghost site (e.g. `https://demo.ghost.io` or `https://your-site.com`).
+  GHOST_CONTENT_API_KEY:
+    kind: secret
+    hint: |
+      Generate a Content API key from your Ghost dashboard:
+      Settings → Integrations → Custom Integration
+
+      For testing, you can use the public demo key:
+      `22444f78447824223cefc48062`
+
+      See https://ghost.org/docs/content-api/
+request_headers:
+  - name: Accept-Version
+    from: literal
+    value: v5.0
+test_queries:
+  - SELECT id, title, slug FROM ghost.posts LIMIT 5
+  - SELECT id, title, slug FROM ghost.pages LIMIT 5
+  - SELECT name, slug, post_count FROM ghost.tags LIMIT 5
+  - SELECT name, slug, post_count FROM ghost.authors LIMIT 5
+tables:
+  - name: posts
+    description: >-
+      All public posts from the Ghost site, ordered by publication date.
+      Includes tags and authors information by default.
+    request:
+      method: GET
+      path: /posts/
+      query:
+        - name: key
+          from: input
+          key: GHOST_CONTENT_API_KEY
+        - name: include
+          from: literal
+          value: tags,authors
+    response:
+      rows_path:
+        - posts
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 15
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique post ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Universally unique identifier of the post.
+        expr:
+          kind: path
+          path:
+            - uuid
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: URL slug for the post.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Title of the post.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: html
+        type: Utf8
+        nullable: true
+        description: HTML content of the post body.
+        expr:
+          kind: path
+          path:
+            - html
+      - name: excerpt
+        type: Utf8
+        nullable: true
+        description: A short excerpt or summary of the post.
+        expr:
+          kind: path
+          path:
+            - excerpt
+      - name: feature_image
+        type: Utf8
+        nullable: true
+        description: URL of the post's cover/feature image.
+        expr:
+          kind: path
+          path:
+            - feature_image
+      - name: featured
+        type: Boolean
+        nullable: true
+        description: Whether this is marked as a featured post.
+        expr:
+          kind: path
+          path:
+            - featured
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Post visibility (e.g. public, members).
+        expr:
+          kind: path
+          path:
+            - visibility
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Date and time when the post was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Date and time when the post was last modified.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: Date and time when the post was published.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - published_at
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Absolute URL of the post on the Ghost site.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: reading_time
+        type: Int64
+        nullable: true
+        description: Estimated reading time in minutes.
+        expr:
+          kind: path
+          path:
+            - reading_time
+      - name: tags
+        type: Json
+        nullable: true
+        description: JSON array of tags associated with this post.
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: authors
+        type: Json
+        nullable: true
+        description: JSON array of authors associated with this post.
+        expr:
+          kind: path
+          path:
+            - authors
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw JSON payload of the post.
+        expr:
+          kind: current_row
+
+  - name: pages
+    description: >-
+      All public static pages from the Ghost site.
+      Includes tags and authors information by default.
+    request:
+      method: GET
+      path: /pages/
+      query:
+        - name: key
+          from: input
+          key: GHOST_CONTENT_API_KEY
+        - name: include
+          from: literal
+          value: tags,authors
+    response:
+      rows_path:
+        - pages
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 15
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique page ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Universally unique identifier of the page.
+        expr:
+          kind: path
+          path:
+            - uuid
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: URL slug for the page.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Title of the page.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: html
+        type: Utf8
+        nullable: true
+        description: HTML content of the page body.
+        expr:
+          kind: path
+          path:
+            - html
+      - name: excerpt
+        type: Utf8
+        nullable: true
+        description: A short excerpt or summary of the page.
+        expr:
+          kind: path
+          path:
+            - excerpt
+      - name: feature_image
+        type: Utf8
+        nullable: true
+        description: URL of the page's cover/feature image.
+        expr:
+          kind: path
+          path:
+            - feature_image
+      - name: featured
+        type: Boolean
+        nullable: true
+        description: Whether this is marked as a featured page.
+        expr:
+          kind: path
+          path:
+            - featured
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Page visibility (e.g. public, members).
+        expr:
+          kind: path
+          path:
+            - visibility
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Date and time when the page was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Date and time when the page was last modified.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: Date and time when the page was published.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - published_at
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Absolute URL of the page on the Ghost site.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: reading_time
+        type: Int64
+        nullable: true
+        description: Estimated reading time in minutes.
+        expr:
+          kind: path
+          path:
+            - reading_time
+      - name: tags
+        type: Json
+        nullable: true
+        description: JSON array of tags associated with this page.
+        expr:
+          kind: path
+          path:
+            - tags
+      - name: authors
+        type: Json
+        nullable: true
+        description: JSON array of authors associated with this page.
+        expr:
+          kind: path
+          path:
+            - authors
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw JSON payload of the page.
+        expr:
+          kind: current_row
+
+  - name: tags
+    description: All tags defined on the Ghost site, with associated post counts.
+    request:
+      method: GET
+      path: /tags/
+      query:
+        - name: key
+          from: input
+          key: GHOST_CONTENT_API_KEY
+        - name: include
+          from: literal
+          value: count.posts
+    response:
+      rows_path:
+        - tags
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 15
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique tag ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the tag.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: URL slug for the tag.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: description
+        type: Utf8
+        nullable: true
+        description: A short description of the tag.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: feature_image
+        type: Utf8
+        nullable: true
+        description: URL of the cover image associated with the tag.
+        expr:
+          kind: path
+          path:
+            - feature_image
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Tag visibility (public or internal).
+        expr:
+          kind: path
+          path:
+            - visibility
+      - name: accent_color
+        type: Utf8
+        nullable: true
+        description: Hex color code assigned to the tag.
+        expr:
+          kind: path
+          path:
+            - accent_color
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Absolute URL of the tag page on the Ghost site.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: post_count
+        type: Int64
+        nullable: true
+        description: Number of public posts tagged with this tag.
+        expr:
+          kind: path
+          path:
+            - count
+            - posts
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw JSON payload of the tag.
+        expr:
+          kind: current_row
+
+  - name: authors
+    description: All authors who have published content on the Ghost site, with associated post counts.
+    request:
+      method: GET
+      path: /authors/
+      query:
+        - name: key
+          from: input
+          key: GHOST_CONTENT_API_KEY
+        - name: include
+          from: literal
+          value: count.posts
+    response:
+      rows_path:
+        - authors
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 15
+        max: 100
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique author ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Full display name of the author.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: URL slug for the author.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: profile_image
+        type: Utf8
+        nullable: true
+        description: URL of the author's profile image.
+        expr:
+          kind: path
+          path:
+            - profile_image
+      - name: cover_image
+        type: Utf8
+        nullable: true
+        description: URL of the author's cover image.
+        expr:
+          kind: path
+          path:
+            - cover_image
+      - name: bio
+        type: Utf8
+        nullable: true
+        description: Biography of the author.
+        expr:
+          kind: path
+          path:
+            - bio
+      - name: website
+        type: Utf8
+        nullable: true
+        description: Personal website URL of the author.
+        expr:
+          kind: path
+          path:
+            - website
+      - name: location
+        type: Utf8
+        nullable: true
+        description: Geographical location of the author.
+        expr:
+          kind: path
+          path:
+            - location
+      - name: facebook
+        type: Utf8
+        nullable: true
+        description: Facebook username or URL of the author.
+        expr:
+          kind: path
+          path:
+            - facebook
+      - name: twitter
+        type: Utf8
+        nullable: true
+        description: Twitter handle or URL of the author.
+        expr:
+          kind: path
+          path:
+            - twitter
+      - name: url
+        type: Utf8
+        nullable: true
+        description: Absolute URL of the author's page on the Ghost site.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: post_count
+        type: Int64
+        nullable: true
+        description: Number of public posts written by this author.
+        expr:
+          kind: path
+          path:
+            - count
+            - posts
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw JSON payload of the author.
+        expr:
+          kind: current_row

--- a/sources/community/ghost/manifest.yaml
+++ b/sources/community/ghost/manifest.yaml
@@ -42,13 +42,13 @@ tables:
     description: >-
       All public posts from the Ghost site, ordered by publication date
       (newest first, `published_at DESC`) by default. Includes tags and
-      authors information. Use the optional `filter` parameter with Ghost
+      authors information. Use the optional `nql_filter` parameter with Ghost
       NQL syntax to narrow results server-side (e.g. `tag:news`,
-      `featured:true`, `author:jane`) and `order` to change sort order
+      `featured:true`, `author:jane`) and `nql_order` to change sort order
       (e.g. `published_at ASC`).
     filters:
-      - name: filter
-      - name: order
+      - name: nql_filter
+      - name: nql_order
     request:
       method: GET
       path: /posts/
@@ -61,10 +61,10 @@ tables:
           value: tags,authors
         - name: filter
           from: filter
-          key: filter
+          key: nql_filter
         - name: order
           from: filter
-          key: order
+          key: nql_order
     response:
       rows_path:
         - posts
@@ -214,6 +214,20 @@ tables:
           kind: path
           path:
             - authors
+      - name: nql_filter
+        type: Utf8
+        nullable: true
+        description: Echoes the Ghost NQL filter expression applied to this request.
+        expr:
+          kind: from_filter
+          key: nql_filter
+      - name: nql_order
+        type: Utf8
+        nullable: true
+        description: Echoes the Ghost NQL order expression applied to this request.
+        expr:
+          kind: from_filter
+          key: nql_order
       - name: raw
         type: Json
         nullable: false
@@ -225,12 +239,12 @@ tables:
     description: >-
       All public static pages from the Ghost site, ordered by title
       (ascending, `title ASC`) by default. Includes tags and authors
-      information. Use the optional `filter` parameter with Ghost NQL
-      syntax to narrow results server-side and `order` to change sort
+      information. Use the optional `nql_filter` parameter with Ghost NQL
+      syntax to narrow results server-side and `nql_order` to change sort
       order.
     filters:
-      - name: filter
-      - name: order
+      - name: nql_filter
+      - name: nql_order
     request:
       method: GET
       path: /pages/
@@ -243,10 +257,10 @@ tables:
           value: tags,authors
         - name: filter
           from: filter
-          key: filter
+          key: nql_filter
         - name: order
           from: filter
-          key: order
+          key: nql_order
     response:
       rows_path:
         - pages
@@ -396,6 +410,20 @@ tables:
           kind: path
           path:
             - authors
+      - name: nql_filter
+        type: Utf8
+        nullable: true
+        description: Echoes the Ghost NQL filter expression applied to this request.
+        expr:
+          kind: from_filter
+          key: nql_filter
+      - name: nql_order
+        type: Utf8
+        nullable: true
+        description: Echoes the Ghost NQL order expression applied to this request.
+        expr:
+          kind: from_filter
+          key: nql_order
       - name: raw
         type: Json
         nullable: false

--- a/sources/community/ghost/manifest.yaml
+++ b/sources/community/ghost/manifest.yaml
@@ -41,10 +41,14 @@ tables:
   - name: posts
     description: >-
       All public posts from the Ghost site, ordered by publication date
-      (newest first, `published_at DESC`). Includes tags and authors
-      information by default. Provider-side Ghost NQL filtering is not
-      exposed — use SQL WHERE clauses to filter by tag, author, featured
-      status, etc. after fetch.
+      (newest first, `published_at DESC`) by default. Includes tags and
+      authors information. Use the optional `filter` parameter with Ghost
+      NQL syntax to narrow results server-side (e.g. `tag:news`,
+      `featured:true`, `author:jane`) and `order` to change sort order
+      (e.g. `published_at ASC`).
+    filters:
+      - name: filter
+      - name: order
     request:
       method: GET
       path: /posts/
@@ -55,6 +59,12 @@ tables:
         - name: include
           from: literal
           value: tags,authors
+        - name: filter
+          from: filter
+          key: filter
+        - name: order
+          from: filter
+          key: order
     response:
       rows_path:
         - posts
@@ -214,9 +224,13 @@ tables:
   - name: pages
     description: >-
       All public static pages from the Ghost site, ordered by title
-      (ascending, `title ASC`). Includes tags and authors information by
-      default. Provider-side Ghost NQL filtering is not exposed — use SQL
-      WHERE clauses to filter after fetch.
+      (ascending, `title ASC`) by default. Includes tags and authors
+      information. Use the optional `filter` parameter with Ghost NQL
+      syntax to narrow results server-side and `order` to change sort
+      order.
+    filters:
+      - name: filter
+      - name: order
     request:
       method: GET
       path: /pages/
@@ -227,6 +241,12 @@ tables:
         - name: include
           from: literal
           value: tags,authors
+        - name: filter
+          from: filter
+          key: filter
+        - name: order
+          from: filter
+          key: order
     response:
       rows_path:
         - pages
@@ -385,10 +405,10 @@ tables:
 
   - name: tags
     description: >-
-      Public tags defined on the Ghost site, with associated post counts.
-      Internal tags (names starting with `#`) are excluded via a
-      provider-side `visibility:public` filter. Tags with zero posts are
-      included; filter them with `WHERE post_count > 0` if needed.
+      Public tags associated with at least one published post on the Ghost
+      site, with post counts. Internal tags (names starting with `#`) are
+      excluded via a provider-side `visibility:public` filter. Ghost does
+      not return tags that have no associated posts.
     request:
       method: GET
       path: /tags/


### PR DESCRIPTION
### Description

This PR adds a new community source integration for **Ghost CMS**, enabling users to query public posts, pages, tags, and authors via the Ghost Content API using SQL.

Closes #637

### Included Tables

* **`posts`**: Public posts from the Ghost site, ordered by publication date (newest first, `published_at DESC`). Includes tag and author relation details by default.
* **`pages`**: Public pages from the Ghost site, ordered by title (`title ASC`). Includes tag and author relation details by default.
* **`tags`**: Public tags on the site (internal tags excluded via provider-side `visibility:public` filter), including their post counts (`post_count`).
* **`authors`**: Authors who have published content on the site, including their post counts (`post_count`).
* All tables include a `raw` JSON column mapped via `kind: current_row` to allow querying any unmapped nested properties using JSON extraction functions.

> **Note:** Ghost `posts` and `pages` support server-side NQL filtering and ordering via `nql_filter` and `nql_order` SQL columns. These map directly to Ghost's `filter` and `order` API parameters. Example:
> ```sql
> coral sql "SELECT title, url FROM ghost.posts WHERE nql_filter = 'tag:getting-started' LIMIT 5"
> ```

### Files Changed

* `sources/community/ghost/manifest.yaml` - Declarative HTTP source manifest specifying request paths, pagination, columns, and test queries.
* `sources/community/ghost/README.md` - Documentation covering setup instructions, authentication (with the public demo key), `GHOST_SITE_URL` clarification (admin/API origin), and sample/advanced SQL queries.

### Verification & Test Output

#### 1. Manifest Linting
```bash
coral source lint sources/community/ghost/manifest.yaml
# Output: Manifest is valid
```

#### 2. Connection and Declared Query Tests
Using the public Ghost demo credentials (`GHOST_SITE_URL="https://demo.ghost.io"` and `GHOST_CONTENT_API_KEY="22444f78447824223cefc48062"`):
```text
Added source ghost

  ✓ ghost connected successfully

    ghost (4 tables)
    ├─ authors
    ├─ pages
    ├─ posts
    └─ tags
    Query tests
    4 declared · 4 passed · 0 failed

    ✓ SELECT id, title, slug FROM ghost.posts LIMIT 5
      5 rows

    ✓ SELECT id, title, slug FROM ghost.pages LIMIT 5
      4 rows

    ✓ SELECT name, slug, post_count FROM ghost.tags LIMIT 5
      4 rows

    ✓ SELECT name, slug, post_count FROM ghost.authors LIMIT 5
      5 rows
```

#### 3. Manual SQL Verification
```sql
coral sql "SELECT title, published_at FROM ghost.posts LIMIT 5"
```
```text
+----------------------------------------------------------------+----------------------+
| title                                                          | published_at         |
+----------------------------------------------------------------+----------------------+
| Start here for a quick overview of everything you need to know | 2021-03-18T11:56:44Z |
| Customizing your brand and design settings                     | 2021-03-18T11:56:43Z |
| Writing and managing content in Ghost, an advanced guide       | 2021-03-18T11:56:42Z |
| Building your audience with subscriber signups                 | 2021-03-18T11:56:41Z |
| Selling premium memberships with recurring revenue             | 2021-03-18T11:56:40Z |
+----------------------------------------------------------------+----------------------+
```

#### 4. Tags Visibility Filter Verification
```sql
coral sql "SELECT name, visibility, post_count FROM ghost.tags ORDER BY name"
```
```text
+-----------------+------------+------------+
| name            | visibility | post_count |
+-----------------+------------+------------+
| Fables          | public     | 1          |
| Fiction         | public     | 4          |
| Getting Started | public     | 7          |
| Speeches        | public     | 2          |
+-----------------+------------+------------+
```
All returned tags are `public` — internal tags are excluded by the provider-side filter.

#### 5. NQL Filter Verification
```sql
coral sql "SELECT title, url, nql_filter FROM ghost.posts WHERE nql_filter = 'tag:getting-started' LIMIT 5"
```
```text
+----------------------------------------------------------------+--------------------------------+---------------------+
| title                                                          | url                            | nql_filter          |
+----------------------------------------------------------------+--------------------------------+---------------------+
| Start here for a quick overview of everything you need to know | https://demo.ghost.io/welcome/ | tag:getting-started |
| Customizing your brand and design settings                     | https://demo.ghost.io/design/  | tag:getting-started |
| Writing and managing content in Ghost, an advanced guide       | https://demo.ghost.io/write/   | tag:getting-started |
+----------------------------------------------------------------+--------------------------------+---------------------+
```