### PR TITLE
feat(sources/pypi): add PyPI package stats source

### DIFF
--- a/sources/community/pypi/README.md
+++ b/sources/community/pypi/README.md
@@ -9,7 +9,7 @@ No authentication is required — the endpoint is fully public.
 
 | Table | Description |
 | ----- | ----------- |
-| `pypi.packages` | Retrieve last week and last month download stats for any package |
+| `pypi.packages` | Retrieve last day, last week, and last month download stats for any package |
 
 ## Setup
 

--- a/sources/community/pypi/README.md
+++ b/sources/community/pypi/README.md
@@ -1,0 +1,43 @@
+# PyPI — Coral community source
+
+Query PyPI package download statistics using SQL.
+
+## Overview
+
+This source exposes the public [pypistats.org](https://pypistats.org) API as a read-only SQL table.
+No authentication is required — the endpoint is fully public.
+
+| Table | Description |
+| ----- | ----------- |
+| `pypi.packages` | Retrieve last week and last month download stats for any package |
+
+## Setup
+
+No API token or authentication is needed. Add the source directly:
+
+```bash
+coral source add --file sources/community/pypi/manifest.yaml
+```
+
+## Example query
+
+```sql
+SELECT last_month_downloads, last_week_downloads
+FROM pypi.packages
+WHERE name = 'fastapi'
+LIMIT 1;
+```
+
+## Validation
+
+Lint the manifest:
+
+```bash
+coral source lint sources/community/pypi/manifest.yaml
+```
+
+Run test query:
+
+```bash
+coral sql "SELECT * FROM pypi.packages WHERE name = 'fastapi'"
+```

--- a/sources/community/pypi/manifest.yaml
+++ b/sources/community/pypi/manifest.yaml
@@ -5,6 +5,11 @@ description: PyPI package download statistics from pypistats.org.
 backend: http
 base_url: https://pypistats.org/api
 
+test_queries:
+  - >-
+    SELECT package, last_day_downloads, last_week_downloads, last_month_downloads
+    FROM pypi.packages WHERE name = 'requests' LIMIT 1
+
 tables:
   - name: packages
     description: PyPI package download stats.

--- a/sources/community/pypi/manifest.yaml
+++ b/sources/community/pypi/manifest.yaml
@@ -15,28 +15,23 @@ tables:
       method: GET
       path: /packages/{{filter.name}}/recent
     columns:
-      - name: name
+      - name: package
         type: Utf8
         expr:
-          kind: from_filter
-          key: name
-      - name: version
-        type: Utf8
-        expr:
-          kind: from_filter
-          key: name
-      - name: last_month_downloads
+          kind: path
+          path: ["package"]
+      - name: last_day_downloads
         type: Int64
         expr:
           kind: path
-          path: ["data", "last_month"]
+          path: ["data", "last_day"]
       - name: last_week_downloads
         type: Int64
         expr:
           kind: path
           path: ["data", "last_week"]
-      - name: summary
-        type: Utf8
+      - name: last_month_downloads
+        type: Int64
         expr:
-          kind: from_filter
-          key: name
+          kind: path
+          path: ["data", "last_month"]

--- a/sources/community/pypi/manifest.yaml
+++ b/sources/community/pypi/manifest.yaml
@@ -1,0 +1,42 @@
+dsl_version: 3
+name: pypi
+version: "1.0.0"
+description: PyPI package download statistics from pypistats.org.
+backend: http
+base_url: https://pypistats.org/api
+
+tables:
+  - name: packages
+    description: PyPI package download stats.
+    filters:
+      - name: name
+        required: true
+    request:
+      method: GET
+      path: /packages/{{filter.name}}/recent
+    columns:
+      - name: name
+        type: Utf8
+        expr:
+          kind: from_filter
+          key: name
+      - name: version
+        type: Utf8
+        expr:
+          kind: from_filter
+          key: name
+      - name: last_month_downloads
+        type: Int64
+        expr:
+          kind: path
+          path: ["data", "last_month"]
+      - name: last_week_downloads
+        type: Int64
+        expr:
+          kind: path
+          path: ["data", "last_week"]
+      - name: summary
+        type: Utf8
+        expr:
+          kind: from_filter
+          key: name


### PR DESCRIPTION
## Summary

Add a new `pypi` community source for querying package download statistics from `pypistats.org`.

## What changed

Added:
- `sources/community/pypi/manifest.yaml`
- `sources/community/pypi/README.md`

## Details
Exposes the `pypi.packages` table mapping downloads (`last_month`, `last_week`) and basic details. No authentication required.

## Validation
Linted successfully using `ryl` (`make lint-sources` passes). Tested query execution locally in Coral.