### PR TITLE
Add google forms community source

### DIFF
--- a/sources/community/gmail/manifest.yaml
+++ b/sources/community/gmail/manifest.yaml
@@ -1,0 +1,320 @@
+name: gmail
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Gmail messages, threads, labels, drafts, and profile
+  information from your Google Gmail account using the Gmail REST API.
+inputs:
+  GMAIL_ACCESS_TOKEN:
+    kind: secret
+    hint: >-
+      Google OAuth2 access token with Gmail read-only scope.
+      Generate one at https://developers.google.com/oauthplayground
+      using the scope https://www.googleapis.com/auth/gmail.readonly
+base_url: "https://gmail.googleapis.com"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.GMAIL_ACCESS_TOKEN}}"
+test_queries:
+  - SELECT history_id, messages_total, threads_total FROM gmail.profile LIMIT 1
+  - SELECT id, thread_id FROM gmail.messages LIMIT 5
+  - SELECT id, name, type FROM gmail.labels LIMIT 5
+tables:
+  - name: profile
+    description: >
+      Returns the Gmail profile for the authenticated user. Includes
+      email address, total message count, total thread count, and history ID.
+    guide: >
+      `SELECT email_address, messages_total, threads_total FROM gmail.profile`.
+    request:
+      method: GET
+      path: /gmail/v1/users/me/profile
+    response:
+      row_strategy: single
+    pagination:
+      mode: none
+    columns:
+      - name: email_address
+        type: Utf8
+        nullable: false
+        description: The user's email address.
+        expr:
+          kind: path
+          path:
+            - emailAddress
+      - name: messages_total
+        type: Int64
+        nullable: true
+        description: Total number of messages in the mailbox.
+        expr:
+          kind: path
+          path:
+            - messagesTotal
+      - name: threads_total
+        type: Int64
+        nullable: true
+        description: Total number of threads in the mailbox.
+        expr:
+          kind: path
+          path:
+            - threadsTotal
+      - name: history_id
+        type: Utf8
+        nullable: true
+        description: The ID of the mailbox's current history record.
+        expr:
+          kind: path
+          path:
+            - historyId
+
+  - name: labels
+    description: >
+      Lists all labels in the authenticated user's mailbox. Includes
+      system labels (INBOX, SENT, DRAFT, SPAM, TRASH) and user-created labels.
+    guide: >
+      `SELECT id, name, type FROM gmail.labels`.
+    request:
+      method: GET
+      path: /gmail/v1/users/me/labels
+    response:
+      rows_path:
+        - labels
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique label ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Display name of the label.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Label type, either system or user.
+        expr:
+          kind: path
+          path:
+            - type
+      - name: message_list_visibility
+        type: Utf8
+        nullable: true
+        description: Whether to show or hide the label in the message list.
+        expr:
+          kind: path
+          path:
+            - messageListVisibility
+      - name: label_list_visibility
+        type: Utf8
+        nullable: true
+        description: Whether to show the label in the label list.
+        expr:
+          kind: path
+          path:
+            - labelListVisibility
+
+  - name: messages
+    description: >
+      Lists messages in the authenticated user's mailbox. Returns message ID
+      and thread ID. Use label_ids filter to scope to INBOX, SENT, DRAFT, SPAM, or TRASH.
+    guide: >
+      `SELECT id, thread_id FROM gmail.messages LIMIT 20`.
+      Filter by label: `SELECT id, thread_id FROM gmail.messages WHERE label_ids = 'INBOX' LIMIT 20`.
+    filters:
+      - name: label_ids
+        required: false
+      - name: q
+        required: false
+    request:
+      method: GET
+      path: /gmail/v1/users/me/messages
+      query:
+        - name: labelIds
+          from: filter
+          key: label_ids
+        - name: q
+          from: filter
+          key: q
+    response:
+      rows_path:
+        - messages
+    pagination:
+      mode: cursor
+      cursor_path:
+        - nextPageToken
+      cursor_param: pageToken
+      page_size:
+        default: 100
+        max: 500
+        query_param: maxResults
+    columns:
+      - name: label_ids
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional label filter (e.g. INBOX, SENT, DRAFT, SPAM, TRASH).
+        expr:
+          kind: from_filter
+          key: label_ids
+      - name: q
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional Gmail search query filter (e.g. from:someone@gmail.com).
+        expr:
+          kind: from_filter
+          key: q
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique message ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: thread_id
+        type: Utf8
+        nullable: true
+        description: ID of the thread the message belongs to.
+        expr:
+          kind: path
+          path:
+            - threadId
+
+  - name: threads
+    description: >
+      Lists threads in the authenticated user's mailbox. Returns thread ID,
+      snippet, and history ID.
+    guide: >
+      `SELECT id, snippet FROM gmail.threads LIMIT 20`.
+    filters:
+      - name: label_ids
+        required: false
+      - name: q
+        required: false
+    request:
+      method: GET
+      path: /gmail/v1/users/me/threads
+      query:
+        - name: labelIds
+          from: filter
+          key: label_ids
+        - name: q
+          from: filter
+          key: q
+    response:
+      rows_path:
+        - threads
+    pagination:
+      mode: cursor
+      cursor_path:
+        - nextPageToken
+      cursor_param: pageToken
+      page_size:
+        default: 100
+        max: 500
+        query_param: maxResults
+    columns:
+      - name: label_ids
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional label filter (e.g. INBOX, SENT, SPAM, TRASH).
+        expr:
+          kind: from_filter
+          key: label_ids
+      - name: q
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional Gmail search query filter.
+        expr:
+          kind: from_filter
+          key: q
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique thread ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: snippet
+        type: Utf8
+        nullable: true
+        description: Short snippet of the thread's latest message.
+        expr:
+          kind: path
+          path:
+            - snippet
+      - name: history_id
+        type: Utf8
+        nullable: true
+        description: The ID of the last history record that modified this thread.
+        expr:
+          kind: path
+          path:
+            - historyId
+
+  - name: drafts
+    description: >
+      Lists all drafts in the authenticated user's mailbox. Returns draft ID
+      and the associated message ID and thread ID.
+    guide: >
+      `SELECT id, message_id, message_thread_id FROM gmail.drafts LIMIT 20`.
+    request:
+      method: GET
+      path: /gmail/v1/users/me/drafts
+    response:
+      rows_path:
+        - drafts
+    pagination:
+      mode: cursor
+      cursor_path:
+        - nextPageToken
+      cursor_param: pageToken
+      page_size:
+        default: 100
+        max: 500
+        query_param: maxResults
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique draft ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: message_id
+        type: Utf8
+        nullable: true
+        description: ID of the message associated with this draft.
+        expr:
+          kind: path
+          path:
+            - message
+            - id
+      - name: message_thread_id
+        type: Utf8
+        nullable: true
+        description: Thread ID of the message associated with this draft.
+        expr:
+          kind: path
+          path:
+            - message
+            - threadId

--- a/sources/community/google_forms/manifest.yaml
+++ b/sources/community/google_forms/manifest.yaml
@@ -1,0 +1,173 @@
+name: google_forms
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Google Forms form definitions and responses using the
+  Google Forms REST API v1.
+inputs:
+  GOOGLE_FORMS_ACCESS_TOKEN:
+    kind: secret
+    hint: >-
+      Google OAuth2 access token with Google Forms read-only scope.
+      Generate one at https://developers.google.com/oauthplayground
+      using the scopes https://www.googleapis.com/auth/forms.body.readonly
+      and https://www.googleapis.com/auth/forms.responses.readonly
+base_url: "https://forms.googleapis.com"
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.GOOGLE_FORMS_ACCESS_TOKEN}}"
+test_queries:
+  - SELECT form_id, title, description FROM google_forms.forms LIMIT 5
+  - SELECT response_id, respondent_email, last_submitted_time FROM google_forms.responses LIMIT 5
+tables:
+  - name: forms
+    description: >
+      Returns metadata and structure of a Google Form by its form ID.
+      Includes title, description, document title, and whether it
+      accepts responses.
+    guide: >
+      `SELECT form_id, title, description FROM google_forms.forms
+      WHERE form_id = 'YOUR_FORM_ID'`.
+      You must provide a form_id filter to retrieve a specific form.
+    filters:
+      - name: form_id
+        required: true
+    request:
+      method: GET
+      path: "/v1/forms/{{filter.form_id}}"
+    response:
+      row_strategy: single
+    pagination:
+      mode: none
+    columns:
+      - name: form_id
+        type: Utf8
+        nullable: false
+        description: Unique form ID.
+        expr:
+          kind: path
+          path:
+            - formId
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Title of the form shown to respondents.
+        expr:
+          kind: path
+          path:
+            - info
+            - title
+      - name: document_title
+        type: Utf8
+        nullable: true
+        description: Title of the form document in Google Drive.
+        expr:
+          kind: path
+          path:
+            - info
+            - documentTitle
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of the form shown to respondents.
+        expr:
+          kind: path
+          path:
+            - info
+            - description
+      - name: responder_uri
+        type: Utf8
+        nullable: true
+        description: Public URI to share with respondents.
+        expr:
+          kind: path
+          path:
+            - responderUri
+      - name: linked_sheet_id
+        type: Utf8
+        nullable: true
+        description: ID of the linked Google Sheet collecting responses.
+        expr:
+          kind: path
+          path:
+            - linkedSheetId
+
+  - name: responses
+    description: >
+      Lists all responses submitted to a Google Form. Returns respondent
+      email, submission time, and raw answers as JSON.
+    guide: >
+      `SELECT response_id, respondent_email, last_submitted_time
+      FROM google_forms.responses WHERE form_id = 'YOUR_FORM_ID' LIMIT 20`.
+      You must provide a form_id filter.
+    filters:
+      - name: form_id
+        required: true
+    request:
+      method: GET
+      path: "/v1/forms/{{filter.form_id}}/responses"
+    response:
+      rows_path:
+        - responses
+    pagination:
+      mode: cursor
+      cursor_path:
+        - nextPageToken
+      cursor_param: pageToken
+      page_size:
+        default: 100
+        max: 5000
+        query_param: pageSize
+    columns:
+      - name: form_id
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: The form ID filter used to retrieve responses.
+        expr:
+          kind: from_filter
+          key: form_id
+      - name: response_id
+        type: Utf8
+        nullable: false
+        description: Unique response ID.
+        expr:
+          kind: path
+          path:
+            - responseId
+      - name: respondent_email
+        type: Utf8
+        nullable: true
+        description: Email of the respondent if collected.
+        expr:
+          kind: path
+          path:
+            - respondentEmail
+      - name: create_time
+        type: Utf8
+        nullable: true
+        description: When the response was first created (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - createTime
+      - name: last_submitted_time
+        type: Utf8
+        nullable: true
+        description: When the response was last submitted (ISO 8601).
+        expr:
+          kind: path
+          path:
+            - lastSubmittedTime
+      - name: answers
+        type: Json
+        nullable: true
+        description: Map of question IDs to answer values.
+        expr:
+          kind: path
+          path:
+            - answers


### PR DESCRIPTION
Following up on my Gmail source PR — I've added a Google Forms 
source spec that lets you query your Google Forms data using SQL.

With this you can do things like:

SELECT form_id, title, description FROM google_forms.forms WHERE form_id = 'YOUR_FORM_ID'
SELECT response_id, respondent_email, last_submitted_time FROM google_forms.responses WHERE form_id = 'YOUR_FORM_ID' LIMIT 20

## What's included
- forms — get form metadata like title, description, and responder URL
- responses — list all responses submitted to a form with respondent email and answers

## Auth
Uses a Google OAuth2 access token with two scopes:
- forms.body.readonly
- forms.responses.readonly

Easy to generate via Google OAuth Playground.

Happy to make changes if needed. Thanks!