### PR TITLE
refactor(ui/traces): tighten waterfall layout

### DIFF
--- a/ui/src/views/traces-page.css.ts
+++ b/ui/src/views/traces-page.css.ts
@@ -345,25 +345,27 @@ export const waterfallTimelinePane = style({
   minHeight: 0,
   minWidth: 360,
   overflow: 'hidden',
-  rowGap: 10,
 })
-export const waterfallTickRow = style({
-  display: 'grid',
-  flexShrink: 0,
-  gridTemplateColumns: '320px minmax(0, 1fr)',
-})
+export const waterfallTickRow = style({ display: 'contents' })
 export const waterfallLabel = style({
+  backgroundColor: theme.surface.mainContent,
   height: 24,
+  insetBlockStart: 0,
   minWidth: 0,
   paddingBlockEnd: 4,
+  position: 'sticky',
+  zIndex: 2,
 })
 export const waterfallTimeline = style({
+  backgroundColor: theme.surface.mainContent,
   borderBlockEnd: `1px solid ${theme.stroke.primary}`,
   height: 24,
+  insetBlockStart: 0,
   minWidth: 0,
   overflow: 'hidden',
   paddingBlockEnd: 4,
-  position: 'relative',
+  position: 'sticky',
+  zIndex: 2,
 })
 export const waterfallTick = style({
   color: theme.content.tertiary,
@@ -407,13 +409,13 @@ export const waterfallRowsViewport = style({
   flex: 1,
   minHeight: 0,
   minWidth: 0,
-  overflow: 'auto',
 })
 export const waterfallRowsGrid = style({
   alignItems: 'start',
   display: 'grid',
-  gridTemplateColumns: '320px minmax(0, 1fr)',
+  gridTemplateColumns: 'minmax(0, max-content) minmax(0, 1fr)',
   minWidth: 0,
+  rowGap: 10,
 })
 export const waterfallLabelsColumn = style({
   display: 'flex',
@@ -579,7 +581,7 @@ export const waterfallBar = style({
   display: 'flex',
   height: 20,
   insetBlockStart: 2,
-  minWidth: 2,
+  minWidth: 6,
   overflow: 'hidden',
   paddingInline: 8,
   position: 'absolute',
@@ -625,7 +627,8 @@ export const waterfallBarLabelOutside = style({
   transform: 'translateY(-50%)',
   whiteSpace: 'nowrap',
   selectors: {
-    '&[data-align="end"]': { textAlign: 'right' },
+    '&[data-align="start"]': { marginInlineStart: 8 },
+    '&[data-align="end"]': { marginInlineEnd: 8, textAlign: 'right' },
   },
 })
 export const waterfallHttpDetail = style({

--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 import * as Button from '@/wax/components/button'
 import { Icon } from '@/wax/components/icon'
 import { KeyboardShortcut } from '@/wax/components/keyboard-shortcut'
+import * as ScrollArea from '@/wax/components/scroll-area'
 import { Typography } from '@/wax/components/typography'
 import { getTrace } from '@/lib/coral-traces-client'
 import { TraceStatus, type GetTraceResponse, type TraceSpan } from '@/generated/coral/v1/traces_pb'
@@ -330,6 +331,7 @@ function WaterfallRow({
   onHover,
   reserveToggleSpace,
   row,
+  showMeta,
 }: {
   collapsed: boolean
   expanded: boolean
@@ -339,11 +341,12 @@ function WaterfallRow({
   onHover: (spanId: string | null) => void
   reserveToggleSpace: boolean
   row: TimelineRow
+  showMeta: boolean
 }) {
   const { childCount, depth, span } = row
   const tone = spanTone(span)
   const label = spanDisplayLabel(span)
-  const meta = spanDisplayMeta(span, label)
+  const meta = showMeta ? spanDisplayMeta(span, label) : ''
   const isNoisyInternalSpan =
     tone === 'span' &&
     span.kind === 'internal' &&
@@ -581,9 +584,9 @@ function TimelineWaterfall({
   return (
     <div className={s.waterfallRoot} ref={rootRef}>
       <div className={s.waterfallTimelinePane}>
-        <WaterfallTickRow durationMs={durationMs} />
-        <div className={s.waterfallRowsViewport} role="tree">
-          <div className={s.waterfallRowsGrid}>
+        <ScrollArea.Container className={s.waterfallRowsViewport} constrainWidth>
+          <div className={s.waterfallRowsGrid} role="tree">
+            <WaterfallTickRow durationMs={durationMs} />
             <div className={s.waterfallLabelsColumn}>
               {rows.map((row) => (
                 <WaterfallRow
@@ -598,6 +601,7 @@ function TimelineWaterfall({
                   }
                   reserveToggleSpace={proMode}
                   row={row}
+                  showMeta={proMode}
                 />
               ))}
             </div>
@@ -618,7 +622,7 @@ function TimelineWaterfall({
               ))}
             </div>
           </div>
-        </div>
+        </ScrollArea.Container>
       </div>
       {renderedHttpSpan && (
         <>


### PR DESCRIPTION
## Summary
- Hide the span meta subtitle (`client · 200 · coral`) outside `?pro` mode, since in normal mode it's always the same shape.
- Widen narrow-bar `minWidth` and add an 8px gap before outside-of-bar duration labels so they don't crowd the bar.
- Replace the waterfall rows' raw `overflow: auto` with the wax `ScrollArea.Container`.
- Unify the tick row and the rows into one grid so column 1 sizes to the widest label via `max-content`; the sticky tick cells get a solid background so the scroll thumb doesn't show through them.

## Test plan

<img width="1483" height="802" alt="image" src="https://github.com/user-attachments/assets/6425f85a-d488-4691-8573-0c42ad8b7106" />
<img width="1491" height="817" alt="image" src="https://github.com/user-attachments/assets/e8070985-02ab-401b-b532-383c7831c6ae" />
