### PR TITLE
feat(sources/community/spotify): add Spotify community source

### DIFF
--- a/sources/community/spotify/README.md
+++ b/sources/community/spotify/README.md
@@ -8,6 +8,10 @@ the Spotify Web API with OAuth 2.0 authorization-code and PKCE.
 
 ### 1. Create a Spotify app
 
+> **Spotify Premium required**: the app owner must hold an active Spotify
+> Premium subscription (including Family or Duo plans) to use the Web API in
+> Development Mode. If the subscription lapses, the app will stop working.
+
 Open the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
 and create an app (or use an existing one).
 
@@ -37,11 +41,16 @@ cargo run -p coral-cli -- source add --file sources/community/spotify/manifest.y
 ```
 
 Coral will open your browser to the Spotify authorization page. After you
-approve the requested scopes, Coral stores the access token automatically and
-handles token refresh.
+approve the requested scopes, Coral stores the access token and refresh token
+automatically. Token refresh is handled transparently — no manual intervention
+is needed.
 
-To paste a token manually instead of using the browser flow, run the source
-add command and choose **Paste access token** when prompted.
+**Manual token path (short-lived)**: To paste a token instead of using the
+browser flow, run the source add command and choose **Paste access token** when
+prompted. `SPOTIFY_CLIENT_ID` is not required for this path. However, Spotify
+access tokens expire after **one hour** and cannot be refreshed without the
+Client ID. The paste path is intended for quick testing only — it will stop
+working after expiry.
 
 ### 4. Verify
 
@@ -111,13 +120,16 @@ ORDER BY added_at DESC
 LIMIT 20;
 ```
 
-Saved tracks by a specific artist:
+Saved tracks by a specific artist (note: `artist_name` is not pushed down
+to Spotify — Coral fetches pages until the result is complete or the fetch
+limit is reached):
 
 ```sql
 SELECT track_name, album_name, added_at, duration_ms
 FROM spotify.saved_tracks
 WHERE artist_name = 'Radiohead'
-ORDER BY added_at DESC;
+ORDER BY added_at DESC
+LIMIT 50;
 ```
 
 Explicit saved tracks sorted by popularity:
@@ -196,9 +208,18 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 ## Notes
 
+- **Spotify Premium required**: the app owner must hold an active Spotify
+  Premium subscription to use the Web API in Development Mode. This includes
+  Family and Duo plans. If the subscription lapses, API calls will fail.
+- **Token expiry and refresh**: Spotify access tokens expire after one hour.
+  The OAuth browser flow issues a refresh token, which Coral uses automatically.
+  The **Paste access token** path does not issue a refresh token and will stop
+  working after one hour unless `SPOTIFY_CLIENT_ID` is also set — in which
+  case Coral can still refresh. Use the browser flow for long-lived usage.
 - **OAuth PKCE**: Spotify requires PKCE for public clients. No client secret is
   used or stored. The `SPOTIFY_CLIENT_ID` variable holds the app's Client ID,
-  which is not secret.
+  which is not a credential. It can be left blank for the paste-token path,
+  but token refresh will not work without it.
 - **Redirect URI**: Spotify requires the loopback IP literal
   `http://127.0.0.1:53682/oauth/callback`. Add this URI exactly in your
   Spotify app dashboard. `localhost` and `127.0.0.1:0` are not accepted.
@@ -207,14 +228,20 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
   must be manually added to the **Users and Access** allowlist in the Spotify
   Developer Dashboard. Moving beyond 5 users requires Extended Quota Mode,
   which Spotify currently grants only to registered organizations.
+- **saved_tracks fetch limit**: `saved_tracks` has a default fetch limit of
+  100 tracks. Filters such as `artist_name` are not pushed down to Spotify —
+  Coral fetches pages until the limit is reached or pages are exhausted.
+  Always include a `LIMIT` clause when querying with non-pushdown filters to
+  avoid scanning a large library and hitting Spotify's rolling rate limit.
 - **Offset pagination**: All four tables use offset-based pagination with a
   maximum page size of 50. Spotify caps the total reachable offset at 1000 for
   some endpoints. Users with very large libraries may not be able to page
   beyond the first 1000 items.
 - **Nested fields**: Several columns are sourced from nested API response
-  objects. `tracks_total` in `playlists` comes from `tracks.total`.
-  `followers_total` in `top_artists` comes from `followers.total`. These are
-  not flat fields in the Spotify response.
+  objects. `tracks_total` in `playlists` comes from `tracks.total` on each
+  SimplifiedPlaylistObject — this is the track count for that individual
+  playlist, not the total number of playlists. `followers_total` in
+  `top_artists` comes from `followers.total`. These are not flat fields.
 - **Primary artist**: `artist_name` and `artist_id` in `saved_tracks` and
   `top_tracks` reflect the first element of the API's `artists` array. Use
   the `artists` Json column for the complete artist list.
@@ -224,8 +251,6 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 - **description and public nullability**: `description` is null for
   unmodified or unverified playlists. `public` can be null when the status is
   not applicable.
-- **Token refresh**: Coral handles OAuth token refresh automatically using the
-  stored refresh token. No manual intervention is required.
 - **Rate limits**: The Spotify Web API enforces rate limits on a rolling
   30-second window. On a `429 Too Many Requests` response Spotify returns a
   `Retry-After` header. Coral will surface the error; add retries or reduce

--- a/sources/community/spotify/README.md
+++ b/sources/community/spotify/README.md
@@ -1,0 +1,244 @@
+# Spotify community source
+
+The `spotify` community source exposes read-only Spotify data through Coral
+SQL. Query your playlists, saved tracks, top artists, and top tracks using
+the Spotify Web API with OAuth 2.0 authorization-code and PKCE.
+
+## Setup
+
+### 1. Create a Spotify app
+
+Open the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
+and create an app (or use an existing one).
+
+In the app settings, add the following redirect URI exactly as shown:
+
+```
+http://127.0.0.1:53682/oauth/callback
+```
+
+> **Important**: Spotify no longer accepts `localhost` aliases. The loopback
+> IP literal `127.0.0.1` is required. Using `localhost` will cause
+> authorization to fail.
+
+Copy the **Client ID** from the app dashboard. Do not use the client secret —
+this source uses the PKCE public-client flow and does not need one.
+
+### 2. Set your Client ID
+
+```sh
+export SPOTIFY_CLIENT_ID="<your_client_id>"
+```
+
+### 3. Add the source
+
+```sh
+cargo run -p coral-cli -- source add --file sources/community/spotify/manifest.yaml
+```
+
+Coral will open your browser to the Spotify authorization page. After you
+approve the requested scopes, Coral stores the access token automatically and
+handles token refresh.
+
+To paste a token manually instead of using the browser flow, run the source
+add command and choose **Paste access token** when prompted.
+
+### 4. Verify
+
+```sh
+cargo run -p coral-cli -- source test spotify
+```
+
+## Required scopes
+
+| Scope | Tables |
+|---|---|
+| `playlist-read-private` | `spotify.playlists` |
+| `playlist-read-collaborative` | `spotify.playlists` |
+| `user-library-read` | `spotify.saved_tracks` |
+| `user-top-read` | `spotify.top_artists`, `spotify.top_tracks` |
+
+Coral requests all four scopes in a single authorization. If you scope your
+token manually, include every scope for the tables you plan to query.
+
+## Tables
+
+| Table | Description | Optional filters | Pagination |
+|---|---|---|---|
+| `spotify.playlists` | Playlists owned by or followed by the authenticated user | none | offset |
+| `spotify.saved_tracks` | Tracks saved to the user's Liked Songs library | none | offset |
+| `spotify.top_artists` | Top artists by listening affinity | `time_range` | offset |
+| `spotify.top_tracks` | Top tracks by listening affinity | `time_range` | offset |
+
+All tables are read-only. This source does not create, modify, or delete any
+Spotify data.
+
+The `time_range` filter for `top_artists` and `top_tracks` accepts:
+
+| Value | Window |
+|---|---|
+| `short_term` | approximately last 4 weeks |
+| `medium_term` | approximately last 6 months (default) |
+| `long_term` | approximately last 1 year |
+
+## Example queries
+
+List your playlists with track counts:
+
+```sql
+SELECT id, name, tracks_total, owner_name, public, collaborative
+FROM spotify.playlists
+ORDER BY name
+LIMIT 20;
+```
+
+Find your longest collaborative playlists:
+
+```sql
+SELECT id, name, tracks_total, owner_name
+FROM spotify.playlists
+WHERE collaborative IS TRUE
+ORDER BY tracks_total DESC
+LIMIT 10;
+```
+
+Most recently saved tracks with primary artist:
+
+```sql
+SELECT added_at, track_name, artist_name, album_name, popularity
+FROM spotify.saved_tracks
+ORDER BY added_at DESC
+LIMIT 20;
+```
+
+Saved tracks by a specific artist:
+
+```sql
+SELECT track_name, album_name, added_at, duration_ms
+FROM spotify.saved_tracks
+WHERE artist_name = 'Radiohead'
+ORDER BY added_at DESC;
+```
+
+Explicit saved tracks sorted by popularity:
+
+```sql
+SELECT track_name, artist_name, popularity, album_name
+FROM spotify.saved_tracks
+WHERE explicit IS TRUE
+ORDER BY popularity DESC
+LIMIT 20;
+```
+
+Your all-time top artists with genre and follower data:
+
+```sql
+SELECT name, popularity, followers_total, genres_joined
+FROM spotify.top_artists
+WHERE time_range = 'long_term'
+ORDER BY popularity DESC
+LIMIT 20;
+```
+
+Compare your top artists across time ranges:
+
+```sql
+SELECT 'short_term' AS period, name, popularity FROM spotify.top_artists WHERE time_range = 'short_term'
+UNION ALL
+SELECT 'long_term'  AS period, name, popularity FROM spotify.top_artists WHERE time_range = 'long_term'
+ORDER BY period, popularity DESC;
+```
+
+Your recent top tracks with album context:
+
+```sql
+SELECT name, artist_name, album_name, popularity, duration_ms
+FROM spotify.top_tracks
+WHERE time_range = 'short_term'
+ORDER BY popularity DESC
+LIMIT 20;
+```
+
+Cross-reference top tracks against saved library:
+
+```sql
+SELECT t.name, t.artist_name, t.popularity,
+       s.added_at IS NOT NULL AS in_library
+FROM spotify.top_tracks t
+LEFT JOIN spotify.saved_tracks s ON t.id = s.track_id
+WHERE t.time_range = 'medium_term'
+ORDER BY t.popularity DESC
+LIMIT 20;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/spotify/manifest.yaml
+```
+
+Install and run the built-in test queries:
+
+```sh
+export SPOTIFY_CLIENT_ID="<your_client_id>"
+cargo run -p coral-cli -- source add --file sources/community/spotify/manifest.yaml
+cargo run -p coral-cli -- source test spotify
+```
+
+Inspect registered tables and columns:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'spotify'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'spotify' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- **OAuth PKCE**: Spotify requires PKCE for public clients. No client secret is
+  used or stored. The `SPOTIFY_CLIENT_ID` variable holds the app's Client ID,
+  which is not secret.
+- **Redirect URI**: Spotify requires the loopback IP literal
+  `http://127.0.0.1:53682/oauth/callback`. Add this URI exactly in your
+  Spotify app dashboard. `localhost` and `127.0.0.1:0` are not accepted.
+- **Development Mode limit**: Spotify apps in Development Mode allow at most
+  5 authenticated users (the app owner plus 4 others). Each additional user
+  must be manually added to the **Users and Access** allowlist in the Spotify
+  Developer Dashboard. Moving beyond 5 users requires Extended Quota Mode,
+  which Spotify currently grants only to registered organizations.
+- **Offset pagination**: All four tables use offset-based pagination with a
+  maximum page size of 50. Spotify caps the total reachable offset at 1000 for
+  some endpoints. Users with very large libraries may not be able to page
+  beyond the first 1000 items.
+- **Nested fields**: Several columns are sourced from nested API response
+  objects. `tracks_total` in `playlists` comes from `tracks.total`.
+  `followers_total` in `top_artists` comes from `followers.total`. These are
+  not flat fields in the Spotify response.
+- **Primary artist**: `artist_name` and `artist_id` in `saved_tracks` and
+  `top_tracks` reflect the first element of the API's `artists` array. Use
+  the `artists` Json column for the complete artist list.
+- **album_release_date format**: Spotify returns release dates with variable
+  precision — YYYY, YYYY-MM, or YYYY-MM-DD. The column is exposed as `Utf8`
+  to preserve the original string.
+- **description and public nullability**: `description` is null for
+  unmodified or unverified playlists. `public` can be null when the status is
+  not applicable.
+- **Token refresh**: Coral handles OAuth token refresh automatically using the
+  stored refresh token. No manual intervention is required.
+- **Rate limits**: The Spotify Web API enforces rate limits on a rolling
+  30-second window. On a `429 Too Many Requests` response Spotify returns a
+  `Retry-After` header. Coral will surface the error; add retries or reduce
+  query frequency if you hit limits.
+
+## Out of scope for v1
+
+- Track audio features (endpoint restricted to pre-approved apps by Spotify)
+- Artist related tracks and related artists (restricted endpoint)
+- Track recommendations (restricted endpoint)
+- Playlist track contents (requires per-playlist requests)
+- Recently played tracks (`user-read-recently-played` scope)
+- Followed artists (`user-follow-read` scope)
+- Saved albums (`user-library-read` scope, separate endpoint)
+- User profile (`user-read-private`, `user-read-email` scopes)
+- Write operations of any kind

--- a/sources/community/spotify/README.md
+++ b/sources/community/spotify/README.md
@@ -47,10 +47,10 @@ is needed.
 
 **Manual token path (short-lived)**: To paste a token instead of using the
 browser flow, run the source add command and choose **Paste access token** when
-prompted. `SPOTIFY_CLIENT_ID` is not required for this path. However, Spotify
-access tokens expire after **one hour** and cannot be refreshed without the
-Client ID. The paste path is intended for quick testing only — it will stop
-working after expiry.
+prompted. `SPOTIFY_CLIENT_ID` is not required for this path. However, the paste
+path bypasses the OAuth flow entirely — no refresh token is issued. Spotify
+access tokens expire after **one hour** with no way to refresh them. This path
+is intended for quick testing only.
 
 ### 4. Verify
 
@@ -212,14 +212,15 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
   Premium subscription to use the Web API in Development Mode. This includes
   Family and Duo plans. If the subscription lapses, API calls will fail.
 - **Token expiry and refresh**: Spotify access tokens expire after one hour.
-  The OAuth browser flow issues a refresh token, which Coral uses automatically.
-  The **Paste access token** path does not issue a refresh token and will stop
-  working after one hour unless `SPOTIFY_CLIENT_ID` is also set — in which
-  case Coral can still refresh. Use the browser flow for long-lived usage.
+  The OAuth browser flow issues a refresh token, which Coral uses automatically
+  for transparent long-lived access. The **Paste access token** path bypasses
+  the OAuth flow and issues no refresh token — the token expires after one hour
+  with no refresh capability regardless of whether `SPOTIFY_CLIENT_ID` is set.
+  Use the browser flow for any usage beyond quick testing.
 - **OAuth PKCE**: Spotify requires PKCE for public clients. No client secret is
   used or stored. The `SPOTIFY_CLIENT_ID` variable holds the app's Client ID,
   which is not a credential. It can be left blank for the paste-token path,
-  but token refresh will not work without it.
+  but no refresh token is available on that path regardless.
 - **Redirect URI**: Spotify requires the loopback IP literal
   `http://127.0.0.1:53682/oauth/callback`. Add this URI exactly in your
   Spotify app dashboard. `localhost` and `127.0.0.1:0` are not accepted.

--- a/sources/community/spotify/README.md
+++ b/sources/community/spotify/README.md
@@ -235,13 +235,16 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
   Always include a `LIMIT` clause when querying with non-pushdown filters to
   avoid scanning a large library and hitting Spotify's rolling rate limit.
 - **Offset pagination**: All four tables use offset-based pagination with a
-  maximum page size of 50. Spotify caps the total reachable offset at 1000 for
-  some endpoints. Users with very large libraries may not be able to page
-  beyond the first 1000 items.
+  maximum page size of 50. The `playlists` table supports a maximum offset
+  of 100,000 (per the Spotify API spec). The `saved_tracks` and `top_artists`
+  / `top_tracks` tables do not document a hard offset cap in the current API
+  reference for the access levels this source uses.
 - **Nested fields**: Several columns are sourced from nested API response
-  objects. `tracks_total` in `playlists` comes from `tracks.total` on each
-  SimplifiedPlaylistObject — this is the track count for that individual
-  playlist, not the total number of playlists. `followers_total` in
+  objects. `tracks_total` in `playlists` comes from `items.total` on each
+  `SimplifiedPlaylistObject` — this is the `PlaylistTracksRefObject` that
+  holds a link and the track count for that playlist. The `tracks` field
+  carrying the same data is marked deprecated in the Spotify OpenAPI schema
+  (February 2026) with "Use `items` instead". `followers_total` in
   `top_artists` comes from `followers.total`. These are not flat fields.
 - **Primary artist**: `artist_name` and `artist_id` in `saved_tracks` and
   `top_tracks` reflect the first element of the API's `artists` array. Use

--- a/sources/community/spotify/manifest.yaml
+++ b/sources/community/spotify/manifest.yaml
@@ -279,8 +279,10 @@ tables:
               - added_at
       - name: track_id
         type: Utf8
-        nullable: false
-        description: Spotify track ID.
+        nullable: true
+        description: >-
+          Spotify track ID. Null for local files in the user's library
+          (is_local = true) — those tracks have no Spotify ID.
         expr:
           kind: path
           path:

--- a/sources/community/spotify/manifest.yaml
+++ b/sources/community/spotify/manifest.yaml
@@ -62,10 +62,11 @@ inputs:
       Make sure http://127.0.0.1:53682/oauth/callback is listed as an
       allowed redirect URI in that app's settings.
 
-      Leave blank only if you are using the "Paste access token" method
-      and are managing token refresh yourself. Spotify access tokens
-      expire after one hour and cannot be refreshed without the Client
-      ID — the paste path is therefore short-lived.
+      Leave blank only if you are using the "Paste access token" method.
+      That path bypasses the OAuth flow entirely — no refresh token is issued,
+      so the pasted token will expire after one hour with no way to refresh it.
+      SPOTIFY_CLIENT_ID does not help on the paste path. Use the browser OAuth
+      flow for long-lived access.
 
 auth:
   type: HeaderAuth

--- a/sources/community/spotify/manifest.yaml
+++ b/sources/community/spotify/manifest.yaml
@@ -1,0 +1,835 @@
+name: spotify
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query playlists, saved tracks, top artists, and top tracks from Spotify
+  using OAuth 2.0 authorization-code with PKCE. All data is read-only and
+  scoped to the authenticated Spotify user.
+base_url: https://api.spotify.com
+
+inputs:
+  SPOTIFY_TOKEN:
+    kind: secret
+    hint: |
+      Spotify OAuth access token with read-only scopes. Click
+      "Connect with Spotify" to authorize through the browser — Coral
+      will handle the PKCE flow and store the token automatically.
+
+      You must supply your own Spotify app Client ID. Create a Spotify
+      app at https://developer.spotify.com/dashboard, add
+      http://127.0.0.1:53682/oauth/callback as an allowed redirect URI
+      (do not use localhost — Spotify requires the loopback IP literal),
+      copy the Client ID, and set SPOTIFY_CLIENT_ID before running
+      source add.
+
+      Note: apps in Development Mode are limited to 5 authenticated
+      users. Extended Quota Mode is required for broader access and is
+      available only to registered organizations.
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with Spotify
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: required
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            endpoints:
+              authorization_url: https://accounts.spotify.com/authorize
+              token_url: https://accounts.spotify.com/api/token
+            client:
+              id:
+                input: SPOTIFY_CLIENT_ID
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - playlist-read-private
+                  - playlist-read-collaborative
+                  - user-library-read
+                  - user-top-read
+        - type: source_config
+          label: Paste access token
+
+  SPOTIFY_CLIENT_ID:
+    kind: variable
+    hint: |
+      Your Spotify app Client ID (not the client secret). Find it in the
+      Spotify Developer Dashboard at https://developer.spotify.com/dashboard
+      after creating or selecting an app. Make sure
+      http://127.0.0.1:53682/oauth/callback is listed as a redirect URI
+      in that app's settings.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.SPOTIFY_TOKEN}}
+
+test_queries:
+  - SELECT id, name, tracks_total FROM spotify.playlists LIMIT 1
+  - SELECT track_id, track_name, artist_name FROM spotify.saved_tracks LIMIT 1
+  - SELECT id, name, popularity FROM spotify.top_artists LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────────
+  # playlists — current user's playlists
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: playlists
+    description: >-
+      Playlists owned by or followed by the authenticated Spotify user.
+      Returns both public and private playlists, and collaborative
+      playlists the user follows. Paginated up to 50 per page.
+    guide: |
+      Each row is one simplified playlist object. `id` is the Spotify
+      playlist ID. `tracks_total` is the number of tracks in the playlist
+      — it is a nested field (tracks.total in the API response).
+      `owner_id` and `owner_name` identify the playlist creator.
+      `public` can be true, false, or null. `description` is null for
+      unmodified or unverified playlists.
+      Use `id` to fetch full track details via the Spotify API.
+    request:
+      method: GET
+      path: /v1/me/playlists
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 20
+        max: 50
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Spotify playlist ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Playlist name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: >-
+          Playlist description. Only populated for modified or verified
+          playlists; null otherwise.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: public
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether the playlist is public (true), private (false), or
+          status is not relevant (null).
+        expr:
+          kind: path
+          path:
+            - public
+      - name: collaborative
+        type: Boolean
+        nullable: false
+        description: Whether the owner allows other users to modify the playlist.
+        expr:
+          kind: path
+          path:
+            - collaborative
+      - name: snapshot_id
+        type: Utf8
+        nullable: true
+        description: >-
+          Snapshot version identifier. Changes whenever the playlist is
+          modified. Use to detect playlist mutations.
+        expr:
+          kind: path
+          path:
+            - snapshot_id
+      - name: tracks_total
+        type: Int64
+        nullable: true
+        description: >-
+          Number of tracks in the playlist. Sourced from the nested
+          tracks.total field in the Spotify API response.
+        expr:
+          kind: path
+          path:
+            - tracks
+            - total
+      - name: owner_id
+        type: Utf8
+        nullable: true
+        description: Spotify user ID of the playlist owner.
+        expr:
+          kind: path
+          path:
+            - owner
+            - id
+      - name: owner_name
+        type: Utf8
+        nullable: true
+        description: Display name of the playlist owner.
+        expr:
+          kind: path
+          path:
+            - owner
+            - display_name
+      - name: uri
+        type: Utf8
+        nullable: true
+        description: Spotify URI for the playlist (spotify:playlist:<id>).
+        expr:
+          kind: path
+          path:
+            - uri
+      - name: href
+        type: Utf8
+        nullable: true
+        description: Web API link to the full playlist object.
+        expr:
+          kind: path
+          path:
+            - href
+      - name: external_url
+        type: Utf8
+        nullable: true
+        description: Spotify open URL for the playlist.
+        expr:
+          kind: path
+          path:
+            - external_urls
+            - spotify
+      - name: image_url
+        type: Utf8
+        nullable: true
+        description: URL of the first (largest) playlist cover image.
+        expr:
+          kind: first_array_item_path
+          path:
+            - images
+          item_path:
+            - url
+      - name: images
+        type: Json
+        nullable: true
+        description: >-
+          Full images array. Each object contains url, height, and width.
+          Up to three images are returned by Spotify, widest first.
+        expr:
+          kind: path
+          path:
+            - images
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # saved_tracks — tracks saved to the user's library
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: saved_tracks
+    description: >-
+      Tracks saved to the authenticated user's "Liked Songs" library,
+      ordered by most recently added. Each row is one saved track with
+      full track metadata, primary artist fields, and album fields.
+      Paginated up to 50 per page.
+    guide: |
+      Each row corresponds to one item in the Spotify API response. The
+      API wraps each track in a SavedTrackObject (added_at + track), so
+      all track fields are accessed through the nested track object.
+      `added_at` is the ISO 8601 time the track was saved.
+      `artist_name` and `artist_id` reflect the first listed artist.
+      Use `artists` (Json) for the complete artist list.
+      `album_image_url` is the first (largest) album cover image URL.
+    request:
+      method: GET
+      path: /v1/me/tracks
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 20
+        max: 50
+        query_param: limit
+    columns:
+      - name: added_at
+        type: Timestamp
+        nullable: true
+        description: ISO 8601 timestamp when the track was added to the library.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - added_at
+      - name: track_id
+        type: Utf8
+        nullable: false
+        description: Spotify track ID.
+        expr:
+          kind: path
+          path:
+            - track
+            - id
+      - name: track_name
+        type: Utf8
+        nullable: false
+        description: Track title.
+        expr:
+          kind: path
+          path:
+            - track
+            - name
+      - name: duration_ms
+        type: Int64
+        nullable: true
+        description: Track length in milliseconds.
+        expr:
+          kind: path
+          path:
+            - track
+            - duration_ms
+      - name: explicit
+        type: Boolean
+        nullable: true
+        description: Whether the track has explicit lyrics.
+        expr:
+          kind: path
+          path:
+            - track
+            - explicit
+      - name: popularity
+        type: Int64
+        nullable: true
+        description: Track popularity score from 0 (low) to 100 (high).
+        expr:
+          kind: path
+          path:
+            - track
+            - popularity
+      - name: track_number
+        type: Int64
+        nullable: true
+        description: Track number on its album.
+        expr:
+          kind: path
+          path:
+            - track
+            - track_number
+      - name: disc_number
+        type: Int64
+        nullable: true
+        description: Disc number the track belongs to (usually 1).
+        expr:
+          kind: path
+          path:
+            - track
+            - disc_number
+      - name: is_local
+        type: Boolean
+        nullable: true
+        description: Whether the track is a local file rather than a Spotify track.
+        expr:
+          kind: path
+          path:
+            - track
+            - is_local
+      - name: track_uri
+        type: Utf8
+        nullable: true
+        description: Spotify URI for the track (spotify:track:<id>).
+        expr:
+          kind: path
+          path:
+            - track
+            - uri
+      - name: track_url
+        type: Utf8
+        nullable: true
+        description: Spotify open URL for the track.
+        expr:
+          kind: path
+          path:
+            - track
+            - external_urls
+            - spotify
+      - name: isrc
+        type: Utf8
+        nullable: true
+        description: International Standard Recording Code for the track.
+        expr:
+          kind: path
+          path:
+            - track
+            - external_ids
+            - isrc
+      - name: artist_id
+        type: Utf8
+        nullable: true
+        description: Spotify ID of the primary (first-listed) artist.
+        expr:
+          kind: first_array_item_path
+          path:
+            - track
+            - artists
+          item_path:
+            - id
+      - name: artist_name
+        type: Utf8
+        nullable: true
+        description: Name of the primary (first-listed) artist.
+        expr:
+          kind: first_array_item_path
+          path:
+            - track
+            - artists
+          item_path:
+            - name
+      - name: artists
+        type: Json
+        nullable: true
+        description: >-
+          Full artists array for this track. Each object contains id,
+          name, type, uri, and external_urls.
+        expr:
+          kind: path
+          path:
+            - track
+            - artists
+      - name: album_id
+        type: Utf8
+        nullable: true
+        description: Spotify ID of the album this track belongs to.
+        expr:
+          kind: path
+          path:
+            - track
+            - album
+            - id
+      - name: album_name
+        type: Utf8
+        nullable: true
+        description: Album name.
+        expr:
+          kind: path
+          path:
+            - track
+            - album
+            - name
+      - name: album_release_date
+        type: Utf8
+        nullable: true
+        description: >-
+          Album release date. Format varies (YYYY, YYYY-MM, or
+          YYYY-MM-DD) depending on the precision Spotify reports.
+        expr:
+          kind: path
+          path:
+            - track
+            - album
+            - release_date
+      - name: album_total_tracks
+        type: Int64
+        nullable: true
+        description: Total number of tracks on the album.
+        expr:
+          kind: path
+          path:
+            - track
+            - album
+            - total_tracks
+      - name: album_image_url
+        type: Utf8
+        nullable: true
+        description: URL of the first (largest) album cover image.
+        expr:
+          kind: first_array_item_path
+          path:
+            - track
+            - album
+            - images
+          item_path:
+            - url
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # top_artists — user's top artists by listening affinity
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: top_artists
+    description: >-
+      The authenticated user's top artists ordered by listening affinity.
+      Affinity is calculated over the period defined by time_range.
+      Returns up to 50 artists per time range. Paginated up to 50 per page.
+    guide: |
+      Each row is one full Spotify artist object. `popularity` is a
+      0–100 score. `followers_total` is sourced from the nested
+      followers.total field. `genres` is a Json array of genre strings;
+      `genres_joined` exposes the same data as a comma-separated string
+      for simpler queries. `image_url` is the first (largest) artist
+      photo URL.
+      Filter by `time_range` to select the affinity window:
+        short_term   ≈ 4 weeks
+        medium_term  ≈ 6 months (default)
+        long_term    ≈ 1 year
+    filters:
+      - name: time_range
+        required: false
+    request:
+      method: GET
+      path: /v1/me/top/artists
+      query:
+        - name: time_range
+          from: filter
+          key: time_range
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 20
+        max: 50
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Spotify artist ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Artist name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: popularity
+        type: Int64
+        nullable: true
+        description: Artist popularity score from 0 (low) to 100 (high).
+        expr:
+          kind: path
+          path:
+            - popularity
+      - name: followers_total
+        type: Int64
+        nullable: true
+        description: >-
+          Total Spotify follower count. Sourced from the nested
+          followers.total field in the API response.
+        expr:
+          kind: path
+          path:
+            - followers
+            - total
+      - name: genres
+        type: Json
+        nullable: true
+        description: Array of genre strings the artist is associated with.
+        expr:
+          kind: path
+          path:
+            - genres
+      - name: genres_joined
+        type: Utf8
+        nullable: true
+        description: Comma-separated genre list. Convenient for string matching.
+        expr:
+          kind: join_array
+          path:
+            - genres
+      - name: uri
+        type: Utf8
+        nullable: true
+        description: Spotify URI for the artist (spotify:artist:<id>).
+        expr:
+          kind: path
+          path:
+            - uri
+      - name: href
+        type: Utf8
+        nullable: true
+        description: Web API link to the full artist object.
+        expr:
+          kind: path
+          path:
+            - href
+      - name: external_url
+        type: Utf8
+        nullable: true
+        description: Spotify open URL for the artist.
+        expr:
+          kind: path
+          path:
+            - external_urls
+            - spotify
+      - name: image_url
+        type: Utf8
+        nullable: true
+        description: URL of the first (largest) artist photo.
+        expr:
+          kind: first_array_item_path
+          path:
+            - images
+          item_path:
+            - url
+      - name: images
+        type: Json
+        nullable: true
+        description: >-
+          Full images array. Each object contains url, height, and width.
+          Up to three sizes are returned by Spotify, widest first.
+        expr:
+          kind: path
+          path:
+            - images
+      - name: time_range_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the time_range filter used for this query
+          (short_term, medium_term, or long_term).
+        expr:
+          kind: from_filter
+          key: time_range
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # top_tracks — user's top tracks by listening affinity
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: top_tracks
+    description: >-
+      The authenticated user's top tracks ordered by listening affinity.
+      Affinity is calculated over the period defined by time_range.
+      Returns up to 50 tracks per time range. Paginated up to 50 per page.
+      Requires the same user-top-read scope as top_artists.
+    guide: |
+      Each row is one full Spotify track object. Field layout mirrors
+      saved_tracks without the added_at wrapper — paths start directly
+      at the top-level track fields (e.g. id, name, duration_ms).
+      `artist_name` and `artist_id` reflect the first listed artist.
+      Filter by `time_range` to select the affinity window:
+        short_term   ≈ 4 weeks
+        medium_term  ≈ 6 months (default)
+        long_term    ≈ 1 year
+    filters:
+      - name: time_range
+        required: false
+    request:
+      method: GET
+      path: /v1/me/top/tracks
+      query:
+        - name: time_range
+          from: filter
+          key: time_range
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 20
+        max: 50
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Spotify track ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Track title.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: duration_ms
+        type: Int64
+        nullable: true
+        description: Track length in milliseconds.
+        expr:
+          kind: path
+          path:
+            - duration_ms
+      - name: explicit
+        type: Boolean
+        nullable: true
+        description: Whether the track has explicit lyrics.
+        expr:
+          kind: path
+          path:
+            - explicit
+      - name: popularity
+        type: Int64
+        nullable: true
+        description: Track popularity score from 0 (low) to 100 (high).
+        expr:
+          kind: path
+          path:
+            - popularity
+      - name: track_number
+        type: Int64
+        nullable: true
+        description: Track number on its album.
+        expr:
+          kind: path
+          path:
+            - track_number
+      - name: disc_number
+        type: Int64
+        nullable: true
+        description: Disc number the track belongs to (usually 1).
+        expr:
+          kind: path
+          path:
+            - disc_number
+      - name: is_local
+        type: Boolean
+        nullable: true
+        description: Whether the track is a local file rather than a Spotify track.
+        expr:
+          kind: path
+          path:
+            - is_local
+      - name: uri
+        type: Utf8
+        nullable: true
+        description: Spotify URI for the track (spotify:track:<id>).
+        expr:
+          kind: path
+          path:
+            - uri
+      - name: track_url
+        type: Utf8
+        nullable: true
+        description: Spotify open URL for the track.
+        expr:
+          kind: path
+          path:
+            - external_urls
+            - spotify
+      - name: isrc
+        type: Utf8
+        nullable: true
+        description: International Standard Recording Code for the track.
+        expr:
+          kind: path
+          path:
+            - external_ids
+            - isrc
+      - name: artist_id
+        type: Utf8
+        nullable: true
+        description: Spotify ID of the primary (first-listed) artist.
+        expr:
+          kind: first_array_item_path
+          path:
+            - artists
+          item_path:
+            - id
+      - name: artist_name
+        type: Utf8
+        nullable: true
+        description: Name of the primary (first-listed) artist.
+        expr:
+          kind: first_array_item_path
+          path:
+            - artists
+          item_path:
+            - name
+      - name: artists
+        type: Json
+        nullable: true
+        description: >-
+          Full artists array for this track. Each object contains id,
+          name, type, uri, and external_urls.
+        expr:
+          kind: path
+          path:
+            - artists
+      - name: album_id
+        type: Utf8
+        nullable: true
+        description: Spotify ID of the album this track belongs to.
+        expr:
+          kind: path
+          path:
+            - album
+            - id
+      - name: album_name
+        type: Utf8
+        nullable: true
+        description: Album name.
+        expr:
+          kind: path
+          path:
+            - album
+            - name
+      - name: album_release_date
+        type: Utf8
+        nullable: true
+        description: >-
+          Album release date. Format varies (YYYY, YYYY-MM, or
+          YYYY-MM-DD) depending on the precision Spotify reports.
+        expr:
+          kind: path
+          path:
+            - album
+            - release_date
+      - name: album_total_tracks
+        type: Int64
+        nullable: true
+        description: Total number of tracks on the album.
+        expr:
+          kind: path
+          path:
+            - album
+            - total_tracks
+      - name: album_image_url
+        type: Utf8
+        nullable: true
+        description: URL of the first (largest) album cover image.
+        expr:
+          kind: first_array_item_path
+          path:
+            - album
+            - images
+          item_path:
+            - url
+      - name: time_range_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the time_range filter used for this query
+          (short_term, medium_term, or long_term).
+        expr:
+          kind: from_filter
+          key: time_range

--- a/sources/community/spotify/manifest.yaml
+++ b/sources/community/spotify/manifest.yaml
@@ -54,12 +54,18 @@ inputs:
 
   SPOTIFY_CLIENT_ID:
     kind: variable
+    default: ""
     hint: |
-      Your Spotify app Client ID (not the client secret). Find it in the
-      Spotify Developer Dashboard at https://developer.spotify.com/dashboard
-      after creating or selecting an app. Make sure
-      http://127.0.0.1:53682/oauth/callback is listed as a redirect URI
-      in that app's settings.
+      Your Spotify app Client ID (not the client secret). Required for
+      the OAuth browser flow. Find it in the Spotify Developer Dashboard
+      at https://developer.spotify.com/dashboard after creating an app.
+      Make sure http://127.0.0.1:53682/oauth/callback is listed as an
+      allowed redirect URI in that app's settings.
+
+      Leave blank only if you are using the "Paste access token" method
+      and are managing token refresh yourself. Spotify access tokens
+      expire after one hour and cannot be refreshed without the Client
+      ID — the paste path is therefore short-lived.
 
 auth:
   type: HeaderAuth
@@ -243,6 +249,7 @@ tables:
       ordered by most recently added. Each row is one saved track with
       full track metadata, primary artist fields, and album fields.
       Paginated up to 50 per page.
+    fetch_limit_default: 100
     guide: |
       Each row corresponds to one item in the Spotify API response. The
       API wraps each track in a SavedTrackObject (added_at + track), so

--- a/sources/community/spotify/manifest.yaml
+++ b/sources/community/spotify/manifest.yaml
@@ -92,10 +92,11 @@ tables:
     guide: |
       Each row is one simplified playlist object. `id` is the Spotify
       playlist ID. `tracks_total` is the number of tracks in the playlist
-      — it is a nested field (tracks.total in the API response).
-      `owner_id` and `owner_name` identify the playlist creator.
-      `public` can be true, false, or null. `description` is null for
-      unmodified or unverified playlists.
+      — it is a nested field (items.total in the API response, where
+      `items` is the PlaylistTracksRefObject on each SimplifiedPlaylistObject,
+      not the outer paging array). `owner_id` and `owner_name` identify the
+      playlist creator. `public` can be true, false, or null.
+      `description` is null for unmodified or unverified playlists.
       Use `id` to fetch full track details via the Spotify API.
     request:
       method: GET
@@ -171,11 +172,14 @@ tables:
         nullable: true
         description: >-
           Number of tracks in the playlist. Sourced from the nested
-          tracks.total field in the Spotify API response.
+          items.total field in the Spotify API response (the
+          PlaylistTracksRefObject on each SimplifiedPlaylistObject).
+          The `tracks` field serving the same data is deprecated in
+          the Spotify OpenAPI schema as of February 2026.
         expr:
           kind: path
           path:
-            - tracks
+            - items
             - total
       - name: owner_id
         type: Utf8


### PR DESCRIPTION
Fixes #734

Add a new `spotify` community source that lets Coral query a Spotify
user's playlists, saved tracks, top artists, and top tracks through SQL
— enabling music library analysis, listening affinity queries, and
cross-table joins.

This change is manifest-only and uses Coral's existing HTTP source-spec
model with the OAuth 2.0 authorization-code + PKCE credential block.
Read-only. No CLI, MCP, config, or runtime changes.

## What changed

Added:

- `sources/community/spotify/manifest.yaml`
- `sources/community/spotify/README.md`

## Source scope

**Inputs:**

- `SPOTIFY_TOKEN` — OAuth access token (secret), collected via browser
  PKCE flow or manual paste
- `SPOTIFY_CLIENT_ID` — Spotify app Client ID (variable), required to
  initiate the OAuth flow

**OAuth:**

- Flow: `authorization_code` with `pkce: required`
- Redirect URI: `http://127.0.0.1:53682/oauth/callback`
- Authorization URL: `https://accounts.spotify.com/authorize`
- Token URL: `https://accounts.spotify.com/api/token`
- Scopes: `playlist-read-private playlist-read-collaborative
  user-library-read user-top-read`

**Tables:**

- `spotify.playlists`
  - `GET /v1/me/playlists`
  - offset pagination, page size up to 50
  - 13 columns including `id`, `name`, `tracks_total`, `owner_id`,
    `owner_name`, `public`, `collaborative`, `snapshot_id`,
    `image_url`, `external_url`
  - `tracks_total` sourced from nested `tracks.total` API field

- `spotify.saved_tracks`
  - `GET /v1/me/tracks`
  - offset pagination, page size up to 50
  - 19 columns including `added_at`, `track_id`, `track_name`,
    `artist_name`, `artist_id`, `artists`, `album_name`,
    `album_release_date`, `album_image_url`, `isrc`
  - all track fields accessed through the nested `track` object
    in the SavedTrackObject API response

- `spotify.top_artists`
  - `GET /v1/me/top/artists`
  - offset pagination, page size up to 50
  - optional `time_range` filter (`short_term`, `medium_term`,
    `long_term`)
  - 13 columns including `id`, `name`, `popularity`,
    `followers_total`, `genres`, `genres_joined`, `image_url`
  - `followers_total` sourced from nested `followers.total` API field

- `spotify.top_tracks`
  - `GET /v1/me/top/tracks`
  - offset pagination, page size up to 50
  - optional `time_range` filter (same as `top_artists`)
  - 18 columns including `id`, `name`, `duration_ms`, `explicit`,
    `popularity`, `artist_name`, `album_name`, `album_image_url`
  - same `user-top-read` scope as `top_artists` — no additional scope
    needed

## Implementation notes

- `auth`: `Authorization: Bearer {{input.SPOTIFY_TOKEN}}` via
  `HeaderAuth`
- This is the first community source to use the OAuth credential
  block with `type: oauth`, `flow.type: authorization_code`, and
  `flow.pkce: required`
- `artist_name`, `artist_id`, and all `image_url` columns are
  extracted from response arrays using `first_array_item_path` —
  integer array indexing is not supported in the DSL
- `genres_joined` uses `join_array` to expose the `genres` string
  array as a comma-separated scalar
- `added_at` in `saved_tracks` uses `format_timestamp input: iso8601`
- `time_range_filter` in `top_artists` and `top_tracks` is a
  `virtual: true` echo column via `from_filter`
- Spotify apps in Development Mode are limited to 5 authenticated
  users; documented in README and hint text
  
  
<img width="1078" height="242" alt="image" src="https://github.com/user-attachments/assets/27edf496-8f80-4d8e-9de9-99b5e11e0081" />


## Out of scope

Not included in v1:

- Audio features endpoint (restricted by Spotify to pre-approved apps)
- Artist related tracks and related artists (restricted endpoint)
- Track recommendations (restricted endpoint)
- Playlist track contents (requires per-playlist requests)
- Recently played tracks, followed artists, saved albums, user profile
- Write operations of any kind
