### PR TITLE
feat(sources/community/argocd): add argocd community source

### DIFF
--- a/sources/community/argocd/README.md
+++ b/sources/community/argocd/README.md
@@ -1,0 +1,189 @@
+# Argo CD (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Argo CD REST API v1)
+**Tables:** 4
+**Base URL:** `{{input.ARGOCD_BASE_URL}}/api/v1`
+
+Query Argo CD applications, projects, clusters, and repositories through Coral SQL using the [Argo CD REST API](https://cd.apps.argoproj.io/swagger-ui/). Use this data source for GitOps deployment state auditing, cluster alignment tracking, repo sync health monitoring, and managing environment topologies across self-hosted Argo CD installations.
+
+Coral exposes read-only `GET` tables. Write operations (syncing applications, creating projects, refreshing repositories) are out of scope for v1.
+
+## Install
+
+Community sources are not bundled with the Coral binary. From the Coral repo root (or with a copied manifest):
+
+```bash
+coral source add --file sources/community/argocd/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to `coral source add --file`.
+
+Set credentials via environment variables (recommended) or `coral source add --file ... --interactive`.
+
+## Inputs
+
+| Input | Kind | Required | Description |
+| --- | --- | --- | --- |
+| `ARGOCD_BASE_URL` | variable | yes | Root API URL of your Argo CD instance with **no** trailing slash and **no** `/api/v1` path suffix (for example `https://argocd.example.com` or `http://localhost:8080`). |
+| `ARGOCD_AUTH_TOKEN` | secret | yes | Authentication token generated via your Argo CD panel under User Settings or via `argocd account generate-token`. |
+
+---
+
+## Tables overview
+
+| Table | API endpoint | Required filter | Pagination |
+| --- | --- | --- | --- |
+| `applications` | `GET /api/v1/applications` | — | Wrapped array response (`items`) |
+| `projects` | `GET /api/v1/projects` | — | Wrapped array response (`items`) |
+| `clusters` | `GET /api/v1/clusters` | — | Raw array response |
+| `repositories` | `GET /api/v1/repositories` | — | Raw array response |
+
+---
+
+## Filters and API mapping
+
+Coral maps declared SQL filters to native Argo CD API query parameters. Only listed filters are pushed directly down to the REST endpoint; other clauses are filtered in-memory.
+
+| SQL filter | Argo CD query param | Tables |
+| --- | --- | --- |
+| `project` | query `project` | `applications` |
+
+---
+
+## Table reference
+
+### `argocd.applications`
+
+Deployed GitOps applications managed under Argo CD controllers.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `name` | Utf8 | Name of the application |
+| `namespace` | Utf8 | Target cluster namespace where resources are deployed |
+| `destination_server` | Utf8 | Target cluster API server host location endpoint |
+| `repo_url` | Utf8 | Source control repository URL containing configurations (returns null for multi-source applications) |
+| `target_revision` | Utf8 | Tracked Git revision tag, branch, or pinned commit SHA (returns null for multi-source applications) |
+| `path` | Utf8 | Target file directory path within the source repository (returns null for multi-source applications) |
+| `sync_status` | Utf8 | Sync status relative to Git state (e.g., `Synced`, `OutOfSync`) |
+| `health_status` | Utf8 | Operational resource status evaluation (e.g., `Healthy`, `Degraded`) |
+| `project` | Utf8 | Argo CD project scope assignment grouping |
+| `created_at` | Timestamp | Timestamp detailing when the application was registered |
+
+**Optional filter:** `project`
+
+### `argocd.projects`
+
+AppProjects defining deployment boundaries, resource limits, and cluster permissions.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `name` | Utf8 | Project unique target name identification |
+| `description` | Utf8 | Text details explaining project target environment roles |
+
+### `argocd.clusters`
+
+Connected Kubernetes clusters managed by Argo CD.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `name` | Utf8 | Human-friendly deployment cluster label name |
+| `server` | Utf8 | Host destination API endpoint location of the control plane |
+| `connection_status` | Utf8 | Connectivity evaluation metric status value (e.g., `Successful`) |
+
+### `argocd.repositories`
+
+Configured Git and Helm repositories connected to Argo CD.
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `repo_url` | Utf8 | Connected endpoint sync source repository URL |
+| `type` | Utf8 | Version controller storage backend engine layout (`git` or `helm`) |
+| `connection_status` | Utf8 | Active connection diagnostic authentication status output |
+
+---
+
+## Example queries
+
+### Active Application Delivery Auditing
+```sql
+SELECT name, namespace, destination_server, sync_status, health_status 
+FROM argocd.applications 
+WHERE health_status = 'Degraded' 
+LIMIT 50;
+```
+
+```sql
+SELECT name, repo_url, target_revision, created_at 
+FROM argocd.applications 
+WHERE project = 'production'
+ORDER BY created_at DESC;
+```
+
+### Connected Infrastructure Cluster Review
+```sql
+SELECT name, server, connection_status 
+FROM argocd.clusters 
+WHERE connection_status != 'Successful';
+```
+
+### GitOps Source Repository Status
+```sql
+SELECT repo_url, type, connection_status 
+FROM argocd.repositories 
+ORDER BY type DESC;
+```
+
+---
+
+## Validation
+
+Run the following format and syntax pipeline validation commands prior to generating a GitHub pull request:
+
+```bash
+# YAML and file style compliance check
+make lint-sources
+
+# Structural schema and type mapping verification
+coral source lint sources/community/argocd/manifest.yaml
+```
+
+Execute a live target connection test locally:
+
+```bash
+export ARGOCD_BASE_URL=https://argocd.example.com
+export ARGOCD_AUTH_TOKEN=your_jwt_token_here
+
+coral source add --file sources/community/argocd/manifest.yaml
+coral source test argocd
+```
+
+Example smoke-test output:
+
+```text
+$ coral source test argocd
+
+  ✓ argocd connected successfully
+
+    argocd (4 tables)
+    ├─ applications
+    ├─ projects
+    ├─ clusters
+    └─ repositories
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+  ✓ SELECT name, namespace FROM argocd.applications LIMIT 1
+    1 row
+```
+
+---
+
+## Limitations
+
+- **Read-only source.** No sync operations, resource creation, or remote deployment modifications.
+- **No sync or deployment execution.** Reconciliations must be triggered via the Argo CD UI, CLI, or Git engines.
+- **No streaming/watch support.** Data updates rely on polling API cycles; live stream channels are out of scope for v1.
+- **RBAC permissions affect visible resources.** Returned SQL rows are strictly bounded by your personal access token's access controls.
+- **Large Argo CD instances should use SQL `LIMIT`.** Instances with thousands of tracked application records should include tight constraints to prevent memory limits during unpacking operations.
+- **Only REST API-visible resources are modeled.** Underlying custom fields or unexposed cluster telemetry targets are omitted from row strategizing.

--- a/sources/community/argocd/manifest.yaml
+++ b/sources/community/argocd/manifest.yaml
@@ -1,0 +1,183 @@
+name: argocd
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Argo CD applications, projects, clusters, and repositories via the 
+  Argo CD REST API to audit GitOps states and cluster delivery topologies.
+base_url: "{{input.ARGOCD_BASE_URL}}/api/v1"
+
+inputs:
+  ARGOCD_BASE_URL:
+    kind: variable
+    hint: |
+      Argo CD server API root URL with NO trailing slash and no /api suffix,
+      for example `https://argocd.example.com` or `http://localhost:8080`.
+  ARGOCD_AUTH_TOKEN:
+    kind: secret
+    hint: |
+      Argo CD authentication token (JWT authentication token generated via 
+      Argo CD settings account tokens or via `argocd account generate-token`).
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.ARGOCD_AUTH_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT name, namespace FROM argocd.applications LIMIT 1
+
+tables:
+  - name: applications
+    description: Deployed GitOps applications managed by Argo CD.
+    filters:
+      - name: project
+        required: false
+    request:
+      method: GET
+      path: /applications
+      query:
+        - name: project
+          from: filter
+          key: project
+    response:
+      row_strategy: direct
+      root_key: items
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Name of the application.
+        expr: {kind: path, path: [metadata, name]}
+      - name: namespace
+        type: Utf8
+        nullable: true
+        description: Target cluster namespace where the application resources reside.
+        expr: {kind: path, path: [spec, destination, namespace]}
+      - name: destination_server
+        type: Utf8
+        nullable: true
+        description: Target cluster API server host location endpoint.
+        expr: {kind: path, path: [spec, destination, server]}
+      - name: repo_url
+        type: Utf8
+        nullable: true
+        description: Git repository URL containing the source configurations (returns null for multi-source applications).
+        expr: {kind: path, path: [spec, source, repoURL]}
+      - name: target_revision
+        type: Utf8
+        nullable: true
+        description: Tracked Git revision tag, branch, or commit pin (returns null for multi-source applications).
+        expr: {kind: path, path: [spec, source, targetRevision]}
+      - name: path
+        type: Utf8
+        nullable: true
+        description: Directory path within the source repository (returns null for multi-source applications).
+        expr: {kind: path, path: [spec, source, path]}
+      - name: sync_status
+        type: Utf8
+        nullable: true
+        description: Application sync status relative to Git state (Synced, OutOfSync).
+        expr: {kind: path, path: [status, sync, status]}
+      - name: health_status
+        type: Utf8
+        nullable: true
+        description: Live operational evaluation health state (Healthy, Degraded, Progressing).
+        expr: {kind: path, path: [status, health, status]}
+      - name: project
+        type: Utf8
+        nullable: true
+        description: Argo CD control group project assignment name.
+        expr: {kind: path, path: [spec, project]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp detailing when the application was registered.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [metadata, creationTimestamp]}
+
+  - name: projects
+    description: AppProjects organizing application operational scopes and permissions.
+    request:
+      method: GET
+      path: /projects
+    response:
+      row_strategy: direct
+      root_key: items
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Project structural identification name.
+        expr: {kind: path, path: [metadata, name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Project contextual details text.
+        expr: {kind: path, path: [spec, description]}
+
+  - name: clusters
+    description: Target infrastructure Kubernetes clusters connected to Argo CD.
+    request:
+      method: GET
+      path: /clusters
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Cluster designation string name.
+        expr: {kind: path, path: [name]}
+      - name: server
+        type: Utf8
+        nullable: false
+        description: Host endpoint location URL of the cluster control plane API.
+        expr: {kind: path, path: [server]}
+      - name: connection_status
+        type: Utf8
+        nullable: true
+        description: Core cluster connectivity monitoring state.
+        expr: {kind: path, path: [connectionState, status]}
+
+  - name: repositories
+    description: Configured version control repository sync connection sources.
+    request:
+      method: GET
+      path: /repositories
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: repo_url
+        type: Utf8
+        nullable: false
+        description: Connected source URL.
+        expr: {kind: path, path: [repo]}
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Storage server version target driver flavor (git, helm).
+        expr: {kind: path, path: [type]}
+      - name: connection_status
+        type: Utf8
+        nullable: true
+        description: State index health monitoring check responses.
+        expr: {kind: path, path: [connectionState, status]}
+        


### PR DESCRIPTION
## Summary

Adds a new Argo CD community source under:

`sources/community/argocd`

This source allows Coral users and AI agents to query Argo CD applications, projects, clusters, and repositories through the Argo CD REST API.

## Included tables

* `applications`
* `projects`
* `clusters`
* `repositories`

## Features

* Bearer token authentication
* SQL filter support
* Timestamp normalization
* Example SQL workflows
* Validation and smoke-test documentation
* Read-only GitOps visibility

## Notes

* `applications` supports optional `project` filter pushdown
* Applications and projects use wrapped `items` list responses
* Initial implementation focuses on read-only operational visibility

## Validation

Validated locally using:

```bash
make lint-sources
coral source lint sources/community/argocd/manifest.yaml
```

Smoke test:

```bash
coral source test argocd
```

## Related issue

Closes #726 