### PR TITLE
feat(sources/community/coolify): add coolify community source

### DIFF
--- a/sources/community/coolify/README.md
+++ b/sources/community/coolify/README.md
@@ -1,0 +1,212 @@
+# Coolify (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Coolify REST API v1)
+**Tables:** 5
+**Base URL:** `{{input.COOLIFY_BASE_URL}}/api/v1`
+
+Query Coolify projects, environments, servers, applications, and active deployments through Coral SQL using the [Coolify REST API](https://coolify.io/docs/api-reference). Use this data source for PaaS state auditing, deployment tracking, server health monitoring, and managing environment topologies across self-hosted instances or Coolify Cloud accounts.
+
+Coral exposes read-only `GET` tables. Write operations (triggering deployments, stopping services, provisioning resources) are out of scope for v1.
+
+## Install
+
+Community sources are not bundled with the Coral binary. From the Coral repo root (or with a copied manifest):
+
+```bash
+coral source add --file sources/community/coolify/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to `coral source add --file`.
+
+Set credentials via environment variables (recommended) or `coral source add --file ... --interactive`.
+
+## Inputs
+
+| Input | Kind | Required | Description |
+| --- | --- | --- | --- |
+| `COOLIFY_BASE_URL` | variable | yes | Root URL of your instance with **no** trailing slash and **no** `/api/v1` path suffix (for example `https://coolify.example.com` or `http://localhost:8000`). |
+| `COOLIFY_API_TOKEN` | secret | yes | Personal API token obtained from your Coolify panel under **Keys & Tokens → API tokens**. |
+
+---
+
+## Tables overview
+
+| Table | API endpoint | Required filter | Pagination |
+| --- | --- | --- | --- |
+| `projects` | `GET /api/v1/projects` | — | Full array response |
+| `environments` | `GET /api/v1/projects/{project_uuid}/environments` | `project_uuid` | Full array response |
+| `servers` | `GET /api/v1/servers` | — | Full array response |
+| `applications` | `GET /api/v1/applications` | — | Full array response |
+| `deployments` | `GET /api/v1/deployments` | — | Full array response |
+
+Project-scoped environment tables require an explicit SQL lookup condition, for example `WHERE project_uuid = 'string-uuid'`.
+
+---
+
+## Filters and API mapping
+
+Coral maps declared SQL filters to native Coolify API query parameters. Only listed filters are pushed directly down to the REST endpoint; other clauses are filtered in-memory.
+
+| SQL filter | Coolify query param | Tables |
+| --- | --- | --- |
+| `project_uuid` | path `{project_uuid}` | `environments` |
+| `tag` | query `tag` | `applications` |
+
+---
+
+## Table reference
+
+### `coolify.projects`
+
+Top-level grouping for your environments and resources.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Int64 | Internal database ID of the project |
+| `uuid` | Utf8 | Project unique UUID |
+| `name` | Utf8 | Project name |
+| `description` | Utf8 | Optional project description |
+
+### `coolify.environments`
+
+Environments (e.g., production, staging) configured within a project.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `project_uuid` | Utf8 | Parent project UUID from the required filter |
+| `id` | Int64 | Internal database ID of the environment |
+| `name` | Utf8 | Environment name |
+| `description` | Utf8 | Optional environment description |
+| `project_id` | Int64 | Relational project ID |
+| `created_at` | Timestamp | Environment creation time |
+| `updated_at` | Timestamp | Last record update time |
+
+**Required filter:** `project_uuid`
+
+### `coolify.servers`
+
+Registered server nodes managed by Coolify.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Int64 | Internal database ID of the server |
+| `uuid` | Utf8 | Server UUID |
+| `name` | Utf8 | Server name |
+| `description` | Utf8 | Server description |
+| `ip` | Utf8 | IP address or hostname used for SSH connections |
+| `user` | Utf8 | SSH username |
+| `port` | Int64 | SSH connection port |
+| `proxy_type` | Utf8 | Embedded reverse proxy engine type (traefik, caddy, etc.) |
+| `unreachable_count`| Int64 | Consecutively failed health check counts |
+
+### `coolify.applications`
+
+Deployed microservices, websites, and codebases.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `tag` | Utf8 | Optional tag identifier filter |
+| `id` | Int64 | Internal application ID |
+| `uuid` | Utf8 | Application unique UUID |
+| `name` | Utf8 | Application name |
+| `description` | Utf8 | Application text details |
+| `status` | Utf8 | Current container execution status |
+| `fqdn` | Utf8 | Configured domain routing points |
+| `git_repository` | Utf8 | Source control origin target |
+| `git_branch` | Utf8 | Monitored branch target |
+| `git_commit_sha` | Utf8 | Active running deployment commit hash |
+| `build_pack` | Utf8 | Deployment builder framework (nixpacks, dockerfile, etc.) |
+| `environment_id` | Int64 | Parent environment ID linkage |
+| `destination_id` | Int64 | Destination infrastructure server ID |
+| `health_check_enabled`| Boolean | State of endpoint automated monitoring checks |
+| `created_at` | Timestamp | Application registration date |
+| `updated_at` | Timestamp | Last configuration change date |
+
+### `coolify.deployments`
+
+Active or historic application build queue tracking.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Int64 | Internal deployment row ID |
+| `deployment_uuid` | Utf8 | Deployment worker execution UUID |
+| `application_id` | Utf8 | Target resource identity string |
+| `application_name` | Utf8 | Target resource name |
+| `server_id` | Int64 | Destination build runner node ID |
+| `server_name` | Utf8 | Destination build runner name |
+| `status` | Utf8 | Active step state (in-progress, finished, failed) |
+| `commit` | Utf8 | Processing commit hash identifier |
+| `commit_message` | Utf8 | Associated deployment code commit logs |
+| `deployment_url` | Utf8 | Direct internal panel path link to review build standard outputs |
+| `force_rebuild` | Boolean | True if image builds ran without active layer caches |
+| `is_webhook` | Boolean | True if automated git webhooks initiated execution |
+| `is_api` | Boolean | True if manual execution triggers calls via endpoint loops |
+| `rollback` | Boolean | True if rollback triggers invoked state actions |
+| `git_type` | Utf8 | Code hosting hub provider origin details |
+| `created_at` | Timestamp | Start timestamps for delivery operations |
+| `updated_at` | Timestamp | End or final state synchronization check timestamps |
+
+---
+
+## Example queries
+
+### Project Topology Discovery
+```sql
+SELECT uuid, name, description 
+FROM coolify.projects 
+ORDER BY name;
+```
+
+```sql
+SELECT name, description, created_at 
+FROM coolify.environments 
+WHERE project_uuid = '0189b2c4-e5fd-7264-ba36-8cf9b3d2efaa';
+```
+
+### Server Cluster Auditing
+```sql
+SELECT name, ip, user, port, proxy_type, unreachable_count 
+FROM coolify.servers 
+WHERE unreachable_count > 0;
+```
+
+### Application Routing and Source Controls
+```sql
+SELECT name, status, fqdn, git_repository, git_branch 
+FROM coolify.applications 
+WHERE status = 'running' 
+LIMIT 50;
+```
+
+### Pipeline Deployment Queue Review
+```sql
+SELECT application_name, server_name, status, commit_message, deployment_url 
+FROM coolify.deployments 
+WHERE status = 'in-progress' 
+ORDER BY created_at DESC;
+```
+
+---
+
+## Validation
+
+Run the following format and syntax pipeline validation commands prior to generating a GitHub pull request:
+
+```bash
+# YAML and file style compliance check
+make lint-sources
+
+# Structural schema and type mapping verification
+coral source lint sources/community/coolify/manifest.yaml
+```
+
+Execute a live target connection test locally:
+
+```bash
+export COOLIFY_BASE_URL=https://coolify.example.com
+export COOLIFY_API_TOKEN=your_token_here
+
+coral source add --file sources/community/coolify/manifest.yaml
+coral source test coolify
+```

--- a/sources/community/coolify/manifest.yaml
+++ b/sources/community/coolify/manifest.yaml
@@ -1,0 +1,385 @@
+name: coolify
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Coolify projects, environments, servers, applications, and active
+  deployments via the Coolify REST API (self-hosted or Coolify Cloud).
+base_url: "{{input.COOLIFY_BASE_URL}}/api/v1"
+
+inputs:
+  COOLIFY_BASE_URL:
+    kind: variable
+    hint: |
+      Coolify instance base root URL with NO trailing slash and no /api suffix,
+      for example `https://coolify.example.com` or `http://localhost:8000`.
+  COOLIFY_API_TOKEN:
+    kind: secret
+    hint: |
+      Bearer API token from Coolify Keys & Tokens → API tokens. The token
+      must have read access to the resources you query.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.COOLIFY_API_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT uuid, name FROM coolify.projects LIMIT 1
+
+tables:
+  - name: projects
+    description: Coolify projects (top-level grouping for environments and resources).
+    request:
+      method: GET
+      path: /projects
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        description: Internal project ID.
+        expr: {kind: path, path: [id]}
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Project UUID.
+        expr: {kind: path, path: [uuid]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Project name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Project description.
+        expr: {kind: path, path: [description]}
+
+  - name: environments
+    description: Environments within a specific Coolify project.
+    filters:
+      - name: project_uuid
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_uuid}}/environments
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: project_uuid
+        type: Utf8
+        nullable: false
+        description: Project UUID from the required project_uuid filter.
+        expr: {kind: from_filter, key: project_uuid}
+      - name: id
+        type: Int64
+        nullable: true
+        description: Internal environment ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Environment name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Environment description.
+        expr: {kind: path, path: [description]}
+      - name: project_id
+        type: Int64
+        nullable: true
+        description: Internal project ID on the environment record.
+        expr: {kind: path, path: [project_id]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Environment creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: servers
+    description: Registered Coolify servers (deployment targets).
+    request:
+      method: GET
+      path: /servers
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        description: Internal server ID.
+        expr: {kind: path, path: [id]}
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Server UUID.
+        expr: {kind: path, path: [uuid]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Server name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Server description.
+        expr: {kind: path, path: [description]}
+      - name: ip
+        type: Utf8
+        nullable: true
+        description: Server IP address or hostname.
+        expr: {kind: path, path: [ip]}
+      - name: user
+        type: Utf8
+        nullable: true
+        description: SSH user for the server.
+        expr: {kind: path, path: [user]}
+      - name: port
+        type: Int64
+        nullable: true
+        description: SSH port.
+        expr: {kind: path, path: [port]}
+      - name: proxy_type
+        type: Utf8
+        nullable: true
+        description: Reverse proxy type (traefik, caddy, none).
+        expr: {kind: path, path: [proxy, type]}
+      - name: unreachable_count
+        type: Int64
+        nullable: true
+        description: Count of consecutive unreachable checks.
+        expr: {kind: path, path: [unreachable_count]}
+
+  - name: applications
+    description: Deployed applications across all projects and environments.
+    filters:
+      - name: tag
+        required: false
+    request:
+      method: GET
+      path: /applications
+      query:
+        - name: tag
+          from: filter
+          key: tag
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: tag
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Tag filter value when `WHERE tag = '...'` is used.
+        expr: {kind: from_filter, key: tag}
+      - name: id
+        type: Int64
+        nullable: true
+        description: Internal application ID.
+        expr: {kind: path, path: [id]}
+      - name: uuid
+        type: Utf8
+        nullable: false
+        description: Application UUID.
+        expr: {kind: path, path: [uuid]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Application name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Application description.
+        expr: {kind: path, path: [description]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Application runtime status.
+        expr: {kind: path, path: [status]}
+      - name: fqdn
+        type: Utf8
+        nullable: true
+        description: Application domains (FQDN).
+        expr: {kind: path, path: [fqdn]}
+      - name: git_repository
+        type: Utf8
+        nullable: true
+        description: Git repository URL.
+        expr: {kind: path, path: [git_repository]}
+      - name: git_branch
+        type: Utf8
+        nullable: true
+        description: Git branch.
+        expr: {kind: path, path: [git_branch]}
+      - name: git_commit_sha
+        type: Utf8
+        nullable: true
+        description: Deployed Git commit SHA.
+        expr: {kind: path, path: [git_commit_sha]}
+      - name: build_pack
+        type: Utf8
+        nullable: true
+        description: Build pack (nixpacks, static, dockerfile, dockercompose).
+        expr: {kind: path, path: [build_pack]}
+      - name: environment_id
+        type: Int64
+        nullable: true
+        description: Internal environment ID.
+        expr: {kind: path, path: [environment_id]}
+      - name: destination_id
+        type: Int64
+        nullable: true
+        description: Internal destination (server) ID.
+        expr: {kind: path, path: [destination_id]}
+      - name: health_check_enabled
+        type: Boolean
+        nullable: true
+        description: Whether HTTP health checks are enabled.
+        expr: {kind: path, path: [health_check_enabled]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Application creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: deployments
+    description: Currently running deployments across the Coolify instance.
+    request:
+      method: GET
+      path: /deployments
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: true
+        description: Internal deployment queue ID.
+        expr: {kind: path, path: [id]}
+      - name: deployment_uuid
+        type: Utf8
+        nullable: true
+        description: Deployment UUID.
+        expr: {kind: path, path: [deployment_uuid]}
+      - name: application_id
+        type: Utf8
+        nullable: true
+        description: Application identifier on the deployment record.
+        expr: {kind: path, path: [application_id]}
+      - name: application_name
+        type: Utf8
+        nullable: true
+        description: Application name.
+        expr: {kind: path, path: [application_name]}
+      - name: server_id
+        type: Int64
+        nullable: true
+        description: Internal server ID.
+        expr: {kind: path, path: [server_id]}
+      - name: server_name
+        type: Utf8
+        nullable: true
+        description: Target server name.
+        expr: {kind: path, path: [server_name]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Deployment status (in-progress, finished, failed, etc.).
+        expr: {kind: path, path: [status]}
+      - name: commit
+        type: Utf8
+        nullable: true
+        description: Git commit SHA being deployed.
+        expr: {kind: path, path: [commit]}
+      - name: commit_message
+        type: Utf8
+        nullable: true
+        description: Git commit message.
+        expr: {kind: path, path: [commit_message]}
+      - name: deployment_url
+        type: Utf8
+        nullable: true
+        description: URL to view the deployment in Coolify.
+        expr: {kind: path, path: [deployment_url]}
+      - name: force_rebuild
+        type: Boolean
+        nullable: true
+        description: Whether the deployment forced a rebuild without cache.
+        expr: {kind: path, path: [force_rebuild]}
+      - name: is_webhook
+        type: Boolean
+        nullable: true
+        description: Whether the deployment was triggered by a webhook.
+        expr: {kind: path, path: [is_webhook]}
+      - name: is_api
+        type: Boolean
+        nullable: true
+        description: Whether the deployment was triggered via API.
+        expr: {kind: path, path: [is_api]}
+      - name: rollback
+        type: Boolean
+        nullable: true
+        description: Whether this deployment is a rollback.
+        expr: {kind: path, path: [rollback]}
+      - name: git_type
+        type: Utf8
+        nullable: true
+        description: Git provider type.
+        expr: {kind: path, path: [git_type]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Deployment start time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last deployment status update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}

--- a/sources/community/keycloak/README.md
+++ b/sources/community/keycloak/README.md
@@ -190,8 +190,8 @@ fetch (or may not be supported).
 | SQL filter | Keycloak query param | Tables |
 | --- | --- | --- |
 | `realm` | path `{realm}` | `clients`, `groups`, `roles`, `users`, `admin_events` |
-| `search` | `search` | `groups`, `roles`, `users` |
-| `q` | `q` (custom-attribute `key:value` syntax) | `groups`, `users` |
+| `search` | `search` | `roles`, `users` |
+| `q` | `q` (custom-attribute `key:value` syntax) | `users` |
 | `username` | `username` | `users` |
 | `email` | `email` | `users` |
 | `enabled` | `enabled` (boolean) | `users` |
@@ -213,8 +213,9 @@ On `users`, use `email` or `search` for email/name lookups. The `q` filter maps
 to Keycloak's custom-attribute query syntax (`key:value`, for example
 `department:engineering` or `team:support status:active`).
 
-On `groups`, `search` matches group names. The `q` filter searches group custom
-attributes using the same `key:value` syntax.
+`keycloak.groups` does not expose `search` or `q` filters in v1. Keycloak can
+return nested matches under `subGroups` when those parameters are used, but this
+source only emits the top-level response array as flat rows.
 
 Always use `LIMIT` on large realms. Paginated tables use `max` (default 100,
 cap 100 per request); Coral follows pages with `first` until the SQL `LIMIT`
@@ -260,8 +261,9 @@ attributes as `key:value`)
 ### `keycloak.groups`
 
 Top-level groups in a realm. Keycloak's `GET /admin/realms/{realm}/groups`
-list endpoint returns **`id` and `name` only** for each row; hierarchy fields
-such as `path` and `parentId` are not part of this v1 table.
+returns a hierarchy; Coral emits **only the top-level array** as flat rows with
+**`id` and `name`**. Nested `subGroups` (including matches from Keycloak's
+`search` / `q` parameters) are not flattened in v1.
 
 | Column | Type | Description |
 | --- | --- | --- |
@@ -271,8 +273,7 @@ such as `path` and `parentId` are not part of this v1 table.
 
 **Required filter:** `realm`
 
-**Optional filters:** `search` (group name), `q` (custom attributes as
-`key:value`)
+**Optional filters:** none
 
 ### `keycloak.clients`
 
@@ -383,7 +384,6 @@ LIMIT 10;
 SELECT id, name
 FROM keycloak.groups
 WHERE realm = 'my-app'
-  AND search = 'ops'
 ORDER BY name
 LIMIT 50;
 ```
@@ -533,8 +533,9 @@ $ coral sql "SELECT table_name, required_filters FROM coral.tables WHERE schema_
 - **Realm roles only.** `roles` lists realm roles; client roles and user/client
   role mappings are not exposed in v1.
 - **Groups top-level only.** `groups` exposes top-level `id` and `name` from
-  the Admin REST list endpoint. Nested subgroups, membership, and hierarchy
-  fields (`path`, `parentId`) are not modeled in v1.
+  the Admin REST list endpoint. Nested `subGroups`, membership, hierarchy
+  fields (`path`, `parentId`), and server-side `search` / `q` group filters are
+  not modeled in v1.
 - **Admin events require configuration.** The realm must record admin events;
   otherwise the table is legitimately empty.
 - **Token scope and TTL.** Access is limited to the bearer token’s roles and

--- a/sources/community/keycloak/README.md
+++ b/sources/community/keycloak/README.md
@@ -78,20 +78,41 @@ test -n "$KEYCLOAK_ACCESS_TOKEN" && echo "Token acquired"
 
 **Client credentials (service account, production-friendly):**
 
-1. In the Keycloak Admin Console, create a **confidential** client.
-2. Enable **Service accounts**.
-3. Under **Service account roles**, assign `realm-management` roles needed for
-   your queries, for example:
-   - `view-realm` — `realms`, realm metadata
-   - `view-users` — `users`, `groups`
-   - `view-clients` — `clients`
-   - `view-events` — `admin_events`
-   - `view-realm` (includes role listing) — `roles`
-4. Exchange credentials for a token:
+Keycloak has two common setups. Roles are **not** assigned on the client
+itself — they are assigned to the client's **service account user** under
+**Clients → {your client} → Service account roles → Assign role**.
+
+| Setup | Where to create the client | Where to assign roles | Token endpoint |
+| --- | --- | --- | --- |
+| **Single-realm** | Target realm (for example `my-app`) | That realm's built-in **`realm-management`** client | `/realms/my-app/protocol/openid-connect/token` |
+| **Cross-realm** | **`master`** realm | **`master-realm`** for master data, plus each target realm's **`realm-management`** client for that realm's inventory | `/realms/master/protocol/openid-connect/token` |
+
+**Single-realm (simplest first success):**
+
+1. In the target realm, create a **confidential** client and enable **Service
+   accounts**.
+2. Open **Service account roles → Assign role**, filter by clients, choose
+   **`realm-management`** (within a realm) or **`{realm}-realm`** (when assigning
+   from a master-realm client to a target realm), and assign the read roles you
+   need:
+
+   Keycloak has no `view-groups` role. Use `query-groups` to list/search groups;
+   add `view-users` if you need full group representations from the API.
+
+   | Role | Tables |
+   | --- | --- |
+   | `query-realms` / `view-realm` | `realms` (lists realms the token can view) |
+   | `query-users` / `view-users` | `users` |
+   | `query-groups` (add `view-users` to read group details) | `groups` |
+   | `query-clients` / `view-clients` | `clients` |
+   | `view-realm` | `roles` |
+   | `view-events` | `admin_events` |
+
+3. Request a token from the **same realm** that hosts the client:
 
 ```bash
 export KEYCLOAK_BASE_URL=https://auth.example.com
-export KEYCLOAK_REALM=master          # realm that hosts the client
+export KEYCLOAK_REALM=my-app              # realm that hosts the client
 export KEYCLOAK_CLIENT_ID=my-admin-client
 export KEYCLOAK_CLIENT_SECRET=<secret>
 
@@ -105,6 +126,23 @@ export KEYCLOAK_ACCESS_TOKEN=$(
   | jq -r .access_token
 )
 ```
+
+**Cross-realm (master client):**
+
+1. Create the confidential client in the **`master`** realm with **Service
+   accounts** enabled.
+2. Under **Service account roles**, assign:
+   - From client **`master-realm`**: `view-realm` and `query-realms` so
+     `GET /admin/realms` (the `realms` table) returns realms you can access.
+   - From each target realm's **`realm-management`** client (for example
+     `my-app-realm` in the role picker): the same `view-*` / `query-*` roles
+     listed above for that realm's tables.
+3. Request the token from **`master`** (`KEYCLOAK_REALM=master`).
+
+`keycloak.realms` calls `GET /admin/realms`, which returns **only realms the
+token can view**. A single-realm service account typically sees just that
+realm; a cross-realm master client needs `query-realms` / `view-realm` on
+`master-realm` plus per-realm `realm-management` roles for each target realm.
 
 Grant only the roles required for read-only inventory and audit use cases.
 
@@ -165,8 +203,11 @@ fetch (or may not be supported).
 | `auth_user` | `authUser` | `admin_events` |
 | `auth_ip_address` | `authIpAddress` | `admin_events` |
 
-Use ISO-8601 timestamps for `date_from` and `date_to` when your Keycloak
-version accepts them (for example `2026-05-01T00:00:00Z`).
+For `date_from` and `date_to` on `admin_events`, Coral forwards the filter
+values directly to Keycloak's `dateFrom` / `dateTo` query parameters. Use
+**`yyyy-MM-dd`** (for example `2026-05-01`) or **epoch milliseconds** (for
+example `1746057600000`). Full ISO-8601 timestamps such as
+`2026-05-01T00:00:00Z` are **not** accepted and can return `400 Bad Request`.
 
 Always use `LIMIT` on large realms. Paginated tables use `max` (default 100,
 cap 100 per request); Coral follows pages with `first` until the SQL `LIMIT`
@@ -271,7 +312,7 @@ Admin audit events for a realm.
 | `resource_type` | Utf8 | Affected resource type |
 | `resource_path` | Utf8 | Affected resource path |
 | `error` | Utf8 | Error message when the operation failed |
-| `representation` | Json | Resource representation when present |
+| `representation` | Utf8 | Serialized resource JSON when present (Keycloak returns a string; parse in SQL if needed) |
 
 **Required filter:** `realm`
 
@@ -358,8 +399,20 @@ LIMIT 20;
 SELECT operation_type, resource_path, representation
 FROM keycloak.admin_events
 WHERE realm = 'my-app'
-  AND date_from = '2026-05-01T00:00:00Z'
-  AND date_to = '2026-05-20T23:59:59Z'
+  AND date_from = '2026-05-01'
+  AND date_to = '2026-05-20'
+ORDER BY time DESC
+LIMIT 100;
+```
+
+Epoch-millisecond bounds are also valid:
+
+```sql
+SELECT operation_type, resource_path
+FROM keycloak.admin_events
+WHERE realm = 'my-app'
+  AND date_from = '1746057600000'
+  AND date_to = '1747785599000'
 ORDER BY time DESC
 LIMIT 100;
 ```
@@ -376,7 +429,8 @@ make lint-sources
 coral source lint sources/community/keycloak/manifest.yaml
 ```
 
-Live smoke test against a running Keycloak:
+Live smoke test against a running Keycloak (tested with
+`quay.io/keycloak/keycloak:latest`, dev mode):
 
 ```bash
 export KEYCLOAK_BASE_URL=http://localhost:8080
@@ -391,6 +445,58 @@ coral sql "SELECT operation_type, resource_path FROM keycloak.admin_events WHERE
 
 coral source info keycloak --verbose
 coral sql "SELECT table_name, required_filters FROM coral.tables WHERE schema_name = 'keycloak'"
+```
+
+Sanitized output from a local run (password grant against `admin-cli` in
+`master`; admin events empty until **Realm settings → Events** is enabled):
+
+```text
+$ coral source test keycloak
+
+  ✓ keycloak connected successfully
+
+    keycloak (6 tables)
+    ├─ admin_events
+    ├─ clients
+    ├─ groups
+    ├─ realms
+    ├─ roles
+    └─ users
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+    ✓ SELECT realm, enabled FROM keycloak.realms LIMIT 1
+      1 row
+
+$ coral sql "SELECT realm, enabled FROM keycloak.realms LIMIT 5"
++--------+---------+
+| realm  | enabled |
++--------+---------+
+| master | true    |
++--------+---------+
+
+$ coral sql "SELECT username, email FROM keycloak.users WHERE realm = 'master' LIMIT 5"
++----------+-------+
+| username | email |
++----------+-------+
+| admin    |       |
++----------+-------+
+
+$ coral sql "SELECT operation_type, resource_path FROM keycloak.admin_events WHERE realm = 'master' ORDER BY time DESC LIMIT 5"
+++
+++
+
+$ coral sql "SELECT table_name, required_filters FROM coral.tables WHERE schema_name = 'keycloak'"
++--------------+------------------+
+| table_name   | required_filters |
++--------------+------------------+
+| admin_events | realm            |
+| clients      | realm            |
+| groups       | realm            |
+| realms       |                  |
+| roles        | realm            |
+| users        | realm            |
++--------------+------------------+
 ```
 
 ## Agent and SQL workflow tips

--- a/sources/community/keycloak/README.md
+++ b/sources/community/keycloak/README.md
@@ -1,0 +1,420 @@
+# Keycloak (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Keycloak Admin REST API)
+**Tables:** 6
+**Base URL:** `{{input.KEYCLOAK_BASE_URL}}`
+
+Query Keycloak IAM inventory and admin audit data through Coral SQL using the
+[Keycloak Admin REST API](https://www.keycloak.org/docs-api/latest/rest-api/index.html).
+Use this source for realm discovery, user and group inventory, OAuth client
+audits, realm role review, and admin event forensics across self-hosted
+Keycloak or managed deployments that expose the standard `/admin` endpoints.
+
+Coral exposes read-only `GET` tables. Write operations (create, update, delete)
+are out of scope for v1.
+
+## Install
+
+Community sources are not bundled with the Coral binary. From the Coral repo
+root (or with a copied manifest):
+
+```bash
+coral source add --file sources/community/keycloak/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to
+`coral source add --file`.
+
+Set credentials via environment variables (recommended) or
+`coral source add --file ... --interactive`.
+
+## Inputs
+
+| Input | Kind | Required | Description |
+| --- | --- | --- | --- |
+| `KEYCLOAK_BASE_URL` | variable | yes | Server root URL with **no** trailing slash (for example `http://localhost:8080` or `https://auth.example.com`). Coral calls `{base}/admin/realms/...`. |
+| `KEYCLOAK_ACCESS_TOKEN` | secret | yes | Bearer access token for the Admin API. Short-lived; refresh or re-issue when queries return `401`. |
+
+## Setup
+
+### 1. Run Keycloak locally (optional)
+
+Quick local instance for development:
+
+```bash
+docker run -p 8080:8080 \
+  -e KEYCLOAK_ADMIN=admin \
+  -e KEYCLOAK_ADMIN_PASSWORD=admin \
+  quay.io/keycloak/keycloak:latest \
+  start-dev
+```
+
+Default admin console: `http://localhost:8080` (user `admin` / password `admin`).
+
+### 2. Obtain an access token
+
+Coral sends `Authorization: Bearer <token>`. Tokens are obtained from your
+realm’s OpenID Connect token endpoint (commonly `master` for admin tasks).
+
+**Password grant (`admin-cli`, local dev):**
+
+```bash
+export KEYCLOAK_BASE_URL=http://localhost:8080
+
+export KEYCLOAK_ACCESS_TOKEN=$(
+  curl -s -X POST \
+    "$KEYCLOAK_BASE_URL/realms/master/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "client_id=admin-cli" \
+    -d "username=admin" \
+    -d "password=admin" \
+    -d "grant_type=password" \
+  | jq -r .access_token
+)
+
+test -n "$KEYCLOAK_ACCESS_TOKEN" && echo "Token acquired"
+```
+
+**Client credentials (service account, production-friendly):**
+
+1. In the Keycloak Admin Console, create a **confidential** client.
+2. Enable **Service accounts**.
+3. Under **Service account roles**, assign `realm-management` roles needed for
+   your queries, for example:
+   - `view-realm` — `realms`, realm metadata
+   - `view-users` — `users`, `groups`
+   - `view-clients` — `clients`
+   - `view-events` — `admin_events`
+   - `view-realm` (includes role listing) — `roles`
+4. Exchange credentials for a token:
+
+```bash
+export KEYCLOAK_BASE_URL=https://auth.example.com
+export KEYCLOAK_REALM=master          # realm that hosts the client
+export KEYCLOAK_CLIENT_ID=my-admin-client
+export KEYCLOAK_CLIENT_SECRET=<secret>
+
+export KEYCLOAK_ACCESS_TOKEN=$(
+  curl -s -X POST \
+    "$KEYCLOAK_BASE_URL/realms/$KEYCLOAK_REALM/protocol/openid-connect/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials" \
+    -d "client_id=$KEYCLOAK_CLIENT_ID" \
+    -d "client_secret=$KEYCLOAK_CLIENT_SECRET" \
+  | jq -r .access_token
+)
+```
+
+Grant only the roles required for read-only inventory and audit use cases.
+
+### 3. Enable admin events (for `admin_events`)
+
+If `keycloak.admin_events` returns no rows:
+
+1. Open the target realm in the Admin Console.
+2. **Realm settings → Events**.
+3. Enable **Save events** and **Admin events** (and set retention as needed).
+
+### 4. Add and verify the source
+
+```bash
+export KEYCLOAK_BASE_URL=http://localhost:8080   # or your deployment URL
+export KEYCLOAK_ACCESS_TOKEN=<token>
+
+coral source add --file sources/community/keycloak/manifest.yaml
+coral source test keycloak
+```
+
+`coral source test keycloak` runs `SELECT realm, enabled FROM keycloak.realms
+LIMIT 1`, which checks base URL, token, and Admin API reachability.
+
+## Tables overview
+
+| Table | API endpoint | Required filter | Pagination |
+| --- | --- | --- | --- |
+| `realms` | `GET /admin/realms` | — | Full list per request |
+| `clients` | `GET /admin/realms/{realm}/clients` | `realm` | `first` / `max` |
+| `groups` | `GET /admin/realms/{realm}/groups` | `realm` | `first` / `max` |
+| `roles` | `GET /admin/realms/{realm}/roles` | `realm` | `first` / `max` |
+| `users` | `GET /admin/realms/{realm}/users` | `realm` | `first` / `max` |
+| `admin_events` | `GET /admin/realms/{realm}/admin-events` | `realm` | `first` / `max` |
+
+Realm-scoped tables require a SQL filter, for example `WHERE realm = 'master'`.
+Discover realm names from `keycloak.realms`.
+
+## Filters and API mapping
+
+Coral maps declared SQL filters to Keycloak query parameters. Only filters
+listed below are pushed to the API; other `WHERE` clauses are applied after
+fetch (or may not be supported).
+
+| SQL filter | Keycloak query param | Tables |
+| --- | --- | --- |
+| `realm` | path `{realm}` | `clients`, `groups`, `roles`, `users`, `admin_events` |
+| `search` | `search` | `groups`, `roles`, `users` |
+| `q` | `q` | `groups`, `users` |
+| `username` | `username` | `users` |
+| `email` | `email` | `users` |
+| `enabled` | `enabled` (boolean) | `users` |
+| `date_from` | `dateFrom` | `admin_events` |
+| `date_to` | `dateTo` | `admin_events` |
+| `operation_types` | `operationTypes` | `admin_events` |
+| `resource_path` | `resourcePath` | `admin_events` |
+| `auth_client` | `authClient` | `admin_events` |
+| `auth_user` | `authUser` | `admin_events` |
+| `auth_ip_address` | `authIpAddress` | `admin_events` |
+
+Use ISO-8601 timestamps for `date_from` and `date_to` when your Keycloak
+version accepts them (for example `2026-05-01T00:00:00Z`).
+
+Always use `LIMIT` on large realms. Paginated tables use `max` (default 100,
+cap 100 per request); Coral follows pages with `first` until the SQL `LIMIT`
+is satisfied or the API returns fewer than `max` rows.
+
+## Table reference
+
+### `keycloak.realms`
+
+All realms on the server. Entry point for discovering realm names.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Utf8 | Realm ID (often matches realm name) |
+| `realm` | Utf8 | Realm name (URL segment) |
+| `display_name` | Utf8 | Human-readable name |
+| `enabled` | Boolean | Whether the realm is enabled |
+| `ssl_required` | Utf8 | SSL policy (`external`, `all`, `none`, etc.) |
+
+**Filters:** none
+
+### `keycloak.users`
+
+Users in a realm (minimal profile columns for inventory and joins).
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `realm` | Utf8 | Realm from the `realm` filter (echoed on each row) |
+| `id` | Utf8 | User ID |
+| `username` | Utf8 | Username |
+| `email` | Utf8 | Email address |
+| `first_name` | Utf8 | First name |
+| `last_name` | Utf8 | Last name |
+| `enabled` | Boolean | Account enabled |
+| `email_verified` | Boolean | Email verified flag |
+| `created_at` | Timestamp | Account creation time (Keycloak epoch milliseconds) |
+
+**Required filter:** `realm`
+
+**Optional filters:** `search`, `q`, `username`, `email`, `enabled`
+
+### `keycloak.groups`
+
+Groups in a realm (top-level list; nested membership requires separate Admin API calls not in v1).
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `realm` | Utf8 | Realm from the `realm` filter |
+| `id` | Utf8 | Group ID |
+| `name` | Utf8 | Group name |
+| `path` | Utf8 | Full path in the group hierarchy |
+| `parent_id` | Utf8 | Parent group ID, if any |
+
+**Required filter:** `realm`
+
+**Optional filters:** `search`, `q`
+
+### `keycloak.clients`
+
+OAuth/OIDC (and SAML) clients in a realm.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `realm` | Utf8 | Realm from the `realm` filter |
+| `id` | Utf8 | Internal client UUID |
+| `client_id` | Utf8 | Client identifier (`clientId`) |
+| `name` | Utf8 | Display name |
+| `description` | Utf8 | Client description |
+| `enabled` | Boolean | Client enabled |
+| `protocol` | Utf8 | Protocol (`openid-connect`, `saml`, etc.) |
+| `public_client` | Boolean | Public vs confidential client |
+
+**Required filter:** `realm`
+
+### `keycloak.roles`
+
+Realm-level roles (not per-client roles or user role mappings).
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `realm` | Utf8 | Realm from the `realm` filter |
+| `id` | Utf8 | Role ID |
+| `name` | Utf8 | Role name |
+| `description` | Utf8 | Role description |
+| `composite` | Boolean | Composite role flag |
+| `client_role` | Boolean | Client role flag (`false` for realm roles) |
+
+**Required filter:** `realm`
+
+**Optional filter:** `search`
+
+### `keycloak.admin_events`
+
+Admin audit events for a realm.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `realm` | Utf8 | Realm from the `realm` filter |
+| `time` | Timestamp | Event time (epoch milliseconds) |
+| `realm_id` | Utf8 | Realm ID on the event payload |
+| `operation_type` | Utf8 | `CREATE`, `UPDATE`, `DELETE`, `ACTION`, etc. |
+| `resource_type` | Utf8 | Affected resource type |
+| `resource_path` | Utf8 | Affected resource path |
+| `error` | Utf8 | Error message when the operation failed |
+| `representation` | Json | Resource representation when present |
+
+**Required filter:** `realm`
+
+**Optional filters:** `date_from`, `date_to`, `operation_types`, `resource_path`,
+`auth_client`, `auth_user`, `auth_ip_address`
+
+## Example queries
+
+### Realms and connectivity
+
+```sql
+SELECT realm, display_name, enabled, ssl_required
+FROM keycloak.realms
+ORDER BY realm;
+```
+
+```sql
+SELECT realm, enabled
+FROM keycloak.realms;
+```
+
+### Users
+
+```sql
+SELECT username, email, enabled, created_at
+FROM keycloak.users
+WHERE realm = 'master'
+LIMIT 10;
+```
+
+```sql
+SELECT id, username, email, first_name, last_name, enabled, email_verified
+FROM keycloak.users
+WHERE realm = 'my-app'
+  AND enabled = true
+ORDER BY username
+LIMIT 100;
+```
+
+```sql
+SELECT id, username, email
+FROM keycloak.users
+WHERE realm = 'my-app'
+  AND q = 'alice@example.com'
+LIMIT 10;
+```
+
+### Groups, clients, and roles
+
+```sql
+SELECT name, path, parent_id
+FROM keycloak.groups
+WHERE realm = 'my-app'
+ORDER BY path
+LIMIT 50;
+```
+
+```sql
+SELECT client_id, id, name, enabled, protocol, public_client
+FROM keycloak.clients
+WHERE realm = 'my-app'
+  AND enabled = true
+LIMIT 50;
+```
+
+```sql
+SELECT name, description, composite, client_role
+FROM keycloak.roles
+WHERE realm = 'my-app'
+ORDER BY name;
+```
+
+### Admin events
+
+```sql
+SELECT time, operation_type, resource_type, resource_path, error
+FROM keycloak.admin_events
+WHERE realm = 'master'
+ORDER BY time DESC
+LIMIT 20;
+```
+
+```sql
+SELECT operation_type, resource_path, representation
+FROM keycloak.admin_events
+WHERE realm = 'my-app'
+  AND date_from = '2026-05-01T00:00:00Z'
+  AND date_to = '2026-05-20T23:59:59Z'
+ORDER BY time DESC
+LIMIT 100;
+```
+
+## Validation
+
+Run before opening a PR or after changing the manifest:
+
+```bash
+# YAML style (repo root)
+make lint-sources
+
+# Manifest schema and table definitions
+coral source lint sources/community/keycloak/manifest.yaml
+```
+
+Live smoke test against a running Keycloak:
+
+```bash
+export KEYCLOAK_BASE_URL=http://localhost:8080
+export KEYCLOAK_ACCESS_TOKEN=<token>
+
+coral source add --file sources/community/keycloak/manifest.yaml
+coral source test keycloak
+
+coral sql "SELECT realm, enabled FROM keycloak.realms LIMIT 5"
+coral sql "SELECT username, email FROM keycloak.users WHERE realm = 'master' LIMIT 5"
+coral sql "SELECT operation_type, resource_path FROM keycloak.admin_events WHERE realm = 'master' ORDER BY time DESC LIMIT 5"
+
+coral source info keycloak --verbose
+coral sql "SELECT table_name, required_filters FROM coral.tables WHERE schema_name = 'keycloak'"
+```
+
+## Agent and SQL workflow tips
+
+1. Start with `keycloak.realms` to list realm names.
+2. Pass `WHERE realm = '<name>'` on every realm-scoped table.
+3. Prefer API filters (`username`, `email`, `q`, `search`, date range on
+   `admin_events`) over fetching large pages and filtering in SQL.
+4. Use `LIMIT` on every inventory query in production realms.
+5. Inspect `coral.columns` for exact column names:
+   `SELECT column_name, data_type FROM coral.columns WHERE schema_name = 'keycloak' AND table_name = 'users'`.
+
+## Limitations
+
+- **Read-only.** No create, update, or delete via this source.
+- **Realm roles only.** `roles` lists realm roles; client roles and user/client
+  role mappings are not exposed in v1.
+- **Groups list only.** Subgroups and membership require additional Admin API
+  endpoints not modeled here.
+- **Admin events require configuration.** The realm must record admin events;
+  otherwise the table is legitimately empty.
+- **Token scope and TTL.** Access is limited to the bearer token’s roles and
+  lifetime; re-issue tokens when you see `401` responses.
+- **Pagination.** Keycloak uses `first` and `max` (max 100 per request). Very
+  large result sets need tight `LIMIT` and server-side filters.
+- **`realms` is unpaginated.** Coral fetches the full realm list once per query;
+  use SQL `LIMIT` for display only.

--- a/sources/community/keycloak/README.md
+++ b/sources/community/keycloak/README.md
@@ -191,7 +191,7 @@ fetch (or may not be supported).
 | --- | --- | --- |
 | `realm` | path `{realm}` | `clients`, `groups`, `roles`, `users`, `admin_events` |
 | `search` | `search` | `groups`, `roles`, `users` |
-| `q` | `q` | `groups`, `users` |
+| `q` | `q` (custom-attribute `key:value` syntax) | `groups`, `users` |
 | `username` | `username` | `users` |
 | `email` | `email` | `users` |
 | `enabled` | `enabled` (boolean) | `users` |
@@ -208,6 +208,13 @@ values directly to Keycloak's `dateFrom` / `dateTo` query parameters. Use
 **`yyyy-MM-dd`** (for example `2026-05-01`) or **epoch milliseconds** (for
 example `1746057600000`). Full ISO-8601 timestamps such as
 `2026-05-01T00:00:00Z` are **not** accepted and can return `400 Bad Request`.
+
+On `users`, use `email` or `search` for email/name lookups. The `q` filter maps
+to Keycloak's custom-attribute query syntax (`key:value`, for example
+`department:engineering` or `team:support status:active`).
+
+On `groups`, `search` matches group names. The `q` filter searches group custom
+attributes using the same `key:value` syntax.
 
 Always use `LIMIT` on large realms. Paginated tables use `max` (default 100,
 cap 100 per request); Coral follows pages with `first` until the SQL `LIMIT`
@@ -247,23 +254,25 @@ Users in a realm (minimal profile columns for inventory and joins).
 
 **Required filter:** `realm`
 
-**Optional filters:** `search`, `q`, `username`, `email`, `enabled`
+**Optional filters:** `search`, `username`, `email`, `enabled`, `q` (custom
+attributes as `key:value`)
 
 ### `keycloak.groups`
 
-Groups in a realm (top-level list; nested membership requires separate Admin API calls not in v1).
+Top-level groups in a realm. Keycloak's `GET /admin/realms/{realm}/groups`
+list endpoint returns **`id` and `name` only** for each row; hierarchy fields
+such as `path` and `parentId` are not part of this v1 table.
 
 | Column | Type | Description |
 | --- | --- | --- |
 | `realm` | Utf8 | Realm from the `realm` filter |
 | `id` | Utf8 | Group ID |
 | `name` | Utf8 | Group name |
-| `path` | Utf8 | Full path in the group hierarchy |
-| `parent_id` | Utf8 | Parent group ID, if any |
 
 **Required filter:** `realm`
 
-**Optional filters:** `search`, `q`
+**Optional filters:** `search` (group name), `q` (custom attributes as
+`key:value`)
 
 ### `keycloak.clients`
 
@@ -356,17 +365,26 @@ LIMIT 100;
 SELECT id, username, email
 FROM keycloak.users
 WHERE realm = 'my-app'
-  AND q = 'alice@example.com'
+  AND email = 'alice@example.com'
+LIMIT 10;
+```
+
+```sql
+SELECT id, username, email
+FROM keycloak.users
+WHERE realm = 'my-app'
+  AND q = 'department:engineering'
 LIMIT 10;
 ```
 
 ### Groups, clients, and roles
 
 ```sql
-SELECT name, path, parent_id
+SELECT id, name
 FROM keycloak.groups
 WHERE realm = 'my-app'
-ORDER BY path
+  AND search = 'ops'
+ORDER BY name
 LIMIT 50;
 ```
 
@@ -503,8 +521,8 @@ $ coral sql "SELECT table_name, required_filters FROM coral.tables WHERE schema_
 
 1. Start with `keycloak.realms` to list realm names.
 2. Pass `WHERE realm = '<name>'` on every realm-scoped table.
-3. Prefer API filters (`username`, `email`, `q`, `search`, date range on
-   `admin_events`) over fetching large pages and filtering in SQL.
+3. Prefer API filters (`username`, `email`, `search`, custom-attribute `q`, date
+   range on `admin_events`) over fetching large pages and filtering in SQL.
 4. Use `LIMIT` on every inventory query in production realms.
 5. Inspect `coral.columns` for exact column names:
    `SELECT column_name, data_type FROM coral.columns WHERE schema_name = 'keycloak' AND table_name = 'users'`.
@@ -514,8 +532,9 @@ $ coral sql "SELECT table_name, required_filters FROM coral.tables WHERE schema_
 - **Read-only.** No create, update, or delete via this source.
 - **Realm roles only.** `roles` lists realm roles; client roles and user/client
   role mappings are not exposed in v1.
-- **Groups list only.** Subgroups and membership require additional Admin API
-  endpoints not modeled here.
+- **Groups top-level only.** `groups` exposes top-level `id` and `name` from
+  the Admin REST list endpoint. Nested subgroups, membership, and hierarchy
+  fields (`path`, `parentId`) are not modeled in v1.
 - **Admin events require configuration.** The realm must record admin events;
   otherwise the table is legitimately empty.
 - **Token scope and TTL.** Access is limited to the bearer token’s roles and

--- a/sources/community/keycloak/manifest.yaml
+++ b/sources/community/keycloak/manifest.yaml
@@ -423,7 +423,9 @@ tables:
         description: Error message when the operation failed.
         expr: {kind: path, path: [error]}
       - name: representation
-        type: Json
+        type: Utf8
         nullable: true
-        description: Serialized resource representation when present.
+        description: >-
+          Serialized resource representation as returned by Keycloak (JSON text
+          string when present).
         expr: {kind: path, path: [representation]}

--- a/sources/community/keycloak/manifest.yaml
+++ b/sources/community/keycloak/manifest.yaml
@@ -135,25 +135,15 @@ tables:
 
   - name: groups
     description: >-
-      Top-level groups in a realm (id and name only; Keycloak's list endpoint
-      does not return hierarchy fields in v1).
+      Top-level groups in a realm (id and name only). Coral emits the top-level
+      JSON array from GET /admin/realms/{realm}/groups; nested subGroups are not
+      flattened in v1.
     filters:
       - name: realm
         required: true
-      - name: search
-        mode: search
-      - name: q
-        mode: search
     request:
       method: GET
       path: /admin/realms/{{filter.realm}}/groups
-      query:
-        - name: search
-          from: filter
-          key: search
-        - name: q
-          from: filter
-          key: q
     response:
       row_strategy: direct
     pagination:

--- a/sources/community/keycloak/manifest.yaml
+++ b/sources/community/keycloak/manifest.yaml
@@ -134,7 +134,9 @@ tables:
         expr: {kind: path, path: [publicClient]}
 
   - name: groups
-    description: Groups in a realm.
+    description: >-
+      Top-level groups in a realm (id and name only; Keycloak's list endpoint
+      does not return hierarchy fields in v1).
     filters:
       - name: realm
         required: true
@@ -178,16 +180,6 @@ tables:
         nullable: true
         description: Group name.
         expr: {kind: path, path: [name]}
-      - name: path
-        type: Utf8
-        nullable: true
-        description: Full group path in the hierarchy.
-        expr: {kind: path, path: [path]}
-      - name: parent_id
-        type: Utf8
-        nullable: true
-        description: Parent group ID, if any.
-        expr: {kind: path, path: [parentId]}
 
   - name: roles
     description: Realm-level roles in a realm.

--- a/sources/community/keycloak/manifest.yaml
+++ b/sources/community/keycloak/manifest.yaml
@@ -1,0 +1,429 @@
+name: keycloak
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Keycloak realms, clients, groups, realm roles, users, and admin events
+  via the Admin REST API (self-hosted or managed).
+base_url: "{{input.KEYCLOAK_BASE_URL}}"
+
+inputs:
+  KEYCLOAK_BASE_URL:
+    kind: variable
+    hint: |
+      Keycloak server base URL with no trailing slash, for example
+      `http://localhost:8080` or `https://auth.example.com`.
+  KEYCLOAK_ACCESS_TOKEN:
+    kind: secret
+    hint: |
+      Bearer access token for the Admin REST API. Obtain with the admin-cli
+      client (password grant) or a service account with client credentials.
+      The token must include roles such as view-realm, view-users, and
+      view-events for the tables you query.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.KEYCLOAK_ACCESS_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT realm, enabled FROM keycloak.realms LIMIT 1
+
+tables:
+  - name: realms
+    description: Keycloak realms on the server.
+    request:
+      method: GET
+      path: /admin/realms
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Realm ID (usually matches realm name).
+        expr: {kind: path, path: [id]}
+      - name: realm
+        type: Utf8
+        nullable: false
+        description: Realm name (URL segment).
+        expr: {kind: path, path: [realm]}
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Human-readable realm name.
+        expr: {kind: path, path: [displayName]}
+      - name: enabled
+        type: Boolean
+        nullable: true
+        description: Whether the realm is enabled.
+        expr: {kind: path, path: [enabled]}
+      - name: ssl_required
+        type: Utf8
+        nullable: true
+        description: SSL requirement policy for the realm.
+        expr: {kind: path, path: [sslRequired]}
+
+  - name: clients
+    description: OAuth/OIDC clients in a realm.
+    filters:
+      - name: realm
+        required: true
+    request:
+      method: GET
+      path: /admin/realms/{{filter.realm}}/clients
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: first
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: max
+    columns:
+      - name: realm
+        type: Utf8
+        nullable: false
+        description: Realm from the required realm filter.
+        expr: {kind: from_filter, key: realm}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Internal client UUID.
+        expr: {kind: path, path: [id]}
+      - name: client_id
+        type: Utf8
+        nullable: true
+        description: Client identifier (clientId).
+        expr: {kind: path, path: [clientId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Client display name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Client description.
+        expr: {kind: path, path: [description]}
+      - name: enabled
+        type: Boolean
+        nullable: true
+        description: Whether the client is enabled.
+        expr: {kind: path, path: [enabled]}
+      - name: protocol
+        type: Utf8
+        nullable: true
+        description: Protocol (openid-connect, saml, etc.).
+        expr: {kind: path, path: [protocol]}
+      - name: public_client
+        type: Boolean
+        nullable: true
+        description: Whether this is a public client.
+        expr: {kind: path, path: [publicClient]}
+
+  - name: groups
+    description: Groups in a realm.
+    filters:
+      - name: realm
+        required: true
+      - name: search
+        mode: search
+      - name: q
+        mode: search
+    request:
+      method: GET
+      path: /admin/realms/{{filter.realm}}/groups
+      query:
+        - name: search
+          from: filter
+          key: search
+        - name: q
+          from: filter
+          key: q
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: first
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: max
+    columns:
+      - name: realm
+        type: Utf8
+        nullable: false
+        description: Realm from the required realm filter.
+        expr: {kind: from_filter, key: realm}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Group ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Group name.
+        expr: {kind: path, path: [name]}
+      - name: path
+        type: Utf8
+        nullable: true
+        description: Full group path in the hierarchy.
+        expr: {kind: path, path: [path]}
+      - name: parent_id
+        type: Utf8
+        nullable: true
+        description: Parent group ID, if any.
+        expr: {kind: path, path: [parentId]}
+
+  - name: roles
+    description: Realm-level roles in a realm.
+    filters:
+      - name: realm
+        required: true
+      - name: search
+        mode: search
+    request:
+      method: GET
+      path: /admin/realms/{{filter.realm}}/roles
+      query:
+        - name: search
+          from: filter
+          key: search
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: first
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: max
+    columns:
+      - name: realm
+        type: Utf8
+        nullable: false
+        description: Realm from the required realm filter.
+        expr: {kind: from_filter, key: realm}
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Role ID.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Role name.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Role description.
+        expr: {kind: path, path: [description]}
+      - name: composite
+        type: Boolean
+        nullable: true
+        description: Whether the role is composite.
+        expr: {kind: path, path: [composite]}
+      - name: client_role
+        type: Boolean
+        nullable: true
+        description: Whether this is a client role (false for realm roles).
+        expr: {kind: path, path: [clientRole]}
+
+  - name: users
+    description: Users in a realm (minimal profile columns).
+    filters:
+      - name: realm
+        required: true
+      - name: search
+        mode: search
+      - name: q
+        mode: search
+      - name: username
+      - name: email
+      - name: enabled
+    request:
+      method: GET
+      path: /admin/realms/{{filter.realm}}/users
+      query:
+        - name: search
+          from: filter
+          key: search
+        - name: q
+          from: filter
+          key: q
+        - name: username
+          from: filter
+          key: username
+        - name: email
+          from: filter
+          key: email
+        - name: enabled
+          from: filter_bool
+          key: enabled
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: first
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: max
+    columns:
+      - name: realm
+        type: Utf8
+        nullable: false
+        description: Realm from the required realm filter.
+        expr: {kind: from_filter, key: realm}
+      - name: id
+        type: Utf8
+        nullable: false
+        description: User ID.
+        expr: {kind: path, path: [id]}
+      - name: username
+        type: Utf8
+        nullable: true
+        description: Username.
+        expr: {kind: path, path: [username]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Email address.
+        expr: {kind: path, path: [email]}
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: First name.
+        expr: {kind: path, path: [firstName]}
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Last name.
+        expr: {kind: path, path: [lastName]}
+      - name: enabled
+        type: Boolean
+        nullable: true
+        description: Whether the user account is enabled.
+        expr: {kind: path, path: [enabled]}
+      - name: email_verified
+        type: Boolean
+        nullable: true
+        description: Whether the email address is verified.
+        expr: {kind: path, path: [emailVerified]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Account creation time (Keycloak epoch milliseconds).
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [createdTimestamp]}
+
+  - name: admin_events
+    description: Admin audit events for a realm.
+    filters:
+      - name: realm
+        required: true
+      - name: date_from
+      - name: date_to
+      - name: operation_types
+      - name: resource_path
+      - name: auth_client
+      - name: auth_user
+      - name: auth_ip_address
+    request:
+      method: GET
+      path: /admin/realms/{{filter.realm}}/admin-events
+      query:
+        - name: dateFrom
+          from: filter
+          key: date_from
+        - name: dateTo
+          from: filter
+          key: date_to
+        - name: operationTypes
+          from: filter
+          key: operation_types
+        - name: resourcePath
+          from: filter
+          key: resource_path
+        - name: authClient
+          from: filter
+          key: auth_client
+        - name: authUser
+          from: filter
+          key: auth_user
+        - name: authIpAddress
+          from: filter
+          key: auth_ip_address
+    response:
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: first
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 100
+        query_param: max
+    columns:
+      - name: realm
+        type: Utf8
+        nullable: false
+        description: Realm from the required realm filter.
+        expr: {kind: from_filter, key: realm}
+      - name: time
+        type: Timestamp
+        nullable: true
+        description: Event time (epoch milliseconds).
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [time]}
+      - name: realm_id
+        type: Utf8
+        nullable: true
+        description: Realm ID on the event.
+        expr: {kind: path, path: [realmId]}
+      - name: operation_type
+        type: Utf8
+        nullable: true
+        description: Operation type (CREATE, UPDATE, DELETE, etc.).
+        expr: {kind: path, path: [operationType]}
+      - name: resource_type
+        type: Utf8
+        nullable: true
+        description: Resource type affected.
+        expr: {kind: path, path: [resourceType]}
+      - name: resource_path
+        type: Utf8
+        nullable: true
+        description: Resource path affected.
+        expr: {kind: path, path: [resourcePath]}
+      - name: error
+        type: Utf8
+        nullable: true
+        description: Error message when the operation failed.
+        expr: {kind: path, path: [error]}
+      - name: representation
+        type: Json
+        nullable: true
+        description: Serialized resource representation when present.
+        expr: {kind: path, path: [representation]}


### PR DESCRIPTION
## Summary

Adds a new Coolify community source under:

`sources/community/coolify`

This source allows Coral users and AI agents to query Coolify infrastructure and deployment metadata through the Coolify REST API.

## Included tables

* `projects`
* `environments`
* `servers`
* `applications`
* `deployments`

## Features

* Bearer token authentication
* SQL filter support
* Timestamp normalization
* Example SQL workflows
* Validation and smoke-test documentation
* Read-only inventory and deployment visibility

## Notes

* `environments` requires `WHERE project_uuid = '...'`
* `deployments` models the data returned by `GET /deployments`
* Initial implementation focuses on read-only operational visibility

## Validation

Validated locally against a running Coolify instance.

```bash
make lint-sources
coral source lint sources/community/coolify/manifest.yaml
coral source test coolify
```

Example queries executed successfully:

```sql
SELECT name, ip, proxy_type
FROM coolify.servers
LIMIT 10;
```

```sql
SELECT name, status, fqdn
FROM coolify.applications
LIMIT 10;
```

## Related issue

Closes #729 
