### PR TITLE
feat(sources/community/groq_ai): add Groq AI community source

### DIFF
--- a/sources/community/groq_ai/README.md
+++ b/sources/community/groq_ai/README.md
@@ -57,6 +57,14 @@ Interactive install also works:
 coral source add --interactive --file sources/community/groq_ai/manifest.yaml
 ```
 
+## Provider docs
+
+- Groq API reference: https://console.groq.com/docs/api-reference
+- Groq models: https://console.groq.com/docs/models
+- Groq text/chat guide: https://console.groq.com/docs/text-chat
+- Groq rate limits: https://console.groq.com/docs/rate-limits
+- Groq model permissions: https://console.groq.com/docs/model-permissions
+
 ## Tables
 
 | Table | Description | Required filters |
@@ -70,32 +78,34 @@ coral source add --interactive --file sources/community/groq_ai/manifest.yaml
 Lists models available from `GET /models`.
 
 ```sql
-SELECT id, object, owned_by, active, context_window
+SELECT id, object, owned_by, active, context_window, max_completion_tokens
 FROM groq_ai.models
 LIMIT 20;
 ```
 
 ### `groq_ai.model`
 
-Fetches metadata for one model from `GET /models/{model_id}`.
+Fetches metadata for one model from `GET /models/{model_id}`. Slash-containing
+model IDs such as `groq/compound-mini` are supported by Coral's HTTP request
+builder and are covered by the validation output below.
 
 ```sql
-SELECT id, object, owned_by, active, context_window
+SELECT id, object, owned_by, active, context_window, max_completion_tokens
 FROM groq_ai.model
-WHERE model_id = 'llama-3.3-70b-versatile';
+WHERE model_id = 'groq/compound-mini';
 ```
 
 ### `groq_ai.chat_completions`
 
 Runs a single user-message chat completion through `POST /chat/completions`.
-Use `max_tokens` when you want to keep validation output small.
+Use `max_completion_tokens` when you want to keep validation output small.
 
 ```sql
-SELECT content, finish_reason
+SELECT content, finish_reason, max_completion_tokens
 FROM groq_ai.chat_completions
 WHERE model = 'llama-3.3-70b-versatile'
   AND prompt = 'What is Python? Reply in one short line under 15 words.'
-  AND max_tokens = 40
+  AND max_completion_tokens = 40
 LIMIT 1;
 ```
 
@@ -113,8 +123,8 @@ coral source add --file sources/community/groq_ai/manifest.yaml
 coral source test groq_ai
 ```
 
-The declared test queries cover model discovery and two chat-completion smoke
-tests:
+The declared test queries cover model discovery, two chat-completion smoke
+tests, and a detail lookup for a slash-containing model ID:
 
 ```sql
 SELECT * FROM groq_ai.models LIMIT 5;
@@ -129,6 +139,11 @@ SELECT content
 FROM groq_ai.chat_completions
 WHERE model = 'llama-3.3-70b-versatile'
   AND prompt = 'What is Python?'
+LIMIT 1;
+
+SELECT id, owned_by, active
+FROM groq_ai.model
+WHERE model_id = 'groq/compound-mini'
 LIMIT 1;
 ```
 
@@ -164,22 +179,25 @@ Output:
 ```text
 Added source groq_ai
 
-  ✓ groq_ai connected successfully
+  PASS groq_ai connected successfully
 
     groq_ai (3 tables)
-    ├─ chat_completions
-    ├─ model
-    └─ models
+    - chat_completions
+    - model
+    - models
     Query tests
-    3 declared · 3 passed · 0 failed
+    4 declared - 4 passed - 0 failed
 
-    ✓ SELECT * FROM groq_ai.models LIMIT 5
+    PASS SELECT * FROM groq_ai.models LIMIT 5
       5 rows
 
-    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
+    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
       1 row
 
-    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
+    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
+      1 row
+
+    PASS SELECT id, owned_by, active FROM groq_ai.model WHERE model_id = 'groq/compound-mini' LIMIT 1
       1 row
 ```
 
@@ -194,22 +212,25 @@ coral source test groq_ai
 Output:
 
 ```text
-  ✓ groq_ai connected successfully
+  PASS groq_ai connected successfully
 
     groq_ai (3 tables)
-    ├─ chat_completions
-    ├─ model
-    └─ models
+    - chat_completions
+    - model
+    - models
     Query tests
-    3 declared · 3 passed · 0 failed
+    4 declared - 4 passed - 0 failed
 
-    ✓ SELECT * FROM groq_ai.models LIMIT 5
+    PASS SELECT * FROM groq_ai.models LIMIT 5
       5 rows
 
-    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
+    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
       1 row
 
-    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
+    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
+      1 row
+
+    PASS SELECT id, owned_by, active FROM groq_ai.model WHERE model_id = 'groq/compound-mini' LIMIT 1
       1 row
 ```
 
@@ -231,6 +252,45 @@ Output:
 | model            |
 | models           |
 +------------------+
+```
+
+#### Confirm column discovery
+
+Command:
+
+```bash
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'groq_ai' ORDER BY table_name, ordinal_position"
+```
+
+Output:
+
+```text
++------------------+-----------------------+-----------+
+| table_name       | column_name           | data_type |
++------------------+-----------------------+-----------+
+| chat_completions | model                 | Utf8      |
+| chat_completions | prompt                | Utf8      |
+| chat_completions | max_completion_tokens | Int64     |
+| chat_completions | index                 | Int64     |
+| chat_completions | finish_reason         | Utf8      |
+| chat_completions | content               | Utf8      |
+| chat_completions | message_role          | Utf8      |
+| model            | model_id              | Utf8      |
+| model            | id                    | Utf8      |
+| model            | object                | Utf8      |
+| model            | owned_by              | Utf8      |
+| model            | active                | Boolean   |
+| model            | context_window        | Int64     |
+| model            | max_completion_tokens | Int64     |
+| model            | public_apps           | Json      |
+| models           | id                    | Utf8      |
+| models           | object                | Utf8      |
+| models           | owned_by              | Utf8      |
+| models           | active                | Boolean   |
+| models           | context_window        | Int64     |
+| models           | max_completion_tokens | Int64     |
+| models           | public_apps           | Json      |
++------------------+-----------------------+-----------+
 ```
 
 #### Confirm input discovery
@@ -256,17 +316,17 @@ Output:
 Command:
 
 ```bash
-coral sql "SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python? Reply in one short line under 15 words.' LIMIT 1"
+coral sql "SELECT content, max_completion_tokens FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python? Reply in one short line under 15 words.' AND max_completion_tokens = 40 LIMIT 1"
 ```
 
 Output:
 
 ```text
-+----------------------------------------------+
-| content                                      |
-+----------------------------------------------+
-| Python is a high-level programming language. |
-+----------------------------------------------+
++----------------------------------------------+-----------------------+
+| content                                      | max_completion_tokens |
++----------------------------------------------+-----------------------+
+| Python is a high-level programming language. | 40                    |
++----------------------------------------------+-----------------------+
 ```
 
 #### Query Groq model metadata
@@ -291,13 +351,34 @@ Output:
 +-------------------------------------------+--------+-------------+
 ```
 
+#### Query one slash-containing model ID
+
+Command:
+
+```bash
+coral sql "SELECT id, object, owned_by, active, context_window, max_completion_tokens FROM groq_ai.model WHERE model_id = 'groq/compound-mini' LIMIT 1"
+```
+
+Output:
+
+```text
++--------------------+--------+----------+--------+----------------+-----------------------+
+| id                 | object | owned_by | active | context_window | max_completion_tokens |
++--------------------+--------+----------+--------+----------------+-----------------------+
+| groq/compound-mini | model  | Groq     | true   | 131072         | 8192                  |
++--------------------+--------+----------+--------+----------------+-----------------------+
+```
+
 ## Implementation notes
 
 - Uses Coral source-spec DSL v3 with the HTTP backend.
 - Uses `HeaderAuth` with `Authorization: Bearer {{input.GROQ_API_KEY}}`.
 - Maps Groq's `data` array from `GET /models` into `groq_ai.models`.
+- Maps Groq model metadata, including `public_apps` and
+  `max_completion_tokens`, onto `groq_ai.models` and `groq_ai.model`.
 - Maps `choices[*].message.content` from `POST /chat/completions` into
   `groq_ai.chat_completions.content`.
+- Sends the current Groq chat parameter `max_completion_tokens`.
 - Echoes required SQL filters such as `model`, `prompt`, and `model_id` back as
   virtual columns so query results keep their request context.
 - Does not require runtime, CLI, MCP, or UI changes.
@@ -308,8 +389,9 @@ Output:
 - `chat_completions` performs a live API call for each query.
 - The chat table supports one user message per query. It is intended for
   validation and lightweight SQL workflows, not as a full chat client.
-- Responses, available models, rate limits, and errors depend on the Groq
-  account, API key permissions, and the selected model.
+- Responses, available models, permissions, rate limits, and errors depend on
+  the Groq account, API key permissions, selected model, and current provider
+  limits.
 
 ## Contributing
 

--- a/sources/community/groq_ai/README.md
+++ b/sources/community/groq_ai/README.md
@@ -1,51 +1,83 @@
-# Groq AI Community Source
+# Groq AI community source
+
+Query GroqCloud model metadata and run simple chat completions through Coral SQL.
+This source adds Groq's OpenAI-compatible API to the community catalog so users
+and agents can inspect available models, verify model configuration, and smoke
+test prompts without leaving the Coral workflow.
 
 **Version:** 0.1.0
 **Backend:** HTTP
 **Tables:** 3
 **Base URL:** `https://api.groq.com/openai/v1`
 
-Query GroqCloud model metadata and run chat completions through Coral SQL. This community source is useful when you want to inspect available models or test prompts against Groq without leaving the SQL workflow.
+## Why this source
 
-## Install
+Groq is a common inference provider for fast LLM experiments, agent prototypes,
+and production chat workloads. Coral did not have a Groq source yet, so this
+community spec gives the reef a focused read/query surface for:
 
-Community sources are not bundled with the Coral binary. Add the manifest from this directory:
+- Discovering active GroqCloud models from SQL.
+- Looking up metadata for one model before using it in an agent or workflow.
+- Running a bounded chat-completion prompt as an integration smoke test.
+- Joining model metadata with other Coral sources in local analysis workflows.
+
+The v1 surface is intentionally narrow and read-oriented. It proves Coral can
+authenticate against Groq, call Groq's OpenAI-compatible endpoints, map JSON
+responses into tables, and validate the source with declared test queries.
+
+## Installation
+
+Community sources are not bundled with the Coral binary. Clone the Coral
+repository and add the manifest from this directory:
 
 ```bash
 coral source add --file sources/community/groq_ai/manifest.yaml
 ```
 
-Or copy `manifest.yaml` into your workspace and pass that path to `coral source add --file`.
+You can also copy `manifest.yaml` into another workspace and pass that path to
+`coral source add --file`.
 
 ## Authentication
 
-Requires `GROQ_API_KEY`.
+Create or copy an API key from the GroqCloud console:
 
-Create or copy a key from:
 https://console.groq.com/keys
 
-The key is sent as a bearer token to Groq's OpenAI-compatible API.
+Set the key as `GROQ_API_KEY` before adding or testing the source. Coral sends
+it as a bearer token to Groq's OpenAI-compatible API.
 
 ```bash
 export GROQ_API_KEY="your_groq_api_key"
 coral source add --file sources/community/groq_ai/manifest.yaml
 ```
 
-## Table categories
+Interactive install also works:
 
-| Table | Description |
-| --- | --- |
-| `models` | Active GroqCloud models returned by the Models API |
-| `model` | Metadata for one Groq model ID |
-| `chat_completions` | One chat completion request using SQL filters |
+```bash
+coral source add --interactive --file sources/community/groq_ai/manifest.yaml
+```
 
-## Example queries
+## Tables
+
+| Table | Description | Required filters |
+| --- | --- | --- |
+| `groq_ai.models` | Active GroqCloud models returned by the Models API. | None |
+| `groq_ai.model` | Metadata for one Groq model ID. | `model_id` |
+| `groq_ai.chat_completions` | Run one chat completion request using SQL filters. | `model`, `prompt` |
+
+### `groq_ai.models`
+
+Lists models available from `GET /models`.
 
 ```sql
-SELECT id, object, owned_by
+SELECT id, object, owned_by, active, context_window
 FROM groq_ai.models
 LIMIT 20;
 ```
+
+### `groq_ai.model`
+
+Fetches metadata for one model from `GET /models/{model_id}`.
 
 ```sql
 SELECT id, object, owned_by, active, context_window
@@ -53,29 +85,84 @@ FROM groq_ai.model
 WHERE model_id = 'llama-3.3-70b-versatile';
 ```
 
+### `groq_ai.chat_completions`
+
+Runs a single user-message chat completion through `POST /chat/completions`.
+Use `max_tokens` when you want to keep validation output small.
+
 ```sql
 SELECT content, finish_reason
+FROM groq_ai.chat_completions
+WHERE model = 'llama-3.3-70b-versatile'
+  AND prompt = 'What is Python? Reply in one short line under 15 words.'
+  AND max_tokens = 40
+LIMIT 1;
+```
+
+## Validation
+
+Run the source-level checks before opening or updating a PR:
+
+```bash
+coral source lint sources/community/groq_ai/manifest.yaml
+
+export GROQ_API_KEY="your_groq_api_key"
+coral source add --file sources/community/groq_ai/manifest.yaml
+coral source test groq_ai
+```
+
+The declared test queries cover model discovery and two chat-completion smoke
+tests:
+
+```sql
+SELECT * FROM groq_ai.models LIMIT 5;
+
+SELECT content
+FROM groq_ai.chat_completions
+WHERE model = 'llama-3.3-70b-versatile'
+  AND prompt = 'Reply with exactly: Coral Groq works'
+LIMIT 1;
+
+SELECT content
 FROM groq_ai.chat_completions
 WHERE model = 'llama-3.3-70b-versatile'
   AND prompt = 'What is Python?'
 LIMIT 1;
 ```
 
-## Validation
+For PR proof, the local verification script used for this contribution is:
 
-```bash
-coral source lint sources/community/groq_ai/manifest.yaml
-export GROQ_API_KEY=...
-coral source add --file sources/community/groq_ai/manifest.yaml
-coral source test groq_ai
+```powershell
+coral-forge-agent\scripts\groq_ai_pr_proof.ps1
 ```
+
+Screenshots from that proof run are stored under:
+
+```text
+output_proof/groq_ai
+```
+
+## Implementation notes
+
+- Uses Coral source-spec DSL v3 with the HTTP backend.
+- Uses `HeaderAuth` with `Authorization: Bearer {{input.GROQ_API_KEY}}`.
+- Maps Groq's `data` array from `GET /models` into `groq_ai.models`.
+- Maps `choices[*].message.content` from `POST /chat/completions` into
+  `groq_ai.chat_completions.content`.
+- Echoes required SQL filters such as `model`, `prompt`, and `model_id` back as
+  virtual columns so query results keep their request context.
+- Does not require runtime, CLI, MCP, or UI changes.
 
 ## Limitations
 
-- The `chat_completions` table performs an API call for each query.
-- Keep prompts short and bounded for demos and tests.
-- The table supports a single user message because it is meant to prove Coral can call Groq through SQL, not replace a full chat client.
+- This source is read/query oriented and does not manage Groq account settings.
+- `chat_completions` performs a live API call for each query.
+- The chat table supports one user message per query. It is intended for
+  validation and lightweight SQL workflows, not as a full chat client.
+- Responses, available models, rate limits, and errors depend on the Groq
+  account, API key permissions, and the selected model.
 
 ## Contributing
 
-Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md), run `make lint-sources`, and include the validation steps you used in the PR description.
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md), keep the manifest focused,
+and include the validation commands plus proof output in the PR description.

--- a/sources/community/groq_ai/README.md
+++ b/sources/community/groq_ai/README.md
@@ -101,7 +101,9 @@ LIMIT 1;
 
 ## Validation
 
-Run the source-level checks before opening or updating a PR:
+Run the source-level checks with a valid `GROQ_API_KEY` before opening or
+updating a PR. The API key is required for `source add`, `source test`, and live
+SQL queries, but it should never be printed or committed.
 
 ```bash
 coral source lint sources/community/groq_ai/manifest.yaml
@@ -130,16 +132,163 @@ WHERE model = 'llama-3.3-70b-versatile'
 LIMIT 1;
 ```
 
-For PR proof, the local verification script used for this contribution is:
+### Live validation output
 
-```powershell
-coral-forge-agent\scripts\groq_ai_pr_proof.ps1
+The following output was captured from a live validation run using a real
+GroqCloud API key.
+
+#### Manifest lint
+
+Command:
+
+```bash
+coral source lint sources/community/groq_ai/manifest.yaml
 ```
 
-Screenshots from that proof run are stored under:
+Output:
 
 ```text
-output_proof/groq_ai
+Manifest is valid
+```
+
+#### Add source and run declared tests
+
+Command:
+
+```bash
+coral source add --file sources/community/groq_ai/manifest.yaml
+```
+
+Output:
+
+```text
+Added source groq_ai
+
+  ✓ groq_ai connected successfully
+
+    groq_ai (3 tables)
+    ├─ chat_completions
+    ├─ model
+    └─ models
+    Query tests
+    3 declared · 3 passed · 0 failed
+
+    ✓ SELECT * FROM groq_ai.models LIMIT 5
+      5 rows
+
+    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
+      1 row
+
+    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
+      1 row
+```
+
+#### Re-run source tests
+
+Command:
+
+```bash
+coral source test groq_ai
+```
+
+Output:
+
+```text
+  ✓ groq_ai connected successfully
+
+    groq_ai (3 tables)
+    ├─ chat_completions
+    ├─ model
+    └─ models
+    Query tests
+    3 declared · 3 passed · 0 failed
+
+    ✓ SELECT * FROM groq_ai.models LIMIT 5
+      5 rows
+
+    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
+      1 row
+
+    ✓ SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
+      1 row
+```
+
+#### Confirm table discovery
+
+Command:
+
+```bash
+coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'groq_ai' ORDER BY table_name"
+```
+
+Output:
+
+```text
++------------------+
+| table_name       |
++------------------+
+| chat_completions |
+| model            |
+| models           |
++------------------+
+```
+
+#### Confirm input discovery
+
+Command:
+
+```bash
+coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'groq_ai' ORDER BY key"
+```
+
+Output:
+
+```text
++--------------+--------+----------+
+| key          | kind   | required |
++--------------+--------+----------+
+| GROQ_API_KEY | secret | true     |
++--------------+--------+----------+
+```
+
+#### Run a live chat completion query
+
+Command:
+
+```bash
+coral sql "SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python? Reply in one short line under 15 words.' LIMIT 1"
+```
+
+Output:
+
+```text
++----------------------------------------------+
+| content                                      |
++----------------------------------------------+
+| Python is a high-level programming language. |
++----------------------------------------------+
+```
+
+#### Query Groq model metadata
+
+Command:
+
+```bash
+coral sql "SELECT id, object, owned_by FROM groq_ai.models LIMIT 5"
+```
+
+Output:
+
+```text
++-------------------------------------------+--------+-------------+
+| id                                        | object | owned_by    |
++-------------------------------------------+--------+-------------+
+| canopylabs/orpheus-arabic-saudi           | model  | Canopy Labs |
+| meta-llama/llama-4-scout-17b-16e-instruct | model  | Meta        |
+| whisper-large-v3                          | model  | OpenAI      |
+| meta-llama/llama-prompt-guard-2-22m       | model  | Meta        |
+| groq/compound-mini                        | model  | Groq        |
++-------------------------------------------+--------+-------------+
 ```
 
 ## Implementation notes

--- a/sources/community/groq_ai/README.md
+++ b/sources/community/groq_ai/README.md
@@ -1,0 +1,81 @@
+# Groq AI Community Source
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 3
+**Base URL:** `https://api.groq.com/openai/v1`
+
+Query GroqCloud model metadata and run chat completions through Coral SQL. This community source is useful when you want to inspect available models or test prompts against Groq without leaving the SQL workflow.
+
+## Install
+
+Community sources are not bundled with the Coral binary. Add the manifest from this directory:
+
+```bash
+coral source add --file sources/community/groq_ai/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to `coral source add --file`.
+
+## Authentication
+
+Requires `GROQ_API_KEY`.
+
+Create or copy a key from:
+https://console.groq.com/keys
+
+The key is sent as a bearer token to Groq's OpenAI-compatible API.
+
+```bash
+export GROQ_API_KEY="your_groq_api_key"
+coral source add --file sources/community/groq_ai/manifest.yaml
+```
+
+## Table categories
+
+| Table | Description |
+| --- | --- |
+| `models` | Active GroqCloud models returned by the Models API |
+| `model` | Metadata for one Groq model ID |
+| `chat_completions` | One chat completion request using SQL filters |
+
+## Example queries
+
+```sql
+SELECT id, object, owned_by
+FROM groq_ai.models
+LIMIT 20;
+```
+
+```sql
+SELECT id, object, owned_by, active, context_window
+FROM groq_ai.model
+WHERE model_id = 'llama-3.3-70b-versatile';
+```
+
+```sql
+SELECT content, finish_reason
+FROM groq_ai.chat_completions
+WHERE model = 'llama-3.3-70b-versatile'
+  AND prompt = 'What is Python?'
+LIMIT 1;
+```
+
+## Validation
+
+```bash
+coral source lint sources/community/groq_ai/manifest.yaml
+export GROQ_API_KEY=...
+coral source add --file sources/community/groq_ai/manifest.yaml
+coral source test groq_ai
+```
+
+## Limitations
+
+- The `chat_completions` table performs an API call for each query.
+- Keep prompts short and bounded for demos and tests.
+- The table supports a single user message because it is meant to prove Coral can call Groq through SQL, not replace a full chat client.
+
+## Contributing
+
+Follow [CONTRIBUTING.md](../../../CONTRIBUTING.md), run `make lint-sources`, and include the validation steps you used in the PR description.

--- a/sources/community/groq_ai/manifest.yaml
+++ b/sources/community/groq_ai/manifest.yaml
@@ -1,0 +1,192 @@
+name: groq_ai
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Groq AI community source for querying GroqCloud OpenAI-compatible model metadata.
+base_url: https://api.groq.com/openai/v1
+inputs:
+  GROQ_API_KEY:
+    kind: secret
+    hint: |
+      GroqCloud API key.
+
+      Create or copy an API key from:
+      https://console.groq.com/keys
+
+      The key is sent as a Bearer token to Groq's OpenAI-compatible API.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.GROQ_API_KEY}}"
+test_queries:
+  - SELECT * FROM groq_ai.models LIMIT 5
+  - "SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1"
+  - "SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1"
+tables:
+  - name: models
+    description: Active GroqCloud models available through the Models API.
+    request:
+      method: GET
+      path: /models
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Model ID used in Groq API calls.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: owned_by
+        type: Utf8
+        nullable: true
+        description: Owning organization or provider.
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the model is active.
+      - name: context_window
+        type: Int64
+        nullable: true
+        description: Context window size when returned by the API.
+  - name: chat_completions
+    description: Run one Groq chat completion using required SQL filters for model and prompt.
+    filters:
+      - name: model
+        required: true
+      - name: prompt
+        required: true
+      - name: max_tokens
+        required: false
+    request:
+      method: POST
+      path: /chat/completions
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - messages
+            - "0"
+            - role
+          from: literal
+          value: user
+        - path:
+            - messages
+            - "0"
+            - content
+          from: filter
+          key: prompt
+        - path:
+            - max_tokens
+          from: filter_int
+          key: max_tokens
+    response:
+      rows_path:
+        - choices
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Model ID supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: prompt
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Prompt supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: prompt
+      - name: index
+        type: Int64
+        nullable: true
+        description: Choice index.
+      - name: finish_reason
+        type: Utf8
+        nullable: true
+        description: Why the model stopped.
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Assistant response text.
+        expr:
+          kind: path
+          path:
+            - message
+            - content
+      - name: message_role
+        type: Utf8
+        nullable: true
+        description: Assistant message role.
+        expr:
+          kind: path
+          path:
+            - message
+            - role
+      - name: public_apps
+        type: Json
+        nullable: true
+        description: Public app metadata when returned by the API.
+        expr:
+          kind: path
+          path:
+            - public_apps
+  - name: model
+    description: Metadata for a specific Groq model ID.
+    filters:
+      - name: model_id
+        required: true
+    request:
+      method: GET
+      path: /models/{{filter.model_id}}
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Model ID supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model_id
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Model ID.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: owned_by
+        type: Utf8
+        nullable: true
+        description: Owning organization or provider.
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the model is active.
+      - name: context_window
+        type: Int64
+        nullable: true
+        description: Context window size when returned by the API.

--- a/sources/community/groq_ai/manifest.yaml
+++ b/sources/community/groq_ai/manifest.yaml
@@ -24,6 +24,7 @@ test_queries:
   - SELECT * FROM groq_ai.models LIMIT 5
   - "SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1"
   - "SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1"
+  - "SELECT id, owned_by, active FROM groq_ai.model WHERE model_id = 'groq/compound-mini' LIMIT 1"
 tables:
   - name: models
     description: Active GroqCloud models available through the Models API.
@@ -56,6 +57,14 @@ tables:
         type: Int64
         nullable: true
         description: Context window size when returned by the API.
+      - name: max_completion_tokens
+        type: Int64
+        nullable: true
+        description: Maximum completion tokens when returned by the API.
+      - name: public_apps
+        type: Json
+        nullable: true
+        description: Public app metadata when returned by the API.
   - name: chat_completions
     description: Run one Groq chat completion using required SQL filters for model and prompt.
     filters:
@@ -63,7 +72,7 @@ tables:
         required: true
       - name: prompt
         required: true
-      - name: max_tokens
+      - name: max_completion_tokens
         required: false
     request:
       method: POST
@@ -90,9 +99,9 @@ tables:
           from: filter
           key: prompt
         - path:
-            - max_tokens
+            - max_completion_tokens
           from: filter_int
-          key: max_tokens
+          key: max_completion_tokens
     response:
       rows_path:
         - choices
@@ -115,6 +124,14 @@ tables:
         expr:
           kind: from_filter
           key: prompt
+      - name: max_completion_tokens
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Maximum completion tokens supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: max_completion_tokens
       - name: index
         type: Int64
         nullable: true
@@ -141,14 +158,6 @@ tables:
           path:
             - message
             - role
-      - name: public_apps
-        type: Json
-        nullable: true
-        description: Public app metadata when returned by the API.
-        expr:
-          kind: path
-          path:
-            - public_apps
   - name: model
     description: Metadata for a specific Groq model ID.
     filters:
@@ -190,3 +199,11 @@ tables:
         type: Int64
         nullable: true
         description: Context window size when returned by the API.
+      - name: max_completion_tokens
+        type: Int64
+        nullable: true
+        description: Maximum completion tokens when returned by the API.
+      - name: public_apps
+        type: Json
+        nullable: true
+        description: Public app metadata when returned by the API.


### PR DESCRIPTION
﻿Closes #753

## Summary

Adds a new `groq_ai` community source under `sources/community/groq_ai`.

This source lets Coral users query GroqCloud's OpenAI-compatible API through SQL. It covers model discovery, single-model metadata lookup, and a simple chat-completion query path for validating Groq API connectivity from Coral.

## What changed

- Added `sources/community/groq_ai/manifest.yaml`
- Added `sources/community/groq_ai/README.md`

## Source scope

| Table | Purpose | Required filters |
| --- | --- | --- |
| `groq_ai.models` | Lists active GroqCloud models from `GET /models`. | None |
| `groq_ai.model` | Fetches metadata for one model from `GET /models/{model_id}`. | `model_id` |
| `groq_ai.chat_completions` | Runs one SQL-driven chat completion through `POST /chat/completions`. | `model`, `prompt` |

## Implementation notes

- Uses Coral source-spec DSL v3 with the HTTP backend.
- Uses `HeaderAuth` with `Authorization: Bearer {{input.GROQ_API_KEY}}`.
- Maps `GET /models` response rows from Groq's `data` array.
- Maps `POST /chat/completions` response rows from Groq's `choices` array.
- Uses Groq's current `max_completion_tokens` chat parameter.
- Exposes documented model metadata fields including `public_apps` and `max_completion_tokens` on `models` / `model`.
- Removes misleading `public_apps` from chat completion choices.
- Includes a declared test for a slash-containing model ID: `groq/compound-mini`.
- No runtime, CLI, MCP, or UI changes are required.

## Provider docs

- Groq API reference: https://console.groq.com/docs/api-reference
- Groq models: https://console.groq.com/docs/models
- Groq text/chat guide: https://console.groq.com/docs/text-chat
- Groq rate limits: https://console.groq.com/docs/rate-limits
- Groq model permissions: https://console.groq.com/docs/model-permissions

## Validation

Validated with a real `GROQ_API_KEY`. The key is not committed or printed.

### 1. Manifest lint

Command:

```bash
coral source lint sources/community/groq_ai/manifest.yaml
```

Output:

```text
Manifest is valid
```

### 2. Source add and declared query tests

Command:

```bash
coral source add --file sources/community/groq_ai/manifest.yaml
```

Output:

```text
Added source groq_ai

  PASS groq_ai connected successfully

    groq_ai (3 tables)
    - chat_completions
    - model
    - models
    Query tests
    4 declared - 4 passed - 0 failed

    PASS SELECT * FROM groq_ai.models LIMIT 5
      5 rows

    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
      1 row

    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
      1 row

    PASS SELECT id, owned_by, active FROM groq_ai.model WHERE model_id = 'groq/compound-mini' LIMIT 1
      1 row
```

### 3. Source test

Command:

```bash
coral source test groq_ai
```

Output:

```text
  PASS groq_ai connected successfully

    groq_ai (3 tables)
    - chat_completions
    - model
    - models
    Query tests
    4 declared - 4 passed - 0 failed

    PASS SELECT * FROM groq_ai.models LIMIT 5
      5 rows

    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'Reply with exactly: Coral Groq works' LIMIT 1
      1 row

    PASS SELECT content FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python?' LIMIT 1
      1 row

    PASS SELECT id, owned_by, active FROM groq_ai.model WHERE model_id = 'groq/compound-mini' LIMIT 1
      1 row
```

### 4. Slash-containing model ID detail lookup

Command:

```bash
coral sql "SELECT id, object, owned_by, active, context_window, max_completion_tokens FROM groq_ai.model WHERE model_id = 'groq/compound-mini' LIMIT 1"
```

Output:

```text
+--------------------+--------+----------+--------+----------------+-----------------------+
| id                 | object | owned_by | active | context_window | max_completion_tokens |
+--------------------+--------+----------+--------+----------------+-----------------------+
| groq/compound-mini | model  | Groq     | true   | 131072         | 8192                  |
+--------------------+--------+----------+--------+----------------+-----------------------+
```

### 5. Chat completion with max_completion_tokens

Command:

```bash
coral sql "SELECT content, max_completion_tokens FROM groq_ai.chat_completions WHERE model = 'llama-3.3-70b-versatile' AND prompt = 'What is Python? Reply in one short line under 15 words.' AND max_completion_tokens = 40 LIMIT 1"
```

Output:

```text
+----------------------------------------------+-----------------------+
| content                                      | max_completion_tokens |
+----------------------------------------------+-----------------------+
| Python is a high-level programming language. | 40                    |
+----------------------------------------------+-----------------------+
```

### 6. Column discovery

Command:

```bash
coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'groq_ai' ORDER BY table_name, ordinal_position"
```

Output:

```text
+------------------+-----------------------+-----------+
| table_name       | column_name           | data_type |
+------------------+-----------------------+-----------+
| chat_completions | model                 | Utf8      |
| chat_completions | prompt                | Utf8      |
| chat_completions | max_completion_tokens | Int64     |
| chat_completions | index                 | Int64     |
| chat_completions | finish_reason         | Utf8      |
| chat_completions | content               | Utf8      |
| chat_completions | message_role          | Utf8      |
| model            | model_id              | Utf8      |
| model            | id                    | Utf8      |
| model            | object                | Utf8      |
| model            | owned_by              | Utf8      |
| model            | active                | Boolean   |
| model            | context_window        | Int64     |
| model            | max_completion_tokens | Int64     |
| model            | public_apps           | Json      |
| models           | id                    | Utf8      |
| models           | object                | Utf8      |
| models           | owned_by              | Utf8      |
| models           | active                | Boolean   |
| models           | context_window        | Int64     |
| models           | max_completion_tokens | Int64     |
| models           | public_apps           | Json      |
+------------------+-----------------------+-----------+
```

## Proof screenshots

The screenshots are hosted from a separate proof-assets branch in my fork so proof images are not included in this PR diff.

![Groq AI proof 1](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/1.png)

![Groq AI proof 2](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/2.png)

![Groq AI proof 3](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/3.png)

![Groq AI proof 4](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/4.png)

![Groq AI proof 5](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/5.png)

![Groq AI proof 6](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/6.png)

![Groq AI proof 7](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/7.png)

![Groq AI proof 8](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/8.png)


![Groq AI reviewer fix proof](https://raw.githubusercontent.com/FiscalMindset/coral/groq-ai-pr-proof-assets/proof/groq_ai/9.png)
