### PR TITLE
feat(sources/community/bitbucket): add bitbucket community source

### DIFF
--- a/sources/community/bitbucket/README.md
+++ b/sources/community/bitbucket/README.md
@@ -1,0 +1,236 @@
+# Bitbucket (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Bitbucket Cloud REST API v2.0)
+**Tables:** 3
+**Base URL:** `https://api.bitbucket.org/2.0`
+
+Query repositories, pull requests, and CI/CD pipelines from Bitbucket Cloud
+via SQL. Designed for engineering analytics: PR cycle times, deployment
+tracking, and compliance reporting. Pairs naturally with the bundled **Jira**
+source for full Atlassian-stack coverage.
+
+## Setup
+
+### 1. Create a Bitbucket OAuth consumer
+
+In your Bitbucket workspace, go to
+**Settings → OAuth consumers → Add consumer**.
+
+Add the following redirect URI exactly as shown:
+
+```
+http://127.0.0.1:53682/oauth/callback
+```
+
+Grant the following permissions:
+
+| Permission | Scope |
+|---|---|
+| Account | Read |
+| Repositories | Read |
+| Pull requests | Read |
+| Pipelines | Read |
+
+Copy the **Key** (this is your `BITBUCKET_CLIENT_ID`) and the **Secret**
+(`BITBUCKET_CLIENT_SECRET`) from the consumer you just created.
+
+### 2. Set your credentials
+
+```sh
+export BITBUCKET_CLIENT_ID="<your-consumer-key>"
+export BITBUCKET_CLIENT_SECRET="<your-consumer-secret>"
+```
+
+### 3. Add the source
+
+```sh
+cargo run -p coral-cli -- source add --file sources/community/bitbucket/manifest.yaml
+```
+
+Coral will open your browser to the Bitbucket authorization page. After you
+approve the requested scopes, Coral stores the access token automatically.
+
+To paste a personal access token instead of using the browser flow, run the
+source add command and choose **Paste personal access token** when prompted.
+Generate a token under **Bitbucket profile → Personal settings → App
+passwords** with Repositories, Pull requests, and Pipelines read access.
+
+### 4. Verify
+
+```sh
+cargo run -p coral-cli -- source test bitbucket
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `bitbucket.repositories` | Repositories in a workspace | `workspace` |
+| `bitbucket.pull_requests` | Pull requests in a repository | `workspace`, `repo_slug` |
+| `bitbucket.pipelines` | CI/CD pipeline runs for a repository | `workspace`, `repo_slug` |
+
+All tables are read-only. This source does not create, modify, or delete any
+Bitbucket data.
+
+### `repositories`
+
+Lists all repositories in a workspace. The `slug` column is the value to
+pass as `repo_slug` when querying `pull_requests` or `pipelines`.
+
+### `pull_requests`
+
+Lists pull requests for one repository. Filter on `state` to narrow results:
+
+| Value | Meaning |
+|---|---|
+| `OPEN` | Pull request is open |
+| `MERGED` | Pull request was merged |
+| `DECLINED` | Pull request was declined |
+| `SUPERSEDED` | Pull request was superseded by another |
+
+### `pipelines`
+
+Lists CI/CD pipeline runs for one repository. `state_name` holds the
+top-level run state (for example `COMPLETED` or `IN_PROGRESS`).
+`state_result_name` holds the result within a completed run (for example
+`SUCCESSFUL` or `FAILED`).
+
+## Filters and pagination
+
+All tables use page-based pagination (`page`, `pagelen`). The default page
+size is 50; the maximum is 100. Always use `LIMIT` when querying large
+workspaces or repositories.
+
+`repositories` requires `workspace`. `pull_requests` and `pipelines` require
+both `workspace` and `repo_slug`.
+
+Bitbucket Cloud does not expose a workspace-discovery endpoint without elevated
+admin scopes. Pass the workspace slug directly as a filter, matching the
+behaviour of the bundled Jira and Confluence sources.
+
+## Example queries
+
+List repositories in a workspace:
+
+```sql
+SELECT slug, name, language, is_private, updated_on
+FROM bitbucket.repositories
+WHERE workspace = 'my-workspace'
+ORDER BY updated_on DESC
+LIMIT 20;
+```
+
+Open pull requests for a repository:
+
+```sql
+SELECT id, title, author_nickname, source_branch, destination_branch, created_on
+FROM bitbucket.pull_requests
+WHERE workspace = 'my-workspace'
+  AND repo_slug = 'my-repo'
+  AND state = 'OPEN'
+ORDER BY created_on DESC
+LIMIT 20;
+```
+
+Merged PR cycle times:
+
+```sql
+SELECT id, title, author_nickname, created_on, updated_on
+FROM bitbucket.pull_requests
+WHERE workspace = 'my-workspace'
+  AND repo_slug = 'my-repo'
+  AND state = 'MERGED'
+ORDER BY updated_on DESC
+LIMIT 50;
+```
+
+Failed pipeline runs:
+
+```sql
+SELECT build_number, creator_nickname, created_on, completed_on
+FROM bitbucket.pipelines
+WHERE workspace = 'my-workspace'
+  AND repo_slug = 'my-repo'
+  AND state_name = 'COMPLETED'
+  AND state_result_name = 'FAILED'
+ORDER BY created_on DESC
+LIMIT 20;
+```
+
+Private repositories in a workspace:
+
+```sql
+SELECT slug, name, language, updated_on
+FROM bitbucket.repositories
+WHERE workspace = 'my-workspace'
+  AND is_private = true
+ORDER BY updated_on DESC
+LIMIT 20;
+```
+
+PRs alongside pipelines for the same repository:
+
+```sql
+SELECT
+  p.id          AS pr_id,
+  p.title       AS pr_title,
+  p.state       AS pr_state,
+  p.author_nickname,
+  p.created_on  AS pr_opened,
+  p.updated_on  AS pr_updated
+FROM bitbucket.pull_requests p
+WHERE p.workspace = 'my-workspace'
+  AND p.repo_slug = 'my-repo'
+  AND p.state = 'MERGED'
+ORDER BY p.updated_on DESC
+LIMIT 20;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/bitbucket/manifest.yaml
+```
+
+Install and run the built-in test queries:
+
+```sh
+export BITBUCKET_CLIENT_ID="<your-consumer-key>"
+export BITBUCKET_CLIENT_SECRET="<your-consumer-secret>"
+cargo run -p coral-cli -- source add --file sources/community/bitbucket/manifest.yaml
+cargo run -p coral-cli -- source test bitbucket
+```
+
+Inspect registered tables and columns:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'bitbucket'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'bitbucket' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- **OAuth requires a confidential client**: Bitbucket Cloud requires
+  `client_secret` for the authorization-code flow; PKCE public-client
+  flows are not currently supported. If Bitbucket adds PKCE support in the
+  future this spec can be updated.
+- **Fixed redirect URI**: the OAuth consumer must be registered with the
+  exact redirect URI `http://127.0.0.1:53682/oauth/callback`.
+- **No workspace discovery**: Bitbucket Cloud does not expose a simple
+  workspace list without admin scopes. Pass the workspace slug directly
+  as a required filter, matching the behaviour of the bundled Jira source.
+- **Page-based pagination**: all tables paginate by `page` and `pagelen`.
+  Always use `LIMIT` on large workspaces or repositories.
+- **Rate limits**: the Bitbucket Cloud API enforces rate limits per OAuth
+  token. Reduce query frequency or add retries if you hit limits.
+
+## Out of scope for v1
+
+- Workspace discovery (requires admin scopes)
+- Commits table
+- Branches table
+- Pipeline steps and log output
+- Write operations of any kind

--- a/sources/community/bitbucket/README.md
+++ b/sources/community/bitbucket/README.md
@@ -51,10 +51,12 @@ cargo run -p coral-cli -- source add --file sources/community/bitbucket/manifest
 Coral will open your browser to the Bitbucket authorization page. After you
 approve the requested scopes, Coral stores the access token automatically.
 
-To paste a personal access token instead of using the browser flow, run the
-source add command and choose **Paste personal access token** when prompted.
-Generate a token under **Bitbucket profile → Personal settings → App
-passwords** with Repositories, Pull requests, and Pipelines read access.
+To paste a token manually instead of using the browser flow, run the source
+add command and choose **Paste personal access token** when prompted. Paste
+an OAuth access token obtained via the Bitbucket OAuth flow. Note that
+Bitbucket App passwords use HTTP Basic auth and are not compatible with this
+source's Bearer token auth scheme — pasting an App password here will result
+in 401 errors.
 
 ### 4. Verify
 
@@ -169,21 +171,26 @@ ORDER BY updated_on DESC
 LIMIT 20;
 ```
 
-PRs alongside pipelines for the same repository:
+Recent pipeline runs alongside open pull requests for the same repository:
 
 ```sql
 SELECT
-  p.id          AS pr_id,
-  p.title       AS pr_title,
-  p.state       AS pr_state,
-  p.author_nickname,
-  p.created_on  AS pr_opened,
-  p.updated_on  AS pr_updated
-FROM bitbucket.pull_requests p
-WHERE p.workspace = 'my-workspace'
-  AND p.repo_slug = 'my-repo'
-  AND p.state = 'MERGED'
-ORDER BY p.updated_on DESC
+  pr.id                  AS pr_id,
+  pr.title               AS pr_title,
+  pr.author_nickname,
+  pr.created_on          AS pr_opened,
+  pi.build_number,
+  pi.state_name,
+  pi.state_result_name,
+  pi.completed_on        AS pipeline_completed
+FROM bitbucket.pull_requests pr
+JOIN bitbucket.pipelines pi
+  ON pr.workspace = pi.workspace
+  AND pr.repo_slug = pi.repo_slug
+WHERE pr.workspace = 'my-workspace'
+  AND pr.repo_slug = 'my-repo'
+  AND pr.state = 'OPEN'
+ORDER BY pi.build_number DESC
 LIMIT 20;
 ```
 

--- a/sources/community/bitbucket/README.md
+++ b/sources/community/bitbucket/README.md
@@ -54,10 +54,11 @@ Coral will open your browser to the Bitbucket authorization page. After you
 approve the requested scopes, Coral stores the access token automatically and
 handles token refresh.
 
-> **Auth note:** this source uses `Authorization: Bearer <oauth_token>` and
-> supports only OAuth access tokens issued by the Bitbucket authorization
-> flow above. Bitbucket App passwords and repository access tokens use HTTP
-> Basic auth and are **not** compatible with this source.
+> **Auth note:** this source uses `Authorization: Bearer <token>` and supports
+> any Bitbucket Bearer token — OAuth access tokens from the flow above, or
+> Bitbucket repository access tokens (which also use Bearer auth). Bitbucket
+> App passwords are the Basic auth variant and are **not** compatible with
+> this source.
 
 ### 4. Verify
 
@@ -73,7 +74,7 @@ Replace `your-workspace` with your Bitbucket workspace slug.
 |---|---|---|---|
 | `bitbucket.repositories` | Repositories in a workspace | `workspace` | — |
 | `bitbucket.pull_requests` | Pull requests in a repository | `workspace`, `repo_slug` | `state` |
-| `bitbucket.pipelines` | CI/CD pipeline runs for a repository | `workspace`, `repo_slug` | `status` |
+| `bitbucket.pipelines` | CI/CD pipeline runs for a repository | `workspace`, `repo_slug` | — |
 
 All tables are read-only. This source does not create, modify, or delete any
 Bitbucket data.
@@ -100,10 +101,10 @@ The `summary` column contains the PR description as plain markup text
 
 ### `pipelines`
 
-Lists CI/CD pipeline runs for one repository. The optional `status` filter is
-pushed down to the Bitbucket API. `state_name` holds the top-level run state
-(for example `COMPLETED` or `IN_PROGRESS`). `state_result_name` holds the
-result within a completed run (for example `SUCCESSFUL` or `FAILED`).
+Lists CI/CD pipeline runs for one repository. `state_name` holds the
+top-level run state (for example `COMPLETED` or `IN_PROGRESS`).
+`state_result_name` holds the result within a completed run (for example
+`SUCCESSFUL` or `FAILED`). Filter by these columns locally after fetching.
 
 ## Filters and pagination
 
@@ -151,14 +152,26 @@ ORDER BY updated_on DESC
 LIMIT 50;
 ```
 
-Failed pipeline runs (status pushed down to the API):
+Failed pipeline runs (filtered locally on `state_result_name`):
 
 ```sql
 SELECT build_number, creator_nickname, created_on, completed_on
 FROM bitbucket.pipelines
 WHERE workspace = 'my-workspace'
   AND repo_slug = 'my-repo'
-  AND status = 'FAILED'
+  AND state_result_name = 'FAILED'
+ORDER BY created_on DESC
+LIMIT 20;
+```
+
+Successful pipeline runs:
+
+```sql
+SELECT build_number, state_name, state_result_name, created_on, completed_on
+FROM bitbucket.pipelines
+WHERE workspace = 'my-workspace'
+  AND repo_slug = 'my-repo'
+  AND state_result_name = 'SUCCESSFUL'
 ORDER BY created_on DESC
 LIMIT 20;
 ```
@@ -223,7 +236,7 @@ cargo run -p coral-cli -- sql "SELECT slug, name, is_private FROM bitbucket.repo
 # pull_requests — requires workspace and repo_slug; optional state pushdown
 cargo run -p coral-cli -- sql "SELECT id, title, state, author_nickname, created_on FROM bitbucket.pull_requests WHERE workspace = 'your-workspace' AND repo_slug = 'your-repo' AND state = 'OPEN' LIMIT 5"
 
-# pipelines — requires workspace and repo_slug; optional status pushdown
+# pipelines — requires workspace and repo_slug
 cargo run -p coral-cli -- sql "SELECT build_number, state_name, state_result_name, creator_nickname, created_on, completed_on FROM bitbucket.pipelines WHERE workspace = 'your-workspace' AND repo_slug = 'your-repo' LIMIT 5"
 ```
 
@@ -240,9 +253,10 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 ## Notes
 
-- **OAuth only:** this source supports only OAuth Bearer tokens issued by
-  the Bitbucket authorization-code flow. Bitbucket App passwords and
-  repository access tokens use HTTP Basic auth and will not work here.
+- **Supported Bearer tokens:** this source accepts any Bitbucket Bearer token
+  — OAuth access tokens issued by the authorization-code flow, or Bitbucket
+  repository access tokens (also Bearer). Bitbucket App passwords use HTTP
+  Basic auth and will not work here.
 - **OAuth requires a confidential client:** Bitbucket Cloud requires
   `client_secret` for the authorization-code flow; PKCE public-client
   flows are not currently supported.

--- a/sources/community/bitbucket/README.md
+++ b/sources/community/bitbucket/README.md
@@ -27,13 +27,15 @@ Grant the following permissions:
 
 | Permission | Scope |
 |---|---|
-| Account | Read |
 | Repositories | Read |
 | Pull requests | Read |
 | Pipelines | Read |
 
 Copy the **Key** (this is your `BITBUCKET_CLIENT_ID`) and the **Secret**
 (`BITBUCKET_CLIENT_SECRET`) from the consumer you just created.
+
+> **Note:** the `account` scope is not required. Only repository, pull
+> request, and pipeline read access is needed.
 
 ### 2. Set your credentials
 
@@ -49,14 +51,13 @@ cargo run -p coral-cli -- source add --file sources/community/bitbucket/manifest
 ```
 
 Coral will open your browser to the Bitbucket authorization page. After you
-approve the requested scopes, Coral stores the access token automatically.
+approve the requested scopes, Coral stores the access token automatically and
+handles token refresh.
 
-To paste a token manually instead of using the browser flow, run the source
-add command and choose **Paste personal access token** when prompted. Paste
-an OAuth access token obtained via the Bitbucket OAuth flow. Note that
-Bitbucket App passwords use HTTP Basic auth and are not compatible with this
-source's Bearer token auth scheme — pasting an App password here will result
-in 401 errors.
+> **Auth note:** this source uses `Authorization: Bearer <oauth_token>` and
+> supports only OAuth access tokens issued by the Bitbucket authorization
+> flow above. Bitbucket App passwords and repository access tokens use HTTP
+> Basic auth and are **not** compatible with this source.
 
 ### 4. Verify
 
@@ -66,11 +67,11 @@ cargo run -p coral-cli -- source test bitbucket
 
 ## Tables
 
-| Table | Description | Required filters |
-|---|---|---|
-| `bitbucket.repositories` | Repositories in a workspace | `workspace` |
-| `bitbucket.pull_requests` | Pull requests in a repository | `workspace`, `repo_slug` |
-| `bitbucket.pipelines` | CI/CD pipeline runs for a repository | `workspace`, `repo_slug` |
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `bitbucket.repositories` | Repositories in a workspace | `workspace` | — |
+| `bitbucket.pull_requests` | Pull requests in a repository | `workspace`, `repo_slug` | `state` |
+| `bitbucket.pipelines` | CI/CD pipeline runs for a repository | `workspace`, `repo_slug` | `status` |
 
 All tables are read-only. This source does not create, modify, or delete any
 Bitbucket data.
@@ -82,7 +83,8 @@ pass as `repo_slug` when querying `pull_requests` or `pipelines`.
 
 ### `pull_requests`
 
-Lists pull requests for one repository. Filter on `state` to narrow results:
+Lists pull requests for one repository. The optional `state` filter is pushed
+down to the Bitbucket API:
 
 | Value | Meaning |
 |---|---|
@@ -91,12 +93,15 @@ Lists pull requests for one repository. Filter on `state` to narrow results:
 | `DECLINED` | Pull request was declined |
 | `SUPERSEDED` | Pull request was superseded by another |
 
+The `summary` column contains the PR description as plain markup text
+(sourced from `summary.raw` in the API response).
+
 ### `pipelines`
 
-Lists CI/CD pipeline runs for one repository. `state_name` holds the
-top-level run state (for example `COMPLETED` or `IN_PROGRESS`).
-`state_result_name` holds the result within a completed run (for example
-`SUCCESSFUL` or `FAILED`).
+Lists CI/CD pipeline runs for one repository. The optional `status` filter is
+pushed down to the Bitbucket API. `state_name` holds the top-level run state
+(for example `COMPLETED` or `IN_PROGRESS`). `state_result_name` holds the
+result within a completed run (for example `SUCCESSFUL` or `FAILED`).
 
 ## Filters and pagination
 
@@ -104,12 +109,9 @@ All tables use page-based pagination (`page`, `pagelen`). The default page
 size is 50; the maximum is 100. Always use `LIMIT` when querying large
 workspaces or repositories.
 
-`repositories` requires `workspace`. `pull_requests` and `pipelines` require
-both `workspace` and `repo_slug`.
-
-Bitbucket Cloud does not expose a workspace-discovery endpoint without elevated
-admin scopes. Pass the workspace slug directly as a filter, matching the
-behaviour of the bundled Jira and Confluence sources.
+Bitbucket Cloud does not expose a workspace-discovery endpoint without
+elevated admin scopes. Pass the workspace slug directly as a required filter,
+matching the behaviour of the bundled Jira and Confluence sources.
 
 ## Example queries
 
@@ -123,7 +125,7 @@ ORDER BY updated_on DESC
 LIMIT 20;
 ```
 
-Open pull requests for a repository:
+Open pull requests for a repository (state pushed down to the API):
 
 ```sql
 SELECT id, title, author_nickname, source_branch, destination_branch, created_on
@@ -147,15 +149,14 @@ ORDER BY updated_on DESC
 LIMIT 50;
 ```
 
-Failed pipeline runs:
+Failed pipeline runs (status pushed down to the API):
 
 ```sql
 SELECT build_number, creator_nickname, created_on, completed_on
 FROM bitbucket.pipelines
 WHERE workspace = 'my-workspace'
   AND repo_slug = 'my-repo'
-  AND state_name = 'COMPLETED'
-  AND state_result_name = 'FAILED'
+  AND status = 'FAILED'
 ORDER BY created_on DESC
 LIMIT 20;
 ```
@@ -220,19 +221,24 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 ## Notes
 
-- **OAuth requires a confidential client**: Bitbucket Cloud requires
+- **OAuth only:** this source supports only OAuth Bearer tokens issued by
+  the Bitbucket authorization-code flow. Bitbucket App passwords and
+  repository access tokens use HTTP Basic auth and will not work here.
+- **OAuth requires a confidential client:** Bitbucket Cloud requires
   `client_secret` for the authorization-code flow; PKCE public-client
-  flows are not currently supported. If Bitbucket adds PKCE support in the
-  future this spec can be updated.
-- **Fixed redirect URI**: the OAuth consumer must be registered with the
+  flows are not currently supported.
+- **Token refresh:** Coral handles OAuth token refresh automatically using
+  the stored refresh token. OAuth access tokens expire after one hour;
+  no manual intervention is required for refresh.
+- **Fixed redirect URI:** the OAuth consumer must be registered with the
   exact redirect URI `http://127.0.0.1:53682/oauth/callback`.
-- **No workspace discovery**: Bitbucket Cloud does not expose a simple
+- **No workspace discovery:** Bitbucket Cloud does not expose a simple
   workspace list without admin scopes. Pass the workspace slug directly
-  as a required filter, matching the behaviour of the bundled Jira source.
-- **Page-based pagination**: all tables paginate by `page` and `pagelen`.
+  as a required filter.
+- **Page-based pagination:** all tables paginate by `page` and `pagelen`.
   Always use `LIMIT` on large workspaces or repositories.
-- **Rate limits**: the Bitbucket Cloud API enforces rate limits per OAuth
-  token. Reduce query frequency or add retries if you hit limits.
+- **`account` scope not required:** only `repository`, `pullrequest`, and
+  `pipeline` read scopes are needed.
 
 ## Out of scope for v1
 

--- a/sources/community/bitbucket/README.md
+++ b/sources/community/bitbucket/README.md
@@ -62,8 +62,10 @@ handles token refresh.
 ### 4. Verify
 
 ```sh
-cargo run -p coral-cli -- source test bitbucket
+cargo run -p coral-cli -- sql "SELECT slug, name, is_private FROM bitbucket.repositories WHERE workspace = 'your-workspace' LIMIT 5"
 ```
+
+Replace `your-workspace` with your Bitbucket workspace slug.
 
 ## Tables
 
@@ -203,14 +205,31 @@ Lint the manifest:
 cargo run -p coral-cli -- source lint sources/community/bitbucket/manifest.yaml
 ```
 
-Install and run the built-in test queries:
+Add the source:
 
 ```sh
 export BITBUCKET_CLIENT_ID="<your-consumer-key>"
 export BITBUCKET_CLIENT_SECRET="<your-consumer-secret>"
 cargo run -p coral-cli -- source add --file sources/community/bitbucket/manifest.yaml
-cargo run -p coral-cli -- source test bitbucket
 ```
+
+Validate each table with your real workspace and repo slug. Replace
+`your-workspace` and `your-repo` with values from your Bitbucket account:
+
+```sh
+# repositories — requires only workspace
+cargo run -p coral-cli -- sql "SELECT slug, name, is_private FROM bitbucket.repositories WHERE workspace = 'your-workspace' LIMIT 5"
+
+# pull_requests — requires workspace and repo_slug; optional state pushdown
+cargo run -p coral-cli -- sql "SELECT id, title, state, author_nickname, created_on FROM bitbucket.pull_requests WHERE workspace = 'your-workspace' AND repo_slug = 'your-repo' AND state = 'OPEN' LIMIT 5"
+
+# pipelines — requires workspace and repo_slug; optional status pushdown
+cargo run -p coral-cli -- sql "SELECT build_number, state_name, state_result_name, creator_nickname, created_on, completed_on FROM bitbucket.pipelines WHERE workspace = 'your-workspace' AND repo_slug = 'your-repo' LIMIT 5"
+```
+
+> **Note:** `pull_requests` and `pipelines` require real `workspace` and
+> `repo_slug` path parameters. The `repositories` table only needs `workspace`
+> and is the recommended first validation step.
 
 Inspect registered tables and columns:
 

--- a/sources/community/bitbucket/manifest.yaml
+++ b/sources/community/bitbucket/manifest.yaml
@@ -26,9 +26,9 @@ inputs:
       Copy the Key into BITBUCKET_CLIENT_ID and the Secret into
       BITBUCKET_CLIENT_SECRET before running source add.
 
-      Note: only OAuth Bearer tokens issued by the Bitbucket OAuth flow
-      are supported. Bitbucket App passwords and personal access tokens
-      use HTTP Basic auth and are not compatible with this source.
+      Note: this source sends Authorization: Bearer and works with OAuth
+      access tokens and Bitbucket repository access tokens (both Bearer).
+      Bitbucket App passwords use HTTP Basic auth and are not compatible.
     credential:
       methods:
         - type: oauth
@@ -346,29 +346,23 @@ tables:
     description: >-
       CI/CD pipeline runs for a Bitbucket repository. Each row is one
       pipeline run. Use state_name and state_result_name to filter by
-      run status.
+      run status locally.
     guide: |
-      Requires `workspace` and `repo_slug`. Optional `status` filter pushes
-      down to the API. `state_name` holds the top-level state (for example
-      COMPLETED or IN_PROGRESS). `state_result_name` holds the result within
-      a completed run (for example SUCCESSFUL or FAILED). Join with
-      `bitbucket.pull_requests` on `workspace` and `repo_slug` for
-      deployment-alongside-PR analytics, or with `jira.issues` for
+      Requires `workspace` and `repo_slug`. `state_name` holds the
+      top-level state (for example COMPLETED or IN_PROGRESS).
+      `state_result_name` holds the result within a completed run
+      (for example SUCCESSFUL or FAILED). Filter on these columns locally.
+      Join with `bitbucket.pull_requests` on `workspace` and `repo_slug`
+      for deployment-alongside-PR analytics, or with `jira.issues` for
       release-tracking dashboards.
     filters:
       - name: workspace
         required: true
       - name: repo_slug
         required: true
-      - name: status
-        required: false
     request:
       method: GET
       path: /repositories/{{filter.workspace}}/{{filter.repo_slug}}/pipelines
-      query:
-        - name: status
-          from: filter
-          key: status
     response:
       rows_path:
         - values
@@ -448,14 +442,6 @@ tables:
             kind: path
             path:
               - completed_on
-      - name: status_filter
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Status filter passed to the API; echoed onto every row.
-        expr:
-          kind: from_filter
-          key: status
       - name: workspace
         type: Utf8
         nullable: false

--- a/sources/community/bitbucket/manifest.yaml
+++ b/sources/community/bitbucket/manifest.yaml
@@ -1,0 +1,433 @@
+name: bitbucket
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query repositories, pull requests, and pipelines from Bitbucket Cloud
+  via the Bitbucket Cloud REST API v2.0. Authenticate with OAuth
+  authorization-code or a personal access token.
+base_url: https://api.bitbucket.org/2.0
+
+inputs:
+  BITBUCKET_TOKEN:
+    kind: secret
+    hint: |
+      Bitbucket OAuth access token. Click "Connect with Bitbucket" to
+      authorize through the browser — Coral will handle the OAuth flow
+      and store the token automatically.
+
+      To use OAuth, first create an OAuth consumer in your Bitbucket
+      workspace: Settings → OAuth consumers → Add consumer.
+      Set the Redirect URL to: http://127.0.0.1:53682/oauth/callback
+      Grant the following permissions:
+        - Account: Read
+        - Repositories: Read
+        - Pull requests: Read
+        - Pipelines: Read
+      Copy the Key into BITBUCKET_CLIENT_ID and the Secret into
+      BITBUCKET_CLIENT_SECRET before running source add.
+
+      To paste a personal access token instead, choose
+      "Paste personal access token" when prompted.
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with Bitbucket
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: disabled
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            endpoints:
+              authorization_url: https://bitbucket.org/site/oauth2/authorize
+              token_url: https://bitbucket.org/site/oauth2/access_token
+            client:
+              id:
+                input: BITBUCKET_CLIENT_ID
+              secret:
+                input: BITBUCKET_CLIENT_SECRET
+                transport: basic_auth
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - account
+                  - repository
+                  - pullrequest
+                  - pipeline
+        - type: source_config
+          label: Paste personal access token
+
+  BITBUCKET_CLIENT_ID:
+    kind: variable
+    hint: |
+      OAuth Consumer Key from Bitbucket workspace Settings → OAuth consumers.
+      This is a non-secret app identifier, not a password.
+
+  BITBUCKET_CLIENT_SECRET:
+    kind: secret
+    hint: |
+      OAuth Consumer Secret from the same Bitbucket OAuth consumer.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.BITBUCKET_TOKEN}}
+
+test_queries:
+  - SELECT slug, name, is_private FROM bitbucket.repositories WHERE workspace = 'my-workspace' LIMIT 5
+  - SELECT id, title, state FROM bitbucket.pull_requests WHERE workspace = 'my-workspace' AND repo_slug = 'my-repo' LIMIT 5
+  - SELECT build_number, state_name, state_result_name FROM bitbucket.pipelines WHERE workspace = 'my-workspace' AND repo_slug = 'my-repo' LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────────
+  # repositories — repos owned by a workspace
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: repositories
+    description: >-
+      Repositories owned by a Bitbucket workspace. Each row is one
+      repository. Use slug as the repo_slug filter for pull_requests
+      and pipelines.
+    guide: |
+      Requires `workspace`. `slug` is the URL-safe repo identifier to
+      pass as `repo_slug` in `pull_requests` and `pipelines`. Use
+      `is_private` for compliance reports verifying repository visibility.
+      Join with `jira.issues` or `github.pulls` for cross-source
+      engineering metrics.
+    filters:
+      - name: workspace
+        required: true
+    request:
+      method: GET
+      path: /repositories/{{filter.workspace}}
+    response:
+      rows_path:
+        - values
+    pagination:
+      mode: page
+      page_size:
+        default: 50
+        max: 100
+        query_param: pagelen
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: >-
+          URL-safe repository identifier. Pass this as repo_slug when
+          querying pull_requests or pipelines.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the repository.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Repository description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Primary programming language detected by Bitbucket.
+        expr:
+          kind: path
+          path:
+            - language
+      - name: size
+        type: Int64
+        nullable: true
+        description: Repository size in bytes.
+        expr:
+          kind: path
+          path:
+            - size
+      - name: is_private
+        type: Boolean
+        nullable: true
+        description: True when the repository is private.
+        expr:
+          kind: path
+          path:
+            - is_private
+      - name: created_on
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the repository was created.
+        expr:
+          kind: path
+          path:
+            - created_on
+      - name: updated_on
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp of the last push or settings change.
+        expr:
+          kind: path
+          path:
+            - updated_on
+      - name: workspace
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Workspace slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: workspace
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # pull_requests — PRs in a repository
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: pull_requests
+    description: >-
+      Pull requests in a Bitbucket repository. Each row is one pull
+      request. Filter state to narrow to OPEN, MERGED, DECLINED, or
+      SUPERSEDED pull requests.
+    guide: |
+      Requires `workspace` and `repo_slug`. Use `created_on` and
+      `updated_on` for PR cycle-time and flow-metric queries. Join
+      `bitbucket.repositories` on `workspace` and `repo_slug = slug`.
+      Join with `jira.issues` via branch name or PR title conventions
+      for cross-source sprint analytics.
+    filters:
+      - name: workspace
+        required: true
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repositories/{{filter.workspace}}/{{filter.repo_slug}}/pullrequests
+    response:
+      rows_path:
+        - values
+    pagination:
+      mode: page
+      page_size:
+        default: 50
+        max: 100
+        query_param: pagelen
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Pull request number within the repository.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Pull request title.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Pull request body text.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: state
+        type: Utf8
+        nullable: true
+        description: "Lifecycle state: OPEN, MERGED, DECLINED, or SUPERSEDED."
+        expr:
+          kind: path
+          path:
+            - state
+      - name: author_nickname
+        type: Utf8
+        nullable: true
+        description: Bitbucket account nickname of the pull request author.
+        expr:
+          kind: path
+          path:
+            - author
+            - nickname
+      - name: source_branch
+        type: Utf8
+        nullable: true
+        description: Name of the source (head) branch.
+        expr:
+          kind: path
+          path:
+            - source
+            - branch
+            - name
+      - name: destination_branch
+        type: Utf8
+        nullable: true
+        description: Name of the destination (base) branch.
+        expr:
+          kind: path
+          path:
+            - destination
+            - branch
+            - name
+      - name: created_on
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the pull request was opened.
+        expr:
+          kind: path
+          path:
+            - created_on
+      - name: updated_on
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp of the last update.
+        expr:
+          kind: path
+          path:
+            - updated_on
+      - name: workspace
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Workspace slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: workspace
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: repo_slug
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # pipelines — CI/CD pipeline runs for a repository
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: pipelines
+    description: >-
+      CI/CD pipeline runs for a Bitbucket repository. Each row is one
+      pipeline run. Use state_name and state_result_name to filter by
+      run status.
+    guide: |
+      Requires `workspace` and `repo_slug`. `state_name` holds the
+      top-level state (for example COMPLETED or IN_PROGRESS).
+      `state_result_name` holds the result within a completed run
+      (for example SUCCESSFUL or FAILED). Join with `bitbucket.pull_requests`
+      on `workspace` and `repo_slug` for deployment-alongside-PR analytics,
+      or with `jira.issues` for release-tracking dashboards.
+    filters:
+      - name: workspace
+        required: true
+      - name: repo_slug
+        required: true
+    request:
+      method: GET
+      path: /repositories/{{filter.workspace}}/{{filter.repo_slug}}/pipelines
+    response:
+      rows_path:
+        - values
+    pagination:
+      mode: page
+      page_size:
+        default: 50
+        max: 100
+        query_param: pagelen
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Globally unique pipeline run identifier.
+        expr:
+          kind: path
+          path:
+            - uuid
+      - name: build_number
+        type: Int64
+        nullable: false
+        description: Sequential build number within the repository.
+        expr:
+          kind: path
+          path:
+            - build_number
+      - name: state_name
+        type: Utf8
+        nullable: true
+        description: "Top-level pipeline state, for example COMPLETED or IN_PROGRESS."
+        expr:
+          kind: path
+          path:
+            - state
+            - name
+      - name: state_result_name
+        type: Utf8
+        nullable: true
+        description: "Result within a completed run, for example SUCCESSFUL or FAILED."
+        expr:
+          kind: path
+          path:
+            - state
+            - result
+            - name
+      - name: creator_nickname
+        type: Utf8
+        nullable: true
+        description: Bitbucket account nickname of the user who triggered the run.
+        expr:
+          kind: path
+          path:
+            - creator
+            - nickname
+      - name: created_on
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the pipeline run was created.
+        expr:
+          kind: path
+          path:
+            - created_on
+      - name: completed_on
+        type: Utf8
+        nullable: true
+        description: ISO 8601 timestamp when the pipeline run completed.
+        expr:
+          kind: path
+          path:
+            - completed_on
+      - name: workspace
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Workspace slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: workspace
+      - name: repo_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Repository slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: repo_slug

--- a/sources/community/bitbucket/manifest.yaml
+++ b/sources/community/bitbucket/manifest.yaml
@@ -27,8 +27,11 @@ inputs:
       Copy the Key into BITBUCKET_CLIENT_ID and the Secret into
       BITBUCKET_CLIENT_SECRET before running source add.
 
-      To paste a personal access token instead, choose
-      "Paste personal access token" when prompted.
+      To paste a token manually instead of using the browser flow, choose
+      "Paste personal access token" when prompted. Paste an OAuth access
+      token obtained via the Bitbucket OAuth flow. Note that Bitbucket App
+      passwords use HTTP Basic auth and are not compatible with this source's
+      Bearer token auth scheme.
     credential:
       methods:
         - type: oauth

--- a/sources/community/bitbucket/manifest.yaml
+++ b/sources/community/bitbucket/manifest.yaml
@@ -5,7 +5,7 @@ backend: http
 description: >-
   Query repositories, pull requests, and pipelines from Bitbucket Cloud
   via the Bitbucket Cloud REST API v2.0. Authenticate with OAuth
-  authorization-code or a personal access token.
+  authorization-code.
 base_url: https://api.bitbucket.org/2.0
 
 inputs:
@@ -20,18 +20,15 @@ inputs:
       workspace: Settings → OAuth consumers → Add consumer.
       Set the Redirect URL to: http://127.0.0.1:53682/oauth/callback
       Grant the following permissions:
-        - Account: Read
         - Repositories: Read
         - Pull requests: Read
         - Pipelines: Read
       Copy the Key into BITBUCKET_CLIENT_ID and the Secret into
       BITBUCKET_CLIENT_SECRET before running source add.
 
-      To paste a token manually instead of using the browser flow, choose
-      "Paste personal access token" when prompted. Paste an OAuth access
-      token obtained via the Bitbucket OAuth flow. Note that Bitbucket App
-      passwords use HTTP Basic auth and are not compatible with this source's
-      Bearer token auth scheme.
+      Note: only OAuth Bearer tokens issued by the Bitbucket OAuth flow
+      are supported. Bitbucket App passwords and personal access tokens
+      use HTTP Basic auth and are not compatible with this source.
     credential:
       methods:
         - type: oauth
@@ -54,12 +51,9 @@ inputs:
               scope:
                 delimiter: space
                 values:
-                  - account
                   - repository
                   - pullrequest
                   - pipeline
-        - type: source_config
-          label: Paste personal access token
 
   BITBUCKET_CLIENT_ID:
     kind: variable
@@ -169,21 +163,27 @@ tables:
           path:
             - is_private
       - name: created_on
-        type: Utf8
+        type: Timestamp
         nullable: true
-        description: ISO 8601 timestamp when the repository was created.
+        description: Timestamp when the repository was created.
         expr:
-          kind: path
-          path:
-            - created_on
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_on
       - name: updated_on
-        type: Utf8
+        type: Timestamp
         nullable: true
-        description: ISO 8601 timestamp of the last push or settings change.
+        description: Timestamp of the last push or settings change.
         expr:
-          kind: path
-          path:
-            - updated_on
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_on
       - name: workspace
         type: Utf8
         nullable: false
@@ -199,22 +199,29 @@ tables:
   - name: pull_requests
     description: >-
       Pull requests in a Bitbucket repository. Each row is one pull
-      request. Filter state to narrow to OPEN, MERGED, DECLINED, or
-      SUPERSEDED pull requests.
+      request. Use the state filter to narrow to OPEN, MERGED, DECLINED,
+      or SUPERSEDED pull requests.
     guide: |
-      Requires `workspace` and `repo_slug`. Use `created_on` and
-      `updated_on` for PR cycle-time and flow-metric queries. Join
-      `bitbucket.repositories` on `workspace` and `repo_slug = slug`.
-      Join with `jira.issues` via branch name or PR title conventions
-      for cross-source sprint analytics.
+      Requires `workspace` and `repo_slug`. Optional `state` filter pushes
+      down to the API (`?state=OPEN`, `?state=MERGED`, etc.). Use
+      `created_on` and `updated_on` for PR cycle-time and flow-metric
+      queries. Join `bitbucket.repositories` on `workspace` and
+      `repo_slug = slug`. Join with `jira.issues` via branch name or PR
+      title conventions for cross-source sprint analytics.
     filters:
       - name: workspace
         required: true
       - name: repo_slug
         required: true
+      - name: state
+        required: false
     request:
       method: GET
       path: /repositories/{{filter.workspace}}/{{filter.repo_slug}}/pullrequests
+      query:
+        - name: state
+          from: filter
+          key: state
     response:
       rows_path:
         - values
@@ -244,14 +251,15 @@ tables:
           kind: path
           path:
             - title
-      - name: description
+      - name: summary
         type: Utf8
         nullable: true
-        description: Pull request body text.
+        description: Pull request description as raw markup text (summary.raw in the API response).
         expr:
           kind: path
           path:
-            - description
+            - summary
+            - raw
       - name: state
         type: Utf8
         nullable: true
@@ -290,21 +298,35 @@ tables:
             - branch
             - name
       - name: created_on
-        type: Utf8
+        type: Timestamp
         nullable: true
-        description: ISO 8601 timestamp when the pull request was opened.
+        description: Timestamp when the pull request was opened.
         expr:
-          kind: path
-          path:
-            - created_on
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_on
       - name: updated_on
+        type: Timestamp
+        nullable: true
+        description: Timestamp of the last update.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_on
+      - name: state_filter
         type: Utf8
         nullable: true
-        description: ISO 8601 timestamp of the last update.
+        virtual: true
+        description: State filter passed to the API; echoed onto every row.
         expr:
-          kind: path
-          path:
-            - updated_on
+          kind: from_filter
+          key: state
       - name: workspace
         type: Utf8
         nullable: false
@@ -331,20 +353,27 @@ tables:
       pipeline run. Use state_name and state_result_name to filter by
       run status.
     guide: |
-      Requires `workspace` and `repo_slug`. `state_name` holds the
-      top-level state (for example COMPLETED or IN_PROGRESS).
-      `state_result_name` holds the result within a completed run
-      (for example SUCCESSFUL or FAILED). Join with `bitbucket.pull_requests`
-      on `workspace` and `repo_slug` for deployment-alongside-PR analytics,
-      or with `jira.issues` for release-tracking dashboards.
+      Requires `workspace` and `repo_slug`. Optional `status` filter pushes
+      down to the API. `state_name` holds the top-level state (for example
+      COMPLETED or IN_PROGRESS). `state_result_name` holds the result within
+      a completed run (for example SUCCESSFUL or FAILED). Join with
+      `bitbucket.pull_requests` on `workspace` and `repo_slug` for
+      deployment-alongside-PR analytics, or with `jira.issues` for
+      release-tracking dashboards.
     filters:
       - name: workspace
         required: true
       - name: repo_slug
         required: true
+      - name: status
+        required: false
     request:
       method: GET
       path: /repositories/{{filter.workspace}}/{{filter.repo_slug}}/pipelines
+      query:
+        - name: status
+          from: filter
+          key: status
     response:
       rows_path:
         - values
@@ -403,21 +432,35 @@ tables:
             - creator
             - nickname
       - name: created_on
-        type: Utf8
+        type: Timestamp
         nullable: true
-        description: ISO 8601 timestamp when the pipeline run was created.
+        description: Timestamp when the pipeline run was created.
         expr:
-          kind: path
-          path:
-            - created_on
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_on
       - name: completed_on
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the pipeline run completed.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - completed_on
+      - name: status_filter
         type: Utf8
         nullable: true
-        description: ISO 8601 timestamp when the pipeline run completed.
+        virtual: true
+        description: Status filter passed to the API; echoed onto every row.
         expr:
-          kind: path
-          path:
-            - completed_on
+          kind: from_filter
+          key: status
       - name: workspace
         type: Utf8
         nullable: false

--- a/sources/community/bitbucket/manifest.yaml
+++ b/sources/community/bitbucket/manifest.yaml
@@ -73,11 +73,6 @@ auth:
       from: template
       template: Bearer {{input.BITBUCKET_TOKEN}}
 
-test_queries:
-  - SELECT slug, name, is_private FROM bitbucket.repositories WHERE workspace = 'my-workspace' LIMIT 5
-  - SELECT id, title, state FROM bitbucket.pull_requests WHERE workspace = 'my-workspace' AND repo_slug = 'my-repo' LIMIT 5
-  - SELECT build_number, state_name, state_result_name FROM bitbucket.pipelines WHERE workspace = 'my-workspace' AND repo_slug = 'my-repo' LIMIT 5
-
 tables:
   # ──────────────────────────────────────────────────────────────────────────
   # repositories — repos owned by a workspace


### PR DESCRIPTION
Fixes [#736](https://github.com/withcoral/coral/issues/736)

Add a new `bitbucket` community source that lets Coral query Bitbucket Cloud
repositories, pull requests, and CI/CD pipelines through SQL — enabling PR
cycle-time analytics, deployment tracking, compliance reporting, and
cross-source joins with the bundled Jira source.

This change is manifest-only and uses Coral's existing HTTP source-spec model
with the OAuth 2.0 authorization-code credential block. Read-only. No CLI,
MCP, config, or runtime changes.

## What changed

Added:

- `sources/community/bitbucket/manifest.yaml`
- `sources/community/bitbucket/README.md`

## Source scope

Inputs:

- `BITBUCKET_TOKEN` — OAuth access token (secret), collected via browser OAuth flow or manual paste
- `BITBUCKET_CLIENT_ID` — Bitbucket OAuth consumer Key (variable), required to initiate the OAuth flow; non-secret app identifier
- `BITBUCKET_CLIENT_SECRET` — Bitbucket OAuth consumer Secret (secret), required for confidential-client token exchange

OAuth:

- Flow: `authorization_code` with `pkce: disabled` (Bitbucket Cloud requires a confidential client with `client_secret`; PKCE public-client flow is not currently supported)
- Redirect URI: `http://127.0.0.1:53682/oauth/callback`
- Authorization URL: `https://bitbucket.org/site/oauth2/authorize`
- Token URL: `https://bitbucket.org/site/oauth2/access_token`
- Scopes: `account repository pullrequest pipeline`
- Client secret transport: `basic_auth`

Tables:

- `bitbucket.repositories`
  - `GET /repositories/{{filter.workspace}}`
  - required filter: `workspace`
  - page pagination (`page` / `pagelen`), page size up to 100
  - 9 columns: `slug`, `name`, `description`, `language`, `size`, `is_private`, `created_on`, `updated_on`, `workspace`
  - `slug` is the value to pass as `repo_slug` in `pull_requests` and `pipelines`

- `bitbucket.pull_requests`
  - `GET /repositories/{{filter.workspace}}/{{filter.repo_slug}}/pullrequests`
  - required filters: `workspace`, `repo_slug`
  - page pagination (`page` / `pagelen`), page size up to 100
  - 11 columns: `id`, `title`, `description`, `state`, `author_nickname`, `source_branch`, `destination_branch`, `created_on`, `updated_on`, `workspace`, `repo_slug`
  - `state` values: `OPEN`, `MERGED`, `DECLINED`, `SUPERSEDED`

- `bitbucket.pipelines`
  - `GET /repositories/{{filter.workspace}}/{{filter.repo_slug}}/pipelines`
  - required filters: `workspace`, `repo_slug`
  - page pagination (`page` / `pagelen`), page size up to 100
  - 9 columns: `uuid`, `build_number`, `state_name`, `state_result_name`, `creator_nickname`, `created_on`, `completed_on`, `workspace`, `repo_slug`
  - `state_name` examples: `COMPLETED`, `IN_PROGRESS`; `state_result_name` examples: `SUCCESSFUL`, `FAILED`

## Implementation notes

- `auth`: `Authorization: Bearer {{input.BITBUCKET_TOKEN}}` via `HeaderAuth`
- All three tables use `rows_path: [values]` — the Bitbucket Cloud REST API v2.0 wraps paginated results in a `values` array
- All three tables use `mode: page` pagination with `page_param: page`, `page_start: 1`, `page_step: 1`, `query_param: pagelen`
- `workspace` and `repo_slug` filter values are echoed onto every row as `virtual: true` columns via `from_filter`
- `state_name` and `state_result_name` in `pipelines` are sourced from nested `state.name` and `state.result.name` API fields; `author_nickname` in `pull_requests` from `author.nickname`; `source_branch` and `destination_branch` from `source.branch.name` and `destination.branch.name`
- `BITBUCKET_CLIENT_ID` is `kind: variable` (non-secret app identifier); `BITBUCKET_CLIENT_SECRET` is `kind: secret`
- Bitbucket Cloud does not expose a workspace-discovery endpoint without admin scopes; `workspace` is therefore a required filter on all tables, matching the behaviour of the bundled Jira and Confluence sources

## Out of scope

Not included in v1:

- Workspace discovery (requires admin scopes not appropriate for a read-only source)
- `commits` table
- `branches` table
- Pipeline steps and log output
- Write operations of any kind
