### PR TITLE
feat(sources/npm): add npm package stats source

### DIFF
--- a/sources/community/npm/README.md
+++ b/sources/community/npm/README.md
@@ -1,0 +1,43 @@
+# npm — Coral community source
+
+Query npm package download statistics using SQL.
+
+## Overview
+
+This source exposes the public [api.npmjs.org](https://api.npmjs.org) API as a read-only SQL table.
+No authentication is required — the endpoint is fully public.
+
+| Table | Description |
+| ----- | ----------- |
+| `npm.packages` | Retrieve monthly download stats for any npm package |
+
+## Setup
+
+No API token or authentication is needed. Add the source directly:
+
+```bash
+coral source add --file sources/community/npm/manifest.yaml
+```
+
+## Example query
+
+```sql
+SELECT monthly_downloads
+FROM npm.packages
+WHERE name = 'express'
+LIMIT 1;
+```
+
+## Validation
+
+Lint the manifest:
+
+```bash
+coral source lint sources/community/npm/manifest.yaml
+```
+
+Run test query:
+
+```bash
+coral sql "SELECT * FROM npm.packages WHERE name = 'express'"
+```

--- a/sources/community/npm/README.md
+++ b/sources/community/npm/README.md
@@ -9,7 +9,7 @@ No authentication is required — the endpoint is fully public.
 
 | Table | Description |
 | ----- | ----------- |
-| `npm.packages` | Retrieve monthly download stats for any npm package |
+| `npm.packages` | Retrieve download stats (daily, weekly, monthly) for any npm package |
 
 ## Setup
 
@@ -22,9 +22,9 @@ coral source add --file sources/community/npm/manifest.yaml
 ## Example query
 
 ```sql
-SELECT monthly_downloads
+SELECT package, downloads, start, end
 FROM npm.packages
-WHERE name = 'express'
+WHERE name = 'express' AND period = 'last-week'
 LIMIT 1;
 ```
 

--- a/sources/community/npm/README.md
+++ b/sources/community/npm/README.md
@@ -9,7 +9,7 @@ No authentication is required — the endpoint is fully public.
 
 | Table | Description |
 | ----- | ----------- |
-| `npm.packages` | Retrieve download stats (daily, weekly, monthly) for any npm package |
+| `npm.packages` | Retrieve download stats for any npm package by period (`last-day`, `last-week`, `last-month`) |
 
 ## Setup
 
@@ -39,5 +39,5 @@ coral source lint sources/community/npm/manifest.yaml
 Run test query:
 
 ```bash
-coral sql "SELECT * FROM npm.packages WHERE name = 'express'"
+coral sql "SELECT * FROM npm.packages WHERE name = 'express' AND period = 'last-month'"
 ```

--- a/sources/community/npm/manifest.yaml
+++ b/sources/community/npm/manifest.yaml
@@ -11,32 +11,36 @@ tables:
     filters:
       - name: name
         required: true
+      - name: period
+        required: false
+        default: last-month
     request:
       method: GET
-      path: /downloads/point/last-month/{{filter.name}}
+      path: /downloads/point/{{filter.period}}/{{filter.name}}
     columns:
-      - name: name
+      - name: package
         type: Utf8
         expr:
-          kind: from_filter
-          key: name
-      - name: version
-        type: Utf8
-        expr:
-          kind: from_filter
-          key: name
-      - name: weekly_downloads
+          kind: path
+          path: ["package"]
+      - name: downloads
         type: Int64
         expr:
           kind: path
           path: ["downloads"]
-      - name: monthly_downloads
-        type: Int64
-        expr:
-          kind: path
-          path: ["downloads"]
-      - name: description
+      - name: start
         type: Utf8
         expr:
+          kind: path
+          path: ["start"]
+      - name: end
+        type: Utf8
+        expr:
+          kind: path
+          path: ["end"]
+      - name: period
+        type: Utf8
+        virtual: true
+        expr:
           kind: from_filter
-          key: name
+          key: period

--- a/sources/community/npm/manifest.yaml
+++ b/sources/community/npm/manifest.yaml
@@ -5,6 +5,11 @@ description: npm package download statistics.
 backend: http
 base_url: https://api.npmjs.org
 
+test_queries:
+  - >-
+    SELECT package, downloads, start, end
+    FROM npm.packages WHERE name = 'express' AND period = 'last-month' LIMIT 1
+
 tables:
   - name: packages
     description: npm package download stats.
@@ -12,8 +17,7 @@ tables:
       - name: name
         required: true
       - name: period
-        required: false
-        default: last-month
+        required: true
     request:
       method: GET
       path: /downloads/point/{{filter.period}}/{{filter.name}}

--- a/sources/community/npm/manifest.yaml
+++ b/sources/community/npm/manifest.yaml
@@ -1,0 +1,42 @@
+dsl_version: 3
+name: npm
+version: "1.0.0"
+description: npm package download statistics.
+backend: http
+base_url: https://api.npmjs.org
+
+tables:
+  - name: packages
+    description: npm package download stats.
+    filters:
+      - name: name
+        required: true
+    request:
+      method: GET
+      path: /downloads/point/last-month/{{filter.name}}
+    columns:
+      - name: name
+        type: Utf8
+        expr:
+          kind: from_filter
+          key: name
+      - name: version
+        type: Utf8
+        expr:
+          kind: from_filter
+          key: name
+      - name: weekly_downloads
+        type: Int64
+        expr:
+          kind: path
+          path: ["downloads"]
+      - name: monthly_downloads
+        type: Int64
+        expr:
+          kind: path
+          path: ["downloads"]
+      - name: description
+        type: Utf8
+        expr:
+          kind: from_filter
+          key: name


### PR DESCRIPTION
## Summary

Add a new `npm` community source for querying package download statistics from `api.npmjs.org`.

## What changed

Added:
- `sources/community/npm/manifest.yaml`
- `sources/community/npm/README.md`

## Details
Exposes the `npm.packages` table mapping monthly/weekly downloads. No authentication required.

## Validation
Linted successfully using `ryl` (`make lint-sources` passes). Tested query execution locally in Coral.