### PR TITLE
perf(ui/traces): Make UI feel snappy

### DIFF
--- a/ui/src/views/TracesPage.tsx
+++ b/ui/src/views/TracesPage.tsx
@@ -198,9 +198,14 @@ export function TracesPage() {
       selectedIndex >= 0 && selectedIndex < filtered.length - 1
         ? filtered[selectedIndex + 1].traceId
         : null
+    const initialSummary =
+      selectedIndex >= 0
+        ? filtered[selectedIndex]
+        : traces.find((trace) => trace.traceId === selectedTraceId)
 
     return (
       <TraceDetail
+        initialSummary={initialSummary}
         newerTraceId={newerTraceId}
         olderTraceId={olderTraceId}
         onClose={() => setSelectedTraceId(null)}

--- a/ui/src/views/traces/trace-detail.tsx
+++ b/ui/src/views/traces/trace-detail.tsx
@@ -73,15 +73,17 @@ function useTraceDetail(traceId: string | null) {
       return
     }
     let stale = false
-    setDetail(null)
     setLoading(true)
     setError(null)
     getTrace(traceId)
       .then((response) => {
-        if (!stale) setDetail(response)
+        if (stale) return
+        setDetail(response)
       })
       .catch((err) => {
-        if (!stale) setError(formatTraceError(err instanceof Error ? err.message : String(err)))
+        if (stale) return
+        setDetail(null)
+        setError(formatTraceError(err instanceof Error ? err.message : String(err)))
       })
       .finally(() => {
         if (!stale) setLoading(false)
@@ -706,6 +708,7 @@ function DetailTabs({
 
 export function TraceDetail({
   extraTabs,
+  initialSummary,
   newerTraceId,
   olderTraceId,
   onClose,
@@ -713,6 +716,7 @@ export function TraceDetail({
   traceId,
 }: {
   extraTabs?: (detail: GetTraceResponse) => ExtraDetailTab[]
+  initialSummary?: GetTraceResponse['summary']
   newerTraceId?: string | null
   olderTraceId?: string | null
   onClose: () => void
@@ -806,7 +810,11 @@ export function TraceDetail({
     () => handleSpanArrowShortcut(1),
     [handleSpanArrowShortcut],
   )
-  const summary = detail?.summary
+  // `detail` here can briefly be the previous trace's response when navigating to a neighbor
+  // (the new fetch is in flight and we don't blank it out). For a frame or two the header/spans
+  // shown are stale. Local fetches resolve in tens of ms, so we accept the flash in exchange for
+  // avoiding a loading spinner on every navigation.
+  const summary = detail?.summary ?? initialSummary
   const httpSpans = useMemo(() => detail?.spans.filter(isHttpSpan) ?? [], [detail?.spans])
   const sources = useMemo(() => sourceNames(detail?.spans ?? []), [detail?.spans])
   const resolvedExtraTabs = useMemo(
@@ -814,7 +822,7 @@ export function TraceDetail({
     [detail, extraTabs],
   )
 
-  if (loading && !detail)
+  if (loading && !detail && !summary)
     return (
       <div className={s.detailEmpty}>
         <Icon name="Loader" className={s.spinner} color="tertiary" />
@@ -827,7 +835,7 @@ export function TraceDetail({
         <EmptyState error={error} />
       </div>
     )
-  if (!detail || !summary) {
+  if (!summary) {
     return (
       <div className={s.detailEmpty}>
         <EmptyState
@@ -921,20 +929,25 @@ export function TraceDetail({
           <div className={s.statGrid}>
             <StatCard label="Duration" value={formatDurationFromNanos(summary.durationNanos)} />
             <StatCard label="Rows" value={formatRows(summary)} />
-            <StatCard label="Table scans" value={sources.length} />
-            <StatCard label="API requests" value={httpSpans.length} />
+            <StatCard label="Table scans" value={detail ? sources.length : '—'} />
+            <StatCard label="API requests" value={detail ? httpSpans.length : '—'} />
           </div>
           <DetailTabs activeTab={activeTab} extraTabs={resolvedExtraTabs} onTab={setActiveTab} />
           <div className={s.tabContent}>
-            {activeTab === 'timeline' && (
-              <TimelineWaterfall
-                expandedHttpSpanId={expandedHttpSpanId}
-                onExpandedHttpSpanIdChange={setExpandedHttpSpanId}
-                onNavigableSpanIdsChange={setNavigableSpanIds}
-                spans={detail.spans}
-                summary={summary}
-              />
-            )}
+            {activeTab === 'timeline' &&
+              (detail ? (
+                <TimelineWaterfall
+                  expandedHttpSpanId={expandedHttpSpanId}
+                  onExpandedHttpSpanIdChange={setExpandedHttpSpanId}
+                  onNavigableSpanIdsChange={setNavigableSpanIds}
+                  spans={detail.spans}
+                  summary={summary}
+                />
+              ) : (
+                <div className={s.detailEmpty}>
+                  <Icon name="Loader" className={s.spinner} color="tertiary" />
+                </div>
+              ))}
             {activeExtraTab?.content}
           </div>
         </div>


### PR DESCRIPTION
## Summary

Switching between traces (and clicking into a trace from the list) used to blank the panel and flash a "Loading trace…" spinner. This is annoying on a local server where the response returns in <100ms.

## Test plan

Before:


https://github.com/user-attachments/assets/ffef9570-f29e-4137-9563-24b0bc9a45a2



After:


https://github.com/user-attachments/assets/d3020c11-d05d-4e3b-8af2-6b35430aee7b

