### PR TITLE
feat(sources/community/openmetadata): add OpenMetadata source

### DIFF
--- a/sources/community/openmetadata/README.md
+++ b/sources/community/openmetadata/README.md
@@ -1,0 +1,119 @@
+# OpenMetadata Coral Source
+
+## What This Source Exposes
+
+This source exposes [OpenMetadata](https://open-metadata.org/) catalog and
+governance metadata as SQL tables in Coral. It is designed for data operations
+visibility: tables, BI dashboards, pipelines, users, teams, owners, tags, and
+glossary terms.
+
+It is read-only and does not mutate catalog metadata.
+
+## Authentication
+
+Provide an OpenMetadata JWT or bot token as `OPENMETADATA_JWT_TOKEN`. Use a
+token with read access to catalog entities, governance metadata, users, and
+teams.
+
+Required inputs:
+
+| Input | Kind | Default | Description |
+|---|---|---|---|
+| `OPENMETADATA_API_BASE` | variable | `http://localhost:8585/api` | Base URL for the OpenMetadata API, without a trailing slash. |
+| `OPENMETADATA_JWT_TOKEN` | secret | - | JWT or bot token with read access to OpenMetadata entities. |
+
+## Setup
+
+```bash
+OPENMETADATA_API_BASE=https://openmetadata.example.com/api \
+OPENMETADATA_JWT_TOKEN=your_token_here \
+coral source add --file sources/community/openmetadata/manifest.yaml
+```
+
+Or run interactively:
+
+```bash
+coral source add --interactive --file sources/community/openmetadata/manifest.yaml
+```
+
+## Tables
+
+| Table | Purpose |
+|---|---|
+| `openmetadata.tables` | Cataloged table entities with owners, tags, domains, and columns. |
+| `openmetadata.dashboards` | BI dashboard entities ingested into OpenMetadata. |
+| `openmetadata.pipelines` | Pipeline entities and orchestration metadata. |
+| `openmetadata.users` | OpenMetadata users with teams and roles. |
+| `openmetadata.teams` | OpenMetadata teams with parent teams and users. |
+| `openmetadata.glossary_terms` | Business glossary terms with owners, tags, children, and related terms. |
+
+## Example Queries
+
+Tables without owners:
+
+```sql
+SELECT fully_qualified_name, database_schema_name, owners
+FROM openmetadata.tables
+WHERE owners IS NULL OR owners = ''
+ORDER BY fully_qualified_name;
+```
+
+Dashboards by owner:
+
+```sql
+SELECT owners, COUNT(*) AS dashboard_count
+FROM openmetadata.dashboards
+GROUP BY owners
+ORDER BY dashboard_count DESC;
+```
+
+Recently updated data assets:
+
+```sql
+SELECT fully_qualified_name, service_name, owners, updated_at
+FROM openmetadata.tables
+ORDER BY updated_at DESC
+LIMIT 25;
+```
+
+Glossary terms that have no owner:
+
+```sql
+SELECT fully_qualified_name, glossary_name, description
+FROM openmetadata.glossary_terms
+WHERE owners IS NULL OR owners = '';
+```
+
+Users with admin access:
+
+```sql
+SELECT name, email, teams, roles
+FROM openmetadata.users
+WHERE is_admin = true
+ORDER BY name;
+```
+
+## Limitations
+
+- List endpoints use OpenMetadata cursor pagination through the `paging.after`
+  field.
+- The source requests commonly useful fields such as `owners`, `tags`,
+  `domains`, `columns`, and `tasks`; availability depends on your OpenMetadata
+  version and permissions.
+- This source does not fetch raw lineage graphs yet. It focuses on inventory,
+  ownership, governance, and entity metadata.
+- This source does not create, update, or delete catalog entities.
+
+## Validation
+
+Local validation for this source:
+
+```text
+YAML parse: passed for sources/community/openmetadata/manifest.yaml
+Coral manifest schema validation: passed for sources/community/openmetadata/manifest.yaml
+git diff --check: passed
+make lint-sources: passed
+Live API tests: not run; require real OpenMetadata credentials
+```
+
+Testing note: live API tests require user-provided credentials and are intentionally not part of default CI. The manifest includes `test_queries`, and no credentials or customer data are committed.

--- a/sources/community/openmetadata/README.md
+++ b/sources/community/openmetadata/README.md
@@ -44,7 +44,7 @@ coral source add --interactive --file sources/community/openmetadata/manifest.ya
 | `openmetadata.dashboards` | BI dashboard entities ingested into OpenMetadata. |
 | `openmetadata.pipelines` | Pipeline entities and orchestration metadata. |
 | `openmetadata.users` | OpenMetadata users with teams and roles. |
-| `openmetadata.teams` | OpenMetadata teams with parent teams and users. |
+| `openmetadata.teams` | OpenMetadata teams with parent teams, child teams, users, owners, domains, and policies. |
 | `openmetadata.glossary_terms` | Business glossary terms with owners, tags, children, and related terms. |
 
 ## Example Queries

--- a/sources/community/openmetadata/README.md
+++ b/sources/community/openmetadata/README.md
@@ -49,13 +49,12 @@ coral source add --interactive --file sources/community/openmetadata/manifest.ya
 
 ## Example Queries
 
-Tables without owners:
+Catalog tables with ownership fields:
 
 ```sql
 SELECT fully_qualified_name, database_schema_name, owners
 FROM openmetadata.tables
-WHERE owners IS NULL OR owners = ''
-ORDER BY fully_qualified_name;
+LIMIT 25;
 ```
 
 Dashboards by owner:
@@ -72,16 +71,15 @@ Recently updated data assets:
 ```sql
 SELECT fully_qualified_name, service_name, owners, updated_at
 FROM openmetadata.tables
-ORDER BY updated_at DESC
 LIMIT 25;
 ```
 
-Glossary terms that have no owner:
+Glossary terms:
 
 ```sql
 SELECT fully_qualified_name, glossary_name, description
 FROM openmetadata.glossary_terms
-WHERE owners IS NULL OR owners = '';
+LIMIT 25;
 ```
 
 Users with admin access:
@@ -93,10 +91,24 @@ WHERE is_admin = true
 ORDER BY name;
 ```
 
+Catalog tables including soft-deleted entities:
+
+```sql
+SELECT fully_qualified_name, deleted, updated_at
+FROM openmetadata.tables
+WHERE include = 'all'
+LIMIT 25;
+```
+
 ## Limitations
 
 - List endpoints use OpenMetadata cursor pagination through the `paging.after`
   field.
+- OpenMetadata list APIs return non-deleted entities by default. Use
+  `include = 'all'` or `include = 'deleted'` when auditing soft-deleted
+  entities.
+- `openmetadata.glossary_terms` accepts `glossary` and `parent` filters for
+  narrowing terms by fully qualified glossary or parent term name.
 - The source requests commonly useful fields such as `owners`, `tags`,
   `domains`, `columns`, and `tasks`; availability depends on your OpenMetadata
   version and permissions.
@@ -113,7 +125,7 @@ YAML parse: passed for sources/community/openmetadata/manifest.yaml
 Coral manifest schema validation: passed for sources/community/openmetadata/manifest.yaml
 git diff --check: passed
 make lint-sources: passed
-Live API tests: not run; require real OpenMetadata credentials
+Live API tests: passed against the OpenMetadata sandbox with `coral source add` and `coral source test openmetadata`
 ```
 
-Testing note: live API tests require user-provided credentials and are intentionally not part of default CI. The manifest includes `test_queries`, and no credentials or customer data are committed.
+Testing note: the live API test used user-provided OpenMetadata credentials. The manifest includes `test_queries`, and no credentials or customer data are committed.

--- a/sources/community/openmetadata/manifest.yaml
+++ b/sources/community/openmetadata/manifest.yaml
@@ -42,7 +42,11 @@ tables:
     description: OpenMetadata table entities with ownership, tags, domains, and column metadata.
     guide: |
       Each row is one cataloged table. Use `fully_qualified_name` to join with
-      external naming conventions and `owners` to audit stewardship.
+      external naming conventions and `owners` to audit stewardship. OpenMetadata
+      returns non-deleted entities by default; use `include = 'all'` or
+      `include = 'deleted'` when auditing soft-deleted entities.
+    filters:
+      - name: include
     request:
       method: GET
       path: /v1/tables
@@ -50,6 +54,9 @@ tables:
         - name: fields
           from: literal
           value: owners,tags,domains,columns
+        - name: include
+          from: filter
+          key: include
     response:
       rows_path: [data]
       row_strategy: direct
@@ -147,9 +154,23 @@ tables:
         type: Boolean
         nullable: true
         description: Whether this entity is soft-deleted.
+      - name: include
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional include filter, such as all, deleted, or non-deleted.
+        expr:
+          kind: from_filter
+          key: include
 
   - name: dashboards
     description: OpenMetadata dashboard entities from BI tools such as Looker, Superset, or Tableau.
+    guide: |
+      Use this table to audit BI assets ingested into OpenMetadata. OpenMetadata
+      returns non-deleted entities by default; use `include = 'all'` or
+      `include = 'deleted'` when auditing soft-deleted dashboards.
+    filters:
+      - name: include
     request:
       method: GET
       path: /v1/dashboards
@@ -157,6 +178,9 @@ tables:
         - name: fields
           from: literal
           value: owners,tags,domains,charts,usageSummary
+        - name: include
+          from: filter
+          key: include
     response:
       rows_path: [data]
       row_strategy: direct
@@ -214,6 +238,15 @@ tables:
           path: [tags]
           item_path: [tagFQN]
           separator: ","
+      - name: domains
+        type: Utf8
+        nullable: true
+        description: Comma-joined assigned domain names.
+        expr:
+          kind: join_array_path
+          path: [domains]
+          item_path: [name]
+          separator: ","
       - name: charts
         type: Json
         nullable: true
@@ -240,9 +273,23 @@ tables:
         type: Boolean
         nullable: true
         description: Whether this entity is soft-deleted.
+      - name: include
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional include filter, such as all, deleted, or non-deleted.
+        expr:
+          kind: from_filter
+          key: include
 
   - name: pipelines
     description: OpenMetadata pipeline entities and orchestration metadata.
+    guide: |
+      Use this table to inventory pipeline metadata and ownership. OpenMetadata
+      returns non-deleted entities by default; use `include = 'all'` or
+      `include = 'deleted'` when auditing soft-deleted pipelines.
+    filters:
+      - name: include
     request:
       method: GET
       path: /v1/pipelines
@@ -250,6 +297,9 @@ tables:
         - name: fields
           from: literal
           value: owners,tags,tasks,followers
+        - name: include
+          from: filter
+          key: include
     response:
       rows_path: [data]
       row_strategy: direct
@@ -311,6 +361,15 @@ tables:
         type: Json
         nullable: true
         description: Pipeline task metadata.
+      - name: followers
+        type: Utf8
+        nullable: true
+        description: Comma-joined follower names.
+        expr:
+          kind: join_array_path
+          path: [followers]
+          item_path: [name]
+          separator: ","
       - name: updated_at
         type: Timestamp
         nullable: true
@@ -328,9 +387,23 @@ tables:
         type: Boolean
         nullable: true
         description: Whether this entity is soft-deleted.
+      - name: include
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional include filter, such as all, deleted, or non-deleted.
+        expr:
+          kind: from_filter
+          key: include
 
   - name: users
     description: OpenMetadata users.
+    guide: |
+      Use this table to audit OpenMetadata users, teams, and roles. OpenMetadata
+      returns non-deleted users by default; use `include = 'all'` or
+      `include = 'deleted'` when auditing soft-deleted users.
+    filters:
+      - name: include
     request:
       method: GET
       path: /v1/users
@@ -338,6 +411,9 @@ tables:
         - name: fields
           from: literal
           value: teams,roles
+        - name: include
+          from: filter
+          key: include
     response:
       rows_path: [data]
       row_strategy: direct
@@ -407,9 +483,23 @@ tables:
         type: Boolean
         nullable: true
         description: Whether this entity is soft-deleted.
+      - name: include
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional include filter, such as all, deleted, or non-deleted.
+        expr:
+          kind: from_filter
+          key: include
 
   - name: teams
     description: OpenMetadata teams.
+    guide: |
+      Use this table to inspect team hierarchy, users, and ownership. OpenMetadata
+      returns non-deleted teams by default; use `include = 'all'` or
+      `include = 'deleted'` when auditing soft-deleted teams.
+    filters:
+      - name: include
     request:
       method: GET
       path: /v1/teams
@@ -417,6 +507,9 @@ tables:
         - name: fields
           from: literal
           value: users,parents,owns
+        - name: include
+          from: filter
+          key: include
     response:
       rows_path: [data]
       row_strategy: direct
@@ -490,12 +583,30 @@ tables:
         nullable: true
         description: User that last updated the entity.
         expr: {kind: path, path: [updatedBy]}
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: Whether this entity is soft-deleted.
+      - name: include
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional include filter, such as all, deleted, or non-deleted.
+        expr:
+          kind: from_filter
+          key: include
 
   - name: glossary_terms
     description: OpenMetadata glossary terms with ownership, tags, domains, and relationships.
+    guide: |
+      Use `glossary` or `parent` to narrow glossary terms by fully qualified
+      glossary or parent term name. OpenMetadata returns non-deleted terms by
+      default; use `include = 'all'` or `include = 'deleted'` when auditing
+      soft-deleted terms.
     filters:
       - name: glossary
       - name: parent
+      - name: include
     request:
       method: GET
       path: /v1/glossaryTerms
@@ -509,6 +620,9 @@ tables:
         - name: parent
           from: filter
           key: parent
+        - name: include
+          from: filter
+          key: include
     response:
       rows_path: [data]
       row_strategy: direct
@@ -566,6 +680,15 @@ tables:
           path: [tags]
           item_path: [tagFQN]
           separator: ","
+      - name: domains
+        type: Utf8
+        nullable: true
+        description: Comma-joined assigned domain names.
+        expr:
+          kind: join_array_path
+          path: [domains]
+          item_path: [name]
+          separator: ","
       - name: synonyms
         type: Json
         nullable: true
@@ -596,3 +719,27 @@ tables:
         type: Boolean
         nullable: true
         description: Whether this entity is soft-deleted.
+      - name: glossary
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional glossary fully qualified name filter.
+        expr:
+          kind: from_filter
+          key: glossary
+      - name: parent
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional parent glossary term fully qualified name filter.
+        expr:
+          kind: from_filter
+          key: parent
+      - name: include
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional include filter, such as all, deleted, or non-deleted.
+        expr:
+          kind: from_filter
+          key: include

--- a/sources/community/openmetadata/manifest.yaml
+++ b/sources/community/openmetadata/manifest.yaml
@@ -1,0 +1,598 @@
+name: openmetadata
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query OpenMetadata tables, dashboards, pipelines, users, teams, and glossary
+  terms for data catalog, ownership, and governance analysis.
+base_url: "{{input.OPENMETADATA_API_BASE}}"
+
+inputs:
+  OPENMETADATA_API_BASE:
+    kind: variable
+    default: http://localhost:8585/api
+    hint: |
+      Base URL for your OpenMetadata API, without a trailing slash.
+      Local quickstart example: http://localhost:8585/api.
+      Remote example: https://openmetadata.example.com/api.
+  OPENMETADATA_JWT_TOKEN:
+    kind: secret
+    hint: |
+      OpenMetadata JWT token or bot token. Use a token with read access to
+      catalog entities, governance metadata, users, and teams.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.OPENMETADATA_JWT_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, fully_qualified_name FROM openmetadata.tables LIMIT 1
+  - SELECT id, name FROM openmetadata.users LIMIT 1
+
+tables:
+  - name: tables
+    description: OpenMetadata table entities with ownership, tags, domains, and column metadata.
+    guide: |
+      Each row is one cataloged table. Use `fully_qualified_name` to join with
+      external naming conventions and `owners` to audit stewardship.
+    request:
+      method: GET
+      path: /v1/tables
+      query:
+        - name: fields
+          from: literal
+          value: owners,tags,domains,columns
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [paging, after]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Table UUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Table name.
+      - name: fully_qualified_name
+        type: Utf8
+        nullable: true
+        description: Fully qualified table name.
+        expr: {kind: path, path: [fullyQualifiedName]}
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name.
+        expr: {kind: path, path: [displayName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Table description.
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: Database service name.
+        expr: {kind: path, path: [service, name]}
+      - name: database_name
+        type: Utf8
+        nullable: true
+        description: Parent database name.
+        expr: {kind: path, path: [database, name]}
+      - name: database_schema_name
+        type: Utf8
+        nullable: true
+        description: Parent schema name.
+        expr: {kind: path, path: [databaseSchema, name]}
+      - name: owners
+        type: Utf8
+        nullable: true
+        description: Comma-joined owner names.
+        expr:
+          kind: join_array_path
+          path: [owners]
+          item_path: [name]
+          separator: ","
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: Comma-joined tag FQNs.
+        expr:
+          kind: join_array_path
+          path: [tags]
+          item_path: [tagFQN]
+          separator: ","
+      - name: domains
+        type: Utf8
+        nullable: true
+        description: Comma-joined assigned domain names.
+        expr:
+          kind: join_array_path
+          path: [domains]
+          item_path: [name]
+          separator: ","
+      - name: columns
+        type: Json
+        nullable: true
+        description: Column metadata returned by OpenMetadata.
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [updatedAt]}
+      - name: updated_by
+        type: Utf8
+        nullable: true
+        description: User that last updated the entity.
+        expr: {kind: path, path: [updatedBy]}
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: Whether this entity is soft-deleted.
+
+  - name: dashboards
+    description: OpenMetadata dashboard entities from BI tools such as Looker, Superset, or Tableau.
+    request:
+      method: GET
+      path: /v1/dashboards
+      query:
+        - name: fields
+          from: literal
+          value: owners,tags,domains,charts,usageSummary
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [paging, after]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Dashboard UUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Dashboard name.
+      - name: fully_qualified_name
+        type: Utf8
+        nullable: true
+        description: Fully qualified dashboard name.
+        expr: {kind: path, path: [fullyQualifiedName]}
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name.
+        expr: {kind: path, path: [displayName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Dashboard description.
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: Dashboard service name.
+        expr: {kind: path, path: [service, name]}
+      - name: owners
+        type: Utf8
+        nullable: true
+        description: Comma-joined owner names.
+        expr:
+          kind: join_array_path
+          path: [owners]
+          item_path: [name]
+          separator: ","
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: Comma-joined tag FQNs.
+        expr:
+          kind: join_array_path
+          path: [tags]
+          item_path: [tagFQN]
+          separator: ","
+      - name: charts
+        type: Json
+        nullable: true
+        description: Charts referenced by the dashboard.
+      - name: usage_summary
+        type: Json
+        nullable: true
+        description: Usage summary, when available.
+        expr: {kind: path, path: [usageSummary]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [updatedAt]}
+      - name: updated_by
+        type: Utf8
+        nullable: true
+        description: User that last updated the entity.
+        expr: {kind: path, path: [updatedBy]}
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: Whether this entity is soft-deleted.
+
+  - name: pipelines
+    description: OpenMetadata pipeline entities and orchestration metadata.
+    request:
+      method: GET
+      path: /v1/pipelines
+      query:
+        - name: fields
+          from: literal
+          value: owners,tags,tasks,followers
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [paging, after]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Pipeline UUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Pipeline name.
+      - name: fully_qualified_name
+        type: Utf8
+        nullable: true
+        description: Fully qualified pipeline name.
+        expr: {kind: path, path: [fullyQualifiedName]}
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name.
+        expr: {kind: path, path: [displayName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Pipeline description.
+      - name: service_name
+        type: Utf8
+        nullable: true
+        description: Pipeline service name.
+        expr: {kind: path, path: [service, name]}
+      - name: owners
+        type: Utf8
+        nullable: true
+        description: Comma-joined owner names.
+        expr:
+          kind: join_array_path
+          path: [owners]
+          item_path: [name]
+          separator: ","
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: Comma-joined tag FQNs.
+        expr:
+          kind: join_array_path
+          path: [tags]
+          item_path: [tagFQN]
+          separator: ","
+      - name: tasks
+        type: Json
+        nullable: true
+        description: Pipeline task metadata.
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [updatedAt]}
+      - name: updated_by
+        type: Utf8
+        nullable: true
+        description: User that last updated the entity.
+        expr: {kind: path, path: [updatedBy]}
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: Whether this entity is soft-deleted.
+
+  - name: users
+    description: OpenMetadata users.
+    request:
+      method: GET
+      path: /v1/users
+      query:
+        - name: fields
+          from: literal
+          value: teams,roles
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [paging, after]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: User UUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Username.
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name.
+        expr: {kind: path, path: [displayName]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+      - name: is_admin
+        type: Boolean
+        nullable: true
+        description: Whether the user is an admin.
+        expr: {kind: path, path: [isAdmin]}
+      - name: teams
+        type: Utf8
+        nullable: true
+        description: Comma-joined team names.
+        expr:
+          kind: join_array_path
+          path: [teams]
+          item_path: [name]
+          separator: ","
+      - name: roles
+        type: Utf8
+        nullable: true
+        description: Comma-joined role names.
+        expr:
+          kind: join_array_path
+          path: [roles]
+          item_path: [name]
+          separator: ","
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [updatedAt]}
+      - name: updated_by
+        type: Utf8
+        nullable: true
+        description: User that last updated the entity.
+        expr: {kind: path, path: [updatedBy]}
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: Whether this entity is soft-deleted.
+
+  - name: teams
+    description: OpenMetadata teams.
+    request:
+      method: GET
+      path: /v1/teams
+      query:
+        - name: fields
+          from: literal
+          value: users,parents,owns
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [paging, after]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Team UUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Team name.
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name.
+        expr: {kind: path, path: [displayName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Team description.
+      - name: team_type
+        type: Utf8
+        nullable: true
+        description: OpenMetadata team type.
+        expr: {kind: path, path: [teamType]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Team email address.
+      - name: users
+        type: Utf8
+        nullable: true
+        description: Comma-joined user names.
+        expr:
+          kind: join_array_path
+          path: [users]
+          item_path: [name]
+          separator: ","
+      - name: parents
+        type: Utf8
+        nullable: true
+        description: Comma-joined parent team names.
+        expr:
+          kind: join_array_path
+          path: [parents]
+          item_path: [name]
+          separator: ","
+      - name: owns
+        type: Json
+        nullable: true
+        description: Entities owned by this team, when requested and returned.
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [updatedAt]}
+      - name: updated_by
+        type: Utf8
+        nullable: true
+        description: User that last updated the entity.
+        expr: {kind: path, path: [updatedBy]}
+
+  - name: glossary_terms
+    description: OpenMetadata glossary terms with ownership, tags, domains, and relationships.
+    filters:
+      - name: glossary
+      - name: parent
+    request:
+      method: GET
+      path: /v1/glossaryTerms
+      query:
+        - name: fields
+          from: literal
+          value: owners,tags,domains,relatedTerms,children,reviewers
+        - name: glossary
+          from: filter
+          key: glossary
+        - name: parent
+          from: filter
+          key: parent
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: after
+      response_cursor_path: [paging, after]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Glossary term UUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Term name.
+      - name: fully_qualified_name
+        type: Utf8
+        nullable: true
+        description: Fully qualified term name.
+        expr: {kind: path, path: [fullyQualifiedName]}
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Display name.
+        expr: {kind: path, path: [displayName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Term description.
+      - name: glossary_name
+        type: Utf8
+        nullable: true
+        description: Parent glossary name.
+        expr: {kind: path, path: [glossary, name]}
+      - name: owners
+        type: Utf8
+        nullable: true
+        description: Comma-joined owner names.
+        expr:
+          kind: join_array_path
+          path: [owners]
+          item_path: [name]
+          separator: ","
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: Comma-joined tag FQNs.
+        expr:
+          kind: join_array_path
+          path: [tags]
+          item_path: [tagFQN]
+          separator: ","
+      - name: synonyms
+        type: Json
+        nullable: true
+        description: Glossary term synonyms.
+      - name: children
+        type: Json
+        nullable: true
+        description: Child glossary terms.
+      - name: related_terms
+        type: Json
+        nullable: true
+        description: Related glossary terms.
+        expr: {kind: path, path: [relatedTerms]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Last update timestamp.
+        expr:
+          kind: format_timestamp
+          input: milliseconds
+          expr: {kind: path, path: [updatedAt]}
+      - name: updated_by
+        type: Utf8
+        nullable: true
+        description: User that last updated the entity.
+        expr: {kind: path, path: [updatedBy]}
+      - name: deleted
+        type: Boolean
+        nullable: true
+        description: Whether this entity is soft-deleted.

--- a/sources/community/openmetadata/manifest.yaml
+++ b/sources/community/openmetadata/manifest.yaml
@@ -177,7 +177,7 @@ tables:
       query:
         - name: fields
           from: literal
-          value: owners,tags,domains,charts,usageSummary
+          value: owners,tags,domains,charts
         - name: include
           from: filter
           key: include
@@ -251,11 +251,6 @@ tables:
         type: Json
         nullable: true
         description: Charts referenced by the dashboard.
-      - name: usage_summary
-        type: Json
-        nullable: true
-        description: Usage summary, when available.
-        expr: {kind: path, path: [usageSummary]}
       - name: updated_at
         type: Timestamp
         nullable: true
@@ -495,9 +490,10 @@ tables:
   - name: teams
     description: OpenMetadata teams.
     guide: |
-      Use this table to inspect team hierarchy, users, and ownership. OpenMetadata
-      returns non-deleted teams by default; use `include = 'all'` or
-      `include = 'deleted'` when auditing soft-deleted teams.
+      Use this table to inspect team hierarchy, users, owners, domains, and
+      policy metadata. OpenMetadata returns non-deleted teams by default; use
+      `include = 'all'` or `include = 'deleted'` when auditing soft-deleted
+      teams.
     filters:
       - name: include
     request:
@@ -506,7 +502,7 @@ tables:
       query:
         - name: fields
           from: literal
-          value: users,parents,owns
+          value: users,parents,owners,children,policies,domains
         - name: include
           from: filter
           key: include
@@ -566,10 +562,37 @@ tables:
           path: [parents]
           item_path: [name]
           separator: ","
-      - name: owns
+      - name: owners
+        type: Utf8
+        nullable: true
+        description: Comma-joined owner names.
+        expr:
+          kind: join_array_path
+          path: [owners]
+          item_path: [name]
+          separator: ","
+      - name: children
+        type: Utf8
+        nullable: true
+        description: Comma-joined child team names.
+        expr:
+          kind: join_array_path
+          path: [children]
+          item_path: [name]
+          separator: ","
+      - name: domains
+        type: Utf8
+        nullable: true
+        description: Comma-joined assigned domain names.
+        expr:
+          kind: join_array_path
+          path: [domains]
+          item_path: [name]
+          separator: ","
+      - name: policies
         type: Json
         nullable: true
-        description: Entities owned by this team, when requested and returned.
+        description: Policies associated with this team, when returned.
       - name: updated_at
         type: Timestamp
         nullable: true


### PR DESCRIPTION
### Summary

Adds a community Coral source for OpenMetadata catalog and governance metadata. The source exposes read-only tables, dashboards, pipelines, users, teams, and glossary terms for ownership, stewardship, and data operations workflows.

### Details

- Adds `sources/community/openmetadata/manifest.yaml` with OpenMetadata API-backed catalog tables.
- Adds `sources/community/openmetadata/README.md` with setup, table coverage, example queries, limitations, and validation notes.
- Keeps the JWT/bot token as `kind: secret`.
- Uses OpenMetadata cursor pagination through `paging.after` and `limit` on list endpoints.
- Adds SQL-usable `include` filters for soft-deleted entity audits, plus glossary narrowing filters.

### Validation

- YAML parsing: passed for `sources/community/openmetadata/manifest.yaml`
- Coral manifest schema validation: passed for `sources/community/openmetadata/manifest.yaml`
- `git diff --check`: passed
- `make lint-sources`: passed
- Live API tests: passed against the OpenMetadata sandbox with `coral source add` and `coral source test openmetadata`

Live Coral result:

```text
Added source openmetadata

✓ openmetadata connected successfully

  openmetadata (6 tables)
  ├─ dashboards
  ├─ glossary_terms
  ├─ pipelines
  ├─ tables
  ├─ teams
  └─ users

  Query tests
  2 declared · 2 passed · 0 failed

  ✓ SELECT id, fully_qualified_name FROM openmetadata.tables LIMIT 1
    1 row

  ✓ SELECT id, name FROM openmetadata.users LIMIT 1
    1 row
```

Representative Coral SQL checks also passed for table ownership fields, dashboard owner grouping, glossary terms, `include = 'all'`, and admin users. No JWT, credentials, or customer data are included.
