### PR TITLE
feat(cli): add runtime feature flags

### DIFF
--- a/crates/coral-app/AGENTS.md
+++ b/crates/coral-app/AGENTS.md
@@ -12,6 +12,7 @@ root.
 - workspace identity and validation
 - source lifecycle and install/remove persistence
 - credential-set identity and credential material persistence
+- runtime feature registry semantics for user-facing `[features]` config
 - bundled-source manifest description and install-time manifest mapping through
   `coral-spec`
 - query-time selection of installed sources before calling `coral-engine`
@@ -39,6 +40,8 @@ root.
   unless they own durable, independent behavior.
 - Persist imported manifests as files under app-owned state; do not inline
   them into `config.toml`.
+- User-facing runtime feature semantics belong in `coral_app::features`; raw
+  config-file persistence, locking, and TOML extraction stay in `state/`.
 - Bundled installs persist source identity plus configured variables and
   secrets, then resolve their manifest from the current binary at runtime.
 - Credential backend selection stays inside `credentials/`. Managers pass

--- a/crates/coral-app/src/bootstrap/env.rs
+++ b/crates/coral-app/src/bootstrap/env.rs
@@ -5,6 +5,8 @@ use std::path::PathBuf;
 use coral_engine::QueryRuntimeContext;
 
 use super::consts::CORAL_CONFIG_DIR;
+use super::error::AppError;
+use crate::state::AppStateLayout;
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct AppEnvironment {
@@ -22,6 +24,13 @@ impl AppEnvironment {
 
     pub(crate) fn coral_config_dir_override(&self) -> Option<PathBuf> {
         self.coral_config_dir_override.clone()
+    }
+
+    pub(crate) fn app_state_layout(
+        &self,
+        config_dir_override: Option<PathBuf>,
+    ) -> Result<AppStateLayout, AppError> {
+        AppStateLayout::discover(config_dir_override.or_else(|| self.coral_config_dir_override()))
     }
 
     pub(crate) fn query_runtime_context(&self) -> QueryRuntimeContext {

--- a/crates/coral-app/src/bootstrap/error.rs
+++ b/crates/coral-app/src/bootstrap/error.rs
@@ -31,6 +31,9 @@ pub enum AppError {
     /// `config.toml` decoding failed.
     #[error(transparent)]
     TomlDecode(#[from] toml::de::Error),
+    /// `config.toml` parsing failed while preserving raw TOML structure.
+    #[error(transparent)]
+    TomlEditDecode(#[from] toml_edit::TomlError),
     /// `config.toml` encoding failed.
     #[error(transparent)]
     TomlEncode(#[from] toml::ser::Error),
@@ -186,6 +189,7 @@ fn app_code(error: &AppError) -> Code {
         AppError::Io(_)
         | AppError::Yaml(_)
         | AppError::TomlDecode(_)
+        | AppError::TomlEditDecode(_)
         | AppError::TomlEncode(_)
         | AppError::Json(_)
         | AppError::Transport(_)

--- a/crates/coral-app/src/bootstrap/mod.rs
+++ b/crates/coral-app/src/bootstrap/mod.rs
@@ -1,9 +1,13 @@
 //! Internal bootstrap seam for assembling the local server runtime.
 
+use std::path::PathBuf;
+
 mod consts;
 mod env;
 mod error;
 mod server;
+
+use crate::state::AppStateLayout;
 
 #[cfg(test)]
 pub(crate) use error::MAX_STATUS_DETAIL_BYTES;
@@ -11,3 +15,9 @@ pub(crate) use error::{app_status, core_status};
 
 pub use error::AppError;
 pub use server::{RunningServer, ServerBuilder, ServerMode, StaticAsset, StaticAssetsProvider};
+
+pub(crate) fn discover_app_state_layout(
+    config_dir_override: Option<PathBuf>,
+) -> Result<AppStateLayout, AppError> {
+    env::AppEnvironment::discover().app_state_layout(config_dir_override)
+}

--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -49,7 +49,7 @@ use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
-use crate::state::{AppStateLayout, ConfigStore};
+use crate::state::ConfigStore;
 use crate::telemetry::TelemetryConfig;
 use crate::telemetry::service::TraceService;
 use crate::transport::GrpcMethodAnnotatedService;
@@ -245,11 +245,7 @@ impl ServerBuilder {
     /// fail to initialize, or the gRPC server cannot be started.
     pub async fn start(self) -> Result<RunningServer, AppError> {
         let env = AppEnvironment::discover();
-        let layout = AppStateLayout::discover(
-            self.config
-                .config_dir
-                .or_else(|| env.coral_config_dir_override()),
-        )?;
+        let layout = env.app_state_layout(self.config.config_dir)?;
         layout.ensure()?;
         let telemetry_config = TelemetryConfig::load(&layout)?;
         let internal_trace_store_dir = telemetry_config

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -1,0 +1,343 @@
+//! Runtime feature registry and effective feature resolution.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use tracing::warn;
+
+use crate::bootstrap::{AppError, discover_app_state_layout};
+use crate::state::{
+    AppStateLayout, RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue,
+};
+
+/// Runtime feature keys recognized by Coral.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Feature {
+    /// Expose the optional MCP `feedback` tool.
+    Feedback,
+}
+
+impl Feature {
+    /// Returns all runtime features recognized by this Coral binary.
+    #[must_use]
+    pub fn all() -> impl ExactSizeIterator<Item = Self> {
+        FEATURE_SPECS.iter().map(|spec| spec.feature)
+    }
+
+    /// Returns the stable key used under `[features]` in `config.toml`.
+    #[must_use]
+    pub fn key(self) -> &'static str {
+        spec_for_feature(self).key
+    }
+
+    /// Returns whether the feature is enabled when no config override exists.
+    #[must_use]
+    pub fn default_enabled(self) -> bool {
+        spec_for_feature(self).default_enabled
+    }
+
+    /// Returns a short human-readable description of the feature.
+    #[must_use]
+    pub fn description(self) -> &'static str {
+        spec_for_feature(self).description
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FeatureSpec {
+    feature: Feature,
+    key: &'static str,
+    default_enabled: bool,
+    description: &'static str,
+}
+
+const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
+    feature: Feature::Feedback,
+    key: "feedback",
+    default_enabled: false,
+    description: "Expose the optional MCP feedback tool.",
+}];
+
+/// How a feature's value is configured in Coral's local config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FeatureConfiguredState {
+    /// No override exists, so the feature uses its built-in default.
+    Default,
+    /// The local config explicitly enables the feature.
+    Enabled,
+    /// The local config explicitly disables the feature.
+    Disabled,
+    /// The local config contains a known feature key with a non-boolean value.
+    InvalidValue,
+    /// The local config uses an unsupported `[features]` container shape.
+    InvalidContainer,
+}
+
+impl FeatureConfiguredState {
+    /// Returns the stable user-facing label for this configured state.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Enabled => "enabled",
+            Self::Disabled => "disabled",
+            Self::InvalidValue => "invalid-value",
+            Self::InvalidContainer => "invalid-container",
+        }
+    }
+}
+
+/// A feature's configured and effective runtime state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FeatureStatus {
+    /// Feature enum variant.
+    pub feature: Feature,
+    /// Stable config key.
+    pub key: &'static str,
+    /// Built-in enabled state when no override exists.
+    pub default_enabled: bool,
+    /// Current config state.
+    pub configured: FeatureConfiguredState,
+    /// Effective runtime state after applying config to the default.
+    pub enabled: bool,
+    /// Short human-readable description.
+    pub description: &'static str,
+}
+
+/// Effective runtime feature state after applying config overrides.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Features {
+    enabled: BTreeMap<Feature, bool>,
+}
+
+impl Default for Features {
+    fn default() -> Self {
+        let enabled = FEATURE_SPECS
+            .iter()
+            .map(|spec| (spec.feature, spec.default_enabled))
+            .collect();
+        Self { enabled }
+    }
+}
+
+impl Features {
+    /// Returns whether a runtime feature is enabled.
+    #[must_use]
+    pub fn enabled(&self, feature: Feature) -> bool {
+        self.enabled.get(&feature).copied().unwrap_or(false)
+    }
+
+    fn from_raw_overrides(raw: &RawFeatureOverrides) -> Self {
+        let mut features = Self::default();
+        for (key, value) in raw.iter() {
+            let Some(spec) = spec_for_key(key) else {
+                warn!(feature = key, "ignoring unknown Coral runtime feature");
+                continue;
+            };
+
+            match value {
+                RawFeatureValue::Bool(enabled) => {
+                    features.enabled.insert(spec.feature, enabled);
+                }
+                RawFeatureValue::UnsupportedType => {
+                    warn!(
+                        feature = key,
+                        "ignoring unsupported Coral runtime feature value; expected boolean"
+                    );
+                }
+            }
+        }
+        features
+    }
+}
+
+/// Loader for runtime features from Coral's local config.
+#[derive(Debug, Clone)]
+pub struct FeatureStore {
+    layout: AppStateLayout,
+}
+
+impl FeatureStore {
+    /// Discovers the Coral app state layout used for runtime feature config.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] when the platform config directory cannot be discovered.
+    pub fn discover(config_dir_override: Option<PathBuf>) -> Result<Self, AppError> {
+        Ok(Self {
+            layout: discover_app_state_layout(config_dir_override)?,
+        })
+    }
+
+    /// Loads the effective runtime feature state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
+    pub fn load(&self) -> Result<Features, AppError> {
+        let raw = crate::state::load_raw_feature_overrides(&self.layout)?;
+        Ok(Features::from_raw_overrides(&raw))
+    }
+
+    /// Lists every known feature with configured and effective status.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
+    pub fn statuses(&self) -> Result<Vec<FeatureStatus>, AppError> {
+        let raw = crate::state::load_raw_feature_overrides(&self.layout)?;
+        let features = Features::from_raw_overrides(&raw);
+        let mut statuses = FEATURE_SPECS
+            .iter()
+            .map(|spec| status_from_raw(spec, &raw, &features))
+            .collect::<Vec<_>>();
+        statuses.sort_by_key(|status| status.key);
+        Ok(statuses)
+    }
+
+    /// Persists a local opt-in override for a known feature key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the key is unknown or the local config cannot be updated.
+    pub fn enable(&self, key: &str) -> Result<(), AppError> {
+        let spec = spec_for_key(key).ok_or_else(|| unknown_feature_error(key))?;
+        crate::state::set_raw_feature_override(&self.layout, spec.key, true)
+    }
+
+    /// Persists a local opt-out for a known feature key, clearing default-false overrides.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if the key is unknown or the local config cannot be updated.
+    pub fn disable(&self, key: &str) -> Result<(), AppError> {
+        let spec = spec_for_key(key).ok_or_else(|| unknown_feature_error(key))?;
+        if spec.default_enabled {
+            crate::state::set_raw_feature_override(&self.layout, spec.key, false)
+        } else {
+            crate::state::clear_raw_feature_override(&self.layout, spec.key)
+        }
+    }
+}
+
+fn status_from_raw(
+    spec: &'static FeatureSpec,
+    raw: &RawFeatureOverrides,
+    features: &Features,
+) -> FeatureStatus {
+    let configured = match raw.container() {
+        RawFeatureContainerState::Unsupported => FeatureConfiguredState::InvalidContainer,
+        RawFeatureContainerState::Missing | RawFeatureContainerState::Table => {
+            match raw.get(spec.key) {
+                Some(RawFeatureValue::Bool(true)) => FeatureConfiguredState::Enabled,
+                Some(RawFeatureValue::Bool(false)) => FeatureConfiguredState::Disabled,
+                Some(RawFeatureValue::UnsupportedType) => FeatureConfiguredState::InvalidValue,
+                None => FeatureConfiguredState::Default,
+            }
+        }
+    };
+
+    FeatureStatus {
+        feature: spec.feature,
+        key: spec.key,
+        default_enabled: spec.default_enabled,
+        configured,
+        enabled: features.enabled(spec.feature),
+        description: spec.description,
+    }
+}
+
+fn unknown_feature_error(key: &str) -> AppError {
+    let mut valid = FEATURE_SPECS
+        .iter()
+        .map(|spec| spec.key)
+        .collect::<Vec<_>>();
+    valid.sort_unstable();
+    let valid = valid.join(", ");
+    AppError::InvalidInput(format!("unknown feature '{key}'. Valid features: {valid}"))
+}
+
+fn spec_for_feature(feature: Feature) -> &'static FeatureSpec {
+    FEATURE_SPECS
+        .iter()
+        .find(|spec| spec.feature == feature)
+        .expect("every Feature variant must have a FeatureSpec")
+}
+
+fn spec_for_key(key: &str) -> Option<&'static FeatureSpec> {
+    FEATURE_SPECS.iter().find(|spec| spec.key == key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(
+        entries: impl IntoIterator<Item = (&'static str, RawFeatureValue)>,
+    ) -> RawFeatureOverrides {
+        RawFeatureOverrides::from_entries_for_tests(entries)
+    }
+
+    #[test]
+    fn defaults_disable_feedback() {
+        let features = Features::default();
+
+        assert!(!features.enabled(Feature::Feedback));
+    }
+
+    #[test]
+    fn known_boolean_override_enables_feedback() {
+        let raw = raw([("feedback", RawFeatureValue::Bool(true))]);
+        let features = Features::from_raw_overrides(&raw);
+
+        assert!(features.enabled(Feature::Feedback));
+    }
+
+    #[test]
+    fn known_boolean_override_disables_feedback() {
+        let raw = raw([("feedback", RawFeatureValue::Bool(false))]);
+        let features = Features::from_raw_overrides(&raw);
+
+        assert!(!features.enabled(Feature::Feedback));
+    }
+
+    #[test]
+    fn unknown_override_is_ignored() {
+        let raw = raw([("future_flag", RawFeatureValue::Bool(true))]);
+        let features = Features::from_raw_overrides(&raw);
+
+        assert!(!features.enabled(Feature::Feedback));
+    }
+
+    #[test]
+    fn unsupported_known_override_is_ignored() {
+        let raw = raw([("feedback", RawFeatureValue::UnsupportedType)]);
+        let features = Features::from_raw_overrides(&raw);
+
+        assert!(!features.enabled(Feature::Feedback));
+    }
+
+    #[test]
+    fn statuses_report_invalid_known_value_without_enabling_feature() {
+        let raw = raw([("feedback", RawFeatureValue::UnsupportedType)]);
+        let features = Features::from_raw_overrides(&raw);
+
+        let statuses = FEATURE_SPECS
+            .iter()
+            .map(|spec| status_from_raw(spec, &raw, &features))
+            .collect::<Vec<_>>();
+        let status = statuses.first().expect("feedback status");
+
+        assert_eq!(status.key, "feedback");
+        assert_eq!(status.configured, FeatureConfiguredState::InvalidValue);
+        assert!(!status.enabled);
+    }
+
+    #[test]
+    fn unknown_feature_error_lists_valid_keys() {
+        let error = unknown_feature_error("nope");
+
+        assert!(error.to_string().contains("unknown feature 'nope'"));
+        assert!(error.to_string().contains("feedback"));
+    }
+}

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -127,6 +127,10 @@ impl Features {
         self.enabled.get(&feature).copied().unwrap_or(false)
     }
 
+    fn feedback_enabled(&self, explicit_enable: bool) -> bool {
+        explicit_enable || self.enabled(Feature::Feedback)
+    }
+
     fn from_raw_overrides(raw: &RawFeatureOverrides) -> Self {
         let mut features = Self::default();
         for (key, value) in raw.iter() {
@@ -149,6 +153,20 @@ impl Features {
         }
         features
     }
+}
+
+/// Resolves whether the MCP feedback tool should be enabled for this process.
+///
+/// Explicit process flags can enable feedback for one run, but cannot disable a
+/// persistent opt-in from local config.
+///
+/// # Errors
+///
+/// Returns [`AppError`] if the local config path cannot be discovered or
+/// `config.toml` exists but cannot be read or parsed.
+pub fn resolve_feedback_enabled(explicit_enable: bool) -> Result<bool, AppError> {
+    let features = FeatureStore::discover(None)?.load()?;
+    Ok(features.feedback_enabled(explicit_enable))
 }
 
 /// Loader for runtime features from Coral's local config.
@@ -286,6 +304,13 @@ mod tests {
     }
 
     #[test]
+    fn explicit_feedback_enable_overrides_default_disabled_feature() {
+        let features = Features::default();
+
+        assert!(features.feedback_enabled(true));
+    }
+
+    #[test]
     fn known_boolean_override_enables_feedback() {
         let raw = raw([("feedback", RawFeatureValue::Bool(true))]);
         let features = Features::from_raw_overrides(&raw);
@@ -299,6 +324,14 @@ mod tests {
         let features = Features::from_raw_overrides(&raw);
 
         assert!(!features.enabled(Feature::Feedback));
+    }
+
+    #[test]
+    fn explicit_feedback_enable_overrides_config_disabled_feature() {
+        let raw = raw([("feedback", RawFeatureValue::Bool(false))]);
+        let features = Features::from_raw_overrides(&raw);
+
+        assert!(features.feedback_enabled(true));
     }
 
     #[test]

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -69,7 +69,7 @@ const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
     feature: Feature::Feedback,
     key: "feedback",
     default_enabled: false,
-    description: "Expose the optional MCP feedback tool.",
+    description: "Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral.",
     enable_flag: "enable-feedback",
     disable_flag: "disable-feedback",
 }];

--- a/crates/coral-app/src/features.rs
+++ b/crates/coral-app/src/features.rs
@@ -41,6 +41,18 @@ impl Feature {
     pub fn description(self) -> &'static str {
         spec_for_feature(self).description
     }
+
+    /// Returns the long flag name for process-local enable overrides.
+    #[must_use]
+    pub fn enable_flag(self) -> &'static str {
+        spec_for_feature(self).enable_flag
+    }
+
+    /// Returns the long flag name for process-local disable overrides.
+    #[must_use]
+    pub fn disable_flag(self) -> &'static str {
+        spec_for_feature(self).disable_flag
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -49,6 +61,8 @@ struct FeatureSpec {
     key: &'static str,
     default_enabled: bool,
     description: &'static str,
+    enable_flag: &'static str,
+    disable_flag: &'static str,
 }
 
 const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
@@ -56,6 +70,8 @@ const FEATURE_SPECS: &[FeatureSpec] = &[FeatureSpec {
     key: "feedback",
     default_enabled: false,
     description: "Expose the optional MCP feedback tool.",
+    enable_flag: "enable-feedback",
+    disable_flag: "disable-feedback",
 }];
 
 /// How a feature's value is configured in Coral's local config.
@@ -127,10 +143,6 @@ impl Features {
         self.enabled.get(&feature).copied().unwrap_or(false)
     }
 
-    fn feedback_enabled(&self, explicit_enable: bool) -> bool {
-        explicit_enable || self.enabled(Feature::Feedback)
-    }
-
     fn from_raw_overrides(raw: &RawFeatureOverrides) -> Self {
         let mut features = Self::default();
         for (key, value) in raw.iter() {
@@ -153,20 +165,31 @@ impl Features {
         }
         features
     }
+
+    fn apply_overrides(&mut self, overrides: &FeatureOverrides) {
+        for (feature, enabled) in overrides.iter() {
+            self.enabled.insert(feature, enabled);
+        }
+    }
 }
 
-/// Resolves whether the MCP feedback tool should be enabled for this process.
-///
-/// Explicit process flags can enable feedback for one run, but cannot disable a
-/// persistent opt-in from local config.
-///
-/// # Errors
-///
-/// Returns [`AppError`] if the local config path cannot be discovered or
-/// `config.toml` exists but cannot be read or parsed.
-pub fn resolve_feedback_enabled(explicit_enable: bool) -> Result<bool, AppError> {
-    let features = FeatureStore::discover(None)?.load()?;
-    Ok(features.feedback_enabled(explicit_enable))
+/// Process-local runtime feature overrides.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FeatureOverrides {
+    enabled: BTreeMap<Feature, bool>,
+}
+
+impl FeatureOverrides {
+    /// Sets a process-local override for a known feature.
+    pub fn set(&mut self, feature: Feature, enabled: bool) {
+        self.enabled.insert(feature, enabled);
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (Feature, bool)> + '_ {
+        self.enabled
+            .iter()
+            .map(|(feature, enabled)| (*feature, *enabled))
+    }
 }
 
 /// Loader for runtime features from Coral's local config.
@@ -197,6 +220,18 @@ impl FeatureStore {
         Ok(Features::from_raw_overrides(&raw))
     }
 
+    /// Loads effective runtime feature state, applying process-local overrides.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
+    pub fn load_with_overrides(&self, overrides: &FeatureOverrides) -> Result<Features, AppError> {
+        let raw = crate::state::load_raw_feature_overrides(&self.layout)?;
+        let mut features = Features::from_raw_overrides(&raw);
+        features.apply_overrides(overrides);
+        Ok(features)
+    }
+
     /// Lists every known feature with configured and effective status.
     ///
     /// # Errors
@@ -205,12 +240,22 @@ impl FeatureStore {
     pub fn statuses(&self) -> Result<Vec<FeatureStatus>, AppError> {
         let raw = crate::state::load_raw_feature_overrides(&self.layout)?;
         let features = Features::from_raw_overrides(&raw);
-        let mut statuses = FEATURE_SPECS
-            .iter()
-            .map(|spec| status_from_raw(spec, &raw, &features))
-            .collect::<Vec<_>>();
-        statuses.sort_by_key(|status| status.key);
-        Ok(statuses)
+        Ok(statuses_from_raw(&raw, &features))
+    }
+
+    /// Lists every known feature, applying process-local overrides to effective state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AppError`] if `config.toml` exists but cannot be read or parsed.
+    pub fn statuses_with_overrides(
+        &self,
+        overrides: &FeatureOverrides,
+    ) -> Result<Vec<FeatureStatus>, AppError> {
+        let raw = crate::state::load_raw_feature_overrides(&self.layout)?;
+        let mut features = Features::from_raw_overrides(&raw);
+        features.apply_overrides(overrides);
+        Ok(statuses_from_raw(&raw, &features))
     }
 
     /// Persists a local opt-in override for a known feature key.
@@ -223,18 +268,14 @@ impl FeatureStore {
         crate::state::set_raw_feature_override(&self.layout, spec.key, true)
     }
 
-    /// Persists a local opt-out for a known feature key, clearing default-false overrides.
+    /// Persists a local opt-out for a known feature key.
     ///
     /// # Errors
     ///
     /// Returns [`AppError`] if the key is unknown or the local config cannot be updated.
     pub fn disable(&self, key: &str) -> Result<(), AppError> {
         let spec = spec_for_key(key).ok_or_else(|| unknown_feature_error(key))?;
-        if spec.default_enabled {
-            crate::state::set_raw_feature_override(&self.layout, spec.key, false)
-        } else {
-            crate::state::clear_raw_feature_override(&self.layout, spec.key)
-        }
+        crate::state::set_raw_feature_override(&self.layout, spec.key, false)
     }
 }
 
@@ -263,6 +304,15 @@ fn status_from_raw(
         enabled: features.enabled(spec.feature),
         description: spec.description,
     }
+}
+
+fn statuses_from_raw(raw: &RawFeatureOverrides, features: &Features) -> Vec<FeatureStatus> {
+    let mut statuses = FEATURE_SPECS
+        .iter()
+        .map(|spec| status_from_raw(spec, raw, features))
+        .collect::<Vec<_>>();
+    statuses.sort_by_key(|status| status.key);
+    statuses
 }
 
 fn unknown_feature_error(key: &str) -> AppError {
@@ -304,10 +354,14 @@ mod tests {
     }
 
     #[test]
-    fn explicit_feedback_enable_overrides_default_disabled_feature() {
-        let features = Features::default();
+    fn process_overrides_enable_default_disabled_feature() {
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::Feedback, true);
+        let mut features = Features::default();
 
-        assert!(features.feedback_enabled(true));
+        features.apply_overrides(&overrides);
+
+        assert!(features.enabled(Feature::Feedback));
     }
 
     #[test]
@@ -327,11 +381,15 @@ mod tests {
     }
 
     #[test]
-    fn explicit_feedback_enable_overrides_config_disabled_feature() {
-        let raw = raw([("feedback", RawFeatureValue::Bool(false))]);
-        let features = Features::from_raw_overrides(&raw);
+    fn process_overrides_disable_config_enabled_feature() {
+        let mut overrides = FeatureOverrides::default();
+        overrides.set(Feature::Feedback, false);
+        let raw = raw([("feedback", RawFeatureValue::Bool(true))]);
+        let mut features = Features::from_raw_overrides(&raw);
 
-        assert!(features.feedback_enabled(true));
+        features.apply_overrides(&overrides);
+
+        assert!(!features.enabled(Feature::Feedback));
     }
 
     #[test]

--- a/crates/coral-app/src/lib.rs
+++ b/crates/coral-app/src/lib.rs
@@ -37,6 +37,7 @@
 pub mod bootstrap;
 mod catalog;
 mod credentials;
+pub mod features;
 mod feedback;
 mod identity;
 mod query;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -351,7 +351,7 @@ fn app_error_type(error: &AppError) -> &'static str {
         AppError::FailedPrecondition(_) => "FAILED_PRECONDITION",
         AppError::Io(_) => "IO",
         AppError::Yaml(_) => "YAML",
-        AppError::TomlDecode(_) => "TOML_DECODE",
+        AppError::TomlDecode(_) | AppError::TomlEditDecode(_) => "TOML_DECODE",
         AppError::TomlEncode(_) => "TOML_ENCODE",
         AppError::Json(_) => "JSON",
         AppError::Transport(_) => "TRANSPORT",

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -239,28 +239,6 @@ pub(crate) fn set_raw_feature_override(
     write_config_document(layout, &doc)
 }
 
-pub(crate) fn clear_raw_feature_override(
-    layout: &AppStateLayout,
-    key: &str,
-) -> Result<(), AppError> {
-    if !layout.config_file().exists() {
-        return Ok(());
-    }
-
-    let _lock = FileLock::exclusive(layout.state_lock())?;
-    if !layout.config_file().exists() {
-        return Ok(());
-    }
-
-    let mut doc = read_config_document(layout)?;
-    ensure_feature_table(&doc)?;
-    let Some(table) = doc.get_mut("features").and_then(Item::as_table_mut) else {
-        return Ok(());
-    };
-    table.remove(key);
-    write_config_document(layout, &doc)
-}
-
 fn raw_feature_overrides_from_document(doc: &DocumentMut) -> RawFeatureOverrides {
     let Some(features) = doc.get("features") else {
         return RawFeatureOverrides::default();
@@ -538,8 +516,7 @@ mod tests {
     use crate::credentials::CredentialStorageKind;
     use super::{
         AppConfig, PersistedAppConfig, RawFeatureContainerState, RawFeatureValue, SourceCatalog,
-        clear_raw_feature_override, load_raw_feature_overrides, render_config,
-        set_raw_feature_override,
+        load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
@@ -955,21 +932,7 @@ enabled = true
     }
 
     #[test]
-    fn clear_raw_feature_override_missing_config_is_noop_without_creating_state() {
-        let temp = TempDir::new().expect("temp dir");
-        let config_dir = temp.path().join("missing-config");
-        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
-
-        clear_raw_feature_override(&layout, "feedback").expect("clear feature");
-
-        assert!(
-            !config_dir.exists(),
-            "clearing absent default-false override should not create config state"
-        );
-    }
-
-    #[test]
-    fn set_and_clear_feature_override_preserve_unrelated_feature_entries() {
+    fn set_raw_feature_override_preserves_unrelated_feature_entries() {
         let temp = TempDir::new().expect("temp dir");
         let layout = test_layout(&temp);
         write_config(
@@ -981,9 +944,9 @@ feedback = true
 "#,
         );
 
-        clear_raw_feature_override(&layout, "feedback").expect("clear feature");
+        set_raw_feature_override(&layout, "feedback", false).expect("set feature");
         let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
-        assert!(!raw.contains("feedback ="));
+        assert!(raw.contains("feedback = false"));
         assert!(raw.contains("future_flag = \"yes\""));
 
         set_raw_feature_override(&layout, "feedback", true).expect("set feature");

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, InlineTable, Item, Value, value};
+use tracing::warn;
 
 use crate::bootstrap::AppError;
 use crate::credentials::CredentialStorageKind;
@@ -38,6 +39,55 @@ struct PersistedAppConfig {
     version: u32,
     #[serde(default)]
     workspaces: BTreeMap<String, PersistedWorkspaceConfig>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct RawFeatureOverrides {
+    entries: BTreeMap<String, RawFeatureValue>,
+    container: RawFeatureContainerState,
+}
+
+impl RawFeatureOverrides {
+    pub(crate) fn container(&self) -> RawFeatureContainerState {
+        self.container
+    }
+
+    pub(crate) fn get(&self, key: &str) -> Option<RawFeatureValue> {
+        self.entries.get(key).copied()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&str, RawFeatureValue)> + '_ {
+        self.entries
+            .iter()
+            .map(|(key, value)| (key.as_str(), *value))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_entries_for_tests(
+        entries: impl IntoIterator<Item = (&'static str, RawFeatureValue)>,
+    ) -> Self {
+        Self {
+            entries: entries
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value))
+                .collect(),
+            container: RawFeatureContainerState::Table,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum RawFeatureContainerState {
+    #[default]
+    Missing,
+    Table,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RawFeatureValue {
+    Bool(bool),
+    UnsupportedType,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -146,6 +196,125 @@ impl SourceCatalog {
         }
 
         removed
+    }
+}
+
+pub(crate) fn load_raw_feature_overrides(
+    layout: &AppStateLayout,
+) -> Result<RawFeatureOverrides, AppError> {
+    if !layout.config_file().exists() {
+        return Ok(RawFeatureOverrides::default());
+    }
+
+    let _lock = FileLock::shared(layout.state_lock())?;
+    if !layout.config_file().exists() {
+        return Ok(RawFeatureOverrides::default());
+    }
+
+    let raw = std::fs::read_to_string(layout.config_file())?;
+    let doc = raw.parse::<DocumentMut>()?;
+    Ok(raw_feature_overrides_from_document(&doc))
+}
+
+pub(crate) fn set_raw_feature_override(
+    layout: &AppStateLayout,
+    key: &str,
+    enabled: bool,
+) -> Result<(), AppError> {
+    let _lock = FileLock::exclusive(layout.state_lock())?;
+    let mut doc = read_config_document(layout)?;
+    ensure_feature_table(&doc)?;
+    if doc.get("features").is_none() {
+        doc.insert("features", toml_edit::table());
+    }
+    let Some(feature_table) = doc.get_mut("features").and_then(Item::as_table_mut) else {
+        return Err(AppError::InvalidInput(
+            "unsupported [features] config; expected a table".to_string(),
+        ));
+    };
+    feature_table.insert(key, value(enabled));
+    if doc.get("version").is_none() {
+        doc.insert("version", value(i64::from(default_config_version())));
+    }
+    write_config_document(layout, &doc)
+}
+
+pub(crate) fn clear_raw_feature_override(
+    layout: &AppStateLayout,
+    key: &str,
+) -> Result<(), AppError> {
+    if !layout.config_file().exists() {
+        return Ok(());
+    }
+
+    let _lock = FileLock::exclusive(layout.state_lock())?;
+    if !layout.config_file().exists() {
+        return Ok(());
+    }
+
+    let mut doc = read_config_document(layout)?;
+    ensure_feature_table(&doc)?;
+    let Some(table) = doc.get_mut("features").and_then(Item::as_table_mut) else {
+        return Ok(());
+    };
+    table.remove(key);
+    write_config_document(layout, &doc)
+}
+
+fn raw_feature_overrides_from_document(doc: &DocumentMut) -> RawFeatureOverrides {
+    let Some(features) = doc.get("features") else {
+        return RawFeatureOverrides::default();
+    };
+
+    let Some(table) = features.as_table() else {
+        warn!("ignoring unsupported [features] config; expected a table");
+        return RawFeatureOverrides {
+            entries: BTreeMap::new(),
+            container: RawFeatureContainerState::Unsupported,
+        };
+    };
+
+    let entries = table
+        .iter()
+        .map(|(key, item)| {
+            let value = item
+                .as_bool()
+                .map_or(RawFeatureValue::UnsupportedType, RawFeatureValue::Bool);
+            (key.to_string(), value)
+        })
+        .collect();
+    RawFeatureOverrides {
+        entries,
+        container: RawFeatureContainerState::Table,
+    }
+}
+
+fn read_config_document(layout: &AppStateLayout) -> Result<DocumentMut, AppError> {
+    if !layout.config_file().exists() {
+        return Ok(DocumentMut::new());
+    }
+    let raw = std::fs::read_to_string(layout.config_file())?;
+    Ok(raw.parse::<DocumentMut>()?)
+}
+
+fn write_config_document(layout: &AppStateLayout, doc: &DocumentMut) -> Result<(), AppError> {
+    if let Some(parent) = layout.config_file().parent() {
+        storage_fs::ensure_dir(parent)?;
+    }
+    storage_fs::write_atomic(layout.config_file(), doc.to_string().as_bytes())?;
+    Ok(())
+}
+
+fn ensure_feature_table(doc: &DocumentMut) -> Result<(), AppError> {
+    let Some(features) = doc.get("features") else {
+        return Ok(());
+    };
+    if features.is_table() {
+        Ok(())
+    } else {
+        Err(AppError::InvalidInput(
+            "unsupported [features] config; expected a table".to_string(),
+        ))
     }
 }
 
@@ -364,10 +533,17 @@ mod tests {
 
     use std::collections::BTreeMap;
 
-    use super::{AppConfig, PersistedAppConfig, SourceCatalog, render_config};
+    use tempfile::TempDir;
+
     use crate::credentials::CredentialStorageKind;
+    use super::{
+        AppConfig, PersistedAppConfig, RawFeatureContainerState, RawFeatureValue, SourceCatalog,
+        clear_raw_feature_override, load_raw_feature_overrides, render_config,
+        set_raw_feature_override,
+    };
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
+    use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
 
     fn default_workspace() -> WorkspaceName {
@@ -386,6 +562,35 @@ mod tests {
             credential_storage: None,
             origin: SourceOrigin::Imported,
         }
+    }
+
+    fn test_layout(temp: &TempDir) -> AppStateLayout {
+        AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout")
+    }
+
+    fn write_config(layout: &AppStateLayout, raw: &str) {
+        std::fs::create_dir_all(
+            layout
+                .config_file()
+                .parent()
+                .expect("config file should have parent"),
+        )
+        .expect("create config dir");
+        std::fs::write(layout.config_file(), raw).expect("write config");
+    }
+
+    fn raw_feature_entries(layout: &AppStateLayout) -> BTreeMap<String, RawFeatureValue> {
+        load_raw_feature_overrides(layout)
+            .expect("feature overrides")
+            .iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect()
+    }
+
+    fn raw_feature_container(layout: &AppStateLayout) -> RawFeatureContainerState {
+        load_raw_feature_overrides(layout)
+            .expect("feature overrides")
+            .container()
     }
 
     #[test]
@@ -552,11 +757,15 @@ version = 1
 endpoint = "http://localhost:4318"
 headers = "from=config"
 
-[trace_history]
-enabled = false
-retention_days = 3
+	[trace_history]
+	enabled = false
+	retention_days = 3
 
-[workspaces.default.sources.github]
+	[features]
+	feedback = true
+	future_feature = "not-yet-known"
+
+	[workspaces.default.sources.github]
 version = "1.0.0"
 variables = {}
 secrets = []
@@ -595,6 +804,18 @@ origin = "bundled"
             raw.contains("retention_days = 3"),
             "trace history retention should be preserved"
         );
+        assert!(
+            raw.contains("[features]"),
+            "features section should be preserved"
+        );
+        assert!(
+            raw.contains("feedback = true"),
+            "known feature override should be preserved"
+        );
+        assert!(
+            raw.contains("future_feature = \"not-yet-known\""),
+            "future feature override should be preserved"
+        );
 
         // The newly added source must be present.
         assert!(raw.contains("[workspaces.default.sources.slack]"));
@@ -630,5 +851,159 @@ origin = "bundled"
         )
         .expect_err("invalid source key should fail");
         assert!(error.to_string().contains("source name"));
+    }
+
+    #[test]
+    fn raw_feature_overrides_default_when_config_file_is_missing_without_creating_state() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("missing-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+
+        let entries = raw_feature_entries(&layout);
+
+        assert!(entries.is_empty());
+        assert!(
+            !config_dir.exists(),
+            "read-only feature loading should not create config state"
+        );
+    }
+
+    #[test]
+    fn raw_feature_overrides_load_supported_table_entries() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        write_config(
+            &layout,
+            r#"
+version = 1
+
+[features]
+feedback = true
+future_flag = false
+wrong_type = "yes"
+
+[features.nested]
+enabled = true
+"#,
+        );
+
+        let entries = raw_feature_entries(&layout);
+
+        assert_eq!(entries.get("feedback"), Some(&RawFeatureValue::Bool(true)));
+        assert_eq!(
+            entries.get("future_flag"),
+            Some(&RawFeatureValue::Bool(false))
+        );
+        assert_eq!(
+            entries.get("wrong_type"),
+            Some(&RawFeatureValue::UnsupportedType)
+        );
+        assert_eq!(
+            entries.get("nested"),
+            Some(&RawFeatureValue::UnsupportedType)
+        );
+    }
+
+    #[test]
+    fn raw_feature_overrides_accept_dotted_feature_table() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        write_config(&layout, "features.feedback = false\n");
+
+        let entries = raw_feature_entries(&layout);
+
+        assert_eq!(entries.get("feedback"), Some(&RawFeatureValue::Bool(false)));
+    }
+
+    #[test]
+    fn raw_feature_overrides_ignore_inline_feature_table() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        write_config(&layout, "features = { feedback = true }\n");
+
+        let entries = raw_feature_entries(&layout);
+
+        assert!(entries.is_empty());
+        assert_eq!(
+            raw_feature_container(&layout),
+            RawFeatureContainerState::Unsupported
+        );
+    }
+
+    #[test]
+    fn raw_feature_overrides_fail_for_invalid_toml() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        write_config(&layout, "[features\nfeedback = true\n");
+
+        let error = load_raw_feature_overrides(&layout).expect_err("invalid TOML should fail");
+
+        assert!(error.to_string().contains("TOML parse error"));
+    }
+
+    #[test]
+    fn set_raw_feature_override_creates_config_file_with_features_table() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+
+        set_raw_feature_override(&layout, "feedback", true).expect("set feature");
+
+        let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
+        assert!(raw.contains("version = 1"));
+        assert!(raw.contains("[features]"));
+        assert!(raw.contains("feedback = true"));
+    }
+
+    #[test]
+    fn clear_raw_feature_override_missing_config_is_noop_without_creating_state() {
+        let temp = TempDir::new().expect("temp dir");
+        let config_dir = temp.path().join("missing-config");
+        let layout = AppStateLayout::discover(Some(config_dir.clone())).expect("layout");
+
+        clear_raw_feature_override(&layout, "feedback").expect("clear feature");
+
+        assert!(
+            !config_dir.exists(),
+            "clearing absent default-false override should not create config state"
+        );
+    }
+
+    #[test]
+    fn set_and_clear_feature_override_preserve_unrelated_feature_entries() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        write_config(
+            &layout,
+            r#"
+[features]
+future_flag = "yes"
+feedback = true
+"#,
+        );
+
+        clear_raw_feature_override(&layout, "feedback").expect("clear feature");
+        let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
+        assert!(!raw.contains("feedback ="));
+        assert!(raw.contains("future_flag = \"yes\""));
+
+        set_raw_feature_override(&layout, "feedback", true).expect("set feature");
+        let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
+        assert!(raw.contains("feedback = true"));
+        assert!(raw.contains("future_flag = \"yes\""));
+    }
+
+    #[test]
+    fn feature_mutations_reject_inline_feature_container_without_rewriting_file() {
+        let temp = TempDir::new().expect("temp dir");
+        let layout = test_layout(&temp);
+        let original = "features = { feedback = true }\n";
+        write_config(&layout, original);
+
+        let error =
+            set_raw_feature_override(&layout, "feedback", true).expect_err("inline features");
+
+        assert!(error.to_string().contains("unsupported [features] config"));
+        let raw = std::fs::read_to_string(layout.config_file()).expect("config file");
+        assert_eq!(raw, original);
     }
 }

--- a/crates/coral-app/src/state/config.rs
+++ b/crates/coral-app/src/state/config.rs
@@ -513,11 +513,11 @@ mod tests {
 
     use tempfile::TempDir;
 
-    use crate::credentials::CredentialStorageKind;
     use super::{
         AppConfig, PersistedAppConfig, RawFeatureContainerState, RawFeatureValue, SourceCatalog,
         load_raw_feature_overrides, render_config, set_raw_feature_override,
     };
+    use crate::credentials::CredentialStorageKind;
     use crate::sources::SourceName;
     use crate::sources::model::{InstalledSource, SourceOrigin};
     use crate::state::AppStateLayout;

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -4,4 +4,8 @@ mod config;
 mod layout;
 
 pub(crate) use config::ConfigStore;
+pub(crate) use config::{
+    RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, clear_raw_feature_override,
+    load_raw_feature_overrides, set_raw_feature_override,
+};
 pub(crate) use layout::AppStateLayout;

--- a/crates/coral-app/src/state/mod.rs
+++ b/crates/coral-app/src/state/mod.rs
@@ -5,7 +5,7 @@ mod layout;
 
 pub(crate) use config::ConfigStore;
 pub(crate) use config::{
-    RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, clear_raw_feature_override,
-    load_raw_feature_overrides, set_raw_feature_override,
+    RawFeatureContainerState, RawFeatureOverrides, RawFeatureValue, load_raw_feature_overrides,
+    set_raw_feature_override,
 };
 pub(crate) use layout::AppStateLayout;

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -22,7 +22,10 @@ use std::path::PathBuf;
 #[cfg(feature = "embedded-ui")]
 use std::sync::Arc;
 
-use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{
+    Arg, ArgAction, ArgGroup, ArgMatches, Args, CommandFactory, Error as ClapError, FromArgMatches,
+    Parser, Subcommand, ValueEnum,
+};
 use clap_complete::{Shell, generate};
 use coral_api::v1::ExecuteSqlRequest;
 #[cfg(feature = "embedded-ui")]
@@ -50,6 +53,8 @@ const DEFAULT_SERVER_PORT: u16 = 1457;
 )]
 /// A local-first SQL interface for APIs, files, and other data sources.
 struct Cli {
+    #[command(flatten)]
+    feature_overrides: FeatureOverrideArgs,
     #[command(subcommand)]
     command: Command,
 }
@@ -109,13 +114,99 @@ struct SqlArgs {
     sql: String,
 }
 
+#[derive(Debug, Default)]
+struct FeatureOverrideArgs {
+    overrides: coral_app::features::FeatureOverrides,
+}
+
+impl FeatureOverrideArgs {
+    fn into_overrides(self) -> coral_app::features::FeatureOverrides {
+        self.overrides
+    }
+}
+
+impl FromArgMatches for FeatureOverrideArgs {
+    fn from_arg_matches(matches: &ArgMatches) -> Result<Self, ClapError> {
+        let mut matches = matches.clone();
+        Self::from_arg_matches_mut(&mut matches)
+    }
+
+    fn from_arg_matches_mut(matches: &mut ArgMatches) -> Result<Self, ClapError> {
+        let mut overrides = coral_app::features::FeatureOverrides::default();
+        apply_feature_override_matches(matches, &mut overrides);
+        Ok(Self { overrides })
+    }
+
+    fn update_from_arg_matches(&mut self, matches: &ArgMatches) -> Result<(), ClapError> {
+        let mut matches = matches.clone();
+        self.update_from_arg_matches_mut(&mut matches)
+    }
+
+    fn update_from_arg_matches_mut(&mut self, matches: &mut ArgMatches) -> Result<(), ClapError> {
+        apply_feature_override_matches(matches, &mut self.overrides);
+        Ok(())
+    }
+}
+
+impl Args for FeatureOverrideArgs {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        add_feature_override_args(cmd)
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        add_feature_override_args(cmd)
+    }
+}
+
+fn apply_feature_override_matches(
+    matches: &ArgMatches,
+    overrides: &mut coral_app::features::FeatureOverrides,
+) {
+    for feature in coral_app::features::Feature::all() {
+        if matches.get_flag(feature.enable_flag()) {
+            overrides.set(feature, true);
+        }
+        if matches.get_flag(feature.disable_flag()) {
+            overrides.set(feature, false);
+        }
+    }
+}
+
+fn add_feature_override_args(mut cmd: clap::Command) -> clap::Command {
+    for feature in coral_app::features::Feature::all() {
+        let key = feature.key();
+        cmd = cmd
+            .arg(
+                Arg::new(feature.enable_flag())
+                    .long(feature.enable_flag())
+                    .help(format!(
+                        "Enable experimental `{key}` feature for this process"
+                    ))
+                    .action(ArgAction::SetTrue)
+                    .global(true),
+            )
+            .arg(
+                Arg::new(feature.disable_flag())
+                    .long(feature.disable_flag())
+                    .help(format!(
+                        "Disable experimental `{key}` feature for this process"
+                    ))
+                    .action(ArgAction::SetTrue)
+                    .global(true),
+            )
+            .group(
+                ArgGroup::new(feature.key())
+                    .arg(feature.enable_flag())
+                    .arg(feature.disable_flag())
+                    .multiple(false),
+            );
+    }
+    cmd
+}
+
 #[derive(Debug, Args)]
 /// Start the MCP server over stdio
-struct McpStdioArgs {
-    /// Expose the feedback submission tool.
-    #[arg(long)]
-    enable_feedback: bool,
-}
+struct McpStdioArgs {}
 
 #[derive(Debug, Args)]
 /// Inspect and manage experimental runtime features
@@ -334,7 +425,11 @@ where
 /// Returns an error if runtime startup, command execution, or output
 /// formatting fails.
 pub async fn run_from_env() -> Result<(), CliError> {
-    let Cli { command } = Cli::parse();
+    let Cli {
+        feature_overrides,
+        command,
+    } = Cli::parse();
+    let feature_overrides = feature_overrides.into_overrides();
     let ctx = coral_app::RunContext {
         trace_parent: env::trace_parent(),
     };
@@ -349,16 +444,23 @@ pub async fn run_from_env() -> Result<(), CliError> {
             .map_err(anyhow::Error::from)?;
             let app = bootstrap.app.clone();
             let result = if is_mcp_stdio {
-                run_app_command(app, command, Some(&ctx)).await
+                run_app_command(app, command, Some(&ctx), &feature_overrides).await
             } else {
-                coral_app::run_with_context(&ctx, Box::pin(run_app_command(app, command, None)))
-                    .await
+                coral_app::run_with_context(
+                    &ctx,
+                    Box::pin(run_app_command(app, command, None, &feature_overrides)),
+                )
+                .await
             };
             bootstrap.shutdown().await;
             result
         }
         RequiredRuntime::None => {
-            coral_app::run_with_context(&ctx, Box::pin(run_no_runtime_command(command))).await
+            coral_app::run_with_context(
+                &ctx,
+                Box::pin(run_no_runtime_command(command, &feature_overrides)),
+            )
+            .await
         }
     }
 }
@@ -413,23 +515,38 @@ async fn run_ui(args: UiArgs) -> Result<(), anyhow::Error> {
 /// Returns an error if argument parsing, command execution, or output
 /// formatting fails.
 pub async fn run(app: AppClient, ctx: coral_app::RunContext) -> Result<(), CliError> {
-    let Cli { command } = Cli::parse();
+    let Cli {
+        feature_overrides,
+        command,
+    } = Cli::parse();
+    let feature_overrides = feature_overrides.into_overrides();
     let is_mcp_stdio = matches!(&command, Command::McpStdio(_));
 
     match command.required_runtime() {
         RequiredRuntime::AppClient if is_mcp_stdio => {
-            run_app_command(app, command, Some(&ctx)).await
+            run_app_command(app, command, Some(&ctx), &feature_overrides).await
         }
         RequiredRuntime::AppClient => {
-            coral_app::run_with_context(&ctx, Box::pin(run_app_command(app, command, None))).await
+            coral_app::run_with_context(
+                &ctx,
+                Box::pin(run_app_command(app, command, None, &feature_overrides)),
+            )
+            .await
         }
         RequiredRuntime::None => {
-            coral_app::run_with_context(&ctx, Box::pin(run_no_runtime_command(command))).await
+            coral_app::run_with_context(
+                &ctx,
+                Box::pin(run_no_runtime_command(command, &feature_overrides)),
+            )
+            .await
         }
     }
 }
 
-async fn run_no_runtime_command(command: Command) -> Result<(), CliError> {
+async fn run_no_runtime_command(
+    command: Command,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), CliError> {
     match command {
         Command::Completion(args) => {
             let mut cmd = Cli::command();
@@ -437,7 +554,7 @@ async fn run_no_runtime_command(command: Command) -> Result<(), CliError> {
             generate(args.shell, &mut cmd, bin_name, &mut std::io::stdout());
             Ok(())
         }
-        Command::Features(args) => run_features(args).map_err(Into::into),
+        Command::Features(args) => run_features(args, feature_overrides).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
         Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
@@ -450,6 +567,7 @@ async fn run_app_command(
     app: AppClient,
     command: Command,
     ctx: Option<&coral_app::RunContext>,
+    feature_overrides: &coral_app::features::FeatureOverrides,
 ) -> Result<(), CliError> {
     match command {
         Command::Sql(args) => {
@@ -477,14 +595,14 @@ async fn run_app_command(
         Command::Onboard => {
             onboard::run(&app).await?;
         }
-        Command::McpStdio(args) => {
-            let feedback_enabled =
-                coral_app::features::resolve_feedback_enabled(args.enable_feedback)
-                    .map_err(anyhow::Error::from)?;
+        Command::McpStdio(_) => {
+            let features = coral_app::features::FeatureStore::discover(None)
+                .and_then(|store| store.load_with_overrides(feature_overrides))
+                .map_err(anyhow::Error::from)?;
             Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {
-                    feedback_enabled,
+                    feedback_enabled: features.enabled(coral_app::features::Feature::Feedback),
                     trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                 },
             ))
@@ -506,18 +624,24 @@ async fn run_app_command(
     Ok(())
 }
 
-fn run_features(args: FeaturesArgs) -> Result<(), anyhow::Error> {
+fn run_features(
+    args: FeaturesArgs,
+    feature_overrides: &coral_app::features::FeatureOverrides,
+) -> Result<(), anyhow::Error> {
     let store = coral_app::features::FeatureStore::discover(None)?;
     match args.command {
         FeaturesCommand::List => {
-            let rows = store.statuses()?.into_iter().map(|status| {
-                [
-                    status.key.to_string(),
-                    status.configured.as_str().to_string(),
-                    status.enabled.to_string(),
-                    status.description.to_string(),
-                ]
-            });
+            let rows = store
+                .statuses_with_overrides(feature_overrides)?
+                .into_iter()
+                .map(|status| {
+                    [
+                        status.key.to_string(),
+                        status.configured.as_str().to_string(),
+                        status.enabled.to_string(),
+                        status.description.to_string(),
+                    ]
+                });
             print_text_table(["Feature", "Configured", "Enabled", "Description"], rows);
         }
         FeaturesCommand::Enable { feature } => {
@@ -809,6 +933,27 @@ mod tests {
             "mcp-stdio",
             "--enable-feedback"
         ]));
+    }
+
+    #[test]
+    fn global_feature_overrides_parse_before_subcommand() {
+        let cli = Cli::try_parse_from(["coral", "--enable-feedback", "mcp-stdio"])
+            .expect("global feature override should parse before subcommand");
+
+        assert!(matches!(cli.command, super::Command::McpStdio(_)));
+    }
+
+    #[test]
+    fn conflicting_global_feature_overrides_are_rejected() {
+        let error = Cli::try_parse_from([
+            "coral",
+            "--enable-feedback",
+            "--disable-feedback",
+            "mcp-stdio",
+        ])
+        .expect_err("conflicting feature overrides should fail");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -64,6 +64,8 @@ enum Command {
     Onboard,
     /// Start the MCP server over stdio
     McpStdio(McpStdioArgs),
+    /// Inspect and manage experimental runtime features
+    Features(FeaturesArgs),
     #[cfg(feature = "embedded-ui")]
     /// Start the local gRPC-Web server with the embedded Coral UI
     Ui(UiArgs),
@@ -113,6 +115,29 @@ struct McpStdioArgs {
     /// Expose the feedback submission tool.
     #[arg(long)]
     enable_feedback: bool,
+}
+
+#[derive(Debug, Args)]
+/// Inspect and manage experimental runtime features
+struct FeaturesArgs {
+    #[command(subcommand)]
+    command: FeaturesCommand,
+}
+
+#[derive(Debug, Subcommand)]
+enum FeaturesCommand {
+    /// List experimental runtime features and their current status
+    List,
+    /// Enable an experimental runtime feature
+    Enable {
+        /// Feature key to enable
+        feature: String,
+    },
+    /// Disable an experimental runtime feature
+    Disable {
+        /// Feature key to disable
+        feature: String,
+    },
 }
 
 #[derive(Debug, Args)]
@@ -243,7 +268,7 @@ impl Command {
             Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
                 RequiredRuntime::AppClient
             }
-            Command::Completion(_) => RequiredRuntime::None,
+            Command::Features(_) | Command::Completion(_) => RequiredRuntime::None,
             #[cfg(feature = "embedded-ui")]
             Command::Ui(_) => RequiredRuntime::None,
         }
@@ -412,6 +437,7 @@ async fn run_no_runtime_command(command: Command) -> Result<(), CliError> {
             generate(args.shell, &mut cmd, bin_name, &mut std::io::stdout());
             Ok(())
         }
+        Command::Features(args) => run_features(args).map_err(Into::into),
         #[cfg(feature = "embedded-ui")]
         Command::Ui(args) => run_ui(args).await.map_err(Into::into),
         Command::Sql(_) | Command::Source(_) | Command::Onboard | Command::McpStdio(_) => {
@@ -452,10 +478,15 @@ async fn run_app_command(
             onboard::run(&app).await?;
         }
         Command::McpStdio(args) => {
+            let features = coral_app::features::FeatureStore::discover(None)
+                .and_then(|store| store.load())
+                .map_err(anyhow::Error::from)?;
+            let feedback_enabled =
+                args.enable_feedback || features.enabled(coral_app::features::Feature::Feedback);
             Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {
-                    feedback_enabled: args.enable_feedback,
+                    feedback_enabled,
                     trace_parent: ctx.and_then(|ctx| ctx.trace_parent.clone()),
                 },
             ))
@@ -465,12 +496,41 @@ async fn run_app_command(
         Command::Completion(_) => {
             unreachable!("no-runtime commands are routed without an app client")
         }
+        Command::Features(_) => {
+            unreachable!("no-runtime commands are routed without an app client")
+        }
         #[cfg(feature = "embedded-ui")]
         Command::Ui(_) => {
             unreachable!("no-runtime commands are routed without an app client")
         }
     }
 
+    Ok(())
+}
+
+fn run_features(args: FeaturesArgs) -> Result<(), anyhow::Error> {
+    let store = coral_app::features::FeatureStore::discover(None)?;
+    match args.command {
+        FeaturesCommand::List => {
+            let rows = store.statuses()?.into_iter().map(|status| {
+                [
+                    status.key.to_string(),
+                    status.configured.as_str().to_string(),
+                    status.enabled.to_string(),
+                    status.description.to_string(),
+                ]
+            });
+            print_text_table(["Feature", "Configured", "Enabled", "Description"], rows);
+        }
+        FeaturesCommand::Enable { feature } => {
+            store.enable(&feature)?;
+            println!("Enabled feature `{feature}` in config.toml.");
+        }
+        FeaturesCommand::Disable { feature } => {
+            store.disable(&feature)?;
+            println!("Disabled feature `{feature}` in config.toml.");
+        }
+    }
     Ok(())
 }
 
@@ -720,6 +780,14 @@ mod tests {
     fn completion_requires_no_runtime() {
         let cli = Cli::try_parse_from(["coral", "completion", "bash"])
             .expect("completion args should parse");
+
+        assert_eq!(cli.command.required_runtime(), RequiredRuntime::None);
+    }
+
+    #[test]
+    fn features_command_requires_no_runtime() {
+        let cli =
+            Cli::try_parse_from(["coral", "features", "list"]).expect("features args should parse");
 
         assert_eq!(cli.command.required_runtime(), RequiredRuntime::None);
     }

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -183,7 +183,8 @@ fn add_feature_override_args(mut cmd: clap::Command) -> clap::Command {
                         "Enable experimental `{key}` feature for this process"
                     ))
                     .action(ArgAction::SetTrue)
-                    .global(true),
+                    .global(true)
+                    .hide(true),
             )
             .arg(
                 Arg::new(feature.disable_flag())
@@ -192,7 +193,8 @@ fn add_feature_override_args(mut cmd: clap::Command) -> clap::Command {
                         "Disable experimental `{key}` feature for this process"
                     ))
                     .action(ArgAction::SetTrue)
-                    .global(true),
+                    .global(true)
+                    .hide(true),
             )
             .group(
                 ArgGroup::new(feature.key())
@@ -869,7 +871,7 @@ async fn run_source_add(app: &AppClient, args: SourceAddArgs) -> Result<(), CliE
 
 #[cfg(test)]
 mod tests {
-    use clap::Parser;
+    use clap::{CommandFactory, Parser};
 
     use super::{Cli, RequiredRuntime, command_enables_stderr_logs};
 
@@ -941,6 +943,24 @@ mod tests {
             .expect("global feature override should parse before subcommand");
 
         assert!(matches!(cli.command, super::Command::McpStdio(_)));
+    }
+
+    #[test]
+    fn global_feature_overrides_are_hidden_from_help() {
+        let mut help = Vec::new();
+        Cli::command()
+            .write_long_help(&mut help)
+            .expect("help should render");
+        let help = String::from_utf8(help).expect("help should be utf8");
+
+        assert!(
+            !help.contains("--enable-feedback"),
+            "feature override flags should not be visible in help: {help}"
+        );
+        assert!(
+            !help.contains("--disable-feedback"),
+            "feature override flags should not be visible in help: {help}"
+        );
     }
 
     #[test]

--- a/crates/coral-cli/src/lib.rs
+++ b/crates/coral-cli/src/lib.rs
@@ -478,11 +478,9 @@ async fn run_app_command(
             onboard::run(&app).await?;
         }
         Command::McpStdio(args) => {
-            let features = coral_app::features::FeatureStore::discover(None)
-                .and_then(|store| store.load())
-                .map_err(anyhow::Error::from)?;
             let feedback_enabled =
-                args.enable_feedback || features.enabled(coral_app::features::Feature::Feedback);
+                coral_app::features::resolve_feedback_enabled(args.enable_feedback)
+                    .map_err(anyhow::Error::from)?;
             Box::pin(coral_mcp::run_stdio_with_client(
                 app,
                 coral_mcp::McpOptions {

--- a/crates/coral-cli/tests/features.rs
+++ b/crates/coral-cli/tests/features.rs
@@ -1,0 +1,320 @@
+#![allow(
+    missing_docs,
+    unused_crate_dependencies,
+    reason = "Integration test crate only uses a subset of dev dependencies."
+)]
+
+use std::fs;
+use std::path::Path;
+
+use assert_cmd::Command;
+use tempfile::TempDir;
+
+fn coral_cmd(config_dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("coral").expect("cargo bin");
+    cmd.env("CORAL_CONFIG_DIR", config_dir);
+    cmd.env_remove("CORAL_ENDPOINT");
+    cmd
+}
+
+fn write_config(config_dir: &Path, raw: &str) {
+    fs::create_dir_all(config_dir).expect("config dir");
+    fs::write(config_dir.join("config.toml"), raw).expect("config file");
+}
+
+fn read_config(config_dir: &Path) -> String {
+    fs::read_to_string(config_dir.join("config.toml")).expect("config file")
+}
+
+#[test]
+fn features_help_lists_enable_disable_without_reset() {
+    let assert = Command::cargo_bin("coral")
+        .expect("cargo bin")
+        .args(["features", "--help"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("list"), "help should list list: {stdout}");
+    assert!(
+        stdout.contains("enable"),
+        "help should list enable: {stdout}"
+    );
+    assert!(
+        stdout.contains("disable"),
+        "help should list disable: {stdout}"
+    );
+    assert!(
+        !stdout.contains("reset"),
+        "help should not list removed reset command: {stdout}"
+    );
+}
+
+#[test]
+fn features_without_subcommand_requires_explicit_action() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("missing-config");
+
+    coral_cmd(&config_dir).arg("features").assert().failure();
+
+    assert!(
+        !config_dir.exists(),
+        "argument validation should not create state"
+    );
+}
+
+#[test]
+fn features_list_shows_feedback_status_without_state_creation() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("missing-config");
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "list"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(stdout.contains("Feature"), "missing table header: {stdout}");
+    assert!(
+        stdout.contains("Configured"),
+        "missing table header: {stdout}"
+    );
+    assert!(stdout.contains("Enabled"), "missing table header: {stdout}");
+    assert!(
+        stdout.contains("feedback"),
+        "missing feedback row: {stdout}"
+    );
+    assert!(
+        stdout.contains("default"),
+        "missing default status: {stdout}"
+    );
+    assert!(
+        stdout.contains("false"),
+        "missing disabled effective state: {stdout}"
+    );
+    assert!(
+        !config_dir.exists(),
+        "read-only feature listing should not create state"
+    );
+}
+
+#[test]
+fn features_enable_creates_config_with_feedback_enabled() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "enable", "feedback"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(stdout, "Enabled feature `feedback` in config.toml.\n");
+
+    let raw = read_config(&config_dir);
+    assert!(raw.contains("version = 1"), "missing config version: {raw}");
+    assert!(raw.contains("[features]"), "missing features table: {raw}");
+    assert!(
+        raw.contains("feedback = true"),
+        "missing feedback opt-in: {raw}"
+    );
+}
+
+#[test]
+fn features_disable_after_enable_clears_default_false_override() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+
+    coral_cmd(&config_dir)
+        .args(["features", "enable", "feedback"])
+        .assert()
+        .success();
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "disable", "feedback"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert_eq!(stdout, "Disabled feature `feedback` in config.toml.\n");
+
+    let raw = read_config(&config_dir);
+    assert!(
+        !raw.contains("feedback ="),
+        "default-false disable should clear feedback override: {raw}"
+    );
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "list"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("feedback"),
+        "missing feedback row: {stdout}"
+    );
+    assert!(
+        stdout.contains("default"),
+        "missing default status: {stdout}"
+    );
+    assert!(stdout.contains("false"), "missing disabled state: {stdout}");
+}
+
+#[test]
+fn features_disable_missing_config_is_noop_without_state_creation() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("missing-config");
+
+    coral_cmd(&config_dir)
+        .args(["features", "disable", "feedback"])
+        .assert()
+        .success();
+
+    assert!(
+        !config_dir.exists(),
+        "disabling a default-false feature should not create state when config is absent"
+    );
+}
+
+#[test]
+fn features_unknown_key_fails_without_writing_config() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "enable", "unknown"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("unknown feature 'unknown'"),
+        "missing unknown feature error: {stderr}"
+    );
+    assert!(
+        stderr.contains("feedback"),
+        "error should mention valid feature keys: {stderr}"
+    );
+    assert!(
+        !config_dir.exists(),
+        "unknown feature must not create state"
+    );
+}
+
+#[test]
+fn feature_mutations_preserve_unknown_keys_and_invalid_values() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    write_config(
+        &config_dir,
+        r#"
+[features]
+future_flag = "yes"
+feedback = true
+"#,
+    );
+
+    coral_cmd(&config_dir)
+        .args(["features", "disable", "feedback"])
+        .assert()
+        .success();
+
+    let raw = read_config(&config_dir);
+    assert!(
+        raw.contains("future_flag = \"yes\""),
+        "lost unknown key: {raw}"
+    );
+    assert!(
+        !raw.contains("feedback ="),
+        "feedback override should be cleared: {raw}"
+    );
+}
+
+#[test]
+fn features_list_reports_invalid_known_value_as_default_effective_state() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    write_config(
+        &config_dir,
+        r#"
+[features]
+feedback = "yes"
+"#,
+    );
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "list"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("invalid-value"),
+        "missing invalid value status: {stdout}"
+    );
+    assert!(
+        stdout.contains("false"),
+        "invalid value should fall back to default disabled state: {stdout}"
+    );
+}
+
+#[test]
+fn features_list_reports_unsupported_container_as_default_effective_state() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    write_config(&config_dir, "features = { feedback = true }\n");
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "list"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("invalid-container"),
+        "missing invalid container status: {stdout}"
+    );
+    assert!(
+        stdout.contains("false"),
+        "invalid container should fall back to default disabled state: {stdout}"
+    );
+}
+
+#[test]
+fn feature_mutations_reject_unsupported_container_without_rewriting_config() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let original = "features = { feedback = true }\n";
+    write_config(&config_dir, original);
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "enable", "feedback"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("unsupported [features] config"),
+        "missing unsupported container error: {stderr}"
+    );
+    assert_eq!(read_config(&config_dir), original);
+}
+
+#[test]
+fn feature_mutations_reject_invalid_toml_without_rewriting_config() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("coral-config");
+    let original = "[features\nfeedback = true\n";
+    write_config(&config_dir, original);
+
+    let assert = coral_cmd(&config_dir)
+        .args(["features", "enable", "feedback"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    assert!(
+        stderr.contains("TOML parse error"),
+        "missing invalid TOML error: {stderr}"
+    );
+    assert_eq!(read_config(&config_dir), original);
+}

--- a/crates/coral-cli/tests/features.rs
+++ b/crates/coral-cli/tests/features.rs
@@ -93,6 +93,10 @@ fn features_list_shows_feedback_status_without_state_creation() {
         "missing disabled effective state: {stdout}"
     );
     assert!(
+        stdout.contains("Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral."),
+        "feature list should match documented feedback text: {stdout}"
+    );
+    assert!(
         !config_dir.exists(),
         "read-only feature listing should not create state"
     );

--- a/crates/coral-cli/tests/features.rs
+++ b/crates/coral-cli/tests/features.rs
@@ -99,6 +99,35 @@ fn features_list_shows_feedback_status_without_state_creation() {
 }
 
 #[test]
+fn features_list_applies_global_process_override_without_state_creation() {
+    let temp = TempDir::new().expect("temp dir");
+    let config_dir = temp.path().join("missing-config");
+
+    let assert = coral_cmd(&config_dir)
+        .args(["--enable-feedback", "features", "list"])
+        .assert()
+        .success();
+
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    assert!(
+        stdout.contains("feedback"),
+        "missing feedback row: {stdout}"
+    );
+    assert!(
+        stdout.contains("default"),
+        "config status should remain default: {stdout}"
+    );
+    assert!(
+        stdout.contains("true"),
+        "process override should enable feature in effective state: {stdout}"
+    );
+    assert!(
+        !config_dir.exists(),
+        "read-only feature listing should not create state"
+    );
+}
+
+#[test]
 fn features_enable_creates_config_with_feedback_enabled() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
@@ -121,7 +150,7 @@ fn features_enable_creates_config_with_feedback_enabled() {
 }
 
 #[test]
-fn features_disable_after_enable_clears_default_false_override() {
+fn features_disable_after_enable_persists_false_override() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("coral-config");
 
@@ -139,8 +168,8 @@ fn features_disable_after_enable_clears_default_false_override() {
 
     let raw = read_config(&config_dir);
     assert!(
-        !raw.contains("feedback ="),
-        "default-false disable should clear feedback override: {raw}"
+        raw.contains("feedback = false"),
+        "disable should persist explicit feedback opt-out: {raw}"
     );
 
     let assert = coral_cmd(&config_dir)
@@ -153,14 +182,14 @@ fn features_disable_after_enable_clears_default_false_override() {
         "missing feedback row: {stdout}"
     );
     assert!(
-        stdout.contains("default"),
-        "missing default status: {stdout}"
+        stdout.contains("disabled"),
+        "missing disabled configured status: {stdout}"
     );
     assert!(stdout.contains("false"), "missing disabled state: {stdout}");
 }
 
 #[test]
-fn features_disable_missing_config_is_noop_without_state_creation() {
+fn features_disable_missing_config_creates_false_override() {
     let temp = TempDir::new().expect("temp dir");
     let config_dir = temp.path().join("missing-config");
 
@@ -169,9 +198,11 @@ fn features_disable_missing_config_is_noop_without_state_creation() {
         .assert()
         .success();
 
+    let raw = read_config(&config_dir);
+    assert!(raw.contains("version = 1"), "missing config version: {raw}");
     assert!(
-        !config_dir.exists(),
-        "disabling a default-false feature should not create state when config is absent"
+        raw.contains("feedback = false"),
+        "disable should persist explicit feedback opt-out: {raw}"
     );
 }
 
@@ -224,8 +255,8 @@ feedback = true
         "lost unknown key: {raw}"
     );
     assert!(
-        !raw.contains("feedback ="),
-        "feedback override should be cleared: {raw}"
+        raw.contains("feedback = false"),
+        "feedback override should be persisted as disabled: {raw}"
     );
 }
 

--- a/crates/coral-cli/tests/harness/mod.rs
+++ b/crates/coral-cli/tests/harness/mod.rs
@@ -3,6 +3,7 @@
     reason = "Integration test crates share this harness, but each target only uses a subset of the helpers."
 )]
 
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
@@ -31,6 +32,7 @@ use coral_api::v1::{
     source_input_spec::Input as ProtoSourceInput,
 };
 use coral_api::{CORAL_ERROR_DOMAIN, CORAL_ERROR_REASON_SOURCE_NOT_FOUND};
+use tempfile::TempDir;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -953,6 +955,7 @@ impl SourceService for MockSourceService {
 
 pub(crate) struct MockServer {
     endpoint_uri: String,
+    config_dir: TempDir,
     shutdown_tx: Option<oneshot::Sender<()>>,
     task: JoinHandle<Result<(), tonic::transport::Error>>,
     captured: Arc<Captured>,
@@ -995,6 +998,7 @@ impl MockServer {
         });
         Self {
             endpoint_uri,
+            config_dir: TempDir::new().expect("mock server config dir"),
             shutdown_tx: Some(shutdown_tx),
             task,
             captured,
@@ -1013,7 +1017,12 @@ impl MockServer {
     pub(crate) fn cmd(&self) -> Command {
         let mut cmd = Command::cargo_bin("coral").expect("cargo bin");
         cmd.env("CORAL_ENDPOINT", &self.endpoint_uri);
+        cmd.env("CORAL_CONFIG_DIR", self.config_dir.path());
         cmd
+    }
+
+    pub(crate) fn config_dir(&self) -> &Path {
+        self.config_dir.path()
     }
 
     pub(crate) fn execute_sql_requests(&self) -> Vec<ExecuteSqlRequest> {

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -321,7 +321,8 @@ async fn mcp_stdio_lists_tools_and_resources() -> Result<(), Box<dyn std::error:
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn std::error::Error>> {
+async fn mcp_stdio_enable_feedback_flag_lists_feedback_tool()
+-> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     let client = start_mcp_client_with_args(&server, &["--enable-feedback"]).await?;
 
@@ -432,7 +433,7 @@ feedback = false
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn mcp_stdio_enable_feedback_flag_overrides_config_disabled()
+async fn mcp_stdio_enable_feedback_override_overrides_config_disabled()
 -> Result<(), Box<dyn std::error::Error>> {
     let server = MockServer::start().await;
     write_config(
@@ -448,6 +449,30 @@ feedback = false
     assert!(
         tools.iter().any(|tool| tool.name.as_ref() == "feedback"),
         "feedback tool should be listed when --enable-feedback is set"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_disable_feedback_override_overrides_config_enabled()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    write_config(
+        &server,
+        r"
+[features]
+feedback = true
+",
+    )?;
+    let client = start_mcp_client_with_args(&server, &["--disable-feedback"]).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().all(|tool| tool.name.as_ref() != "feedback"),
+        "feedback tool should not be listed when --disable-feedback is set"
     );
 
     client.cancel().await?;

--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -10,8 +10,9 @@
 
 mod harness;
 
-use std::process::Stdio;
+use std::process::{Command as StdCommand, Stdio};
 use std::time::Duration;
+use std::{fs, io};
 
 use harness::MockServer;
 use jsonschema::JSONSchema;
@@ -32,6 +33,29 @@ fn json_object(value: &Value) -> Map<String, Value> {
     value.as_object().cloned().expect("json object")
 }
 
+fn write_config(server: &MockServer, raw: &str) -> Result<(), io::Error> {
+    fs::create_dir_all(server.config_dir())?;
+    fs::write(server.config_dir().join("config.toml"), raw)
+}
+
+fn run_features_command(
+    server: &MockServer,
+    args: &[&str],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = StdCommand::new(env!("CARGO_BIN_EXE_coral"))
+        .arg("features")
+        .args(args)
+        .env("CORAL_CONFIG_DIR", server.config_dir())
+        .output()?;
+    assert!(
+        output.status.success(),
+        "features command failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(())
+}
+
 async fn start_mcp_client(
     server: &MockServer,
 ) -> Result<RunningService<RoleClient, ()>, Box<dyn std::error::Error>> {
@@ -46,7 +70,8 @@ async fn start_mcp_client_with_args(
         tokio::process::Command::new(env!("CARGO_BIN_EXE_coral")).configure(|cmd| {
             cmd.arg("mcp-stdio")
                 .args(args)
-                .env("CORAL_ENDPOINT", server.endpoint_uri());
+                .env("CORAL_ENDPOINT", server.endpoint_uri())
+                .env("CORAL_CONFIG_DIR", server.config_dir());
         }),
     )?;
     let client = ().serve(transport).await?;
@@ -160,6 +185,7 @@ async fn mcp_stdio_raw_tools_list_advertises_client_compatible_schemas()
     let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
         .arg("mcp-stdio")
         .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env("CORAL_CONFIG_DIR", server.config_dir())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -316,6 +342,204 @@ async fn mcp_stdio_enable_feedback_lists_feedback_tool() -> Result<(), Box<dyn s
     );
 
     client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_feature_config_enables_feedback_tool() -> Result<(), Box<dyn std::error::Error>>
+{
+    let server = MockServer::start().await;
+    write_config(
+        &server,
+        r"
+[features]
+feedback = true
+",
+    )?;
+    let client = start_mcp_client(&server).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "feedback"),
+        "feedback tool should be listed when [features].feedback is true"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_features_enable_command_enables_feedback_tool()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    run_features_command(&server, &["enable", "feedback"])?;
+    let client = start_mcp_client(&server).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "feedback"),
+        "feedback tool should be listed after `coral features enable feedback`"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_features_disable_command_removes_feedback_tool()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    run_features_command(&server, &["enable", "feedback"])?;
+    run_features_command(&server, &["disable", "feedback"])?;
+    let client = start_mcp_client(&server).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().all(|tool| tool.name.as_ref() != "feedback"),
+        "feedback tool should not be listed after `coral features disable feedback`"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_feature_config_can_leave_feedback_disabled()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    write_config(
+        &server,
+        r"
+[features]
+feedback = false
+",
+    )?;
+    let client = start_mcp_client(&server).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().all(|tool| tool.name.as_ref() != "feedback"),
+        "feedback tool should not be listed when [features].feedback is false"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_enable_feedback_flag_overrides_config_disabled()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    write_config(
+        &server,
+        r"
+[features]
+feedback = false
+",
+    )?;
+    let client = start_mcp_client_with_args(&server, &["--enable-feedback"]).await?;
+
+    let tools = client.list_all_tools().await?;
+    assert!(
+        tools.iter().any(|tool| tool.name.as_ref() == "feedback"),
+        "feedback tool should be listed when --enable-feedback is set"
+    );
+
+    client.cancel().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn mcp_stdio_invalid_feature_entries_do_not_corrupt_stdout()
+-> Result<(), Box<dyn std::error::Error>> {
+    let server = MockServer::start().await;
+    write_config(
+        &server,
+        r#"
+[features]
+feedback = "yes"
+future_flag = true
+"#,
+    )?;
+    let mut child = Command::new(env!("CARGO_BIN_EXE_coral"))
+        .arg("mcp-stdio")
+        .env("CORAL_ENDPOINT", server.endpoint_uri())
+        .env("CORAL_CONFIG_DIR", server.config_dir())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()?;
+    let mut stdin = child.stdin.take().expect("mcp stdio stdin");
+    let stdout = child.stdout.take().expect("mcp stdio stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    write_jsonrpc_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "coral-cli-invalid-feature-test",
+                    "version": "0.0.0"
+                }
+            }
+        }),
+    )
+    .await?;
+    let initialize = read_jsonrpc_response(&mut stdout, 1).await?;
+    assert!(
+        initialize.pointer("/result/protocolVersion").is_some(),
+        "initialize response should include protocolVersion: {initialize}"
+    );
+
+    write_jsonrpc_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+            "params": {}
+        }),
+    )
+    .await?;
+    write_jsonrpc_message(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {}
+        }),
+    )
+    .await?;
+    let tools_list = read_jsonrpc_response(&mut stdout, 2).await?;
+    assert_raw_tools_list_contract(&tools_list);
+    let tools = tools_list
+        .pointer("/result/tools")
+        .and_then(Value::as_array)
+        .expect("tools/list result");
+    assert!(
+        tools
+            .iter()
+            .all(|tool| tool.get("name").and_then(Value::as_str) != Some("feedback")),
+        "invalid feature config must not enable feedback: {tools_list}"
+    );
+
+    drop(stdin);
+    if timeout(Duration::from_secs(5), child.wait()).await.is_err() {
+        child.start_kill()?;
+        child.wait().await?;
+    }
     server.shutdown().await;
     Ok(())
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,7 @@
         "group": "Reference",
         "pages": [
           "reference/cli-reference",
+          "reference/configuration",
           "reference/bundled-sources",
           "reference/community-sources",
           "reference/source-spec-reference"

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -221,7 +221,10 @@ On Windows, the default local state path is
 
 Important files include:
 
-- `config.toml` for installed-source metadata and non-secret variables
+- `config.toml` for installed-source metadata, non-secret variables, and
+  runtime feature opt-ins inspected with `coral features list`, managed by
+  `coral features enable|disable`, or manually under `[features]` with entries
+  such as `feedback = true`
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -221,10 +221,7 @@ On Windows, the default local state path is
 
 Important files include:
 
-- `config.toml` for installed-source metadata, non-secret variables, and
-  runtime feature opt-ins inspected with `coral features list`, managed by
-  `coral features enable|disable`, or manually under `[features]` with entries
-  such as `feedback = true`
+- `config.toml` for installed-source metadata, non-secret variables, and runtime settings. See [Configuration](/reference/configuration).
 - imported source specs under `workspaces/<workspace>/sources/<source>/manifest.yaml`
 - source secrets stored separately within the same local trust boundary
 

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -61,17 +61,44 @@ Some sources expose native search endpoints (for example, GitHub issue search) a
 
 ### Optional feedback tool
 
-Start Coral as `coral mcp-stdio --enable-feedback` to expose the `feedback` tool. Agents can call it when they get blocked or repeat a pattern that isn't working.
+Start Coral as `coral mcp-stdio --enable-feedback` to expose the `feedback` tool for that process.
+
+For a persistent opt-in, run:
+
+```shellscript
+coral features enable feedback
+```
+
+To inspect configured runtime features, run:
+
+```shellscript
+coral features list
+```
+
+To remove the persistent feedback opt-in, run:
+
+```shellscript
+coral features disable feedback
+```
+
+You can also manage the same opt-in manually in Coral's `config.toml`:
+
+```toml
+[features]
+feedback = true
+```
+
+Agents can call the tool when they get blocked or repeat a pattern that isn't working.
 
 Coral stores the report locally (what the agent was trying to do, what it tried, and where it got stuck) and uploads an anonymous copy to Coral's hosted feedback service in the background. No user identifiers are attached to the hosted copy, and reports are used to improve Coral's performance. If hosted upload fails, the local report is still stored.
 
 <Note>
-Only enable this tool if you are comfortable sending the feedback text to Coral.
+Only enable this tool if you are comfortable exposing an agent-callable feedback tool that can send the feedback text to Coral.
 </Note>
 
 ## Client setup
 
-Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`. To include the optional feedback tool, use `coral mcp-stdio --enable-feedback`.
+Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`. To include the optional feedback tool for one process, use `coral mcp-stdio --enable-feedback`; for persistent opt-in, run `coral features enable feedback`.
 
 <Tabs>
 <Tab title="npx add-mcp">

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -19,7 +19,6 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
 | Tool     | `list_columns`   | List columns for one database table with pagination     |
-| Tool     | `feedback`       | Store a local blocked-agent feedback report and upload an anonymous copy to Coral when enabled |
 | Resource | `coral://guide`  | Database workflow guide for agents                     |
 | Resource | `coral://tables` | JSON summaries of database tables and required filters  |
 
@@ -59,46 +58,9 @@ For deeper introspection, query `coral.tables`, `coral.columns`, `coral.filters`
 
 Some sources expose native search endpoints (for example, GitHub issue search) as table functions with `kind = 'search'`. Prefer these over scanning a regular table when the agent needs ranked, query-driven results. They return provider-ranked candidates, so agents should preserve any returned rank columns and use the returned ids plus catalog-described tables to fetch full detail rows when the search result itself is incomplete.
 
-### Optional feedback tool
-
-Start Coral as `coral mcp-stdio --enable-feedback` to expose the `feedback` tool for that process.
-
-For a persistent opt-in, run:
-
-```shellscript
-coral features enable feedback
-```
-
-To inspect configured runtime features, run:
-
-```shellscript
-coral features list
-```
-
-To remove the persistent feedback opt-in, run:
-
-```shellscript
-coral features disable feedback
-```
-
-You can also manage the same opt-in manually in Coral's `config.toml`:
-
-```toml
-[features]
-feedback = true
-```
-
-Agents can call the tool when they get blocked or repeat a pattern that isn't working.
-
-Coral stores the report locally (what the agent was trying to do, what it tried, and where it got stuck) and uploads an anonymous copy to Coral's hosted feedback service in the background. No user identifiers are attached to the hosted copy, and reports are used to improve Coral's performance. If hosted upload fails, the local report is still stored.
-
-<Note>
-Only enable this tool if you are comfortable exposing an agent-callable feedback tool that can send the feedback text to Coral.
-</Note>
-
 ## Client setup
 
-Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`. To include the optional feedback tool for one process, use `coral mcp-stdio --enable-feedback`; for persistent opt-in, run `coral features enable feedback`.
+Coral uses stdio transport. If a client supports a command-based install flow, point it at `coral mcp-stdio`.
 
 <Tabs>
 <Tab title="npx add-mcp">

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -130,6 +130,34 @@ Run the guided source setup flow.
 coral onboard
 ```
 
+## `coral features`
+
+Inspect and manage experimental runtime features in [`config.toml`](/reference/configuration).
+
+### `coral features list`
+
+List all runtime features recognized by the current Coral binary, including their configured and effective status.
+
+```shellscript
+coral features list
+```
+
+### `coral features enable <FEATURE>`
+
+Persistently enable an experimental runtime feature.
+
+```shellscript
+coral features enable feedback
+```
+
+### `coral features disable <FEATURE>`
+
+Remove a persistent runtime feature opt-in from `config.toml`, returning the feature to its built-in default.
+
+```shellscript
+coral features disable feedback
+```
+
 ## `coral ui`
 
 Open the local Coral UI in your browser.

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -132,7 +132,8 @@ coral onboard
 
 ## `coral features`
 
-Inspect and manage experimental runtime features in [`config.toml`](/reference/configuration).
+Coral ships with experimental runtime features that can be enabled on demand.
+These features are defined in [`config.toml`](/reference/configuration).
 
 ### `coral features list`
 
@@ -152,7 +153,10 @@ coral features enable feedback
 
 ### `coral features disable <FEATURE>`
 
-Remove a persistent runtime feature opt-in from `config.toml`, returning the feature to its built-in default.
+Disable updates `config.toml` so the feature is not enabled for future runs.
+For features disabled by default, such as `feedback`, Coral removes the opt-in
+and falls back to the built-in default. The default for each feature is listed
+in [Configuration](/reference/configuration#runtime-features).
 
 ```shellscript
 coral features disable feedback

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -3,6 +3,21 @@ title: "CLI reference"
 description: "Reference for Coral CLI commands and options."
 ---
 
+## Global feature flags
+
+Experimental runtime features can be overridden for a single process with
+top-level flags:
+
+```shellscript
+coral --enable-<FEATURE> <COMMAND>
+coral --disable-<FEATURE> <COMMAND>
+coral --enable-feedback mcp-stdio
+coral --disable-feedback mcp-stdio
+```
+
+These flags do not edit `config.toml`. Use `coral features enable <FEATURE>` or
+`coral features disable <FEATURE>` to persist a preference.
+
 ## `coral sql`
 
 Run one SQL query and exit.
@@ -145,7 +160,8 @@ coral features list
 
 ### `coral features enable <FEATURE>`
 
-Persistently enable an experimental runtime feature.
+Persistently enables an experimental runtime feature. The default for each
+feature is listed in [Configuration](/reference/configuration#runtime-features).
 
 ```shellscript
 coral features enable feedback
@@ -153,10 +169,7 @@ coral features enable feedback
 
 ### `coral features disable <FEATURE>`
 
-Disable updates `config.toml` so the feature is not enabled for future runs.
-For features disabled by default, such as `feedback`, Coral removes the opt-in
-and falls back to the built-in default. The default for each feature is listed
-in [Configuration](/reference/configuration#runtime-features).
+Persistently disables an experimental runtime feature.
 
 ```shellscript
 coral features disable feedback

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -3,21 +3,7 @@ title: "Configuration"
 description: "Reference for Coral's config.toml file and runtime configuration."
 ---
 
-Coral stores local configuration in `config.toml` inside its platform-specific configuration directory.
-
-You can point Coral at a different configuration directory with `CORAL_CONFIG_DIR`:
-
-```shellscript
-export CORAL_CONFIG_DIR=/path/to/coral-config
-```
-
-On Windows PowerShell:
-
-```powershell
-$env:CORAL_CONFIG_DIR = "C:\path\to\coral-config"
-```
-
-On Windows, the default local state path is `%APPDATA%\withcoral\coral\config`.
+Coral stores local configuration in `config.toml` inside its platform-specific [local state directory](/getting-started/installation#local-state).
 
 ## Managed state
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -41,7 +41,7 @@ Feature values must be booleans. Unknown feature keys are preserved in `config.t
 
 | Feature | Default | Description |
 | ------- | ------- | ----------- |
-| `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. |
+| `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. Feedback reports are stored locally and anonymous copies may be uploaded to Coral. |
 
 ## OpenTelemetry
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -1,0 +1,81 @@
+---
+title: "Configuration"
+description: "Reference for Coral's config.toml file and runtime configuration."
+---
+
+Coral stores local configuration in `config.toml` inside its platform-specific configuration directory.
+
+You can point Coral at a different configuration directory with `CORAL_CONFIG_DIR`:
+
+```shellscript
+export CORAL_CONFIG_DIR=/path/to/coral-config
+```
+
+On Windows PowerShell:
+
+```powershell
+$env:CORAL_CONFIG_DIR = "C:\path\to\coral-config"
+```
+
+On Windows, the default local state path is `%APPDATA%\withcoral\coral\config`.
+
+## Managed state
+
+Coral writes source installation state to `config.toml` when you run commands such as `coral source add` and `coral source remove`.
+
+This state includes installed-source metadata and non-secret source variables. Source secrets are stored separately within the same local trust boundary.
+
+<Note>
+  Prefer the `coral source` commands for source state instead of editing workspace entries manually.
+</Note>
+
+## Runtime features
+
+Experimental runtime features are configured under `[features]`.
+
+```toml
+[features]
+feedback = true
+```
+
+You can inspect available features and their effective state with:
+
+```shellscript
+coral features list
+```
+
+Enable or disable a feature with:
+
+```shellscript
+coral features enable feedback
+coral features disable feedback
+```
+
+Feature values must be booleans. Unknown feature keys are preserved in `config.toml` but ignored by Coral.
+
+| Feature | Default | Description |
+| ------- | ------- | ----------- |
+| `feedback` | `false` | Experimental. Exposes the MCP feedback tool when enabled. |
+
+## OpenTelemetry
+
+External OpenTelemetry export is configured under `[otel]`.
+
+```toml
+[otel]
+endpoint = "http://localhost:4318"
+headers = "authorization=Bearer ..."
+log_filter = "info"
+trace_filter = "coral_app=debug"
+service_name = "coral"
+```
+
+Trace history settings are configured under `[trace_history]`.
+
+```toml
+[trace_history]
+enabled = true
+retention_days = 7
+```
+
+See [Observe with OpenTelemetry](/guides/observe-with-opentelemetry) for the full telemetry setup guide.


### PR DESCRIPTION
## Summary

- Add a runtime `[features]` config surface for experimental feature toggles, with known-feature status reporting and invalid/unsupported value handling.
- Add `coral features list`, `coral features enable <feature>`, and `coral features disable <feature>` so users can inspect and manage feature state from the CLI.
- Wire the feedback feature into MCP bootstrap so config-driven feature state and `--enable-feedback` resolve through the same app-level feature model.
- Document the feature config and feedback tool enablement path in the MCP and installation guides.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p coral-cli --test features`
- `cargo test -p coral-app features`
- `cargo test -p coral-cli --features cli-test-server --test mcp`
