### PR TITLE
feat(sources/community/lm_studio): add LM Studio community source

### DIFF
--- a/sources/community/lm_studio/README.md
+++ b/sources/community/lm_studio/README.md
@@ -1,0 +1,321 @@
+# LM Studio community source
+
+Query a local LM Studio server from Coral SQL using LM Studio's
+OpenAI-compatible API. This source lists models visible to the local server,
+runs bounded response and single-turn chat-completion smoke tests, and
+generates embedding vectors from an embedding-capable model.
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** `http://localhost:1234/v1`
+
+## Why this source
+
+LM Studio is a popular local model runtime for testing LLMs on a workstation.
+Coral did not have an LM Studio source yet, so this community spec adds a
+focused read/query surface for:
+
+- Discovering models visible to the LM Studio OpenAI-compatible server.
+- Running bounded response and single-turn chat-completion checks through SQL.
+- Generating an embedding vector from an embedding-capable local model.
+- Joining local model inventory with other Coral sources during agent or
+  workflow debugging.
+
+The v1 surface is intentionally narrow. It uses LM Studio's documented
+OpenAI-compatible endpoints and avoids model-detail path lookups so model IDs
+containing slashes remain safe.
+
+## Installation
+
+Start the LM Studio server from the Developer tab, then add the manifest:
+
+```bash
+coral source add --file sources/community/lm_studio/manifest.yaml
+```
+
+If your LM Studio server uses a different OpenAI-compatible base URL, set
+`LM_STUDIO_BASE_URL` before adding the source:
+
+```bash
+export LM_STUDIO_BASE_URL="http://localhost:1234/v1"
+coral source add --file sources/community/lm_studio/manifest.yaml
+```
+
+Interactive install also works:
+
+```bash
+coral source add --interactive --file sources/community/lm_studio/manifest.yaml
+```
+
+## Authentication
+
+This first version targets the default local LM Studio server shape. LM Studio
+does not require API authentication by default. If the server is configured to
+require API tokens, token-authenticated requests are out of scope for this
+initial source.
+
+## Provider Docs
+
+- LM Studio local server: https://lmstudio.ai/docs/developer/core/server
+- LM Studio API quickstart: https://lmstudio.ai/docs/developer/rest/quickstart
+- LM Studio authentication: https://lmstudio.ai/docs/developer/core/authentication
+- OpenAI-compatible list models: https://lmstudio.ai/docs/developer/openai-compat/models
+- OpenAI-compatible responses: https://lmstudio.ai/docs/developer/openai-compat/responses
+- OpenAI-compatible chat completions: https://lmstudio.ai/docs/developer/openai-compat/chat-completions
+- OpenAI-compatible embeddings: https://lmstudio.ai/docs/developer/openai-compat/embeddings
+- OpenAI-compatible completions: https://lmstudio.ai/docs/developer/openai-compat/completions
+
+## Tables
+
+| Table | Description | Required filters |
+| --- | --- | --- |
+| `lm_studio.models` | Models visible to the OpenAI-compatible server. | None |
+| `lm_studio.responses` | Run one non-streaming Responses API request. | `model`, `input`, `max_output_tokens` |
+| `lm_studio.chat_completions` | Run one non-streaming single-turn chat completion. | `model`, `prompt`, `max_tokens` |
+| `lm_studio.embeddings` | Generate one embedding vector from input text. | `model`, `input` |
+
+### `lm_studio.models`
+
+Lists models returned by `GET /models`.
+
+```sql
+SELECT id, object, owned_by
+FROM lm_studio.models
+LIMIT 20;
+```
+
+### `lm_studio.responses`
+
+Runs a non-streaming request through `POST /responses`. Always pass a positive
+`max_output_tokens` value so the request is bounded. The full `output` field is
+JSON because LM Studio may return message items, reasoning items, tool events,
+or other Responses API output shapes depending on model and request.
+
+```sql
+SELECT status, max_output_tokens, output
+FROM lm_studio.responses
+WHERE model = 'model-identifier'
+  AND input = 'Reply with exactly: Coral Responses works'
+  AND max_output_tokens = 20
+LIMIT 1;
+```
+
+### `lm_studio.chat_completions`
+
+Runs a single user-message chat completion through `POST /chat/completions`.
+Always pass a positive `max_tokens` value so the request is bounded.
+
+```sql
+SELECT content, reasoning_content, finish_reason, max_tokens
+FROM lm_studio.chat_completions
+WHERE model = 'model-identifier'
+  AND prompt = 'Reply with exactly: Coral LM Studio works'
+  AND max_tokens = 20
+LIMIT 1;
+```
+
+This table is single-turn only. It does not expose chat history, image messages,
+tool calls, or structured-output payloads in this first version.
+Reasoning models may return early thinking text in `reasoning_content` before
+answer text appears in `content`.
+
+### `lm_studio.embeddings`
+
+Generates an embedding vector through `POST /embeddings`. Use an
+embedding-capable model loaded or visible in LM Studio. Select `embedding` when
+you need the full vector; validation examples show a short vector preview so
+terminal output stays readable.
+
+```sql
+SELECT model, index, substr(CAST(embedding AS VARCHAR), 1, 80) AS embedding_preview
+FROM lm_studio.embeddings
+WHERE model = 'embedding-model-identifier'
+  AND input = 'Coral source validation'
+LIMIT 1;
+```
+
+## Validation
+
+Run the source-level checks after starting the LM Studio server:
+
+```bash
+coral source lint sources/community/lm_studio/manifest.yaml
+
+export LM_STUDIO_BASE_URL="http://localhost:1234/v1"
+coral source add --file sources/community/lm_studio/manifest.yaml
+coral source test lm_studio
+```
+
+The declared test query covers model discovery:
+
+```sql
+SELECT id, object, owned_by
+FROM lm_studio.models
+LIMIT 5;
+```
+
+Before opening a PR, also capture live output for one chat-completion query and
+one embedding query against real local models. A Responses API smoke test is
+also useful when the loaded model supports it.
+
+### Live validation output
+
+The following output was captured against a local LM Studio server with a
+chat-capable model and an embedding-capable model loaded.
+
+#### Manifest lint
+
+Command:
+
+```bash
+coral source lint sources/community/lm_studio/manifest.yaml
+```
+
+Output:
+
+```text
+Manifest is valid
+```
+
+#### Add source and run declared tests
+
+Command:
+
+```bash
+coral source add --file sources/community/lm_studio/manifest.yaml
+```
+
+Output:
+
+```text
+Added source lm_studio
+
+  PASS lm_studio connected successfully
+
+    lm_studio (4 tables)
+    - chat_completions
+    - embeddings
+    - models
+    - responses
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT id, object, owned_by FROM lm_studio.models LIMIT 5
+      4 rows
+```
+
+#### Re-run source tests
+
+Command:
+
+```bash
+coral source test lm_studio
+```
+
+Output:
+
+```text
+  PASS lm_studio connected successfully
+
+    lm_studio (4 tables)
+    - chat_completions
+    - embeddings
+    - models
+    - responses
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT id, object, owned_by FROM lm_studio.models LIMIT 5
+      4 rows
+```
+
+#### Model inventory query
+
+Command:
+
+```bash
+coral sql "SELECT id, object, owned_by FROM lm_studio.models LIMIT 5"
+```
+
+Output:
+
+```text
++----------------------------------------+--------+--------------------+
+| id                                     | object | owned_by           |
++----------------------------------------+--------+--------------------+
+| text-embedding-nomic-embed-text-v1.5   | model  | organization_owner |
+| google/gemma-4-e4b                     | model  | organization_owner |
+| text-embedding-nomic-embed-text-v1.5:2 | model  | organization_owner |
+| google/gemma-4-e4b:2                   | model  | organization_owner |
++----------------------------------------+--------+--------------------+
+```
+
+#### Bounded chat-completion query
+
+Command:
+
+```bash
+coral sql "SELECT content, reasoning_content, finish_reason, max_tokens FROM lm_studio.chat_completions WHERE model = 'google/gemma-4-e4b' AND prompt = 'Reply with exactly: Coral LM Studio works' AND max_tokens = 20 LIMIT 1"
+```
+
+Output:
+
+```text
++-----------------------+-------------------+---------------+------------+
+| content               | reasoning_content | finish_reason | max_tokens |
++-----------------------+-------------------+---------------+------------+
+| Coral LM Studio works |                   | stop          | 20         |
++-----------------------+-------------------+---------------+------------+
+```
+
+#### Bounded Responses API query
+
+Command:
+
+```bash
+coral sql "SELECT status, max_output_tokens FROM lm_studio.responses WHERE model = 'google/gemma-4-e4b' AND input = 'Reply with exactly: Coral Responses works' AND max_output_tokens = 20 LIMIT 1"
+```
+
+Output:
+
+```text
++-----------+-------------------+
+| status    | max_output_tokens |
++-----------+-------------------+
+| completed | 20                |
++-----------+-------------------+
+```
+
+#### Embedding query
+
+Command:
+
+```bash
+coral sql "SELECT model, index, substr(CAST(embedding AS VARCHAR), 1, 80) AS embedding_preview FROM lm_studio.embeddings WHERE model = 'text-embedding-nomic-embed-text-v1.5' AND input = 'Coral LM Studio source validation' LIMIT 1"
+```
+
+Output:
+
+```text
++--------------------------------------+-------+----------------------------------------------------------------------------------+
+| model                                | index | embedding_preview                                                                |
++--------------------------------------+-------+----------------------------------------------------------------------------------+
+| text-embedding-nomic-embed-text-v1.5 | 0     | [0.01817111112177372,-0.007743862923234701,-0.1390269100666046,-0.05625997856259 |
++--------------------------------------+-------+----------------------------------------------------------------------------------+
+```
+
+## Scope and Limitations
+
+- Targets LM Studio's OpenAI-compatible `/v1` endpoints.
+- Uses the default unauthenticated local server contract.
+- Does not include token-authenticated server mode in this first version.
+- Does not include the legacy `/v1/completions` endpoint.
+- Does not include the native `/api/v1` stateful chat, model load, model unload,
+  download, or MCP integration endpoints.
+- `responses` performs one live API call for each query.
+- `chat_completions` performs one live model call for each query.
+- `chat_completions` is single-turn and non-streaming.
+- `embeddings` requires an embedding-capable model.
+- Model availability depends on the LM Studio server configuration and loaded
+  or visible local models.

--- a/sources/community/lm_studio/manifest.yaml
+++ b/sources/community/lm_studio/manifest.yaml
@@ -1,0 +1,302 @@
+name: lm_studio
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query local LM Studio models and run bounded OpenAI-compatible response, chat, and embedding checks through SQL.
+base_url: "{{input.LM_STUDIO_BASE_URL}}"
+inputs:
+  LM_STUDIO_BASE_URL:
+    kind: variable
+    default: http://localhost:1234/v1
+    hint: |
+      LM Studio OpenAI-compatible API base URL.
+
+      Start the LM Studio local server from the Developer tab. The default
+      OpenAI-compatible API base URL is:
+      http://localhost:1234/v1
+
+      This first version targets the default unauthenticated local LM Studio
+      API server. Servers configured to require API tokens are out of scope for
+      this initial source.
+test_queries:
+  - SELECT id, object, owned_by FROM lm_studio.models LIMIT 5
+tables:
+  - name: models
+    description: Models visible to the LM Studio OpenAI-compatible server from GET /models.
+    request:
+      method: GET
+      path: /models
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Model identifier to use in OpenAI-compatible LM Studio requests.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: created
+        type: Int64
+        nullable: true
+        description: Creation timestamp when returned by the API.
+      - name: owned_by
+        type: Utf8
+        nullable: true
+        description: Owning provider or local owner metadata when returned by the API.
+
+  - name: chat_completions
+    description: Run one non-streaming, single-turn LM Studio chat completion request.
+    filters:
+      - name: model
+        required: true
+      - name: prompt
+        required: true
+      - name: max_tokens
+        required: true
+    request:
+      method: POST
+      path: /chat/completions
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - messages
+            - "0"
+            - role
+          from: literal
+          value: user
+        - path:
+            - messages
+            - "0"
+            - content
+          from: filter
+          key: prompt
+        - path:
+            - max_tokens
+          from: filter_int
+          key: max_tokens
+        - path:
+            - stream
+          from: literal
+          value: false
+    response:
+      rows_path:
+        - choices
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Model supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: prompt
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Prompt supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: prompt
+      - name: max_tokens
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Positive max_tokens value supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: max_tokens
+      - name: index
+        type: Int64
+        nullable: true
+        description: Choice index.
+      - name: finish_reason
+        type: Utf8
+        nullable: true
+        description: Why the model stopped.
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Assistant response text.
+        expr:
+          kind: path
+          path:
+            - message
+            - content
+      - name: reasoning_content
+        type: Utf8
+        nullable: true
+        description: Reasoning text returned by reasoning models when present.
+        expr:
+          kind: path
+          path:
+            - message
+            - reasoning_content
+      - name: message_role
+        type: Utf8
+        nullable: true
+        description: Assistant message role.
+        expr:
+          kind: path
+          path:
+            - message
+            - role
+
+  - name: responses
+    description: Run one non-streaming LM Studio Responses API request with a positive max_output_tokens bound.
+    filters:
+      - name: model
+        required: true
+      - name: input
+        required: true
+      - name: max_output_tokens
+        required: true
+    request:
+      method: POST
+      path: /responses
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - input
+          from: filter
+          key: input
+        - path:
+            - max_output_tokens
+          from: filter_int
+          key: max_output_tokens
+        - path:
+            - stream
+          from: literal
+          value: false
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        description: Model used for the response.
+      - name: input
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Input supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: input
+      - name: max_output_tokens
+        type: Int64
+        nullable: false
+        description: Positive max_output_tokens value supplied in SQL filter.
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Response ID.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Response status.
+      - name: created_at
+        type: Int64
+        nullable: true
+        description: Response creation timestamp.
+      - name: completed_at
+        type: Int64
+        nullable: true
+        description: Response completion timestamp.
+      - name: previous_response_id
+        type: Utf8
+        nullable: true
+        description: Previous response ID when returned.
+      - name: output
+        type: Json
+        nullable: true
+        description: Response output array, including reasoning or message items.
+      - name: usage
+        type: Json
+        nullable: true
+        description: Token usage metadata.
+
+  - name: embeddings
+    description: Generate one embedding vector through the OpenAI-compatible POST /embeddings endpoint.
+    filters:
+      - name: model
+        required: true
+      - name: input
+        required: true
+    request:
+      method: POST
+      path: /embeddings
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - input
+          from: filter
+          key: input
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Embedding model supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: input
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Input text supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: input
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: index
+        type: Int64
+        nullable: true
+        description: Embedding row index.
+      - name: embedding
+        type: Json
+        nullable: true
+        description: Embedding vector returned by LM Studio.


### PR DESCRIPTION
﻿﻿## Summary

Closes #833.

This source lets Coral query a local LM Studio OpenAI-compatible server for visible models, bounded non-streaming Responses API checks, bounded single-turn chat-completion checks, and embedding vectors through SQL.

## Why this source

LM Studio is a popular local model runtime for testing LLMs on a workstation. Coral does not currently include an LM Studio source under `sources/community` or `sources/core`, so this community source adds a focused SQL surface for local LLM workflows.

This source helps users:

- Discover models visible to the LM Studio OpenAI-compatible server.
- Run bounded Responses API and single-turn chat-completion checks through SQL.
- Generate embedding vectors from an embedding-capable local model.
- Join local model inventory with other Coral sources during agent or workflow debugging.

The first version is intentionally narrow. It uses LM Studio's documented OpenAI-compatible endpoints and avoids model-detail path lookups so model IDs containing `/` remain safe.

## Provider docs

- LM Studio local server: https://lmstudio.ai/docs/developer/core/server
- LM Studio API quickstart: https://lmstudio.ai/docs/developer/rest/quickstart
- LM Studio authentication: https://lmstudio.ai/docs/developer/core/authentication
- OpenAI-compatible list models: https://lmstudio.ai/docs/developer/openai-compat/models
- OpenAI-compatible responses: https://lmstudio.ai/docs/developer/openai-compat/responses
- OpenAI-compatible chat completions: https://lmstudio.ai/docs/developer/openai-compat/chat-completions
- OpenAI-compatible embeddings: https://lmstudio.ai/docs/developer/openai-compat/embeddings
- OpenAI-compatible completions: https://lmstudio.ai/docs/developer/openai-compat/completions

## Source shape

- `lm_studio.models` lists models visible through `GET /v1/models`.
- `lm_studio.responses` runs one bounded non-streaming Responses API request with required `model`, `input`, and `max_output_tokens` filters.
- `lm_studio.chat_completions` runs one bounded non-streaming single-turn chat completion with required `model`, `prompt`, and `max_tokens` filters.
- `lm_studio.embeddings` generates one embedding vector through `POST /v1/embeddings` with required `model` and `input` filters.

## Source scope

- Targets LM Studio's OpenAI-compatible `/v1` endpoints.
- Uses the default unauthenticated local server contract.
- Token-authenticated server mode is intentionally out of scope for this first version.
- Chat and Responses calls require positive token bounds.
- Chat is documented as single-turn only.
- The legacy `/v1/completions` endpoint and native `/api/v1` model load/unload/stateful chat endpoints are intentionally out of scope.
- No model-detail path lookup is included, avoiding model-ID path issues for IDs that contain `/`.

## Validation

Validated against a local LM Studio server with chat-capable and embedding-capable models loaded.

### Lint

```bash
$ coral source lint sources/community/lm_studio/manifest.yaml
Manifest is valid
```

### Add source

```bash
$ coral source add --file sources/community/lm_studio/manifest.yaml
Added source lm_studio

  PASS lm_studio connected successfully

    lm_studio (4 tables)
    - chat_completions
    - embeddings
    - models
    - responses
    Query tests
    1 declared - 1 passed - 0 failed

    PASS SELECT id, object, owned_by FROM lm_studio.models LIMIT 5
      4 rows
```

### Source test

```bash
$ coral source test lm_studio
  PASS lm_studio connected successfully

    lm_studio (4 tables)
    - chat_completions
    - embeddings
    - models
    - responses
    Query tests
    1 declared - 1 passed - 0 failed

    PASS SELECT id, object, owned_by FROM lm_studio.models LIMIT 5
      4 rows
```

### Model inventory query

```bash
$ coral sql "SELECT id, object, owned_by FROM lm_studio.models LIMIT 5"
+----------------------------------------+--------+--------------------+
| id                                     | object | owned_by           |
+----------------------------------------+--------+--------------------+
| text-embedding-nomic-embed-text-v1.5   | model  | organization_owner |
| google/gemma-4-e4b                     | model  | organization_owner |
| text-embedding-nomic-embed-text-v1.5:2 | model  | organization_owner |
| google/gemma-4-e4b:2                   | model  | organization_owner |
+----------------------------------------+--------+--------------------+
```

### Bounded chat-completion query

```bash
$ coral sql "SELECT content, reasoning_content, finish_reason, max_tokens FROM lm_studio.chat_completions WHERE model = 'google/gemma-4-e4b' AND prompt = 'Reply with exactly: Coral LM Studio works' AND max_tokens = 20 LIMIT 1"
+-----------------------+-------------------+---------------+------------+
| content               | reasoning_content | finish_reason | max_tokens |
+-----------------------+-------------------+---------------+------------+
| Coral LM Studio works |                   | stop          | 20         |
+-----------------------+-------------------+---------------+------------+
```

### Bounded Responses API query

```bash
$ coral sql "SELECT status, max_output_tokens FROM lm_studio.responses WHERE model = 'google/gemma-4-e4b' AND input = 'Reply with exactly: Coral Responses works' AND max_output_tokens = 20 LIMIT 1"
+-----------+-------------------+
| status    | max_output_tokens |
+-----------+-------------------+
| completed | 20                |
+-----------+-------------------+
```

### Embedding query

```bash
$ coral sql "SELECT model, index, substr(CAST(embedding AS VARCHAR), 1, 80) AS embedding_preview FROM lm_studio.embeddings WHERE model = 'text-embedding-nomic-embed-text-v1.5' AND input = 'Coral LM Studio source validation' LIMIT 1"
+--------------------------------------+-------+----------------------------------------------------------------------------------+
| model                                | index | embedding_preview                                                                |
+--------------------------------------+-------+----------------------------------------------------------------------------------+
| text-embedding-nomic-embed-text-v1.5 | 0     | [0.01817111112177372,-0.007743862923234701,-0.1390269100666046,-0.05625997856259 |
+--------------------------------------+-------+----------------------------------------------------------------------------------+
```

## Screenshots

![LM Studio proof 1 - endpoint check](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/1.png)
![LM Studio proof 2 - lint and add](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/2.png)
![LM Studio proof 3 - tables](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/3.png)
![LM Studio proof 4 - columns](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/4.png)
![LM Studio proof 5 - source test](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/5.png)
![LM Studio proof 6 - model inventory](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/6.png)
![LM Studio proof 7 - bounded chat completion](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/7.png)
![LM Studio proof 8 - responses and embedding preview](https://raw.githubusercontent.com/FiscalMindset/coral/lm-studio-proof-assets/output_proof/lm_studio/8.png)