### PR TITLE
fix(ui/traces): improve span tabs navigation

### DIFF
--- a/ui/src/views/traces/http-span-detail.tsx
+++ b/ui/src/views/traces/http-span-detail.tsx
@@ -112,10 +112,6 @@ function formatRawValue(value: unknown, formatted: string): string {
   return typeof value === 'string' ? value : formatted
 }
 
-function hasBodyValue(value: JsonValue | undefined): boolean {
-  return value !== undefined && value !== null && value !== ''
-}
-
 interface GraphqlBodyPreview {
   bodyKind: BodyKind
   operationName?: string
@@ -390,17 +386,6 @@ function bodyEmptyText(kind: BodyKind, attrs: Record<string, unknown>, truncated
   return `No ${kind} body was recorded for this request.`
 }
 
-function preferredHttpDetailTab(
-  responseBody: JsonValue | undefined,
-  requestBody: JsonValue | undefined,
-  paramsValue: Record<string, string | string[]> | undefined,
-): HttpDetailTab {
-  if (hasBodyValue(responseBody)) return 'response'
-  if (hasBodyValue(requestBody)) return 'request'
-  if (paramsValue) return 'params'
-  return 'response'
-}
-
 function formattedCopyLabel(copyState: CopyState) {
   switch (copyState) {
     case 'formatted':
@@ -443,7 +428,7 @@ export function HttpSpanDetail({
   span: TraceSpan
   traceStart: bigint
 }) {
-  const [activeTab, setActiveTab] = useState<HttpDetailTab>('response')
+  const [activeTab, setActiveTab] = useState<HttpDetailTab>(TAB_IDS[0])
   const [copyState, setCopyState] = useState<CopyState>('idle')
   const attrs = parseJsonObject(span.attributesJson)
   const requestBodyAttrs = bodySpanAttributes(bodySpans, span.spanId, 'request')
@@ -461,7 +446,6 @@ export function HttpSpanDetail({
     responseBodyAttrs?.[RESPONSE_BODY_TRUNCATED_ATTR] ?? attrs[RESPONSE_BODY_TRUNCATED_ATTR],
   )
   const paramsValue = Object.keys(params).length ? params : undefined
-  const preferredTab = preferredHttpDetailTab(responseBody, requestBody, paramsValue)
   const tabLabel = (id: HttpDetailTab) => {
     if (id === 'params') return 'Params'
     if (id === 'request') return `Request body${requestBodyTruncated ? ' (truncated)' : ''}`
@@ -497,7 +481,6 @@ export function HttpSpanDetail({
   const requestOperation = spanRequestOperation(span)
   const requestEndpoint = spanRequestEndpoint(span)
 
-  useEffect(() => setActiveTab(preferredTab), [preferredTab, span.spanId])
   useEffect(() => setCopyState('idle'), [activeTab, span.spanId])
   useEffect(() => {
     if (copyState === 'idle') return

--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -782,11 +782,11 @@ export function TraceDetail({
   const handleSpanArrowShortcut = useCallback(
     (direction: -1 | 1) => (event: KeyboardEvent) => {
       const target = event.target
-      if (target instanceof HTMLElement) {
-        if (target.closest('[data-span-inspector="true"]')) return
-        if (target.isContentEditable || target.matches('input, textarea, select, [role="textbox"]'))
-          return
-      }
+      if (
+        target instanceof HTMLElement &&
+        (target.isContentEditable || target.matches('input, textarea, select, [role="textbox"]'))
+      )
+        return
       if (!expandedHttpSpanId) {
         if (!focusFirstSpan(direction)) return
         event.preventDefault()

--- a/ui/tests/ui/traces.spec.ts
+++ b/ui/tests/ui/traces.spec.ts
@@ -68,6 +68,7 @@ test('lists 10 traces, searches one, opens its details, and opens a span inspect
     'Expand one HTTP span and inspect the captured response body',
   )
   await page.getByRole('button', { name: /^GET github\.pull_requests\b/ }).click()
+  await page.getByRole('tab', { name: 'Response body' }).click()
 
   const spanInspector = page.locator('[data-span-inspector="true"]')
   await expect(spanInspector.getByText('GET github.pull_requests')).toBeVisible()
@@ -107,6 +108,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
     'Open a structured response body and confirm it is pretty printed',
   )
   await page.getByRole('button', { name: /^GET slack\.conversations\b/ }).click()
+  await page.getByRole('tab', { name: 'Response body' }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('"channels": [')).toBeVisible()
@@ -117,6 +119,7 @@ test('renders trace request and response bodies with JSON, GraphQL, and fallback
     'Verify raw text stays readable when parsing fails',
   )
   await page.getByRole('button', { name: /^GET github\.issue_previews\b/ }).click()
+  await page.getByRole('tab', { name: 'Response body' }).click()
 
   await expect(page.getByText('Response body')).toBeVisible()
   await expect(page.getByText('{"oops":')).toBeVisible()


### PR DESCRIPTION
## Summary

- Default to the first tab, but save tab when navigating between tabs
- Arrow left/right to move tabs, down/up spans (previously after you pressed left/right, up/down didn't work)

## Test plan

Arrow up/down to navigate between spans, tab remains the same; can change tab with arrow right/left.