### PR TITLE
feat(sources/community/zoom): add Zoom OAuth community source

### DIFF
--- a/sources/community/zoom/README.md
+++ b/sources/community/zoom/README.md
@@ -1,0 +1,181 @@
+# Zoom community source
+
+The `zoom` community source exposes read-only Zoom user profile, meeting, and
+cloud recording data through Coral SQL. This is the first community source to
+use OAuth authorization-code flow for authentication.
+
+## Setup
+
+This source supports two authentication paths. Both produce a Bearer token
+that Coral uses for API requests.
+
+### Option A: OAuth browser flow
+
+Create a [user-managed OAuth app](https://marketplace.zoom.us/develop/create)
+in the Zoom App Marketplace:
+
+1. Choose **General App** (user-managed) with OAuth.
+2. Under **Scopes**, add:
+   - `user:read:user`
+   - `meeting:read:list_meetings`
+   - `cloud_recording:read:list_user_recordings`
+3. Set the **OAuth Redirect URL** to exactly:
+   ```
+   http://127.0.0.1:53682/oauth/callback
+   ```
+4. Add the same URL to the **OAuth Allow Lists**.
+5. Activate the app, then copy the **Client ID** and **Client Secret**.
+
+```sh
+export ZOOM_CLIENT_ID="<client_id>"
+export ZOOM_CLIENT_SECRET="<client_secret>"
+cargo run -p coral-cli -- source add --interactive --file sources/community/zoom/manifest.yaml
+```
+
+Coral opens a browser for authorization. After granting access, Coral stores
+the token automatically.
+
+### Option B: Paste an access token
+
+Obtain a Zoom access token from a
+[Server-to-Server OAuth app](https://developers.zoom.us/docs/internal-apps/s2s-oauth/)
+or any other method, then paste it directly:
+
+```sh
+export ZOOM_ACCESS_TOKEN="<token>"
+cargo run -p coral-cli -- source add --file sources/community/zoom/manifest.yaml
+```
+
+This path does not require `ZOOM_CLIENT_ID` or `ZOOM_CLIENT_SECRET`. The
+token must include the scopes listed above. Server-to-Server tokens expire
+after one hour; re-run `source add` to refresh.
+
+## Tables
+
+| Table | Purpose |
+| --- | --- |
+| `zoom.user` | Authenticated user profile (one row). Uses `row_strategy: direct` to parse the single root JSON object. |
+| `zoom.meetings` | Meetings for the authenticated user. The `meeting_status` filter controls which Zoom list mode to use (`scheduled`, `live`, `upcoming`, `upcoming_meetings`, `previous_meetings`). Defaults to `scheduled`. |
+| `zoom.recordings` | Cloud recordings. **Requires** `from_date` and `to_date` filters in `yyyy-MM-dd` format, limited to a 1-month range per query. Requires a Pro plan or higher with Cloud Recording enabled. |
+
+All tables are read-only. This source does not create, update, or delete Zoom
+resources.
+
+### Limitations
+
+- **List meetings defaults to `scheduled` only.** The `meeting_status` filter
+  controls which meetings Zoom returns. Without it, only scheduled (unexpired)
+  meetings appear. The `upcoming`, `upcoming_meetings`, and
+  `previous_meetings` modes only span a 6-month window. See
+  [List meetings](https://developers.zoom.us/docs/api/meetings/#tag/meetings/GET/users/{userId}/meetings).
+- **Cloud Recording requires a Pro plan or higher** with Cloud Recording
+  enabled on the Zoom account. Free/Basic plans do not have cloud recordings.
+  See [List recordings](https://developers.zoom.us/docs/api/meetings/#tag/cloud-recording/GET/users/{userId}/recordings).
+- **Recording date range is capped at 1 month per query.** The `from_date`
+  and `to_date` filters are required and must not span more than one calendar
+  month.
+
+## Example queries
+
+Verify credentials and inspect the authenticated user:
+
+```sql
+SELECT id, email, first_name, last_name, role_name, timezone
+FROM zoom.user
+LIMIT 1;
+```
+
+List recent scheduled meetings (default mode):
+
+```sql
+SELECT uuid, topic, start_time, duration, join_url
+FROM zoom.meetings
+LIMIT 20;
+```
+
+List previous meetings from the last 6 months:
+
+```sql
+SELECT uuid, topic, start_time, duration
+FROM zoom.meetings
+WHERE meeting_status = 'previous_meetings'
+LIMIT 10;
+```
+
+Query cloud recordings for a specific month:
+
+```sql
+SELECT uuid, topic, start_time, duration, recording_count, share_url
+FROM zoom.recordings
+WHERE from_date = '2026-05-01' AND to_date = '2026-05-31'
+LIMIT 20;
+```
+
+Inspect individual recording files from a month of recordings:
+
+```sql
+SELECT uuid, topic, recording_files
+FROM zoom.recordings
+WHERE from_date = '2026-04-01' AND to_date = '2026-04-30'
+LIMIT 5;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/zoom/manifest.yaml
+```
+
+Install and test with a token (Option B):
+
+```sh
+export ZOOM_ACCESS_TOKEN="<token>"
+cargo run -p coral-cli -- source add --file sources/community/zoom/manifest.yaml
+cargo run -p coral-cli -- source test zoom
+```
+
+Or using OAuth (Option A):
+
+```sh
+export ZOOM_CLIENT_ID="<client_id>"
+export ZOOM_CLIENT_SECRET="<client_secret>"
+cargo run -p coral-cli -- source add --interactive --file sources/community/zoom/manifest.yaml
+cargo run -p coral-cli -- source test zoom
+```
+
+Inspect the registered source:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description, required_filters FROM coral.tables WHERE schema_name = 'zoom'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, is_required_filter FROM coral.columns WHERE schema_name = 'zoom' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- This is the first community source using OAuth credential methods. The OAuth
+  block under `ZOOM_ACCESS_TOKEN` uses `authorization_code` flow with a fixed
+  loopback redirect URI on port 53682.
+- Zoom's token endpoint requires HTTP Basic authentication for the client
+  credentials exchange (`transport: basic_auth`).
+- Zoom sends `X-RateLimit-Remaining` and `Retry-After` headers on every
+  response. The manifest declares these under `rate_limit` so Coral
+  automatically backs off when a rate limit is hit.
+- The `user` table fetches `GET /users/me`, which returns a single JSON object
+  (not an array). Coral handles this via `row_strategy: direct` with no
+  `rows_path`, producing exactly one row.
+- The `meeting_status` filter controls Zoom's
+  [list mode](https://developers.zoom.us/docs/api/meetings/#tag/meetings/GET/users/{userId}/meetings)
+  and maps to the `type` query parameter in the API. The response column `type`
+  is a separate concept — the numeric meeting kind (1 = instant, 2 = scheduled,
+  etc.).
+- The `recordings` table requires `from_date` and `to_date` because Zoom
+  defaults to the current date when these are omitted, which typically returns
+  no results. The maximum date range per API call is one calendar month.
+- Zoom has migrated to granular scopes. This source uses the granular scope
+  names (`user:read:user`, `meeting:read:list_meetings`,
+  `cloud_recording:read:list_user_recordings`). Legacy scope names such as
+  `user:read` or `recording:read` may also work for older Zoom apps.
+- See the [Zoom API reference](https://developers.zoom.us/docs/api/) for
+  full endpoint documentation.

--- a/sources/community/zoom/README.md
+++ b/sources/community/zoom/README.md
@@ -20,7 +20,7 @@ cloud recording data through Coral SQL.
 
 ```sh
 curl -s -X POST https://zoom.us/oauth/token \
-  -H "Authorization: Basic $(echo -n 'CLIENT_ID:CLIENT_SECRET' | base64 -w 0)" \
+  -H "Authorization: Basic $(printf '%s' 'CLIENT_ID:CLIENT_SECRET' | base64 | tr -d '\n')" \
   -d "grant_type=account_credentials&account_id=ACCOUNT_ID"
 ```
 

--- a/sources/community/zoom/README.md
+++ b/sources/community/zoom/README.md
@@ -1,54 +1,37 @@
 # Zoom community source
 
 The `zoom` community source exposes read-only Zoom user profile, meeting, and
-cloud recording data through Coral SQL. This is the first community source to
-use OAuth authorization-code flow for authentication.
+cloud recording data through Coral SQL.
 
 ## Setup
 
-This source supports two authentication paths. Both produce a Bearer token
-that Coral uses for API requests.
+### 1. Create a Zoom Server-to-Server OAuth app
 
-### Option A: OAuth browser flow
-
-Create a [user-managed OAuth app](https://marketplace.zoom.us/develop/create)
-in the Zoom App Marketplace:
-
-1. Choose **General App** (user-managed) with OAuth.
-2. Under **Scopes**, add:
+1. Go to the [Zoom App Marketplace](https://marketplace.zoom.us/develop/create).
+2. Choose **Server-to-Server OAuth** and create the app.
+3. Under **Scopes**, add:
    - `user:read:user`
    - `meeting:read:list_meetings`
    - `cloud_recording:read:list_user_recordings`
-3. Set the **OAuth Redirect URL** to exactly:
-   ```
-   http://127.0.0.1:53682/oauth/callback
-   ```
-4. Add the same URL to the **OAuth Allow Lists**.
-5. Activate the app, then copy the **Client ID** and **Client Secret**.
+4. **Activate** the app.
+5. Copy the **Account ID**, **Client ID**, and **Client Secret**.
+
+### 2. Obtain an access token
 
 ```sh
-export ZOOM_CLIENT_ID="<client_id>"
-export ZOOM_CLIENT_SECRET="<client_secret>"
-cargo run -p coral-cli -- source add --interactive --file sources/community/zoom/manifest.yaml
+curl -s -X POST https://zoom.us/oauth/token \
+  -H "Authorization: Basic $(echo -n 'CLIENT_ID:CLIENT_SECRET' | base64 -w 0)" \
+  -d "grant_type=account_credentials&account_id=ACCOUNT_ID"
 ```
 
-Coral opens a browser for authorization. After granting access, Coral stores
-the token automatically.
+Copy the `access_token` from the JSON response. Tokens expire after one hour.
 
-### Option B: Paste an access token
-
-Obtain a Zoom access token from a
-[Server-to-Server OAuth app](https://developers.zoom.us/docs/internal-apps/s2s-oauth/)
-or any other method, then paste it directly:
+### 3. Install the source
 
 ```sh
 export ZOOM_ACCESS_TOKEN="<token>"
 cargo run -p coral-cli -- source add --file sources/community/zoom/manifest.yaml
 ```
-
-This path does not require `ZOOM_CLIENT_ID` or `ZOOM_CLIENT_SECRET`. The
-token must include the scopes listed above. Server-to-Server tokens expire
-after one hour; re-run `source add` to refresh.
 
 ## Tables
 
@@ -74,6 +57,8 @@ resources.
 - **Recording date range is capped at 1 month per query.** The `from_date`
   and `to_date` filters are required and must not span more than one calendar
   month.
+- **Tokens expire after one hour.** Re-run the `curl` command and
+  `source add` to refresh.
 
 ## Example queries
 
@@ -128,20 +113,11 @@ Lint the manifest:
 cargo run -p coral-cli -- source lint sources/community/zoom/manifest.yaml
 ```
 
-Install and test with a token (Option B):
+Install and test:
 
 ```sh
 export ZOOM_ACCESS_TOKEN="<token>"
 cargo run -p coral-cli -- source add --file sources/community/zoom/manifest.yaml
-cargo run -p coral-cli -- source test zoom
-```
-
-Or using OAuth (Option A):
-
-```sh
-export ZOOM_CLIENT_ID="<client_id>"
-export ZOOM_CLIENT_SECRET="<client_secret>"
-cargo run -p coral-cli -- source add --interactive --file sources/community/zoom/manifest.yaml
 cargo run -p coral-cli -- source test zoom
 ```
 
@@ -154,11 +130,6 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, is_required_filte
 
 ## Notes
 
-- This is the first community source using OAuth credential methods. The OAuth
-  block under `ZOOM_ACCESS_TOKEN` uses `authorization_code` flow with a fixed
-  loopback redirect URI on port 53682.
-- Zoom's token endpoint requires HTTP Basic authentication for the client
-  credentials exchange (`transport: basic_auth`).
 - Zoom sends `X-RateLimit-Remaining` and `Retry-After` headers on every
   response. The manifest declares these under `rate_limit` so Coral
   automatically backs off when a rate limit is hit.

--- a/sources/community/zoom/manifest.yaml
+++ b/sources/community/zoom/manifest.yaml
@@ -1,0 +1,408 @@
+name: zoom
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query your Zoom user profile, scheduled meetings, and cloud recordings.
+  Read-only access via OAuth authorization-code flow or a pasted access token.
+inputs:
+  ZOOM_CLIENT_ID:
+    kind: variable
+    hint: |
+      Zoom OAuth app Client ID. Create a user-managed OAuth app at
+      https://marketplace.zoom.us/develop/create, select "User-managed app",
+      and copy the Client ID from the app credentials page.
+  ZOOM_CLIENT_SECRET:
+    kind: secret
+    hint: |
+      Zoom OAuth app Client Secret from the same app credentials page.
+  ZOOM_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      Zoom OAuth access token. Use "Connect with Zoom" to authenticate
+      interactively via the OAuth authorization-code flow, or paste an
+      existing access token. Required scopes: user:read:user,
+      meeting:read:list_meetings, cloud_recording:read:list_user_recordings.
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with Zoom
+          description: Authenticate via Zoom OAuth authorization-code flow.
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: disabled
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            redirect_uri_port_mode: fixed
+            endpoints:
+              authorization_url: https://zoom.us/oauth/authorize
+              token_url: https://zoom.us/oauth/token
+            client:
+              id:
+                input: ZOOM_CLIENT_ID
+              secret:
+                input: ZOOM_CLIENT_SECRET
+                transport: basic_auth
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - user:read:user
+                  - meeting:read:list_meetings
+                  - cloud_recording:read:list_user_recordings
+        - type: source_config
+          label: Paste token
+base_url: https://api.zoom.us/v2
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.ZOOM_ACCESS_TOKEN}}
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+rate_limit:
+  remaining_header: X-RateLimit-Remaining
+  retry_after_header: Retry-After
+test_queries:
+  - SELECT id, email, first_name, last_name FROM zoom.user LIMIT 1
+  - SELECT uuid, topic, start_time, duration FROM zoom.meetings LIMIT 5
+  - >-
+    SELECT uuid, topic, start_time, recording_count
+    FROM zoom.recordings
+    WHERE from_date = '2026-05-01' AND to_date = '2026-05-23'
+    LIMIT 5
+  - >-
+    SELECT uuid, topic, type FROM zoom.meetings
+    WHERE meeting_status = 'scheduled'
+    LIMIT 5
+tables:
+  # ------------------------------------------------------------------
+  # zoom.user — authenticated user profile
+  # GET /v2/users/me
+  # Single JSON object at root — no wrapper key, no pagination.
+  # ------------------------------------------------------------------
+  - name: user
+    description: >-
+      Zoom user profile for the authenticated account. Returns one row with
+      account metadata, license type, role, and login history.
+    guide: |
+      Start here to verify credentials and identify the Zoom account used
+      by Coral. This table returns one row for the authenticated user.
+      The `type` column indicates the license tier: 1 = Basic, 2 = Licensed,
+      4 = unassigned (no Meetings Basic), 99 = none (legacy).
+    fetch_limit_default: 1
+    request:
+      method: GET
+      path: /users/me
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Zoom user ID.
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: First name.
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Last name.
+      - name: email
+        type: Utf8
+        nullable: false
+        description: Email address.
+      - name: type
+        type: Int64
+        nullable: false
+        description: >-
+          License type (1 = Basic, 2 = Licensed, 4 = unassigned without
+          Meetings Basic, 99 = none/legacy).
+      - name: role_name
+        type: Utf8
+        nullable: true
+        description: Account role such as Owner, Admin, or Member.
+      - name: timezone
+        type: Utf8
+        nullable: true
+        description: IANA timezone identifier.
+      - name: dept
+        type: Utf8
+        nullable: true
+        description: Department name when configured.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Account creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: last_login_time
+        type: Timestamp
+        nullable: true
+        description: Last login time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - last_login_time
+      - name: pic_url
+        type: Utf8
+        nullable: true
+        description: Profile picture URL.
+      - name: account_id
+        type: Utf8
+        nullable: true
+        description: Zoom account ID.
+      - name: language
+        type: Utf8
+        nullable: true
+        description: Language preference.
+
+  # ------------------------------------------------------------------
+  # zoom.meetings — scheduled meetings for the authenticated user
+  # GET /v2/users/me/meetings
+  # Pagination: next_page_token cursor, page_size query param.
+  # Optional filter: meeting_status → Zoom query param "type".
+  # The response field "type" is a different concept (numeric meeting kind).
+  # ------------------------------------------------------------------
+  - name: meetings
+    description: >-
+      Zoom meetings for the authenticated user. Defaults to scheduled meetings.
+      Use the optional `meeting_status` filter to control which list mode
+      Zoom returns.
+    guide: |
+      Lists meetings for the authenticated user. The `meeting_status` filter
+      controls Zoom's list mode and defaults to `scheduled`. Other values:
+      `live`, `upcoming`, `upcoming_meetings`, `previous_meetings`. Note
+      that `upcoming` and `previous_meetings` only cover the last/next
+      6 months. The response column `type` is a separate concept — it is
+      the numeric meeting kind (1 = instant, 2 = scheduled, etc.).
+    filters:
+      - name: meeting_status
+        description: >-
+          Controls which meetings Zoom returns. Values: scheduled (default),
+          live, upcoming, upcoming_meetings, previous_meetings. Note:
+          upcoming and previous_meetings only span a 6-month window.
+    request:
+      method: GET
+      path: /users/me/meetings
+      query:
+        - name: type
+          from: filter
+          key: meeting_status
+    response:
+      rows_path:
+        - meetings
+    pagination:
+      mode: cursor_query
+      cursor_param: next_page_token
+      response_cursor_path:
+        - next_page_token
+      page_size:
+        default: 30
+        max: 300
+        query_param: page_size
+    columns:
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Unique meeting instance UUID.
+      - name: id
+        type: Int64
+        nullable: false
+        description: Numeric meeting ID.
+      - name: topic
+        type: Utf8
+        nullable: true
+        description: Meeting topic.
+      - name: type
+        type: Int64
+        nullable: true
+        description: >-
+          Meeting type (1 = instant, 2 = scheduled, 3 = recurring no fixed time,
+          8 = recurring fixed time).
+      - name: start_time
+        type: Timestamp
+        nullable: true
+        description: Scheduled start time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - start_time
+      - name: duration
+        type: Int64
+        nullable: true
+        description: Duration in minutes.
+      - name: timezone
+        type: Utf8
+        nullable: true
+        description: Meeting timezone.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Meeting creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: join_url
+        type: Utf8
+        nullable: true
+        description: URL to join the meeting.
+      - name: meeting_status
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Echoes the meeting_status filter used for this scan. This controls
+          Zoom's list mode and is distinct from the response column `type`.
+        expr:
+          kind: from_filter
+          key: meeting_status
+
+  # ------------------------------------------------------------------
+  # zoom.recordings — cloud recordings for the authenticated user
+  # GET /v2/users/me/recordings
+  # Pagination: next_page_token cursor, page_size query param.
+  # Required filters: from_date and to_date (max 1-month range).
+  # Response wrapper: "meetings" (each item has nested recording_files).
+  # ------------------------------------------------------------------
+  - name: recordings
+    description: >-
+      Zoom cloud recordings for the authenticated user. Requires `from_date`
+      and `to_date` filters in `yyyy-MM-dd` format. The maximum date range
+      per query is one month.
+    guide: |
+      Requires `from_date` and `to_date` in the WHERE clause. Both must be
+      in `yyyy-MM-dd` format and the range must not exceed one calendar month.
+      Without these filters the Zoom API defaults to the current date only,
+      which typically returns no results. Each row is one recorded meeting;
+      individual recording files are in the `recording_files` JSON column.
+
+      Example:
+        SELECT uuid, topic, start_time, recording_count
+        FROM zoom.recordings
+        WHERE from_date = '2026-05-01' AND to_date = '2026-05-31'
+        LIMIT 10
+    filters:
+      - name: from_date
+        required: true
+        description: >-
+          Start date in yyyy-MM-dd format. Required. The Zoom API defaults
+          to the current date when omitted, returning few or no results.
+      - name: to_date
+        required: true
+        description: >-
+          End date in yyyy-MM-dd format. Required. The maximum range between
+          from_date and to_date is one calendar month.
+    request:
+      method: GET
+      path: /users/me/recordings
+      query:
+        - name: from
+          from: filter
+          key: from_date
+        - name: to
+          from: filter
+          key: to_date
+    response:
+      rows_path:
+        - meetings
+    pagination:
+      mode: cursor_query
+      cursor_param: next_page_token
+      response_cursor_path:
+        - next_page_token
+      page_size:
+        default: 30
+        max: 300
+        query_param: page_size
+    columns:
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Meeting UUID.
+      - name: id
+        type: Int64
+        nullable: false
+        description: Numeric meeting ID.
+      - name: topic
+        type: Utf8
+        nullable: true
+        description: Meeting topic.
+      - name: start_time
+        type: Timestamp
+        nullable: true
+        description: Recording start time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - start_time
+      - name: duration
+        type: Int64
+        nullable: true
+        description: Duration in minutes.
+      - name: total_size
+        type: Int64
+        nullable: true
+        description: Total recording size in bytes.
+      - name: type
+        type: Utf8
+        nullable: true
+        description: >-
+          Meeting type as returned by Zoom (e.g. 1 = instant, 2 = scheduled,
+          3 = recurring no fixed time, 8 = recurring fixed time). Modeled as
+          Utf8 per Zoom API documentation.
+      - name: share_url
+        type: Utf8
+        nullable: true
+        description: URL to share the recording.
+      - name: recording_count
+        type: Int64
+        nullable: true
+        description: Number of recording files.
+      - name: recording_files
+        type: Json
+        nullable: true
+        description: >-
+          JSON array of recording file objects. Each object contains id,
+          file_type, file_size, play_url, download_url, status, and
+          recording_type.
+      - name: from_date
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Echoes the from_date filter used for this scan.
+        expr:
+          kind: from_filter
+          key: from_date
+      - name: to_date
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Echoes the to_date filter used for this scan.
+        expr:
+          kind: from_filter
+          key: to_date

--- a/sources/community/zoom/manifest.yaml
+++ b/sources/community/zoom/manifest.yaml
@@ -4,54 +4,16 @@ dsl_version: 3
 backend: http
 description: >-
   Query your Zoom user profile, scheduled meetings, and cloud recordings.
-  Read-only access via OAuth authorization-code flow or a pasted access token.
+  Read-only access via a Zoom access token (OAuth or Server-to-Server).
 inputs:
-  ZOOM_CLIENT_ID:
-    kind: variable
-    hint: |
-      Zoom OAuth app Client ID. Create a user-managed OAuth app at
-      https://marketplace.zoom.us/develop/create, select "User-managed app",
-      and copy the Client ID from the app credentials page.
-  ZOOM_CLIENT_SECRET:
-    kind: secret
-    hint: |
-      Zoom OAuth app Client Secret from the same app credentials page.
   ZOOM_ACCESS_TOKEN:
     kind: secret
     hint: |
-      Zoom OAuth access token. Use "Connect with Zoom" to authenticate
-      interactively via the OAuth authorization-code flow, or paste an
-      existing access token. Required scopes: user:read:user,
+      Zoom access token with scopes: user:read:user,
       meeting:read:list_meetings, cloud_recording:read:list_user_recordings.
-    credential:
-      methods:
-        - type: oauth
-          label: Connect with Zoom
-          description: Authenticate via Zoom OAuth authorization-code flow.
-          oauth:
-            flow:
-              type: authorization_code
-              pkce: disabled
-            redirect_uri: http://127.0.0.1:53682/oauth/callback
-            redirect_uri_port_mode: fixed
-            endpoints:
-              authorization_url: https://zoom.us/oauth/authorize
-              token_url: https://zoom.us/oauth/token
-            client:
-              id:
-                input: ZOOM_CLIENT_ID
-              secret:
-                input: ZOOM_CLIENT_SECRET
-                transport: basic_auth
-            scopes:
-              scope:
-                delimiter: space
-                values:
-                  - user:read:user
-                  - meeting:read:list_meetings
-                  - cloud_recording:read:list_user_recordings
-        - type: source_config
-          label: Paste token
+      Obtain a token from a Zoom Server-to-Server OAuth app or any Zoom
+      OAuth flow. See https://developers.zoom.us/docs/internal-apps/s2s-oauth/
+      for Server-to-Server setup.
 base_url: https://api.zoom.us/v2
 auth:
   type: HeaderAuth


### PR DESCRIPTION
Closes #737

## Summary

Adds a new **Zoom** community source. Exposes read-only access to the authenticated user's profile, meetings, and cloud recordings via Zoom API v2.

## What's included

| File | Purpose |
|---|---|
| `sources/community/zoom/manifest.yaml` | Source spec (3 tables, rate limiting, cursor pagination) |
| `sources/community/zoom/README.md` | Setup guide, table docs, example queries, validation commands |

## Tables

| Table | Endpoint | Pagination | Filters |
|---|---|---|---|
| `zoom.user` | `GET /users/me` | None (single object via `row_strategy: direct`) | — |
| `zoom.meetings` | `GET /users/me/meetings` | `cursor_query` (`next_page_token`) | `meeting_status` (optional) |
| `zoom.recordings` | `GET /users/me/recordings` | `cursor_query` (`next_page_token`) | `from_date`, `to_date` (both **required**) |

## Auth

Single input: `ZOOM_ACCESS_TOKEN` (`kind: secret`). Users obtain a token from a [Server-to-Server OAuth app](https://developers.zoom.us/docs/internal-apps/s2s-oauth/) or any Zoom OAuth flow and paste it. Required scopes: `user:read:user`, `meeting:read:list_meetings`, `cloud_recording:read:list_user_recordings`.

## Design decisions

- **`row_strategy: direct` for `user` table** — `/users/me` returns a single JSON object at root, not an array.
- **`from_date` / `to_date` as required filters on `recordings`** — Zoom defaults to the current date only when omitted. Max range per API call is 1 calendar month.
- **`meeting_status` filter on `meetings`** — Maps to Zoom's `type` query parameter. Named `meeting_status` to avoid collision with the response column `type` (numeric meeting kind).
- **`rate_limit` block** — Zoom sends `X-RateLimit-Remaining` and `Retry-After` headers; declared so Coral backs off automatically on 429s.
- **Virtual `from_filter` echo columns** — Follows existing community source patterns for surfacing filter values in query results.

## Live evidence

`coral source add` — connected, 4/4 test queries passed:
Added source zoom ✓ zoom connected successfully zoom (3 tables) — meetings, recordings, user Query tests: 4 declared · 4 passed · 0 failed

