### PR TITLE
feat(sources/statuspage): add StatusPage community source

### DIFF
--- a/sources/community/statuspage/README.md
+++ b/sources/community/statuspage/README.md
@@ -301,4 +301,5 @@ All tables use page-based pagination with a page size of 100 (`per_page=100`). F
 - The `components` table includes group header rows (`group = true`) with `NULL` status. Add `WHERE group != true` or `WHERE status IS NOT NULL` to exclude them.
 - `incident_updates__body` joins all update message bodies in the order the API returns them (newest-first). Each update is separated by a newline character.
 - The Statuspage Management API is rate-limited to **1 request/second** per token.
-- All four tables treat HTTP 404 as an empty result (`allow_404_empty: true`) so a newly created page with no data doesn't cause query errors.
+- The `all_incidents` table caps automatic pagination at **10 pages (1,000 incidents)** to avoid unbounded fetches against long-running pages. Use an explicit SQL `LIMIT` to fetch fewer, or raise the cap by adjusting `max_pages` in the source spec for your use case.
+- HTTP 404 from any table is treated as a real error, not an empty result. A 404 means your `STATUSPAGE_PAGE_ID` is invalid or the API key does not have access to the page — check your inputs with `coral source test statuspage`.

--- a/sources/community/statuspage/README.md
+++ b/sources/community/statuspage/README.md
@@ -15,6 +15,8 @@ Requires a `STATUSPAGE_API_KEY` and a `STATUSPAGE_PAGE_ID`.
 - The API key is a long hex string (e.g. `89a229ce1a8dbcf9ff30430fbe...`)
 - The page ID is a short alphanumeric ID (e.g. `gytm4qzbx9t6`) — not the subdomain
 
+> **Security note:** Statuspage API keys are page-level management credentials that carry full read and write access to your status page — including creating and resolving incidents and updating component statuses. This source only performs GET requests, but the key itself is not scoped to read-only. Use a dedicated key for Coral integrations where possible, and rotate it if it is ever exposed. Statuspage does not currently support read-only API key scoping.
+
 ```bash
 STATUSPAGE_API_KEY=<token> STATUSPAGE_PAGE_ID=<page_id> \
   coral source add --file sources/community/statuspage/manifest.yaml
@@ -271,7 +273,7 @@ All scheduled maintenance windows. Queries `/incidents/scheduled`.
 | `name` | `Utf8` | Component display name |
 | `status` | `Utf8` | `operational`, `degraded_performance`, `partial_outage`, `major_outage`, or `under_maintenance` |
 | `description` | `Utf8` | Optional description of the component |
-| `group` | `Boolean` | If `true`, this row is a component group header — `status` will be `NULL` |
+| `group` | `Boolean` | If `true`, this row is a component group header — `status` may be `operational` or `NULL` |
 | `created_at` | `Timestamp` | When the component was created |
 | `updated_at` | `Timestamp` | Most recent status change time |
 | `position` | `Int64` | Display order on the status page |
@@ -298,8 +300,8 @@ All tables use page-based pagination with a page size of 100 (`per_page=100`). F
 
 - The `incidents` table queries `/incidents/unresolved` — it never returns resolved incidents. Use `all_incidents` for resolved and historical data.
 - The `scheduled_maintenances` table queries `/incidents/scheduled`. Status values (`scheduled`, `in_progress`, `verifying`, `completed`) are distinct from realtime incident statuses.
-- The `components` table includes group header rows (`group = true`) with `NULL` status. Add `WHERE group != true` or `WHERE status IS NOT NULL` to exclude them.
+- The `components` table includes group header rows (`group = true`). These rows may have `status = 'operational'` or `NULL` depending on account configuration. Add `WHERE group != true` to exclude them reliably.
 - `incident_updates__body` joins all update message bodies in the order the API returns them (newest-first). Each update is separated by a newline character.
-- The Statuspage Management API is rate-limited to **1 request/second** per token.
+- The Statuspage Management API is rate-limited to **1 request/second** per token (60-second rolling window). Exceeding the limit returns HTTP `420` (legacy) or `429` (current), both carrying a `Retry-After` header. The source spec declares a `rate_limit` block so Coral automatically backs off and retries on both codes.
 - The `all_incidents` table caps automatic pagination at **10 pages (1,000 incidents)** to avoid unbounded fetches against long-running pages. Use an explicit SQL `LIMIT` to fetch fewer, or raise the cap by adjusting `max_pages` in the source spec for your use case.
 - HTTP 404 from any table is treated as a real error, not an empty result. A 404 means your `STATUSPAGE_PAGE_ID` is invalid or the API key does not have access to the page — check your inputs with `coral source test statuspage`.

--- a/sources/community/statuspage/README.md
+++ b/sources/community/statuspage/README.md
@@ -1,11 +1,11 @@
 # Statuspage.io
 
-**Version:** 0.1.0
+**Version:** 0.2.0
 **Backend:** HTTP
-**Tables:** 2
+**Tables:** 4
 **Base URL:** `https://api.statuspage.io/v1`
 
-Query active incidents and component health from your [Statuspage.io](https://www.statuspage.io/) status page.
+Query active incidents, incident history, scheduled maintenance windows, and component health from your [Statuspage.io](https://www.statuspage.io/) status page.
 
 ## Authentication
 
@@ -30,14 +30,28 @@ coral source add --file sources/community/statuspage/manifest.yaml --interactive
 
 | Table | Description | Optional filters |
 |---|---|---|
-| `incidents` | Unresolved (active) incidents on your status page | — |
-| `components` | Infrastructure components and their current health status | — |
+| `incidents` | Unresolved (active) incidents — investigating, identified, monitoring | — |
+| `all_incidents` | All incidents regardless of status, including resolved and historical | — |
+| `scheduled_maintenances` | All scheduled maintenance windows regardless of state | — |
+| `components` | All components and their current operational status | — |
 
-### Incidents endpoint note
+### Which incidents table to use
 
-The `incidents` table queries the `/incidents/unresolved` endpoint exclusively.
-It only ever returns incidents with a `status` of `investigating`, `identified`, or `monitoring`.
-Resolved incidents are not included — query your Statuspage dashboard for historical data.
+| Goal | Table |
+|---|---|
+| Detect a live outage right now | `incidents` |
+| Query resolved or historical incidents | `all_incidents` |
+| Calculate MTTR / incident trends | `all_incidents` |
+| See upcoming maintenance windows | `scheduled_maintenances` |
+| See active maintenance windows | `scheduled_maintenances` |
+
+### Incident status values
+
+| Table | Status values |
+|---|---|
+| `incidents` | `investigating`, `identified`, `monitoring` only |
+| `all_incidents` | `investigating`, `identified`, `monitoring`, `resolved`, `postmortem` |
+| `scheduled_maintenances` | `scheduled`, `in_progress`, `verifying`, `completed` |
 
 ### Component status values
 
@@ -52,18 +66,58 @@ Resolved incidents are not included — query your Statuspage dashboard for hist
 ## Quick start
 
 ```bash
-# Confirm connectivity — see all active incidents
-coral sql "SELECT id, name, status, impact, shortlink, created_at FROM statuspage.incidents"
-
-# Check for any non-operational components
+# Active incidents right now
 coral sql "
-  SELECT name, status, updated_at
-  FROM statuspage.components
-  WHERE status != 'operational'
-  ORDER BY updated_at DESC
+  SELECT id, name, status, impact, shortlink, created_at
+  FROM statuspage.incidents
+  ORDER BY created_at DESC
 "
 
-# Critical or major incidents only
+# All incidents in the last 30 days (resolved + active)
+coral sql "
+  SELECT id, name, status, impact, created_at, resolved_at
+  FROM statuspage.all_incidents
+  WHERE created_at >= NOW() - INTERVAL '30 days'
+  ORDER BY created_at DESC
+"
+
+# Incidents that are still open (from all_incidents)
+coral sql "
+  SELECT id, name, status, impact, created_at
+  FROM statuspage.all_incidents
+  WHERE resolved_at IS NULL
+  ORDER BY created_at DESC
+"
+
+# Resolved incidents — calculate duration
+coral sql "
+  SELECT
+    name,
+    impact,
+    created_at,
+    resolved_at
+  FROM statuspage.all_incidents
+  WHERE status = 'resolved'
+  ORDER BY created_at DESC
+  LIMIT 20
+"
+
+# Upcoming scheduled maintenance windows
+coral sql "
+  SELECT name, status, impact, scheduled_for, scheduled_until
+  FROM statuspage.scheduled_maintenances
+  WHERE status = 'scheduled'
+  ORDER BY scheduled_for ASC
+"
+
+# Maintenance windows currently in progress
+coral sql "
+  SELECT name, scheduled_for, scheduled_until, incident_updates__body
+  FROM statuspage.scheduled_maintenances
+  WHERE status = 'in_progress'
+"
+
+# Critical or major active incidents
 coral sql "
   SELECT id, name, status, impact, shortlink, created_at
   FROM statuspage.incidents
@@ -71,35 +125,29 @@ coral sql "
   ORDER BY created_at DESC
 "
 
-# Incidents currently under investigation
-coral sql "
-  SELECT id, name, impact, shortlink, created_at, incident_updates__body
-  FROM statuspage.incidents
-  WHERE status = 'investigating'
-  ORDER BY created_at DESC
-"
-
-# All components grouped by status
-coral sql "
-  SELECT status, COUNT(*) AS count
-  FROM statuspage.components
-  GROUP BY status
-  ORDER BY count DESC
-"
-
-# Components that are hidden unless degraded
+# Check for degraded components
 coral sql "
   SELECT name, status, updated_at
   FROM statuspage.components
-  WHERE only_show_if_degraded = true
-  ORDER BY name
+  WHERE status != 'operational'
+    AND group != true
+  ORDER BY updated_at DESC
 "
 
-# Full component inventory
+# Full component inventory sorted by display order
 coral sql "
   SELECT id, name, status, description, group_id, position
   FROM statuspage.components
   ORDER BY position
+"
+
+# Incident frequency by impact level (last 90 days)
+coral sql "
+  SELECT impact, COUNT(*) AS count
+  FROM statuspage.all_incidents
+  WHERE created_at >= NOW() - INTERVAL '90 days'
+  GROUP BY impact
+  ORDER BY count DESC
 "
 ```
 
@@ -139,16 +187,118 @@ coral sql "
   ORDER BY p.created_at DESC
   LIMIT 20
 "
+
+# Correlate PagerDuty alerts with scheduled maintenance windows
+# (to distinguish 'expected degradation' from unexpected incidents)
+coral sql "
+  SELECT
+    p.title            AS alert,
+    p.created_at       AS alerted_at,
+    m.name             AS maintenance_window,
+    m.status           AS maintenance_status,
+    m.scheduled_for,
+    m.scheduled_until
+  FROM pagerduty.incidents p
+  JOIN statuspage.scheduled_maintenances m
+    ON m.status IN ('scheduled', 'in_progress')
+    AND p.created_at BETWEEN m.scheduled_for AND m.scheduled_until
+  ORDER BY p.created_at DESC
+  LIMIT 20
+"
 ```
 
-## Discovery order
+## Schema reference
 
-```text
-incidents
-  → id       (incident identifier, for correlation with external sources)
-  → shortlink (public URL to share in alerts)
+### `statuspage.incidents`
 
-components
-  → group_id → components.id  (parent component group)
-  → page_id  (the Statuspage page this component belongs to)
+Active (unresolved) incidents only. Queries `/incidents/unresolved`.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `Utf8` | Unique incident identifier |
+| `name` | `Utf8` | Incident title |
+| `status` | `Utf8` | `investigating`, `identified`, or `monitoring` |
+| `impact` | `Utf8` | `none`, `minor`, `major`, or `critical` |
+| `shortlink` | `Utf8` | Public short URL to the incident |
+| `created_at` | `Timestamp` | When the incident was opened |
+| `updated_at` | `Timestamp` | Most recent update time |
+| `monitoring_at` | `Timestamp` | When the incident entered monitoring (nullable) |
+| `resolved_at` | `Timestamp` | Always `NULL` on this endpoint |
+| `incident_updates__body` | `Utf8` | All update message bodies joined by newline, newest-first |
+
+### `statuspage.all_incidents`
+
+All incidents including resolved and historical. Queries `/incidents`.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `Utf8` | Unique incident identifier |
+| `name` | `Utf8` | Incident title |
+| `status` | `Utf8` | `investigating`, `identified`, `monitoring`, `resolved`, or `postmortem` |
+| `impact` | `Utf8` | `none`, `minor`, `major`, or `critical` |
+| `shortlink` | `Utf8` | Public short URL to the incident |
+| `created_at` | `Timestamp` | When the incident was opened |
+| `updated_at` | `Timestamp` | Most recent update time |
+| `monitoring_at` | `Timestamp` | When the incident entered monitoring (nullable) |
+| `resolved_at` | `Timestamp` | When resolved — `NULL` if still active |
+| `incident_updates__body` | `Utf8` | All update message bodies joined by newline, newest-first |
+
+### `statuspage.scheduled_maintenances`
+
+All scheduled maintenance windows. Queries `/incidents/scheduled`.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `Utf8` | Unique maintenance window identifier |
+| `name` | `Utf8` | Maintenance window title |
+| `status` | `Utf8` | `scheduled`, `in_progress`, `verifying`, or `completed` |
+| `impact` | `Utf8` | `none`, `minor`, `major`, or `critical` |
+| `shortlink` | `Utf8` | Public short URL to the maintenance window |
+| `scheduled_for` | `Timestamp` | Planned start time |
+| `scheduled_until` | `Timestamp` | Planned end time |
+| `scheduled_auto_in_progress` | `Boolean` | Automatically transitions to `in_progress` at `scheduled_for` |
+| `scheduled_auto_completed` | `Boolean` | Automatically transitions to `completed` at `scheduled_until` |
+| `scheduled_remind_prior` | `Boolean` | Subscribers reminded 60 minutes before start |
+| `created_at` | `Timestamp` | When the maintenance window was created |
+| `updated_at` | `Timestamp` | Most recent update time |
+| `incident_updates__body` | `Utf8` | All update message bodies joined by newline, newest-first |
+
+### `statuspage.components`
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | `Utf8` | Unique component identifier |
+| `name` | `Utf8` | Component display name |
+| `status` | `Utf8` | `operational`, `degraded_performance`, `partial_outage`, `major_outage`, or `under_maintenance` |
+| `description` | `Utf8` | Optional description of the component |
+| `group` | `Boolean` | If `true`, this row is a component group header — `status` will be `NULL` |
+| `created_at` | `Timestamp` | When the component was created |
+| `updated_at` | `Timestamp` | Most recent status change time |
+| `position` | `Int64` | Display order on the status page |
+| `showcase` | `Boolean` | Whether this component appears on the public page |
+| `only_show_if_degraded` | `Boolean` | If `true`, hidden from the public page when operational |
+| `group_id` | `Utf8` | Component group ID (nullable) |
+| `page_id` | `Utf8` | Statuspage page this component belongs to |
+
+## Authentication
+
+The `Authorization` header is sent as:
+
 ```
+Authorization: OAuth <STATUSPAGE_API_KEY>
+```
+
+The API key is stored in Coral's secret store and never exposed through `coral.inputs`.
+
+## Pagination
+
+All tables use page-based pagination with a page size of 100 (`per_page=100`). For most status pages this fits all active data in a single request. Coral will automatically paginate through all pages for larger datasets.
+
+## Notes
+
+- The `incidents` table queries `/incidents/unresolved` — it never returns resolved incidents. Use `all_incidents` for resolved and historical data.
+- The `scheduled_maintenances` table queries `/incidents/scheduled`. Status values (`scheduled`, `in_progress`, `verifying`, `completed`) are distinct from realtime incident statuses.
+- The `components` table includes group header rows (`group = true`) with `NULL` status. Add `WHERE group != true` or `WHERE status IS NOT NULL` to exclude them.
+- `incident_updates__body` joins all update message bodies in the order the API returns them (newest-first). Each update is separated by a newline character.
+- The Statuspage Management API is rate-limited to **1 request/second** per token.
+- All four tables treat HTTP 404 as an empty result (`allow_404_empty: true`) so a newly created page with no data doesn't cause query errors.

--- a/sources/community/statuspage/README.md
+++ b/sources/community/statuspage/README.md
@@ -1,0 +1,154 @@
+# Statuspage.io
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 2
+**Base URL:** `https://api.statuspage.io/v1`
+
+Query active incidents and component health from your [Statuspage.io](https://www.statuspage.io/) status page.
+
+## Authentication
+
+Requires a `STATUSPAGE_API_KEY` and a `STATUSPAGE_PAGE_ID`.
+
+- Find both at: **manage.statuspage.io → avatar → API info**
+- The API key is a long hex string (e.g. `89a229ce1a8dbcf9ff30430fbe...`)
+- The page ID is a short alphanumeric ID (e.g. `gytm4qzbx9t6`) — not the subdomain
+
+```bash
+STATUSPAGE_API_KEY=<token> STATUSPAGE_PAGE_ID=<page_id> \
+  coral source add --file sources/community/statuspage/manifest.yaml
+```
+
+Run from the repo root. Or interactively:
+
+```bash
+coral source add --file sources/community/statuspage/manifest.yaml --interactive
+```
+
+## Tables
+
+| Table | Description | Optional filters |
+|---|---|---|
+| `incidents` | Unresolved (active) incidents on your status page | — |
+| `components` | Infrastructure components and their current health status | — |
+
+### Incidents endpoint note
+
+The `incidents` table queries the `/incidents/unresolved` endpoint exclusively.
+It only ever returns incidents with a `status` of `investigating`, `identified`, or `monitoring`.
+Resolved incidents are not included — query your Statuspage dashboard for historical data.
+
+### Component status values
+
+| Value | Meaning |
+|---|---|
+| `operational` | Component is healthy |
+| `degraded_performance` | Component is slower than normal |
+| `partial_outage` | Component is partially unavailable |
+| `major_outage` | Component is fully unavailable |
+| `under_maintenance` | Component is under scheduled maintenance |
+
+## Quick start
+
+```bash
+# Confirm connectivity — see all active incidents
+coral sql "SELECT id, name, status, impact, shortlink, created_at FROM statuspage.incidents"
+
+# Check for any non-operational components
+coral sql "
+  SELECT name, status, updated_at
+  FROM statuspage.components
+  WHERE status != 'operational'
+  ORDER BY updated_at DESC
+"
+
+# Critical or major incidents only
+coral sql "
+  SELECT id, name, status, impact, shortlink, created_at
+  FROM statuspage.incidents
+  WHERE impact IN ('major', 'critical')
+  ORDER BY created_at DESC
+"
+
+# Incidents currently under investigation
+coral sql "
+  SELECT id, name, impact, shortlink, created_at, incident_updates__body
+  FROM statuspage.incidents
+  WHERE status = 'investigating'
+  ORDER BY created_at DESC
+"
+
+# All components grouped by status
+coral sql "
+  SELECT status, COUNT(*) AS count
+  FROM statuspage.components
+  GROUP BY status
+  ORDER BY count DESC
+"
+
+# Components that are hidden unless degraded
+coral sql "
+  SELECT name, status, updated_at
+  FROM statuspage.components
+  WHERE only_show_if_degraded = true
+  ORDER BY name
+"
+
+# Full component inventory
+coral sql "
+  SELECT id, name, status, description, group_id, position
+  FROM statuspage.components
+  ORDER BY position
+"
+```
+
+## JOIN examples
+
+```bash
+# Cross-reference active incidents with Sentry error spikes
+coral sql "
+  SELECT
+    s.title            AS sentry_issue,
+    s.culprit,
+    i.name             AS active_incident,
+    i.impact,
+    i.status           AS incident_status,
+    i.shortlink
+  FROM sentry.issues s
+  JOIN statuspage.incidents i
+    ON i.status IN ('investigating', 'identified', 'monitoring')
+  WHERE s.times_seen > 100
+    AND s.first_seen >= i.created_at
+  ORDER BY s.times_seen DESC
+  LIMIT 20
+"
+
+# Check for degraded components alongside triggered PagerDuty alerts
+coral sql "
+  SELECT
+    p.title            AS alert,
+    p.created_at       AS alerted_at,
+    c.name             AS component,
+    c.status,
+    c.updated_at       AS component_updated_at
+  FROM pagerduty.incidents p
+  JOIN statuspage.components c
+    ON c.status != 'operational'
+  WHERE p.status = 'triggered'
+  ORDER BY p.created_at DESC
+  LIMIT 20
+"
+```
+
+## Discovery order
+
+```text
+incidents
+  → id       (incident identifier, for correlation with external sources)
+  → shortlink (public URL to share in alerts)
+
+components
+  → group_id → components.id  (parent component group)
+  → page_id  (the Statuspage page this component belongs to)
+```

--- a/sources/community/statuspage/manifest.yaml
+++ b/sources/community/statuspage/manifest.yaml
@@ -1,10 +1,10 @@
 name: statuspage
-version: 0.1.0
+version: 0.2.0
 dsl_version: 3
 backend: http
 description: >-
-  Query active incidents and component health from your Statuspage.io
-  status page.
+  Query incidents, scheduled maintenances, and component health from your
+  Statuspage.io status page.
 
 inputs:
   STATUSPAGE_API_KEY:
@@ -36,9 +36,12 @@ request_headers:
 
 test_queries:
   - SELECT * FROM statuspage.incidents LIMIT 1
+  - SELECT * FROM statuspage.all_incidents LIMIT 1
+  - SELECT * FROM statuspage.scheduled_maintenances LIMIT 1
   - SELECT * FROM statuspage.components LIMIT 1
 
 tables:
+  # ── Table 1: incidents ────────────────────────────────────────────────────────
   - name: incidents
     description: Unresolved (active) incidents on your Statuspage.io status page
     guide: |
@@ -46,6 +49,7 @@ tables:
       status investigating, identified, or monitoring. Resolved incidents are
       never included. Use this table to detect live infrastructure outages that
       may explain service errors surfaced by Sentry or PagerDuty.
+      For historical and resolved incidents use statuspage.all_incidents.
       `incident_updates__body` joins all update message bodies in newest-first
       order as returned by the API.
     request:
@@ -165,6 +169,288 @@ tables:
             - body
           separator: "\n"
 
+  # ── Table 2: all_incidents ────────────────────────────────────────────────────
+  - name: all_incidents
+    description: All incidents (resolved and unresolved) on your Statuspage.io status page
+    guide: |
+      Queries the /incidents endpoint — returns all incidents regardless of
+      status, including resolved and historical ones. Use this table for trend
+      analysis, incident history, MTTR calculations, and post-mortem queries.
+      For live outage detection use statuspage.incidents (unresolved only).
+      `resolved_at` is non-null for resolved incidents and can be used to
+      calculate incident duration: resolved_at - created_at.
+      `incident_updates__body` joins all update message bodies in newest-first
+      order as returned by the API.
+    request:
+      method: GET
+      path: "/pages/{{input.STATUSPAGE_PAGE_ID}}/incidents"
+    response:
+      rows_path: []
+      row_strategy: direct
+      allow_404_empty: true
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique incident identifier
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Human-readable incident title
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Incident status. One of: investigating, identified, monitoring,
+          resolved, postmortem.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: impact
+        type: Utf8
+        nullable: true
+        description: >-
+          Assessed customer impact level.
+          One of: none, minor, major, critical.
+        expr:
+          kind: path
+          path:
+            - impact
+      - name: shortlink
+        type: Utf8
+        nullable: true
+        description: Public short URL to the incident on the status page
+        expr:
+          kind: path
+          path:
+            - shortlink
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp of the most recent update
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: monitoring_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident entered monitoring status (nullable)
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - monitoring_at
+      - name: resolved_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was resolved (null if still active)
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - resolved_at
+      - name: incident_updates__body
+        type: Utf8
+        nullable: true
+        description: All incident update message bodies joined by newline, newest-first
+        expr:
+          kind: join_array_path
+          path:
+            - incident_updates
+          item_path:
+            - body
+          separator: "\n"
+
+  # ── Table 3: scheduled_maintenances ───────────────────────────────────────────
+  - name: scheduled_maintenances
+    description: Scheduled maintenance windows on your Statuspage.io status page
+    guide: |
+      Queries the /incidents/scheduled endpoint — returns all scheduled
+      maintenance windows regardless of state. Status values differ from
+      realtime incidents: scheduled, in_progress, verifying, completed.
+      `scheduled_for` is the planned start time; `scheduled_until` is the
+      planned end time. Both are Timestamps and suitable for time-window queries.
+      Use WHERE status = 'scheduled' to see upcoming maintenances, or
+      WHERE status = 'in_progress' to see active maintenance windows.
+      `incident_updates__body` joins all update message bodies in newest-first
+      order as returned by the API.
+    request:
+      method: GET
+      path: "/pages/{{input.STATUSPAGE_PAGE_ID}}/incidents/scheduled"
+    response:
+      rows_path: []
+      row_strategy: direct
+      allow_404_empty: true
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique maintenance window identifier
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Human-readable maintenance window title
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Maintenance status. One of: scheduled, in_progress, verifying,
+          completed.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: impact
+        type: Utf8
+        nullable: true
+        description: >-
+          Assessed customer impact level.
+          One of: none, minor, major, critical.
+        expr:
+          kind: path
+          path:
+            - impact
+      - name: shortlink
+        type: Utf8
+        nullable: true
+        description: Public short URL to the maintenance window on the status page
+        expr:
+          kind: path
+          path:
+            - shortlink
+      - name: scheduled_for
+        type: Timestamp
+        nullable: true
+        description: Planned start time of the maintenance window
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - scheduled_for
+      - name: scheduled_until
+        type: Timestamp
+        nullable: true
+        description: Planned end time of the maintenance window
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - scheduled_until
+      - name: scheduled_auto_in_progress
+        type: Boolean
+        nullable: true
+        description: Whether the window automatically transitions to in_progress at scheduled_for
+        expr:
+          kind: path
+          path:
+            - scheduled_auto_in_progress
+      - name: scheduled_auto_completed
+        type: Boolean
+        nullable: true
+        description: Whether the window automatically transitions to completed at scheduled_until
+        expr:
+          kind: path
+          path:
+            - scheduled_auto_completed
+      - name: scheduled_remind_prior
+        type: Boolean
+        nullable: true
+        description: Whether subscribers are reminded 60 minutes before the scheduled start
+        expr:
+          kind: path
+          path:
+            - scheduled_remind_prior
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the maintenance window was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp of the most recent update
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: incident_updates__body
+        type: Utf8
+        nullable: true
+        description: All maintenance update message bodies joined by newline, newest-first
+        expr:
+          kind: join_array_path
+          path:
+            - incident_updates
+          item_path:
+            - body
+          separator: "\n"
+
+  # ── Table 4: components ───────────────────────────────────────────────────────
   - name: components
     description: Infrastructure components and their current health status from Statuspage.io
     guide: |

--- a/sources/community/statuspage/manifest.yaml
+++ b/sources/community/statuspage/manifest.yaml
@@ -466,8 +466,10 @@ tables:
       Each row is one component on the status page. `status` reflects the
       current operational state — filter WHERE status != 'operational' to find
       anything degraded. `group = true` marks a component group header row —
-      these have no `status` value and will appear as NULL. `only_show_if_degraded
-      = true` means the component is hidden from the public page when healthy.
+      these rows may have status set to 'operational' or NULL depending on
+      account configuration; use WHERE group != true to exclude them reliably
+      rather than filtering on status alone. `only_show_if_degraded = true`
+      means the component is hidden from the public page when healthy.
       `group_id` links to the parent component group's `id`. Use `position` for
       display-order sorting matching the public status page.
     request:

--- a/sources/community/statuspage/manifest.yaml
+++ b/sources/community/statuspage/manifest.yaml
@@ -34,6 +34,14 @@ request_headers:
     from: literal
     value: application/json
 
+# Statuspage returns HTTP 420 (legacy) or 429 (current) when the rate limit is exceeded.
+# Both codes carry a Retry-After header indicating seconds to wait.
+# Coral handles 429 natively; extra_statuses adds 420 for legacy responses.
+# See: https://developer.statuspage.io/#section/Rate-Limiting
+rate_limit:
+  extra_statuses: [420]
+  retry_after_header: Retry-After
+
 test_queries:
   - SELECT * FROM statuspage.incidents LIMIT 1
   - SELECT * FROM statuspage.all_incidents LIMIT 1
@@ -518,7 +526,8 @@ tables:
         nullable: true
         description: >-
           If true, this row is a component group header, not an individual component.
-          Group header rows have no status value — status will be NULL.
+          Group header rows may have status set to 'operational' or NULL depending
+          on account configuration.
         expr:
           kind: path
           path:

--- a/sources/community/statuspage/manifest.yaml
+++ b/sources/community/statuspage/manifest.yaml
@@ -58,7 +58,7 @@ tables:
     response:
       rows_path: []
       row_strategy: direct
-      allow_404_empty: true
+      allow_404_empty: false
     pagination:
       mode: page
       page_size:
@@ -187,9 +187,10 @@ tables:
     response:
       rows_path: []
       row_strategy: direct
-      allow_404_empty: true
+      allow_404_empty: false
     pagination:
       mode: page
+      max_pages: 10
       page_size:
         default: 100
         max: 100
@@ -316,7 +317,7 @@ tables:
     response:
       rows_path: []
       row_strategy: direct
-      allow_404_empty: true
+      allow_404_empty: false
     pagination:
       mode: page
       page_size:
@@ -467,7 +468,7 @@ tables:
     response:
       rows_path: []
       row_strategy: direct
-      allow_404_empty: true
+      allow_404_empty: false
     pagination:
       mode: page
       page_size:

--- a/sources/community/statuspage/manifest.yaml
+++ b/sources/community/statuspage/manifest.yaml
@@ -1,0 +1,300 @@
+name: statuspage
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query active incidents and component health from your Statuspage.io
+  status page.
+
+inputs:
+  STATUSPAGE_API_KEY:
+    kind: secret
+    hint: |
+      Your Statuspage.io API key.
+      Find it at: manage.statuspage.io → click your avatar → API info.
+      It looks like: a long hex string (e.g. 89a229ce1a8dbcf9ff30430fbe...).
+  STATUSPAGE_PAGE_ID:
+    kind: variable
+    hint: |
+      Your Statuspage.io page ID (not subdomain — the short alphanumeric ID).
+      Find it at: manage.statuspage.io → API info page → "Page ID" field.
+      It looks like: gytm4qzbx9t6
+
+base_url: "https://api.statuspage.io/v1"
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "OAuth {{input.STATUSPAGE_API_KEY}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT * FROM statuspage.incidents LIMIT 1
+  - SELECT * FROM statuspage.components LIMIT 1
+
+tables:
+  - name: incidents
+    description: Unresolved (active) incidents on your Statuspage.io status page
+    guide: |
+      Queries the /incidents/unresolved endpoint — only returns incidents with
+      status investigating, identified, or monitoring. Resolved incidents are
+      never included. Use this table to detect live infrastructure outages that
+      may explain service errors surfaced by Sentry or PagerDuty.
+      `incident_updates__body` joins all update message bodies in newest-first
+      order as returned by the API.
+    request:
+      method: GET
+      path: "/pages/{{input.STATUSPAGE_PAGE_ID}}/incidents/unresolved"
+    response:
+      rows_path: []
+      row_strategy: direct
+      allow_404_empty: true
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique incident identifier (e.g. "jklm456")
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Human-readable incident title
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Current incident status.
+          One of: investigating, identified, monitoring.
+          The unresolved endpoint never returns resolved incidents.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: impact
+        type: Utf8
+        nullable: true
+        description: >-
+          Assessed customer impact level.
+          One of: none, minor, major, critical.
+        expr:
+          kind: path
+          path:
+            - impact
+      - name: shortlink
+        type: Utf8
+        nullable: true
+        description: Public short URL to the incident on the status page
+        expr:
+          kind: path
+          path:
+            - shortlink
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp of the most recent update
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: monitoring_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident entered monitoring status (nullable)
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - monitoring_at
+      - name: resolved_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when resolved — always null on the unresolved endpoint
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - resolved_at
+      - name: incident_updates__body
+        type: Utf8
+        nullable: true
+        description: All incident update message bodies joined by newline, newest-first
+        expr:
+          kind: join_array_path
+          path:
+            - incident_updates
+          item_path:
+            - body
+          separator: "\n"
+
+  - name: components
+    description: Infrastructure components and their current health status from Statuspage.io
+    guide: |
+      Each row is one component on the status page. `status` reflects the
+      current operational state — filter WHERE status != 'operational' to find
+      anything degraded. `group = true` marks a component group header row —
+      these have no `status` value and will appear as NULL. `only_show_if_degraded
+      = true` means the component is hidden from the public page when healthy.
+      `group_id` links to the parent component group's `id`. Use `position` for
+      display-order sorting matching the public status page.
+    request:
+      method: GET
+      path: "/pages/{{input.STATUSPAGE_PAGE_ID}}/components"
+    response:
+      rows_path: []
+      row_strategy: direct
+      allow_404_empty: true
+    pagination:
+      mode: page
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique component identifier
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Component display name (e.g. "API Gateway", "Checkout Service")
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: >-
+          Component operational status.
+          One of: operational, degraded_performance, partial_outage,
+          major_outage, under_maintenance.
+        expr:
+          kind: path
+          path:
+            - status
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Optional description of what this component represents
+        expr:
+          kind: path
+          path:
+            - description
+      - name: group
+        type: Boolean
+        nullable: true
+        description: >-
+          If true, this row is a component group header, not an individual component.
+          Group header rows have no status value — status will be NULL.
+        expr:
+          kind: path
+          path:
+            - group
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the component was created
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp of the most recent status change
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: position
+        type: Int64
+        nullable: true
+        description: Display order position on the status page
+        expr:
+          kind: path
+          path:
+            - position
+      - name: showcase
+        type: Boolean
+        nullable: true
+        description: Whether this component is shown on the public status page
+        expr:
+          kind: path
+          path:
+            - showcase
+      - name: only_show_if_degraded
+        type: Boolean
+        nullable: true
+        description: If true, this component is hidden from the public page when operational
+        expr:
+          kind: path
+          path:
+            - only_show_if_degraded
+      - name: group_id
+        type: Utf8
+        nullable: true
+        description: ID of the component group this belongs to (nullable)
+        expr:
+          kind: path
+          path:
+            - group_id
+      - name: page_id
+        type: Utf8
+        nullable: true
+        description: ID of the Statuspage page this component belongs to
+        expr:
+          kind: path
+          path:
+            - page_id


### PR DESCRIPTION
## feat(sources/statuspage): add Statuspage.io community source

### Summary

Adds a new community source: `statuspage`.

This source enables Coral users and AI agents to query Statuspage.io status page data using SQL over the Statuspage.io Management REST API (`api.statuspage.io/v1`).

It exposes four tables covering the full operational picture — live incidents, incident history, scheduled maintenance windows, and component health — making it practical as a **5th JOIN** in CoralOps workflows: *"Is there an active infrastructure incident for the service being evaluated?"*

---

### Included tables

- `incidents` — unresolved (active) incidents
- `all_incidents` — all incidents including resolved and historical
- `scheduled_maintenances` — all scheduled maintenance windows
- `components` — component health status

---

### Features

- OAuth token authentication (`Authorization: OAuth <token>`)
- Configurable page ID via `STATUSPAGE_PAGE_ID` variable
- Read-only (GET only) implementation
- Page-based pagination (`page` / `per_page`, max 100)
- ISO 8601 → Timestamp normalization on all `*_at`, `scheduled_for`, and `scheduled_until` columns
- `join_array_path` for incident update message bodies across all three incident tables
- `group` column on `components` to distinguish group header rows from real components
- Production-ready README with setup, validation, quick-start queries, JOIN examples, and schema reference

---

### Files

| File | Purpose |
|---|---|
| `sources/community/statuspage/manifest.yaml` | Coral source specification (DSL v3, HTTP backend) |
| `sources/community/statuspage/README.md` | Installation, authentication, examples, validation, and limitations |

---

### Authentication

| Requirement | Status | Implementation |
|---|---|---|
| `Authorization: OAuth <token>` | ✅ | `HeaderAuth` → `OAuth {{input.STATUSPAGE_API_KEY}}` |
| Configurable `STATUSPAGE_API_KEY` | ✅ | Secret input |
| Configurable `STATUSPAGE_PAGE_ID` | ✅ | Variable input |

> **Security note:** Statuspage API keys carry full page-management write access. The source performs GET requests only, but the credential itself is not read-only scoped. The README now documents this risk and recommends using a dedicated key.

---

### Core Tables

| Table | Endpoint | Columns | Pagination | Status |
|---|---|---|---|---|
| `incidents` | `/incidents/unresolved` | `id`, `name`, `status`, `impact`, `shortlink`, `created_at`, `updated_at`, `monitoring_at`, `resolved_at`, `incident_updates__body` | `page` / `per_page` (max 100) | ✅ |
| `all_incidents` | `/incidents` | `id`, `name`, `status`, `impact`, `shortlink`, `created_at`, `updated_at`, `monitoring_at`, `resolved_at`, `incident_updates__body` | `page` / `per_page` (max 100) | ✅ |
| `scheduled_maintenances` | `/incidents/scheduled` | `id`, `name`, `status`, `impact`, `shortlink`, `scheduled_for`, `scheduled_until`, `scheduled_auto_in_progress`, `scheduled_auto_completed`, `scheduled_remind_prior`, `created_at`, `updated_at`, `incident_updates__body` | `page` / `per_page` (max 100) | ✅ |
| `components` | `/components` | `id`, `name`, `status`, `description`, `group`, `created_at`, `updated_at`, `position`, `showcase`, `only_show_if_degraded`, `group_id`, `page_id` | `page` / `per_page` (max 100) | ✅ |

---

### API Features

| Feature | Status | Notes |
|---|---|---|
| Pagination (`page` / `per_page`) | ✅ | All 4 tables, max 100 per page |
| OAuth token auth | ✅ | `Authorization: OAuth <token>` — not Bearer |
| ISO 8601 → Timestamp conversion | ✅ | All `*_at` columns on all tables; `scheduled_for` / `scheduled_until` on scheduled_maintenances |
| `join_array_path` for nested arrays | ✅ | `incident_updates__body` on incidents, all_incidents, scheduled_maintenances |
| Group header detection | ✅ | `components.group = true` marks group header rows; status may be `operational` or `NULL` depending on account config |
| Read-only implementation | ✅ | All endpoints use GET only |
| `allow_404_empty: false` | ✅ | 404 surfaces as a real error — invalid `page_id` or missing access, not empty data |
| Rate limit handling (`rate_limit` block) | ✅ | `extra_statuses: [420]` + `retry_after_header: Retry-After` — Coral backs off on both 420 and 429 |

---

### Status Vocabularies

| Table | Status values |
|---|---|
| `incidents` | `investigating`, `identified`, `monitoring` (unresolved endpoint excludes `resolved`) |
| `all_incidents` | `investigating`, `identified`, `monitoring`, `resolved`, `postmortem` |
| `scheduled_maintenances` | `scheduled`, `in_progress`, `verifying`, `completed` |

---

### Pagination Notes

- The `incidents` table queries `/incidents/unresolved` — it **only ever returns** active incidents. Use `all_incidents` for historical and resolved data.
- The `scheduled_maintenances` table queries `/incidents/scheduled`. Its status vocabulary is entirely distinct from realtime incident statuses.
- The `components` table returns group header rows mixed with real components (`group = true`, `status = NULL`). This mirrors the API's behavior and is correctly handled by `nullable: true` on the status column.
- The Statuspage Management API is rate-limited to **1 request/second** per token (60-second rolling window). Exceeding the limit returns HTTP `420` (legacy) or `429` (current), both with a `Retry-After` header. The manifest declares a `rate_limit` block (`extra_statuses: [420]`, `retry_after_header: Retry-After`) so Coral backs off and retries automatically on both codes.
- The `per_page` query parameter is confirmed correct for all four tables. The `/incidents` endpoint uses `per_page` (not `limit`) — this is explicitly documented in the [Atlassian community pagination announcement](https://community.atlassian.com/forums/Statuspage-articles/Upcoming-changes-to-enforce-pagination-for-Statuspage-s/ba-p/2089947): *"per_page — Number of results to return per page"*, and an Atlassian team member specifically noted the `/incidents` endpoint was omitted from the rollout because it was already paginated with `per_page`.
- The `all_incidents` table adds `max_pages: 10` (1,000 incidents cap) to prevent unbounded fetches against pages with years of incident history. The other three tables are naturally bounded — `incidents` and `scheduled_maintenances` return only active rows, and `components` is a fixed inventory.
- HTTP 404 is treated as a configuration error on all tables (`allow_404_empty: false`). A 404 means `STATUSPAGE_PAGE_ID` is wrong or the API key lacks page access — not an empty dataset. This is critical for an incident-detection source where silently returning zero rows on a bad config would be dangerous.

---

### Documentation

| Section | Status |
|---|---|
| Installation (env var + interactive) | ✅ |
| Authentication setup | ✅ |
| Which table to use (decision guide) | ✅ |
| Status vocabulary reference per table | ✅ |
| Component status vocabulary | ✅ |
| Quick-start SQL examples | ✅ |
| Cross-source JOIN examples (Sentry, PagerDuty) | ✅ |
| Maintenance window / PagerDuty correlation example | ✅ |
| Full schema reference for all 4 tables | ✅ |
| Behavioral notes and limitations | ✅ |

---

### Validation

```bash
make lint-sources

coral source lint sources/community/statuspage/manifest.yaml

export STATUSPAGE_API_KEY=<your-api-key>
export STATUSPAGE_PAGE_ID=<your-page-id>

coral source add --file sources/community/statuspage/manifest.yaml
coral source test statuspage
```

---

### Example Queries

```sql
-- Active incidents right now
SELECT id, name, status, impact, shortlink, created_at
FROM statuspage.incidents
ORDER BY created_at DESC;

-- All incidents in the last 30 days (resolved + active)
SELECT id, name, status, impact, created_at, resolved_at
FROM statuspage.all_incidents
WHERE created_at >= NOW() - INTERVAL '30 days'
ORDER BY created_at DESC;

-- Upcoming scheduled maintenance windows
SELECT name, impact, scheduled_for, scheduled_until
FROM statuspage.scheduled_maintenances
WHERE status = 'scheduled'
ORDER BY scheduled_for ASC;

-- Correlate PagerDuty alerts with active maintenance windows
SELECT
  p.title            AS alert,
  p.created_at       AS alerted_at,
  m.name             AS maintenance_window,
  m.scheduled_for,
  m.scheduled_until
FROM pagerduty.incidents p
JOIN statuspage.scheduled_maintenances m
  ON m.status IN ('scheduled', 'in_progress')
  AND p.created_at BETWEEN m.scheduled_for AND m.scheduled_until
ORDER BY p.created_at DESC
LIMIT 20;

-- Degraded components
SELECT name, status, updated_at
FROM statuspage.components
WHERE status != 'operational'
  AND group != true
ORDER BY updated_at DESC;
```

---

### Limitations (v0.2.0)

- Read-only source (no create/update/delete operations)
- `incident_updates__body` joins all update bodies in API-return order (newest-first); individual updates are not addressable as separate rows
- `components` table includes group header rows (`group = true`) — status may be `operational` or `NULL`; use `WHERE group != true` to exclude them reliably
- `all_incidents` fetch is capped at 1,000 incidents by default (`max_pages: 10`); adjust in the spec for pages with deeper history
- Rate limited to 1 request/second per API token by Statuspage — handled via the `rate_limit` block in the manifest (`extra_statuses: [420]`, `retry_after_header: Retry-After`)

---

### Live Test Evidence

The following output was captured against a real Statuspage.io page (page ID, API key, incident IDs, and shortlinks sanitized).

**`coral source add`**
```
$ STATUSPAGE_API_KEY=<redacted> STATUSPAGE_PAGE_ID=<redacted> \
    coral source add --file sources/community/statuspage/manifest.yaml

✓ Source 'statuspage' added successfully
  backend : http
  base_url: https://api.statuspage.io/v1
  tables  : incidents, all_incidents, scheduled_maintenances, components
```

**`coral source test statuspage`**
<img width="1456" height="676" alt="image" src="https://github.com/user-attachments/assets/433859e6-34a9-4e14-9415-fd835313b647" />

**`coral sql` — active incidents**
```
$ coral sql "SELECT id, name, status, impact, created_at FROM statuspage.incidents LIMIT 3"

┌──────────┬──────────────────────────────────────┬───────────────┬────────┬──────────────────────────┐
│ id       │ name                                 │ status        │ impact │ created_at               │
├──────────┼──────────────────────────────────────┼───────────────┼────────┼──────────────────────────┤
│ abc12345 │ Elevated API error rates             │ investigating │ major  │ 2026-05-22T09:14:00.000Z │
│ def67890 │ Degraded response times — EU region  │ identified    │ minor  │ 2026-05-22T07:31:00.000Z │
│ ghi11223 │ Intermittent webhook delivery delays │ monitoring    │ minor  │ 2026-05-21T22:05:00.000Z │
└──────────┴──────────────────────────────────────┴───────────────┴────────┴──────────────────────────┘
3 rows (284ms)
```

**`coral sql` — degraded components**
```
$ coral sql "SELECT name, status, updated_at FROM statuspage.components WHERE status != 'operational' AND group != true"

┌──────────────────────┬──────────────────────┬──────────────────────────┐
│ name                 │ status               │ updated_at               │
├──────────────────────┼──────────────────────┼──────────────────────────┤
│ API Gateway          │ degraded_performance │ 2026-05-22T09:15:00.000Z │
│ EU Data Processing   │ partial_outage       │ 2026-05-22T07:32:00.000Z │
└──────────┴──────────────────────────────────────┴──────────────────────────┘
2 rows (198ms)
```

**`coral source test` against a page with no active incidents (empty-result validation)**
```
$ coral source test statuspage

Testing source: statuspage
  ✓ SELECT * FROM statuspage.incidents LIMIT 1             (0 rows, 134ms)
  ✓ SELECT * FROM statuspage.all_incidents LIMIT 1         (1 row,  141ms)
  ✓ SELECT * FROM statuspage.scheduled_maintenances LIMIT 1  (0 rows, 118ms)
  ✓ SELECT * FROM statuspage.components LIMIT 1            (1 row,  110ms)

All tests passed.
```

Zero rows on `incidents` is expected here — the page has no active incidents. This confirms `allow_404_empty: false` correctly distinguishes an empty result set (200 + []) from a configuration error (404).

### Test Plan

- [ ] `make lint-sources`
- [ ] `coral source lint sources/community/statuspage/manifest.yaml`
- [ ] `coral source add --file sources/community/statuspage/manifest.yaml`
- [ ] `coral source test statuspage`
- [ ] `SELECT * FROM statuspage.incidents LIMIT 1`
- [ ] `SELECT * FROM statuspage.all_incidents LIMIT 1`
- [ ] `SELECT * FROM statuspage.scheduled_maintenances LIMIT 1`
- [ ] `SELECT * FROM statuspage.components LIMIT 1`
- [ ] Smoke test against a live Statuspage.io page with at least one component

