### PR TITLE
feat(community): add OpenSSF Scorecard source — security health checks for any GitHub repo

### DIFF
--- a/sources/community/scorecard/README.md
+++ b/sources/community/scorecard/README.md
@@ -42,7 +42,7 @@ ORDER BY CASE WHEN score = -1 THEN 999 ELSE score END ASC
 ```
 
 ```sql
--- Only the failing checks (score < 5, excluding N/A)
+-- Low-scoring checks Scorecard flags for review (score < 5, excluding N/A)
 SELECT check_name, score, reason
 FROM scorecard.checks
 WHERE owner = 'django'
@@ -52,11 +52,11 @@ ORDER BY score ASC
 ```
 
 ```sql
--- Quick health summary
+-- Score distribution summary
 SELECT
   COUNT(*) AS total_checks,
-  SUM(CASE WHEN score >= 8 THEN 1 ELSE 0 END) AS passing,
-  SUM(CASE WHEN score >= 0 AND score < 5 THEN 1 ELSE 0 END) AS critical
+  SUM(CASE WHEN score >= 8 THEN 1 ELSE 0 END) AS high_scoring,
+  SUM(CASE WHEN score >= 0 AND score < 5 THEN 1 ELSE 0 END) AS low_scoring
 FROM scorecard.checks
 WHERE owner = 'expressjs'
   AND repo  = 'express'
@@ -82,13 +82,15 @@ WHERE owner = 'expressjs'
 
 ## Score reference
 
+Scores are a heuristic, opinionated signal from the OpenSSF Scorecard tool. They reflect the tool's weighting of each check, not an absolute measure of security. See the [Scorecard scoring docs](https://github.com/ossf/scorecard/blob/main/README.md#aggregate-score) for methodology.
+
 | Score | Meaning |
 |---|---|
-| 10 | Excellent — check fully satisfied |
-| 8–9 | Good — minor issues |
-| 5–7 | Fair — partial compliance |
-| 1–4 | Poor — significant gap |
-| 0 | Critical — check completely unsatisfied |
+| 10 | Highest — check fully satisfied |
+| 8–9 | High |
+| 5–7 | Mid-range |
+| 1–4 | Low — area Scorecard flags for review |
+| 0 | Lowest — check not satisfied |
 | -1 | N/A — check not applicable for this repo |
 
 ## Rate limits

--- a/sources/community/scorecard/README.md
+++ b/sources/community/scorecard/README.md
@@ -1,11 +1,11 @@
 # OpenSSF Scorecard Source for Coral
 
-Adds `scorecard.checks` as a queryable SQL table, powered by the [OpenSSF Scorecard API](https://api.securityscorecards.dev). Returns up to 18 security health checks for any public GitHub repository — no authentication required.
+Adds `scorecard.checks` and `scorecard.project` as queryable SQL tables, powered by the [OpenSSF Scorecard API](https://api.securityscorecards.dev). Returns security health checks for public GitHub repositories tracked by OpenSSF Scorecard — no authentication required.
 
 ## Install
 
 ```bash
-coral source add --file sources/scorecard/manifest.yaml
+coral source add --file sources/community/scorecard/manifest.yaml
 ```
 
 ## What is OpenSSF Scorecard?
@@ -21,11 +21,14 @@ The [Open Source Security Foundation (OpenSSF) Scorecard](https://github.com/oss
 
 Each check produces a score from **0** (critical gap) to **10** (excellent). Score **-1** means the check is not applicable (e.g. no releases to sign).
 
+> **Note:** The Scorecard API serves precomputed results for repositories already indexed by OpenSSF. Repositories not yet tracked return a 404. See the [Scorecard REST API docs](https://github.com/ossf/scorecard#scorecard-rest-api) for details on coverage.
+
 ## Tables
 
 | Table | Required filters | Purpose |
 |---|---|---|
-| `scorecard.checks` | `owner`, `repo` | Security checks for a GitHub repo, each scored 0–10 |
+| `scorecard.checks` | `owner`, `repo` | Per-check scores (0–10) with plain-English reasons |
+| `scorecard.project` | `owner`, `repo` | Aggregate score, scored date, commit SHA, tool version |
 
 ## Usage
 
@@ -69,6 +72,14 @@ WHERE owner = 'django'
 ORDER BY score ASC
 ```
 
+```sql
+-- Check data freshness and which commit was scored
+SELECT date, aggregate_score, repo_commit, scorecard_version
+FROM scorecard.project
+WHERE owner = 'expressjs'
+  AND repo  = 'express'
+```
+
 ## Score reference
 
 | Score | Meaning |
@@ -82,7 +93,7 @@ ORDER BY score ASC
 
 ## Rate limits
 
-The OpenSSF Scorecard API is free and publicly accessible. No API key is required. Scores are computed weekly — data is cached and requests are lightweight.
+The OpenSSF Scorecard API is free and publicly accessible. No API key is required. Scores are precomputed weekly — data is cached and requests are lightweight.
 
 ## DSL features used
 
@@ -90,38 +101,31 @@ The OpenSSF Scorecard API is free and publicly accessible. No API key is require
 |---|---|
 | `{{filter.owner}}` path template | `owner` filter injected into URL path: `/projects/github.com/{owner}/{repo}` |
 | `{{filter.repo}}` path template | `repo` filter injected into URL path |
-| `rows_path: [checks]` | Response is an object; `checks` is the array of security check rows |
+| `rows_path: [checks]` | `checks` table — navigates to the nested `checks` array |
+| `rows_path: []` | `project` table — root object treated as single row |
 | Nested path (`documentation.url`) | `documentation_url` column — nested field access |
-| `from_filter` | `owner` and `repo` echo columns |
-| `pagination: mode: none` | Single API call returns all checks (no pagination needed) |
+| Nested path (`repo.commit`, `scorecard.version`) | `project` table metadata columns |
+| `from_filter` | `owner` and `repo` echo columns in both tables |
+| `pagination: mode: none` | Single API call returns all data (no pagination needed) |
 
 ## Limitations
 
-- Only covers **public** GitHub repositories tracked by OpenSSF Scorecard.
+- Only covers public GitHub repositories **already indexed by OpenSSF Scorecard**. Repositories not in the index return a 404 rather than an empty result.
 - Scores are updated **weekly** — they reflect the state of the repo at last scan time.
-- A 404 error means the repo has not been scored (usually repos with no CI/CD history).
 - `Branch-Protection` may return -1 due to GitHub token limitations in the Scorecard service.
+- The set of checks varies by repository — not all 18 checks apply to every project.
 
 ## Validation
 
 ```
-YAML parse:                     passed for sources/scorecard/manifest.yaml
-Coral manifest schema:          passed (dsl_version: 3, backend: http, 1 table)
+YAML parse:                     passed for sources/community/scorecard/manifest.yaml
+Coral manifest schema:          passed (dsl_version: 3, backend: http, 2 tables)
 test_queries:                   passed — SELECT check_name, score, reason FROM scorecard.checks WHERE owner = 'expressjs' AND repo = 'express' LIMIT 5
-Live API test (no key):         passed — 18 checks, <1s response time
+Live API test (checks):         passed — 18 checks, <1s response time
+Live API test (project):        passed — 1 row: date, aggregate_score, repo_commit, scorecard_version
 Path template ({{filter.*}}):   passed — /projects/github.com/expressjs/express resolved correctly
 rows_path: [checks]:            passed — nested array correctly iterated as rows
-Integration test (RepoSense):   passed — reposense --repo expressjs/express scorecard returns 18 rows
-```
-
-## Used by RepoSense
-
-The `scorecard` command uses this source to surface security posture for any repo:
-
-```bash
-reposense --repo expressjs/express scorecard    # → 18 security checks, color-coded
-reposense --repo django/django scorecard        # → Django's OpenSSF posture
-reposense --repo rust-lang/rust scorecard       # → Rust project security health
+rows_path: []:                  passed — root object returned as single project row
 ```
 
 ## Why this source is unique
@@ -132,4 +136,4 @@ Most security tools focus on **vulnerabilities in dependencies** (CVEs, Dependab
 - Are CI tokens least-privilege? (`Token-Permissions`)
 - Are dependencies reproducible? (`Pinned-Dependencies`)
 
-This is the only coral source that queries the OpenSSF Scorecard API, and it requires no configuration — just `owner` and `repo`, which RepoSense already knows.
+The `project` table adds a data freshness dimension — users can see exactly when the score was produced and which commit was evaluated, which is important when interpreting precomputed weekly results.

--- a/sources/community/scorecard/README.md
+++ b/sources/community/scorecard/README.md
@@ -21,7 +21,7 @@ The [Open Source Security Foundation (OpenSSF) Scorecard](https://github.com/oss
 
 Each check produces a score from **0** (lowest) to **10** (highest). Score **-1** means the check is not applicable (e.g. no releases to sign). Scores are a heuristic signal — checks also carry separate risk levels in the upstream Scorecard project.
 
-> **Note:** The Scorecard API serves precomputed results for repositories already indexed by OpenSSF. Repositories not yet tracked return a 404. See the [Scorecard REST API docs](https://github.com/ossf/scorecard#scorecard-rest-api) for details on coverage.
+> **Note:** The Scorecard API serves precomputed results for repositories already indexed by OpenSSF. Querying an unindexed repository returns zero rows (the underlying API 404 is handled gracefully). See the [Scorecard REST API docs](https://github.com/ossf/scorecard#scorecard-rest-api) for details on coverage.
 
 ## Tables
 
@@ -114,7 +114,7 @@ The OpenSSF Scorecard API is free and publicly accessible. No API key is require
 
 ## Limitations
 
-- Only covers public GitHub repositories **already indexed by OpenSSF Scorecard**. Repositories not in the index return a 404 rather than an empty result.
+- Only covers public GitHub repositories **already indexed by OpenSSF Scorecard**. Querying an unindexed repository returns zero rows — the underlying API 404 is converted to an empty result by `allow_404_empty: true`.
 - Scores are updated **weekly** — they reflect the state of the repo at last scan time.
 - `Branch-Protection` may return -1 due to GitHub token limitations in the Scorecard service.
 - The set of checks varies by repository — not all 18 checks apply to every project.

--- a/sources/community/scorecard/README.md
+++ b/sources/community/scorecard/README.md
@@ -1,0 +1,135 @@
+# OpenSSF Scorecard Source for Coral
+
+Adds `scorecard.checks` as a queryable SQL table, powered by the [OpenSSF Scorecard API](https://api.securityscorecards.dev). Returns up to 18 security health checks for any public GitHub repository — no authentication required.
+
+## Install
+
+```bash
+coral source add --file sources/scorecard/manifest.yaml
+```
+
+## What is OpenSSF Scorecard?
+
+The [Open Source Security Foundation (OpenSSF) Scorecard](https://github.com/ossf/scorecard) automatically evaluates open-source projects against security best practices. It checks things like:
+
+- Are PRs reviewed before merging? (`Code-Review`)
+- Are GitHub Actions tokens scoped to least-privilege? (`Token-Permissions`)
+- Are dependencies pinned by hash? (`Pinned-Dependencies`)
+- Is there a security policy? (`Security-Policy`)
+- Is SAST (static analysis) running on all commits? (`SAST`)
+- Are releases signed? (`Signed-Releases`)
+
+Each check produces a score from **0** (critical gap) to **10** (excellent). Score **-1** means the check is not applicable (e.g. no releases to sign).
+
+## Tables
+
+| Table | Required filters | Purpose |
+|---|---|---|
+| `scorecard.checks` | `owner`, `repo` | Security checks for a GitHub repo, each scored 0–10 |
+
+## Usage
+
+```sql
+-- All security checks for a repo, lowest scores first
+SELECT check_name, score, reason
+FROM scorecard.checks
+WHERE owner = 'expressjs'
+  AND repo  = 'express'
+ORDER BY CASE WHEN score = -1 THEN 999 ELSE score END ASC
+```
+
+```sql
+-- Only the failing checks (score < 5)
+SELECT check_name, score, reason
+FROM scorecard.checks
+WHERE owner = 'django'
+  AND repo  = 'django'
+  AND score < 5
+ORDER BY score ASC
+```
+
+```sql
+-- Quick health summary
+SELECT
+  COUNT(*) AS total_checks,
+  SUM(CASE WHEN score >= 8 THEN 1 ELSE 0 END) AS passing,
+  SUM(CASE WHEN score >= 0 AND score < 5 THEN 1 ELSE 0 END) AS critical
+FROM scorecard.checks
+WHERE owner = 'expressjs'
+  AND repo  = 'express'
+```
+
+```sql
+-- Include documentation links for remediation
+SELECT check_name, score, reason, documentation_url
+FROM scorecard.checks
+WHERE owner = 'django'
+  AND repo  = 'django'
+  AND score < 8
+ORDER BY score ASC
+```
+
+## Score reference
+
+| Score | Meaning |
+|---|---|
+| 10 | Excellent — check fully satisfied |
+| 8–9 | Good — minor issues |
+| 5–7 | Fair — partial compliance |
+| 1–4 | Poor — significant gap |
+| 0 | Critical — check completely unsatisfied |
+| -1 | N/A — check not applicable for this repo |
+
+## Rate limits
+
+The OpenSSF Scorecard API is free and publicly accessible. No API key is required. Scores are computed weekly — data is cached and requests are lightweight.
+
+## DSL features used
+
+| Pattern | Where used |
+|---|---|
+| `{{filter.owner}}` path template | `owner` filter injected into URL path: `/projects/github.com/{owner}/{repo}` |
+| `{{filter.repo}}` path template | `repo` filter injected into URL path |
+| `rows_path: [checks]` | Response is an object; `checks` is the array of security check rows |
+| Nested path (`documentation.url`) | `documentation_url` column — nested field access |
+| `from_filter` | `owner` and `repo` echo columns |
+| `pagination: mode: none` | Single API call returns all checks (no pagination needed) |
+
+## Limitations
+
+- Only covers **public** GitHub repositories tracked by OpenSSF Scorecard.
+- Scores are updated **weekly** — they reflect the state of the repo at last scan time.
+- A 404 error means the repo has not been scored (usually repos with no CI/CD history).
+- `Branch-Protection` may return -1 due to GitHub token limitations in the Scorecard service.
+
+## Validation
+
+```
+YAML parse:                     passed for sources/scorecard/manifest.yaml
+Coral manifest schema:          passed (dsl_version: 3, backend: http, 1 table)
+test_queries:                   passed — SELECT check_name, score, reason FROM scorecard.checks WHERE owner = 'expressjs' AND repo = 'express' LIMIT 5
+Live API test (no key):         passed — 18 checks, <1s response time
+Path template ({{filter.*}}):   passed — /projects/github.com/expressjs/express resolved correctly
+rows_path: [checks]:            passed — nested array correctly iterated as rows
+Integration test (RepoSense):   passed — reposense --repo expressjs/express scorecard returns 18 rows
+```
+
+## Used by RepoSense
+
+The `scorecard` command uses this source to surface security posture for any repo:
+
+```bash
+reposense --repo expressjs/express scorecard    # → 18 security checks, color-coded
+reposense --repo django/django scorecard        # → Django's OpenSSF posture
+reposense --repo rust-lang/rust scorecard       # → Rust project security health
+```
+
+## Why this source is unique
+
+Most security tools focus on **vulnerabilities in dependencies** (CVEs, Dependabot). This source surfaces **security practices in the repo itself**:
+
+- Are PRs reviewed? (`Code-Review`)
+- Are CI tokens least-privilege? (`Token-Permissions`)
+- Are dependencies reproducible? (`Pinned-Dependencies`)
+
+This is the only coral source that queries the OpenSSF Scorecard API, and it requires no configuration — just `owner` and `repo`, which RepoSense already knows.

--- a/sources/community/scorecard/README.md
+++ b/sources/community/scorecard/README.md
@@ -39,12 +39,12 @@ ORDER BY CASE WHEN score = -1 THEN 999 ELSE score END ASC
 ```
 
 ```sql
--- Only the failing checks (score < 5)
+-- Only the failing checks (score < 5, excluding N/A)
 SELECT check_name, score, reason
 FROM scorecard.checks
 WHERE owner = 'django'
   AND repo  = 'django'
-  AND score < 5
+  AND score >= 0 AND score < 5
 ORDER BY score ASC
 ```
 

--- a/sources/community/scorecard/README.md
+++ b/sources/community/scorecard/README.md
@@ -19,7 +19,7 @@ The [Open Source Security Foundation (OpenSSF) Scorecard](https://github.com/oss
 - Is SAST (static analysis) running on all commits? (`SAST`)
 - Are releases signed? (`Signed-Releases`)
 
-Each check produces a score from **0** (critical gap) to **10** (excellent). Score **-1** means the check is not applicable (e.g. no releases to sign).
+Each check produces a score from **0** (lowest) to **10** (highest). Score **-1** means the check is not applicable (e.g. no releases to sign). Scores are a heuristic signal — checks also carry separate risk levels in the upstream Scorecard project.
 
 > **Note:** The Scorecard API serves precomputed results for repositories already indexed by OpenSSF. Repositories not yet tracked return a 404. See the [Scorecard REST API docs](https://github.com/ossf/scorecard#scorecard-rest-api) for details on coverage.
 
@@ -27,8 +27,10 @@ Each check produces a score from **0** (critical gap) to **10** (excellent). Sco
 
 | Table | Required filters | Purpose |
 |---|---|---|
-| `scorecard.checks` | `owner`, `repo` | Per-check scores (0–10) with plain-English reasons |
-| `scorecard.project` | `owner`, `repo` | Aggregate score, scored date, commit SHA, tool version |
+| `scorecard.checks` | `owner`, `repo` | Per-check scores (0–10), reasons, actionable details, and doc links |
+| `scorecard.project` | `owner`, `repo` | Aggregate score, scored timestamp, commit SHA, tool version |
+
+Both tables return empty rows (not an error) when the repository is not yet indexed by OpenSSF Scorecard.
 
 ## Usage
 

--- a/sources/community/scorecard/manifest.yaml
+++ b/sources/community/scorecard/manifest.yaml
@@ -3,37 +3,42 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query OpenSSF Scorecard security health checks for any public GitHub repository.
-  Returns up to 18 security dimensions (code review, branch protection, signed
-  releases, pinned dependencies, SAST, fuzzing, and more) with a score 0–10
-  and a plain-English reason for each. No authentication required. Scores are
-  updated weekly by the OpenSSF Scorecard project.
+  Query OpenSSF Scorecard security health checks for public GitHub repositories
+  tracked by OpenSSF Scorecard. Returns up to 18 security dimensions (code
+  review, branch protection, signed releases, pinned dependencies, SAST,
+  fuzzing, and more) with a score 0–10 and a plain-English reason for each.
+  No authentication required. Scores are precomputed and updated weekly.
+  Repositories not yet indexed by OpenSSF return a 404 (no score available).
 base_url: https://api.securityscorecards.dev
 
 test_queries:
   - SELECT check_name, score, reason FROM scorecard.checks WHERE owner = 'expressjs' AND repo = 'express' LIMIT 5
+  - SELECT date, aggregate_score, repo_commit, scorecard_version FROM scorecard.project WHERE owner = 'expressjs' AND repo = 'express'
 
 tables:
   - name: checks
     description: >-
-      OpenSSF Scorecard security checks for a GitHub repository. Each row is one
-      security dimension (e.g. Code-Review, Branch-Protection, Signed-Releases)
-      with a score from 0 (worst) to 10 (best) and a plain-English reason.
-      Score -1 means the check is not applicable for this repo (e.g. no releases
-      to sign). Works for any public GitHub repository tracked by OpenSSF.
+      OpenSSF Scorecard security checks for a GitHub repository tracked by
+      OpenSSF. Each row is one security dimension (e.g. Code-Review,
+      Branch-Protection, Signed-Releases) with a score from 0 (worst) to 10
+      (best) and a plain-English reason. Score -1 means the check is not
+      applicable for this repo (e.g. no releases to sign). Only repositories
+      indexed by OpenSSF Scorecard return results; others return a 404.
     guide: >-
       Each row is one OpenSSF Scorecard security check for the given GitHub repository.
       Always include BOTH filters:
         WHERE owner = '<github-owner>' AND repo = '<github-repo>'
 
-      Known checks: Binary-Artifacts, Branch-Protection, CII-Best-Practices,
-      Code-Review, Dangerous-Workflow, Fuzzing, License, Maintained,
-      Packaging, Pinned-Dependencies, SAST, Security-Policy,
-      Signed-Releases, Token-Permissions, Vulnerabilities.
+      Known checks (non-exhaustive — set varies by repository):
+      Binary-Artifacts, Branch-Protection, CII-Best-Practices, CI-Tests,
+      Code-Review, Contributors, Dangerous-Workflow, Dependency-Update-Tool,
+      Fuzzing, License, Maintained, Packaging, Pinned-Dependencies, SAST,
+      Security-Policy, Signed-Releases, Token-Permissions, Vulnerabilities.
 
       Scores: 10 = excellent, 0 = critical gap, -1 = not applicable.
       Sort by score ASC to surface which checks need the most improvement.
-      Filter WHERE score < 5 to find critical security gaps.
+      Filter WHERE score >= 0 AND score < 5 to find critical security gaps
+      (exclude -1 N/A values).
     fetch_limit_default: 30
     filters:
       - name: owner
@@ -89,6 +94,100 @@ tables:
           path:
             - documentation
             - url
+
+      - name: owner
+        type: Utf8
+        nullable: true
+        description: Echoes the owner filter used to produce this row.
+        expr:
+          kind: from_filter
+          key: owner
+
+      - name: repo
+        type: Utf8
+        nullable: true
+        description: Echoes the repo filter used to produce this row.
+        expr:
+          kind: from_filter
+          key: repo
+
+  - name: project
+    description: >-
+      Top-level Scorecard result metadata for a GitHub repository. Returns one
+      row with the aggregate score, the date the score was produced, the commit
+      SHA that was evaluated, and the Scorecard tool version. Use this table
+      to check data freshness and to identify which commit was scored.
+      Only repositories indexed by OpenSSF Scorecard return results.
+    guide: >-
+      Returns one row per repository with aggregate metadata.
+      Always include BOTH filters:
+        WHERE owner = '<github-owner>' AND repo = '<github-repo>'
+
+      Use scorecard.project to check when the score was last computed and
+      which commit was evaluated. Join with scorecard.checks for per-check detail.
+    fetch_limit_default: 1
+    filters:
+      - name: owner
+        required: true
+      - name: repo
+        required: true
+    request:
+      method: GET
+      path: /projects/github.com/{{filter.owner}}/{{filter.repo}}
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: date
+        type: Utf8
+        nullable: true
+        description: ISO 8601 date when this Scorecard result was produced (weekly cadence).
+        expr:
+          kind: path
+          path:
+            - date
+
+      - name: aggregate_score
+        type: Float64
+        nullable: true
+        description: >-
+          Overall Scorecard score for the repository, from 0 (worst) to 10
+          (best). Weighted average across all applicable checks.
+        expr:
+          kind: path
+          path:
+            - score
+
+      - name: repo_commit
+        type: Utf8
+        nullable: true
+        description: Git commit SHA of the repository state that was evaluated.
+        expr:
+          kind: path
+          path:
+            - repo
+            - commit
+
+      - name: scorecard_version
+        type: Utf8
+        nullable: true
+        description: Version of the OpenSSF Scorecard tool that produced this result.
+        expr:
+          kind: path
+          path:
+            - scorecard
+            - version
+
+      - name: scorecard_commit
+        type: Utf8
+        nullable: true
+        description: Commit SHA of the Scorecard tool itself used for this evaluation.
+        expr:
+          kind: path
+          path:
+            - scorecard
+            - commit
 
       - name: owner
         type: Utf8

--- a/sources/community/scorecard/manifest.yaml
+++ b/sources/community/scorecard/manifest.yaml
@@ -52,6 +52,7 @@ tables:
     response:
       rows_path:
         - checks
+      allow_404_empty: true
     pagination:
       mode: none
     columns:
@@ -70,8 +71,9 @@ tables:
         type: Int64
         nullable: true
         description: >-
-          Score from 0 (critical gap) to 10 (excellent). -1 means the check
+          Score from 0 (lowest) to 10 (highest). -1 means the check
           is not applicable for this repository (e.g. no releases to sign).
+          Scores are a heuristic signal; checks also carry separate risk levels.
         expr:
           kind: path
           path:
@@ -85,6 +87,27 @@ tables:
           kind: path
           path:
             - reason
+
+      - name: details
+        type: Json
+        nullable: true
+        description: >-
+          Actionable evidence for the check result — workflow files, warnings,
+          and specific findings. Carries the remediation detail behind the reason.
+        expr:
+          kind: path
+          path:
+            - details
+
+      - name: documentation_short
+        type: Utf8
+        nullable: true
+        description: One-line summary of what this check evaluates.
+        expr:
+          kind: path
+          path:
+            - documentation
+            - short
 
       - name: documentation_url
         type: Utf8
@@ -137,17 +160,21 @@ tables:
       path: /projects/github.com/{{filter.owner}}/{{filter.repo}}
     response:
       rows_path: []
+      allow_404_empty: true
     pagination:
       mode: none
     columns:
       - name: date
-        type: Utf8
+        type: Timestamp
         nullable: true
-        description: ISO 8601 date when this Scorecard result was produced (weekly cadence).
+        description: >-
+          Timestamp when this Scorecard result was produced (ISO 8601, weekly cadence).
+          Use to assess data freshness before acting on scores.
         expr:
-          kind: path
+          kind: format_timestamp
           path:
             - date
+          input: iso8601
 
       - name: aggregate_score
         type: Float64

--- a/sources/community/scorecard/manifest.yaml
+++ b/sources/community/scorecard/manifest.yaml
@@ -165,15 +165,18 @@ tables:
       mode: none
     columns:
       - name: date
-        type: Utf8
+        type: Timestamp
         nullable: true
         description: >-
           ISO 8601 timestamp when this Scorecard result was produced (weekly cadence).
           Use to assess data freshness before acting on scores.
         expr:
-          kind: path
-          path:
-            - date
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - date
 
       - name: aggregate_score
         type: Float64

--- a/sources/community/scorecard/manifest.yaml
+++ b/sources/community/scorecard/manifest.yaml
@@ -1,0 +1,107 @@
+name: scorecard
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query OpenSSF Scorecard security health checks for any public GitHub repository.
+  Returns up to 18 security dimensions (code review, branch protection, signed
+  releases, pinned dependencies, SAST, fuzzing, and more) with a score 0–10
+  and a plain-English reason for each. No authentication required. Scores are
+  updated weekly by the OpenSSF Scorecard project.
+base_url: https://api.securityscorecards.dev
+
+test_queries:
+  - SELECT check_name, score, reason FROM scorecard.checks WHERE owner = 'expressjs' AND repo = 'express' LIMIT 5
+
+tables:
+  - name: checks
+    description: >-
+      OpenSSF Scorecard security checks for a GitHub repository. Each row is one
+      security dimension (e.g. Code-Review, Branch-Protection, Signed-Releases)
+      with a score from 0 (worst) to 10 (best) and a plain-English reason.
+      Score -1 means the check is not applicable for this repo (e.g. no releases
+      to sign). Works for any public GitHub repository tracked by OpenSSF.
+    guide: >-
+      Each row is one OpenSSF Scorecard security check for the given GitHub repository.
+      Always include BOTH filters:
+        WHERE owner = '<github-owner>' AND repo = '<github-repo>'
+
+      Known checks: Binary-Artifacts, Branch-Protection, CII-Best-Practices,
+      Code-Review, Dangerous-Workflow, Fuzzing, License, Maintained,
+      Packaging, Pinned-Dependencies, SAST, Security-Policy,
+      Signed-Releases, Token-Permissions, Vulnerabilities.
+
+      Scores: 10 = excellent, 0 = critical gap, -1 = not applicable.
+      Sort by score ASC to surface which checks need the most improvement.
+      Filter WHERE score < 5 to find critical security gaps.
+    fetch_limit_default: 30
+    filters:
+      - name: owner
+        required: true
+      - name: repo
+        required: true
+    request:
+      method: GET
+      path: /projects/github.com/{{filter.owner}}/{{filter.repo}}
+    response:
+      rows_path:
+        - checks
+    pagination:
+      mode: none
+    columns:
+      - name: check_name
+        type: Utf8
+        nullable: false
+        description: >-
+          Name of the security check (e.g. 'Code-Review', 'Branch-Protection',
+          'Signed-Releases', 'Pinned-Dependencies').
+        expr:
+          kind: path
+          path:
+            - name
+
+      - name: score
+        type: Int64
+        nullable: true
+        description: >-
+          Score from 0 (critical gap) to 10 (excellent). -1 means the check
+          is not applicable for this repository (e.g. no releases to sign).
+        expr:
+          kind: path
+          path:
+            - score
+
+      - name: reason
+        type: Utf8
+        nullable: true
+        description: Plain-English explanation of why the check received this score.
+        expr:
+          kind: path
+          path:
+            - reason
+
+      - name: documentation_url
+        type: Utf8
+        nullable: true
+        description: Link to the OpenSSF Scorecard documentation for this check.
+        expr:
+          kind: path
+          path:
+            - documentation
+            - url
+
+      - name: owner
+        type: Utf8
+        nullable: true
+        description: Echoes the owner filter used to produce this row.
+        expr:
+          kind: from_filter
+          key: owner
+
+      - name: repo
+        type: Utf8
+        nullable: true
+        description: Echoes the repo filter used to produce this row.
+        expr:
+          kind: from_filter
+          key: repo

--- a/sources/community/scorecard/manifest.yaml
+++ b/sources/community/scorecard/manifest.yaml
@@ -165,16 +165,15 @@ tables:
       mode: none
     columns:
       - name: date
-        type: Timestamp
+        type: Utf8
         nullable: true
         description: >-
-          Timestamp when this Scorecard result was produced (ISO 8601, weekly cadence).
+          ISO 8601 timestamp when this Scorecard result was produced (weekly cadence).
           Use to assess data freshness before acting on scores.
         expr:
-          kind: format_timestamp
+          kind: path
           path:
             - date
-          input: iso8601
 
       - name: aggregate_score
         type: Float64

--- a/sources/community/scorecard/manifest.yaml
+++ b/sources/community/scorecard/manifest.yaml
@@ -35,10 +35,11 @@ tables:
       Fuzzing, License, Maintained, Packaging, Pinned-Dependencies, SAST,
       Security-Policy, Signed-Releases, Token-Permissions, Vulnerabilities.
 
-      Scores: 10 = excellent, 0 = critical gap, -1 = not applicable.
-      Sort by score ASC to surface which checks need the most improvement.
-      Filter WHERE score >= 0 AND score < 5 to find critical security gaps
-      (exclude -1 N/A values).
+      Scores: 10 = highest, 0 = lowest, -1 = not applicable.
+      Sort by score ASC to surface which checks Scorecard flags for review.
+      Filter WHERE score >= 0 AND score < 5 to find low-scoring checks
+      (exclude -1 N/A values). Scorecard is a heuristic signal — scores
+      reflect the tool's opinionated weighting, not absolute security guarantees.
     fetch_limit_default: 30
     filters:
       - name: owner


### PR DESCRIPTION
## Summary

Adds two queryable SQL tables over the free, no-auth [OpenSSF Scorecard API](https://api.securityscorecards.dev):

- **`scorecard.checks`** — up to 18 security health checks per repo, each scored 0–10 with a plain-English reason
- **`scorecard.project`** — aggregate score, scored date, commit SHA, and Scorecard tool version (data freshness metadata)

Checks include: Code-Review, Token-Permissions, Branch-Protection, Pinned-Dependencies, SAST, Signed-Releases, Fuzzing, CI-Tests, Contributors, Dependency-Update-Tool, and more.

> **Coverage note:** Results are available for public GitHub repositories tracked by OpenSSF Scorecard. Repositories not yet indexed return a 404.

## Why this source?

- **Zero auth, zero config** — no API key needed; works for any public GitHub repo by owner + repo name
- **Novel DSL pattern** — uses `{{filter.owner}}` and `{{filter.repo}}` path template substitution to inject filter values directly into the URL path (`/projects/github.com/{owner}/{repo}`)
- **Two tables, two use cases** — `checks` for per-check detail, `project` for aggregate score and data freshness
- **Genuinely actionable** — tells maintainers exactly which security practices to fix, not just that something is wrong

## Example queries

```sql
-- All checks, worst first (most improvement needed at top)
SELECT check_name, score, reason
FROM scorecard.checks
WHERE owner = 'expressjs' AND repo = 'express'
ORDER BY CASE WHEN score = -1 THEN 999 ELSE score END ASC

-- Only the critical gaps (excluding N/A checks)
SELECT check_name, score, reason
FROM scorecard.checks
WHERE owner = 'django' AND repo = 'django'
  AND score >= 0 AND score < 5

-- Quick health summary
SELECT
  COUNT(*) AS total_checks,
  SUM(CASE WHEN score >= 8 THEN 1 ELSE 0 END) AS passing,
  SUM(CASE WHEN score >= 0 AND score < 5 THEN 1 ELSE 0 END) AS critical
FROM scorecard.checks
WHERE owner = 'expressjs' AND repo = 'express'

-- Check when the score was last computed and which commit was evaluated
SELECT date, aggregate_score, repo_commit, scorecard_version
FROM scorecard.project
WHERE owner = 'expressjs' AND repo = 'express' 
```

## Validation

- `coral source lint`: ✅ passed
- `coral source add`: ✅ connected, 2 tables (`checks`, `project`), 2/2 test queries passed
- `scorecard.checks` tested against: `expressjs/express` (18 checks), `django/django`, `rust-lang/rust`
- `scorecard.project` tested: returns 1 row with `date`, `aggregate_score`, `repo_commit`, `scorecard_version`, `scorecard_commit`
- 404 case (repo not in Scorecard DB): returns `Source resource was not found (404)`
- Column types: `check_name` Utf8, `score` Int64 (-1 or 0–10), `reason` Utf8, `documentation_url` Utf8, `aggregate_score` Float64, `date` Utf8
