### PR TITLE
feat(app): add keychain secret storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6021,13 +6021,12 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-native-keyring-store"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
 dependencies = [
  "byteorder",
  "keyring-core",
- "regex",
  "windows-sys 0.61.2",
  "zeroize",
 ]
@@ -6451,7 +6450,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6490,7 +6489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant",
 ]
 
@@ -6623,7 +6622,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.2",
+ "winnow 1.0.3",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -6651,5 +6650,5 @@ dependencies = [
  "quote",
  "serde",
  "syn",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,6 +128,17 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
 
 [[package]]
 name = "ar_archive_writer"
@@ -389,6 +411,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +445,102 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -457,7 +599,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.1",
  "percent-encoding",
@@ -697,6 +839,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,6 +936,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +999,16 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -922,6 +1105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +1173,7 @@ dependencies = [
 name = "coral-app"
 version = "0.3.0"
 dependencies = [
+ "apple-native-keyring-store",
  "arrow",
  "axum",
  "base64",
@@ -992,6 +1185,7 @@ dependencies = [
  "coral-spec",
  "etcetera",
  "fs2",
+ "keyring-core",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
@@ -1018,6 +1212,8 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
 ]
 
 [[package]]
@@ -2160,6 +2356,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,6 +2406,27 @@ checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2335,6 +2579,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2513,6 +2770,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -2833,6 +3108,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2949,6 +3234,15 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -3136,6 +3430,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -3467,10 +3770,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3612,10 +3931,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3682,6 +4026,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -4399,6 +4752,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,6 +4858,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4881,6 +5264,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -5243,6 +5627,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicase"
@@ -5623,6 +6018,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -6014,6 +6422,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.2",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51fa5406ad9175a8c825a931f8cf347116b531b3634fcb0b627c290f1f2516ff"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.2",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6131,4 +6612,44 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.2",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d5b780599bbde114e39d9a0799577fad1ced5105d38515745f7b3099d8ceda"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d464f5733ffa07a3164d656f18533caace9d0638596721355d73256a410d691"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow 1.0.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,10 @@ glob = "0.3"
 http-body = "1"
 httpdate = "1.0.3"
 jsonschema = { version = "0.18", default-features = false }
+keyring-core = { version = "1.0.0", default-features = false }
+apple-native-keyring-store = { version = "1.0.0", default-features = false, features = ["keychain"] }
+windows-native-keyring-store = { version = "1.0.0", default-features = false }
+zbus-secret-service-keyring-store = { version = "1.0.0", default-features = false, features = ["rt-tokio-crypto-rust"] }
 object_store = { version = "0.13.2", features = ["aws"] }
 opentelemetry = "0.31.0"
 opentelemetry-appender-tracing = "0.31.0"

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -17,7 +17,8 @@ enum SourceOrigin {
 
 // Where an installed source's credential material is stored.
 enum SourceCredentialStorage {
-  // Credential storage was not specified, usually because the source is not installed.
+  // Credential storage was not specified, either because the source is not installed
+  // or because the installed source has no stored credential material.
   SOURCE_CREDENTIAL_STORAGE_UNSPECIFIED = 0;
   // Credential material is stored in Coral's local plaintext secrets file.
   SOURCE_CREDENTIAL_STORAGE_FILE = 1;

--- a/crates/coral-api/proto/coral/v1/sources.proto
+++ b/crates/coral-api/proto/coral/v1/sources.proto
@@ -15,6 +15,16 @@ enum SourceOrigin {
   SOURCE_ORIGIN_IMPORTED = 2;
 }
 
+// Where an installed source's credential material is stored.
+enum SourceCredentialStorage {
+  // Credential storage was not specified, usually because the source is not installed.
+  SOURCE_CREDENTIAL_STORAGE_UNSPECIFIED = 0;
+  // Credential material is stored in Coral's local plaintext secrets file.
+  SOURCE_CREDENTIAL_STORAGE_FILE = 1;
+  // Credential material is stored in the operating-system credential store.
+  SOURCE_CREDENTIAL_STORAGE_KEYCHAIN = 2;
+}
+
 // One configured non-secret source variable.
 message SourceVariable {
   // Logical variable key expected by the source manifest.
@@ -50,6 +60,8 @@ message Source {
   repeated SourceVariable variables = 5;
   // Where this installed source came from.
   SourceOrigin origin = 6;
+  // Where this installed source's credential material is stored.
+  SourceCredentialStorage credential_storage = 7;
 }
 
 // One manifest-declared source input prompt.
@@ -224,6 +236,8 @@ message SourceInfo {
   bool installed = 5;
   // Where this source came from.
   SourceOrigin origin = 6;
+  // Where credential material is stored when this source is installed.
+  SourceCredentialStorage credential_storage = 7;
 }
 
 // Lists all bundled sources available for one workspace.

--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -41,6 +41,12 @@ root.
   them into `config.toml`.
 - Bundled installs persist source identity plus configured variables and
   secrets, then resolve their manifest from the current binary at runtime.
+- Credential backend selection stays inside `credentials/`. Managers pass
+  explicit source credential-storage routes; CLI, MCP, source-spec, and engine
+  code must not know backend implementation details.
+- An installed source's persisted credential-storage route is authoritative.
+  A missing route is legacy file storage, not an instruction to re-run global
+  backend selection.
 - Source `name` is the canonical installed identifier and SQL schema name.
 - `coral-client::local` intentionally depends on `coral-app::ServerBuilder` for
   the explicit local bootstrap seam.

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -16,6 +16,7 @@ base64.workspace = true
 chrono.workspace = true
 etcetera.workspace = true
 fs2.workspace = true
+keyring-core.workspace = true
 opentelemetry.workspace = true
 opentelemetry-appender-tracing.workspace = true
 opentelemetry-otlp.workspace = true
@@ -45,6 +46,15 @@ coral-api.workspace = true
 coral-auth-aws = { path = "../auth/aws" }
 coral-engine.workspace = true
 coral-spec.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-native-keyring-store.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus-secret-service-keyring-store.workspace = true
 
 [dev-dependencies]
 coral-client.workspace = true

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -179,7 +179,9 @@ fn app_code(error: &AppError) -> Code {
         AppError::InvalidInput(_) => Code::InvalidArgument,
         AppError::FailedPrecondition(_)
         | AppError::MissingConfigDir
-        | AppError::Credentials(CredentialsError::Parse(_)) => Code::FailedPrecondition,
+        | AppError::Credentials(CredentialsError::Parse(_) | CredentialsError::Unavailable(_)) => {
+            Code::FailedPrecondition
+        }
         AppError::Io(error) if error.kind() == std::io::ErrorKind::NotFound => Code::NotFound,
         AppError::Io(_)
         | AppError::Yaml(_)

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -38,6 +38,7 @@ use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
 use crate::catalog::service::CatalogService;
+use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
 use crate::feedback::manager::FeedbackManager;
 use crate::feedback::publisher::{
@@ -261,7 +262,9 @@ impl ServerBuilder {
             internal_trace_store_dir.clone(),
         )?;
         let config_store = ConfigStore::new(layout.clone());
-        let credential_store = CredentialStore::new(layout.clone());
+        let credential_config = CredentialStorageConfig::load(&layout)?;
+        let credential_store =
+            CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
         let source_manager = SourceManager::new(
             config_store.clone(),

--- a/crates/coral-app/src/credentials/config.rs
+++ b/crates/coral-app/src/credentials/config.rs
@@ -1,0 +1,61 @@
+//! Credential storage configuration loaded from `config.toml`.
+
+use serde::Deserialize;
+
+use crate::bootstrap::AppError;
+use crate::state::AppStateLayout;
+
+use super::CredentialStoragePreference;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct CredentialStorageConfig {
+    pub(crate) storage: CredentialStoragePreference,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct CredentialStorageConfigFile {
+    #[serde(default)]
+    credentials: CredentialStorageConfigSection,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct CredentialStorageConfigSection {
+    #[serde(default)]
+    storage: CredentialStoragePreference,
+}
+
+impl CredentialStorageConfig {
+    pub(crate) fn load(layout: &AppStateLayout) -> Result<Self, AppError> {
+        if !layout.config_file().exists() {
+            return Ok(Self::default());
+        }
+        let raw = std::fs::read_to_string(layout.config_file())?;
+        let file = toml::from_str::<CredentialStorageConfigFile>(&raw)?;
+        Ok(Self {
+            storage: file.credentials.storage,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_auto_when_section_is_absent() {
+        let file = toml::from_str::<CredentialStorageConfigFile>("version = 1").expect("config");
+        assert_eq!(file.credentials.storage, CredentialStoragePreference::Auto);
+    }
+
+    #[test]
+    fn parses_configured_storage_preference() {
+        let file = toml::from_str::<CredentialStorageConfigFile>(
+            r#"
+[credentials]
+storage = "file"
+"#,
+        )
+        .expect("config");
+        assert_eq!(file.credentials.storage, CredentialStoragePreference::File);
+    }
+}

--- a/crates/coral-app/src/credentials/mod.rs
+++ b/crates/coral-app/src/credentials/mod.rs
@@ -1,5 +1,6 @@
 //! Internal credential-set identity and lifecycle helpers.
 
+pub(crate) mod config;
 pub(crate) mod oauth;
 mod store;
 
@@ -14,7 +15,63 @@ pub(crate) use store::{CredentialStore, CredentialsError};
 
 /// Opaque credential material captured for best-effort rollback.
 #[derive(Clone)]
-pub(crate) struct CredentialMaterialSnapshot(Option<Vec<u8>>);
+pub(crate) struct CredentialMaterialSnapshot {
+    storage: CredentialStorageKind,
+    material: Option<Vec<u8>>,
+}
+
+impl CredentialMaterialSnapshot {
+    fn new(storage: CredentialStorageKind, material: Option<Vec<u8>>) -> Self {
+        Self { storage, material }
+    }
+
+    fn storage(&self) -> CredentialStorageKind {
+        self.storage
+    }
+
+    fn material(&self) -> Option<&[u8]> {
+        self.material.as_deref()
+    }
+}
+
+/// Durable credential material storage backend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CredentialStorageKind {
+    File,
+    Keychain,
+}
+
+impl CredentialStorageKind {
+    pub(crate) fn as_config_value(self) -> &'static str {
+        match self {
+            Self::File => "file",
+            Self::Keychain => "keychain",
+        }
+    }
+}
+
+impl fmt::Display for CredentialStorageKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_config_value().fmt(f)
+    }
+}
+
+/// Configured storage preference for newly installed sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CredentialStoragePreference {
+    #[default]
+    Auto,
+    File,
+    Keychain,
+}
+
+/// Result of replacing credential material.
+pub(crate) struct CredentialWriteOutcome {
+    pub(crate) visible_keys: Vec<String>,
+    pub(crate) storage: CredentialStorageKind,
+}
 
 pub(crate) const CORAL_INTERNAL_KEY_PREFIX: &str = "__coral";
 pub(crate) const OAUTH_INTERNAL_KEY_PREFIX: &str = "__coral_oauth.";
@@ -35,7 +92,7 @@ impl CredentialSetId {
         Self(format!("source.{}", source_name.as_str()))
     }
 
-    pub(super) fn source_name(&self) -> Result<SourceName, AppError> {
+    pub(crate) fn source_name(&self) -> Result<SourceName, AppError> {
         let Some(source_name) = self.0.strip_prefix("source.") else {
             return Err(AppError::FailedPrecondition(format!(
                 "credential set '{}' is not source-backed",
@@ -67,28 +124,35 @@ impl CredentialManager {
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
         secrets: &BTreeMap<String, String>,
-    ) -> Result<Vec<String>, AppError> {
+    ) -> Result<CredentialWriteOutcome, AppError> {
         self.store
-            .replace_material(workspace_name, credential_set_id, secrets)?;
-        Ok(visible_material_keys(secrets))
+            .replace_material(workspace_name, credential_set_id, storage, secrets)?;
+        Ok(CredentialWriteOutcome {
+            visible_keys: visible_material_keys(secrets),
+            storage,
+        })
     }
 
     pub(crate) fn read_material(
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        self.store.read_material(workspace_name, credential_set_id)
+        self.store
+            .read_material(workspace_name, credential_set_id, storage)
     }
 
     pub(crate) fn snapshot_material(
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
     ) -> Result<CredentialMaterialSnapshot, AppError> {
         self.store
-            .snapshot_material(workspace_name, credential_set_id)
+            .snapshot_material(workspace_name, credential_set_id, storage)
     }
 
     pub(crate) fn restore_material(
@@ -105,9 +169,14 @@ impl CredentialManager {
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
     ) -> Result<(), AppError> {
         self.store
-            .remove_material(workspace_name, credential_set_id)
+            .remove_material(workspace_name, credential_set_id, storage)
+    }
+
+    pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, AppError> {
+        self.store.default_write_storage().map_err(Into::into)
     }
 }
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -304,9 +304,8 @@ fn keychain_route_unavailable(
 fn configured_keychain_unavailable(error: CredentialsError) -> CredentialsError {
     match error {
         CredentialsError::Unavailable(detail) => CredentialsError::Unavailable(format!(
-            "keychain credential storage is configured for new source secrets, \
-             but keychain is unavailable: {detail}. Set [credentials] storage = \"file\" \
-             to use plaintext file storage."
+            "keychain credential storage is configured, but keychain is unavailable: \
+             {detail}. Set [credentials] storage = \"file\" to use plaintext file storage."
         )),
         error => error,
     }

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -5,6 +5,8 @@ use std::io;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 
+use sha2::{Digest as _, Sha256};
+
 use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
 use crate::storage::fs as storage_fs;
@@ -43,6 +45,31 @@ impl EncodedCredentialMaterial {
 struct CredentialSetRef<'a> {
     workspace_name: &'a WorkspaceName,
     credential_set_id: &'a CredentialSetId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CredentialConfigNamespace(String);
+
+impl CredentialConfigNamespace {
+    fn from_layout(layout: &AppStateLayout) -> Self {
+        Self::from_config_dir(layout.config_dir())
+    }
+
+    fn from_config_dir(config_dir: &Path) -> Self {
+        let canonical = config_dir
+            .canonicalize()
+            .unwrap_or_else(|_| config_dir.to_path_buf())
+            .to_string_lossy()
+            .into_owned();
+        let digest = Sha256::digest(canonical.as_bytes());
+        let hex = format!("{digest:x}");
+        let short = hex.get(..16).unwrap_or(hex.as_str());
+        Self(format!("config-{short}"))
+    }
+
+    fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
 }
 
 trait CredentialMaterialBackend: Send + Sync {
@@ -92,10 +119,11 @@ impl CredentialStore {
         layout: AppStateLayout,
         preference: CredentialStoragePreference,
     ) -> Self {
+        let config_namespace = CredentialConfigNamespace::from_layout(&layout);
         Self {
             preference,
             file: Arc::new(FileCredentialBackend::new(layout)),
-            keychain: Arc::new(KeychainCredentialBackend::new()),
+            keychain: Arc::new(KeychainCredentialBackend::new(config_namespace)),
         }
     }
 
@@ -486,13 +514,15 @@ impl CredentialMaterialBackend for FileCredentialBackend {
 
 #[derive(Clone)]
 struct KeychainCredentialBackend {
+    config_namespace: CredentialConfigNamespace,
     native: Arc<OnceLock<Result<Arc<keyring_core::CredentialStore>, String>>>,
     probe: Arc<OnceLock<Result<(), String>>>,
 }
 
 impl KeychainCredentialBackend {
-    fn new() -> Self {
+    fn new(config_namespace: CredentialConfigNamespace) -> Self {
         Self {
+            config_namespace,
             native: Arc::new(OnceLock::new()),
             probe: Arc::new(OnceLock::new()),
         }
@@ -517,8 +547,12 @@ impl KeychainCredentialBackend {
 
     fn probe_entry(&self) -> Result<keyring_core::Entry, CredentialsError> {
         let account = format!("probe.{}.{}", std::process::id(), uuid::Uuid::new_v4());
+        let service = format!(
+            "com.withcoral.coral/{}/__probe__",
+            self.config_namespace.as_str()
+        );
         self.native_store()?
-            .build("com.withcoral.coral/__probe__", &account, None)
+            .build(&service, &account, None)
             .map_err(|error| keychain_error(&error))
     }
 
@@ -575,7 +609,7 @@ impl CredentialMaterialBackend for KeychainCredentialBackend {
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<Option<EncodedCredentialMaterial>, CredentialsError> {
-        let entry = KeychainEntryAddress::from_set(set);
+        let entry = KeychainEntryAddress::from_set(&self.config_namespace, set);
         self.run_native(move |backend| {
             backend.probe_native()?;
             match backend
@@ -594,7 +628,7 @@ impl CredentialMaterialBackend for KeychainCredentialBackend {
         set: &CredentialSetRef<'_>,
         material: Option<&EncodedCredentialMaterial>,
     ) -> Result<(), CredentialsError> {
-        let entry = KeychainEntryAddress::from_set(set);
+        let entry = KeychainEntryAddress::from_set(&self.config_namespace, set);
         let value = material
             .map(|material| {
                 std::str::from_utf8(material.bytes())
@@ -625,7 +659,7 @@ impl CredentialMaterialBackend for KeychainCredentialBackend {
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
-        let entry = KeychainEntryAddress::from_set(set);
+        let entry = KeychainEntryAddress::from_set(&self.config_namespace, set);
         self.run_native(move |backend| {
             backend.probe_native()?;
             match backend
@@ -670,9 +704,13 @@ struct KeychainEntryAddress {
 }
 
 impl KeychainEntryAddress {
-    fn from_set(set: &CredentialSetRef<'_>) -> Self {
+    fn from_set(config_namespace: &CredentialConfigNamespace, set: &CredentialSetRef<'_>) -> Self {
         Self {
-            service: format!("com.withcoral.coral/{}", set.workspace_name.as_str()),
+            service: format!(
+                "com.withcoral.coral/{}/workspace/{}",
+                config_namespace.as_str(),
+                set.workspace_name.as_str()
+            ),
             account: set.credential_set_id.to_string(),
         }
     }
@@ -1080,6 +1118,63 @@ mod tests {
             *self.lock_material()? = snapshot.material().map(ToOwned::to_owned);
             Ok(())
         }
+    }
+
+    #[test]
+    fn keychain_address_namespaces_by_config_workspace_and_credential_set() {
+        let config_namespace = super::CredentialConfigNamespace("config-test".to_string());
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let set = CredentialSetRef {
+            workspace_name: &workspace_name,
+            credential_set_id: &credential_set_id,
+        };
+
+        let address = super::KeychainEntryAddress::from_set(&config_namespace, &set);
+
+        assert_eq!(
+            address.service,
+            "com.withcoral.coral/config-test/workspace/default"
+        );
+        assert_eq!(address.account, credential_set_id.to_string());
+    }
+
+    #[test]
+    fn config_namespace_separates_same_source_in_different_config_dirs() {
+        let temp = TempDir::new().expect("temp dir");
+        let first_dir = temp.path().join("first-config");
+        let second_dir = temp.path().join("second-config");
+        std::fs::create_dir_all(&first_dir).expect("first config dir");
+        std::fs::create_dir_all(&second_dir).expect("second config dir");
+        let first_namespace = super::CredentialConfigNamespace::from_config_dir(&first_dir);
+        let second_namespace = super::CredentialConfigNamespace::from_config_dir(&second_dir);
+        let workspace_name = WorkspaceName::parse("default").expect("workspace");
+        let source_name = SourceName::parse("github").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let set = CredentialSetRef {
+            workspace_name: &workspace_name,
+            credential_set_id: &credential_set_id,
+        };
+
+        let first = super::KeychainEntryAddress::from_set(&first_namespace, &set);
+        let second = super::KeychainEntryAddress::from_set(&second_namespace, &set);
+
+        assert_ne!(first.service, second.service);
+        assert_eq!(first.account, second.account);
+    }
+
+    #[test]
+    fn config_namespace_uses_canonical_config_dir() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("coral-config");
+        std::fs::create_dir_all(&config_dir).expect("config dir");
+        let equivalent = config_dir.join("..").join("coral-config");
+
+        assert_eq!(
+            super::CredentialConfigNamespace::from_config_dir(&config_dir),
+            super::CredentialConfigNamespace::from_config_dir(&equivalent)
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -65,7 +65,7 @@ impl CredentialConfigNamespace {
         let digest = hasher.finalize();
         let hex = format!("{digest:x}");
         let short = hex.get(..16).unwrap_or(hex.as_str());
-        Self(format!("config-{short}"))
+        Self(short.to_string())
     }
 
     fn as_str(&self) -> &str {
@@ -1144,7 +1144,7 @@ mod tests {
 
     #[test]
     fn keychain_address_namespaces_by_config_workspace_and_credential_set() {
-        let config_namespace = super::CredentialConfigNamespace("config-test".to_string());
+        let config_namespace = super::CredentialConfigNamespace("test".to_string());
         let workspace_name = WorkspaceName::parse("default").expect("workspace");
         let source_name = SourceName::parse("github").expect("source");
         let credential_set_id = CredentialSetId::for_source(&source_name);
@@ -1157,7 +1157,7 @@ mod tests {
 
         assert_eq!(
             address.service,
-            "com.withcoral.coral/config-test/workspace/default"
+            "com.withcoral.coral/test/workspace/default"
         );
         assert_eq!(address.account, credential_set_id.to_string());
     }

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -1,6 +1,7 @@
 //! Credential material persistence behind file and keychain storage backends.
 
 use std::collections::BTreeMap;
+use std::ffi::OsStr;
 use std::io;
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
@@ -58,10 +59,10 @@ impl CredentialConfigNamespace {
     fn from_config_dir(config_dir: &Path) -> Self {
         let canonical = config_dir
             .canonicalize()
-            .unwrap_or_else(|_| config_dir.to_path_buf())
-            .to_string_lossy()
-            .into_owned();
-        let digest = Sha256::digest(canonical.as_bytes());
+            .unwrap_or_else(|_| config_dir.to_path_buf());
+        let mut hasher = Sha256::new();
+        update_hasher_with_os_str(&mut hasher, canonical.as_os_str());
+        let digest = hasher.finalize();
         let hex = format!("{digest:x}");
         let short = hex.get(..16).unwrap_or(hex.as_str());
         Self(format!("config-{short}"))
@@ -70,6 +71,27 @@ impl CredentialConfigNamespace {
     fn as_str(&self) -> &str {
         self.0.as_str()
     }
+}
+
+#[cfg(unix)]
+fn update_hasher_with_os_str(hasher: &mut Sha256, value: &OsStr) {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    hasher.update(value.as_bytes());
+}
+
+#[cfg(windows)]
+fn update_hasher_with_os_str(hasher: &mut Sha256, value: &OsStr) {
+    use std::os::windows::ffi::OsStrExt as _;
+
+    for unit in value.encode_wide() {
+        hasher.update(unit.to_le_bytes());
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn update_hasher_with_os_str(hasher: &mut Sha256, value: &OsStr) {
+    hasher.update(value.to_string_lossy().as_bytes());
 }
 
 trait CredentialMaterialBackend: Send + Sync {
@@ -1174,6 +1196,26 @@ mod tests {
         assert_eq!(
             super::CredentialConfigNamespace::from_config_dir(&config_dir),
             super::CredentialConfigNamespace::from_config_dir(&equivalent)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_namespace_hashes_non_utf8_config_dir_losslessly() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt as _;
+
+        let temp = TempDir::new().expect("temp dir");
+        let first_dir = temp
+            .path()
+            .join(OsString::from_vec(b"coral-config-\xff".to_vec()));
+        let second_dir = temp
+            .path()
+            .join(OsString::from_vec(b"coral-config-\xfe".to_vec()));
+
+        assert_ne!(
+            super::CredentialConfigNamespace::from_config_dir(&first_dir),
+            super::CredentialConfigNamespace::from_config_dir(&second_dir)
         );
     }
 

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -1,8 +1,9 @@
-//! Plaintext credential material persistence under the app state directory.
+//! Credential material persistence behind file and keychain storage backends.
 
 use std::collections::BTreeMap;
 use std::io;
 use std::path::Path;
+use std::sync::{Arc, OnceLock};
 
 use crate::bootstrap::AppError;
 use crate::state::AppStateLayout;
@@ -10,37 +11,155 @@ use crate::storage::fs as storage_fs;
 use crate::storage::fs::FileLock;
 use crate::workspaces::WorkspaceName;
 
-use super::{CredentialMaterialSnapshot, CredentialSetId};
+use super::{
+    CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
+};
 
-/// Errors returned by the plaintext credential env-file helpers.
+/// Errors returned by credential material storage helpers.
 #[derive(Debug, thiserror::Error)]
 pub enum CredentialsError {
     #[error(transparent)]
     Io(#[from] io::Error),
-    #[error("invalid secrets env file: {0}")]
+    #[error("invalid credential material: {0}")]
     Parse(String),
+    #[error("credential storage unavailable: {0}")]
+    Unavailable(String),
+    #[error("credential snapshot storage mismatch: snapshot is {snapshot}, requested {requested}")]
+    SnapshotStorageMismatch {
+        snapshot: &'static str,
+        requested: &'static str,
+    },
+}
+
+#[derive(Clone)]
+struct EncodedCredentialMaterial(Vec<u8>);
+
+impl EncodedCredentialMaterial {
+    fn bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+struct CredentialSetRef<'a> {
+    workspace_name: &'a WorkspaceName,
+    credential_set_id: &'a CredentialSetId,
+}
+
+trait CredentialMaterialBackend: Send + Sync {
+    fn kind(&self) -> CredentialStorageKind;
+
+    fn probe(&self) -> Result<(), CredentialsError> {
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<Option<EncodedCredentialMaterial>, CredentialsError>;
+
+    fn write(
+        &self,
+        set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError>;
+
+    fn snapshot(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError>;
+
+    fn restore(
+        &self,
+        set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError>;
 }
 
 #[derive(Clone)]
 pub(crate) struct CredentialStore {
-    layout: AppStateLayout,
+    preference: CredentialStoragePreference,
+    file: Arc<dyn CredentialMaterialBackend>,
+    keychain: Arc<dyn CredentialMaterialBackend>,
 }
 
 impl CredentialStore {
+    #[cfg(test)]
     pub(crate) fn new(layout: AppStateLayout) -> Self {
-        Self { layout }
+        Self::with_preference(layout, CredentialStoragePreference::File)
+    }
+
+    pub(crate) fn with_preference(
+        layout: AppStateLayout,
+        preference: CredentialStoragePreference,
+    ) -> Self {
+        Self {
+            preference,
+            file: Arc::new(FileCredentialBackend::new(layout)),
+            keychain: Arc::new(KeychainCredentialBackend::new()),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_keychain_backend(
+        layout: AppStateLayout,
+        preference: CredentialStoragePreference,
+        keychain: Arc<dyn CredentialMaterialBackend>,
+    ) -> Self {
+        Self {
+            preference,
+            file: Arc::new(FileCredentialBackend::new(layout)),
+            keychain,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_unavailable_keychain_for_test(
+        layout: AppStateLayout,
+        preference: CredentialStoragePreference,
+    ) -> Self {
+        Self::with_keychain_backend(
+            layout,
+            preference,
+            Arc::new(TestKeychainBackend::unavailable()),
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_available_keychain_for_test(
+        layout: AppStateLayout,
+        preference: CredentialStoragePreference,
+    ) -> Self {
+        Self::with_keychain_backend(
+            layout,
+            preference,
+            Arc::new(TestKeychainBackend::available()),
+        )
     }
 
     pub(crate) fn replace_material(
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
         values: &BTreeMap<String, String>,
     ) -> Result<(), AppError> {
-        let path = self.material_file(workspace_name, credential_set_id)?;
-        tracing::trace!(%credential_set_id, "replacing credential material");
-        let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        save_values_unlocked(&path, values)?;
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        let backend = self.backend(storage);
+        tracing::trace!(%credential_set_id, %storage, "replacing credential material");
+        let encoded = if values.is_empty() {
+            None
+        } else {
+            Some(encode_values(storage, values)?)
+        };
+        contextualize_storage_error(
+            backend.write(&set, encoded.as_ref()),
+            "writing",
+            credential_set_id,
+            storage,
+        )?;
         Ok(())
     }
 
@@ -48,21 +167,43 @@ impl CredentialStore {
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        let path = self.material_file(workspace_name, credential_set_id)?;
-        tracing::trace!(%credential_set_id, "reading credential material");
-        load_file(&path).map_err(Into::into)
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "reading credential material");
+        let encoded = contextualize_storage_error(
+            self.backend(storage).read(&set),
+            "reading",
+            credential_set_id,
+            storage,
+        )?;
+        match encoded {
+            Some(encoded) => decode_values(storage, encoded.bytes()).map_err(Into::into),
+            None => Ok(BTreeMap::new()),
+        }
     }
 
     pub(crate) fn snapshot_material(
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
     ) -> Result<CredentialMaterialSnapshot, AppError> {
-        let path = self.material_file(workspace_name, credential_set_id)?;
-        tracing::trace!(%credential_set_id, "snapshotting credential material");
-        let _lock = FileLock::shared(self.layout.state_lock())?;
-        snapshot_file(&path).map_err(Into::into)
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "snapshotting credential material");
+        contextualize_storage_error(
+            self.backend(storage).snapshot(&set),
+            "snapshotting",
+            credential_set_id,
+            storage,
+        )
+        .map_err(Into::into)
     }
 
     pub(crate) fn restore_material(
@@ -71,10 +212,18 @@ impl CredentialStore {
         credential_set_id: &CredentialSetId,
         snapshot: &CredentialMaterialSnapshot,
     ) -> Result<(), AppError> {
-        let path = self.material_file(workspace_name, credential_set_id)?;
-        tracing::trace!(%credential_set_id, "restoring credential material");
-        let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        restore_snapshot_unlocked(&path, snapshot)?;
+        let storage = snapshot.storage();
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "restoring credential material");
+        contextualize_storage_error(
+            self.backend(storage).restore(&set, snapshot),
+            "restoring",
+            credential_set_id,
+            storage,
+        )?;
         Ok(())
     }
 
@@ -82,55 +231,493 @@ impl CredentialStore {
         &self,
         workspace_name: &WorkspaceName,
         credential_set_id: &CredentialSetId,
+        storage: CredentialStorageKind,
     ) -> Result<(), AppError> {
-        let path = self.material_file(workspace_name, credential_set_id)?;
-        tracing::trace!(%credential_set_id, "removing credential material");
-        let _lock = FileLock::exclusive(self.layout.state_lock())?;
-        remove_file_if_exists_unlocked(&path)?;
+        let set = CredentialSetRef {
+            workspace_name,
+            credential_set_id,
+        };
+        tracing::trace!(%credential_set_id, %storage, "removing credential material");
+        contextualize_storage_error(
+            self.backend(storage).write(&set, None),
+            "removing",
+            credential_set_id,
+            storage,
+        )?;
         Ok(())
+    }
+
+    pub(crate) fn default_write_storage(&self) -> Result<CredentialStorageKind, CredentialsError> {
+        match self.preference {
+            CredentialStoragePreference::File => Ok(CredentialStorageKind::File),
+            CredentialStoragePreference::Keychain => {
+                self.keychain
+                    .probe()
+                    .map_err(configured_keychain_unavailable)?;
+                Ok(CredentialStorageKind::Keychain)
+            }
+            CredentialStoragePreference::Auto => match self.keychain.probe() {
+                Ok(()) => Ok(CredentialStorageKind::Keychain),
+                Err(error) => {
+                    tracing::warn!(detail = %error, "keychain unavailable; using plaintext file credential storage");
+                    Ok(CredentialStorageKind::File)
+                }
+            },
+        }
+    }
+
+    fn backend(&self, storage: CredentialStorageKind) -> &dyn CredentialMaterialBackend {
+        match storage {
+            CredentialStorageKind::File => self.file.as_ref(),
+            CredentialStorageKind::Keychain => self.keychain.as_ref(),
+        }
+    }
+}
+
+fn contextualize_storage_error<T>(
+    result: Result<T, CredentialsError>,
+    operation: &'static str,
+    credential_set_id: &CredentialSetId,
+    storage: CredentialStorageKind,
+) -> Result<T, CredentialsError> {
+    if storage == CredentialStorageKind::Keychain {
+        result.map_err(|error| keychain_route_unavailable(error, operation, credential_set_id))
+    } else {
+        result
+    }
+}
+
+fn keychain_route_unavailable(
+    error: CredentialsError,
+    operation: &'static str,
+    credential_set_id: &CredentialSetId,
+) -> CredentialsError {
+    match error {
+        CredentialsError::Unavailable(detail) => CredentialsError::Unavailable(format!(
+            "source credential set '{credential_set_id}' is configured for keychain storage, \
+             but keychain is unavailable while {operation}: {detail}"
+        )),
+        error => error,
+    }
+}
+
+fn configured_keychain_unavailable(error: CredentialsError) -> CredentialsError {
+    match error {
+        CredentialsError::Unavailable(detail) => CredentialsError::Unavailable(format!(
+            "keychain credential storage is configured for new source secrets, \
+             but keychain is unavailable: {detail}. Set [credentials] storage = \"file\" \
+             to use plaintext file storage."
+        )),
+        error => error,
+    }
+}
+
+#[cfg(test)]
+struct TestKeychainBackend {
+    available: bool,
+    material: std::sync::Mutex<Option<Vec<u8>>>,
+}
+
+#[cfg(test)]
+impl TestKeychainBackend {
+    fn available() -> Self {
+        Self {
+            available: true,
+            material: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn unavailable() -> Self {
+        Self {
+            available: false,
+            material: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn lock_material(
+        &self,
+    ) -> Result<std::sync::MutexGuard<'_, Option<Vec<u8>>>, CredentialsError> {
+        self.material.lock().map_err(|error| {
+            CredentialsError::Unavailable(format!("test keychain lock poisoned: {error}"))
+        })
+    }
+}
+
+#[cfg(test)]
+impl CredentialMaterialBackend for TestKeychainBackend {
+    fn kind(&self) -> CredentialStorageKind {
+        CredentialStorageKind::Keychain
+    }
+
+    fn probe(&self) -> Result<(), CredentialsError> {
+        if self.available {
+            Ok(())
+        } else {
+            Err(CredentialsError::Unavailable(
+                "test keychain unavailable".to_string(),
+            ))
+        }
+    }
+
+    fn read(
+        &self,
+        _set: &CredentialSetRef<'_>,
+    ) -> Result<Option<EncodedCredentialMaterial>, CredentialsError> {
+        self.probe()?;
+        Ok(self.lock_material()?.clone().map(EncodedCredentialMaterial))
+    }
+
+    fn write(
+        &self,
+        _set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        self.probe()?;
+        *self.lock_material()? = material.map(|material| material.bytes().to_vec());
+        Ok(())
+    }
+
+    fn snapshot(
+        &self,
+        _set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        self.probe()?;
+        Ok(CredentialMaterialSnapshot::new(
+            self.kind(),
+            self.lock_material()?.clone(),
+        ))
+    }
+
+    fn restore(
+        &self,
+        _set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        self.probe()?;
+        *self.lock_material()? = snapshot.material().map(ToOwned::to_owned);
+        Ok(())
+    }
+}
+
+struct FileCredentialBackend {
+    layout: AppStateLayout,
+}
+
+impl FileCredentialBackend {
+    fn new(layout: AppStateLayout) -> Self {
+        Self { layout }
     }
 
     fn material_file(
         &self,
-        workspace_name: &WorkspaceName,
-        credential_set_id: &CredentialSetId,
-    ) -> Result<std::path::PathBuf, AppError> {
-        let source_name = credential_set_id.source_name()?;
-        Ok(self.layout.secret_file(workspace_name, &source_name))
+        set: &CredentialSetRef<'_>,
+    ) -> Result<std::path::PathBuf, CredentialsError> {
+        let source_name = set
+            .credential_set_id
+            .source_name()
+            .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+        Ok(self.layout.secret_file(set.workspace_name, &source_name))
     }
 }
 
+impl CredentialMaterialBackend for FileCredentialBackend {
+    fn kind(&self) -> CredentialStorageKind {
+        CredentialStorageKind::File
+    }
+
+    fn read(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<Option<EncodedCredentialMaterial>, CredentialsError> {
+        let path = self.material_file(set)?;
+        match std::fs::read(path) {
+            Ok(bytes) => Ok(Some(EncodedCredentialMaterial(bytes))),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn write(
+        &self,
+        set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        let path = self.material_file(set)?;
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        match material {
+            Some(material) => write_file_unlocked(&path, material.bytes()),
+            None => remove_file_if_exists_unlocked(&path).map_err(Into::into),
+        }
+    }
+
+    fn snapshot(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        let path = self.material_file(set)?;
+        let _lock = FileLock::shared(self.layout.state_lock())?;
+        match std::fs::read(path) {
+            Ok(bytes) => Ok(CredentialMaterialSnapshot::new(self.kind(), Some(bytes))),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                Ok(CredentialMaterialSnapshot::new(self.kind(), None))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn restore(
+        &self,
+        set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        if snapshot.storage() != self.kind() {
+            return Err(CredentialsError::SnapshotStorageMismatch {
+                snapshot: snapshot.storage().as_config_value(),
+                requested: self.kind().as_config_value(),
+            });
+        }
+        let path = self.material_file(set)?;
+        let _lock = FileLock::exclusive(self.layout.state_lock())?;
+        match snapshot.material() {
+            Some(bytes) => write_file_unlocked(&path, bytes),
+            None => remove_file_if_exists_unlocked(&path).map_err(Into::into),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct KeychainCredentialBackend {
+    native: Arc<OnceLock<Result<Arc<keyring_core::CredentialStore>, String>>>,
+    probe: Arc<OnceLock<Result<(), String>>>,
+}
+
+impl KeychainCredentialBackend {
+    fn new() -> Self {
+        Self {
+            native: Arc::new(OnceLock::new()),
+            probe: Arc::new(OnceLock::new()),
+        }
+    }
+
+    fn native_store(&self) -> Result<Arc<keyring_core::CredentialStore>, CredentialsError> {
+        match self.native.get_or_init(native_keychain_store) {
+            Ok(store) => Ok(Arc::clone(store)),
+            Err(error) => Err(CredentialsError::Unavailable(error.clone())),
+        }
+    }
+
+    fn entry(&self, set: &CredentialSetRef<'_>) -> Result<keyring_core::Entry, CredentialsError> {
+        let service = format!("com.withcoral.coral/{}", set.workspace_name.as_str());
+        let account = set.credential_set_id.to_string();
+        self.native_store()?
+            .build(&service, &account, None)
+            .map_err(|error| keychain_error(&error))
+    }
+
+    fn probe_entry(&self) -> Result<keyring_core::Entry, CredentialsError> {
+        let account = format!("probe.{}.{}", std::process::id(), uuid::Uuid::new_v4());
+        self.native_store()?
+            .build("com.withcoral.coral/__probe__", &account, None)
+            .map_err(|error| keychain_error(&error))
+    }
+
+    fn run_probe(&self) -> Result<(), CredentialsError> {
+        let entry = self.probe_entry()?;
+        entry
+            .set_password("ok")
+            .map_err(|error| keychain_error(&error))?;
+        let stored = entry
+            .get_password()
+            .map_err(|error| keychain_error(&error))?;
+        if stored != "ok" {
+            if let Err(error) = entry.delete_credential() {
+                tracing::warn!(detail = %error, "keychain probe cleanup failed");
+            }
+            return Err(CredentialsError::Unavailable(
+                "keychain probe read back unexpected value".to_string(),
+            ));
+        }
+        entry
+            .delete_credential()
+            .map_err(|error| keychain_error(&error))?;
+        Ok(())
+    }
+}
+
+impl CredentialMaterialBackend for KeychainCredentialBackend {
+    fn kind(&self) -> CredentialStorageKind {
+        CredentialStorageKind::Keychain
+    }
+
+    fn probe(&self) -> Result<(), CredentialsError> {
+        match self
+            .probe
+            .get_or_init(|| self.run_probe().map_err(|error| error.to_string()))
+        {
+            Ok(()) => Ok(()),
+            Err(error) => Err(CredentialsError::Unavailable(error.clone())),
+        }
+    }
+
+    fn read(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<Option<EncodedCredentialMaterial>, CredentialsError> {
+        self.probe()?;
+        match self.entry(set)?.get_password() {
+            Ok(value) => Ok(Some(EncodedCredentialMaterial(value.into_bytes()))),
+            Err(keyring_core::Error::NoEntry) => Ok(None),
+            Err(error) => Err(keychain_error(&error)),
+        }
+    }
+
+    fn write(
+        &self,
+        set: &CredentialSetRef<'_>,
+        material: Option<&EncodedCredentialMaterial>,
+    ) -> Result<(), CredentialsError> {
+        self.probe()?;
+        let entry = self.entry(set)?;
+        match material {
+            Some(material) => {
+                let value = std::str::from_utf8(material.bytes()).map_err(|error| {
+                    CredentialsError::Parse(format!(
+                        "keychain material is not valid UTF-8: {error}"
+                    ))
+                })?;
+                entry
+                    .set_password(value)
+                    .map_err(|error| keychain_error(&error))
+            }
+            None => match entry.delete_credential() {
+                Ok(()) | Err(keyring_core::Error::NoEntry) => Ok(()),
+                Err(error) => Err(keychain_error(&error)),
+            },
+        }
+    }
+
+    fn snapshot(
+        &self,
+        set: &CredentialSetRef<'_>,
+    ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
+        self.probe()?;
+        match self.entry(set)?.get_password() {
+            Ok(value) => Ok(CredentialMaterialSnapshot::new(
+                self.kind(),
+                Some(value.into_bytes()),
+            )),
+            Err(keyring_core::Error::NoEntry) => {
+                Ok(CredentialMaterialSnapshot::new(self.kind(), None))
+            }
+            Err(error) => Err(keychain_error(&error)),
+        }
+    }
+
+    fn restore(
+        &self,
+        set: &CredentialSetRef<'_>,
+        snapshot: &CredentialMaterialSnapshot,
+    ) -> Result<(), CredentialsError> {
+        if snapshot.storage() != self.kind() {
+            return Err(CredentialsError::SnapshotStorageMismatch {
+                snapshot: snapshot.storage().as_config_value(),
+                requested: self.kind().as_config_value(),
+            });
+        }
+        match snapshot.material() {
+            Some(bytes) => self.write(set, Some(&EncodedCredentialMaterial(bytes.to_vec()))),
+            None => self.write(set, None),
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn native_keychain_store() -> Result<Arc<keyring_core::CredentialStore>, String> {
+    apple_native_keyring_store::keychain::Store::new()
+        .map(|store| store as Arc<keyring_core::CredentialStore>)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(windows)]
+fn native_keychain_store() -> Result<Arc<keyring_core::CredentialStore>, String> {
+    windows_native_keyring_store::Store::new()
+        .map(|store| store as Arc<keyring_core::CredentialStore>)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn native_keychain_store() -> Result<Arc<keyring_core::CredentialStore>, String> {
+    zbus_secret_service_keyring_store::Store::new()
+        .map(|store| store as Arc<keyring_core::CredentialStore>)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(not(any(target_os = "macos", windows, target_os = "linux")))]
+fn native_keychain_store() -> Result<Arc<keyring_core::CredentialStore>, String> {
+    Err("native keychain storage is not supported on this platform".to_string())
+}
+
+fn keychain_error(error: &keyring_core::Error) -> CredentialsError {
+    CredentialsError::Unavailable(error.to_string())
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct KeychainMaterialDocument {
+    version: u32,
+    values: BTreeMap<String, String>,
+}
+
+fn encode_values(
+    storage: CredentialStorageKind,
+    values: &BTreeMap<String, String>,
+) -> Result<EncodedCredentialMaterial, CredentialsError> {
+    match storage {
+        CredentialStorageKind::File => Ok(EncodedCredentialMaterial(
+            render_env_file(values).into_bytes(),
+        )),
+        CredentialStorageKind::Keychain => {
+            let document = KeychainMaterialDocument {
+                version: 1,
+                values: values.clone(),
+            };
+            serde_json::to_vec(&document)
+                .map(EncodedCredentialMaterial)
+                .map_err(|error| CredentialsError::Parse(error.to_string()))
+        }
+    }
+}
+
+fn decode_values(
+    storage: CredentialStorageKind,
+    bytes: &[u8],
+) -> Result<BTreeMap<String, String>, CredentialsError> {
+    match storage {
+        CredentialStorageKind::File => {
+            let raw = std::str::from_utf8(bytes)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+            parse_env_file(raw)
+        }
+        CredentialStorageKind::Keychain => {
+            let document: KeychainMaterialDocument = serde_json::from_slice(bytes)
+                .map_err(|error| CredentialsError::Parse(error.to_string()))?;
+            if document.version != 1 {
+                return Err(CredentialsError::Parse(format!(
+                    "unsupported keychain credential material version {}",
+                    document.version
+                )));
+            }
+            Ok(document.values)
+        }
+    }
+}
+
+#[cfg(test)]
 fn load_file(path: &Path) -> Result<BTreeMap<String, String>, CredentialsError> {
     if !path.exists() {
         return Ok(BTreeMap::new());
     }
 
     parse_env_file(&std::fs::read_to_string(path)?)
-}
-
-fn snapshot_file(path: &Path) -> Result<CredentialMaterialSnapshot, CredentialsError> {
-    match std::fs::read(path) {
-        Ok(bytes) => Ok(CredentialMaterialSnapshot(Some(bytes))),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {
-            Ok(CredentialMaterialSnapshot(None))
-        }
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn restore_snapshot_unlocked(
-    path: &Path,
-    snapshot: &CredentialMaterialSnapshot,
-) -> Result<(), CredentialsError> {
-    match &snapshot.0 {
-        Some(bytes) => {
-            let parent = path.parent().unwrap_or_else(|| Path::new("."));
-            storage_fs::ensure_dir(parent)?;
-            storage_fs::write_atomic(path, bytes)?;
-        }
-        None => remove_file_if_exists_unlocked(path)?,
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -143,6 +730,7 @@ fn save_file(
     save_values_unlocked(path, values)
 }
 
+#[cfg(test)]
 fn save_values_unlocked(
     path: &Path,
     values: &BTreeMap<String, String>,
@@ -152,9 +740,17 @@ fn save_values_unlocked(
         return Ok(());
     }
 
+    write_file_unlocked(path, render_env_file(values).as_bytes())
+}
+
+fn write_file_unlocked(path: &Path, bytes: &[u8]) -> Result<(), CredentialsError> {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     storage_fs::ensure_dir(parent)?;
+    storage_fs::write_atomic(path, bytes)?;
+    Ok(())
+}
 
+fn render_env_file(values: &BTreeMap<String, String>) -> String {
     let mut output = String::new();
     for (env_var, value) in values {
         output.push_str(env_var);
@@ -162,9 +758,7 @@ fn save_values_unlocked(
         output.push_str(&encode_env_value(value));
         output.push('\n');
     }
-
-    storage_fs::write_atomic(path, output.as_bytes())?;
-    Ok(())
+    output
 }
 
 fn remove_file_if_exists_unlocked(path: &Path) -> Result<(), io::Error> {
@@ -286,13 +880,108 @@ fn encode_env_value(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::sync::{Arc, Mutex};
 
+    use super::{CredentialMaterialBackend, CredentialSetRef, EncodedCredentialMaterial};
     use super::{CredentialStore, decode_env_value, encode_env_value, load_file, save_file};
-    use crate::credentials::CredentialSetId;
+    use crate::credentials::{
+        CredentialMaterialSnapshot, CredentialSetId, CredentialStorageKind,
+        CredentialStoragePreference,
+    };
     use crate::sources::SourceName;
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
     use tempfile::TempDir;
+
+    struct FakeKeychainBackend {
+        probe_ok: bool,
+        material: Mutex<Option<Vec<u8>>>,
+    }
+
+    impl FakeKeychainBackend {
+        fn available() -> Arc<Self> {
+            Arc::new(Self {
+                probe_ok: true,
+                material: Mutex::new(None),
+            })
+        }
+
+        fn unavailable() -> Arc<Self> {
+            Arc::new(Self {
+                probe_ok: false,
+                material: Mutex::new(None),
+            })
+        }
+
+        fn material_bytes(&self) -> Option<Vec<u8>> {
+            self.material.lock().expect("material lock").clone()
+        }
+
+        fn lock_material(
+            &self,
+        ) -> Result<std::sync::MutexGuard<'_, Option<Vec<u8>>>, super::CredentialsError> {
+            self.material.lock().map_err(|error| {
+                super::CredentialsError::Unavailable(format!(
+                    "fake keychain lock poisoned: {error}"
+                ))
+            })
+        }
+    }
+
+    impl CredentialMaterialBackend for FakeKeychainBackend {
+        fn kind(&self) -> CredentialStorageKind {
+            CredentialStorageKind::Keychain
+        }
+
+        fn probe(&self) -> Result<(), super::CredentialsError> {
+            if self.probe_ok {
+                Ok(())
+            } else {
+                Err(super::CredentialsError::Unavailable(
+                    "fake keychain unavailable".to_string(),
+                ))
+            }
+        }
+
+        fn read(
+            &self,
+            _set: &CredentialSetRef<'_>,
+        ) -> Result<Option<EncodedCredentialMaterial>, super::CredentialsError> {
+            self.probe()?;
+            Ok(self.lock_material()?.clone().map(EncodedCredentialMaterial))
+        }
+
+        fn write(
+            &self,
+            _set: &CredentialSetRef<'_>,
+            material: Option<&EncodedCredentialMaterial>,
+        ) -> Result<(), super::CredentialsError> {
+            self.probe()?;
+            *self.lock_material()? = material.map(|material| material.bytes().to_vec());
+            Ok(())
+        }
+
+        fn snapshot(
+            &self,
+            _set: &CredentialSetRef<'_>,
+        ) -> Result<CredentialMaterialSnapshot, super::CredentialsError> {
+            self.probe()?;
+            Ok(CredentialMaterialSnapshot::new(
+                self.kind(),
+                self.lock_material()?.clone(),
+            ))
+        }
+
+        fn restore(
+            &self,
+            _set: &CredentialSetRef<'_>,
+            snapshot: &CredentialMaterialSnapshot,
+        ) -> Result<(), super::CredentialsError> {
+            self.probe()?;
+            *self.lock_material()? = snapshot.material().map(ToOwned::to_owned);
+            Ok(())
+        }
+    }
 
     #[test]
     fn round_trips_encoded_secret_values() {
@@ -328,13 +1017,23 @@ mod tests {
 
         let values = BTreeMap::from([("API_TOKEN".to_string(), "secret-token".to_string())]);
         store
-            .replace_material(&workspace_name, &credential_set_id, &values)
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &values,
+            )
             .expect("replace malformed material");
         assert_eq!(load_file(&path).expect("load replaced material"), values);
 
         std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
         store
-            .replace_material(&workspace_name, &credential_set_id, &BTreeMap::new())
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &BTreeMap::new(),
+            )
             .expect("remove malformed material");
         assert!(!path.exists(), "empty replacement should remove material");
     }
@@ -352,18 +1051,30 @@ mod tests {
         let path = layout.secret_file(&workspace_name, &source_name);
 
         store
-            .remove_material(&workspace_name, &credential_set_id)
+            .remove_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("missing material should be removable");
 
         std::fs::create_dir_all(path.parent().expect("secret parent")).expect("secret parent dir");
         std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
         store
-            .remove_material(&workspace_name, &credential_set_id)
+            .remove_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("malformed material should be removable");
         assert!(!path.exists(), "remove should delete material");
 
         store
-            .remove_material(&workspace_name, &credential_set_id)
+            .remove_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("second remove should still be successful");
     }
 
@@ -382,11 +1093,20 @@ mod tests {
         std::fs::write(&path, "BROKEN\n").expect("write malformed existing env file");
 
         let snapshot = store
-            .snapshot_material(&workspace_name, &credential_set_id)
+            .snapshot_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("snapshot malformed material");
         let values = BTreeMap::from([("API_TOKEN".to_string(), "secret-token".to_string())]);
         store
-            .replace_material(&workspace_name, &credential_set_id, &values)
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::File,
+                &values,
+            )
             .expect("replace material");
 
         store
@@ -395,6 +1115,147 @@ mod tests {
         assert_eq!(
             std::fs::read(&path).expect("restored bytes"),
             b"BROKEN\n".to_vec()
+        );
+    }
+
+    #[test]
+    fn auto_prefers_keychain_when_probe_succeeds() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let keychain = FakeKeychainBackend::available();
+        let store = CredentialStore::with_keychain_backend(
+            layout,
+            CredentialStoragePreference::Auto,
+            keychain.clone(),
+        );
+        assert_eq!(
+            store.default_write_storage().expect("storage"),
+            CredentialStorageKind::Keychain
+        );
+    }
+
+    #[test]
+    fn auto_falls_back_to_file_when_keychain_probe_fails() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let store = CredentialStore::with_keychain_backend(
+            layout,
+            CredentialStoragePreference::Auto,
+            FakeKeychainBackend::unavailable(),
+        );
+        assert_eq!(
+            store.default_write_storage().expect("storage"),
+            CredentialStorageKind::File
+        );
+    }
+
+    #[test]
+    fn explicit_file_uses_file_even_when_keychain_probe_fails() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let store = CredentialStore::with_keychain_backend(
+            layout,
+            CredentialStoragePreference::File,
+            FakeKeychainBackend::unavailable(),
+        );
+        assert_eq!(
+            store.default_write_storage().expect("storage"),
+            CredentialStorageKind::File
+        );
+    }
+
+    #[test]
+    fn explicit_keychain_fails_when_probe_fails() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let store = CredentialStore::with_keychain_backend(
+            layout,
+            CredentialStoragePreference::Keychain,
+            FakeKeychainBackend::unavailable(),
+        );
+        let error = store
+            .default_write_storage()
+            .expect_err("explicit keychain should fail");
+        assert!(
+            matches!(error, super::CredentialsError::Unavailable(_)),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error.to_string().contains("storage = \"file\""),
+            "explicit keychain failure should include file-storage hint: {error}"
+        );
+    }
+
+    #[test]
+    fn keychain_backend_stores_one_versioned_document() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let keychain = FakeKeychainBackend::available();
+        let store = CredentialStore::with_keychain_backend(
+            layout,
+            CredentialStoragePreference::Keychain,
+            keychain.clone(),
+        );
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+        let values = BTreeMap::from([
+            ("API_TOKEN".to_string(), "secret-token".to_string()),
+            (
+                "__coral_oauth.QVBJX1RPS0VO.method".to_string(),
+                "oauth".to_string(),
+            ),
+        ]);
+
+        store
+            .replace_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+                &values,
+            )
+            .expect("write keychain material");
+
+        let raw = keychain.material_bytes().expect("keychain blob");
+        let document: serde_json::Value = serde_json::from_slice(&raw).expect("json");
+        assert_eq!(document.get("version"), Some(&serde_json::json!(1)));
+        assert_eq!(
+            document
+                .get("values")
+                .and_then(|values| values.get("API_TOKEN")),
+            Some(&serde_json::json!("secret-token"))
+        );
+        assert_eq!(
+            store
+                .read_material(
+                    &workspace_name,
+                    &credential_set_id,
+                    CredentialStorageKind::Keychain,
+                )
+                .expect("read keychain material"),
+            values
+        );
+
+        store
+            .remove_material(
+                &workspace_name,
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+            )
+            .expect("remove keychain material");
+        assert!(
+            keychain.material_bytes().is_none(),
+            "remove should delete the stored keychain document"
         );
     }
 }

--- a/crates/coral-app/src/credentials/store.rs
+++ b/crates/coral-app/src/credentials/store.rs
@@ -506,11 +506,13 @@ impl KeychainCredentialBackend {
         }
     }
 
-    fn entry(&self, set: &CredentialSetRef<'_>) -> Result<keyring_core::Entry, CredentialsError> {
-        let service = format!("com.withcoral.coral/{}", set.workspace_name.as_str());
-        let account = set.credential_set_id.to_string();
+    fn entry_for(
+        &self,
+        service: &str,
+        account: &str,
+    ) -> Result<keyring_core::Entry, CredentialsError> {
         self.native_store()?
-            .build(&service, &account, None)
+            .build(service, account, None)
             .map_err(|error| keychain_error(&error))
     }
 
@@ -519,6 +521,23 @@ impl KeychainCredentialBackend {
         self.native_store()?
             .build("com.withcoral.coral/__probe__", &account, None)
             .map_err(|error| keychain_error(&error))
+    }
+
+    fn run_native<T, F>(&self, operation: F) -> Result<T, CredentialsError>
+    where
+        T: Send + 'static,
+        F: FnOnce(Self) -> Result<T, CredentialsError> + Send + 'static,
+    {
+        run_native_keychain(self.clone(), operation)
+    }
+
+    fn probe_native(&self) -> Result<(), CredentialsError> {
+        match self.probe.get_or_init(|| {
+            catch_native_keychain_panic(|| self.run_probe()).map_err(|error| error.to_string())
+        }) {
+            Ok(()) => Ok(()),
+            Err(error) => Err(CredentialsError::Unavailable(error.clone())),
+        }
     }
 
     fn run_probe(&self) -> Result<(), CredentialsError> {
@@ -550,25 +569,25 @@ impl CredentialMaterialBackend for KeychainCredentialBackend {
     }
 
     fn probe(&self) -> Result<(), CredentialsError> {
-        match self
-            .probe
-            .get_or_init(|| self.run_probe().map_err(|error| error.to_string()))
-        {
-            Ok(()) => Ok(()),
-            Err(error) => Err(CredentialsError::Unavailable(error.clone())),
-        }
+        self.run_native(|backend| backend.probe_native())
     }
 
     fn read(
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<Option<EncodedCredentialMaterial>, CredentialsError> {
-        self.probe()?;
-        match self.entry(set)?.get_password() {
-            Ok(value) => Ok(Some(EncodedCredentialMaterial(value.into_bytes()))),
-            Err(keyring_core::Error::NoEntry) => Ok(None),
-            Err(error) => Err(keychain_error(&error)),
-        }
+        let entry = KeychainEntryAddress::from_set(set);
+        self.run_native(move |backend| {
+            backend.probe_native()?;
+            match backend
+                .entry_for(&entry.service, &entry.account)?
+                .get_password()
+            {
+                Ok(value) => Ok(Some(EncodedCredentialMaterial(value.into_bytes()))),
+                Err(keyring_core::Error::NoEntry) => Ok(None),
+                Err(error) => Err(keychain_error(&error)),
+            }
+        })
     }
 
     fn write(
@@ -576,41 +595,55 @@ impl CredentialMaterialBackend for KeychainCredentialBackend {
         set: &CredentialSetRef<'_>,
         material: Option<&EncodedCredentialMaterial>,
     ) -> Result<(), CredentialsError> {
-        self.probe()?;
-        let entry = self.entry(set)?;
-        match material {
-            Some(material) => {
-                let value = std::str::from_utf8(material.bytes()).map_err(|error| {
-                    CredentialsError::Parse(format!(
-                        "keychain material is not valid UTF-8: {error}"
-                    ))
-                })?;
-                entry
-                    .set_password(value)
-                    .map_err(|error| keychain_error(&error))
+        let entry = KeychainEntryAddress::from_set(set);
+        let value = material
+            .map(|material| {
+                std::str::from_utf8(material.bytes())
+                    .map(ToOwned::to_owned)
+                    .map_err(|error| {
+                        CredentialsError::Parse(format!(
+                            "keychain material is not valid UTF-8: {error}"
+                        ))
+                    })
+            })
+            .transpose()?;
+        self.run_native(move |backend| {
+            backend.probe_native()?;
+            let entry = backend.entry_for(&entry.service, &entry.account)?;
+            match value {
+                Some(value) => entry
+                    .set_password(&value)
+                    .map_err(|error| keychain_error(&error)),
+                None => match entry.delete_credential() {
+                    Ok(()) | Err(keyring_core::Error::NoEntry) => Ok(()),
+                    Err(error) => Err(keychain_error(&error)),
+                },
             }
-            None => match entry.delete_credential() {
-                Ok(()) | Err(keyring_core::Error::NoEntry) => Ok(()),
-                Err(error) => Err(keychain_error(&error)),
-            },
-        }
+        })
     }
 
     fn snapshot(
         &self,
         set: &CredentialSetRef<'_>,
     ) -> Result<CredentialMaterialSnapshot, CredentialsError> {
-        self.probe()?;
-        match self.entry(set)?.get_password() {
-            Ok(value) => Ok(CredentialMaterialSnapshot::new(
-                self.kind(),
-                Some(value.into_bytes()),
-            )),
-            Err(keyring_core::Error::NoEntry) => {
-                Ok(CredentialMaterialSnapshot::new(self.kind(), None))
+        let entry = KeychainEntryAddress::from_set(set);
+        self.run_native(move |backend| {
+            backend.probe_native()?;
+            match backend
+                .entry_for(&entry.service, &entry.account)?
+                .get_password()
+            {
+                Ok(value) => Ok(CredentialMaterialSnapshot::new(
+                    CredentialStorageKind::Keychain,
+                    Some(value.into_bytes()),
+                )),
+                Err(keyring_core::Error::NoEntry) => Ok(CredentialMaterialSnapshot::new(
+                    CredentialStorageKind::Keychain,
+                    None,
+                )),
+                Err(error) => Err(keychain_error(&error)),
             }
-            Err(error) => Err(keychain_error(&error)),
-        }
+        })
     }
 
     fn restore(
@@ -629,6 +662,73 @@ impl CredentialMaterialBackend for KeychainCredentialBackend {
             None => self.write(set, None),
         }
     }
+}
+
+#[derive(Clone)]
+struct KeychainEntryAddress {
+    service: String,
+    account: String,
+}
+
+impl KeychainEntryAddress {
+    fn from_set(set: &CredentialSetRef<'_>) -> Self {
+        Self {
+            service: format!("com.withcoral.coral/{}", set.workspace_name.as_str()),
+            account: set.credential_set_id.to_string(),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn run_native_keychain<T, F>(
+    backend: KeychainCredentialBackend,
+    operation: F,
+) -> Result<T, CredentialsError>
+where
+    T: Send + 'static,
+    F: FnOnce(KeychainCredentialBackend) -> Result<T, CredentialsError> + Send + 'static,
+{
+    std::thread::Builder::new()
+        .name("coral-keychain".to_string())
+        .spawn(move || catch_native_keychain_panic(|| operation(backend)))
+        .map_err(|error| {
+            CredentialsError::Unavailable(format!(
+                "failed to start native keychain worker thread: {error}"
+            ))
+        })?
+        .join()
+        .unwrap_or_else(|payload| Err(native_keychain_panic_error(payload.as_ref())))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run_native_keychain<T, F>(
+    backend: KeychainCredentialBackend,
+    operation: F,
+) -> Result<T, CredentialsError>
+where
+    T: Send + 'static,
+    F: FnOnce(KeychainCredentialBackend) -> Result<T, CredentialsError> + Send + 'static,
+{
+    catch_native_keychain_panic(|| operation(backend))
+}
+
+fn catch_native_keychain_panic<T, F>(operation: F) -> Result<T, CredentialsError>
+where
+    F: FnOnce() -> Result<T, CredentialsError>,
+{
+    std::panic::catch_unwind(std::panic::AssertUnwindSafe(operation))
+        .unwrap_or_else(|payload| Err(native_keychain_panic_error(payload.as_ref())))
+}
+
+fn native_keychain_panic_error(payload: &(dyn std::any::Any + Send)) -> CredentialsError {
+    let message = if let Some(message) = payload.downcast_ref::<&'static str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
+    };
+    CredentialsError::Unavailable(format!("native keychain operation panicked: {message}"))
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -193,13 +193,17 @@ impl QueryManager {
         let installed = resolve_installed_manifest(workspace_name, source, &self.layout)?;
         let source_spec = installed.source_spec;
         validate_required_variables(source, source_spec.declared_inputs())?;
-        let credential_set_id = CredentialSetId::for_source(&source.name);
-        let credential_storage = source.effective_credential_storage();
-        let stored_secrets = self.credential_manager.read_material(
-            workspace_name,
-            &credential_set_id,
-            credential_storage,
-        )?;
+        let stored_secrets =
+            if let Some(credential_storage) = source.credential_storage_for_material() {
+                let credential_set_id = CredentialSetId::for_source(&source.name);
+                self.credential_manager.read_material(
+                    workspace_name,
+                    &credential_set_id,
+                    credential_storage,
+                )?
+            } else {
+                BTreeMap::new()
+            };
         let mut resolved_secrets = BTreeMap::new();
         let missing_secrets: Vec<String> = source_spec
             .required_secret_names()

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -15,7 +15,7 @@ use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{CredentialManager, CredentialSetId};
+use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
@@ -170,6 +170,9 @@ impl QueryManager {
         for source in catalog.workspace_sources(workspace_name) {
             match self.load_query_source(workspace_name, &source) {
                 Ok((query_source, _version)) => query_sources.push(query_source),
+                Err(error @ AppError::Credentials(CredentialsError::Unavailable(_))) => {
+                    return Err(error);
+                }
                 Err(error) => {
                     tracing::warn!(
                         source = %source.name,
@@ -191,9 +194,12 @@ impl QueryManager {
         let source_spec = installed.source_spec;
         validate_required_variables(source, source_spec.declared_inputs())?;
         let credential_set_id = CredentialSetId::for_source(&source.name);
-        let stored_secrets = self
-            .credential_manager
-            .read_material(workspace_name, &credential_set_id)?;
+        let credential_storage = source.effective_credential_storage();
+        let stored_secrets = self.credential_manager.read_material(
+            workspace_name,
+            &credential_set_id,
+            credential_storage,
+        )?;
         let mut resolved_secrets = BTreeMap::new();
         let missing_secrets: Vec<String> = source_spec
             .required_secret_names()
@@ -397,10 +403,13 @@ fn validate_required_variables(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
     use tempfile::TempDir;
 
     use super::*;
-    use crate::credentials::CredentialStore;
+    use crate::credentials::{CredentialStorageKind, CredentialStoragePreference, CredentialStore};
+    use crate::sources::model::SourceOrigin;
 
     struct QueryManagerFixture {
         _temp: TempDir,
@@ -441,5 +450,58 @@ mod tests {
             .http_body_capture_max_bytes
             .expect("body capture config");
         assert_eq!(config, 42);
+    }
+
+    #[test]
+    fn load_query_sources_fails_closed_for_unavailable_keychain_source() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let workspace_name = WorkspaceName::default();
+        let source_name = SourceName::parse("github").expect("source name");
+        config_store
+            .upsert_source(
+                &workspace_name,
+                InstalledSource {
+                    name: source_name,
+                    version: None,
+                    variables: BTreeMap::new(),
+                    secrets: vec!["GITHUB_TOKEN".to_string()],
+                    credential_storage: Some(CredentialStorageKind::Keychain),
+                    origin: SourceOrigin::Bundled,
+                },
+            )
+            .expect("persist source");
+        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let manager = QueryManager::new(
+            config_store,
+            CredentialManager::new(credential_store),
+            QueryRuntimeContext::default(),
+            layout,
+            Vec::new(),
+        );
+
+        let error = manager
+            .load_query_sources(&workspace_name)
+            .expect_err("unavailable keychain should fail closed");
+
+        assert!(
+            matches!(
+                error,
+                AppError::Credentials(CredentialsError::Unavailable(_))
+            ),
+            "unexpected error: {error:#}"
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("configured for keychain storage"),
+            "keychain-routed query failure should name the routed backend: {error}"
+        );
     }
 }

--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -80,6 +80,7 @@ pub(crate) fn resolve_installed_manifest(
         )));
     }
     candidate.installed = true;
+    candidate.credential_storage = Some(source.effective_credential_storage());
     Ok(InstalledSourceManifest {
         source_spec,
         candidate,
@@ -108,6 +109,7 @@ fn candidate_from_manifest(
         inputs: manifest.declared_inputs().to_vec(),
         installed,
         origin,
+        credential_storage: None,
     })
 }
 

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -9,7 +9,7 @@ use crate::credentials::oauth::{
 };
 use crate::credentials::{
     CORAL_INTERNAL_KEY_PREFIX, CredentialManager, CredentialMaterialSnapshot, CredentialSetId,
-    CredentialsError,
+    CredentialStorageKind, CredentialsError,
 };
 use crate::sources::SourceName;
 use crate::sources::catalog::{
@@ -132,6 +132,7 @@ struct PersistSourceRequest<'a> {
     manifest_yaml: Option<&'a str>,
     bindings: ValidatedBindings,
     origin: SourceOrigin,
+    credential_storage: CredentialStorageKind,
 }
 
 struct SourceRollbackState {
@@ -205,13 +206,22 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<CandidateSource>, AppError> {
-        let installed = self
-            .config_store
-            .list_workspace_sources(workspace_name)?
-            .into_iter()
-            .map(|source| source.name)
+        let installed_sources = self.config_store.list_workspace_sources(workspace_name)?;
+        let installed = installed_sources
+            .iter()
+            .map(|source| source.name.clone())
             .collect::<BTreeSet<_>>();
-        list_bundled_sources(&installed)
+        let installed_storage = installed_sources
+            .iter()
+            .map(|source| (source.name.clone(), source.effective_credential_storage()))
+            .collect::<BTreeMap<_, _>>();
+        let mut candidates = list_bundled_sources(&installed)?;
+        for candidate in &mut candidates {
+            if let Some(storage) = installed_storage.get(&candidate.name) {
+                candidate.credential_storage = Some(*storage);
+            }
+        }
+        Ok(candidates)
     }
 
     pub(crate) fn create_bundled_source(
@@ -221,11 +231,13 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
+        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
         let stored_material = self.source_material_for_validation(
             workspace_name,
             &candidate,
             &command.bindings,
             &BTreeSet::new(),
+            credential_storage,
         )?;
         let bindings = validate_bindings(&candidate, &command.bindings, &stored_material)?;
         self.persist_source(
@@ -235,6 +247,7 @@ impl SourceManager {
                 manifest_yaml: None,
                 bindings,
                 origin: SourceOrigin::Bundled,
+                credential_storage,
             },
         )
     }
@@ -247,6 +260,7 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
+        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
         let oauth_input_keys = command
             .oauth_credential_retrievals
             .iter()
@@ -257,6 +271,7 @@ impl SourceManager {
             &candidate,
             &command.bindings,
             &oauth_input_keys,
+            credential_storage,
         )?;
         let bindings = self
             .bindings_with_oauth_material(
@@ -274,6 +289,7 @@ impl SourceManager {
                 manifest_yaml: None,
                 bindings,
                 origin: SourceOrigin::Bundled,
+                credential_storage,
             },
         )
     }
@@ -286,11 +302,13 @@ impl SourceManager {
         let mut candidate =
             describe_manifest(&command.manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
         let stored_material = self.source_material_for_validation(
             workspace_name,
             &candidate,
             &command.bindings,
             &BTreeSet::new(),
+            credential_storage,
         )?;
         let bindings = validate_bindings(&candidate, &command.bindings, &stored_material)?;
         self.persist_source(
@@ -300,6 +318,7 @@ impl SourceManager {
                 manifest_yaml: Some(&command.manifest_yaml),
                 bindings,
                 origin: SourceOrigin::Imported,
+                credential_storage,
             },
         )
     }
@@ -313,6 +332,7 @@ impl SourceManager {
         let mut candidate =
             describe_manifest(&command.manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
+        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
         let oauth_input_keys = command
             .oauth_credential_retrievals
             .iter()
@@ -323,6 +343,7 @@ impl SourceManager {
             &candidate,
             &command.bindings,
             &oauth_input_keys,
+            credential_storage,
         )?;
         let bindings = self
             .bindings_with_oauth_material(
@@ -340,6 +361,7 @@ impl SourceManager {
                 manifest_yaml: Some(&command.manifest_yaml),
                 bindings,
                 origin: SourceOrigin::Imported,
+                credential_storage,
             },
         )
     }
@@ -353,6 +375,7 @@ impl SourceManager {
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
+        let credential_storage = stored.effective_credential_storage();
         let previous = SourceRollbackState {
             source: stored,
             manifest_yaml: match removed.origin {
@@ -361,25 +384,28 @@ impl SourceManager {
                     self.layout.manifest_file(workspace_name, source_name),
                 )?),
             },
-            credential_material: self
-                .credential_manager
-                .snapshot_material(workspace_name, &credential_set_id)?,
+            credential_material: self.credential_manager.snapshot_material(
+                workspace_name,
+                &credential_set_id,
+                credential_storage,
+            )?,
         };
-        if let Err(error) = self
-            .credential_manager
-            .remove_material(workspace_name, &credential_set_id)
-        {
-            self.restore_source_rollback_state(workspace_name, source_name, Some(previous));
+        if let Err(error) = self.credential_manager.remove_material(
+            workspace_name,
+            &credential_set_id,
+            credential_storage,
+        ) {
+            self.restore_source_rollback_state(workspace_name, source_name, Some(previous), None);
             return Err(error);
         }
         if source_dir.exists()
             && let Err(error) = std::fs::remove_dir_all(&source_dir)
         {
-            self.restore_source_rollback_state(workspace_name, source_name, Some(previous));
+            self.restore_source_rollback_state(workspace_name, source_name, Some(previous), None);
             return Err(error.into());
         }
         if let Err(error) = self.config_store.remove_source(workspace_name, source_name) {
-            self.restore_source_rollback_state(workspace_name, source_name, Some(previous));
+            self.restore_source_rollback_state(workspace_name, source_name, Some(previous), None);
             return Err(error);
         }
         cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
@@ -410,19 +436,24 @@ impl SourceManager {
         if let Err(error) =
             self.persist_manifest_artifact(workspace_name, &source_name, request.manifest_yaml)
         {
-            self.restore_source_rollback_state(workspace_name, &source_name, previous);
+            self.restore_source_rollback_state(workspace_name, &source_name, previous, None);
             return Err(error);
         }
 
         let credential_set_id = CredentialSetId::for_source(&source_name);
-        let mut credential_material = match self
-            .credential_manager
-            .read_material(workspace_name, &credential_set_id)
-        {
+        let mut credential_material = match self.credential_manager.read_material(
+            workspace_name,
+            &credential_set_id,
+            request.credential_storage,
+        ) {
             Ok(material) => material,
-            Err(AppError::Credentials(CredentialsError::Parse(_))) => BTreeMap::new(),
+            Err(AppError::Credentials(CredentialsError::Parse(_)))
+                if request.credential_storage == CredentialStorageKind::File =>
+            {
+                BTreeMap::new()
+            }
             Err(error) => {
-                self.restore_source_rollback_state(workspace_name, &source_name, previous);
+                self.restore_source_rollback_state(workspace_name, &source_name, previous, None);
                 return Err(error);
             }
         };
@@ -439,14 +470,20 @@ impl SourceManager {
             credential_material.retain(|key, _| !material_key_belongs_to_input(key, input_key));
         }
         credential_material.extend(request.bindings.secrets);
-        let persisted_secret_keys = match self.credential_manager.replace_material(
+        let credential_write = match self.credential_manager.replace_material(
             workspace_name,
             &credential_set_id,
+            request.credential_storage,
             &credential_material,
         ) {
-            Ok(secrets) => secrets,
+            Ok(outcome) => outcome,
             Err(error) => {
-                self.restore_source_rollback_state(workspace_name, &source_name, previous);
+                self.restore_source_rollback_state(
+                    workspace_name,
+                    &source_name,
+                    previous,
+                    Some(request.credential_storage),
+                );
                 return Err(error);
             }
         };
@@ -459,14 +496,20 @@ impl SourceManager {
             name: source_name.clone(),
             version: persisted_version,
             variables: request.bindings.variables,
-            secrets: persisted_secret_keys,
+            secrets: credential_write.visible_keys,
+            credential_storage: Some(credential_write.storage),
             origin: request.origin,
         };
         if let Err(error) = self
             .config_store
             .upsert_source(workspace_name, stored.clone())
         {
-            self.restore_source_rollback_state(workspace_name, &source_name, previous);
+            self.restore_source_rollback_state(
+                workspace_name,
+                &source_name,
+                previous,
+                Some(credential_write.storage),
+            );
             return Err(error);
         }
         let mut resolved = stored;
@@ -489,14 +532,20 @@ impl SourceManager {
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
+        credential_storage: CredentialStorageKind,
     ) -> Result<BTreeMap<String, String>, AppError> {
         let credential_set_id = CredentialSetId::for_source(source_name);
-        match self
-            .credential_manager
-            .read_material(workspace_name, &credential_set_id)
-        {
+        match self.credential_manager.read_material(
+            workspace_name,
+            &credential_set_id,
+            credential_storage,
+        ) {
             Ok(material) => Ok(material),
-            Err(AppError::Credentials(CredentialsError::Parse(_))) => Ok(BTreeMap::new()),
+            Err(AppError::Credentials(CredentialsError::Parse(_)))
+                if credential_storage == CredentialStorageKind::File =>
+            {
+                Ok(BTreeMap::new())
+            }
             Err(error) => Err(error),
         }
     }
@@ -507,6 +556,7 @@ impl SourceManager {
         candidate: &CandidateSource,
         bindings: &SourceBindings,
         filled_secret_keys: &BTreeSet<String>,
+        credential_storage: CredentialStorageKind,
     ) -> Result<BTreeMap<String, String>, AppError> {
         let supplied_secrets = collect_unique_secrets(&bindings.secrets)?;
         let needs_stored_material = candidate.inputs.iter().any(|input| {
@@ -516,9 +566,21 @@ impl SourceManager {
                 && !filled_secret_keys.contains(&input.key)
         });
         if needs_stored_material {
-            self.read_source_material(workspace_name, &candidate.name)
+            self.read_source_material(workspace_name, &candidate.name, credential_storage)
         } else {
             Ok(BTreeMap::new())
+        }
+    }
+
+    fn source_write_storage(
+        &self,
+        workspace_name: &WorkspaceName,
+        source_name: &SourceName,
+    ) -> Result<CredentialStorageKind, AppError> {
+        match self.config_store.get_source(workspace_name, source_name) {
+            Ok(source) => Ok(source.effective_credential_storage()),
+            Err(AppError::SourceNotFound(_)) => self.credential_manager.default_write_storage(),
+            Err(error) => Err(error),
         }
     }
 
@@ -658,9 +720,12 @@ impl SourceManager {
             Err(error) => return Err(error),
         };
         let credential_set_id = CredentialSetId::for_source(source_name);
-        let credential_material = self
-            .credential_manager
-            .snapshot_material(workspace_name, &credential_set_id)?;
+        let credential_storage = source.effective_credential_storage();
+        let credential_material = self.credential_manager.snapshot_material(
+            workspace_name,
+            &credential_set_id,
+            credential_storage,
+        )?;
         Ok(Some(SourceRollbackState {
             manifest_yaml: match source.origin {
                 SourceOrigin::Bundled => None,
@@ -678,6 +743,7 @@ impl SourceManager {
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
         previous: Option<SourceRollbackState>,
+        new_material_storage: Option<CredentialStorageKind>,
     ) {
         if let Some(previous) = previous {
             let manifest_path = self.layout.manifest_file(workspace_name, source_name);
@@ -721,9 +787,12 @@ impl SourceManager {
                 warn!("rollback: failed to remove source directory: {e}");
             }
             let credential_set_id = CredentialSetId::for_source(source_name);
-            if let Err(e) = self
-                .credential_manager
-                .remove_material(workspace_name, &credential_set_id)
+            if let Some(storage) = new_material_storage
+                && let Err(e) = self.credential_manager.remove_material(
+                    workspace_name,
+                    &credential_set_id,
+                    storage,
+                )
             {
                 warn!("rollback: failed to remove source credential material: {e}");
             }
@@ -1039,7 +1108,10 @@ mod tests {
         ImportSourceWithCredentialsEvent, PendingImportSourceWithCredentialsEvent, SourceBinding,
         SourceBindings, SourceManager, SourceOAuthCredentialRetrieval, normalize_binding_key,
     };
-    use crate::credentials::{CredentialManager, CredentialSetId, CredentialStore};
+    use crate::credentials::{
+        CredentialManager, CredentialSetId, CredentialStorageKind, CredentialStoragePreference,
+        CredentialStore,
+    };
     use crate::sources::SourceName;
     use crate::state::{AppStateLayout, ConfigStore};
     use crate::workspaces::WorkspaceName;
@@ -1266,6 +1338,76 @@ tables:
     }
 
     #[test]
+    fn import_new_source_uses_keychain_when_auto_probe_succeeds() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::with_available_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Auto,
+        );
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = SourceManager::new(config_store, credential_manager.clone(), layout.clone());
+        let source_name = SourceName::parse("secured_messages").expect("source");
+        let credential_set_id = CredentialSetId::for_source(&source_name);
+
+        let source = manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings {
+                        variables: vec![],
+                        secrets: vec![SourceBinding {
+                            key: "API_TOKEN".to_string(),
+                            value: "secret-token".to_string(),
+                        }],
+                    },
+                },
+            )
+            .expect("import source");
+
+        assert_eq!(
+            source.credential_storage,
+            Some(CredentialStorageKind::Keychain)
+        );
+        assert!(
+            !layout
+                .secret_file(&default_workspace(), &source_name)
+                .exists(),
+            "keychain-routed install should not create plaintext material"
+        );
+        let stored = credential_manager
+            .read_material(
+                &default_workspace(),
+                &credential_set_id,
+                CredentialStorageKind::Keychain,
+            )
+            .expect("read keychain material");
+        assert_eq!(
+            stored.get("API_TOKEN").map(String::as_str),
+            Some("secret-token")
+        );
+
+        manager
+            .delete_source(&default_workspace(), &source_name)
+            .expect("delete source");
+        assert!(
+            credential_manager
+                .read_material(
+                    &default_workspace(),
+                    &credential_set_id,
+                    CredentialStorageKind::Keychain,
+                )
+                .expect("read removed keychain material")
+                .is_empty(),
+            "delete should remove keychain-routed material"
+        );
+    }
+
+    #[test]
     fn import_replaces_malformed_existing_credential_material() {
         let temp = TempDir::new().expect("temp dir");
         let layout =
@@ -1382,6 +1524,7 @@ tables:
             .replace_material(
                 &default_workspace(),
                 &credential_set_id,
+                CredentialStorageKind::File,
                 &BTreeMap::from([
                     ("API_TOKEN".to_string(), "oauth-token".to_string()),
                     (
@@ -1404,7 +1547,11 @@ tables:
 
         assert_eq!(source.secrets, vec!["API_TOKEN"]);
         let material = credential_manager
-            .read_material(&default_workspace(), &credential_set_id)
+            .read_material(
+                &default_workspace(),
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("read material");
         assert_eq!(
             material.get("API_TOKEN").map(String::as_str),
@@ -1469,6 +1616,7 @@ tables:
             .replace_material(
                 &default_workspace(),
                 &credential_set_id,
+                CredentialStorageKind::File,
                 &BTreeMap::from([
                     ("API_TOKEN".to_string(), "oauth-token".to_string()),
                     (
@@ -1500,7 +1648,11 @@ tables:
             .expect("import source");
 
         let material = credential_manager
-            .read_material(&default_workspace(), &credential_set_id)
+            .read_material(
+                &default_workspace(),
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("read material");
         assert_eq!(
             material.get("API_TOKEN").map(String::as_str),
@@ -1585,7 +1737,11 @@ tables:
             Some("test-code")
         );
         let material = credential_manager
-            .read_material(&default_workspace(), &credential_set_id)
+            .read_material(
+                &default_workspace(),
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("read material");
         assert_eq!(
             material.get("API_TOKEN").map(String::as_str),
@@ -1659,7 +1815,11 @@ tables:
             "preflight validation should fail before OAuth retrieval starts"
         );
         let material = credential_manager
-            .read_material(&default_workspace(), &credential_set_id)
+            .read_material(
+                &default_workspace(),
+                &credential_set_id,
+                CredentialStorageKind::File,
+            )
             .expect("read material");
         assert_eq!(
             material.get("API_TOKEN").map(String::as_str),

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -132,13 +132,13 @@ struct PersistSourceRequest<'a> {
     manifest_yaml: Option<&'a str>,
     bindings: ValidatedBindings,
     origin: SourceOrigin,
-    credential_storage: CredentialStorageKind,
+    credential_storage: Option<CredentialStorageKind>,
 }
 
 struct SourceRollbackState {
     source: InstalledSource,
     manifest_yaml: Option<String>,
-    credential_material: CredentialMaterialSnapshot,
+    credential_material: Option<CredentialMaterialSnapshot>,
 }
 
 impl SourceManager {
@@ -213,7 +213,11 @@ impl SourceManager {
             .collect::<BTreeSet<_>>();
         let installed_storage = installed_sources
             .iter()
-            .map(|source| (source.name.clone(), source.effective_credential_storage()))
+            .filter_map(|source| {
+                source
+                    .credential_storage_for_material()
+                    .map(|storage| (source.name.clone(), storage))
+            })
             .collect::<BTreeMap<_, _>>();
         let mut candidates = list_bundled_sources(&installed)?;
         for candidate in &mut candidates {
@@ -231,15 +235,26 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
-        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
+        let validation_storage = self.source_validation_storage(
+            workspace_name,
+            &candidate,
+            &command.bindings,
+            &BTreeSet::new(),
+        )?;
         let stored_material = self.source_material_for_validation(
             workspace_name,
             &candidate,
             &command.bindings,
             &BTreeSet::new(),
-            credential_storage,
+            validation_storage,
         )?;
         let bindings = validate_bindings(&candidate, &command.bindings, &stored_material)?;
+        let credential_storage = self.source_persist_storage(
+            workspace_name,
+            &candidate.name,
+            &bindings,
+            !stored_material.is_empty(),
+        )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -260,19 +275,25 @@ impl SourceManager {
     ) -> Result<InstalledSource, AppError> {
         let bundled = load_bundled_source(&command.name)?;
         let candidate = self.describe_bundled_source(workspace_name, &bundled.manifest_yaml)?;
-        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
         let oauth_input_keys = command
             .oauth_credential_retrievals
             .iter()
             .map(|credential| credential.input_key.clone())
             .collect::<BTreeSet<_>>();
+        let validation_storage = self.source_validation_storage(
+            workspace_name,
+            &candidate,
+            &command.bindings,
+            &oauth_input_keys,
+        )?;
         let stored_material = self.source_material_for_validation(
             workspace_name,
             &candidate,
             &command.bindings,
             &oauth_input_keys,
-            credential_storage,
+            validation_storage,
         )?;
+        let has_stored_material = !stored_material.is_empty();
         let bindings = self
             .bindings_with_oauth_material(
                 &candidate,
@@ -282,6 +303,12 @@ impl SourceManager {
                 events,
             )
             .await?;
+        let credential_storage = self.source_persist_storage(
+            workspace_name,
+            &candidate.name,
+            &bindings,
+            has_stored_material,
+        )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -302,15 +329,26 @@ impl SourceManager {
         let mut candidate =
             describe_manifest(&command.manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
-        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
+        let validation_storage = self.source_validation_storage(
+            workspace_name,
+            &candidate,
+            &command.bindings,
+            &BTreeSet::new(),
+        )?;
         let stored_material = self.source_material_for_validation(
             workspace_name,
             &candidate,
             &command.bindings,
             &BTreeSet::new(),
-            credential_storage,
+            validation_storage,
         )?;
         let bindings = validate_bindings(&candidate, &command.bindings, &stored_material)?;
+        let credential_storage = self.source_persist_storage(
+            workspace_name,
+            &candidate.name,
+            &bindings,
+            !stored_material.is_empty(),
+        )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -332,19 +370,25 @@ impl SourceManager {
         let mut candidate =
             describe_manifest(&command.manifest_yaml, SourceOrigin::Imported, false)?;
         candidate.installed = self.source_exists(workspace_name, &candidate.name)?;
-        let credential_storage = self.source_write_storage(workspace_name, &candidate.name)?;
         let oauth_input_keys = command
             .oauth_credential_retrievals
             .iter()
             .map(|credential| credential.input_key.clone())
             .collect::<BTreeSet<_>>();
+        let validation_storage = self.source_validation_storage(
+            workspace_name,
+            &candidate,
+            &command.bindings,
+            &oauth_input_keys,
+        )?;
         let stored_material = self.source_material_for_validation(
             workspace_name,
             &candidate,
             &command.bindings,
             &oauth_input_keys,
-            credential_storage,
+            validation_storage,
         )?;
+        let has_stored_material = !stored_material.is_empty();
         let bindings = self
             .bindings_with_oauth_material(
                 &candidate,
@@ -354,6 +398,12 @@ impl SourceManager {
                 events,
             )
             .await?;
+        let credential_storage = self.source_persist_storage(
+            workspace_name,
+            &candidate.name,
+            &bindings,
+            has_stored_material,
+        )?;
         self.persist_source(
             workspace_name,
             PersistSourceRequest {
@@ -375,7 +425,16 @@ impl SourceManager {
         let removed = self.populate_source_version_or_keep(workspace_name, stored.clone());
         let source_dir = self.layout.source_dir(workspace_name, source_name);
         let credential_set_id = CredentialSetId::for_source(source_name);
-        let credential_storage = stored.effective_credential_storage();
+        let credential_storage = stored.credential_storage_for_material();
+        let credential_material = credential_storage
+            .map(|storage| {
+                self.credential_manager.snapshot_material(
+                    workspace_name,
+                    &credential_set_id,
+                    storage,
+                )
+            })
+            .transpose()?;
         let previous = SourceRollbackState {
             source: stored,
             manifest_yaml: match removed.origin {
@@ -384,17 +443,15 @@ impl SourceManager {
                     self.layout.manifest_file(workspace_name, source_name),
                 )?),
             },
-            credential_material: self.credential_manager.snapshot_material(
+            credential_material,
+        };
+        if let Some(credential_storage) = credential_storage
+            && let Err(error) = self.credential_manager.remove_material(
                 workspace_name,
                 &credential_set_id,
                 credential_storage,
-            )?,
-        };
-        if let Err(error) = self.credential_manager.remove_material(
-            workspace_name,
-            &credential_set_id,
-            credential_storage,
-        ) {
+            )
+        {
             self.restore_source_rollback_state(workspace_name, source_name, Some(previous), None);
             return Err(error);
         }
@@ -440,52 +497,69 @@ impl SourceManager {
             return Err(error);
         }
 
-        let credential_set_id = CredentialSetId::for_source(&source_name);
-        let mut credential_material = match self.credential_manager.read_material(
-            workspace_name,
-            &credential_set_id,
-            request.credential_storage,
-        ) {
-            Ok(material) => material,
-            Err(AppError::Credentials(CredentialsError::Parse(_)))
-                if request.credential_storage == CredentialStorageKind::File =>
-            {
-                BTreeMap::new()
+        let (visible_secret_keys, credential_storage) = if let Some(requested_storage) =
+            request.credential_storage
+        {
+            let credential_set_id = CredentialSetId::for_source(&source_name);
+            let mut credential_material = match self.credential_manager.read_material(
+                workspace_name,
+                &credential_set_id,
+                requested_storage,
+            ) {
+                Ok(material) => material,
+                Err(AppError::Credentials(CredentialsError::Parse(_)))
+                    if requested_storage == CredentialStorageKind::File =>
+                {
+                    BTreeMap::new()
+                }
+                Err(error) => {
+                    self.restore_source_rollback_state(
+                        workspace_name,
+                        &source_name,
+                        previous,
+                        None,
+                    );
+                    return Err(error);
+                }
+            };
+            let expected_secret_keys = request
+                .candidate
+                .inputs
+                .iter()
+                .filter(|input| input.kind == ManifestInputKind::Secret)
+                .map(|input| input.key.clone())
+                .collect::<BTreeSet<_>>();
+            credential_material
+                .retain(|key, _| material_key_belongs_to_source_secret(key, &expected_secret_keys));
+            for input_key in &request.bindings.replaced_oauth_inputs {
+                credential_material.retain(|key, _| !material_key_belongs_to_input(key, input_key));
             }
-            Err(error) => {
-                self.restore_source_rollback_state(workspace_name, &source_name, previous, None);
-                return Err(error);
-            }
-        };
-        let expected_secret_keys = request
-            .candidate
-            .inputs
-            .iter()
-            .filter(|input| input.kind == ManifestInputKind::Secret)
-            .map(|input| input.key.clone())
-            .collect::<BTreeSet<_>>();
-        credential_material
-            .retain(|key, _| material_key_belongs_to_source_secret(key, &expected_secret_keys));
-        for input_key in &request.bindings.replaced_oauth_inputs {
-            credential_material.retain(|key, _| !material_key_belongs_to_input(key, input_key));
-        }
-        credential_material.extend(request.bindings.secrets);
-        let credential_write = match self.credential_manager.replace_material(
-            workspace_name,
-            &credential_set_id,
-            request.credential_storage,
-            &credential_material,
-        ) {
-            Ok(outcome) => outcome,
-            Err(error) => {
-                self.restore_source_rollback_state(
-                    workspace_name,
-                    &source_name,
-                    previous,
-                    Some(request.credential_storage),
-                );
-                return Err(error);
-            }
+            credential_material.extend(request.bindings.secrets);
+            let credential_write = match self.credential_manager.replace_material(
+                workspace_name,
+                &credential_set_id,
+                requested_storage,
+                &credential_material,
+            ) {
+                Ok(outcome) => outcome,
+                Err(error) => {
+                    self.restore_source_rollback_state(
+                        workspace_name,
+                        &source_name,
+                        previous,
+                        Some(requested_storage),
+                    );
+                    return Err(error);
+                }
+            };
+            let credential_storage = if credential_write.visible_keys.is_empty() {
+                None
+            } else {
+                Some(credential_write.storage)
+            };
+            (credential_write.visible_keys, credential_storage)
+        } else {
+            (Vec::new(), None)
         };
 
         let persisted_version = match request.origin {
@@ -496,8 +570,8 @@ impl SourceManager {
             name: source_name.clone(),
             version: persisted_version,
             variables: request.bindings.variables,
-            secrets: credential_write.visible_keys,
-            credential_storage: Some(credential_write.storage),
+            secrets: visible_secret_keys,
+            credential_storage,
             origin: request.origin,
         };
         if let Err(error) = self
@@ -508,7 +582,7 @@ impl SourceManager {
                 workspace_name,
                 &source_name,
                 previous,
-                Some(credential_write.storage),
+                credential_storage,
             );
             return Err(error);
         }
@@ -556,30 +630,68 @@ impl SourceManager {
         candidate: &CandidateSource,
         bindings: &SourceBindings,
         filled_secret_keys: &BTreeSet<String>,
-        credential_storage: CredentialStorageKind,
+        credential_storage: Option<CredentialStorageKind>,
     ) -> Result<BTreeMap<String, String>, AppError> {
-        let supplied_secrets = collect_unique_secrets(&bindings.secrets)?;
-        let needs_stored_material = candidate.inputs.iter().any(|input| {
-            input.kind == ManifestInputKind::Secret
-                && input.required
-                && !supplied_secrets.contains_key(&input.key)
-                && !filled_secret_keys.contains(&input.key)
-        });
-        if needs_stored_material {
-            self.read_source_material(workspace_name, &candidate.name, credential_storage)
-        } else {
-            Ok(BTreeMap::new())
+        if !source_needs_stored_material_for_validation(candidate, bindings, filled_secret_keys)? {
+            return Ok(BTreeMap::new());
+        }
+
+        match credential_storage {
+            Some(credential_storage) => {
+                self.read_source_material(workspace_name, &candidate.name, credential_storage)
+            }
+            None => Ok(BTreeMap::new()),
         }
     }
 
-    fn source_write_storage(
+    fn source_validation_storage(
+        &self,
+        workspace_name: &WorkspaceName,
+        candidate: &CandidateSource,
+        bindings: &SourceBindings,
+        filled_secret_keys: &BTreeSet<String>,
+    ) -> Result<Option<CredentialStorageKind>, AppError> {
+        if !source_needs_stored_material_for_validation(candidate, bindings, filled_secret_keys)? {
+            return Ok(None);
+        }
+
+        match self
+            .config_store
+            .get_source(workspace_name, &candidate.name)
+        {
+            Ok(source) => Ok(source.credential_storage_for_material()),
+            Err(AppError::SourceNotFound(_))
+                if self
+                    .layout
+                    .secret_file(workspace_name, &candidate.name)
+                    .exists() =>
+            {
+                Ok(Some(CredentialStorageKind::File))
+            }
+            Err(AppError::SourceNotFound(_)) => Ok(None),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn source_persist_storage(
         &self,
         workspace_name: &WorkspaceName,
         source_name: &SourceName,
-    ) -> Result<CredentialStorageKind, AppError> {
+        bindings: &ValidatedBindings,
+        has_stored_material: bool,
+    ) -> Result<Option<CredentialStorageKind>, AppError> {
         match self.config_store.get_source(workspace_name, source_name) {
-            Ok(source) => Ok(source.effective_credential_storage()),
-            Err(AppError::SourceNotFound(_)) => self.credential_manager.default_write_storage(),
+            Ok(source) if !source.secrets.is_empty() => {
+                Ok(Some(source.effective_credential_storage()))
+            }
+            Ok(_) | Err(AppError::SourceNotFound(_))
+                if bindings.secrets.is_empty() && !has_stored_material =>
+            {
+                Ok(None)
+            }
+            Ok(_) | Err(AppError::SourceNotFound(_)) => {
+                self.credential_manager.default_write_storage().map(Some)
+            }
             Err(error) => Err(error),
         }
     }
@@ -720,12 +832,16 @@ impl SourceManager {
             Err(error) => return Err(error),
         };
         let credential_set_id = CredentialSetId::for_source(source_name);
-        let credential_storage = source.effective_credential_storage();
-        let credential_material = self.credential_manager.snapshot_material(
-            workspace_name,
-            &credential_set_id,
-            credential_storage,
-        )?;
+        let credential_material = source
+            .credential_storage_for_material()
+            .map(|credential_storage| {
+                self.credential_manager.snapshot_material(
+                    workspace_name,
+                    &credential_set_id,
+                    credential_storage,
+                )
+            })
+            .transpose()?;
         Ok(Some(SourceRollbackState {
             manifest_yaml: match source.origin {
                 SourceOrigin::Bundled => None,
@@ -766,12 +882,27 @@ impl SourceManager {
                 None => {}
             }
             let credential_set_id = CredentialSetId::for_source(source_name);
-            if let Err(e) = self.credential_manager.restore_material(
-                workspace_name,
-                &credential_set_id,
-                &previous.credential_material,
-            ) {
-                warn!("rollback: failed to restore source credential material: {e}");
+            match previous.credential_material {
+                Some(credential_material) => {
+                    if let Err(e) = self.credential_manager.restore_material(
+                        workspace_name,
+                        &credential_set_id,
+                        &credential_material,
+                    ) {
+                        warn!("rollback: failed to restore source credential material: {e}");
+                    }
+                }
+                None => {
+                    if let Some(storage) = new_material_storage
+                        && let Err(e) = self.credential_manager.remove_material(
+                            workspace_name,
+                            &credential_set_id,
+                            storage,
+                        )
+                    {
+                        warn!("rollback: failed to remove new source credential material: {e}");
+                    }
+                }
             }
             if let Err(e) = self
                 .config_store
@@ -918,6 +1049,20 @@ fn validate_bindings(
         replaced_oauth_inputs: secret_values.keys().cloned().collect(),
         secrets: secret_values,
     })
+}
+
+fn source_needs_stored_material_for_validation(
+    candidate: &CandidateSource,
+    bindings: &SourceBindings,
+    filled_secret_keys: &BTreeSet<String>,
+) -> Result<bool, AppError> {
+    let supplied_secrets = collect_unique_secrets(&bindings.secrets)?;
+    Ok(candidate.inputs.iter().any(|input| {
+        input.kind == ManifestInputKind::Secret
+            && input.required
+            && !supplied_secrets.contains_key(&input.key)
+            && !filled_secret_keys.contains(&input.key)
+    }))
 }
 
 fn material_key_belongs_to_source_secret(
@@ -1142,6 +1287,27 @@ auth:
 tables:
   - name: messages
     description: Secured messages
+    request:
+      method: GET
+      path: /messages
+    response: {}
+    columns:
+      - name: id
+        type: Utf8
+"#
+        .to_string()
+    }
+
+    fn manifest_without_secrets() -> String {
+        r#"
+name: public_messages
+version: 0.1.0
+dsl_version: 3
+backend: http
+base_url: "https://example.com"
+tables:
+  - name: messages
+    description: Public messages
     request:
       method: GET
       path: /messages
@@ -1404,6 +1570,79 @@ tables:
                 .expect("read removed keychain material")
                 .is_empty(),
             "delete should remove keychain-routed material"
+        );
+    }
+
+    #[test]
+    fn import_source_without_secret_material_does_not_probe_keychain() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = SourceManager::new(config_store, credential_manager, layout.clone());
+        let source_name = SourceName::parse("public_messages").expect("source");
+
+        let source = manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_without_secrets(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect("import source");
+
+        assert!(source.secrets.is_empty());
+        assert_eq!(source.credential_storage, None);
+        assert!(
+            !layout
+                .secret_file(&default_workspace(), &source_name)
+                .exists(),
+            "credential material should not be created for a source without secrets"
+        );
+        let config_raw =
+            std::fs::read_to_string(layout.config_file()).expect("read rendered config");
+        assert!(
+            !config_raw.contains("credential_storage"),
+            "source without credential material should not persist a storage route"
+        );
+    }
+
+    #[test]
+    fn import_missing_secret_does_not_probe_keychain_for_new_source() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        layout.ensure().expect("ensure layout");
+        let config_store = ConfigStore::new(layout.clone());
+        let credential_store = CredentialStore::with_unavailable_keychain_for_test(
+            layout.clone(),
+            CredentialStoragePreference::Keychain,
+        );
+        let credential_manager = CredentialManager::new(credential_store);
+        let manager = SourceManager::new(config_store, credential_manager, layout);
+
+        let error = manager
+            .import_source(
+                &default_workspace(),
+                &ImportSourceCommand {
+                    manifest_yaml: manifest_with_secret(),
+                    bindings: SourceBindings::default(),
+                },
+            )
+            .expect_err("missing required secret should fail validation");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing required source secret 'API_TOKEN'"),
+            "unexpected error: {error:#}"
         );
     }
 

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 use coral_spec::ManifestInputSpec;
 use serde::{Deserialize, Serialize};
 
+use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 
 /// App-owned description of a source candidate that can be installed.
@@ -16,6 +17,7 @@ pub(crate) struct CandidateSource {
     pub(crate) inputs: Vec<ManifestInputSpec>,
     pub(crate) installed: bool,
     pub(crate) origin: SourceOrigin,
+    pub(crate) credential_storage: Option<CredentialStorageKind>,
 }
 
 /// App-owned model for one source installed in a workspace.
@@ -35,8 +37,21 @@ pub(crate) struct InstalledSource {
     /// Logical secret keys referenced by this source.
     #[serde(default)]
     pub(crate) secrets: Vec<String>,
+    /// Storage backend that owns this source's credential material.
+    ///
+    /// `None` means a legacy pre-keychain install, which is treated as file
+    /// storage until the source is removed and re-added.
+    #[serde(default)]
+    pub(crate) credential_storage: Option<CredentialStorageKind>,
     /// Where this installed source came from.
     pub(crate) origin: SourceOrigin,
+}
+
+impl InstalledSource {
+    pub(crate) fn effective_credential_storage(&self) -> CredentialStorageKind {
+        self.credential_storage
+            .unwrap_or(CredentialStorageKind::File)
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/coral-app/src/sources/model.rs
+++ b/crates/coral-app/src/sources/model.rs
@@ -52,6 +52,14 @@ impl InstalledSource {
         self.credential_storage
             .unwrap_or(CredentialStorageKind::File)
     }
+
+    pub(crate) fn credential_storage_for_material(&self) -> Option<CredentialStorageKind> {
+        if self.secrets.is_empty() {
+            None
+        } else {
+            Some(self.effective_credential_storage())
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -493,7 +493,7 @@ fn create_bundled_source_with_o_auth_response_from_import_response(
 }
 
 fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSource) -> Source {
-    let credential_storage = source.effective_credential_storage();
+    let credential_storage = source.credential_storage_for_material();
     Source {
         workspace: Some(workspace_to_proto(workspace_name)),
         name: source.name.as_str().to_string(),
@@ -512,7 +512,7 @@ fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSo
             .map(|(key, value)| SourceVariable { key, value })
             .collect(),
         origin: proto_source_origin(source.origin) as i32,
-        credential_storage: proto_source_credential_storage(Some(credential_storage)) as i32,
+        credential_storage: proto_source_credential_storage(credential_storage) as i32,
     }
 }
 

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -16,9 +16,10 @@ use coral_api::v1::{
     OAuthCredentialEndpoints, OAuthCredentialInput, OAuthCredentialRetrieval, OAuthCredentialScope,
     OAuthCredentialScopes, OauthCredentialClientSecretTransport, OauthCredentialPkceMode,
     OauthCredentialRedirectUriPortMode, OauthCredentialScopeDelimiter, Source,
-    SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod, SourceInfo,
-    SourceInputSpec, SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput,
-    SourceVariable, SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
+    SourceConfigCredentialMethod, SourceCredential, SourceCredentialMethod,
+    SourceCredentialStorage as ProtoSourceCredentialStorage, SourceInfo, SourceInputSpec,
+    SourceOrigin as ProtoSourceOrigin, SourceSecret, SourceSecretInput, SourceVariable,
+    SourceVariableInput, ValidateSourceRequest, ValidateSourceResponse,
     create_bundled_source_with_o_auth_response, import_source_response,
     source_credential_method::Method as ProtoCredentialMethod,
     source_input_spec::Input as ProtoSourceInput,
@@ -31,6 +32,7 @@ use coral_spec::{
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
+use crate::credentials::CredentialStorageKind;
 use crate::query::manager::QueryManager;
 use crate::sources::SourceName;
 use crate::sources::manager::{
@@ -491,6 +493,7 @@ fn create_bundled_source_with_o_auth_response_from_import_response(
 }
 
 fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSource) -> Source {
+    let credential_storage = source.effective_credential_storage();
     Source {
         workspace: Some(workspace_to_proto(workspace_name)),
         name: source.name.as_str().to_string(),
@@ -509,6 +512,7 @@ fn installed_source_to_proto(workspace_name: &WorkspaceName, source: InstalledSo
             .map(|(key, value)| SourceVariable { key, value })
             .collect(),
         origin: proto_source_origin(source.origin) as i32,
+        credential_storage: proto_source_credential_storage(Some(credential_storage)) as i32,
     }
 }
 
@@ -516,6 +520,16 @@ fn proto_source_origin(origin: SourceOrigin) -> ProtoSourceOrigin {
     match origin {
         SourceOrigin::Bundled => ProtoSourceOrigin::Bundled,
         SourceOrigin::Imported => ProtoSourceOrigin::Imported,
+    }
+}
+
+fn proto_source_credential_storage(
+    storage: Option<CredentialStorageKind>,
+) -> ProtoSourceCredentialStorage {
+    match storage {
+        Some(CredentialStorageKind::File) => ProtoSourceCredentialStorage::File,
+        Some(CredentialStorageKind::Keychain) => ProtoSourceCredentialStorage::Keychain,
+        None => ProtoSourceCredentialStorage::Unspecified,
     }
 }
 
@@ -531,6 +545,7 @@ fn candidate_source_to_proto(source: CandidateSource) -> SourceInfo {
             .collect(),
         installed: source.installed,
         origin: proto_source_origin(source.origin) as i32,
+        credential_storage: proto_source_credential_storage(source.credential_storage) as i32,
     }
 }
 

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
 
 use crate::bootstrap::AppError;
+use crate::credentials::CredentialStorageKind;
 use crate::sources::SourceName;
 use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::AppStateLayout;
@@ -53,6 +54,8 @@ struct PersistedInstalledSource {
     variables: BTreeMap<String, String>,
     #[serde(default)]
     secrets: Vec<String>,
+    #[serde(default)]
+    credential_storage: Option<CredentialStorageKind>,
     origin: SourceOrigin,
 }
 
@@ -63,6 +66,7 @@ impl PersistedInstalledSource {
             version: self.version,
             variables: self.variables,
             secrets: self.secrets,
+            credential_storage: self.credential_storage,
             origin: self.origin,
         }
     }
@@ -74,6 +78,7 @@ impl From<&InstalledSource> for PersistedInstalledSource {
             version: value.version.clone(),
             variables: value.variables.clone(),
             secrets: value.secrets.clone(),
+            credential_storage: value.credential_storage,
             origin: value.origin,
         }
     }
@@ -273,6 +278,14 @@ fn render_config(config: &PersistedAppConfig, existing_raw: Option<&str>) -> Str
             }
             source_item["variables"] = Item::Value(render_inline_table(&source.variables));
             source_item["secrets"] = Item::Value(render_string_array(&source.secrets));
+            if let Some(credential_storage) = source.credential_storage {
+                source_item["credential_storage"] = value(credential_storage.as_config_value());
+            } else {
+                let source_table = source_item
+                    .as_table_mut()
+                    .expect("source config entry should be a table after initialization");
+                source_table.remove("credential_storage");
+            }
             source_item["origin"] = value(source.origin.as_config_value());
         }
     }
@@ -352,6 +365,7 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::{AppConfig, PersistedAppConfig, SourceCatalog, render_config};
+    use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::workspaces::WorkspaceName;
@@ -369,6 +383,7 @@ mod tests {
                 "https://api.github.com".to_string(),
             )]),
             secrets: vec!["GITHUB_TOKEN".to_string()],
+            credential_storage: None,
             origin: SourceOrigin::Imported,
         }
     }
@@ -441,6 +456,37 @@ origin = "bundled"
             Some(&"https://api.github.com".to_string())
         );
         assert_eq!(sources[0].secrets, vec!["GITHUB_TOKEN".to_string()]);
+        assert_eq!(sources[0].credential_storage, None);
+        assert_eq!(
+            sources[0].effective_credential_storage(),
+            CredentialStorageKind::File
+        );
+    }
+
+    #[test]
+    fn round_trips_source_credential_storage() {
+        let workspace_name = default_workspace();
+        let mut source = installed_source("github");
+        source.credential_storage = Some(CredentialStorageKind::Keychain);
+        let mut catalog = SourceCatalog::default();
+        catalog.upsert_source(&workspace_name, source);
+        let config = AppConfig {
+            version: 1,
+            catalog,
+        };
+
+        let raw = render_config(&PersistedAppConfig::from(&config), None);
+        assert!(raw.contains("credential_storage = \"keychain\""));
+
+        let loaded = AppConfig::try_from(
+            toml::from_str::<PersistedAppConfig>(&raw).expect("config should parse"),
+        )
+        .expect("config");
+        let sources = loaded.catalog.workspace_sources(&workspace_name);
+        assert_eq!(
+            sources[0].credential_storage,
+            Some(CredentialStorageKind::Keychain)
+        );
     }
 
     #[test]

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -54,6 +54,10 @@ impl AppStateLayout {
         &self.config_file
     }
 
+    pub(crate) fn config_dir(&self) -> &Path {
+        &self.config_dir
+    }
+
     pub(crate) fn state_lock(&self) -> &Path {
         &self.state_lock
     }

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -40,6 +40,7 @@ impl GrpcHarness {
     }
 
     async fn start_with_parts(temp_dir: TempDir, config_dir: PathBuf) -> Self {
+        ensure_file_credentials_config(&config_dir);
         let server = ServerBuilder::new()
             .with_config_dir(&config_dir)
             .start()
@@ -167,6 +168,22 @@ impl GrpcHarness {
         )
         .expect("query rows")
     }
+}
+
+fn ensure_file_credentials_config(config_dir: &Path) {
+    std::fs::create_dir_all(config_dir).expect("create config dir");
+    let config_file = config_dir.join("config.toml");
+    let raw = std::fs::read_to_string(&config_file).unwrap_or_default();
+    if raw.contains("[credentials]") {
+        return;
+    }
+    let separator = if raw.is_empty() || raw.ends_with('\n') {
+        ""
+    } else {
+        "\n"
+    };
+    let updated = format!("{raw}{separator}\n[credentials]\nstorage = \"file\"\n");
+    std::fs::write(config_file, updated).expect("write test credential config");
 }
 
 impl FailingHttpFixture {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -9,9 +9,10 @@ use std::fs;
 use coral_api::v1::{
     CreateBundledSourceRequest, DeleteSourceRequest, DiscoverSourcesRequest, ExecuteSqlRequest,
     ExplainSqlRequest, GetSourceInfoRequest, GetSourceRequest, ImportSourceRequest,
-    ListCatalogRequest, PaginationRequest, QueryTestFailure, QueryTestSuccess, SourceOrigin,
-    SourceSecret, SourceVariable, ValidateSourceRequest, Workspace, catalog_item,
-    import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
+    ListCatalogRequest, PaginationRequest, QueryTestFailure, QueryTestSuccess,
+    SourceCredentialStorage, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
+    Workspace, catalog_item, import_source_response, query_test_result,
+    source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::default_workspace;
 use tempfile::TempDir;
@@ -36,6 +37,10 @@ async fn import_source_persists_and_lists() {
     assert_eq!(added.name, "local_messages");
     assert_eq!(added.version, "0.1.0");
     assert_eq!(added.origin, SourceOrigin::Imported as i32);
+    assert_eq!(
+        added.credential_storage,
+        SourceCredentialStorage::File as i32
+    );
     assert!(added.variables.is_empty());
     assert!(added.secrets.is_empty());
 
@@ -43,6 +48,7 @@ async fn import_source_persists_and_lists() {
         fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
     assert!(config_raw.contains("[workspaces.default.sources.local_messages]"));
     assert!(config_raw.contains("secrets = []"));
+    assert!(config_raw.contains("credential_storage = \"file\""));
     assert!(!config_raw.contains("credential_set_id"));
     assert!(!config_raw.contains("[workspaces.default.credentials"));
     assert!(!config_raw.contains("manifest_yaml = "));
@@ -58,6 +64,10 @@ async fn import_source_persists_and_lists() {
     let listed = harness.list_sources().await;
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].name, "local_messages");
+    assert_eq!(
+        listed[0].credential_storage,
+        SourceCredentialStorage::File as i32
+    );
 }
 
 #[tokio::test]
@@ -98,6 +108,10 @@ async fn import_source_with_secrets_and_variables_get_source_returns_details() {
     assert_eq!(fetched.name, "secured_messages");
     assert_eq!(fetched.version, "0.1.0");
     assert_eq!(fetched.origin, SourceOrigin::Imported as i32);
+    assert_eq!(
+        fetched.credential_storage,
+        SourceCredentialStorage::File as i32
+    );
     assert_eq!(fetched.variables, imported.variables);
     assert_eq!(fetched.secrets, imported.secrets);
 }
@@ -808,6 +822,10 @@ async fn get_source_info_returns_available_bundled_metadata() {
     assert_eq!(info.name, "github");
     assert_eq!(info.origin, SourceOrigin::Bundled as i32);
     assert!(!info.installed);
+    assert_eq!(
+        info.credential_storage,
+        SourceCredentialStorage::Unspecified as i32
+    );
     assert!(!info.description.is_empty());
     assert!(!info.version.is_empty());
     assert!(
@@ -850,6 +868,10 @@ async fn get_source_info_uses_effective_installed_imported_manifest() {
     assert_eq!(info.version, "0.1.0");
     assert_eq!(info.origin, SourceOrigin::Imported as i32);
     assert!(info.installed);
+    assert_eq!(
+        info.credential_storage,
+        SourceCredentialStorage::File as i32
+    );
     assert_eq!(info.inputs.len(), 2);
     assert_eq!(info.inputs[0].key, "API_BASE");
     match info.inputs[0].input.as_ref().expect("input metadata") {

--- a/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
+++ b/crates/coral-app/tests/grpc/source_lifecycle_tests.rs
@@ -39,7 +39,7 @@ async fn import_source_persists_and_lists() {
     assert_eq!(added.origin, SourceOrigin::Imported as i32);
     assert_eq!(
         added.credential_storage,
-        SourceCredentialStorage::File as i32
+        SourceCredentialStorage::Unspecified as i32
     );
     assert!(added.variables.is_empty());
     assert!(added.secrets.is_empty());
@@ -48,7 +48,7 @@ async fn import_source_persists_and_lists() {
         fs::read_to_string(harness.config_dir().join("config.toml")).expect("read config");
     assert!(config_raw.contains("[workspaces.default.sources.local_messages]"));
     assert!(config_raw.contains("secrets = []"));
-    assert!(config_raw.contains("credential_storage = \"file\""));
+    assert!(!config_raw.contains("credential_storage"));
     assert!(!config_raw.contains("credential_set_id"));
     assert!(!config_raw.contains("[workspaces.default.credentials"));
     assert!(!config_raw.contains("manifest_yaml = "));
@@ -66,7 +66,7 @@ async fn import_source_persists_and_lists() {
     assert_eq!(listed[0].name, "local_messages");
     assert_eq!(
         listed[0].credential_storage,
-        SourceCredentialStorage::File as i32
+        SourceCredentialStorage::Unspecified as i32
     );
 }
 

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -502,9 +502,11 @@ async fn run_source(app: &AppClient, args: SourceArgs) -> Result<(), CliError> {
                         source.name,
                         source.version,
                         source_ops::source_origin_label(source.origin).to_string(),
+                        source_ops::source_credential_storage_label(source.credential_storage)
+                            .to_string(),
                     ]
                 });
-                print_text_table(["Source", "Version", "Origin"], rows);
+                print_text_table(["Source", "Version", "Origin", "Secrets"], rows);
             }
         }
         SourceCommand::Info { name, verbose } => {
@@ -673,7 +675,11 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
         }
         _ => unreachable!("clap enforces exactly one of name or file"),
     };
-    println!("Added source {}", response.name);
+    println!(
+        "Added source {} (secrets: {})",
+        response.name,
+        source_ops::source_credential_storage_label(response.credential_storage)
+    );
     source_ops::validate_and_warn(app, &response.name, source_ops::TableDisplayLimit::DEFAULT)
         .await
         .map_err(Into::into)

--- a/crates/coral-cli/src/onboard.rs
+++ b/crates/coral-cli/src/onboard.rs
@@ -362,6 +362,7 @@ mod tests {
             inputs: Vec::new(),
             installed: true,
             origin: 1,
+            credential_storage: 1,
         };
         let item = format_source_list_item(&source, 10);
         assert!(item.starts_with("✓ "));
@@ -378,6 +379,7 @@ mod tests {
             inputs: Vec::new(),
             installed: false,
             origin: 1,
+            credential_storage: 0,
         };
         let item = format_source_list_item(&source, 10);
         assert!(item.starts_with("  "));
@@ -393,6 +395,7 @@ mod tests {
             inputs: Vec::new(),
             installed: false,
             origin: 1,
+            credential_storage: 0,
         };
         let long = SourceInfo {
             name: "statusgator".to_string(),
@@ -401,6 +404,7 @@ mod tests {
             inputs: Vec::new(),
             installed: false,
             origin: 1,
+            credential_storage: 0,
         };
         let width = 11; // len of "statusgator"
         let short_item = format_source_list_item(&short, width);

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -587,9 +587,10 @@ pub(crate) fn source_origin_label(origin: i32) -> &'static str {
 
 pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
     match SourceCredentialStorage::try_from(storage) {
+        Ok(SourceCredentialStorage::Unspecified) => "none",
         Ok(SourceCredentialStorage::File) => "file (plaintext)",
         Ok(SourceCredentialStorage::Keychain) => "keychain",
-        Ok(SourceCredentialStorage::Unspecified) | Err(_) => "unknown",
+        Err(_) => "unknown",
     }
 }
 

--- a/crates/coral-cli/src/source_ops.rs
+++ b/crates/coral-cli/src/source_ops.rs
@@ -8,9 +8,9 @@ use coral_api::v1::{
     CreateBundledSourceWithOAuthResponse, DeleteSourceRequest, DiscoverSourcesRequest,
     GetSourceInfoRequest, ImportSourceRequest, ImportSourceResponse, ListSourcesRequest,
     OAuthCredentialInput, OAuthCredentialRetrieval, QueryTestFailure, QueryTestSuccess, Source,
-    SourceInfo, SourceOrigin, SourceSecret, SourceVariable, ValidateSourceRequest,
-    ValidateSourceResponse, create_bundled_source_with_o_auth_response, import_source_response,
-    query_test_result, source_input_spec::Input as ProtoSourceInput,
+    SourceCredentialStorage, SourceInfo, SourceOrigin, SourceSecret, SourceVariable,
+    ValidateSourceRequest, ValidateSourceResponse, create_bundled_source_with_o_auth_response,
+    import_source_response, query_test_result, source_input_spec::Input as ProtoSourceInput,
 };
 use coral_client::{AppClient, DecodedStatusError, decode_status_error, default_workspace};
 use coral_spec::{
@@ -350,6 +350,12 @@ fn print_source_info_response(source: &SourceInfo, verbose: bool) {
     println!("{}", style(&source.name).bold());
     println!("  Status:      {status}");
     println!("  Origin:      {}", source_origin_label(source.origin));
+    if source.installed {
+        println!(
+            "  Secrets:     {}",
+            source_credential_storage_label(source.credential_storage)
+        );
+    }
     println!("  Version:     {}", source.version);
     if !source.description.is_empty() {
         println!("  Description: {}", source.description);
@@ -579,6 +585,14 @@ pub(crate) fn source_origin_label(origin: i32) -> &'static str {
     }
 }
 
+pub(crate) fn source_credential_storage_label(storage: i32) -> &'static str {
+    match SourceCredentialStorage::try_from(storage) {
+        Ok(SourceCredentialStorage::File) => "file (plaintext)",
+        Ok(SourceCredentialStorage::Keychain) => "keychain",
+        Ok(SourceCredentialStorage::Unspecified) | Err(_) => "unknown",
+    }
+}
+
 pub(crate) async fn validate_and_print(
     app: &AppClient,
     source_name: &str,
@@ -712,6 +726,10 @@ pub(crate) fn print_validation_pretty(
         "  {} {}",
         style("✓").green(),
         style(format!("{} connected successfully", source.name)).bold()
+    );
+    println!(
+        "  Secrets: {}",
+        source_credential_storage_label(source.credential_storage)
     );
 
     // Group tables by schema, sorted.

--- a/crates/coral-cli/tests/cli_e2e.rs
+++ b/crates/coral-cli/tests/cli_e2e.rs
@@ -17,7 +17,8 @@ use arrow::record_batch::RecordBatch;
 #[cfg(feature = "embedded-ui")]
 use assert_cmd::Command;
 use coral_api::v1::{
-    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, SourceInfo, SourceOrigin,
+    DiscoverSourcesResponse, ExecuteSqlResponse, ListSourcesResponse, SourceCredentialStorage,
+    SourceInfo, SourceOrigin,
 };
 use tonic::Code;
 
@@ -95,10 +96,10 @@ async fn source_list_renders_configured_sources() {
     assert_eq!(
         nonempty_lines(&stdout),
         vec![
-            "Source  Version  Origin",
-            "------  -------  --------",
-            "github  1.0.0    bundled",
-            "jira    2.0.0    imported",
+            "Source  Version  Origin    Secrets",
+            "------  -------  --------  ----------------",
+            "github  1.0.0    bundled   file (plaintext)",
+            "jira    2.0.0    imported  file (plaintext)",
         ],
         "expected configured source list"
     );
@@ -787,6 +788,7 @@ async fn source_test_suggests_add_for_uninstalled_bundled_source() {
                     inputs: Vec::new(),
                     installed: false,
                     origin: SourceOrigin::Bundled as i32,
+                    credential_storage: SourceCredentialStorage::Unspecified as i32,
                 }],
             }),
     )

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -25,8 +25,8 @@ use coral_api::v1::{
     ImportSourceRequest, ImportSourceResponse, ListCatalogRequest, ListCatalogResponse,
     ListColumnsRequest, ListColumnsResponse, ListSourcesRequest, ListSourcesResponse,
     PaginationRequest, PaginationResponse, QueryPlan, SearchCatalogRequest, SearchCatalogResponse,
-    Source, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput, Table, TableSummary,
-    ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
+    Source, SourceCredentialStorage, SourceInfo, SourceInputSpec, SourceOrigin, SourceSecretInput,
+    Table, TableSummary, ValidateSourceRequest, ValidateSourceResponse, Workspace, catalog_item,
     create_bundled_source_with_o_auth_response, import_source_response,
     source_input_spec::Input as ProtoSourceInput,
 };
@@ -54,6 +54,7 @@ fn mock_source() -> Source {
         secrets: Vec::new(),
         variables: Vec::new(),
         origin: SourceOrigin::Bundled as i32,
+        credential_storage: SourceCredentialStorage::File as i32,
     }
 }
 
@@ -285,6 +286,7 @@ fn mock_discover_response() -> DiscoverSourcesResponse {
                 }],
                 installed: true,
                 origin: SourceOrigin::Bundled as i32,
+                credential_storage: SourceCredentialStorage::File as i32,
             },
             SourceInfo {
                 name: "slack".to_string(),
@@ -293,6 +295,7 @@ fn mock_discover_response() -> DiscoverSourcesResponse {
                 inputs: Vec::new(),
                 installed: false,
                 origin: SourceOrigin::Bundled as i32,
+                credential_storage: SourceCredentialStorage::Unspecified as i32,
             },
         ],
     }
@@ -326,6 +329,7 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             }],
             installed: true,
             origin: SourceOrigin::Bundled as i32,
+            credential_storage: SourceCredentialStorage::File as i32,
         }),
         "slack" => Ok(SourceInfo {
             name: "slack".to_string(),
@@ -334,6 +338,7 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             inputs: Vec::new(),
             installed: false,
             origin: SourceOrigin::Bundled as i32,
+            credential_storage: SourceCredentialStorage::Unspecified as i32,
         }),
         "jira" => Ok(SourceInfo {
             name: "jira".to_string(),
@@ -342,6 +347,7 @@ fn mock_source_info(name: &str) -> Result<SourceInfo, Status> {
             inputs: Vec::new(),
             installed: true,
             origin: SourceOrigin::Imported as i32,
+            credential_storage: SourceCredentialStorage::File as i32,
         }),
         _ => Err(Status::not_found(format!("unknown source '{name}'"))),
     }
@@ -442,6 +448,7 @@ impl Default for MockServerConfig {
                         secrets: Vec::new(),
                         variables: Vec::new(),
                         origin: SourceOrigin::Bundled as i32,
+                        credential_storage: SourceCredentialStorage::File as i32,
                     },
                     Source {
                         workspace: Some(workspace()),
@@ -450,6 +457,7 @@ impl Default for MockServerConfig {
                         secrets: Vec::new(),
                         variables: Vec::new(),
                         origin: SourceOrigin::Imported as i32,
+                        credential_storage: SourceCredentialStorage::File as i32,
                     },
                 ],
             }),

--- a/crates/coral-cli/tests/source.rs
+++ b/crates/coral-cli/tests/source.rs
@@ -13,8 +13,8 @@ use std::process::Command;
 
 #[cfg(feature = "cli-test-server")]
 use coral_api::v1::{
-    QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, SourceOrigin,
-    ValidateSourceResponse, Workspace, query_test_result,
+    QueryTestFailure, QueryTestResult, QueryTestSuccess, Source, SourceCredentialStorage,
+    SourceOrigin, ValidateSourceResponse, Workspace, query_test_result,
 };
 #[cfg(feature = "cli-test-server")]
 use harness::MockServer;
@@ -100,6 +100,7 @@ async fn source_test_exits_non_zero_when_query_tests_fail() {
             secrets: Vec::new(),
             variables: Vec::new(),
             origin: SourceOrigin::Imported as i32,
+            credential_storage: SourceCredentialStorage::File as i32,
         }),
         tables: Vec::new(),
         table_functions: Vec::new(),
@@ -150,6 +151,7 @@ async fn source_test_succeeds_when_query_tests_pass() {
             secrets: Vec::new(),
             variables: Vec::new(),
             origin: SourceOrigin::Imported as i32,
+            credential_storage: SourceCredentialStorage::File as i32,
         }),
         tables: Vec::new(),
         table_functions: Vec::new(),

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -124,7 +124,7 @@ fn first_visible_table(tables: &[TableSummary]) -> Option<(&str, &str)> {
 
 #[cfg(test)]
 mod tests {
-    use coral_api::v1::{Source, TableSummary, Workspace};
+    use coral_api::v1::{Source, SourceCredentialStorage, TableSummary, Workspace};
 
     use super::{guide_resource_content, initial_instructions};
     use crate::surface::values::format_schema_table_equivalent;
@@ -139,6 +139,7 @@ mod tests {
             secrets: Vec::new(),
             variables: Vec::new(),
             origin: 0,
+            credential_storage: SourceCredentialStorage::Unspecified as i32,
         }
     }
 

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -71,10 +71,9 @@ Supported values:
 | `keychain` | Require OS credential storage. If unavailable, source installation fails. |
 | `file` | Store source secrets in plaintext `secrets.env` files under Coral's config directory. |
 
-Each installed source records its own credential storage route. Changing the
-global preference does not rewrite routes that already exist. Existing plaintext
-sources remain file-backed; remove and re-add a source if you want it to use
-the current default backend.
+<Note>
+Changing the global preference does not rewrite existing credentials. To update those, remove and re-add the source you want to update.
+</Note>
 
 ## What you still need to trust
 

--- a/docs/project/security.mdx
+++ b/docs/project/security.mdx
@@ -17,9 +17,10 @@ This release is intended for single-user local use:
   Windows machine.
 - You choose which source specs to install, which credentials to provide, and
   which MCP clients or scripts may call Coral.
-- Coral stores configuration and source secrets under the local Coral config
-  directory, which defaults to the platform config directory and can be changed
-  with `CORAL_CONFIG_DIR`.
+- Coral stores configuration under the local Coral config directory, which
+  defaults to the platform config directory and can be changed with
+  `CORAL_CONFIG_DIR`. Source secrets default to OS credential storage when the
+  local keychain is usable, with plaintext file storage available as fallback.
 - CLI and MCP queries run through the same local runtime. The internal gRPC
   server binds to loopback, and the MCP server uses stdio transport.
 
@@ -34,8 +35,14 @@ whether a value is configured.
 Coral's current protections are aimed at accidental exposure within that local
 trust boundary:
 
-- Source secrets are stored separately from non-secret source variables, in
-  plaintext local files rather than in `config.toml`.
+- Source secrets are stored separately from non-secret source variables and are
+  never written into `config.toml`.
+- By default, sources use the operating-system credential store when Coral
+  can successfully write, read, and delete a probe item. On macOS this uses
+  Keychain; on Windows, Credential Manager; on Linux, Secret Service.
+- If keychain probing fails in `auto` mode, Coral stores source secrets in
+  plaintext local files and reports the route as `file (plaintext)` in source
+  output.
 - State files written by Coral use private file permissions on Unix systems.
   On Windows, Coral stores local state under
   `%APPDATA%\withcoral\coral\config` by default and relies on the user's
@@ -46,6 +53,28 @@ trust boundary:
   paths.
 - MCP clients can query installed sources, but they do not receive raw stored
   secret values through the discovery tables or resources.
+
+## Secret storage configuration
+
+Coral reads the credential storage preference from `config.toml`:
+
+```toml
+[credentials]
+storage = "auto"
+```
+
+Supported values:
+
+| Value | Behavior |
+| --- | --- |
+| `auto` | Default. Use keychain when the probe succeeds; otherwise use plaintext file storage. |
+| `keychain` | Require OS credential storage. If unavailable, source installation fails. |
+| `file` | Store source secrets in plaintext `secrets.env` files under Coral's config directory. |
+
+Each installed source records its own credential storage route. Changing the
+global preference does not rewrite routes that already exist. Existing plaintext
+sources remain file-backed; remove and re-add a source if you want it to use
+the current default backend.
 
 ## What you still need to trust
 
@@ -60,9 +89,10 @@ you configure; it does not make an otherwise untrusted local agent safe.
   token, so prefer read-only and least-privilege credentials.
 - A custom source spec can direct Coral to make HTTP requests or read local file
   locations declared by that spec. Only install source specs you trust.
-- Anyone who can read your local Coral config directory or control your user
-  account should be treated as able to read stored source secrets and use the
-  configured sources.
+- Anyone who can control your user account should be treated as able to use the
+  configured sources. If a source uses file-backed secret storage, anyone who
+  can read your local Coral config directory should also be treated as able to
+  read its stored source secrets.
 - Coral does not attempt to protect against a compromised machine, compromised
   MCP client, malicious shell environment, or malicious upstream API response.
 
@@ -71,6 +101,8 @@ you configure; it does not make an otherwise untrusted local agent safe.
 - Scope provider tokens to the minimum data your workflow needs.
 - Put Coral's config directory on a local disk protected by your operating
   system account controls.
+- Use `coral source list` or `coral source info <NAME>` to inspect whether a
+  source uses `keychain` or `file (plaintext)` secret storage.
 - Review custom source specs before installing them, especially `base_url`,
   `auth`, and file `location` fields.
 - Configure `coral mcp-stdio` only in MCP clients you are comfortable allowing

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -86,7 +86,8 @@ If the source is already installed, running this command again replaces its stor
 Sources use OS credential storage by default when Coral can write, read, and
 delete a keychain probe item. If the keychain is unavailable in `auto` mode,
 Coral stores the source secrets in plaintext file storage and shows
-`file (plaintext)` in source output.
+`file (plaintext)` in source output. Sources with no stored secret material show
+`none`.
 
 ### `coral source add --file <PATH>`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -41,6 +41,9 @@ List sources currently installed.
 coral source list
 ```
 
+The output includes the source's secret storage route: `keychain` or
+`file (plaintext)`.
+
 ### `coral source info <NAME>`
 
 Show metadata for a source: whether it is installed, its origin, version, description, and inputs. Works for bundled sources and imported sources installed via `coral source add --file`.
@@ -79,6 +82,13 @@ coral source add --interactive github
 ```
 
 If the source is already installed, running this command again replaces its stored credentials with the new values you provide. After installation, it prints the discovered tables and runs any optional top-level `test_queries` declared in the source spec to validate the connection. Any post-install validation issue is reported as a warning here so the source remains installed and re-runnable.
+
+Sources use OS credential storage by default when Coral can write, read, and
+delete a keychain probe item. If the keychain is unavailable in `auto` mode,
+Coral stores the source secrets in plaintext file storage and shows
+`file (plaintext)` in source output. Existing file-backed sources stay
+file-backed; remove and re-add a source to move it to the current default
+backend.
 
 ### `coral source add --file <PATH>`
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -86,9 +86,7 @@ If the source is already installed, running this command again replaces its stor
 Sources use OS credential storage by default when Coral can write, read, and
 delete a keychain probe item. If the keychain is unavailable in `auto` mode,
 Coral stores the source secrets in plaintext file storage and shows
-`file (plaintext)` in source output. Existing file-backed sources stay
-file-backed; remove and re-add a source to move it to the current default
-backend.
+`file (plaintext)` in source output.
 
 ### `coral source add --file <PATH>`
 


### PR DESCRIPTION
## Intent

Store source secrets in the OS keychain by default when a usable native backend is available, while preserving plaintext file storage as the fallback for systems without keychain support.

The goal is to keep secret material behind a storage abstraction so source lifecycle, query execution, and CLI surfaces do not need to know backend-specific details.

## Changes

- Add credential storage routing with `auto`, `keychain`, and `file` preferences.
- Persist each installed source's credential storage route in source metadata.
- Add file and keychain credential backends behind the app credential store.
- Fail closed when an installed keychain-backed source cannot read its secrets.
- Surface credential storage in source list/info/add output and API responses.
- Cover source lifecycle, query loading, config preference, and backend behavior with tests.

## Validation

- `make rust-checks`
- Linux VM smoke validation: default `auto` falls back to file when no Secret Service backend is available; explicit `keychain` reports the unavailable backend clearly.
- Will test on Windows today.
