### PR TITLE
feat(sources): Add Trello Community Source

### DIFF
--- a/sources/community/trello/README.md
+++ b/sources/community/trello/README.md
@@ -59,3 +59,29 @@ WHERE c.board_id = 'your_board_id_here'
 
 - **Pagination:** Trello's board-level endpoints generally return all lists/cards for a board in a single response, bounded by API limits. For exceptionally large boards (thousands of cards), the API might truncate the response. This source does not currently support `before`/`since` offset pagination.
 - **Read-Only:** This source provides read-only visibility into Trello and does not support creating, updating, or archiving cards.
+
+## Live Testing Results
+
+### Testing boards query
+```console
+$ coral sql "SELECT id, name, closed FROM trello.boards LIMIT 5;"
++--------------------------+------+--------+
+| id                       | name | closed |
++--------------------------+------+--------+
+| 6a1410bae00948891ddabc14 | test | false  |
++--------------------------+------+--------+
+```
+
+### Testing cards query
+```console
+$ coral sql "SELECT id, name FROM trello.cards WHERE board_id = '6a1410bae00948891ddabc14' LIMIT 5;"
++--------------------------+-----------+
+| id                       | name      |
++--------------------------+-----------+
+| 6a1410bae00948891ddabc48 | Product   |
+| 6a1410bae00948891ddabc4e | Marketing |
+| 6a1410bae00948891ddabc51 | Sales     |
+| 6a1410bae00948891ddabc54 | Support   |
+| 6a1410bae00948891ddabc57 | People    |
++--------------------------+-----------+
+```

--- a/sources/community/trello/README.md
+++ b/sources/community/trello/README.md
@@ -1,11 +1,13 @@
 # Trello
+
 A community source that exposes Trello boards, lists, cards, and members to Coral SQL.
 
 ## Authentication
+
 Trello requires an **API Key** and a **User Token** to authenticate requests.
 
-1.  **Get your API Key:** Log in to Trello and go to the [Power-Up Admin page](https://trello.com/power-ups/admin). Create a new Power-Up if you don't have one, and copy the **API Key**.
-2.  **Get your API Token:** On the same page, next to the API Key, look for the option to generate a token manually. **Note:** Ensure you grant the token at least **read** access (this is usually the default) so it has permission to fetch your boards, lists, and cards. Click authorize and copy your **Token**.
+1. **Get your API Key:** Log in to Trello and go to the [Power-Up Admin page](https://trello.com/power-ups/admin). Create a new Power-Up if you don't have one, and copy the **API Key**.
+2. **Get your API Token:** On the same page, next to the API Key, look for the option to generate a token manually. To limit access to what this source needs, generate a **read-only token** by using the authorization URL with `scope=read` appended — for example: `https://trello.com/1/authorize?key=YOUR_KEY&name=coral-trello&scope=read&expiration=never&response_type=token`. Click authorize and copy your **Token**. See the [Trello authorization docs](https://developer.atlassian.com/cloud/trello/guides/rest-api/authorization/) for full details.
 
 Set the following environment variables before running Coral:
 
@@ -49,8 +51,8 @@ FROM trello.boards;
 SELECT id, name, due, due_complete, list_id
 FROM trello.cards
 WHERE board_id = 'your_board_id_here'
-LIMIT 50
-ORDER BY pos ASC;
+ORDER BY pos ASC
+LIMIT 50;
 ```
 
 ### Scope cards by date window on a large board
@@ -58,8 +60,8 @@ ORDER BY pos ASC;
 SELECT id, name, due, list_id
 FROM trello.cards
 WHERE board_id = 'your_board_id_here'
-  AND since = '2024-01-01'
-  AND before = '2024-03-31';
+AND since = '2024-01-01'
+AND before = '2024-03-31';
 ```
 
 ### Join cards with their corresponding list names
@@ -71,15 +73,16 @@ SELECT
 FROM trello.cards c
 JOIN trello.lists l ON c.list_id = l.id
 WHERE c.board_id = 'your_board_id_here'
-  AND l.board_id = 'your_board_id_here';
+AND l.board_id = 'your_board_id_here';
 ```
 
 ## Rate Limits
 
-Trello enforces two independent rate limits on the REST API:
+Trello enforces three independent rate limits on the REST API:
 
 - **300 requests per 10 seconds** per API key
 - **100 requests per 10 seconds** per token
+- **100 requests per 900 seconds** per token for `/1/members/` endpoints — this applies to the `trello.boards` table, which calls `/1/members/me/boards`
 
 When a limit is exceeded Trello returns HTTP **429**. Coral will surface this as a source error. To stay within limits, use the `limit`, `since`, and `before` filters on `trello.cards` to avoid broad board scans, and avoid running many board-scoped queries in rapid succession.
 

--- a/sources/community/trello/README.md
+++ b/sources/community/trello/README.md
@@ -1,0 +1,61 @@
+# Trello
+
+A community source that exposes Trello boards, lists, cards, and members to Coral SQL.
+
+## Authentication
+
+Trello requires an **API Key** and a **User Token** to authenticate requests.
+
+1.  **Get your API Key:** Log in to Trello and go to the [Power-Up Admin page](https://trello.com/power-ups/admin). Create a new Power-Up if you don't have one, and copy the **API Key**.
+2.  **Get your API Token:** On the same page, next to the API Key, look for the option to generate a token manually. Click it, authorize the app, and copy your **Token**.
+
+Set the following environment variables before running Coral:
+```bash
+export TRELLO_API_KEY="your_trello_api_key"
+export TRELLO_API_TOKEN="your_trello_user_token"
+```
+
+## Tables
+
+| Table | Description | Required Filters |
+| :--- | :--- | :--- |
+| `trello.boards` | Lists all boards you belong to | None |
+| `trello.lists` | Lists all lists (columns) on a board | `board_id` |
+| `trello.cards` | Lists all cards on a board | `board_id` |
+| `trello.members`| Lists all members on a board | `board_id` |
+
+> [!IMPORTANT]
+> Because Trello's API is heavily board-centric, you **must** provide a `board_id` in the `WHERE` clause when querying `lists`, `cards`, and `members`. You can find your `board_id` by first querying the `boards` table.
+
+## Example Queries
+
+### Find your boards
+```sql
+SELECT id, name, closed
+FROM trello.boards;
+```
+
+### Get all cards on a specific board
+```sql
+SELECT id, name, due, due_complete, list_id
+FROM trello.cards
+WHERE board_id = 'your_board_id_here'
+ORDER BY pos ASC;
+```
+
+### Join cards with their corresponding list names
+```sql
+SELECT
+  c.name AS card_name,
+  l.name AS list_name,
+  c.due
+FROM trello.cards c
+JOIN trello.lists l ON c.list_id = l.id
+WHERE c.board_id = 'your_board_id_here'
+  AND l.board_id = 'your_board_id_here';
+```
+
+## Limitations
+
+- **Pagination:** Trello's board-level endpoints generally return all lists/cards for a board in a single response, bounded by API limits. For exceptionally large boards (thousands of cards), the API might truncate the response. This source does not currently support `before`/`since` offset pagination.
+- **Read-Only:** This source provides read-only visibility into Trello and does not support creating, updating, or archiving cards.

--- a/sources/community/trello/README.md
+++ b/sources/community/trello/README.md
@@ -7,7 +7,7 @@ A community source that exposes Trello boards, lists, cards, and members to Cora
 Trello requires an **API Key** and a **User Token** to authenticate requests.
 
 1.  **Get your API Key:** Log in to Trello and go to the [Power-Up Admin page](https://trello.com/power-ups/admin). Create a new Power-Up if you don't have one, and copy the **API Key**.
-2.  **Get your API Token:** On the same page, next to the API Key, look for the option to generate a token manually. Click it, authorize the app, and copy your **Token**.
+2.  **Get your API Token:** On the same page, next to the API Key, look for the option to generate a token manually. **Note:** Ensure you grant the token at least **read** access (this is usually the default) so it has permission to fetch your boards, lists, and cards. Click authorize and copy your **Token**.
 
 Set the following environment variables before running Coral:
 ```bash

--- a/sources/community/trello/README.md
+++ b/sources/community/trello/README.md
@@ -1,15 +1,14 @@
 # Trello
-
 A community source that exposes Trello boards, lists, cards, and members to Coral SQL.
 
 ## Authentication
-
 Trello requires an **API Key** and a **User Token** to authenticate requests.
 
 1.  **Get your API Key:** Log in to Trello and go to the [Power-Up Admin page](https://trello.com/power-ups/admin). Create a new Power-Up if you don't have one, and copy the **API Key**.
 2.  **Get your API Token:** On the same page, next to the API Key, look for the option to generate a token manually. **Note:** Ensure you grant the token at least **read** access (this is usually the default) so it has permission to fetch your boards, lists, and cards. Click authorize and copy your **Token**.
 
 Set the following environment variables before running Coral:
+
 ```bash
 export TRELLO_API_KEY="your_trello_api_key"
 export TRELLO_API_TOKEN="your_trello_user_token"
@@ -17,15 +16,25 @@ export TRELLO_API_TOKEN="your_trello_user_token"
 
 ## Tables
 
-| Table | Description | Required Filters |
-| :--- | :--- | :--- |
-| `trello.boards` | Lists all boards you belong to | None |
-| `trello.lists` | Lists all lists (columns) on a board | `board_id` |
-| `trello.cards` | Lists all cards on a board | `board_id` |
-| `trello.members`| Lists all members on a board | `board_id` |
+| Table | Description | Required Filters | Optional Filters |
+| :--- | :--- | :--- | :--- |
+| `trello.boards` | Lists all boards you belong to | None | — |
+| `trello.lists` | Lists all lists (columns) on a board | `board_id` | `filter` |
+| `trello.cards` | Lists all cards on a board | `board_id` | `filter`, `limit`, `since`, `before` |
+| `trello.members`| Lists all members on a board | `board_id` | — |
 
 > [!IMPORTANT]
 > Because Trello's API is heavily board-centric, you **must** provide a `board_id` in the `WHERE` clause when querying `lists`, `cards`, and `members`. You can find your `board_id` by first querying the `boards` table.
+
+### `trello.cards` filter reference
+
+| Filter | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `board_id` | string | — | **Required.** Board to fetch cards from. |
+| `filter` | string | `all` | Card status: `all`, `closed`, `none`, `open`, `visible`. |
+| `limit` | integer | `50` | Max cards returned. Trello maximum is 1000. Keep low on large boards. |
+| `since` | string | — | ISO 8601 date or card ID. Return cards created on or after this point. |
+| `before` | string | — | ISO 8601 date or card ID. Return cards created on or before this point. |
 
 ## Example Queries
 
@@ -35,12 +44,22 @@ SELECT id, name, closed
 FROM trello.boards;
 ```
 
-### Get all cards on a specific board
+### Get cards on a board (with conservative limit)
 ```sql
 SELECT id, name, due, due_complete, list_id
 FROM trello.cards
 WHERE board_id = 'your_board_id_here'
+LIMIT 50
 ORDER BY pos ASC;
+```
+
+### Scope cards by date window on a large board
+```sql
+SELECT id, name, due, list_id
+FROM trello.cards
+WHERE board_id = 'your_board_id_here'
+  AND since = '2024-01-01'
+  AND before = '2024-03-31';
 ```
 
 ### Join cards with their corresponding list names
@@ -55,9 +74,20 @@ WHERE c.board_id = 'your_board_id_here'
   AND l.board_id = 'your_board_id_here';
 ```
 
+## Rate Limits
+
+Trello enforces two independent rate limits on the REST API:
+
+- **300 requests per 10 seconds** per API key
+- **100 requests per 10 seconds** per token
+
+When a limit is exceeded Trello returns HTTP **429**. Coral will surface this as a source error. To stay within limits, use the `limit`, `since`, and `before` filters on `trello.cards` to avoid broad board scans, and avoid running many board-scoped queries in rapid succession.
+
+See the [Trello rate limits documentation](https://developer.atlassian.com/cloud/trello/guides/rest-api/rate-limits/) for full details.
+
 ## Limitations
 
-- **Pagination:** Trello's board-level endpoints generally return all lists/cards for a board in a single response, bounded by API limits. For exceptionally large boards (thousands of cards), the API might truncate the response. This source does not currently support `before`/`since` offset pagination.
+- **Card fetch size:** The `trello.cards` endpoint defaults to 50 cards per request. Use the `limit` filter (max 1000) and `since`/`before` date filters to control fetch size on large boards.
 - **Read-Only:** This source provides read-only visibility into Trello and does not support creating, updating, or archiving cards.
 
 ## Live Testing Results

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -40,8 +40,6 @@ tables:
     request:
       method: GET
       path: /members/me/boards
-    response:
-      row_strategy: array
     columns:
       - name: id
         type: Utf8
@@ -85,8 +83,6 @@ tables:
     request:
       method: GET
       path: /boards/{{filter.board_id}}/lists
-    response:
-      row_strategy: array
     columns:
       - name: id
         type: Utf8
@@ -130,8 +126,6 @@ tables:
     request:
       method: GET
       path: /boards/{{filter.board_id}}/cards
-    response:
-      row_strategy: array
     columns:
       - name: id
         type: Utf8
@@ -157,7 +151,10 @@ tables:
         type: Timestamp
         nullable: true
         description: The due date of the card.
-        expr: {kind: format_timestamp, input: iso8601, path: [due]}
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [due]}
       - name: due_complete
         type: Boolean
         nullable: true
@@ -200,8 +197,6 @@ tables:
     request:
       method: GET
       path: /boards/{{filter.board_id}}/members
-    response:
-      row_strategy: array
     columns:
       - name: id
         type: Utf8

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -80,6 +80,9 @@ tables:
     description: >
       Lists all lists (columns) on a specific board.
       Requires the `board_id` filter.
+    filters:
+      - name: board_id
+        required: true
     request:
       method: GET
       path: /boards/{{filter.board_id}}/lists
@@ -123,6 +126,9 @@ tables:
     description: >
       Lists all cards on a specific board.
       Requires the `board_id` filter.
+    filters:
+      - name: board_id
+        required: true
     request:
       method: GET
       path: /boards/{{filter.board_id}}/cards
@@ -194,6 +200,9 @@ tables:
     description: >
       Lists all members on a specific board.
       Requires the `board_id` filter.
+    filters:
+      - name: board_id
+        required: true
     request:
       method: GET
       path: /boards/{{filter.board_id}}/members

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -63,6 +63,11 @@ tables:
         nullable: true
         description: Whether the board is closed (archived).
         expr: {kind: path, path: [closed]}
+      - name: organization_id
+        type: Utf8
+        nullable: true
+        description: The ID of the organization this board belongs to.
+        expr: {kind: path, path: [idOrganization]}
       - name: url
         type: Utf8
         nullable: true
@@ -85,6 +90,8 @@ tables:
     filters:
       - name: board_id
         required: true
+      - name: filter
+        required: false
     request:
       method: GET
       path: /boards/{{filter.board_id}}/lists
@@ -96,8 +103,9 @@ tables:
           from: input
           key: TRELLO_API_TOKEN
         - name: filter
-          from: literal
-          value: all
+          from: filter
+          key: filter
+          default: all
     columns:
       - name: id
         type: Utf8
@@ -124,6 +132,12 @@ tables:
         nullable: false
         description: The ID of the board this list belongs to.
         expr: {kind: from_filter, key: board_id}
+      - name: filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter lists by status (all, closed, none, open).
+        expr: {kind: from_filter, key: filter}
       - name: raw
         type: Json
         nullable: false
@@ -141,6 +155,8 @@ tables:
     filters:
       - name: board_id
         required: true
+      - name: filter
+        required: false
     request:
       method: GET
       path: /boards/{{filter.board_id}}/cards
@@ -152,8 +168,9 @@ tables:
           from: input
           key: TRELLO_API_TOKEN
         - name: filter
-          from: literal
-          value: all
+          from: filter
+          key: filter
+          default: all
     columns:
       - name: id
         type: Utf8
@@ -203,6 +220,12 @@ tables:
         nullable: false
         description: The ID of the board the card belongs to.
         expr: {kind: from_filter, key: board_id}
+      - name: filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Filter cards by status (all, closed, none, open, visible).
+        expr: {kind: from_filter, key: filter}
       - name: url
         type: Utf8
         nullable: true

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -10,6 +10,7 @@ base_url: "https://api.trello.com/1"
 inputs:
   TRELLO_API_KEY:
     kind: variable
+    required: true
     hint: >-
       Your Trello API Key. You can get this from the Trello Power-Up Admin
       page (https://trello.com/power-ups/admin).

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -9,7 +9,7 @@ base_url: "https://api.trello.com/1"
 
 inputs:
   TRELLO_API_KEY:
-    kind: variable
+    kind: secret
     required: true
     hint: >-
       Your Trello API Key. You can get this from the Trello Power-Up Admin
@@ -150,12 +150,23 @@ tables:
   # ──────────────────────────────────────────────────────────────────────
   - name: cards
     description: >
-      Lists all cards on a specific board.
-      Requires the `board_id` filter.
+      Lists cards on a specific board. Requires the `board_id` filter.
+      Use `limit` to cap results (default 50, max 1000), and `since`/`before`
+      to scope by date or card ID to avoid large fetches on active boards.
+    guide: >
+      Start with `SELECT id, name, list_id, due FROM trello.cards
+      WHERE board_id = 'your_board_id' LIMIT 50`. For large boards,
+      add `since` or `before` to narrow the window.
     filters:
       - name: board_id
         required: true
       - name: filter
+        required: false
+      - name: limit
+        required: false
+      - name: since
+        required: false
+      - name: before
         required: false
     request:
       method: GET
@@ -171,6 +182,16 @@ tables:
           from: filter
           key: filter
           default: all
+        - name: limit
+          from: filter
+          key: limit
+          default: "50"
+        - name: since
+          from: filter
+          key: since
+        - name: before
+          from: filter
+          key: before
     columns:
       - name: id
         type: Utf8
@@ -224,8 +245,28 @@ tables:
         type: Utf8
         nullable: true
         virtual: true
-        description: Filter cards by status (all, closed, none, open, visible).
+        description: Card status filter used (all, closed, none, open, visible).
         expr: {kind: from_filter, key: filter}
+      - name: limit
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Maximum number of cards fetched (default 50, max 1000).
+        expr: {kind: from_filter, key: limit}
+      - name: since
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Return cards created on or after this ISO 8601 date or card ID.
+        expr: {kind: from_filter, key: since}
+      - name: before
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Return cards created on or before this ISO 8601 date or card ID.
+        expr: {kind: from_filter, key: before}
       - name: url
         type: Utf8
         nullable: true

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -95,6 +95,9 @@ tables:
         - name: token
           from: input
           key: TRELLO_API_TOKEN
+        - name: filter
+          from: literal
+          value: all
     columns:
       - name: id
         type: Utf8
@@ -148,6 +151,9 @@ tables:
         - name: token
           from: input
           key: TRELLO_API_TOKEN
+        - name: filter
+          from: literal
+          value: all
     columns:
       - name: id
         type: Utf8

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -20,12 +20,6 @@ inputs:
       Your Trello User API Token. Keep this secret. You can generate a token
       by visiting the authorization URL after getting your API Key.
 
-auth:
-  type: HeaderAuth
-  headers:
-    - name: Authorization
-      from: template
-      template: "OAuth oauth_consumer_key=\"{{input.TRELLO_API_KEY}}\", oauth_token=\"{{input.TRELLO_API_TOKEN}}\""
 
 test_queries:
   - SELECT id, name FROM trello.boards LIMIT 1
@@ -39,7 +33,7 @@ tables:
       Lists all boards the authenticated user belongs to.
     request:
       method: GET
-      path: /members/me/boards
+      path: /members/me/boards?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
     columns:
       - name: id
         type: Utf8
@@ -85,7 +79,7 @@ tables:
         required: true
     request:
       method: GET
-      path: /boards/{{filter.board_id}}/lists
+      path: /boards/{{filter.board_id}}/lists?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
     columns:
       - name: id
         type: Utf8
@@ -131,7 +125,7 @@ tables:
         required: true
     request:
       method: GET
-      path: /boards/{{filter.board_id}}/cards
+      path: /boards/{{filter.board_id}}/cards?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
     columns:
       - name: id
         type: Utf8
@@ -205,7 +199,7 @@ tables:
         required: true
     request:
       method: GET
-      path: /boards/{{filter.board_id}}/members
+      path: /boards/{{filter.board_id}}/members?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
     columns:
       - name: id
         type: Utf8

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -1,0 +1,236 @@
+---
+name: trello
+version: "0.1.0"
+dsl_version: 3
+backend: http
+description: >-
+  Query Trello boards, lists, cards, and members via the Trello REST API.
+base_url: "https://api.trello.com/1"
+
+inputs:
+  TRELLO_API_KEY:
+    kind: variable
+    hint: >-
+      Your Trello API Key. You can get this from the Trello Power-Up Admin
+      page (https://trello.com/power-ups/admin).
+  TRELLO_API_TOKEN:
+    kind: secret
+    required: true
+    hint: >-
+      Your Trello User API Token. Keep this secret. You can generate a token
+      by visiting the authorization URL after getting your API Key.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "OAuth oauth_consumer_key=\"{{input.TRELLO_API_KEY}}\", oauth_token=\"{{input.TRELLO_API_TOKEN}}\""
+
+test_queries:
+  - SELECT id, name FROM trello.boards LIMIT 1
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # boards — list all boards for the authenticated user
+  # ──────────────────────────────────────────────────────────────────────
+  - name: boards
+    description: >
+      Lists all boards the authenticated user belongs to.
+    request:
+      method: GET
+      path: /members/me/boards
+    response:
+      row_strategy: array
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: The unique ID of the board.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The name of the board.
+        expr: {kind: path, path: [name]}
+      - name: desc
+        type: Utf8
+        nullable: true
+        description: The description of the board.
+        expr: {kind: path, path: [desc]}
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the board is closed (archived).
+        expr: {kind: path, path: [closed]}
+      - name: url
+        type: Utf8
+        nullable: true
+        description: The URL of the board.
+        expr: {kind: path, path: [url]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw board object.
+        expr:
+          kind: current_row
+
+  # ──────────────────────────────────────────────────────────────────────
+  # lists — list all lists on a specific board
+  # ──────────────────────────────────────────────────────────────────────
+  - name: lists
+    description: >
+      Lists all lists (columns) on a specific board.
+      Requires the `board_id` filter.
+    request:
+      method: GET
+      path: /boards/{{filter.board_id}}/lists
+    response:
+      row_strategy: array
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: The unique ID of the list.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The name of the list.
+        expr: {kind: path, path: [name]}
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the list is closed (archived).
+        expr: {kind: path, path: [closed]}
+      - name: pos
+        type: Float64
+        nullable: true
+        description: The position of the list on the board.
+        expr: {kind: path, path: [pos]}
+      - name: board_id
+        type: Utf8
+        nullable: false
+        description: The ID of the board this list belongs to.
+        expr: {kind: from_filter, key: board_id}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw list object.
+        expr:
+          kind: current_row
+
+  # ──────────────────────────────────────────────────────────────────────
+  # cards — list all cards on a specific board
+  # ──────────────────────────────────────────────────────────────────────
+  - name: cards
+    description: >
+      Lists all cards on a specific board.
+      Requires the `board_id` filter.
+    request:
+      method: GET
+      path: /boards/{{filter.board_id}}/cards
+    response:
+      row_strategy: array
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: The unique ID of the card.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The name of the card.
+        expr: {kind: path, path: [name]}
+      - name: desc
+        type: Utf8
+        nullable: true
+        description: The description of the card.
+        expr: {kind: path, path: [desc]}
+      - name: closed
+        type: Boolean
+        nullable: true
+        description: Whether the card is closed (archived).
+        expr: {kind: path, path: [closed]}
+      - name: due
+        type: Timestamp
+        nullable: true
+        description: The due date of the card.
+        expr: {kind: format_timestamp, input: iso8601, path: [due]}
+      - name: due_complete
+        type: Boolean
+        nullable: true
+        description: Whether the due date is marked complete.
+        expr: {kind: path, path: [dueComplete]}
+      - name: pos
+        type: Float64
+        nullable: true
+        description: The position of the card in its list.
+        expr: {kind: path, path: [pos]}
+      - name: list_id
+        type: Utf8
+        nullable: true
+        description: The ID of the list the card belongs to.
+        expr: {kind: path, path: [idList]}
+      - name: board_id
+        type: Utf8
+        nullable: false
+        description: The ID of the board the card belongs to.
+        expr: {kind: from_filter, key: board_id}
+      - name: url
+        type: Utf8
+        nullable: true
+        description: The URL of the card.
+        expr: {kind: path, path: [url]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw card object.
+        expr:
+          kind: current_row
+
+  # ──────────────────────────────────────────────────────────────────────
+  # members — list all members on a specific board
+  # ──────────────────────────────────────────────────────────────────────
+  - name: members
+    description: >
+      Lists all members on a specific board.
+      Requires the `board_id` filter.
+    request:
+      method: GET
+      path: /boards/{{filter.board_id}}/members
+    response:
+      row_strategy: array
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: The unique ID of the member.
+        expr: {kind: path, path: [id]}
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: The full name of the member.
+        expr: {kind: path, path: [fullName]}
+      - name: username
+        type: Utf8
+        nullable: true
+        description: The username of the member.
+        expr: {kind: path, path: [username]}
+      - name: initials
+        type: Utf8
+        nullable: true
+        description: The initials of the member.
+        expr: {kind: path, path: [initials]}
+      - name: board_id
+        type: Utf8
+        nullable: false
+        description: The ID of the board.
+        expr: {kind: from_filter, key: board_id}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw member object.
+        expr:
+          kind: current_row

--- a/sources/community/trello/manifest.yaml
+++ b/sources/community/trello/manifest.yaml
@@ -34,7 +34,14 @@ tables:
       Lists all boards the authenticated user belongs to.
     request:
       method: GET
-      path: /members/me/boards?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
+      path: /members/me/boards
+      query:
+        - name: key
+          from: input
+          key: TRELLO_API_KEY
+        - name: token
+          from: input
+          key: TRELLO_API_TOKEN
     columns:
       - name: id
         type: Utf8
@@ -80,7 +87,14 @@ tables:
         required: true
     request:
       method: GET
-      path: /boards/{{filter.board_id}}/lists?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
+      path: /boards/{{filter.board_id}}/lists
+      query:
+        - name: key
+          from: input
+          key: TRELLO_API_KEY
+        - name: token
+          from: input
+          key: TRELLO_API_TOKEN
     columns:
       - name: id
         type: Utf8
@@ -126,7 +140,14 @@ tables:
         required: true
     request:
       method: GET
-      path: /boards/{{filter.board_id}}/cards?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
+      path: /boards/{{filter.board_id}}/cards
+      query:
+        - name: key
+          from: input
+          key: TRELLO_API_KEY
+        - name: token
+          from: input
+          key: TRELLO_API_TOKEN
     columns:
       - name: id
         type: Utf8
@@ -200,7 +221,14 @@ tables:
         required: true
     request:
       method: GET
-      path: /boards/{{filter.board_id}}/members?key={{input.TRELLO_API_KEY}}&token={{input.TRELLO_API_TOKEN}}
+      path: /boards/{{filter.board_id}}/members
+      query:
+        - name: key
+          from: input
+          key: TRELLO_API_KEY
+        - name: token
+          from: input
+          key: TRELLO_API_TOKEN
     columns:
       - name: id
         type: Utf8


### PR DESCRIPTION
Fixes #762.

### Summary

This PR adds a community source spec for **Trello**, exposing boards, lists, cards, and members as SQL-queryable tables via the Trello REST API. Authentication is implemented using the standard API key and token query parameters.

### Motivation

Trello is a highly popular visual work management tool. Integrating Trello into Coral allows users to query their project management data directly via SQL, unlocking a wealth of project tracking and analytics capabilities.

### Credential Overview

Trello uses a dual-parameter authentication approach involving an API Key and a User API Token. These are passed as `key` and `token` query parameters on every request.

| Field | Value |
|---|---|
| Credentials Setup | [Trello Power-Up Admin](https://trello.com/power-ups/admin) |
| Client inputs | `TRELLO_API_KEY` (variable) + `TRELLO_API_TOKEN` (secret) |
| Allowed Origins | `http://localhost` (or `*`) for manual token generation |

### Table Schema

| Table | Endpoint | Description |
|---|---|---|
| `boards` | `GET /1/members/me/boards` | All boards the authenticated user belongs to |
| `lists` | `GET /1/boards/{board_id}/lists` | All lists (columns) on a specific board (requires `board_id`) |
| `cards` | `GET /1/boards/{board_id}/cards` | All cards on a specific board (requires `board_id`) |
| `members` | `GET /1/boards/{board_id}/members` | All members on a specific board (requires `board_id`) |

### Example SQL Queries

```sql
-- Join cards with their corresponding list names
SELECT
  c.name AS card_name,
  l.name AS list_name,
  c.due
FROM trello.cards c
JOIN trello.lists l ON c.list_id = l.id
WHERE c.board_id = 'YOUR_BOARD_ID'
  AND l.board_id = 'YOUR_BOARD_ID';
```

### Live Testing Results

**Testing boards query:**
```console
$ coral sql "SELECT id, name, closed FROM trello.boards LIMIT 5;"
+--------------------------+------+--------+
| id                       | name | closed |
+--------------------------+------+--------+
| 6a1410bae00948891ddabc14 | test | false  |
+--------------------------+------+--------+
```

**Testing cards query:**
```console
$ coral sql "SELECT id, name FROM trello.cards WHERE board_id = '6a1410bae00948891ddabc14' LIMIT 5;"
+--------------------------+-----------+
| id                       | name      |
+--------------------------+-----------+
| 6a1410bae00948891ddabc48 | Product   |
| 6a1410bae00948891ddabc4e | Marketing |
| 6a1410bae00948891ddabc51 | Sales     |
| 6a1410bae00948891ddabc54 | Support   |
| 6a1410bae00948891ddabc57 | People    |
+--------------------------+-----------+
```