### PR TITLE
feat(sources/community/google_tasks): add Google Tasks community source

### DIFF
--- a/sources/community/google_tasks/README.md
+++ b/sources/community/google_tasks/README.md
@@ -1,0 +1,96 @@
+# Google Tasks Community Source
+
+Exposes user task lists and individual task items as standard SQL tables using the official Google Tasks REST API v1 via a local-first SQL runtime.
+
+## Authentication
+
+This source requires setting up an OAuth 2.0 Desktop Application client inside your personal Google Cloud Console.
+
+* **GOOGLE_CLIENT_ID**: Generated Desktop application Client ID.
+* **GOOGLE_CLIENT_SECRET**: Accompanying Client Secret.
+
+Make sure to enable the **Google Tasks API** in your Google API Library before authenticating.
+
+## Setup
+
+To link this source schema locally to your Coral workspace, run:
+```bash
+coral source add --file sources/community/google_tasks/manifest.yaml
+```
+
+## Tables
+
+### `task_lists`
+Lists metadata for all task lists owned by or shared with the authenticated user. Entry-point table; requires no filters.
+
+### `tasks`
+Lists specific task items. 
+
+**Crucial Note:** This table requires a mandatory filter clause on `tasklist_id` due to upstream Google API design constraints.
+
+**API Pushdown Filters:**
+You can efficiently filter tasks at the API layer by utilizing the following optional filters in your `WHERE` clauses:
+* `show_completed` (Boolean) - Include completed tasks.
+* `show_hidden` (Boolean) - Include hidden tasks (required to see tasks completed in Google first-party clients).
+* `show_deleted` (Boolean) - Include deleted tasks.
+* `due_min` / `due_max` (String) - Filter by due date bounds (RFC 3339).
+* `completed_min` / `completed_max` (String) - Filter by completion date bounds (RFC 3339).
+* `updated_min` (String) - Filter by last updated date bound (RFC 3339).
+
+## Example Queries
+
+### 1. Discover your task list IDs
+```sql
+SELECT id, title, updated FROM google_tasks.task_lists;
+```
+
+### 2. Query incomplete tasks from a targeted list
+```sql
+SELECT id, title, due 
+FROM google_tasks.tasks 
+WHERE tasklist_id = 'your_list_id_here' 
+  AND status = 'needsAction';
+```
+
+### 3. Track completed items across lists via a JOIN
+```sql
+SELECT 
+    l.title AS list_name, 
+    t.title AS task_name, 
+    t.completed
+FROM google_tasks.tasks t
+JOIN google_tasks.task_lists l ON t.tasklist_id = l.id
+WHERE t.status = 'completed';
+```
+
+### 4. Fetch hidden and completed tasks from the API layer
+```sql
+SELECT id, title, completed, hidden
+FROM google_tasks.tasks 
+WHERE tasklist_id = 'your_list_id_here' 
+  AND show_completed = true 
+  AND show_hidden = true;
+```
+
+### 5. Filter by specific due dates using pushdown API parameters
+```sql
+SELECT title, due 
+FROM google_tasks.tasks 
+WHERE tasklist_id = 'your_list_id_here' 
+  AND due_min = '2023-10-01T00:00:00Z'
+  AND due_max = '2023-10-31T23:59:59Z';
+```
+
+### 6. Extremely fast single-item lookups (Point Queries)
+```sql
+-- This routes directly to the `/tasks/v1/users/@me/lists/{id}` endpoint
+SELECT * FROM google_tasks.task_lists WHERE id = 'your_list_id_here';
+
+-- This routes directly to the `/tasks/v1/lists/{tasklist}/tasks/{id}` endpoint
+SELECT * FROM google_tasks.tasks 
+WHERE tasklist_id = 'your_list_id_here' 
+  AND id = 'your_task_id_here';
+```
+
+## API Documentation
+Reference: [Google Tasks REST API v1 Reference](https://developers.google.com/tasks/api/reference/rest/v1)

--- a/sources/community/google_tasks/README.md
+++ b/sources/community/google_tasks/README.md
@@ -31,10 +31,10 @@ pattern. You need a Google Cloud project with the Google Tasks API enabled.
 coral source add --interactive --file sources/community/google_tasks/manifest.yaml
 ```
 
-Coral uses authorization-code flow with PKCE and a random loopback redirect
-port (`http://127.0.0.1:{random}/oauth/callback`). The authorization URL
-includes `access_type=offline&prompt=consent` so Google issues a refresh
-token on first consent. Coral refreshes access tokens automatically.
+Coral uses authorization-code flow with PKCE and a random loopback
+redirect port (`http://127.0.0.1:{random}/oauth/callback`). The
+authorization URL includes `access_type=offline&prompt=consent` so
+Google issues a refresh token on first consent.
 
 If the browser cannot open (e.g. headless/WSL), Coral prints the
 authorization URL. Open it manually, complete consent, then paste the

--- a/sources/community/google_tasks/README.md
+++ b/sources/community/google_tasks/README.md
@@ -1,62 +1,96 @@
 # Google Tasks Community Source
 
-Exposes user task lists and individual task items as standard SQL tables using the official Google Tasks REST API v1 via a local-first SQL runtime.
+Exposes user task lists and individual task items as standard SQL tables using the official Google Tasks REST API v1.
 
 ## Authentication
 
-This source requires setting up an OAuth 2.0 Desktop Application client inside your personal Google Cloud Console.
+This source uses **OAuth 2.0 authorization-code flow with PKCE**. You need a Google Cloud project with the Google Tasks API enabled.
 
-* **GOOGLE_CLIENT_ID**: Generated Desktop application Client ID.
-* **GOOGLE_CLIENT_SECRET**: Accompanying Client Secret.
+### Required inputs
 
-Make sure to enable the **Google Tasks API** in your Google API Library before authenticating.
+| Input | Kind | Description |
+|---|---|---|
+| `GOOGLE_CLIENT_ID` | variable | OAuth 2.0 Client ID from Google Cloud Console |
+| `GOOGLE_CLIENT_SECRET` | secret | OAuth 2.0 Client Secret from Google Cloud Console |
+| `GOOGLE_TASKS_TOKEN` | secret | OAuth access token — Coral opens a browser flow automatically |
 
-## Setup
+### Setup steps
 
-To link this source schema locally to your Coral workspace, run:
-```bash
+1. Go to [Google Cloud Console](https://console.cloud.google.com/) → **APIs & Services** → **Enabled APIs** and enable the **Google Tasks API**.
+2. Go to **APIs & Services** → **Credentials** → **Create Credentials** → **OAuth 2.0 Client ID**.
+3. Choose **Desktop app** as the application type.
+4. Copy the **Client ID** and **Client Secret**.
+5. Add the source — Coral will open a browser window to complete the OAuth consent flow:
+
+```sh
 coral source add --file sources/community/google_tasks/manifest.yaml
 ```
 
+Coral requests the `tasks.readonly` scope. The authorization URL includes `access_type=offline&prompt=consent` so Google issues a refresh token on first consent, keeping the token alive across sessions.
+
+### Required scope
+
+| Scope | Tables |
+|---|---|
+| `https://www.googleapis.com/auth/tasks.readonly` | `google_tasks.task_lists`, `google_tasks.tasks` |
+
 ## Tables
 
-### `task_lists`
-Lists metadata for all task lists owned by or shared with the authenticated user. Entry-point table; requires no filters.
+### `google_tasks.task_lists`
 
-### `tasks`
-Lists specific task items. 
+Lists metadata for all task lists owned by or shared with the authenticated user. Entry-point table; no required filters.
 
-**Crucial Note:** This table requires a mandatory filter clause on `tasklist_id` due to upstream Google API design constraints.
+Filtering by `id` routes directly to the single-object endpoint (`GET /tasks/v1/users/@me/lists/{id}`) and returns exactly one row.
 
-**API Pushdown Filters:**
-You can efficiently filter tasks at the API layer by utilizing the following optional filters in your `WHERE` clauses:
-* `show_completed` (Boolean) - Include completed tasks.
-* `show_hidden` (Boolean) - Include hidden tasks (required to see tasks completed in Google first-party clients).
-* `show_deleted` (Boolean) - Include deleted tasks.
-* `due_min` / `due_max` (String) - Filter by due date bounds (RFC 3339).
-* `completed_min` / `completed_max` (String) - Filter by completion date bounds (RFC 3339).
-* `updated_min` (String) - Filter by last updated date bound (RFC 3339).
+### `google_tasks.tasks`
 
-## Example Queries
+Lists individual task items from a specific task list.
+
+**`tasklist_id` is required** — obtain it from `google_tasks.task_lists`.
+
+Filtering by both `tasklist_id` and `id` routes directly to the single-object endpoint (`GET /tasks/v1/lists/{tasklist}/tasks/{id}`) and returns exactly one row.
+
+**API-level pushdown filters** (sent as query parameters to Google's API):
+
+| Filter | Type | Default | Description |
+|---|---|---|---|
+| `show_completed` | Boolean | false | Include completed tasks |
+| `show_hidden` | Boolean | false | Include hidden tasks (needed for tasks completed in Google apps) |
+| `show_deleted` | Boolean | false | Include deleted tasks |
+| `show_assigned` | Boolean | false | Include tasks assigned from Google Docs or Google Chat |
+| `due_min` | String | — | Lower bound for due date (RFC 3339) |
+| `due_max` | String | — | Upper bound for due date (RFC 3339) |
+| `completed_min` | String | — | Lower bound for completion date (RFC 3339) |
+| `completed_max` | String | — | Upper bound for completion date (RFC 3339) |
+| `updated_min` | String | — | Lower bound for last modification date (RFC 3339) |
+
+## Rate limits
+
+Google Tasks enforces a courtesy quota of **50,000 queries per day** per project (see [Google Tasks usage limits](https://developers.google.com/workspace/tasks/limits)). Both tables default to `fetch_limit_default: 100` rows per query. Use `LIMIT` and date-range filters to keep individual queries bounded on large task lists.
+
+## Example queries
 
 ### 1. Discover your task list IDs
+
 ```sql
 SELECT id, title, updated FROM google_tasks.task_lists;
 ```
 
-### 2. Query incomplete tasks from a targeted list
+### 2. Query incomplete tasks from a specific list
+
 ```sql
-SELECT id, title, due 
-FROM google_tasks.tasks 
-WHERE tasklist_id = 'your_list_id_here' 
+SELECT id, title, due
+FROM google_tasks.tasks
+WHERE tasklist_id = 'your_list_id_here'
   AND status = 'needsAction';
 ```
 
-### 3. Track completed items across lists via a JOIN
+### 3. Find completed tasks in a single list (with metadata join)
+
 ```sql
-SELECT 
-    l.title AS list_name, 
-    t.title AS task_name, 
+SELECT
+    l.title AS list_name,
+    t.title AS task_name,
     t.completed
 FROM google_tasks.tasks t
 JOIN google_tasks.task_lists l ON t.tasklist_id = l.id
@@ -64,34 +98,53 @@ WHERE t.tasklist_id = 'your_list_id_here'
   AND t.status = 'completed';
 ```
 
-### 4. Fetch hidden and completed tasks from the API layer
+### 4. Include hidden and completed tasks via API pushdown
+
 ```sql
 SELECT id, title, completed, hidden
-FROM google_tasks.tasks 
-WHERE tasklist_id = 'your_list_id_here' 
-  AND show_completed = true 
+FROM google_tasks.tasks
+WHERE tasklist_id = 'your_list_id_here'
+  AND show_completed = true
   AND show_hidden = true;
 ```
 
-### 5. Filter by specific due dates using pushdown API parameters
+### 5. Include tasks assigned from Google Docs or Chat
+
 ```sql
-SELECT title, due 
-FROM google_tasks.tasks 
-WHERE tasklist_id = 'your_list_id_here' 
-  AND due_min = '2023-10-01T00:00:00Z'
-  AND due_max = '2023-10-31T23:59:59Z';
+SELECT id, title, status, web_view_link
+FROM google_tasks.tasks
+WHERE tasklist_id = 'your_list_id_here'
+  AND show_assigned = true;
 ```
 
-### 6. Extremely fast single-item lookups (Point Queries)
+### 6. Filter tasks by due date range
+
 ```sql
--- This routes directly to the `/tasks/v1/users/@me/lists/{id}` endpoint
+SELECT title, due
+FROM google_tasks.tasks
+WHERE tasklist_id = 'your_list_id_here'
+  AND due_min = '2024-01-01T00:00:00Z'
+  AND due_max = '2024-01-31T23:59:59Z';
+```
+
+### 7. Single-item point queries (route directly to GET endpoints)
+
+```sql
+-- Routes to GET /tasks/v1/users/@me/lists/{id} — returns one row
 SELECT * FROM google_tasks.task_lists WHERE id = 'your_list_id_here';
 
--- This routes directly to the `/tasks/v1/lists/{tasklist}/tasks/{id}` endpoint
-SELECT * FROM google_tasks.tasks 
-WHERE tasklist_id = 'your_list_id_here' 
+-- Routes to GET /tasks/v1/lists/{tasklist}/tasks/{id} — returns one row
+SELECT * FROM google_tasks.tasks
+WHERE tasklist_id = 'your_list_id_here'
   AND id = 'your_task_id_here';
 ```
 
-## API Documentation
-Reference: [Google Tasks REST API v1 Reference](https://developers.google.com/tasks/api/reference/rest/v1)
+## API reference
+
+- [Google Tasks REST API v1](https://developers.google.com/tasks/reference/rest/v1)
+- [tasks.tasklists.list](https://developers.google.com/workspace/tasks/reference/rest/v1/tasklists/list)
+- [tasks.tasklists.get](https://developers.google.com/workspace/tasks/reference/rest/v1/tasklists/get)
+- [tasks.tasks.list](https://developers.google.com/workspace/tasks/reference/rest/v1/tasks/list)
+- [tasks.tasks.get](https://developers.google.com/workspace/tasks/reference/rest/v1/tasks/get)
+- [OAuth and authorization](https://developers.google.com/workspace/tasks/auth)
+- [Usage limits](https://developers.google.com/workspace/tasks/limits)

--- a/sources/community/google_tasks/README.md
+++ b/sources/community/google_tasks/README.md
@@ -60,7 +60,8 @@ SELECT
     t.completed
 FROM google_tasks.tasks t
 JOIN google_tasks.task_lists l ON t.tasklist_id = l.id
-WHERE t.status = 'completed';
+WHERE t.tasklist_id = 'your_list_id_here'
+  AND t.status = 'completed';
 ```
 
 ### 4. Fetch hidden and completed tasks from the API layer

--- a/sources/community/google_tasks/README.md
+++ b/sources/community/google_tasks/README.md
@@ -25,10 +25,10 @@ pattern. You need a Google Cloud project with the Google Tasks API enabled.
    **OAuth 2.0 Client ID**.
 3. Choose **Desktop app** as the application type.
 4. Copy the **Client ID** and **Client Secret**.
-5. Add the source — Coral opens a browser window for the OAuth consent flow:
+5. Add the source interactively — Coral opens a browser window for the OAuth consent flow:
 
 ```sh
-coral source add --file sources/community/google_tasks/manifest.yaml
+coral source add --interactive --file sources/community/google_tasks/manifest.yaml
 ```
 
 Coral uses authorization-code flow with PKCE and a random loopback redirect
@@ -105,13 +105,17 @@ large task lists.
 SELECT id, title, updated FROM google_tasks.task_lists;
 ```
 
-### 2. Query tasks that still need action
+### 2. Exclude completed tasks (only incomplete tasks)
+
+Use the `show_completed = false` pushdown filter to have the API return
+only incomplete tasks. Without this filter, Google returns completed tasks
+by default.
 
 ```sql
 SELECT id, title, due
 FROM google_tasks.tasks
 WHERE tasklist_id = 'YOUR_LIST_ID'
-  AND status = 'needsAction';
+  AND show_completed = false;
 ```
 
 ### 3. Full completion history (visible + hidden completed tasks)

--- a/sources/community/google_tasks/README.md
+++ b/sources/community/google_tasks/README.md
@@ -26,7 +26,7 @@ This source uses **OAuth 2.0 authorization-code flow with PKCE**. You need a Goo
 coral source add --file sources/community/google_tasks/manifest.yaml
 ```
 
-Coral requests the `tasks.readonly` scope. The authorization URL includes `access_type=offline&prompt=consent` so Google issues a refresh token on first consent, keeping the token alive across sessions.
+Coral uses authorization-code flow with PKCE and a fixed loopback redirect URI (`http://127.0.0.1:53682/oauth/callback`). The authorization URL includes `access_type=offline&prompt=consent` so Google issues a refresh token on first consent, keeping the token alive across sessions.
 
 ### Required scope
 
@@ -40,22 +40,18 @@ Coral requests the `tasks.readonly` scope. The authorization URL includes `acces
 
 Lists metadata for all task lists owned by or shared with the authenticated user. Entry-point table; no required filters.
 
-Filtering by `id` routes directly to the single-object endpoint (`GET /tasks/v1/users/@me/lists/{id}`) and returns exactly one row.
-
 ### `google_tasks.tasks`
 
 Lists individual task items from a specific task list.
 
 **`tasklist_id` is required** — obtain it from `google_tasks.task_lists`.
 
-Filtering by both `tasklist_id` and `id` routes directly to the single-object endpoint (`GET /tasks/v1/lists/{tasklist}/tasks/{id}`) and returns exactly one row.
-
 **API-level pushdown filters** (sent as query parameters to Google's API):
 
-| Filter | Type | Default | Description |
+| Filter column | Type | API default | Description |
 |---|---|---|---|
-| `show_completed` | Boolean | false | Include completed tasks |
-| `show_hidden` | Boolean | false | Include hidden tasks (needed for tasks completed in Google apps) |
+| `show_completed` | Boolean | **true** | Include completed tasks. Google returns them by default; set `false` to exclude. |
+| `show_hidden` | Boolean | false | Include hidden tasks (tasks completed in Google first-party clients) |
 | `show_deleted` | Boolean | false | Include deleted tasks |
 | `show_assigned` | Boolean | false | Include tasks assigned from Google Docs or Google Chat |
 | `due_min` | String | — | Lower bound for due date (RFC 3339) |
@@ -63,6 +59,8 @@ Filtering by both `tasklist_id` and `id` routes directly to the single-object en
 | `completed_min` | String | — | Lower bound for completion date (RFC 3339) |
 | `completed_max` | String | — | Upper bound for completion date (RFC 3339) |
 | `updated_min` | String | — | Lower bound for last modification date (RFC 3339) |
+
+These filters are exposed as virtual columns so they can be used in `WHERE` clauses and appear in query results.
 
 ## Rate limits
 
@@ -76,7 +74,7 @@ Google Tasks enforces a courtesy quota of **50,000 queries per day** per project
 SELECT id, title, updated FROM google_tasks.task_lists;
 ```
 
-### 2. Query incomplete tasks from a specific list
+### 2. Query tasks that still need action
 
 ```sql
 SELECT id, title, due
@@ -85,7 +83,7 @@ WHERE tasklist_id = 'your_list_id_here'
   AND status = 'needsAction';
 ```
 
-### 3. Find completed tasks in a single list (with metadata join)
+### 3. Find completed tasks in a list (with list metadata join)
 
 ```sql
 SELECT
@@ -98,17 +96,25 @@ WHERE t.tasklist_id = 'your_list_id_here'
   AND t.status = 'completed';
 ```
 
-### 4. Include hidden and completed tasks via API pushdown
+### 4. Exclude completed tasks (override the API default)
+
+```sql
+SELECT id, title, due
+FROM google_tasks.tasks
+WHERE tasklist_id = 'your_list_id_here'
+  AND show_completed = false;
+```
+
+### 5. Include hidden tasks
 
 ```sql
 SELECT id, title, completed, hidden
 FROM google_tasks.tasks
 WHERE tasklist_id = 'your_list_id_here'
-  AND show_completed = true
   AND show_hidden = true;
 ```
 
-### 5. Include tasks assigned from Google Docs or Chat
+### 6. Include tasks assigned from Google Docs or Chat
 
 ```sql
 SELECT id, title, status, web_view_link
@@ -117,7 +123,7 @@ WHERE tasklist_id = 'your_list_id_here'
   AND show_assigned = true;
 ```
 
-### 6. Filter tasks by due date range
+### 7. Filter tasks by due date range
 
 ```sql
 SELECT title, due
@@ -127,24 +133,10 @@ WHERE tasklist_id = 'your_list_id_here'
   AND due_max = '2024-01-31T23:59:59Z';
 ```
 
-### 7. Single-item point queries (route directly to GET endpoints)
-
-```sql
--- Routes to GET /tasks/v1/users/@me/lists/{id} — returns one row
-SELECT * FROM google_tasks.task_lists WHERE id = 'your_list_id_here';
-
--- Routes to GET /tasks/v1/lists/{tasklist}/tasks/{id} — returns one row
-SELECT * FROM google_tasks.tasks
-WHERE tasklist_id = 'your_list_id_here'
-  AND id = 'your_task_id_here';
-```
-
 ## API reference
 
 - [Google Tasks REST API v1](https://developers.google.com/tasks/reference/rest/v1)
 - [tasks.tasklists.list](https://developers.google.com/workspace/tasks/reference/rest/v1/tasklists/list)
-- [tasks.tasklists.get](https://developers.google.com/workspace/tasks/reference/rest/v1/tasklists/get)
 - [tasks.tasks.list](https://developers.google.com/workspace/tasks/reference/rest/v1/tasks/list)
-- [tasks.tasks.get](https://developers.google.com/workspace/tasks/reference/rest/v1/tasks/get)
-- [OAuth and authorization](https://developers.google.com/workspace/tasks/auth)
+- [OAuth for installed apps](https://developers.google.com/identity/protocols/oauth2/native-app)
 - [Usage limits](https://developers.google.com/workspace/tasks/limits)

--- a/sources/community/google_tasks/README.md
+++ b/sources/community/google_tasks/README.md
@@ -1,32 +1,44 @@
 # Google Tasks Community Source
 
-Exposes user task lists and individual task items as standard SQL tables using the official Google Tasks REST API v1.
+Exposes user task lists and individual task items as standard SQL tables
+using the official Google Tasks REST API v1.
 
 ## Authentication
 
-This source uses **OAuth 2.0 authorization-code flow with PKCE**. You need a Google Cloud project with the Google Tasks API enabled.
+This source uses **OAuth 2.0 authorization-code flow with PKCE** over a
+random loopback redirect port, matching the Google native-app OAuth
+pattern. You need a Google Cloud project with the Google Tasks API enabled.
 
 ### Required inputs
 
 | Input | Kind | Description |
 |---|---|---|
-| `GOOGLE_CLIENT_ID` | variable | OAuth 2.0 Client ID from Google Cloud Console |
-| `GOOGLE_CLIENT_SECRET` | secret | OAuth 2.0 Client Secret from Google Cloud Console |
-| `GOOGLE_TASKS_TOKEN` | secret | OAuth access token — Coral opens a browser flow automatically |
+| `GOOGLE_TASKS_OAUTH_CLIENT_ID` | variable | OAuth 2.0 Client ID (Desktop app) from Google Cloud Console |
+| `GOOGLE_TASKS_OAUTH_CLIENT_SECRET` | secret | OAuth 2.0 Client Secret from Google Cloud Console |
+| `GOOGLE_TASKS_ACCESS_TOKEN` | secret | OAuth access token — Coral opens a browser flow automatically |
 
 ### Setup steps
 
-1. Go to [Google Cloud Console](https://console.cloud.google.com/) → **APIs & Services** → **Enabled APIs** and enable the **Google Tasks API**.
-2. Go to **APIs & Services** → **Credentials** → **Create Credentials** → **OAuth 2.0 Client ID**.
+1. Go to [Google Cloud Console](https://console.cloud.google.com/) →
+   **APIs & Services** → **Enabled APIs** and enable the **Google Tasks API**.
+2. Go to **APIs & Services** → **Credentials** → **Create Credentials** →
+   **OAuth 2.0 Client ID**.
 3. Choose **Desktop app** as the application type.
 4. Copy the **Client ID** and **Client Secret**.
-5. Add the source — Coral will open a browser window to complete the OAuth consent flow:
+5. Add the source — Coral opens a browser window for the OAuth consent flow:
 
 ```sh
 coral source add --file sources/community/google_tasks/manifest.yaml
 ```
 
-Coral uses authorization-code flow with PKCE and a fixed loopback redirect URI (`http://127.0.0.1:53682/oauth/callback`). The authorization URL includes `access_type=offline&prompt=consent` so Google issues a refresh token on first consent, keeping the token alive across sessions.
+Coral uses authorization-code flow with PKCE and a random loopback redirect
+port (`http://127.0.0.1:{random}/oauth/callback`). The authorization URL
+includes `access_type=offline&prompt=consent` so Google issues a refresh
+token on first consent. Coral refreshes access tokens automatically.
+
+If the browser cannot open (e.g. headless/WSL), Coral prints the
+authorization URL. Open it manually, complete consent, then paste the
+redirect URL back into the terminal.
 
 ### Required scope
 
@@ -38,7 +50,8 @@ Coral uses authorization-code flow with PKCE and a fixed loopback redirect URI (
 
 ### `google_tasks.task_lists`
 
-Lists metadata for all task lists owned by or shared with the authenticated user. Entry-point table; no required filters.
+Lists metadata for all task lists owned by or shared with the authenticated
+user. Entry-point table; no required filters.
 
 ### `google_tasks.tasks`
 
@@ -51,7 +64,7 @@ Lists individual task items from a specific task list.
 | Filter column | Type | API default | Description |
 |---|---|---|---|
 | `show_completed` | Boolean | **true** | Include completed tasks. Google returns them by default; set `false` to exclude. |
-| `show_hidden` | Boolean | false | Include hidden tasks (tasks completed in Google first-party clients) |
+| `show_hidden` | Boolean | false | Include hidden tasks (tasks completed in Google first-party clients). Required alongside `show_completed` for full completion history. |
 | `show_deleted` | Boolean | false | Include deleted tasks |
 | `show_assigned` | Boolean | false | Include tasks assigned from Google Docs or Google Chat |
 | `due_min` | String | — | Lower bound for due date (RFC 3339) |
@@ -60,11 +73,29 @@ Lists individual task items from a specific task list.
 | `completed_max` | String | — | Upper bound for completion date (RFC 3339) |
 | `updated_min` | String | — | Lower bound for last modification date (RFC 3339) |
 
-These filters are exposed as virtual columns so they can be used in `WHERE` clauses and appear in query results.
+These filters are exposed as virtual columns so they can be used in
+`WHERE` clauses.
+
+### Assignment metadata
+
+Tasks assigned from Google Docs or Google Chat carry `assignmentInfo`
+with origin details. The following columns expose this data:
+
+| Column | Description |
+|---|---|
+| `assignment_surface_type` | `DOCUMENT` (Google Docs) or `SPACE` (Google Chat) |
+| `assignment_link_to_task` | Absolute link to the task in its origin surface |
+| `assignment_drive_file_id` | Drive file ID when surface is DOCUMENT |
+| `assignment_space` | Chat space identifier (`spaces/{space}`) when surface is SPACE |
+| `assignment_info` | Full raw `assignmentInfo` JSON object |
 
 ## Rate limits
 
-Google Tasks enforces a courtesy quota of **50,000 queries per day** per project (see [Google Tasks usage limits](https://developers.google.com/workspace/tasks/limits)). Both tables default to `fetch_limit_default: 100` rows per query. Use `LIMIT` and date-range filters to keep individual queries bounded on large task lists.
+Google Tasks enforces a courtesy quota of **50,000 queries per day** per
+project (see [Google Tasks usage limits](https://developers.google.com/workspace/tasks/limits)).
+Both tables default to `fetch_limit_default: 100` rows per query. Use
+`LIMIT` and date-range filters to keep individual queries bounded on
+large task lists.
 
 ## Example queries
 
@@ -79,11 +110,24 @@ SELECT id, title, updated FROM google_tasks.task_lists;
 ```sql
 SELECT id, title, due
 FROM google_tasks.tasks
-WHERE tasklist_id = 'your_list_id_here'
+WHERE tasklist_id = 'YOUR_LIST_ID'
   AND status = 'needsAction';
 ```
 
-### 3. Find completed tasks in a list (with list metadata join)
+### 3. Full completion history (visible + hidden completed tasks)
+
+Tasks completed in first-party Google clients (web UI, mobile) become
+*hidden*. To see all completed tasks, set both filters:
+
+```sql
+SELECT id, title, completed
+FROM google_tasks.tasks
+WHERE tasklist_id = 'YOUR_LIST_ID'
+  AND show_completed = true
+  AND show_hidden = true;
+```
+
+### 4. Completed tasks with list metadata join
 
 ```sql
 SELECT
@@ -92,43 +136,32 @@ SELECT
     t.completed
 FROM google_tasks.tasks t
 JOIN google_tasks.task_lists l ON t.tasklist_id = l.id
-WHERE t.tasklist_id = 'your_list_id_here'
+WHERE t.tasklist_id = 'YOUR_LIST_ID'
+  AND t.show_completed = true
+  AND t.show_hidden = true
   AND t.status = 'completed';
 ```
 
-### 4. Exclude completed tasks (override the API default)
+### 5. Tasks assigned from Google Docs or Chat
 
 ```sql
-SELECT id, title, due
+SELECT
+    id,
+    title,
+    assignment_surface_type,
+    assignment_link_to_task,
+    assignment_drive_file_id
 FROM google_tasks.tasks
-WHERE tasklist_id = 'your_list_id_here'
-  AND show_completed = false;
-```
-
-### 5. Include hidden tasks
-
-```sql
-SELECT id, title, completed, hidden
-FROM google_tasks.tasks
-WHERE tasklist_id = 'your_list_id_here'
-  AND show_hidden = true;
-```
-
-### 6. Include tasks assigned from Google Docs or Chat
-
-```sql
-SELECT id, title, status, web_view_link
-FROM google_tasks.tasks
-WHERE tasklist_id = 'your_list_id_here'
+WHERE tasklist_id = 'YOUR_LIST_ID'
   AND show_assigned = true;
 ```
 
-### 7. Filter tasks by due date range
+### 6. Filter tasks by due date range
 
 ```sql
 SELECT title, due
 FROM google_tasks.tasks
-WHERE tasklist_id = 'your_list_id_here'
+WHERE tasklist_id = 'YOUR_LIST_ID'
   AND due_min = '2024-01-01T00:00:00Z'
   AND due_max = '2024-01-31T23:59:59Z';
 ```
@@ -138,5 +171,6 @@ WHERE tasklist_id = 'your_list_id_here'
 - [Google Tasks REST API v1](https://developers.google.com/tasks/reference/rest/v1)
 - [tasks.tasklists.list](https://developers.google.com/workspace/tasks/reference/rest/v1/tasklists/list)
 - [tasks.tasks.list](https://developers.google.com/workspace/tasks/reference/rest/v1/tasks/list)
+- [Task resource (assignmentInfo)](https://developers.google.com/workspace/tasks/reference/rest/v1/tasks)
 - [OAuth for installed apps](https://developers.google.com/identity/protocols/oauth2/native-app)
 - [Usage limits](https://developers.google.com/workspace/tasks/limits)

--- a/sources/community/google_tasks/manifest.yaml
+++ b/sources/community/google_tasks/manifest.yaml
@@ -22,17 +22,17 @@ inputs:
     kind: secret
     hint: |
       Google Tasks OAuth access token. Use "Connect with Google" to authenticate
-      interactively via the OAuth authorization-code flow. Required scope:
-      https://www.googleapis.com/auth/tasks.readonly
+      interactively via the OAuth authorization-code flow with PKCE. Required
+      scope: https://www.googleapis.com/auth/tasks.readonly
     credential:
       methods:
         - type: oauth
           label: Connect with Google
-          description: Authenticate via Google OAuth authorization-code flow.
+          description: Authenticate via Google OAuth authorization-code flow with PKCE.
           oauth:
             flow:
               type: authorization_code
-              pkce: disabled
+              pkce: required
             redirect_uri: http://127.0.0.1:53682/oauth/callback
             redirect_uri_port_mode: fixed
             endpoints:
@@ -71,8 +71,8 @@ test_queries:
 tables:
   # ------------------------------------------------------------------
   # google_tasks.task_lists — all task lists accessible to the user
-  # GET /tasks/v1/users/@me/lists        (list all)
-  # GET /tasks/v1/users/@me/lists/{id}   (single object — row_strategy: direct)
+  # GET /tasks/v1/users/@me/lists
+  # Pagination: pageToken cursor, maxResults query param (max 1000).
   # ------------------------------------------------------------------
   - name: task_lists
     description: >-
@@ -81,28 +81,18 @@ tables:
     guide: |
       Entry-point table. Returns all task lists visible to the authenticated user.
       Obtain the `id` from here to query specific items in the `tasks` table.
-      Filtering by `id` routes directly to the single task list endpoint.
     fetch_limit_default: 100
-    filters:
-      - name: id
-        required: false
     request:
       method: GET
       path: /tasks/v1/users/@me/lists
-    requests:
-      - when_filters:
-          - id
-        method: GET
-        path: /tasks/v1/users/@me/lists/{{filter.id}}
     response:
       rows_path:
         - items
-      row_strategy: direct
     pagination:
       mode: cursor_query
       page_size:
         default: 100
-        max: 100
+        max: 1000
         query_param: maxResults
       cursor_param: pageToken
       response_cursor_path:
@@ -143,42 +133,43 @@ tables:
 
   # ------------------------------------------------------------------
   # google_tasks.tasks — task items inside a list
-  # GET /tasks/v1/lists/{tasklist}/tasks              (list all)
-  # GET /tasks/v1/lists/{tasklist}/tasks/{id}         (single object — row_strategy: direct)
+  # GET /tasks/v1/lists/{tasklist}/tasks
   # Required filter: tasklist_id (PATH param).
-  # Optional filters: show_completed, show_hidden, show_assigned, due_min, etc (QUERY params).
-  # Note: showAssigned=true is required to include tasks assigned from Docs/Chat.
+  # Optional filters pushed to API as query params: showCompleted (default true
+  # per Google API), showDeleted, showHidden, showAssigned, dueMin, dueMax,
+  # completedMin, completedMax, updatedMin.
   # ------------------------------------------------------------------
   - name: tasks
     description: >-
       Individual task items contained within a designated task list.
       Requires `tasklist_id` (from `google_tasks.task_lists.id`).
-      Optionally filter by `id` for single-task lookups, or by
-      `show_completed`, `show_hidden`, `show_assigned`, `due_min`, etc.
+      Optionally filter by `show_completed`, `show_hidden`, `show_assigned`,
+      `due_min`, `due_max`, `completed_min`, `completed_max`, or `updated_min`.
     guide: |
       Requires `tasklist_id` — obtain it from `google_tasks.task_lists`.
 
-      **Point Queries:** Filtering by both `tasklist_id` and `id` routes directly
-      to the single task endpoint and returns one row.
+      **Completed Tasks:** Google Tasks API returns completed tasks by default
+      (`showCompleted` defaults to true). Pass `show_completed = false` to
+      exclude them.
 
-      **Hidden Tasks:** By default, Google Tasks API does not return hidden
-      tasks or tasks completed in first-party clients (like the web UI or mobile app).
-      To see these tasks, include `show_completed = true` AND `show_hidden = true`.
+      **Hidden Tasks:** Hidden tasks (tasks completed in Google first-party
+      clients like the web UI or mobile app) are not returned by default.
+      Pass `show_hidden = true` to include them.
 
-      **Assigned Tasks:** Tasks assigned from Google Docs or Google Chat are not
-      returned by default. Pass `show_assigned = true` to include them.
+      **Assigned Tasks:** Tasks assigned from Google Docs or Google Chat are
+      not returned by default. Pass `show_assigned = true` to include them.
 
-      **Dates:** Filters like `due_min`, `due_max`, `completed_min`, and `completed_max`
-      accept RFC 3339 formatted timestamps (e.g., `2023-10-01T00:00:00Z`).
+      **Dates:** Filters like `due_min`, `due_max`, `completed_min`, and
+      `completed_max` accept RFC 3339 formatted timestamps
+      (e.g., `2024-01-01T00:00:00Z`).
 
-      **Rate limits:** Google Tasks enforces a courtesy rate limit of 50,000 queries
-      per day. Avoid unbounded scans on large lists; use `LIMIT` and date-range filters.
+      **Rate limits:** Google Tasks enforces a courtesy rate limit of 50,000
+      queries per day. Use `LIMIT` and date-range filters to keep queries
+      bounded on large task lists.
     fetch_limit_default: 100
     filters:
       - name: tasklist_id
         required: true
-      - name: id
-        required: false
       - name: show_completed
         required: false
       - name: show_deleted
@@ -228,16 +219,9 @@ tables:
         - name: updatedMin
           from: filter
           key: updated_min
-    requests:
-      - when_filters:
-          - tasklist_id
-          - id
-        method: GET
-        path: /tasks/v1/lists/{{filter.tasklist_id}}/tasks/{{filter.id}}
     response:
       rows_path:
         - items
-      row_strategy: direct
     pagination:
       mode: cursor_query
       page_size:
@@ -259,7 +243,7 @@ tables:
       - name: tasklist_id
         type: Utf8
         nullable: false
-        description: Virtual column mapping back to the filtered task list identifier.
+        description: The task list this task belongs to (echoes the required filter).
         expr:
           kind: from_filter
           key: tasklist_id
@@ -322,7 +306,7 @@ tables:
       - name: deleted
         type: Boolean
         nullable: true
-        description: Whether the task has been deleted (only returned if `show_deleted = true`).
+        description: Whether the task has been deleted (only present if `show_deleted = true`).
         expr:
           kind: path
           path:
@@ -330,7 +314,7 @@ tables:
       - name: hidden
         type: Boolean
         nullable: true
-        description: Whether the task is hidden (only returned if `show_hidden = true`).
+        description: Whether the task is hidden (only present if `show_hidden = true`).
         expr:
           kind: path
           path:
@@ -369,3 +353,84 @@ tables:
           kind: path
           path:
             - links
+      # Virtual columns that echo pushdown filter values back into the result
+      # so that WHERE clauses on these names are valid during query planning.
+      - name: show_completed
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the show_completed filter. When set to false, excludes completed
+          tasks. Google Tasks API returns completed tasks by default (true).
+        expr:
+          kind: from_filter
+          key: show_completed
+      - name: show_deleted
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the show_deleted filter. Set to true to include deleted tasks in results.
+        expr:
+          kind: from_filter
+          key: show_deleted
+      - name: show_hidden
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the show_hidden filter. Set to true to include hidden tasks
+          (tasks completed in Google first-party clients).
+        expr:
+          kind: from_filter
+          key: show_hidden
+      - name: show_assigned
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the show_assigned filter. Set to true to include tasks assigned
+          from Google Docs or Google Chat.
+        expr:
+          kind: from_filter
+          key: show_assigned
+      - name: due_min
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the due_min filter (RFC 3339). Lower bound for task due date.
+        expr:
+          kind: from_filter
+          key: due_min
+      - name: due_max
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the due_max filter (RFC 3339). Upper bound for task due date.
+        expr:
+          kind: from_filter
+          key: due_max
+      - name: completed_min
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the completed_min filter (RFC 3339). Lower bound for completion date.
+        expr:
+          kind: from_filter
+          key: completed_min
+      - name: completed_max
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the completed_max filter (RFC 3339). Upper bound for completion date.
+        expr:
+          kind: from_filter
+          key: completed_max
+      - name: updated_min
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Echoes the updated_min filter (RFC 3339). Lower bound for last modification date.
+        expr:
+          kind: from_filter
+          key: updated_min

--- a/sources/community/google_tasks/manifest.yaml
+++ b/sources/community/google_tasks/manifest.yaml
@@ -9,55 +9,53 @@ description: >-
 base_url: "https://tasks.googleapis.com"
 
 inputs:
-  GOOGLE_CLIENT_ID:
-    kind: variable
-    hint: |
-      Your Google Cloud Console OAuth 2.0 Desktop Application Client ID.
-      Ensure the Google Tasks API is enabled in your Google Cloud Project.
-  GOOGLE_CLIENT_SECRET:
+  GOOGLE_TASKS_ACCESS_TOKEN:
     kind: secret
     hint: |
-      Your Google Cloud Console OAuth 2.0 Desktop Application Client Secret.
-  GOOGLE_TASKS_TOKEN:
-    kind: secret
-    hint: |
-      Google Tasks OAuth access token. Use "Connect with Google" to authenticate
-      interactively via the OAuth authorization-code flow with PKCE. Required
-      scope: https://www.googleapis.com/auth/tasks.readonly
+      Google Tasks OAuth 2.0 access token. Use "Connect Google Tasks" to
+      authenticate interactively, or paste an existing access token issued
+      with the https://www.googleapis.com/auth/tasks.readonly scope.
     credential:
       methods:
         - type: oauth
-          label: Connect with Google
-          description: Authenticate via Google OAuth authorization-code flow with PKCE.
+          label: Connect Google Tasks
+          description: Use Google OAuth to retrieve a Tasks access token.
+          hint: |
+            Enable the Google Tasks API in a Google Cloud project and create
+            an OAuth 2.0 client of type "Desktop app", then enter its Client
+            ID and Client Secret below. Requests read-only access with the
+            `https://www.googleapis.com/auth/tasks.readonly` scope.
+            See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
           oauth:
             flow:
               type: authorization_code
               pkce: required
-            redirect_uri: http://127.0.0.1:53682/oauth/callback
-            redirect_uri_port_mode: fixed
+            redirect_uri: http://127.0.0.1
+            redirect_uri_port_mode: random
             endpoints:
               authorization_url: "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent"
               token_url: https://oauth2.googleapis.com/token
             client:
               id:
-                input: GOOGLE_CLIENT_ID
+                input: GOOGLE_TASKS_OAUTH_CLIENT_ID
               secret:
-                input: GOOGLE_CLIENT_SECRET
-                transport: basic_auth
+                input: GOOGLE_TASKS_OAUTH_CLIENT_SECRET
+                transport: request_body
             scopes:
               scope:
                 delimiter: space
                 values:
                   - https://www.googleapis.com/auth/tasks.readonly
         - type: source_config
-          label: Paste token
+          label: Paste access token
+          description: Paste an existing Google Tasks OAuth access token.
 
 auth:
   type: HeaderAuth
   headers:
     - name: Authorization
       from: template
-      template: "Bearer {{input.GOOGLE_TASKS_TOKEN}}"
+      template: "Bearer {{input.GOOGLE_TASKS_ACCESS_TOKEN}}"
 
 request_headers:
   - name: Accept
@@ -66,7 +64,6 @@ request_headers:
 
 test_queries:
   - SELECT id, title, updated FROM google_tasks.task_lists LIMIT 5
-  - SELECT id, title, status FROM google_tasks.tasks WHERE tasklist_id = 'your-task-list-id' LIMIT 5
 
 tables:
   # ------------------------------------------------------------------
@@ -77,10 +74,12 @@ tables:
   - name: task_lists
     description: >-
       Personal and shared task lists belonging to the authenticated user.
-      Use the `id` from this table as the `tasklist_id` filter when querying the `tasks` table.
+      Use the `id` from this table as the `tasklist_id` filter when querying
+      the `tasks` table.
     guide: |
-      Entry-point table. Returns all task lists visible to the authenticated user.
-      Obtain the `id` from here to query specific items in the `tasks` table.
+      Entry-point table. Returns all task lists visible to the authenticated
+      user. Obtain the `id` from here to query specific items in the `tasks`
+      table.
     fetch_limit_default: 100
     request:
       method: GET
@@ -117,7 +116,7 @@ tables:
       - name: updated
         type: Timestamp
         nullable: true
-        description: Last modification time of the task list (RFC 3339 formatted).
+        description: Last modification time of the task list (RFC 3339).
         expr:
           kind: path
           path:
@@ -135,9 +134,7 @@ tables:
   # google_tasks.tasks — task items inside a list
   # GET /tasks/v1/lists/{tasklist}/tasks
   # Required filter: tasklist_id (PATH param).
-  # Optional filters pushed to API as query params: showCompleted (default true
-  # per Google API), showDeleted, showHidden, showAssigned, dueMin, dueMax,
-  # completedMin, completedMax, updatedMin.
+  # Optional filters pushed to API as query params.
   # ------------------------------------------------------------------
   - name: tasks
     description: >-
@@ -148,24 +145,25 @@ tables:
     guide: |
       Requires `tasklist_id` — obtain it from `google_tasks.task_lists`.
 
-      **Completed Tasks:** Google Tasks API returns completed tasks by default
-      (`showCompleted` defaults to true). Pass `show_completed = false` to
-      exclude them.
+      **Completed Tasks:** Google Tasks API returns completed tasks by
+      default (`showCompleted` defaults to true). However, tasks completed
+      in first-party Google clients (web UI, mobile app) become *hidden*
+      and are only visible when `show_hidden = true` is also set. To get
+      a full completion history, use both `show_completed = true` and
+      `show_hidden = true`.
 
-      **Hidden Tasks:** Hidden tasks (tasks completed in Google first-party
-      clients like the web UI or mobile app) are not returned by default.
-      Pass `show_hidden = true` to include them.
-
-      **Assigned Tasks:** Tasks assigned from Google Docs or Google Chat are
-      not returned by default. Pass `show_assigned = true` to include them.
+      **Assigned Tasks:** Tasks assigned from Google Docs or Google Chat
+      are not returned by default. Pass `show_assigned = true` to include
+      them. These tasks carry `assignment_info` with their origin surface,
+      link, and Drive/Space metadata.
 
       **Dates:** Filters like `due_min`, `due_max`, `completed_min`, and
       `completed_max` accept RFC 3339 formatted timestamps
       (e.g., `2024-01-01T00:00:00Z`).
 
-      **Rate limits:** Google Tasks enforces a courtesy rate limit of 50,000
-      queries per day. Use `LIMIT` and date-range filters to keep queries
-      bounded on large task lists.
+      **Rate limits:** Google Tasks enforces a courtesy rate limit of
+      50,000 queries per day. Use `LIMIT` and date-range filters to keep
+      queries bounded on large task lists.
     fetch_limit_default: 100
     filters:
       - name: tasklist_id
@@ -250,7 +248,7 @@ tables:
       - name: title
         type: Utf8
         nullable: true
-        description: Title / header summary of the task item.
+        description: Title of the task item.
         expr:
           kind: path
           path:
@@ -258,7 +256,8 @@ tables:
       - name: status
         type: Utf8
         nullable: false
-        description: Current structural status of the task (`needsAction` or `completed`).
+        description: >-
+          Current status of the task: `needsAction` or `completed`.
         expr:
           kind: path
           path:
@@ -266,7 +265,7 @@ tables:
       - name: due
         type: Timestamp
         nullable: true
-        description: Due date of the task (RFC 3339 formatted date portion, midnight UTC).
+        description: Due date of the task (RFC 3339, midnight UTC).
         expr:
           kind: path
           path:
@@ -274,7 +273,7 @@ tables:
       - name: completed
         type: Timestamp
         nullable: true
-        description: Completion timestamp of the task (RFC 3339 formatted).
+        description: Completion timestamp of the task (RFC 3339).
         expr:
           kind: path
           path:
@@ -282,7 +281,7 @@ tables:
       - name: notes
         type: Utf8
         nullable: true
-        description: Detailed descriptions or notes appended to the task item.
+        description: Notes or description appended to the task.
         expr:
           kind: path
           path:
@@ -290,7 +289,7 @@ tables:
       - name: parent
         type: Utf8
         nullable: true
-        description: Parent task identifier if this item acts as a subtask.
+        description: Parent task identifier if this is a subtask.
         expr:
           kind: path
           path:
@@ -298,7 +297,7 @@ tables:
       - name: position
         type: Utf8
         nullable: true
-        description: String indicating the position of the task among its sibling tasks.
+        description: Position of the task among its sibling tasks.
         expr:
           kind: path
           path:
@@ -306,7 +305,7 @@ tables:
       - name: deleted
         type: Boolean
         nullable: true
-        description: Whether the task has been deleted (only present if `show_deleted = true`).
+        description: Whether the task has been deleted (only present when show_deleted is true).
         expr:
           kind: path
           path:
@@ -314,7 +313,7 @@ tables:
       - name: hidden
         type: Boolean
         nullable: true
-        description: Whether the task is hidden (only present if `show_hidden = true`).
+        description: Whether the task is hidden (only present when show_hidden is true).
         expr:
           kind: path
           path:
@@ -322,7 +321,7 @@ tables:
       - name: updated
         type: Timestamp
         nullable: true
-        description: Last modification timestamp of the task (RFC 3339 formatted).
+        description: Last modification timestamp of the task (RFC 3339).
         expr:
           kind: path
           path:
@@ -330,7 +329,7 @@ tables:
       - name: self_link
         type: Utf8
         nullable: true
-        description: URL pointing to this task.
+        description: URL pointing to this task resource.
         expr:
           kind: path
           path:
@@ -338,13 +337,68 @@ tables:
       - name: web_view_link
         type: Utf8
         nullable: true
-        description: >-
-          Absolute link to the task in the Google Tasks web UI. Present on
-          tasks assigned from Google Docs or Chat.
+        description: Link to the task in the Google Tasks web UI.
         expr:
           kind: path
           path:
             - webViewLink
+      - name: assignment_surface_type
+        type: Utf8
+        nullable: true
+        description: >-
+          Origin surface for assigned tasks: DOCUMENT (Google Docs) or
+          SPACE (Google Chat). Null for non-assigned tasks.
+        expr:
+          kind: path
+          path:
+            - assignmentInfo
+            - surfaceType
+      - name: assignment_link_to_task
+        type: Utf8
+        nullable: true
+        description: >-
+          Absolute link to the assigned task in its origin surface
+          (the specific document or chat space).
+        expr:
+          kind: path
+          path:
+            - assignmentInfo
+            - linkToTask
+      - name: assignment_drive_file_id
+        type: Utf8
+        nullable: true
+        description: >-
+          Drive file ID of the document where the task was assigned.
+          Present when assignment_surface_type is DOCUMENT.
+        expr:
+          kind: path
+          path:
+            - assignmentInfo
+            - driveResourceInfo
+            - driveFileId
+      - name: assignment_space
+        type: Utf8
+        nullable: true
+        description: >-
+          Chat space identifier (spaces/{space}) where the task was assigned.
+          Present when assignment_surface_type is SPACE.
+        expr:
+          kind: path
+          path:
+            - assignmentInfo
+            - spaceInfo
+            - space
+      - name: assignment_info
+        type: Json
+        nullable: true
+        description: >-
+          Full raw assignmentInfo object. Contains surfaceType, linkToTask,
+          driveResourceInfo, and spaceInfo for tasks assigned from Google
+          Docs or Google Chat.
+        expr:
+          kind: path
+          path:
+            - assignmentInfo
       - name: links
         type: Json
         nullable: true
@@ -353,15 +407,15 @@ tables:
           kind: path
           path:
             - links
-      # Virtual columns that echo pushdown filter values back into the result
-      # so that WHERE clauses on these names are valid during query planning.
+      # Virtual columns that echo pushdown filter values so that
+      # WHERE clauses on these names pass query planning.
       - name: show_completed
         type: Boolean
         nullable: true
         virtual: true
         description: >-
-          Echoes the show_completed filter. When set to false, excludes completed
-          tasks. Google Tasks API returns completed tasks by default (true).
+          Echoes the show_completed filter. Google returns completed tasks
+          by default (true). Set false to exclude them.
         expr:
           kind: from_filter
           key: show_completed
@@ -369,8 +423,7 @@ tables:
         type: Boolean
         nullable: true
         virtual: true
-        description: >-
-          Echoes the show_deleted filter. Set to true to include deleted tasks in results.
+        description: Echoes the show_deleted filter. Set true to include deleted tasks.
         expr:
           kind: from_filter
           key: show_deleted
@@ -379,7 +432,7 @@ tables:
         nullable: true
         virtual: true
         description: >-
-          Echoes the show_hidden filter. Set to true to include hidden tasks
+          Echoes the show_hidden filter. Set true to include hidden tasks
           (tasks completed in Google first-party clients).
         expr:
           kind: from_filter
@@ -389,8 +442,8 @@ tables:
         nullable: true
         virtual: true
         description: >-
-          Echoes the show_assigned filter. Set to true to include tasks assigned
-          from Google Docs or Google Chat.
+          Echoes the show_assigned filter. Set true to include tasks
+          assigned from Google Docs or Google Chat.
         expr:
           kind: from_filter
           key: show_assigned

--- a/sources/community/google_tasks/manifest.yaml
+++ b/sources/community/google_tasks/manifest.yaml
@@ -15,22 +15,24 @@ inputs:
       Google Tasks OAuth 2.0 access token. Use "Connect Google Tasks" to
       authenticate interactively, or paste an existing access token issued
       with the https://www.googleapis.com/auth/tasks.readonly scope.
+
+      For interactive setup, enable the Google Tasks API in a Google Cloud
+      project and create an OAuth 2.0 client of type "Desktop app", then
+      enter its Client ID and Client Secret when prompted. See
+      https://support.google.com/cloud/answer/6158849.
     credential:
       methods:
         - type: oauth
           label: Connect Google Tasks
-          description: Use Google OAuth to retrieve a Tasks access token.
-          hint: |
-            Enable the Google Tasks API in a Google Cloud project and create
-            an OAuth 2.0 client of type "Desktop app", then enter its Client
-            ID and Client Secret below. Requests read-only access with the
-            `https://www.googleapis.com/auth/tasks.readonly` scope.
-            See [Google OAuth client setup](https://support.google.com/cloud/answer/6158849).
+          description: >-
+            Use Google OAuth to retrieve a Tasks access token.
+            Requests read-only access with the
+            https://www.googleapis.com/auth/tasks.readonly scope.
           oauth:
             flow:
               type: authorization_code
               pkce: required
-            redirect_uri: http://127.0.0.1
+            redirect_uri: http://127.0.0.1/oauth/callback
             redirect_uri_port_mode: random
             endpoints:
               authorization_url: "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent"
@@ -118,9 +120,12 @@ tables:
         nullable: true
         description: Last modification time of the task list (RFC 3339).
         expr:
-          kind: path
-          path:
-            - updated
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated
       - name: self_link
         type: Utf8
         nullable: true
@@ -267,17 +272,23 @@ tables:
         nullable: true
         description: Due date of the task (RFC 3339, midnight UTC).
         expr:
-          kind: path
-          path:
-            - due
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - due
       - name: completed
         type: Timestamp
         nullable: true
         description: Completion timestamp of the task (RFC 3339).
         expr:
-          kind: path
-          path:
-            - completed
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - completed
       - name: notes
         type: Utf8
         nullable: true
@@ -323,9 +334,12 @@ tables:
         nullable: true
         description: Last modification timestamp of the task (RFC 3339).
         expr:
-          kind: path
-          path:
-            - updated
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated
       - name: self_link
         type: Utf8
         nullable: true

--- a/sources/community/google_tasks/manifest.yaml
+++ b/sources/community/google_tasks/manifest.yaml
@@ -1,0 +1,335 @@
+name: google_tasks
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query task lists and tasks from the Google Tasks API. Supports fetching
+  all your personal and shared task lists, and allows deep filtering of tasks
+  by due dates, completion status, and visibility.
+base_url: "https://tasks.googleapis.com"
+
+inputs:
+  GOOGLE_CLIENT_ID:
+    kind: variable
+    hint: |
+      Your Google Cloud Console OAuth 2.0 Desktop Application Client ID.
+      Ensure the Google Tasks API is enabled in your Google Cloud Project.
+  GOOGLE_CLIENT_SECRET:
+    kind: secret
+    hint: |
+      Your Google Cloud Console OAuth 2.0 Desktop Application Client Secret.
+  GOOGLE_TASKS_TOKEN:
+    kind: secret
+    hint: Secured OAuth access token for Google Tasks API queries.
+    credential:
+      methods:
+        - type: oauth
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: disabled
+            redirect_uri: "http://127.0.0.1:0"
+            redirect_uri_port_mode: random
+            endpoints:
+              authorization_url: "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent"
+              token_url: "https://oauth2.googleapis.com/token"
+            client:
+              id:
+                input: GOOGLE_CLIENT_ID
+              secret:
+                input: GOOGLE_CLIENT_SECRET
+                transport: request_body
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - "https://www.googleapis.com/auth/tasks.readonly"
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.GOOGLE_TASKS_TOKEN}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, title, updated FROM google_tasks.task_lists LIMIT 5
+  - SELECT id, title, status FROM google_tasks.tasks WHERE tasklist_id = 'your-task-list-id' LIMIT 5
+
+tables:
+  # ------------------------------------------------------------------
+  # google_tasks.task_lists — all task lists accessible to the user
+  # GET /tasks/v1/users/@me/lists
+  # ------------------------------------------------------------------
+  - name: task_lists
+    description: >-
+      Personal and shared task lists belonging to the authenticated user.
+      Use the `id` from this table as the `tasklist_id` filter when querying the `tasks` table.
+    guide: |
+      Entry-point table. Returns all task lists visible to the authenticated user.
+      Obtain the `id` from here to query specific items in the `tasks` table.
+      Point queries by `id` are supported and will route to the single task list endpoint.
+    filters:
+      - name: id
+        required: false
+    request:
+      method: GET
+      path: /tasks/v1/users/@me/lists
+    requests:
+      - when_filters:
+          - id
+        method: GET
+        path: /tasks/v1/users/@me/lists/{{filter.id}}
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 100
+        max: 100
+        query_param: maxResults
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the task list.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Title of the task list.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Last modification time of the task list (RFC 3339 formatted).
+        expr:
+          kind: path
+          path:
+            - updated
+      - name: self_link
+        type: Utf8
+        nullable: true
+        description: URL pointing to this task list.
+        expr:
+          kind: path
+          path:
+            - selfLink
+
+  # ------------------------------------------------------------------
+  # google_tasks.tasks — task items inside a list
+  # GET /tasks/v1/lists/{tasklist}/tasks
+  # Required filter: tasklist_id (PATH param).
+  # Optional filters: show_completed, show_hidden, due_min, etc (QUERY params).
+  # ------------------------------------------------------------------
+  - name: tasks
+    description: >-
+      Individual task items contained within a designated task list.
+      Requires `tasklist_id` (from `google_tasks.task_lists.id`).
+      Optionally filter by `id` for point queries, or `show_completed`, `show_hidden`, `due_min`, etc.
+    guide: |
+      Requires `tasklist_id` — obtain it from `google_tasks.task_lists`.
+      
+      **Point Queries:** Filtering by `id` will route directly to the single task endpoint.
+      
+      **Hidden Tasks:** By default, Google Tasks API does not return hidden
+      tasks or tasks completed in first-party clients (like the web UI or mobile app).
+      To see these tasks, you MUST include the filters `show_completed = true` AND
+      `show_hidden = true`.
+      
+      **Dates:** Filters like `due_min`, `due_max`, `completed_min`, and `completed_max`
+      accept RFC 3339 formatted timestamps (e.g., `2023-10-01T00:00:00Z`).
+    filters:
+      - name: tasklist_id
+        required: true
+      - name: id
+        required: false
+      - name: show_completed
+        required: false
+      - name: show_deleted
+        required: false
+      - name: show_hidden
+        required: false
+      - name: due_min
+        required: false
+      - name: due_max
+        required: false
+      - name: completed_min
+        required: false
+      - name: completed_max
+        required: false
+      - name: updated_min
+        required: false
+    request:
+      method: GET
+      path: /tasks/v1/lists/{{filter.tasklist_id}}/tasks
+      query:
+        - name: showCompleted
+          from: filter
+          key: show_completed
+        - name: showDeleted
+          from: filter
+          key: show_deleted
+        - name: showHidden
+          from: filter
+          key: show_hidden
+        - name: dueMin
+          from: filter
+          key: due_min
+        - name: dueMax
+          from: filter
+          key: due_max
+        - name: completedMin
+          from: filter
+          key: completed_min
+        - name: completedMax
+          from: filter
+          key: completed_max
+        - name: updatedMin
+          from: filter
+          key: updated_min
+    requests:
+      - when_filters:
+          - tasklist_id
+          - id
+        method: GET
+        path: /tasks/v1/lists/{{filter.tasklist_id}}/tasks/{{filter.id}}
+    response:
+      rows_path:
+        - items
+    pagination:
+      mode: cursor_query
+      page_size:
+        default: 100
+        max: 100
+        query_param: maxResults
+      cursor_param: pageToken
+      response_cursor_path:
+        - nextPageToken
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the task item.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: tasklist_id
+        type: Utf8
+        nullable: false
+        description: Virtual column mapping back to the filtered task list identifier.
+        expr:
+          kind: from_filter
+          key: tasklist_id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Title / header summary of the task item.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: status
+        type: Utf8
+        nullable: false
+        description: Current structural status of the task (`needsAction` or `completed`).
+        expr:
+          kind: path
+          path:
+            - status
+      - name: due
+        type: Timestamp
+        nullable: true
+        description: Due date of the task (RFC 3339 formatted date portion, midnight UTC).
+        expr:
+          kind: path
+          path:
+            - due
+      - name: completed
+        type: Timestamp
+        nullable: true
+        description: Completion timestamp of the task (RFC 3339 formatted).
+        expr:
+          kind: path
+          path:
+            - completed
+      - name: notes
+        type: Utf8
+        nullable: true
+        description: Detailed descriptions or notes appended to the task item.
+        expr:
+          kind: path
+          path:
+            - notes
+      - name: parent
+        type: Utf8
+        nullable: true
+        description: Parent task identifier if this item acts as a subtask.
+        expr:
+          kind: path
+          path:
+            - parent
+      - name: position
+        type: Utf8
+        nullable: true
+        description: String indicating the position of the task among its sibling tasks.
+        expr:
+          kind: path
+          path:
+            - position
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: Whether the task has been deleted (only returned if `show_deleted = true`).
+        expr:
+          kind: path
+          path:
+            - deleted
+      - name: hidden
+        type: Boolean
+        nullable: true
+        description: Whether the task is hidden (only returned if `show_hidden = true`).
+        expr:
+          kind: path
+          path:
+            - hidden
+      - name: updated
+        type: Timestamp
+        nullable: true
+        description: Last modification timestamp of the task (RFC 3339 formatted).
+        expr:
+          kind: path
+          path:
+            - updated
+      - name: self_link
+        type: Utf8
+        nullable: true
+        description: URL pointing to this task.
+        expr:
+          kind: path
+          path:
+            - selfLink
+      - name: links
+        type: Json
+        nullable: true
+        description: JSON array of links to related web pages (e.g. emails in Gmail).
+        expr:
+          kind: path
+          path:
+            - links

--- a/sources/community/google_tasks/manifest.yaml
+++ b/sources/community/google_tasks/manifest.yaml
@@ -5,7 +5,7 @@ backend: http
 description: >-
   Query task lists and tasks from the Google Tasks API. Supports fetching
   all your personal and shared task lists, and allows deep filtering of tasks
-  by due dates, completion status, and visibility.
+  by due dates, completion status, assignment, and visibility.
 base_url: "https://tasks.googleapis.com"
 
 inputs:
@@ -14,28 +14,43 @@ inputs:
     hint: |
       Your Google Cloud Console OAuth 2.0 Desktop Application Client ID.
       Ensure the Google Tasks API is enabled in your Google Cloud Project.
+  GOOGLE_CLIENT_SECRET:
+    kind: secret
+    hint: |
+      Your Google Cloud Console OAuth 2.0 Desktop Application Client Secret.
   GOOGLE_TASKS_TOKEN:
     kind: secret
-    hint: Secured OAuth access token for Google Tasks API queries.
+    hint: |
+      Google Tasks OAuth access token. Use "Connect with Google" to authenticate
+      interactively via the OAuth authorization-code flow. Required scope:
+      https://www.googleapis.com/auth/tasks.readonly
     credential:
       methods:
         - type: oauth
+          label: Connect with Google
+          description: Authenticate via Google OAuth authorization-code flow.
           oauth:
             flow:
               type: authorization_code
-              pkce: required
+              pkce: disabled
             redirect_uri: http://127.0.0.1:53682/oauth/callback
+            redirect_uri_port_mode: fixed
             endpoints:
-              authorization_url: https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent
+              authorization_url: "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent"
               token_url: https://oauth2.googleapis.com/token
             client:
               id:
                 input: GOOGLE_CLIENT_ID
+              secret:
+                input: GOOGLE_CLIENT_SECRET
+                transport: basic_auth
             scopes:
               scope:
                 delimiter: space
                 values:
                   - https://www.googleapis.com/auth/tasks.readonly
+        - type: source_config
+          label: Paste token
 
 auth:
   type: HeaderAuth
@@ -56,7 +71,8 @@ test_queries:
 tables:
   # ------------------------------------------------------------------
   # google_tasks.task_lists — all task lists accessible to the user
-  # GET /tasks/v1/users/@me/lists
+  # GET /tasks/v1/users/@me/lists        (list all)
+  # GET /tasks/v1/users/@me/lists/{id}   (single object — row_strategy: direct)
   # ------------------------------------------------------------------
   - name: task_lists
     description: >-
@@ -65,7 +81,8 @@ tables:
     guide: |
       Entry-point table. Returns all task lists visible to the authenticated user.
       Obtain the `id` from here to query specific items in the `tasks` table.
-      Point queries by `id` are supported and will route to the single task list endpoint.
+      Filtering by `id` routes directly to the single task list endpoint.
+    fetch_limit_default: 100
     filters:
       - name: id
         required: false
@@ -80,6 +97,7 @@ tables:
     response:
       rows_path:
         - items
+      row_strategy: direct
     pagination:
       mode: cursor_query
       page_size:
@@ -125,27 +143,37 @@ tables:
 
   # ------------------------------------------------------------------
   # google_tasks.tasks — task items inside a list
-  # GET /tasks/v1/lists/{tasklist}/tasks
+  # GET /tasks/v1/lists/{tasklist}/tasks              (list all)
+  # GET /tasks/v1/lists/{tasklist}/tasks/{id}         (single object — row_strategy: direct)
   # Required filter: tasklist_id (PATH param).
-  # Optional filters: show_completed, show_hidden, due_min, etc (QUERY params).
+  # Optional filters: show_completed, show_hidden, show_assigned, due_min, etc (QUERY params).
+  # Note: showAssigned=true is required to include tasks assigned from Docs/Chat.
   # ------------------------------------------------------------------
   - name: tasks
     description: >-
       Individual task items contained within a designated task list.
       Requires `tasklist_id` (from `google_tasks.task_lists.id`).
-      Optionally filter by `id` for point queries, or `show_completed`, `show_hidden`, `due_min`, etc.
+      Optionally filter by `id` for single-task lookups, or by
+      `show_completed`, `show_hidden`, `show_assigned`, `due_min`, etc.
     guide: |
       Requires `tasklist_id` — obtain it from `google_tasks.task_lists`.
 
-      **Point Queries:** Filtering by `id` will route directly to the single task endpoint.
+      **Point Queries:** Filtering by both `tasklist_id` and `id` routes directly
+      to the single task endpoint and returns one row.
 
       **Hidden Tasks:** By default, Google Tasks API does not return hidden
       tasks or tasks completed in first-party clients (like the web UI or mobile app).
-      To see these tasks, you MUST include the filters `show_completed = true` AND
-      `show_hidden = true`.
+      To see these tasks, include `show_completed = true` AND `show_hidden = true`.
+
+      **Assigned Tasks:** Tasks assigned from Google Docs or Google Chat are not
+      returned by default. Pass `show_assigned = true` to include them.
 
       **Dates:** Filters like `due_min`, `due_max`, `completed_min`, and `completed_max`
       accept RFC 3339 formatted timestamps (e.g., `2023-10-01T00:00:00Z`).
+
+      **Rate limits:** Google Tasks enforces a courtesy rate limit of 50,000 queries
+      per day. Avoid unbounded scans on large lists; use `LIMIT` and date-range filters.
+    fetch_limit_default: 100
     filters:
       - name: tasklist_id
         required: true
@@ -156,6 +184,8 @@ tables:
       - name: show_deleted
         required: false
       - name: show_hidden
+        required: false
+      - name: show_assigned
         required: false
       - name: due_min
         required: false
@@ -180,6 +210,9 @@ tables:
         - name: showHidden
           from: filter
           key: show_hidden
+        - name: showAssigned
+          from: filter
+          key: show_assigned
         - name: dueMin
           from: filter
           key: due_min
@@ -204,6 +237,7 @@ tables:
     response:
       rows_path:
         - items
+      row_strategy: direct
     pagination:
       mode: cursor_query
       page_size:
@@ -317,6 +351,16 @@ tables:
           kind: path
           path:
             - selfLink
+      - name: web_view_link
+        type: Utf8
+        nullable: true
+        description: >-
+          Absolute link to the task in the Google Tasks web UI. Present on
+          tasks assigned from Google Docs or Chat.
+        expr:
+          kind: path
+          path:
+            - webViewLink
       - name: links
         type: Json
         nullable: true

--- a/sources/community/google_tasks/manifest.yaml
+++ b/sources/community/google_tasks/manifest.yaml
@@ -14,10 +14,6 @@ inputs:
     hint: |
       Your Google Cloud Console OAuth 2.0 Desktop Application Client ID.
       Ensure the Google Tasks API is enabled in your Google Cloud Project.
-  GOOGLE_CLIENT_SECRET:
-    kind: secret
-    hint: |
-      Your Google Cloud Console OAuth 2.0 Desktop Application Client Secret.
   GOOGLE_TASKS_TOKEN:
     kind: secret
     hint: Secured OAuth access token for Google Tasks API queries.
@@ -27,23 +23,19 @@ inputs:
           oauth:
             flow:
               type: authorization_code
-              pkce: disabled
-            redirect_uri: "http://127.0.0.1:0"
-            redirect_uri_port_mode: random
+              pkce: required
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
             endpoints:
-              authorization_url: "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent"
-              token_url: "https://oauth2.googleapis.com/token"
+              authorization_url: https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent
+              token_url: https://oauth2.googleapis.com/token
             client:
               id:
                 input: GOOGLE_CLIENT_ID
-              secret:
-                input: GOOGLE_CLIENT_SECRET
-                transport: request_body
             scopes:
               scope:
                 delimiter: space
                 values:
-                  - "https://www.googleapis.com/auth/tasks.readonly"
+                  - https://www.googleapis.com/auth/tasks.readonly
 
 auth:
   type: HeaderAuth
@@ -144,14 +136,14 @@ tables:
       Optionally filter by `id` for point queries, or `show_completed`, `show_hidden`, `due_min`, etc.
     guide: |
       Requires `tasklist_id` — obtain it from `google_tasks.task_lists`.
-      
+
       **Point Queries:** Filtering by `id` will route directly to the single task endpoint.
-      
+
       **Hidden Tasks:** By default, Google Tasks API does not return hidden
       tasks or tasks completed in first-party clients (like the web UI or mobile app).
       To see these tasks, you MUST include the filters `show_completed = true` AND
       `show_hidden = true`.
-      
+
       **Dates:** Filters like `due_min`, `due_max`, `completed_min`, and `completed_max`
       accept RFC 3339 formatted timestamps (e.g., `2023-10-01T00:00:00Z`).
     filters:


### PR DESCRIPTION
# Description
Fixes #738

Add a new google_tasks community source that lets Coral query a user's personal and shared task lists, and individual tasks through SQL — enabling deep task filtering, completion analysis, and cross-list joins.

This change is manifest-only and uses Coral's existing HTTP source-spec model with the OAuth 2.0 authorization-code credential block. Read-only. No CLI, MCP, config, or runtime changes.

## What changed
**Added:**
- `sources/community/google_tasks/manifest.yaml`
- `sources/community/google_tasks/README.md`

## Source scope
**Inputs:**
- `GOOGLE_TASKS_TOKEN` — OAuth access token (secret), collected via browser flow.
- `GOOGLE_CLIENT_ID` — Google Cloud Desktop App Client ID (variable), required to initiate the OAuth flow.
- `GOOGLE_CLIENT_SECRET` — Google Cloud Desktop App Client Secret (secret), required for token exchange.

**OAuth:**
- Flow: `authorization_code` with `pkce: disabled`
- Redirect URI: `http://127.0.0.1:0` (`random` port mode)
- Authorization URL: `https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent`
- Token URL: `https://oauth2.googleapis.com/token`
- Secret transport: `request_body`
- Scopes: `https://www.googleapis.com/auth/tasks.readonly`

**Tables:**

### `google_tasks.task_lists`
- `GET /tasks/v1/users/@me/lists`
- `cursor_query` pagination, `maxResults` up to 100
- 4 columns including `id`, `title`, `updated`, `self_link`
- Dynamically routes to `GET /tasks/v1/users/@me/lists/{id}` when an `id` is provided in the `WHERE` clause.

### `google_tasks.tasks`
- `GET /tasks/v1/lists/{tasklist}/tasks`
- `cursor_query` pagination, `maxResults` up to 100
- 8 optional API pushdown filters (`show_completed`, `show_deleted`, `show_hidden`, `due_min`, `due_max`, `completed_min`, `completed_max`, `updated_min`) mapped to query parameters.
- 14 columns including `id`, `tasklist_id`, `title`, `status`, `due`, `completed`, `notes`, `parent`, `links`.
- Dynamically routes to `GET /tasks/v1/lists/{tasklist}/tasks/{id}` when an `id` is provided in the `WHERE` clause.

## Implementation notes
- `auth`: `Authorization: Bearer {{input.GOOGLE_TASKS_TOKEN}}` via `HeaderAuth`.
- Uses `requests` blocks for both tables to enable lightning-fast direct routing for point queries by `id` (bypassing the list endpoints entirely).
- Extracts complex JSON objects directly via simple `.path` definitions.
- `tasklist_id` constraint is strictly enforced as a `required: true` filter and injected into the URL path.
- `tasklist_id` is exposed in the `tasks` table as a `virtual: true` echo column via `from_filter`.

## Out of scope
Not included in v1:
- Write operations of any kind (creating, updating, deleting tasks/lists).
- Moving tasks between positions or lists.
- Clearing completed tasks.
