### PR TITLE
feat(sources/community/notion): add notion community source

### DIFF
--- a/sources/community/notion/README.md
+++ b/sources/community/notion/README.md
@@ -1,0 +1,222 @@
+# Notion (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Notion REST API v1)
+**Tables:** 4
+**Base URL:** `https://api.notion.com/v1`
+
+Query workspace users, pages, databases, and block content from Notion via
+SQL. Designed for knowledge-base analytics, content audits, and cross-source
+joins with the bundled **Linear**, **GitHub**, and **Jira** sources.
+
+## Setup
+
+Two authentication methods are supported. An internal integration token is
+the simplest option for personal or team use.
+
+### Option 1 — Internal integration token (recommended for most users)
+
+1. Go to [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
+   and click **New integration**.
+2. Give it a name, select your workspace, and set the capabilities to
+   **Read content** and **Read user information without email** (or with email
+   if you need the `email` column on `notion.users`).
+3. Copy the **Internal Integration Token** (`secret_xxx`).
+4. **Share your pages and databases with the integration** — go to each
+   Notion page or database, click **Share**, and invite the integration by
+   name. Only shared content will appear in query results.
+
+```sh
+export NOTION_TOKEN="secret_xxx"
+cargo run -p coral-cli -- source add --file sources/community/notion/manifest.yaml
+```
+
+When prompted, choose **Paste internal integration token** and enter the token.
+
+### Option 2 — OAuth (for public integrations)
+
+1. Go to [https://www.notion.so/my-integrations](https://www.notion.so/my-integrations)
+   and create a **Public integration**.
+2. Add `http://127.0.0.1:53682/oauth/callback` as an allowed redirect URI.
+3. Copy the **OAuth Client ID** and **OAuth Client Secret**.
+
+```sh
+export NOTION_CLIENT_ID="<your-client-id>"
+export NOTION_CLIENT_SECRET="<your-client-secret>"
+cargo run -p coral-cli -- source add --file sources/community/notion/manifest.yaml
+```
+
+When prompted, choose **Connect with Notion** to complete the browser OAuth
+flow.
+
+### Verify
+
+```sh
+cargo run -p coral-cli -- sql "SELECT id, name, type FROM notion.users LIMIT 5"
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `notion.users` | Workspace members (people and bots) | — |
+| `notion.databases` | Databases shared with the integration | — |
+| `notion.pages` | Pages shared with the integration | — |
+| `notion.blocks` | Child blocks of a page or block | `block_id` |
+
+All tables are read-only. This source does not create, modify, or delete any
+Notion content.
+
+### `users`
+
+Lists all workspace members visible to the integration. `type` is either
+`person` or `bot`. `email` is only populated for person users when the
+integration has the **Read user information with email** capability enabled.
+
+### `databases`
+
+Lists all databases shared with the integration, discovered via the Notion
+search API. `title` is extracted from the first element of the rich text
+title array in the API response. Use `id` as a reference when building
+downstream queries.
+
+### `pages`
+
+Lists all pages shared with the integration, discovered via the Notion search
+API. Use `id` as `block_id` in `notion.blocks` to retrieve page content.
+`created_by_id` and `last_edited_by_id` join to `notion.users.id`.
+
+### `blocks`
+
+Lists direct child blocks of a page or block. Requires `block_id` — pass a
+page ID from `notion.pages` or any block ID. Use `has_children` to identify
+blocks with nested content; query again with that block's `id` as `block_id`
+to retrieve deeper levels.
+
+Block types include: `paragraph`, `heading_1`, `heading_2`, `heading_3`,
+`to_do`, `code`, `bulleted_list_item`, `numbered_list_item`, `image`,
+`divider`, and others.
+
+## Example queries
+
+List workspace members:
+
+```sql
+SELECT id, name, type, email
+FROM notion.users
+ORDER BY name
+LIMIT 20;
+```
+
+List all databases the integration can see:
+
+```sql
+SELECT id, title, created_time, last_edited_time, url
+FROM notion.databases
+ORDER BY last_edited_time DESC
+LIMIT 20;
+```
+
+Recently edited pages:
+
+```sql
+SELECT id, url, created_time, last_edited_time, archived
+FROM notion.pages
+WHERE archived = false
+ORDER BY last_edited_time DESC
+LIMIT 20;
+```
+
+Page content blocks for a known page:
+
+```sql
+SELECT id, type, has_children, created_time
+FROM notion.blocks
+WHERE block_id = 'your-page-id'
+ORDER BY created_time
+LIMIT 50;
+```
+
+Join pages with the user who last edited them:
+
+```sql
+SELECT p.url, p.last_edited_time, u.name AS last_edited_by
+FROM notion.pages p
+LEFT JOIN notion.users u ON p.last_edited_by_id = u.id
+WHERE p.archived = false
+ORDER BY p.last_edited_time DESC
+LIMIT 20;
+```
+
+Cross-source: Notion users alongside Linear users:
+
+```sql
+SELECT n.name AS notion_name, n.email, l.name AS linear_name
+FROM notion.users n
+LEFT JOIN linear.users l ON LOWER(n.email) = LOWER(l.email)
+WHERE n.type = 'person'
+ORDER BY n.name
+LIMIT 20;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/notion/manifest.yaml
+```
+
+Add the source and validate each table:
+
+```sh
+export NOTION_TOKEN="secret_xxx"
+cargo run -p coral-cli -- source add --file sources/community/notion/manifest.yaml
+
+# users — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, type FROM notion.users LIMIT 5"
+
+# databases — no required filters
+cargo run -p coral-cli -- sql "SELECT id, title, last_edited_time FROM notion.databases LIMIT 5"
+
+# pages — no required filters
+cargo run -p coral-cli -- sql "SELECT id, url, last_edited_time FROM notion.pages LIMIT 5"
+
+# blocks — requires block_id (use a real page ID from notion.pages above)
+cargo run -p coral-cli -- sql "SELECT id, type, has_children FROM notion.blocks WHERE block_id = 'your-page-id' LIMIT 5"
+```
+
+Inspect registered tables and columns:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'notion'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'notion' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- **Integration permissions:** Notion requires pages and databases to be
+  explicitly shared with the integration. Content not shared will not appear
+  in query results.
+- **Internal token vs OAuth:** internal integration tokens are simpler for
+  personal use; OAuth is preferred for multi-user or public integrations.
+  Both use `Authorization: Bearer` and are compatible with this source.
+- **`email` column:** only populated for person users when the integration
+  has the **Read user information with email** capability enabled.
+- **`title` on databases:** extracted from `title[0].plain_text` in the
+  Notion API response. Databases without a title return null.
+- **`blocks` depth:** the blocks table returns only direct children of the
+  given `block_id`. For nested content, query recursively using child block
+  IDs with `has_children = true`.
+- **Notion-Version header:** this source uses API version `2022-06-28`,
+  the current stable version.
+- **Rate limits:** the Notion API enforces rate limits of approximately 3
+  requests per second per integration. Reduce query frequency if you hit
+  limits.
+
+## Out of scope for v1
+
+- Query database rows (`POST /databases/{id}/query`)
+- Page properties beyond timestamps and audit fields
+- Comments (`GET /comments`)
+- Write operations of any kind

--- a/sources/community/notion/manifest.yaml
+++ b/sources/community/notion/manifest.yaml
@@ -1,0 +1,461 @@
+name: notion
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query users, pages, databases, and block children from Notion
+  via the Notion REST API v1.
+base_url: https://api.notion.com/v1
+
+inputs:
+  NOTION_TOKEN:
+    kind: secret
+    hint: |
+      Connect your Notion workspace via "Connect with Notion" below, or
+      paste an internal integration token.
+
+      To use OAuth, create a public Notion integration at
+      https://www.notion.so/my-integrations, set the redirect URI to
+      http://127.0.0.1:53682/oauth/callback, and copy the OAuth Client
+      ID and Secret into NOTION_CLIENT_ID and NOTION_CLIENT_SECRET.
+
+      To use an internal integration token, create an internal integration
+      at https://www.notion.so/my-integrations and paste the secret_xxx
+      token when prompted. Make sure to share the pages and databases you
+      want to query with the integration.
+
+      Note: this source sends Authorization: Bearer and works with both
+      OAuth access tokens and internal integration tokens (both Bearer).
+    credential:
+      methods:
+        - type: oauth
+          label: Connect with Notion
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: disabled
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            endpoints:
+              authorization_url: https://api.notion.com/v1/oauth/authorize
+              token_url: https://api.notion.com/v1/oauth/token
+            client:
+              id:
+                input: NOTION_CLIENT_ID
+              secret:
+                input: NOTION_CLIENT_SECRET
+                transport: basic_auth
+        - type: source_config
+          label: Paste internal integration token
+
+  NOTION_CLIENT_ID:
+    kind: variable
+    hint: |
+      OAuth Client ID from your Notion public integration settings at
+      https://www.notion.so/my-integrations.
+
+  NOTION_CLIENT_SECRET:
+    kind: secret
+    hint: |
+      OAuth Client Secret from your Notion public integration settings.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.NOTION_TOKEN}}
+
+request_headers:
+  - name: Notion-Version
+    from: literal
+    value: "2022-06-28"
+  - name: Content-Type
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name, type FROM notion.users LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────────
+  # users — workspace members
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: users
+    description: >-
+      Members of the Notion workspace visible to the integration.
+      Returns both person and bot users.
+    guide: |
+      No required filters. Use `type` to distinguish person users from
+      bots. `email` is only populated for person users and only when the
+      integration has the user email capability enabled. Join `name` or
+      `email` with `linear.users` or `github.members` for cross-tool
+      team analytics.
+    request:
+      method: GET
+      path: /users
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: cursor_query
+      cursor_param: start_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 100
+        query_param: page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Notion user ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Display name of the user.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: "User type: person or bot."
+        expr:
+          kind: path
+          path:
+            - type
+      - name: email
+        type: Utf8
+        nullable: true
+        description: >-
+          Email address for person users. Only populated when the
+          integration has the user email capability enabled.
+        expr:
+          kind: path
+          path:
+            - person
+            - email
+      - name: avatar_url
+        type: Utf8
+        nullable: true
+        description: URL of the user avatar image.
+        expr:
+          kind: path
+          path:
+            - avatar_url
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # databases — databases the integration has access to
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: databases
+    description: >-
+      Databases the integration has access to in the workspace, discovered
+      via the Notion search API. Only databases explicitly shared with the
+      integration are returned.
+    guide: |
+      No required filters. Uses POST /search with a database filter.
+      Only databases shared with the integration appear. Use `id` as
+      `database_id` when querying pages or building downstream queries.
+      `title` is extracted from the first element of the rich text title
+      array in the API response.
+    request:
+      method: POST
+      path: /search
+      body:
+        - path:
+            - filter
+            - value
+          from: literal
+          value: database
+        - path:
+            - filter
+            - property
+          from: literal
+          value: object
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: cursor_body
+      cursor_body_path:
+        - start_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 100
+        body_path:
+          - page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Notion database ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: >-
+          Database title extracted from the first rich text element of
+          the title array in the API response.
+        expr:
+          kind: path
+          path:
+            - title
+            - "0"
+            - plain_text
+      - name: created_time
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the database was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_time
+      - name: last_edited_time
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the database was last edited.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - last_edited_time
+      - name: url
+        type: Utf8
+        nullable: true
+        description: URL of the database in Notion.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the database is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # pages — pages the integration has access to
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: pages
+    description: >-
+      Pages the integration has access to in the workspace, discovered
+      via the Notion search API. Only pages explicitly shared with the
+      integration are returned.
+    guide: |
+      No required filters. Uses POST /search with a page filter. Only
+      pages shared with the integration appear. Use `id` as `block_id`
+      in `notion.blocks` to retrieve page content. `title` is extracted
+      from the first element of the rich text title array under the
+      page properties Title field.
+    request:
+      method: POST
+      path: /search
+      body:
+        - path:
+            - filter
+            - value
+          from: literal
+          value: page
+        - path:
+            - filter
+            - property
+          from: literal
+          value: object
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: cursor_body
+      cursor_body_path:
+        - start_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 100
+        body_path:
+          - page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Notion page ID. Pass as block_id to notion.blocks to fetch content.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: created_time
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the page was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_time
+      - name: last_edited_time
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the page was last edited.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - last_edited_time
+      - name: url
+        type: Utf8
+        nullable: true
+        description: URL of the page in Notion.
+        expr:
+          kind: path
+          path:
+            - url
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the page is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: created_by_id
+        type: Utf8
+        nullable: true
+        description: ID of the user who created the page.
+        expr:
+          kind: path
+          path:
+            - created_by
+            - id
+      - name: last_edited_by_id
+        type: Utf8
+        nullable: true
+        description: ID of the user who last edited the page.
+        expr:
+          kind: path
+          path:
+            - last_edited_by
+            - id
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # blocks — child blocks of a page or block
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: blocks
+    description: >-
+      Child blocks of a Notion page or block. Each row is one direct
+      child block. Use for extracting structured content from known pages.
+    guide: |
+      Requires `block_id`. Pass a page ID from `notion.pages` or any
+      block ID to retrieve its direct children. Use `has_children` to
+      identify blocks with nested content — those require a separate
+      query with the child block's `id` as `block_id`. `type` indicates
+      the block kind such as paragraph, heading_1, to_do, code, or
+      bulleted_list_item.
+    filters:
+      - name: block_id
+        required: true
+    request:
+      method: GET
+      path: /blocks/{{filter.block_id}}/children
+    response:
+      rows_path:
+        - results
+    pagination:
+      mode: cursor_query
+      cursor_param: start_cursor
+      response_cursor_path:
+        - next_cursor
+      page_size:
+        default: 100
+        max: 100
+        query_param: page_size
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Block ID. Pass as block_id to retrieve nested children.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: type
+        type: Utf8
+        nullable: true
+        description: >-
+          Block type such as paragraph, heading_1, heading_2, heading_3,
+          to_do, code, bulleted_list_item, numbered_list_item, or image.
+        expr:
+          kind: path
+          path:
+            - type
+      - name: created_time
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the block was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_time
+      - name: last_edited_time
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the block was last edited.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - last_edited_time
+      - name: has_children
+        type: Boolean
+        nullable: true
+        description: >-
+          Whether this block has nested child blocks. Query again with
+          this block's id as block_id to retrieve them.
+        expr:
+          kind: path
+          path:
+            - has_children
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the block is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: block_id
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Page or block ID passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: block_id


### PR DESCRIPTION
Fixes #755 

Add a new Notion community source that lets Coral query Notion workspace
users, pages, databases, and block content through SQL — enabling knowledge-base
analytics, content audits, documentation discovery, and cross-source joins with
the bundled GitHub, Jira, and Linear sources.

This change is manifest-only and uses Coral's existing HTTP source-spec model
with support for both internal integration tokens and OAuth 2.0 authentication.
Read-only. No CLI, MCP, config, or runtime changes.

## What changed

Added:

- `sources/community/notion/manifest.yaml`
- `sources/community/notion/README.md`

## Source scope

### Inputs

- `NOTION_TOKEN` — Notion internal integration token (secret), used for bearer-token authentication with internal integrations

- `NOTION_CLIENT_ID` — Notion OAuth client ID (variable), required to initiate OAuth authentication for public integrations

- `NOTION_CLIENT_SECRET` — Notion OAuth client secret (secret), required for OAuth token exchange

### Authentication

Supported methods:

- Internal integration token authentication
- OAuth 2.0 authorization-code flow

OAuth:

- Flow: `authorization_code`
- Redirect URI: `http://127.0.0.1:53682/oauth/callback`
- Authorization URL: `https://api.notion.com/v1/oauth/authorize`
- Token URL: `https://api.notion.com/v1/oauth/token`

Headers:

- `Authorization: Bearer {{token}}`
- `Notion-Version: 2022-06-28`

Permissions:

- Read content
- Read user information without email
- Optional: Read user information with email (required for `notion.users.email`)

## Tables

### `notion.users`

- `GET /users`
- cursor pagination using `start_cursor` and `next_cursor`
- 6 columns including: `id`, `name`, `type`, `email`

Lists workspace members visible to the integration.

`type` values include:

- `person`
- `bot`

`email` is populated only when the integration has email-read capability enabled.

### `notion.databases`

- `POST /search`
- filters results where `object = database`
- cursor pagination using `start_cursor` and `next_cursor`
- 6 columns including:
  `id`, `title`, `created_time`, `last_edited_time`, `archived`, `url`

Lists databases shared with the integration.

### `notion.pages`

- `POST /search`
- filters results where `object = page`
- cursor pagination using `start_cursor` and `next_cursor`
- 8 columns including:
  `id`, `url`, `created_time`, `last_edited_time`, `archived`, `created_by_id`, `last_edited_by_id`

Lists pages shared with the integration.

### `notion.blocks`

- `GET /blocks/{{filter.block_id}}/children`
- required filter: `block_id`
- cursor pagination using `start_cursor` and `next_cursor`
- 6 columns including:
  `id`, `type`, `has_children`, `created_time`

Returns direct child blocks for a page or block.

Supports recursive traversal through `has_children`.

## Implementation notes

- auth: `Authorization: Bearer {{input.NOTION_TOKEN}}` via `HeaderAuth`
- All requests include `Notion-Version: 2022-06-28` as required by the Notion API
- Search-based tables use `rows_path: [results]`
- Pagination uses `next_cursor` and `start_cursor`
- Database titles are extracted from `title[0].plain_text`
- `created_by_id` and `last_edited_by_id` on `notion.pages` join against `notion.users.id`
- Only pages and databases explicitly shared with the integration are queryable
- Blocks table returns only direct child blocks; nested traversal requires recursive queries
- `NOTION_CLIENT_ID` is `kind: variable`
- `NOTION_CLIENT_SECRET` and `NOTION_TOKEN` are `kind: secret`

## Out of scope

Not included in v1:

- Database row querying (`POST /databases/{id}/query`)
- Comments support
- Advanced page property extraction
- Write operations of any kind
- Workspace-wide discovery outside explicitly shared content
- Webhook/event support

## Live-test evidence

<img width="873" height="360" alt="Screenshot 2026-05-26 140840" src="https://github.com/user-attachments/assets/21b445d3-f598-473b-a440-37b69057cf3b" />



`notion.users` — workspace members, person/bot type:

<img width="870" height="178" alt="Screenshot 2026-05-26 140920" src="https://github.com/user-attachments/assets/c56a40e7-08aa-4b7f-a212-0d4b2fd92f0e" />


`notion.databases` — title extracted from rich text array, timestamp parsing:

<img width="1009" height="162" alt="Screenshot 2026-05-26 140937" src="https://github.com/user-attachments/assets/e36f2500-feda-4b1d-8755-6886a576897b" />


`notion.pages` — url, timestamp parsing, archived field:

<img width="1318" height="137" alt="Screenshot 2026-05-26 140956" src="https://github.com/user-attachments/assets/d5e41f6c-d060-4ef8-86c5-f687e5657a48" />


`notion.blocks` — block_id filter, block types, has_children:

<img width="1427" height="220" alt="Screenshot 2026-05-26 141013" src="https://github.com/user-attachments/assets/1b7bafb3-15c3-4488-8d71-02581e2897e9" />


Source connected successfully, 1 test query passed, all four tables return live data. Timestamps parse correctly as ISO 8601. Block types and nested field extraction work correctly.