### PR TITLE
feat(plugins/coral/skills): add dbt-cloud-health agent skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,4 +1,4 @@
-{
+﻿{
   "name": "Coral",
   "interface": {
     "displayName": "Coral"
@@ -6,6 +6,18 @@
   "plugins": [
     {
       "name": "coral",
+      "source": {
+        "source": "local",
+        "path": "./plugins/coral"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Engineering"
+    },
+    {
+      "name": "dbt-cloud-health",
       "source": {
         "source": "local",
         "path": "./plugins/coral"

--- a/plugins/coral/skills/dbt-cloud-health/SKILL.md
+++ b/plugins/coral/skills/dbt-cloud-health/SKILL.md
@@ -1,0 +1,73 @@
+﻿# dbt Cloud Health Skill
+
+Use this skill to query dbt Cloud jobs, runs, and environments through Coral SQL.
+The dbt_cloud source exposes three tables: `dbt_cloud.jobs`, `dbt_cloud.runs`, and `dbt_cloud.environments`.
+
+## Source Setup
+
+Before querying, ensure the dbt_cloud source is added:
+- `DBT_CLOUD_ACCOUNT_ID`: your account ID (e.g. 70506183135511)
+- `DBT_CLOUD_API_TOKEN`: service token with read access
+- `DBT_CLOUD_BASE_URL`: e.g. https://xd792.us1.dbt.com
+
+## Workflow
+
+1. Identify what the user wants: job health, run failures, environment info, or cross-source analysis.
+2. Discover tables with `list_catalog` or `search_catalog` if scope is unclear.
+3. Always query `dbt_cloud.jobs` first to get job_id values before filtering runs.
+4. Use available filters on `dbt_cloud.runs`: job_id, status, project_id, environment_id.
+5. Status codes: 1=Queued, 2=Starting, 3=Running, 10=Success, 20=Error, 30=Cancelled.
+6. For cross-source joins (e.g. with github), complete each source scan first, then join locally.
+7. Keep queries focused: select only needed columns, always add LIMIT unless full output is requested.
+8. Summarize findings clearly: job name, status, timing, and recommended next action.
+
+## Query Rules
+
+- Filter runs by status=20 to find errors; status=10 for successes.
+- Use `job_id` filter to push filtering to the API — do not scan all runs unnecessarily.
+- `duration`, `queued_duration`, `run_duration` are strings (e.g. "00:01:23") — use for display, not arithmetic.
+- `raw` column contains the full JSON object — use it only when a specific field is not in named columns.
+- Virtual columns (job_id_filter, status_filter, etc.) echo applied filters — useful for verification.
+- Required filters must appear in WHERE; inspect `required_filters` and `is_required_filter` if unsure.
+- Secret inputs always return `value = NULL`; use `is_set` to check credentials.
+
+## Common Queries
+
+```sql
+-- Recent failed runs
+SELECT r.id, j.name as job_name, r.status, r.started_at, r.duration
+FROM dbt_cloud.runs r
+JOIN dbt_cloud.jobs j ON j.id = r.job_id
+WHERE r.status = 20
+ORDER BY r.started_at DESC
+LIMIT 20;
+
+-- Job health summary
+SELECT j.name, j.id, j.state, j.created_at
+FROM dbt_cloud.jobs j
+ORDER BY j.updated_at DESC
+LIMIT 50;
+
+-- Environment overview
+SELECT e.name, e.type, e.deployment_type, e.state
+FROM dbt_cloud.environments e
+ORDER BY e.name;
+
+-- Runs for a specific job
+SELECT id, status, started_at, finished_at, duration
+FROM dbt_cloud.runs
+WHERE job_id = <job_id>
+ORDER BY started_at DESC
+LIMIT 10;
+```
+
+## Boundaries
+
+- Do not scan all runs without a filter — use job_id or status to limit API calls.
+- Manifest fallback only by request; summarize table/filter shape instead of dumping raw manifest.
+- Do not treat empty results as failures — the account may have no runs matching the filter.
+
+## Feedback
+
+If the MCP `feedback` tool is available, file feedback when Coral blocks progress or the dbt Cloud API returns unexpected results.
+Include `trying_to_do`, `tried`, and `stuck` with table names, query snippets, and error text.

--- a/plugins/coral/skills/dbt-cloud-health/SKILL.md
+++ b/plugins/coral/skills/dbt-cloud-health/SKILL.md
@@ -1,4 +1,4 @@
-﻿# dbt Cloud Health Skill
++# dbt Cloud Health Skill
 
 Use this skill to query dbt Cloud jobs, runs, and environments through Coral SQL.
 The dbt_cloud source exposes three tables: `dbt_cloud.jobs`, `dbt_cloud.runs`, and `dbt_cloud.environments`.

--- a/plugins/coral/skills/dbt-cloud-health/agents/openai.yaml
+++ b/plugins/coral/skills/dbt-cloud-health/agents/openai.yaml
@@ -1,0 +1,4 @@
+﻿interface:
+  display_name: "dbt Cloud Health"
+  short_description: "Query dbt Cloud jobs, runs, and environments through Coral"
+  default_prompt: "Use $coral to query dbt Cloud job health, run failures, and environment status through Coral MCP."

--- a/plugins/coral/skills/dbt-cloud-health/agents/openai.yaml
+++ b/plugins/coral/skills/dbt-cloud-health/agents/openai.yaml
@@ -1,4 +1,4 @@
-﻿interface:
+interface:
   display_name: "dbt Cloud Health"
   short_description: "Query dbt Cloud jobs, runs, and environments through Coral"
   default_prompt: "Use $coral to query dbt Cloud job health, run failures, and environment status through Coral MCP."


### PR DESCRIPTION
## 🏴‍☠️ dbt Cloud Health — Personal Agent Skill

### What this is
A Coral agent skill that turns your dbt Cloud account into a queryable SQL interface. Ask your agent "which jobs failed last week?" or "what environments do I have?" — no dashboards, no clicking around, just SQL.

### Why I built this
I contributed the `dbt_cloud` community source to Coral (merged PR #627 — jobs, runs, environments tables). This skill is the natural next step: now that the source exists, agents need to know *how to use it well*. This skill teaches them exactly that.

### What's inside

| File | Purpose |
|------|---------|
| `SKILL.md` | Workflow, query rules, status codes, common patterns |
| `agents/openai.yaml` | Agent interface — display name, short description, default prompt |
| `marketplace.json` | Registered the skill in the Coral plugin marketplace |

### Demo — this works right now

```sql
-- What jobs do I have?
SELECT name, id, state, created_at
FROM dbt_cloud.jobs
ORDER BY updated_at DESC;

-- Which runs failed recently?
SELECT r.id, j.name, r.status, r.started_at, r.duration
FROM dbt_cloud.runs r
JOIN dbt_cloud.jobs j ON j.id = r.job_id
WHERE r.status = 20
ORDER BY r.started_at DESC
LIMIT 20;

-- Cross-source: failed runs + GitHub PRs merged around same time
SELECT r.started_at, j.name as job_name, p.title as pr_title
FROM dbt_cloud.runs r
JOIN dbt_cloud.jobs j ON j.id = r.job_id
JOIN github.pulls p
  ON p.merged_at BETWEEN r.started_at - interval '2 hours' AND r.started_at
WHERE r.status = 20;

-- Environment health
SELECT name, type, deployment_type, state
FROM dbt_cloud.environments
ORDER BY name;
```

### End-to-end story
1. ✅ Built the `dbt_cloud` source spec (PR #627 — merged)
2. ✅ Connected source locally — `dbt_cloud connected successfully`
3. ✅ Queried GitHub issues + PRs live via Coral MCP
4. ✅ Built this skill so any agent knows how to query dbt Cloud intelligently

### Tested with
- `coral 0.2.1+fa18a00` on Windows 10
- dbt Cloud Starter trial (xd792.us1.dbt.com)
- GitHub source (362 tables, live data confirmed)
- Queried 1000 open PRs from withcoral/coral in **8.3 seconds** via Coral MCP

### Pirates of the Coral-bean
Track 2: Personal Agent — every dbt developer's first mate. 🧭