### PR TITLE
feat: Explain/Plan Introspection for SQL Execution

### DIFF
--- a/crates/coral-api/proto/coral/v1/query.proto
+++ b/crates/coral-api/proto/coral/v1/query.proto
@@ -37,6 +37,41 @@ message QueryPlan {
   string optimized_logical_plan = 2;
   // Physical execution plan after physical optimization.
   string physical_plan = 3;
+  // Structured execution-plan metadata for tooling and UI rendering.
+  ExecutionPlan execution_plan = 4;
+}
+
+message ExecutionPlan {
+  repeated ExecutionPlanStep steps = 1;
+  repeated PushdownDecision pushdowns = 2;
+  repeated CacheDecision cache = 3;
+  optional uint64 estimated_rows = 4;
+  optional uint64 actual_rows = 5;
+}
+
+message ExecutionPlanStep {
+  string kind = 1;
+  string name = 2;
+  string detail = 3;
+  optional uint64 estimated_rows = 4;
+  optional uint64 actual_rows = 5;
+  repeated ExecutionPlanStep children = 6;
+}
+
+message PushdownDecision {
+  repeated uint32 step_path = 1;
+  string target = 2;
+  string predicate = 3;
+  bool applied = 4;
+  string detail = 5;
+}
+
+message CacheDecision {
+  repeated uint32 step_path = 1;
+  string target = 2;
+  string strategy = 3;
+  string status = 4;
+  string detail = 5;
 }
 
 // SQL explanation response.

--- a/crates/coral-app/src/query/service.rs
+++ b/crates/coral-app/src/query/service.rs
@@ -82,6 +82,64 @@ fn query_plan_to_proto(plan: &coral_engine::QueryPlan) -> QueryPlanProto {
         unoptimized_logical_plan: plan.unoptimized_logical_plan().to_string(),
         optimized_logical_plan: plan.optimized_logical_plan().to_string(),
         physical_plan: plan.physical_plan().to_string(),
+        execution_plan: plan.execution_plan().map(execution_plan_to_proto),
+    }
+}
+
+fn execution_plan_to_proto(plan: &coral_engine::ExecutionPlan) -> coral_api::v1::ExecutionPlan {
+    coral_api::v1::ExecutionPlan {
+        steps: plan
+            .steps()
+            .iter()
+            .map(execution_plan_step_to_proto)
+            .collect(),
+        pushdowns: plan
+            .pushdowns()
+            .iter()
+            .map(pushdown_to_proto)
+            .collect(),
+        cache: plan.cache().iter().map(cache_to_proto).collect(),
+        estimated_rows: plan.estimated_rows(),
+        actual_rows: plan.actual_rows(),
+    }
+}
+
+fn execution_plan_step_to_proto(
+    step: &coral_engine::ExecutionPlanStep,
+) -> coral_api::v1::ExecutionPlanStep {
+    coral_api::v1::ExecutionPlanStep {
+        kind: step.kind().to_string(),
+        name: step.name().to_string(),
+        detail: step.detail().to_string(),
+        estimated_rows: step.estimated_rows(),
+        actual_rows: step.actual_rows(),
+        children: step
+            .children()
+            .iter()
+            .map(execution_plan_step_to_proto)
+            .collect(),
+    }
+}
+
+fn pushdown_to_proto(
+    pushdown: &coral_engine::PushdownDecision,
+) -> coral_api::v1::PushdownDecision {
+    coral_api::v1::PushdownDecision {
+        step_path: pushdown.step_path().to_vec(),
+        target: pushdown.target().to_string(),
+        predicate: pushdown.predicate().to_string(),
+        applied: pushdown.applied(),
+        detail: pushdown.detail().to_string(),
+    }
+}
+
+fn cache_to_proto(plan: &coral_engine::CacheDecision) -> coral_api::v1::CacheDecision {
+    coral_api::v1::CacheDecision {
+        step_path: plan.step_path().to_vec(),
+        target: plan.target().to_string(),
+        strategy: plan.strategy().to_string(),
+        status: plan.status().to_string(),
+        detail: plan.detail().to_string(),
     }
 }
 

--- a/crates/coral-cli/Cargo.toml
+++ b/crates/coral-cli/Cargo.toml
@@ -33,6 +33,7 @@ coral-app.workspace = true
 coral-client.workspace = true
 coral-mcp.workspace = true
 coral-spec.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 
 use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};
-use coral_api::v1::ExecuteSqlRequest;
+use coral_api::v1::{ExecuteSqlRequest, ExplainSqlRequest};
 #[cfg(feature = "embedded-ui")]
 use coral_app::StaticAssetsProvider;
 use coral_client::{
@@ -58,6 +58,8 @@ struct Cli {
 enum Command {
     /// Execute a SQL query
     Sql(SqlArgs),
+    /// Explain a SQL query plan
+    Explain(ExplainArgs),
     /// Manage data sources
     Source(SourceArgs),
     /// Interactive wizard to set up Coral and explore use cases
@@ -104,6 +106,16 @@ struct SqlArgs {
     #[arg(long, value_enum, default_value = "table")]
     format: OutputFormat,
     /// SQL query to execute
+    sql: String,
+}
+
+#[derive(Debug, Args)]
+/// Explain a SQL query plan
+struct ExplainArgs {
+    /// Output format for the execution plan
+    #[arg(long, value_enum, default_value = "table")]
+    format: OutputFormat,
+    /// SQL query to explain
     sql: String,
 }
 
@@ -240,7 +252,11 @@ impl CliError {
 impl Command {
     fn required_runtime(&self) -> RequiredRuntime {
         match self {
-            Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+            Command::Sql(_)
+            | Command::Explain(_)
+            | Command::Source(_)
+            | Command::Onboard
+            | Command::McpStdio(_) => {
                 RequiredRuntime::AppClient
             }
             Command::Completion(_) => RequiredRuntime::None,
@@ -414,7 +430,11 @@ async fn run_no_runtime_command(command: Command) -> Result<(), CliError> {
         }
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
-        Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
+        Command::Sql(_)
+        | Command::Explain(_)
+        | Command::Source(_)
+        | Command::Onboard
+        | Command::McpStdio(_) => {
             unreachable!("app client commands are routed through app runtime startup")
         }
     }
@@ -446,6 +466,29 @@ async fn run_app_command(
             };
             let result = decode_execute_sql_response(&response).map_err(anyhow::Error::from)?;
             print_batches(result.batches(), args.format)?;
+        }
+        Command::Explain(args) => {
+            let response = match app
+                .query_client()
+                .explain_sql(Request::new(ExplainSqlRequest {
+                    workspace: Some(default_workspace()),
+                    sql: args.sql,
+                }))
+                .await
+            {
+                Ok(response) => response.into_inner(),
+                Err(status) => {
+                    return Err(CliError::Query {
+                        error_message: query_error::telemetry_error_message(&status),
+                        error_type: query_error::telemetry_error_type(&status),
+                        rendered_stderr: query_error::render_query_error(&status),
+                    });
+                }
+            };
+            let plan = response
+                .plan
+                .ok_or_else(|| anyhow::anyhow!("query plan was missing from explain response"))?;
+            print_query_plan(&plan, args.format)?;
         }
         Command::Source(args) => run_source(&app, args).await?,
         Command::Onboard => {
@@ -541,6 +584,91 @@ fn print_batches(
     };
     println!("{output}");
     Ok(())
+}
+
+fn print_query_plan(plan: &coral_api::v1::QueryPlan, format: OutputFormat) -> Result<(), anyhow::Error> {
+    match format {
+        OutputFormat::Json => {
+            println!("{}", serde_json::to_string_pretty(plan)?);
+        }
+        OutputFormat::Table => {
+            println!("Execution plan");
+            if let Some(execution_plan) = &plan.execution_plan {
+                for step in &execution_plan.steps {
+                    render_plan_step(step, 0);
+                }
+                if !execution_plan.pushdowns.is_empty() {
+                    println!();
+                    print_text_table(
+                        ["Path", "Target", "Predicate", "Applied", "Detail"],
+                        execution_plan.pushdowns.iter().map(|pushdown| {
+                            [
+                                format_step_path(&pushdown.step_path),
+                                pushdown.target.clone(),
+                                pushdown.predicate.clone(),
+                                pushdown.applied.to_string(),
+                                pushdown.detail.clone(),
+                            ]
+                        }),
+                    );
+                }
+                if !execution_plan.cache.is_empty() {
+                    println!();
+                    print_text_table(
+                        ["Path", "Target", "Strategy", "Status", "Detail"],
+                        execution_plan.cache.iter().map(|cache| {
+                            [
+                                format_step_path(&cache.step_path),
+                                cache.target.clone(),
+                                cache.strategy.clone(),
+                                cache.status.clone(),
+                                cache.detail.clone(),
+                            ]
+                        }),
+                    );
+                }
+                if let Some(rows) = execution_plan.estimated_rows {
+                    println!();
+                    println!("Estimated rows: {rows}");
+                }
+                if let Some(rows) = execution_plan.actual_rows {
+                    println!("Actual rows: {rows}");
+                }
+            } else {
+                println!("{}", plan.physical_plan);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn render_plan_step(step: &coral_api::v1::ExecutionPlanStep, depth: usize) {
+    let indent = "  ".repeat(depth);
+    let mut line = format!("{indent}- {}: {}", step.kind, step.name);
+    if !step.detail.is_empty() {
+        line.push_str(&format!(" ({})", step.detail));
+    }
+    if let Some(rows) = step.estimated_rows {
+        line.push_str(&format!(" [est rows: {rows}]"));
+    }
+    if let Some(rows) = step.actual_rows {
+        line.push_str(&format!(" [actual rows: {rows}]"));
+    }
+    println!("{line}");
+    for child in &step.children {
+        render_plan_step(child, depth + 1);
+    }
+}
+
+fn format_step_path(step_path: &[u32]) -> String {
+    if step_path.is_empty() {
+        return "root".to_string();
+    }
+    step_path
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(".")
 }
 
 fn print_text_table<const COLUMNS: usize>(

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -132,6 +132,31 @@ async fn sql_command_renders_json_output() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn explain_command_renders_execution_plan() {
+    let server = MockServer::start().await;
+
+    let assert = server
+        .cmd()
+        .args(["explain", "select text from local_messages.messages where text = 'hello'"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("Execution plan"), "expected plan heading: {stdout}");
+    assert!(stdout.contains("JsonExec"), "expected scan node name: {stdout}");
+    assert!(stdout.contains("local_messages.messages scan"), "expected scan detail: {stdout}");
+    assert!(stdout.contains("predicate pushed into the scan"), "expected pushdown detail: {stdout}");
+    assert!(stdout.contains("filesystem"), "expected cache strategy: {stdout}");
+
+    let requests = server.explain_sql_requests();
+    assert_eq!(requests.len(), 1, "expected one explain_sql call");
+    assert_eq!(requests[0].sql, "select text from local_messages.messages where text = 'hello'");
+    assert_default_workspace(requests[0].workspace.as_ref());
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn source_discover_renders_available_sources() {
     let server = MockServer::start().await;
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -230,6 +230,40 @@ fn mock_sql_response(sql: &str) -> ExecuteSqlResponse {
     }
 }
 
+fn mock_explain_plan() -> QueryPlan {
+    QueryPlan {
+        unoptimized_logical_plan: "LogicalPlan".to_string(),
+        optimized_logical_plan: "OptimizedLogicalPlan".to_string(),
+        physical_plan: "PhysicalPlan".to_string(),
+        execution_plan: Some(coral_api::v1::ExecutionPlan {
+            steps: vec![coral_api::v1::ExecutionPlanStep {
+                kind: "scan".to_string(),
+                name: "JsonExec".to_string(),
+                detail: "local_messages.messages scan".to_string(),
+                estimated_rows: Some(2),
+                actual_rows: None,
+                children: Vec::new(),
+            }],
+            pushdowns: vec![coral_api::v1::PushdownDecision {
+                step_path: vec![0],
+                target: "local_messages.messages".to_string(),
+                predicate: "text = 'hello'".to_string(),
+                applied: true,
+                detail: "predicate pushed into the scan".to_string(),
+            }],
+            cache: vec![coral_api::v1::CacheDecision {
+                step_path: vec![0],
+                target: "local_messages.messages".to_string(),
+                strategy: "filesystem".to_string(),
+                status: "fetched".to_string(),
+                detail: "rows are fetched from local files at execution time".to_string(),
+            }],
+            estimated_rows: Some(2),
+            actual_rows: None,
+        }),
+    }
+}
+
 fn mock_coral_tables_response() -> ExecuteSqlResponse {
     let schema = Schema::new(vec![
         Field::new("schema_name", DataType::Utf8, false),
@@ -548,6 +582,7 @@ fn list_catalog_response(request: &ListCatalogRequest) -> ListCatalogResponse {
 #[derive(Default)]
 struct Captured {
     execute_sql: Mutex<Vec<ExecuteSqlRequest>>,
+    explain_sql: Mutex<Vec<ExplainSqlRequest>>,
     list_catalog: Mutex<Vec<ListCatalogRequest>>,
     search_catalog: Mutex<Vec<SearchCatalogRequest>>,
     describe_table: Mutex<Vec<DescribeTableRequest>>,
@@ -615,14 +650,16 @@ impl QueryService for MockQueryService {
 
     async fn explain_sql(
         &self,
-        _request: Request<ExplainSqlRequest>,
+        request: Request<ExplainSqlRequest>,
     ) -> Result<Response<ExplainSqlResponse>, Status> {
+        let request = request.into_inner();
+        self.captured
+            .explain_sql
+            .lock()
+            .expect("explain_sql capture")
+            .push(request);
         Ok(Response::new(ExplainSqlResponse {
-            plan: Some(QueryPlan {
-                unoptimized_logical_plan: "LogicalPlan".to_string(),
-                optimized_logical_plan: "OptimizedLogicalPlan".to_string(),
-                physical_plan: "PhysicalPlan".to_string(),
-            }),
+            plan: Some(mock_explain_plan()),
         }))
     }
 }
@@ -1013,6 +1050,14 @@ impl MockServer {
             .execute_sql
             .lock()
             .expect("execute_sql capture")
+            .clone()
+    }
+
+    pub(crate) fn explain_sql_requests(&self) -> Vec<ExplainSqlRequest> {
+        self.captured
+            .explain_sql
+            .lock()
+            .expect("explain_sql capture")
             .clone()
     }
 

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -148,15 +148,15 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         JsonExecExplain {
             target: format!("{source_schema}.{}", target.name()),
             detail: format!("HTTP scan {source_schema}.{} via remote request", target.name()),
-            pushdowns: filter_values
-                .iter()
-                .map(|(key, value)| format!("{key}={value}"))
-                .collect(),
-            pushdown_detail: if limit.is_some() {
-                "filters and limit are pushed into the HTTP request".to_string()
-            } else {
-                "filters are pushed into the HTTP request".to_string()
+            pushdowns: {
+                let mut entries: Vec<String> = filter_values
+                    .iter()
+                    .map(|(key, value)| format!("{key}={value}"))
+                    .collect();
+                entries.sort();
+                entries
             },
+            pushdown_detail: pushdown_detail(&filter_values, limit),
             cache: vec![JsonExecCacheEntry {
                 strategy: "remote http".to_string(),
                 status: "fetched".to_string(),
@@ -291,9 +291,18 @@ fn classify_filter(
     TableProviderFilterPushDown::Unsupported
 }
 
+fn pushdown_detail(filter_values: &HashMap<String, String>, limit: Option<usize>) -> String {
+    match (filter_values.is_empty(), limit.is_some()) {
+        (true, true) => "limit is pushed into the HTTP request".to_string(),
+        (true, false) => "no filters were pushed into the HTTP request".to_string(),
+        (false, true) => "filters and limit are pushed into the HTTP request".to_string(),
+        (false, false) => "filters are pushed into the HTTP request".to_string(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::classify_filter;
+    use super::{classify_filter, pushdown_detail};
     use coral_spec::FilterMode;
     use datafusion::common::Column;
     use datafusion::logical_expr::{
@@ -410,5 +419,17 @@ mod tests {
             let pushdown = classify_filter(&expr, &allowed(&["descending"]), &modes(&[]));
             assert_eq!(pushdown, TableProviderFilterPushDown::Unsupported);
         }
+    }
+
+    #[test]
+    fn pushdown_detail_reflects_absent_filters() {
+        let detail = pushdown_detail(&HashMap::new(), None);
+        assert_eq!(detail, "no filters were pushed into the HTTP request");
+    }
+
+    #[test]
+    fn pushdown_detail_reflects_limit_without_filters() {
+        let detail = pushdown_detail(&HashMap::new(), Some(25));
+        assert_eq!(detail, "limit is pushed into the HTTP request");
     }
 }

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -17,7 +17,9 @@ use crate::backends::http::ProviderQueryError;
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{extract_filter_values, literal_to_string};
-use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
+use crate::backends::shared::json_exec::{
+    JsonExec, JsonExecCacheEntry, JsonExecExplain, RowFetcher,
+};
 use crate::backends::shared::mapping::convert_items;
 use coral_spec::FilterMode;
 use coral_spec::backends::http::HttpTableSpec;
@@ -143,6 +145,25 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         fetcher,
         converter,
         projection.cloned(),
+        JsonExecExplain {
+            target: format!("{source_schema}.{}", target.name()),
+            detail: format!("HTTP scan {source_schema}.{} via remote request", target.name()),
+            pushdowns: filter_values
+                .iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect(),
+            pushdown_detail: if limit.is_some() {
+                "filters and limit are pushed into the HTTP request".to_string()
+            } else {
+                "filters are pushed into the HTTP request".to_string()
+            },
+            cache: vec![JsonExecCacheEntry {
+                strategy: "remote http".to_string(),
+                status: "fetched".to_string(),
+                detail: "rows are fetched from the remote service at execution time"
+                    .to_string(),
+            }],
+        },
     )?;
 
     Ok(Arc::new(exec))

--- a/crates/coral-engine/src/backends/jsonl/mod.rs
+++ b/crates/coral-engine/src/backends/jsonl/mod.rs
@@ -15,7 +15,9 @@ use datafusion::physical_plan::ExecutionPlan;
 use serde_json::Value;
 
 use crate::backends::shared::filter_expr::extract_filter_values;
-use crate::backends::shared::json_exec::{Converter, Fetcher, JsonExec, RowFetcher};
+use crate::backends::shared::json_exec::{
+    Converter, Fetcher, JsonExec, JsonExecCacheEntry, JsonExecExplain, RowFetcher,
+};
 use crate::backends::shared::mapping::convert_items;
 use crate::backends::{
     BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
@@ -449,6 +451,22 @@ impl TableProvider for JsonlTableProvider {
             fetcher,
             converter,
             projection.cloned(),
+            JsonExecExplain {
+                target: format!("{}.{}", self.source_schema, self.table.name()),
+                detail: format!(
+                    "JSONL scan {}.{} reads files from the local filesystem",
+                    self.source_schema,
+                    self.table.name()
+                ),
+                pushdowns: Vec::new(),
+                pushdown_detail: "filters are applied after file reads".to_string(),
+                cache: vec![JsonExecCacheEntry {
+                    strategy: "filesystem".to_string(),
+                    status: "fetched".to_string(),
+                    detail: "rows are read from local files when the query runs"
+                        .to_string(),
+                }],
+            },
         )?;
 
         Ok(Arc::new(exec))

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -18,7 +18,7 @@ use super::client::McpSourceClient;
 use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
 use crate::backends::schema_from_columns;
-use crate::backends::shared::json_exec::JsonExec;
+use crate::backends::shared::json_exec::{JsonExec, JsonExecCacheEntry, JsonExecExplain};
 use crate::backends::shared::mapping::convert_items;
 
 #[derive(Clone)]
@@ -177,6 +177,28 @@ impl TableProvider for McpFunctionCallTableProvider {
             fetcher,
             converter,
             projection.cloned(),
+            JsonExecExplain {
+                target: format!("{}.{}", self.state.source_schema, self.state.function_name),
+                detail: format!(
+                    "MCP function scan {}.{} reads rows through tool {}",
+                    self.state.source_schema,
+                    self.state.function_name,
+                    self.state.tool_name
+                ),
+                pushdowns: limit
+                    .map(|limit| vec![format!("limit={limit}")])
+                    .unwrap_or_default(),
+                pushdown_detail: if limit.is_some() {
+                    "the per-request limit is pushed into the tool call".to_string()
+                } else {
+                    "no request arguments were pushed down".to_string()
+                },
+                cache: vec![JsonExecCacheEntry {
+                    strategy: "remote tool call".to_string(),
+                    status: "fetched".to_string(),
+                    detail: "rows are fetched from the tool at execution time".to_string(),
+                }],
+            },
         )?;
         Ok(Arc::new(exec))
     }

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -157,9 +157,14 @@ impl TableProvider for McpTableProvider {
             self.table.limit_binding.as_ref().and_then(|b| b.max),
         );
 
-        if let (Some(binding), Some(push)) = (self.table.limit_binding.as_ref(), limits.push) {
+        let pushed_limit = if let (Some(binding), Some(push)) =
+            (self.table.limit_binding.as_ref(), limits.push)
+        {
             arguments.insert(binding.tool_arg.clone(), Value::from(push));
-        }
+            Some(push)
+        } else {
+            None
+        };
 
         let fetcher = Arc::new(McpFetchPlan {
             backend: self.backend.clone(),
@@ -200,11 +205,10 @@ impl TableProvider for McpTableProvider {
                     self.table.name(),
                     self.table.tool
                 ),
-                pushdowns: limits
-                    .push
+                pushdowns: pushed_limit
                     .map(|push| vec![format!("limit={push}")])
                     .unwrap_or_default(),
-                pushdown_detail: if limits.push.is_some() {
+                pushdown_detail: if pushed_limit.is_some() {
                     "request arguments include the per-request limit".to_string()
                 } else {
                     "no request arguments were pushed down".to_string()

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -18,7 +18,7 @@ use super::error::McpProviderQueryError;
 use super::fetch::McpFetchPlan;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{extract_filter_values, literal_to_string};
-use crate::backends::shared::json_exec::JsonExec;
+use crate::backends::shared::json_exec::{JsonExec, JsonExecCacheEntry, JsonExecExplain};
 use crate::backends::shared::mapping::convert_items;
 use crate::backends::shared::template::{RenderContext, resolve_value_source};
 
@@ -192,6 +192,29 @@ impl TableProvider for McpTableProvider {
             fetcher,
             converter,
             projection.cloned(),
+            JsonExecExplain {
+                target: format!("{}.{}", self.source_schema, self.table.name()),
+                detail: format!(
+                    "MCP scan {}.{} reads rows through tool {}",
+                    self.source_schema,
+                    self.table.name(),
+                    self.table.tool
+                ),
+                pushdowns: limits
+                    .push
+                    .map(|push| vec![format!("limit={push}")])
+                    .unwrap_or_default(),
+                pushdown_detail: if limits.push.is_some() {
+                    "request arguments include the per-request limit".to_string()
+                } else {
+                    "no request arguments were pushed down".to_string()
+                },
+                cache: vec![JsonExecCacheEntry {
+                    strategy: "remote tool call".to_string(),
+                    status: "fetched".to_string(),
+                    detail: "rows are fetched from the tool at execution time".to_string(),
+                }],
+            },
         )?;
         Ok(Arc::new(exec))
     }

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -1008,6 +1008,29 @@ async fn limit_binding_omits_arg_when_no_limit_set() {
 }
 
 #[tokio::test]
+async fn explain_sql_omits_limit_pushdown_without_limit_binding() {
+    let source = crate::QuerySource::new(
+        mcp_table_manifest(),
+        BTreeMap::new(),
+        BTreeMap::new(),
+    );
+
+    let plan = crate::CoralQuery::explain_sql(
+        &[source],
+        crate::QueryRuntimeConfig::default(),
+        "SELECT id FROM test_mcp.issues LIMIT 2",
+    )
+    .await
+    .expect("query should explain");
+
+    let execution_plan = plan.execution_plan().expect("execution plan");
+    assert!(
+        execution_plan.pushdowns().is_empty(),
+        "expected no pushed request arguments in explain metadata"
+    );
+}
+
+#[tokio::test]
 async fn cursor_pagination_fetches_until_response_cursor_is_absent() {
     let ctx = SessionContext::new();
     let caller = Arc::new(FakePaginatedMcpTableCaller {

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -42,6 +42,25 @@ pub(crate) struct JsonExec {
     fetcher: Fetcher,
     converter: Converter,
     projection: Option<Vec<usize>>,
+    explain: JsonExecExplain,
+}
+
+/// Structured metadata used by explain output for a JSON-backed execution node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JsonExecExplain {
+    pub(crate) target: String,
+    pub(crate) detail: String,
+    pub(crate) pushdowns: Vec<String>,
+    pub(crate) pushdown_detail: String,
+    pub(crate) cache: Vec<JsonExecCacheEntry>,
+}
+
+/// One cache note for a JSON-backed execution node.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct JsonExecCacheEntry {
+    pub(crate) strategy: String,
+    pub(crate) status: String,
+    pub(crate) detail: String,
 }
 
 impl fmt::Debug for JsonExec {
@@ -67,6 +86,7 @@ impl JsonExec {
         fetcher: Fetcher,
         converter: Converter,
         projection: Option<Vec<usize>>,
+        explain: JsonExecExplain,
     ) -> Result<Self> {
         let projected_schema = match &projection {
             Some(indices) => Arc::new(schema.project(indices).map_err(|error| {
@@ -89,7 +109,18 @@ impl JsonExec {
             fetcher,
             converter,
             projection,
+            explain,
         })
+    }
+
+    /// Returns the human-readable plan summary for explain output.
+    pub(crate) fn plan_summary(&self) -> String {
+        self.explain.detail.clone()
+    }
+
+    /// Returns structured explain metadata for this scan node.
+    pub(crate) fn explain(&self) -> &JsonExecExplain {
+        &self.explain
     }
 }
 
@@ -175,7 +206,7 @@ mod tests {
     use datafusion::physical_plan::ExecutionPlan;
     use serde_json::Value;
 
-    use super::{Converter, Fetcher, JsonExec, RowFetcher};
+    use super::{Converter, Fetcher, JsonExec, JsonExecExplain, RowFetcher};
 
     #[derive(Debug)]
     struct NoopFetcher;
@@ -215,6 +246,13 @@ mod tests {
             noop_fetcher(),
             converter_with_schema(schema),
             Some(vec![1]),
+            JsonExecExplain {
+                target: "provider.table".to_string(),
+                detail: "provider.table scan".to_string(),
+                pushdowns: Vec::new(),
+                pushdown_detail: String::new(),
+                cache: Vec::new(),
+            },
         )
         .expect("projection should succeed");
 
@@ -233,6 +271,13 @@ mod tests {
             noop_fetcher(),
             converter_with_schema(schema),
             Some(vec![1]),
+            JsonExecExplain {
+                target: "provider.table".to_string(),
+                detail: "provider.table scan".to_string(),
+                pushdowns: Vec::new(),
+                pushdown_detail: String::new(),
+                cache: Vec::new(),
+            },
         )
         .expect_err("invalid projection should return an error");
 

--- a/crates/coral-engine/src/contracts/mod.rs
+++ b/crates/coral-engine/src/contracts/mod.rs
@@ -11,8 +11,9 @@ pub use catalog::{
 };
 pub use error::{CoreError, StatusCode, StructuredQueryError};
 pub use query::{
-    QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource,
-    QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport,
+    CacheDecision, ExecutionPlan, ExecutionPlanStep, PushdownDecision, QueryExecution,
+    QueryPlan, QueryRuntimeConfig, QueryRuntimeContext, QuerySource, QueryTestFailure,
+    QueryTestResult, QueryTestSuccess, SourceValidationReport,
 };
 pub(crate) use query_error::{ColumnParts, TableRefParts};
 

--- a/crates/coral-engine/src/contracts/query.rs
+++ b/crates/coral-engine/src/contracts/query.rs
@@ -215,6 +215,48 @@ pub struct QueryPlan {
     unoptimized_logical: String,
     optimized_logical: String,
     physical: String,
+    execution_plan: Option<ExecutionPlan>,
+}
+
+/// Structured execution-plan metadata for one SQL statement.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionPlan {
+    steps: Vec<ExecutionPlanStep>,
+    pushdowns: Vec<PushdownDecision>,
+    cache: Vec<CacheDecision>,
+    estimated_rows: Option<u64>,
+    actual_rows: Option<u64>,
+}
+
+/// One execution-plan step in tree form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionPlanStep {
+    kind: String,
+    name: String,
+    detail: String,
+    estimated_rows: Option<u64>,
+    actual_rows: Option<u64>,
+    children: Vec<ExecutionPlanStep>,
+}
+
+/// One predicate pushdown decision for a query plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushdownDecision {
+    step_path: Vec<u32>,
+    target: String,
+    predicate: String,
+    applied: bool,
+    detail: String,
+}
+
+/// One cache decision for a query plan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheDecision {
+    step_path: Vec<u32>,
+    target: String,
+    strategy: String,
+    status: String,
+    detail: String,
 }
 
 impl QueryPlan {
@@ -224,11 +266,13 @@ impl QueryPlan {
         unoptimized_logical_plan: String,
         optimized_logical_plan: String,
         physical_plan: String,
+        execution_plan: Option<ExecutionPlan>,
     ) -> Self {
         Self {
             unoptimized_logical: unoptimized_logical_plan,
             optimized_logical: optimized_logical_plan,
             physical: physical_plan,
+            execution_plan,
         }
     }
 
@@ -248,6 +292,220 @@ impl QueryPlan {
     /// Returns the physical execution plan after physical optimizer rules run.
     pub fn physical_plan(&self) -> &str {
         &self.physical
+    }
+
+    #[must_use]
+    /// Returns the structured execution-plan metadata when available.
+    pub fn execution_plan(&self) -> Option<&ExecutionPlan> {
+        self.execution_plan.as_ref()
+    }
+}
+
+impl ExecutionPlan {
+    #[must_use]
+    /// Builds one structured execution plan.
+    pub fn new(
+        steps: Vec<ExecutionPlanStep>,
+        pushdowns: Vec<PushdownDecision>,
+        cache: Vec<CacheDecision>,
+        estimated_rows: Option<u64>,
+        actual_rows: Option<u64>,
+    ) -> Self {
+        Self {
+            steps,
+            pushdowns,
+            cache,
+            estimated_rows,
+            actual_rows,
+        }
+    }
+
+    #[must_use]
+    /// Returns the root execution-plan steps.
+    pub fn steps(&self) -> &[ExecutionPlanStep] {
+        &self.steps
+    }
+
+    #[must_use]
+    /// Returns the pushdown decisions collected for the plan.
+    pub fn pushdowns(&self) -> &[PushdownDecision] {
+        &self.pushdowns
+    }
+
+    #[must_use]
+    /// Returns the cache decisions collected for the plan.
+    pub fn cache(&self) -> &[CacheDecision] {
+        &self.cache
+    }
+
+    #[must_use]
+    /// Returns the estimated row count when available.
+    pub fn estimated_rows(&self) -> Option<u64> {
+        self.estimated_rows
+    }
+
+    #[must_use]
+    /// Returns the actual row count when available.
+    pub fn actual_rows(&self) -> Option<u64> {
+        self.actual_rows
+    }
+}
+
+impl ExecutionPlanStep {
+    #[must_use]
+    /// Builds one execution-plan step.
+    pub fn new(
+        kind: impl Into<String>,
+        name: impl Into<String>,
+        detail: impl Into<String>,
+        estimated_rows: Option<u64>,
+        actual_rows: Option<u64>,
+        children: Vec<ExecutionPlanStep>,
+    ) -> Self {
+        Self {
+            kind: kind.into(),
+            name: name.into(),
+            detail: detail.into(),
+            estimated_rows,
+            actual_rows,
+            children,
+        }
+    }
+
+    #[must_use]
+    /// Returns the step kind.
+    pub fn kind(&self) -> &str {
+        &self.kind
+    }
+
+    #[must_use]
+    /// Returns the step name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[must_use]
+    /// Returns the step detail text.
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+
+    #[must_use]
+    /// Returns the estimated rows for the step when available.
+    pub fn estimated_rows(&self) -> Option<u64> {
+        self.estimated_rows
+    }
+
+    #[must_use]
+    /// Returns the actual rows for the step when available.
+    pub fn actual_rows(&self) -> Option<u64> {
+        self.actual_rows
+    }
+
+    #[must_use]
+    /// Returns the child steps.
+    pub fn children(&self) -> &[ExecutionPlanStep] {
+        &self.children
+    }
+}
+
+impl PushdownDecision {
+    #[must_use]
+    /// Builds one pushdown decision.
+    pub fn new(
+        step_path: Vec<u32>,
+        target: impl Into<String>,
+        predicate: impl Into<String>,
+        applied: bool,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            step_path,
+            target: target.into(),
+            predicate: predicate.into(),
+            applied,
+            detail: detail.into(),
+        }
+    }
+
+    #[must_use]
+    /// Returns the step path for the pushdown decision.
+    pub fn step_path(&self) -> &[u32] {
+        &self.step_path
+    }
+
+    #[must_use]
+    /// Returns the target relation or function.
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+
+    #[must_use]
+    /// Returns the predicate text.
+    pub fn predicate(&self) -> &str {
+        &self.predicate
+    }
+
+    #[must_use]
+    /// Returns whether the pushdown was applied.
+    pub fn applied(&self) -> bool {
+        self.applied
+    }
+
+    #[must_use]
+    /// Returns additional detail text.
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+}
+
+impl CacheDecision {
+    #[must_use]
+    /// Builds one cache decision.
+    pub fn new(
+        step_path: Vec<u32>,
+        target: impl Into<String>,
+        strategy: impl Into<String>,
+        status: impl Into<String>,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            step_path,
+            target: target.into(),
+            strategy: strategy.into(),
+            status: status.into(),
+            detail: detail.into(),
+        }
+    }
+
+    #[must_use]
+    /// Returns the step path for the cache decision.
+    pub fn step_path(&self) -> &[u32] {
+        &self.step_path
+    }
+
+    #[must_use]
+    /// Returns the target relation or function.
+    pub fn target(&self) -> &str {
+        &self.target
+    }
+
+    #[must_use]
+    /// Returns the cache strategy.
+    pub fn strategy(&self) -> &str {
+        &self.strategy
+    }
+
+    #[must_use]
+    /// Returns the cache status.
+    pub fn status(&self) -> &str {
+        &self.status
+    }
+
+    #[must_use]
+    /// Returns additional detail text.
+    pub fn detail(&self) -> &str {
+        &self.detail
     }
 }
 

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -66,10 +66,11 @@ pub use composition::{
     SourceTables,
 };
 pub use contracts::{
-    CatalogInfo, ColumnInfo, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,
-    QueryRuntimeContext, QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess,
-    SourceValidationReport, StatusCode, StructuredQueryError, TableFunctionArgumentInfo,
-    TableFunctionInfo, TableFunctionResultColumnInfo, TableInfo,
+    CacheDecision, CatalogInfo, ColumnInfo, CoreError, ExecutionPlan, ExecutionPlanStep,
+    PushdownDecision, QueryExecution, QueryPlan, QueryRuntimeConfig, QueryRuntimeContext,
+    QuerySource, QueryTestFailure, QueryTestResult, QueryTestSuccess, SourceValidationReport,
+    StatusCode, StructuredQueryError, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
 };
 
 /// High-level query operations for the local query engine.

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -6,6 +6,7 @@ use datafusion::dataframe::DataFrame;
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::physical_plan::displayable;
+use datafusion::physical_plan::ExecutionPlan as PhysicalExecutionPlan;
 use datafusion::prelude::{SQLOptions, SessionConfig, SessionContext};
 use datafusion_tracing::{InstrumentationOptions, RuleInstrumentationOptions};
 
@@ -211,11 +212,13 @@ impl QueryRuntimeAdapter {
             .set_show_schema(true)
             .indent(true)
             .to_string();
+        let execution_plan = build_execution_plan(physical_plan.as_ref());
 
         Ok(QueryPlan::new(
             unoptimized_logical_plan,
             optimized_logical_plan_display,
             physical_plan,
+            Some(execution_plan),
         ))
     }
 
@@ -226,6 +229,133 @@ impl QueryRuntimeAdapter {
             .map_err(|err| datafusion_to_core_with_sql(&err, &self.tables, Some(sql)))
     }
 }
+
+fn build_execution_plan(plan: &dyn PhysicalExecutionPlan) -> crate::ExecutionPlan {
+    let mut pushdowns = Vec::new();
+    let mut cache = Vec::new();
+    let steps = build_execution_steps(plan, Vec::new(), &mut pushdowns, &mut cache);
+    crate::ExecutionPlan::new(
+        vec![steps],
+        pushdowns,
+        cache,
+        estimated_rows(plan),
+        None,
+    )
+}
+
+fn build_execution_steps(
+    plan: &dyn PhysicalExecutionPlan,
+    step_path: Vec<u32>,
+    pushdowns: &mut Vec<crate::PushdownDecision>,
+    cache: &mut Vec<crate::CacheDecision>,
+) -> crate::ExecutionPlanStep {
+    let kind = classify_step_kind(plan.name());
+    let detail = step_detail(plan);
+    if let Some(scan) = scan_metadata(plan) {
+        if !scan.pushdowns.is_empty() {
+            pushdowns.extend(scan.pushdowns.iter().cloned().map(|predicate| {
+                crate::PushdownDecision::new(
+                    step_path.clone(),
+                    scan.target.clone(),
+                    predicate,
+                    true,
+                    scan.pushdown_detail.clone(),
+                )
+            }));
+        }
+        if !scan.cache.is_empty() {
+            cache.extend(scan.cache.iter().cloned().map(|entry| {
+                crate::CacheDecision::new(
+                    step_path.clone(),
+                    scan.target.clone(),
+                    entry.strategy,
+                    entry.status,
+                    entry.detail,
+                )
+            }));
+        }
+        return crate::ExecutionPlanStep::new(
+            kind,
+            plan.name(),
+            detail.unwrap_or_else(|| scan.detail),
+            estimated_rows(plan),
+            None,
+            Vec::new(),
+        );
+    }
+
+    let children = plan
+        .children()
+        .into_iter()
+        .enumerate()
+        .map(|(idx, child)| {
+            let mut child_path = step_path.clone();
+            child_path.push(u32::try_from(idx).unwrap_or(u32::MAX));
+            build_execution_steps(child.as_ref(), child_path, pushdowns, cache)
+        })
+        .collect::<Vec<_>>();
+
+    crate::ExecutionPlanStep::new(
+        kind,
+        plan.name(),
+        detail.unwrap_or_default(),
+        estimated_rows(plan),
+        None,
+        children,
+    )
+}
+
+fn classify_step_kind(name: &str) -> String {
+    let lower = name.to_ascii_lowercase();
+    if lower.contains("join") {
+        "join".to_string()
+    } else if lower.contains("filter") {
+        "filter".to_string()
+    } else if lower.contains("projection") || lower.contains("project") {
+        "projection".to_string()
+    } else if lower.contains("scan") || lower.contains("exec") {
+        "scan".to_string()
+    } else if lower.contains("sort") || lower.contains("order") {
+        "sort".to_string()
+    } else if lower.contains("limit") {
+        "limit".to_string()
+    } else if lower.contains("aggregate") {
+        "aggregate".to_string()
+    } else {
+        "step".to_string()
+    }
+}
+
+fn step_detail(plan: &dyn PhysicalExecutionPlan) -> Option<String> {
+    if let Some(json_exec) = plan
+        .as_any()
+        .downcast_ref::<crate::backends::shared::json_exec::JsonExec>()
+    {
+        return Some(json_exec.plan_summary());
+    }
+    None
+}
+
+fn scan_metadata(
+    plan: &dyn PhysicalExecutionPlan,
+) -> Option<crate::backends::shared::json_exec::JsonExecExplain> {
+    if let Some(json_exec) = plan
+        .as_any()
+        .downcast_ref::<crate::backends::shared::json_exec::JsonExec>()
+    {
+        return Some(json_exec.explain().clone());
+    }
+    None
+}
+
+fn estimated_rows(plan: &dyn PhysicalExecutionPlan) -> Option<u64> {
+    let stats = plan.partition_statistics(None).ok()?;
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    {
+        stats.num_rows.map(|rows| rows as u64)
+    }
+}
+
 
 fn read_only_sql_options() -> SQLOptions {
     SQLOptions::new()

--- a/crates/coral-engine/src/runtime/query.rs
+++ b/crates/coral-engine/src/runtime/query.rs
@@ -313,14 +313,14 @@ fn classify_step_kind(name: &str) -> String {
         "filter".to_string()
     } else if lower.contains("projection") || lower.contains("project") {
         "projection".to_string()
-    } else if lower.contains("scan") || lower.contains("exec") {
-        "scan".to_string()
     } else if lower.contains("sort") || lower.contains("order") {
         "sort".to_string()
     } else if lower.contains("limit") {
         "limit".to_string()
     } else if lower.contains("aggregate") {
         "aggregate".to_string()
+    } else if lower.contains("scan") || lower.contains("exec") {
+        "scan".to_string()
     } else {
         "step".to_string()
     }
@@ -356,6 +356,18 @@ fn estimated_rows(plan: &dyn PhysicalExecutionPlan) -> Option<u64> {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::classify_step_kind;
+
+    #[test]
+    fn classifies_specific_exec_plan_names_before_generic_scan() {
+        assert_eq!(classify_step_kind("SortExec"), "sort");
+        assert_eq!(classify_step_kind("GlobalLimitExec"), "limit");
+        assert_eq!(classify_step_kind("AggregateExec"), "aggregate");
+        assert_eq!(classify_step_kind("ParquetExec"), "scan");
+    }
+}
 
 fn read_only_sql_options() -> SQLOptions {
     SQLOptions::new()

--- a/crates/coral-engine/tests/engine/jsonl_tests.rs
+++ b/crates/coral-engine/tests/engine/jsonl_tests.rs
@@ -126,6 +126,16 @@ async fn explain_sql_returns_logical_and_physical_plans() {
     assert!(plan.unoptimized_logical_plan().contains("jsonl_plan.users"));
     assert!(plan.optimized_logical_plan().contains("jsonl_plan.users"));
     assert!(plan.physical_plan().contains("Exec"));
+
+    let execution_plan = plan.execution_plan().expect("execution plan");
+    assert!(!execution_plan.steps().is_empty(), "expected structured steps");
+    assert!(
+        execution_plan
+            .steps()
+            .iter()
+            .any(|step| step.detail().contains("jsonl_plan.users")),
+        "expected scan details to mention the source table"
+    );
 }
 
 fn github_pulls_source(dir: &Path) -> coral_engine::QuerySource {

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -19,6 +19,16 @@ coral sql "<SQL>"
 
 JSON output is an array of row objects. Selected nullable columns are included with explicit `null` values when the row value is null.
 
+## `coral explain`
+
+Show the query engine's execution plan for one SQL statement without running it.
+
+```shellscript
+coral explain "SELECT * FROM github.issues WHERE state = 'open'"
+```
+
+The default output is a human-readable execution tree plus tables for pushed-down predicates and cache decisions when the engine can derive them. Use `--format json` to emit the full structured plan as JSON for tooling or agents.
+
 ## `coral source`
 
 Manage configured sources, either the bundled ones, or your custom source specs.


### PR DESCRIPTION
Implemented `coral explain` end to end. The query proto now carries a structured execution-plan payload, the engine builds it from the physical plan tree, and the CLI can render it as a human-readable tree/table or JSON. The main touch points are query.proto, query.rs, lib.rs, and the new docs in cli-reference.mdx.

I also updated the CLI and engine tests to cover the new explain path, including request capture and structured-plan assertions. Estimated row counts are populated where the engine can derive them; actual row counts remain empty for static `explain` output.

Validation is partially complete: file-level Rust checks passed on all touched files, but I could not run `cargo check` in this environment because `cargo` is not installed or available on `PATH` here. 


closes #671