### PR TITLE
feat(sources/community/deps_dev): add deps_dev community source

### DIFF
--- a/sources/community/deps_dev/README.md
+++ b/sources/community/deps_dev/README.md
@@ -1,0 +1,175 @@
+# deps.dev Connector
+
+This source queries package metadata, dependency graphs, and security advisories from the [deps.dev API](https://docs.deps.dev/api/v3/).
+No credentials are required.
+
+> **URL encoding**: Coral does not automatically URL-encode filter values
+> interpolated into API paths. Package names containing special characters —
+> such as scoped npm packages (`@types/react` → `%40types%2Freact`) or Maven
+> coordinates with colons (`org.apache.logging.log4j:log4j-core` →
+> `org.apache.logging.log4j%3Alog4j-core`) — must be percent-encoded in your
+> `WHERE` clause filter values.
+
+## Start querying
+
+Inspect metadata for a package version:
+
+```sql
+SELECT version, published_at, licenses, advisory_keys, related_projects
+FROM deps_dev.versions
+WHERE system = 'NPM'
+  AND package_name = 'minimist'
+  AND version = '0.0.8'
+LIMIT 1;
+```
+
+Fetch the dependency graph nodes for a package version:
+
+```sql
+SELECT dependency_system, dependency_name, dependency_version, relation
+FROM deps_dev.dependencies
+WHERE system = 'NPM'
+  AND package_name = 'minimist'
+  AND version = '0.0.8';
+```
+
+Fetch the declared dependency requirements payload:
+
+```sql
+SELECT npm, pypi, maven, cargo
+FROM deps_dev.requirements
+WHERE system = 'NPM'
+  AND package_name = 'minimist'
+  AND version = '0.0.8'
+LIMIT 1;
+```
+
+Fetch full advisory details for an OSV ID or GHSA:
+
+```sql
+SELECT title, cvss3_score, aliases
+FROM deps_dev.advisories
+WHERE advisory_id = 'GHSA-vh95-rmgr-6w4m'
+LIMIT 1;
+```
+
+Query a Go module version:
+
+```sql
+SELECT version, published_at, licenses
+FROM deps_dev.versions
+WHERE system = 'GO'
+  AND package_name = 'golang.org%2Fx%2Ftext'
+  AND version = 'v0.3.7'
+LIMIT 1;
+```
+
+Fetch the edges of a dependency graph to reconstruct topology:
+
+```sql
+SELECT from_node, to_node, requirement
+FROM deps_dev.dependency_edges
+WHERE system = 'NPM'
+  AND package_name = 'react'
+  AND version = '18.2.0';
+```
+
+Fetch project health metrics and OpenSSF Scorecards:
+
+```sql
+SELECT open_issues_count, stars_count, license
+FROM deps_dev.projects
+WHERE project_id = 'github.com%2Fgolang%2Fgo'
+LIMIT 1;
+```
+
+## Tables
+
+### By required filter
+
+| Filter pattern | Tables | Example |
+|---|---|---|
+| `system` + `package_name` | 1 | `WHERE system = 'NPM' AND package_name = 'minimist'` |
+| `system` + `package_name` + `version` | 4 | `WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'` |
+| `advisory_id` | 1 | `WHERE advisory_id = 'GHSA-vh95-rmgr-6w4m'` |
+| `project_id` | 1 | `WHERE project_id = 'github.com%2Fgolang%2Fgo'` |
+
+### versions
+
+Fetches metadata for one package version. Maps to
+`GET /v3/systems/{system}/packages/{package_name}/versions/{version}`.
+
+Useful columns include:
+- `licenses`
+- `advisory_keys`
+- `links`
+- `slsa_provenances`
+- `attestations`
+- `related_projects`
+- `registries`
+
+### packages
+
+Fetches project-level details and a list of all available versions. Maps to
+`GET /v3/systems/{system}/packages/{package_name}`.
+
+The `versions` column is a JSON array where each element contains
+`versionKey.system`, `versionKey.name`, `versionKey.version`, `publishedAt`,
+`isDefault`, `isDeprecated`, and `deprecatedReason`.
+
+### dependencies
+
+Fetches the resolved dependency graph nodes for a specific package version. Maps to
+`GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`.
+
+Includes `is_bundled` to indicate whether a node is bundled into the package version.
+
+### dependency_edges
+
+Fetches the resolved dependency graph edges for a specific package version. Used
+alongside `dependencies` to fully reconstruct dependency topology. Maps to the same
+endpoint `GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`
+but extracts the `edges` array.
+
+### requirements
+
+Fetches declared dependency requirements for a package version. Maps to
+`GET /v3/systems/{system}/packages/{package_name}/versions/{version}:requirements`.
+
+The requirements are split into ecosystem-specific columns: `npm`, `maven`,
+`pypi`, `cargo`, `go`, `rubygems`, and `nuget`. Only the column matching the
+queried system will contain data; the others will be null.
+
+### advisories
+
+Fetches detailed vulnerability/advisory metadata given an advisory key (e.g., OSV/GHSA ID). Maps to
+`GET /v3/advisories/{advisory_id}`.
+
+Includes `advisory_url` for quick navigation to the advisory detail page.
+
+### projects
+
+Fetches project-level health metrics like GitHub stars, forks, issues, and OpenSSF Scorecard data. Maps to
+`GET /v3/projects/{project_id}`.
+
+Requires URL-encoding for the `project_id` (e.g. `github.com%2Fgolang%2Fgo`).
+
+## Supported systems
+
+deps.dev supports the following package systems: `NPM`, `PYPI`, `MAVEN`, `GO`,
+`CARGO`, `RUBYGEMS`, and `NUGET`. Use the system names exactly as expected by
+deps.dev (uppercase).
+
+### Package naming notes
+
+- Maven uses `group:artifact` coordinates (for example `org.apache.logging.log4j:log4j-core`).
+- PyPI names are normalized per PEP 503 (lowercase, normalize `-`, `_`, `.` to `-`).
+- NuGet names are lowercased per NuGet API normalization rules.
+- Scoped npm packages (e.g. `@types/react`) require URL-encoding: `%40types%2Freact`.
+
+## Rate limiting
+
+The deps.dev API is public and requires no authentication. The API documentation
+does not specify rate limits, but as a public Google service, excessive request
+volume may be throttled. Use `LIMIT` clauses and specific filters to keep
+request counts reasonable.

--- a/sources/community/deps_dev/README.md
+++ b/sources/community/deps_dev/README.md
@@ -9,6 +9,10 @@ No credentials are required.
 > coordinates with colons (`org.apache.logging.log4j:log4j-core` →
 > `org.apache.logging.log4j%3Alog4j-core`) — must be percent-encoded in your
 > `WHERE` clause filter values.
+>
+> **Canonicalization**: deps.dev may canonicalize package, version, advisory,
+> and project identifiers. The primary identifier columns return the canonical
+> values from the API response; `requested_*` columns preserve submitted filters.
 
 ## Start querying
 
@@ -31,6 +35,17 @@ FROM deps_dev.dependencies
 WHERE system = 'NPM'
   AND package_name = 'minimist'
   AND version = '0.0.8';
+```
+
+Fetch the full dependency graph payload when you need to reconstruct topology:
+
+```sql
+SELECT nodes, edges, error
+FROM deps_dev.dependency_graph
+WHERE system = 'NPM'
+  AND package_name = 'react'
+  AND version = '18.2.0'
+LIMIT 1;
 ```
 
 Fetch the declared dependency requirements payload:
@@ -64,7 +79,7 @@ WHERE system = 'GO'
 LIMIT 1;
 ```
 
-Fetch the edges of a dependency graph to reconstruct topology:
+Fetch the edges of a dependency graph:
 
 ```sql
 SELECT from_node, to_node, requirement
@@ -83,16 +98,25 @@ WHERE project_id = 'github.com%2Fgolang%2Fgo'
 LIMIT 1;
 ```
 
+Find package versions built from a project:
+
+```sql
+SELECT system, package_name, version, relation_type
+FROM deps_dev.project_package_versions
+WHERE project_id = 'github.com%2Ffacebook%2Freact'
+LIMIT 5;
+```
+
 ## Tables
 
 ### By required filter
 
 | Filter pattern | Tables | Example |
 |---|---|---|
-| `system` + `package_name` | 1 | `WHERE system = 'NPM' AND package_name = 'minimist'` |
-| `system` + `package_name` + `version` | 4 | `WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'` |
-| `advisory_id` | 1 | `WHERE advisory_id = 'GHSA-vh95-rmgr-6w4m'` |
-| `project_id` | 1 | `WHERE project_id = 'github.com%2Fgolang%2Fgo'` |
+| `system` + `package_name` | `packages` | `WHERE system = 'NPM' AND package_name = 'minimist'` |
+| `system` + `package_name` + `version` | `versions`, `dependency_graph`, `dependencies`, `requirements`, `dependency_edges` | `WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'` |
+| `advisory_id` | `advisories` | `WHERE advisory_id = 'GHSA-vh95-rmgr-6w4m'` |
+| `project_id` | `projects`, `project_package_versions` | `WHERE project_id = 'github.com%2Fgolang%2Fgo'` |
 
 ### versions
 
@@ -100,6 +124,10 @@ Fetches metadata for one package version. Maps to
 `GET /v3/systems/{system}/packages/{package_name}/versions/{version}`.
 
 Useful columns include:
+
+- `requested_system`
+- `requested_package_name`
+- `requested_version`
 - `licenses`
 - `advisory_keys`
 - `links`
@@ -113,9 +141,22 @@ Useful columns include:
 Fetches project-level details and a list of all available versions. Maps to
 `GET /v3/systems/{system}/packages/{package_name}`.
 
+Includes `requested_system` and `requested_package_name` to preserve the
+submitted filters when deps.dev canonicalizes the package key.
+
 The `versions` column is a JSON array where each element contains
 `versionKey.system`, `versionKey.name`, `versionKey.version`, `publishedAt`,
 `isDefault`, `isDeprecated`, and `deprecatedReason`.
+
+### dependency_graph
+
+Fetches the full resolved dependency graph for a specific package version. Maps to
+`GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`.
+
+Returns the provider's `nodes`, `edges`, and graph-level `error` together so
+`edges[].fromNode` and `edges[].toNode` can be interpreted as indexes into the
+same `nodes` array. Resolved dependency graphs are currently available only for
+`NPM`, `CARGO`, `MAVEN`, and `PYPI`.
 
 ### dependencies
 
@@ -123,13 +164,18 @@ Fetches the resolved dependency graph nodes for a specific package version. Maps
 `GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`.
 
 Includes `is_bundled` to indicate whether a node is bundled into the package version.
+Use `dependency_graph` when you need to interpret edge indexes against the full
+nodes array. Resolved dependency graphs are currently available only for `NPM`,
+`CARGO`, `MAVEN`, and `PYPI`.
 
 ### dependency_edges
 
-Fetches the resolved dependency graph edges for a specific package version. Used
-alongside `dependencies` to fully reconstruct dependency topology. Maps to the same
-endpoint `GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`
-but extracts the `edges` array.
+Fetches the resolved dependency graph edges for a specific package version. Maps
+to the same endpoint `GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`
+but extracts the `edges` array. Edge indexes refer to positions in the provider's
+nodes array; use `dependency_graph` to retrieve `nodes` and `edges` together for
+topology reconstruction. Resolved dependency graphs are currently available only
+for `NPM`, `CARGO`, `MAVEN`, and `PYPI`.
 
 ### requirements
 
@@ -146,6 +192,7 @@ Fetches detailed vulnerability/advisory metadata given an advisory key (e.g., OS
 `GET /v3/advisories/{advisory_id}`.
 
 Includes `advisory_url` for quick navigation to the advisory detail page.
+Includes `requested_advisory_id` when deps.dev canonicalizes the advisory key.
 
 ### projects
 
@@ -153,12 +200,27 @@ Fetches project-level health metrics like GitHub stars, forks, issues, and OpenS
 `GET /v3/projects/{project_id}`.
 
 Requires URL-encoding for the `project_id` (e.g. `github.com%2Fgolang%2Fgo`).
+Includes `requested_project_id` when deps.dev canonicalizes the project key.
+
+### project_package_versions
+
+Fetches package versions known to be built from a project. Maps to
+`GET /v3/projects/{project_id}:packageversions`.
+
+Use this table to start from a repository-like project ID and discover package
+versions you can join into `versions`, `dependencies`, `requirements`, or
+`dependency_graph`. deps.dev returns at most 1500 package versions, with
+attestation-derived mappings served first.
 
 ## Supported systems
 
 deps.dev supports the following package systems: `NPM`, `PYPI`, `MAVEN`, `GO`,
 `CARGO`, `RUBYGEMS`, and `NUGET`. Use the system names exactly as expected by
 deps.dev (uppercase).
+
+Resolved dependency graph tables (`dependency_graph`, `dependencies`, and
+`dependency_edges`) have narrower deps.dev coverage and are currently available
+only for `NPM`, `CARGO`, `MAVEN`, and `PYPI`.
 
 ### Package naming notes
 

--- a/sources/community/deps_dev/manifest.yaml
+++ b/sources/community/deps_dev/manifest.yaml
@@ -29,6 +29,11 @@ test_queries:
     WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'
     LIMIT 1
   - >
+    SELECT nodes, edges, error
+    FROM deps_dev.dependency_graph
+    WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'
+    LIMIT 1
+  - >
     SELECT raw
     FROM deps_dev.requirements
     WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'
@@ -46,13 +51,18 @@ test_queries:
   - >
     SELECT dependency_name, dependency_version, relation
     FROM deps_dev.dependencies
-    WHERE system = 'MAVEN' AND package_name = 'org.apache.logging.log4j:log4j-core' AND version = '2.17.1'
+    WHERE system = 'MAVEN' AND package_name = 'org.apache.logging.log4j%3Alog4j-core' AND version = '2.17.1'
     LIMIT 5
   - >
     SELECT open_issues_count, stars_count, license
     FROM deps_dev.projects
     WHERE project_id = 'github.com%2Fgolang%2Fgo'
     LIMIT 1
+  - >
+    SELECT system, package_name, version, relation_type
+    FROM deps_dev.project_package_versions
+    WHERE project_id = 'github.com%2Ffacebook%2Freact'
+    LIMIT 5
   - >
     SELECT from_node, to_node, requirement
     FROM deps_dev.dependency_edges
@@ -84,25 +94,52 @@ tables:
     columns:
       - name: system
         type: Utf8
+        nullable: true
+        description: Canonical package system returned by deps.dev.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - system
+      - name: package_name
+        type: Utf8
+        nullable: true
+        description: Canonical package name returned by deps.dev.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - name
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Canonical package version returned by deps.dev.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - version
+      - name: requested_system
+        type: Utf8
         nullable: false
         virtual: true
-        description: Requested package system (NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, or NUGET).
+        description: Package system submitted in the request.
         expr:
           kind: from_filter
           key: system
-      - name: package_name
+      - name: requested_package_name
         type: Utf8
         nullable: false
         virtual: true
-        description: Requested package name.
+        description: Package name submitted in the request.
         expr:
           kind: from_filter
           key: package_name
-      - name: version
+      - name: requested_version
         type: Utf8
         nullable: false
         virtual: true
-        description: Requested package version.
+        description: Package version submitted in the request.
         expr:
           kind: from_filter
           key: version
@@ -226,17 +263,35 @@ tables:
     columns:
       - name: system
         type: Utf8
-        nullable: false
-        virtual: true
-        description: Requested system (NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, or NUGET).
+        nullable: true
+        description: Canonical package system returned by deps.dev.
         expr:
-          kind: from_filter
-          key: system
+          kind: path
+          path:
+            - packageKey
+            - system
       - name: package_name
+        type: Utf8
+        nullable: true
+        description: Canonical package name returned by deps.dev.
+        expr:
+          kind: path
+          path:
+            - packageKey
+            - name
+      - name: requested_system
         type: Utf8
         nullable: false
         virtual: true
-        description: Requested package name.
+        description: Package system submitted in the request.
+        expr:
+          kind: from_filter
+          key: system
+      - name: requested_package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Package name submitted in the request.
         expr:
           kind: from_filter
           key: package_name
@@ -258,12 +313,116 @@ tables:
         expr:
           kind: current_row
 
+  - name: dependency_graph
+    description: Fetch the full resolved dependency graph for a package version.
+    guide: >
+      Requires system, package_name, and version. Returns the graph-level nodes,
+      edges, and error payload together so edge from_node and to_node indexes can
+      be interpreted against the original nodes array. Resolved dependency graphs
+      are currently available only for NPM, CARGO, MAVEN, and PYPI.
+    filters:
+      - name: system
+        required: true
+      - name: package_name
+        required: true
+      - name: version
+        required: true
+    request:
+      method: GET
+      path: /v3/systems/{{filter.system}}/packages/{{filter.package_name}}/versions/{{filter.version}}:dependencies
+    response:
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: system
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package system submitted in the request.
+        expr:
+          kind: from_filter
+          key: system
+      - name: package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package name submitted in the request.
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: version
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package version submitted in the request.
+        expr:
+          kind: from_filter
+          key: version
+      - name: requested_system
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package system submitted in the request.
+        expr:
+          kind: from_filter
+          key: system
+      - name: requested_package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package name submitted in the request.
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: requested_version
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package version submitted in the request.
+        expr:
+          kind: from_filter
+          key: version
+      - name: nodes
+        type: Json
+        nullable: true
+        description: Dependency graph nodes; edge indexes refer to positions in this array.
+        expr:
+          kind: path
+          path:
+            - nodes
+      - name: edges
+        type: Json
+        nullable: true
+        description: Dependency graph edges with fromNode and toNode indexes into nodes.
+        expr:
+          kind: path
+          path:
+            - edges
+      - name: error
+        type: Utf8
+        nullable: true
+        description: Graph-level dependency resolution error, when deps.dev returns one.
+        expr:
+          kind: path
+          path:
+            - error
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full dependency graph payload.
+        expr:
+          kind: current_row
+
   - name: dependencies
     description: Fetch the resolved dependency graph for a package version.
     guide: >
       Requires system, package_name, and version. Returns the nodes in the
-      resolved dependency graph. Package names containing special characters
-      must be URL-encoded.
+      resolved dependency graph. Use dependency_graph when you need to interpret
+      edge indexes against the full nodes array. Resolved dependency graphs are
+      currently available only for NPM, CARGO, MAVEN, and PYPI. Package names
+      containing special characters must be URL-encoded.
     filters:
       - name: system
         required: true
@@ -492,9 +651,18 @@ tables:
     columns:
       - name: advisory_id
         type: Utf8
+        nullable: true
+        description: Canonical advisory ID returned by deps.dev.
+        expr:
+          kind: path
+          path:
+            - advisoryKey
+            - id
+      - name: requested_advisory_id
+        type: Utf8
         nullable: false
         virtual: true
-        description: Requested advisory ID.
+        description: Advisory ID submitted in the request.
         expr:
           kind: from_filter
           key: advisory_id
@@ -548,7 +716,7 @@ tables:
   - name: projects
     description: Fetch project-level health metrics including OpenSSF Scorecards.
     guide: >
-      Requires project_id (e.g. github.com/golang/go). Package names containing special
+      Requires project_id (e.g. github.com/golang/go). Project IDs containing special
       characters must be URL-encoded (e.g. github.com%2Fgolang%2Fgo).
     filters:
       - name: project_id
@@ -564,9 +732,18 @@ tables:
     columns:
       - name: project_id
         type: Utf8
+        nullable: true
+        description: Canonical project ID returned by deps.dev.
+        expr:
+          kind: path
+          path:
+            - projectKey
+            - id
+      - name: requested_project_id
+        type: Utf8
         nullable: false
         virtual: true
-        description: Requested project ID.
+        description: Project ID submitted in the request.
         expr:
           kind: from_filter
           key: project_id
@@ -641,12 +818,119 @@ tables:
         expr:
           kind: current_row
 
+  - name: project_package_versions
+    description: Fetch package versions known to be built from a project.
+    guide: >
+      Requires project_id (e.g. github.com%2Ffacebook%2Freact). Returns known mappings
+      between the project and package versions, with attestation-derived mappings
+      served first by deps.dev. Project IDs containing special characters must be
+      URL-encoded (e.g. github.com%2Ffacebook%2Freact).
+    fetch_limit_default: 100
+    filters:
+      - name: project_id
+        required: true
+    request:
+      method: GET
+      path: /v3/projects/{{filter.project_id}}:packageversions
+    response:
+      allow_404_empty: true
+      rows_path:
+        - versions
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Project ID submitted in the request.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: requested_project_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Project ID submitted in the request.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: system
+        type: Utf8
+        nullable: true
+        description: Package system for the mapped version.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - system
+      - name: package_name
+        type: Utf8
+        nullable: true
+        description: Package name for the mapped version.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - name
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Package version built from the project.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - version
+      - name: relation_type
+        type: Utf8
+        nullable: true
+        description: Relationship between the project and package version.
+        expr:
+          kind: path
+          path:
+            - relationType
+      - name: relation_provenance
+        type: Utf8
+        nullable: true
+        description: How deps.dev discovered the project-to-version mapping.
+        expr:
+          kind: path
+          path:
+            - relationProvenance
+      - name: slsa_provenances
+        type: Json
+        nullable: true
+        description: SLSA provenance statements linking the version to the project.
+        expr:
+          kind: path
+          path:
+            - slsaProvenances
+      - name: attestations
+        type: Json
+        nullable: true
+        description: Attestations linking the version to the project.
+        expr:
+          kind: path
+          path:
+            - attestations
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full project package-version mapping object.
+        expr:
+          kind: current_row
+
   - name: dependency_edges
-    description: Fetch the dependency graph edges for a package version to reconstruct topology.
+    description: Fetch the dependency graph edges for a package version.
     guide: >
       Requires system, package_name, and version. Returns the edges in the
-      resolved dependency graph. Package names containing special characters
-      must be URL-encoded.
+      resolved dependency graph. Edge indexes refer to the provider's nodes array;
+      use dependency_graph to retrieve nodes and edges together when reconstructing
+      topology. Resolved dependency graphs are currently available only for NPM,
+      CARGO, MAVEN, and PYPI. Package names containing special characters must be
+      URL-encoded.
     filters:
       - name: system
         required: true

--- a/sources/community/deps_dev/manifest.yaml
+++ b/sources/community/deps_dev/manifest.yaml
@@ -350,7 +350,7 @@ tables:
           path:
             - relation
       - name: errors
-        type: Utf8
+        type: Json
         nullable: true
         description: Error messages during dependency resolution (JSON array of strings).
         expr:

--- a/sources/community/deps_dev/manifest.yaml
+++ b/sources/community/deps_dev/manifest.yaml
@@ -1,0 +1,721 @@
+name: deps_dev
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query package metadata, dependency trees, and security advisories from the
+  deps.dev API. Supports NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, and NUGET.
+  Package names containing special characters (such as scoped npm packages
+  or Maven group:artifact coordinates) must be URL-encoded in filter values.
+base_url: https://api.deps.dev
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+test_queries:
+  - >
+    SELECT version, licenses, advisory_keys
+    FROM deps_dev.versions
+    WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'
+    LIMIT 1
+  - >
+    SELECT versions
+    FROM deps_dev.packages
+    WHERE system = 'NPM' AND package_name = 'minimist'
+    LIMIT 1
+  - >
+    SELECT dependency_name, dependency_version
+    FROM deps_dev.dependencies
+    WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'
+    LIMIT 1
+  - >
+    SELECT raw
+    FROM deps_dev.requirements
+    WHERE system = 'NPM' AND package_name = 'minimist' AND version = '0.0.8'
+    LIMIT 1
+  - >
+    SELECT title
+    FROM deps_dev.advisories
+    WHERE advisory_id = 'GHSA-vh95-rmgr-6w4m'
+    LIMIT 1
+  - >
+    SELECT version, licenses
+    FROM deps_dev.versions
+    WHERE system = 'GO' AND package_name = 'golang.org%2Fx%2Ftext' AND version = 'v0.3.7'
+    LIMIT 1
+  - >
+    SELECT dependency_name, dependency_version, relation
+    FROM deps_dev.dependencies
+    WHERE system = 'MAVEN' AND package_name = 'org.apache.logging.log4j:log4j-core' AND version = '2.17.1'
+    LIMIT 5
+  - >
+    SELECT open_issues_count, stars_count, license
+    FROM deps_dev.projects
+    WHERE project_id = 'github.com%2Fgolang%2Fgo'
+    LIMIT 1
+  - >
+    SELECT from_node, to_node, requirement
+    FROM deps_dev.dependency_edges
+    WHERE system = 'NPM' AND package_name = 'react' AND version = '18.2.0'
+    LIMIT 5
+tables:
+  - name: versions
+    description: Metadata for one package version from deps.dev.
+    guide: >
+      Requires system, package_name, and version. Use this table to inspect
+      package version metadata such as licenses, advisory keys, upstream
+      projects, and registry links. Package names containing special
+      characters must be URL-encoded (e.g. %40types%2Freact for @types/react).
+    filters:
+      - name: system
+        required: true
+      - name: package_name
+        required: true
+      - name: version
+        required: true
+    request:
+      method: GET
+      path: /v3/systems/{{filter.system}}/packages/{{filter.package_name}}/versions/{{filter.version}}
+    response:
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: system
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested package system (NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, or NUGET).
+        expr:
+          kind: from_filter
+          key: system
+      - name: package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested package name.
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: version
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested package version.
+        expr:
+          kind: from_filter
+          key: version
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: Time the package version was published.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - publishedAt
+      - name: is_default
+        type: Boolean
+        nullable: true
+        description: Whether deps.dev marks this as the default version.
+        expr:
+          kind: path
+          path:
+            - isDefault
+      - name: is_deprecated
+        type: Boolean
+        nullable: true
+        description: Whether the package version is deprecated.
+        expr:
+          kind: path
+          path:
+            - isDeprecated
+      - name: deprecated_reason
+        type: Utf8
+        nullable: true
+        description: Deprecation reason when available.
+        expr:
+          kind: path
+          path:
+            - deprecatedReason
+      - name: licenses
+        type: Json
+        nullable: true
+        description: License identifiers reported for this package version.
+        expr:
+          kind: path
+          path:
+            - licenses
+      - name: advisory_keys
+        type: Json
+        nullable: true
+        description: Advisory keys associated with this package version.
+        expr:
+          kind: path
+          path:
+            - advisoryKeys
+      - name: links
+        type: Json
+        nullable: true
+        description: Homepage, source repository, issue tracker, registry, and other links.
+        expr:
+          kind: path
+          path:
+            - links
+      - name: slsa_provenances
+        type: Json
+        nullable: true
+        description: SLSA provenance records for this package version.
+        expr:
+          kind: path
+          path:
+            - slsaProvenances
+      - name: attestations
+        type: Json
+        nullable: true
+        description: Attestations for this package version.
+        expr:
+          kind: path
+          path:
+            - attestations
+      - name: related_projects
+        type: Json
+        nullable: true
+        description: Upstream projects related to this package version.
+        expr:
+          kind: path
+          path:
+            - relatedProjects
+      - name: registries
+        type: Json
+        nullable: true
+        description: Package registries where this version is available.
+        expr:
+          kind: path
+          path:
+            - registries
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full raw deps.dev version object.
+        expr:
+          kind: current_row
+
+  - name: packages
+    description: Fetch package-level metadata (all versions) from deps.dev.
+    guide: >
+      Requires system and package_name. Use this table to inspect project-level
+      details, including the list of all available versions. Package names
+      containing special characters must be URL-encoded.
+    filters:
+      - name: system
+        required: true
+      - name: package_name
+        required: true
+    request:
+      method: GET
+      path: /v3/systems/{{filter.system}}/packages/{{filter.package_name}}
+    response:
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: system
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested system (NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, or NUGET).
+        expr:
+          kind: from_filter
+          key: system
+      - name: package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested package name.
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: versions
+        type: Json
+        nullable: true
+        description: >
+          JSON array of version objects, each containing versionKey.system,
+          versionKey.name, versionKey.version, publishedAt, isDefault,
+          isDeprecated, and deprecatedReason.
+        expr:
+          kind: path
+          path:
+            - versions
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full package object.
+        expr:
+          kind: current_row
+
+  - name: dependencies
+    description: Fetch the resolved dependency graph for a package version.
+    guide: >
+      Requires system, package_name, and version. Returns the nodes in the
+      resolved dependency graph. Package names containing special characters
+      must be URL-encoded.
+    filters:
+      - name: system
+        required: true
+      - name: package_name
+        required: true
+      - name: version
+        required: true
+    request:
+      method: GET
+      path: /v3/systems/{{filter.system}}/packages/{{filter.package_name}}/versions/{{filter.version}}:dependencies
+    response:
+      allow_404_empty: true
+      rows_path:
+        - nodes
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: system
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package system (NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, or NUGET).
+        expr:
+          kind: from_filter
+          key: system
+      - name: package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package name.
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: version
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package version.
+        expr:
+          kind: from_filter
+          key: version
+      - name: dependency_system
+        type: Utf8
+        nullable: true
+        description: Dependency system.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - system
+      - name: dependency_name
+        type: Utf8
+        nullable: true
+        description: Dependency package name.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - name
+      - name: dependency_version
+        type: Utf8
+        nullable: true
+        description: Dependency version.
+        expr:
+          kind: path
+          path:
+            - versionKey
+            - version
+      - name: is_bundled
+        type: Boolean
+        nullable: true
+        description: Whether the dependency node is bundled in the package version.
+        expr:
+          kind: path
+          path:
+            - bundled
+      - name: relation
+        type: Utf8
+        nullable: true
+        description: Relationship (SELF, DIRECT, or INDIRECT).
+        expr:
+          kind: path
+          path:
+            - relation
+      - name: errors
+        type: Utf8
+        nullable: true
+        description: Error messages during dependency resolution (JSON array of strings).
+        expr:
+          kind: path
+          path:
+            - errors
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full node object.
+        expr:
+          kind: current_row
+
+  - name: requirements
+    description: Fetch declared dependency requirements for a package version.
+    guide: >
+      Requires system, package_name, and version. Returns system-specific
+      requirements keyed by ecosystem (npm, maven, pypi, cargo, go, rubygems,
+      or nuget). Inspect the npm, maven, pypi, cargo, go, rubygems, or nuget
+      JSON columns for ecosystem-specific dependency details.
+    filters:
+      - name: system
+        required: true
+      - name: package_name
+        required: true
+      - name: version
+        required: true
+    request:
+      method: GET
+      path: /v3/systems/{{filter.system}}/packages/{{filter.package_name}}/versions/{{filter.version}}:requirements
+    response:
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: system
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package system (NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, or NUGET).
+        expr:
+          kind: from_filter
+          key: system
+      - name: package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package name.
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: version
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package version.
+        expr:
+          kind: from_filter
+          key: version
+      - name: npm
+        type: Json
+        nullable: true
+        description: npm-specific requirements (dependencies, devDependencies, peerDependencies, etc).
+        expr:
+          kind: path
+          path:
+            - npm
+      - name: maven
+        type: Json
+        nullable: true
+        description: Maven-specific requirements (dependencies, dependencyManagement, properties, etc).
+        expr:
+          kind: path
+          path:
+            - maven
+      - name: pypi
+        type: Json
+        nullable: true
+        description: PyPI-specific requirements (dependencies, providedExtras, requiredPythonVersion, etc).
+        expr:
+          kind: path
+          path:
+            - pypi
+      - name: cargo
+        type: Json
+        nullable: true
+        description: Cargo-specific requirements (dependencies with kind, optional, features, etc).
+        expr:
+          kind: path
+          path:
+            - cargo
+      - name: go
+        type: Json
+        nullable: true
+        description: Go-specific requirements (directDependencies, indirectDependencies, replaces, excludes).
+        expr:
+          kind: path
+          path:
+            - go
+      - name: rubygems
+        type: Json
+        nullable: true
+        description: RubyGems-specific requirements (runtimeDependencies, devDependencies, platform, etc).
+        expr:
+          kind: path
+          path:
+            - rubygems
+      - name: nuget
+        type: Json
+        nullable: true
+        description: NuGet-specific requirements (dependencyGroups, targetFrameworks, etc).
+        expr:
+          kind: path
+          path:
+            - nuget
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full requirements payload.
+        expr:
+          kind: current_row
+
+  - name: advisories
+    description: Fetch advisory details by advisory key.
+    guide: >
+      Requires advisory_id (e.g. OSV ID or GHSA). Use this table to fetch full advisory metadata.
+    filters:
+      - name: advisory_id
+        required: true
+    request:
+      method: GET
+      path: /v3/advisories/{{filter.advisory_id}}
+    response:
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: advisory_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested advisory ID.
+        expr:
+          kind: from_filter
+          key: advisory_id
+      - name: advisory_url
+        type: Utf8
+        nullable: true
+        description: Advisory URL on osv.dev.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Title of the advisory.
+        expr:
+          kind: path
+          path:
+            - title
+      - name: cvss3_score
+        type: Float64
+        nullable: true
+        description: CVSSv3 base score.
+        expr:
+          kind: path
+          path:
+            - cvss3Score
+      - name: cvss3_vector
+        type: Utf8
+        nullable: true
+        description: CVSSv3 vector.
+        expr:
+          kind: path
+          path:
+            - cvss3Vector
+      - name: aliases
+        type: Json
+        nullable: true
+        description: Advisory aliases (e.g. CVE IDs).
+        expr:
+          kind: path
+          path:
+            - aliases
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full advisory object.
+        expr:
+          kind: current_row
+
+  - name: projects
+    description: Fetch project-level health metrics including OpenSSF Scorecards.
+    guide: >
+      Requires project_id (e.g. github.com/golang/go). Package names containing special
+      characters must be URL-encoded (e.g. github.com%2Fgolang%2Fgo).
+    filters:
+      - name: project_id
+        required: true
+    request:
+      method: GET
+      path: /v3/projects/{{filter.project_id}}
+    response:
+      allow_404_empty: true
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: project_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Requested project ID.
+        expr:
+          kind: from_filter
+          key: project_id
+      - name: open_issues_count
+        type: Int64
+        nullable: true
+        description: Number of open issues on the project repository.
+        expr:
+          kind: path
+          path:
+            - openIssuesCount
+      - name: stars_count
+        type: Int64
+        nullable: true
+        description: Number of stars on the project repository.
+        expr:
+          kind: path
+          path:
+            - starsCount
+      - name: forks_count
+        type: Int64
+        nullable: true
+        description: Number of forks on the project repository.
+        expr:
+          kind: path
+          path:
+            - forksCount
+      - name: license
+        type: Utf8
+        nullable: true
+        description: Primary license identifier.
+        expr:
+          kind: path
+          path:
+            - license
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Project description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: homepage
+        type: Utf8
+        nullable: true
+        description: Project homepage URL.
+        expr:
+          kind: path
+          path:
+            - homepage
+      - name: scorecard
+        type: Json
+        nullable: true
+        description: Full OpenSSF Scorecard report.
+        expr:
+          kind: path
+          path:
+            - scorecard
+      - name: oss_fuzz
+        type: Json
+        nullable: true
+        description: OSS-Fuzz integration status.
+        expr:
+          kind: path
+          path:
+            - ossFuzz
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full project metadata payload.
+        expr:
+          kind: current_row
+
+  - name: dependency_edges
+    description: Fetch the dependency graph edges for a package version to reconstruct topology.
+    guide: >
+      Requires system, package_name, and version. Returns the edges in the
+      resolved dependency graph. Package names containing special characters
+      must be URL-encoded.
+    filters:
+      - name: system
+        required: true
+      - name: package_name
+        required: true
+      - name: version
+        required: true
+    request:
+      method: GET
+      path: /v3/systems/{{filter.system}}/packages/{{filter.package_name}}/versions/{{filter.version}}:dependencies
+    response:
+      allow_404_empty: true
+      rows_path:
+        - edges
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: system
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package system (NPM, PYPI, MAVEN, GO, CARGO, RUBYGEMS, or NUGET).
+        expr:
+          kind: from_filter
+          key: system
+      - name: package_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package name.
+        expr:
+          kind: from_filter
+          key: package_name
+      - name: version
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Root package version.
+        expr:
+          kind: from_filter
+          key: version
+      - name: from_node
+        type: Int64
+        nullable: true
+        description: Index of the origin node in the graph.
+        expr:
+          kind: path
+          path:
+            - fromNode
+      - name: to_node
+        type: Int64
+        nullable: true
+        description: Index of the destination node in the graph.
+        expr:
+          kind: path
+          path:
+            - toNode
+      - name: requirement
+        type: Utf8
+        nullable: true
+        description: Version requirement expression for this edge.
+        expr:
+          kind: path
+          path:
+            - requirement
+      - name: raw
+        type: Json
+        nullable: true
+        description: Full edge object.
+        expr:
+          kind: current_row


### PR DESCRIPTION
## Changes

Added a new `deps_dev` community source for querying package metadata, full dependency graph topologies, version requirements, and security advisories from the public [deps.dev API v3](https://docs.deps.dev/api/v3/).

Tables included and their mapped endpoints:

- **`versions`** → [`GET /v3/systems/{system}/packages/{package_name}/versions/{version}`](https://docs.deps.dev/api/v3/#getversion)
- **`packages`** → [`GET /v3/systems/{system}/packages/{package_name}`](https://docs.deps.dev/api/v3/#getpackage)
- **`dependencies`** (Nodes) → [`GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`](https://docs.deps.dev/api/v3/#getdependencies)
- **`dependency_edges`** (Topology) → [`GET /v3/systems/{system}/packages/{package_name}/versions/{version}:dependencies`](https://docs.deps.dev/api/v3/#getdependencies) (Extracting the `edges` array)
- **`requirements`** → [`GET /v3/systems/{system}/packages/{package_name}/versions/{version}:requirements`](https://docs.deps.dev/api/v3/#getrequirements)
- **`projects`** → [`GET /v3/projects/{project_id}`](https://docs.deps.dev/api/v3/#getproject)
- **`advisories`** → [`GET /v3/advisories/{advisory_id}`](https://docs.deps.dev/api/v3/#getadvisory)

## Why it changed

This source enables users to inspect supply-chain metadata, dependency relationships, and vulnerability information across major package ecosystems directly from Coral without requiring custom API integrations.

Beyond simple metadata lookups, this implementation brings advanced security features directly to SQL:
- **OpenSSF Scorecards**: By joining with the `projects` table, users can query repository health metrics, OSS-Fuzz status, and detailed OpenSSF Scorecard JSON directly.
- **Topological Analysis**: By utilizing the `dependency_edges` table alongside the `dependencies` node table, users can reconstruct full dependency trees in SQL to find exactly how an indirect vulnerability was introduced.

Supported ecosystems include: **NPM**, **PyPI**, **Maven**, **Go**, **Cargo**, **RubyGems**, and **NuGet**.

## Advanced Use Cases / Cool Stuff

**1. Find vulnerable transitive dependencies**

Query a package’s resolved dependencies, then inspect each dependency version’s `advisory_keys` via `versions`, and expand the advisory metadata through `advisories`.

**2. Reconstruct dependency topology safely**

Use `dependency_graph` for graph reconstruction because it preserves `nodes` and `edges` in the same response row. This keeps deps.dev’s node-index semantics intact.

**3. Audit package health from upstream projects**

Use `related_projects` from `versions`, or start with `projects`, to inspect repository health, OpenSSF Scorecard metadata, OSS-Fuzz status, stars, forks, open issues, license, and homepage.

**4. Start from a GitHub project and discover packages**

Use `project_package_versions` to go from a project such as `github.com%2Ffacebook%2Freact` to known package versions, then join into `versions`, `requirements`, or dependency graph tables.

**5. Compare declared vs resolved dependencies**

Use `requirements` for declared ecosystem-specific requirements and `dependency_graph` / `dependencies` for resolved graph data. This helps distinguish what a package declared from what deps.dev resolved.

**6. Cross-ecosystem package intelligence**

The source covers npm, PyPI, Maven, Go, Cargo, RubyGems, and NuGet metadata in a single SQL schema, which makes multi-ecosystem supply-chain questions easier to ask from agents or dashboards.

## Try It

These examples show the main workflows this source enables: package
canonicalization, dependency graph inspection, project-to-package discovery,
project health auditing, and vulnerability triage.

### Canonicalization

deps.dev may canonicalize package names. This query preserves both the canonical
response and the submitted filters:

```sql
SELECT
  system,
  package_name,
  version,
  requested_system,
  requested_package_name,
  requested_version
FROM deps_dev.versions
WHERE system = 'PYPI'
  AND package_name = 'Django'
  AND version = '4.2.0'
LIMIT 1;
```

Example:
```text
+--------+--------------+---------+------------------+------------------------+-------------------+
| system | package_name | version | requested_system | requested_package_name | requested_version |
+--------+--------------+---------+------------------+------------------------+-------------------+
| PYPI   | django       | 4.2.0   | PYPI             | Django                 | 4.2.0             |
+--------+--------------+---------+------------------+------------------------+-------------------+
```

### Dependency Graph Topology

Use `dependency_graph` when you need the original graph shape. It keeps `nodes`
and `edges` together because deps.dev edges reference node array indexes:

```sql
SELECT
  system,
  package_name,
  version,
  nodes,
  edges,
  error
FROM deps_dev.dependency_graph
WHERE system = 'NPM'
  AND package_name = 'react'
  AND version = '18.2.0'
LIMIT 1;
```

For a more readable dependency-node view:

```sql
SELECT
  dependency_name,
  dependency_version,
  relation
FROM deps_dev.dependencies
WHERE system = 'NPM'
  AND package_name = 'react'
  AND version = '18.2.0'
LIMIT 10;
```

Example:
```text
+-----------------+--------------------+----------+
| dependency_name | dependency_version | relation |
+-----------------+--------------------+----------+
| react           | 18.2.0             | SELF     |
| js-tokens       | 4.0.0              | INDIRECT |
| loose-envify    | 1.4.0              | DIRECT   |
+-----------------+--------------------+----------+
```

For a readable edge view:

```sql
SELECT
  from_node,
  to_node,
  requirement
FROM deps_dev.dependency_edges
WHERE system = 'NPM'
  AND package_name = 'react'
  AND version = '18.2.0'
LIMIT 10;
```

### Project To Package Versions

Start from a GitHub project and discover package versions built from it:

```sql
SELECT
  system,
  package_name,
  version,
  relation_type,
  relation_provenance
FROM deps_dev.project_package_versions
WHERE project_id = 'github.com%2Ffacebook%2Freact'
LIMIT 10;
```

### Project Health And OpenSSF Scorecard

Query project health metadata, including OpenSSF Scorecard data:

```sql
SELECT
  project_id,
  requested_project_id,
  stars_count,
  forks_count,
  open_issues_count,
  license,
  scorecard
FROM deps_dev.projects
WHERE project_id = 'github.com%2Ffacebook%2Freact'
LIMIT 1;
```
Example :
```text
+---------------------------+-------------------------------+-------------+-------------+-------------------+---------+---------------+
| project_id                | requested_project_id          | stars_count | forks_count | open_issues_count | license | overall_score |
+---------------------------+-------------------------------+-------------+-------------+-------------------+---------+---------------+
| github.com/facebook/react | github.com%2Ffacebook%2Freact | 245277      | 51104       | 1308              | MIT     | 6.7           |
+---------------------------+-------------------------------+-------------+-------------+-------------------+---------+---------------+
```

### Vulnerability Metadata

Expand an advisory key into richer vulnerability metadata:

```sql
SELECT
  advisory_id,
  title,
  cvss3_score,
  aliases
FROM deps_dev.advisories
WHERE advisory_id = 'GHSA-vh95-rmgr-6w4m'
LIMIT 1;
```

Example:

```text
+---------------------+---------------------------------+-------------+-------------------+
| advisory_id         | title                           | cvss3_score | aliases           |
+---------------------+---------------------------------+-------------+-------------------+
| GHSA-vh95-rmgr-6w4m | Prototype Pollution in minimist | 5.6         | ["CVE-2020-7598"] |
+---------------------+---------------------------------+-------------+-------------------+
```

### Declared Vs Resolved Dependencies

Compare declared requirements with the resolved dependency graph.

Declared requirements:

```sql
SELECT
  npm,
  raw
FROM deps_dev.requirements
WHERE system = 'NPM'
  AND package_name = 'react'
  AND version = '18.2.0'
LIMIT 1;
```

Resolved dependencies:

```sql
SELECT
  dependency_name,
  dependency_version,
  relation
FROM deps_dev.dependencies
WHERE system = 'NPM'
  AND package_name = 'react'
  AND version = '18.2.0'
LIMIT 20;
```


## Source Quality Notes

- Canonical identifiers are mapped from deps.dev response keys.
- Submitted request values are preserved in `requested_*` columns.
- `dependency_graph` preserves `nodes`, `edges`, and `error` together for correct topology reconstruction.
- Graph-table documentation calls out deps.dev’s narrower resolved-graph ecosystem coverage.
- Path examples use percent-encoded values where Coral interpolates filters into URLs.
- `project_package_versions` has `fetch_limit_default: 100`, since deps.dev can return up to 1500 mappings for one project.

## How it was tested

- Verified manifest mappings against the official [deps.dev API v3 docs](https://docs.deps.dev/api/v3/).
- Built Coral locally using `cargo build --release` and `cargo install --path crates/coral-cli`.
- Verified the source using `coral source add --file sources/community/deps_dev/manifest.yaml`.
- Ran live queries across npm, Maven, PyPI, Go, project, advisory, dependency graph, and project-package mapping workflows.
- Confirmed canonicalization behavior with PyPI package casing (`Django` → `django`) while preserving submitted filter values in `requested_*`.
- Confirmed project canonicalization behavior (`github.com%2Fgolang%2Fgo` → `github.com/golang/go`) while preserving `requested_project_id`.
- Confirmed graph rows expose `nodes`, `edges`, and `error` together through `dependency_graph`.
- Confirmed `git diff --check` passes and the manifest parses as YAML.

## User-visible impact

- Users can query `deps_dev.*` tables directly from SQL.
- No authentication or API token is required.
- Package and project identifiers containing reserved route characters must be percent-encoded, for example `%40types%2Freact`, `golang.org%2Fx%2Ftext`, `org.apache.logging.log4j%3Alog4j-core`, and `github.com%2Fgolang%2Fgo`.
