### PR TITLE
feat(sources/community/asana): add Asana community source

### DIFF
--- a/sources/community/asana/README.md
+++ b/sources/community/asana/README.md
@@ -16,13 +16,16 @@ Personal Access Tokens (PAT) for scripts and CI pipelines.
 
 1. Go to [https://app.asana.com/0/my-apps](https://app.asana.com/0/my-apps) and create a new app.
 2. Under **Redirect URIs**, add exactly: `http://127.0.0.1:53682/oauth/callback`
-3. Copy the **Client ID** into `ASANA_CLIENT_ID` and the **Client Secret** into `ASANA_CLIENT_SECRET`.
-4. Run `coral source add --file sources/community/asana/manifest.yaml` and click **Sign in with Asana** to complete the browser-based flow.
+3. Under **Permission scopes**, enable the **`default`** scope (Full Permissions).
+4. Copy the **Client ID** into `ASANA_CLIENT_ID` and the **Client Secret** into `ASANA_CLIENT_SECRET`.
+5. Run `coral source add --file sources/community/asana/manifest.yaml` and click **Sign in with Asana** to complete the browser-based flow.
 
-> **Scope:** The OAuth flow requests four narrow read-only scopes:
-> `workspaces:read`, `projects:read`, `tasks:read`, `sections:read`.
-> These grant read access to all workspaces, projects, tasks, and sections
-> visible to the authorized user — no write permissions are requested.
+> **Why Full Permissions?** Asana's OAuth scopes are per-resource (e.g., `projects:read`,
+> `tasks:read`), but the [Sections API](https://developers.asana.com/reference/getsectionsforproject)
+> has no documented granular scope. Asana states that endpoints without an associated scope
+> require the `default` scope (Full Permissions). Since this source includes a `sections` table,
+> the OAuth flow requests `default` to cover all four tables. If the `default` scope is not
+> enabled in your app's Permission scopes, the OAuth flow will fail with `forbidden_scopes`.
 
 ### Option 2 — Personal Access Token
 

--- a/sources/community/asana/README.md
+++ b/sources/community/asana/README.md
@@ -17,7 +17,7 @@ Personal Access Tokens (PAT) for scripts and CI pipelines.
 1. Go to [https://app.asana.com/0/my-apps](https://app.asana.com/0/my-apps) and create a new app.
 2. Under **Redirect URIs**, add exactly: `http://127.0.0.1:53682/oauth/callback`
 3. Copy the **Client ID** into `ASANA_CLIENT_ID` and the **Client Secret** into `ASANA_CLIENT_SECRET`.
-4. Run `coral source add` and click **Sign in with Asana** to complete the browser-based flow.
+4. Run `coral source add --file sources/community/asana/manifest.yaml` and click **Sign in with Asana** to complete the browser-based flow.
 
 > **Scope:** The `default` scope grants read access to all workspaces, projects, tasks, and
 > sections visible to the authorized user.
@@ -26,7 +26,7 @@ Personal Access Tokens (PAT) for scripts and CI pipelines.
 
 1. Go to [https://app.asana.com/0/my-apps](https://app.asana.com/0/my-apps) → **Create new token**.
 2. Give the token a name and copy it.
-3. Run `coral source add` and paste the token when prompted for `ASANA_TOKEN`.
+3. Run `coral source add --file sources/community/asana/manifest.yaml` and paste the token when prompted for `ASANA_TOKEN`.
 
 ```bash
 coral source add --file sources/community/asana/manifest.yaml

--- a/sources/community/asana/README.md
+++ b/sources/community/asana/README.md
@@ -19,8 +19,10 @@ Personal Access Tokens (PAT) for scripts and CI pipelines.
 3. Copy the **Client ID** into `ASANA_CLIENT_ID` and the **Client Secret** into `ASANA_CLIENT_SECRET`.
 4. Run `coral source add --file sources/community/asana/manifest.yaml` and click **Sign in with Asana** to complete the browser-based flow.
 
-> **Scope:** The `default` scope grants read access to all workspaces, projects, tasks, and
-> sections visible to the authorized user.
+> **Scope:** The OAuth flow requests four narrow read-only scopes:
+> `workspaces:read`, `projects:read`, `tasks:read`, `sections:read`.
+> These grant read access to all workspaces, projects, tasks, and sections
+> visible to the authorized user — no write permissions are requested.
 
 ### Option 2 — Personal Access Token
 
@@ -39,17 +41,22 @@ API docs: [https://developers.asana.com/reference/rest-api-reference](https://de
 | Table | Description | Required filters | Optional filters |
 |---|---|---|---|
 | `workspaces` | All workspaces visible to the authenticated user | — | — |
-| `projects` | Projects across all workspaces or within one workspace | — | `workspace_gid` |
-| `tasks` | Tasks within a specific project | `project_gid` | — |
+| `projects` | Projects within a specific workspace | `workspace_gid` | — |
+| `tasks` | Tasks within a specific project | `project_gid` | `completed_since` |
 | `sections` | Sections (columns / swim-lanes) within a specific project | `project_gid` | — |
 
 ### Key design notes
 
 - **Start with `workspaces`.** It requires no filters and returns the GIDs you'll use everywhere else.
-- **`projects` is optionally scoped.** Without `workspace_gid` the API returns projects across all
-  workspaces visible to the token — useful for a global view. Supply `workspace_gid` to limit scope.
-- **`tasks` and `sections` require `project_gid`.** Asana's API models these as project-scoped
-  resources. Get the GID from `asana.projects.gid` first.
+- **`projects` requires `workspace_gid`.** Asana's API warns that `GET /projects` may timeout for
+  large domains without a workspace or team filter, so this source always requires one. Get the GID
+  from `asana.workspaces.gid`.
+- **`tasks` requires `project_gid`, and supports `completed_since`.** The Asana API documents
+  `completed_since` as a server-side filter: pass an ISO 8601 timestamp to fetch only incomplete
+  tasks and tasks completed after that timestamp, or pass the keyword `now` to fetch only open
+  tasks. Without it, the API returns the project's full task history — potentially very large on
+  active projects and rate-limit-unfriendly (Asana free tier: 150 req/min per user).
+- **`sections` requires `project_gid`.** Asana models sections as project-scoped resources.
 - **Typical flow:** `workspaces` → `projects` (filter by `workspace_gid`) → `tasks` or `sections`
   (filter by `project_gid`).
 - **`resource_subtype` on tasks** distinguishes milestones (`milestone`), approvals (`approval`),
@@ -61,22 +68,28 @@ API docs: [https://developers.asana.com/reference/rest-api-reference](https://de
 
 ```text
 workspaces   → all workspaces (entry point, no filter needed)
-projects     → projects in a workspace  (optional workspace_gid filter)
-tasks        → tasks in a project       (requires project_gid)
+projects     → projects in a workspace  (requires workspace_gid)
+tasks        → tasks in a project       (requires project_gid, optional completed_since)
 sections     → sections in a project    (requires project_gid)
 ```
 
-### `projects` optional filter
+### `projects` required filter
 
 | Filter | Description |
 |---|---|
-| `workspace_gid` | Limit projects to a specific workspace. Get the GID from `asana.workspaces`. |
+| `workspace_gid` | Workspace to list projects for. Get the GID from `asana.workspaces`. |
 
 ### `tasks` required filter
 
 | Filter | Description |
 |---|---|
 | `project_gid` | The project whose tasks to fetch. Get the GID from `asana.projects`. |
+
+### `tasks` optional filter
+
+| Filter | Description |
+|---|---|
+| `completed_since` | ISO 8601 timestamp or the keyword `now`. When set, the Asana API returns only incomplete tasks and tasks completed after the given timestamp. Recommended for active projects to avoid fetching the full task history. |
 
 ### `sections` required filter
 
@@ -98,12 +111,12 @@ coral sql "
   LIMIT 20
 "
 
-# Step 3 — list open tasks in a project
+# Step 3 — list open tasks in a project (server-side filter)
 coral sql "
   SELECT gid, name, due_on, assignee_name
   FROM asana.tasks
   WHERE project_gid = 'your-project-gid'
-    AND completed = false
+    AND completed_since = 'now'
   ORDER BY due_on ASC
   LIMIT 50
 "
@@ -147,7 +160,7 @@ WHERE workspace_gid = 'your-workspace-gid'
 ORDER BY name;
 ```
 
-### List open tasks in a project sorted by due date
+### List open tasks using server-side completed_since pushdown
 
 ```sql
 SELECT
@@ -159,25 +172,24 @@ SELECT
   resource_subtype
 FROM asana.tasks
 WHERE project_gid = 'your-project-gid'
-  AND completed = false
+  AND completed_since = 'now'
 ORDER BY due_on ASC NULLS LAST
 LIMIT 100;
 ```
 
-### Find overdue incomplete tasks
+### Find tasks completed in the last 7 days
 
 ```sql
 SELECT
   gid,
   name,
-  due_on,
-  assignee_name,
-  modified_at
+  completed_at,
+  assignee_name
 FROM asana.tasks
 WHERE project_gid = 'your-project-gid'
-  AND completed = false
-  AND due_on < current_date
-ORDER BY due_on ASC;
+  AND completed_since = '2025-05-20T00:00:00Z'
+  AND completed = true
+ORDER BY completed_at DESC;
 ```
 
 ### List sections in a project

--- a/sources/community/asana/README.md
+++ b/sources/community/asana/README.md
@@ -1,0 +1,193 @@
+# Asana
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 4
+**Base URL:** `https://app.asana.com/api/1.0`
+
+Query workspaces, projects, tasks, and sections from Asana via the Asana REST API v1.0.
+
+## Authentication
+
+Asana supports two authentication methods: OAuth (recommended for interactive use) and
+Personal Access Tokens (PAT) for scripts and CI pipelines.
+
+### Option 1 — OAuth (recommended)
+
+1. Go to [https://app.asana.com/0/my-apps](https://app.asana.com/0/my-apps) and create a new app.
+2. Under **Redirect URIs**, add exactly: `http://127.0.0.1:53682/oauth/callback`
+3. Copy the **Client ID** into `ASANA_CLIENT_ID` and the **Client Secret** into `ASANA_CLIENT_SECRET`.
+4. Run `coral source add` and click **Sign in with Asana** to complete the browser-based flow.
+
+> **Scope:** The `default` scope grants read access to all workspaces, projects, tasks, and
+> sections visible to the authorized user.
+
+### Option 2 — Personal Access Token
+
+1. Go to [https://app.asana.com/0/my-apps](https://app.asana.com/0/my-apps) → **Create new token**.
+2. Give the token a name and copy it.
+3. Run `coral source add` and paste the token when prompted for `ASANA_TOKEN`.
+
+```bash
+coral source add --file sources/community/asana/manifest.yaml
+```
+
+API docs: [https://developers.asana.com/reference/rest-api-reference](https://developers.asana.com/reference/rest-api-reference)
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `workspaces` | All workspaces visible to the authenticated user | — | — |
+| `projects` | Projects across all workspaces or within one workspace | — | `workspace_gid` |
+| `tasks` | Tasks within a specific project | `project_gid` | — |
+| `sections` | Sections (columns / swim-lanes) within a specific project | `project_gid` | — |
+
+### Key design notes
+
+- **Start with `workspaces`.** It requires no filters and returns the GIDs you'll use everywhere else.
+- **`projects` is optionally scoped.** Without `workspace_gid` the API returns projects across all
+  workspaces visible to the token — useful for a global view. Supply `workspace_gid` to limit scope.
+- **`tasks` and `sections` require `project_gid`.** Asana's API models these as project-scoped
+  resources. Get the GID from `asana.projects.gid` first.
+- **Typical flow:** `workspaces` → `projects` (filter by `workspace_gid`) → `tasks` or `sections`
+  (filter by `project_gid`).
+- **`resource_subtype` on tasks** distinguishes milestones (`milestone`), approvals (`approval`),
+  and regular tasks (`default_task`). Filter locally after fetching.
+- **`due_on` vs `due_at` on tasks.** Asana sets one or the other, never both.
+  `due_on` is a date string (`YYYY-MM-DD`); `due_at` is a full timestamp for time-specific deadlines.
+- **Rate limits.** The Asana free tier allows 150 requests per minute per user. All tables fetch
+  100 items per page to minimize round-trips.
+
+```text
+workspaces   → all workspaces (entry point, no filter needed)
+projects     → projects in a workspace  (optional workspace_gid filter)
+tasks        → tasks in a project       (requires project_gid)
+sections     → sections in a project    (requires project_gid)
+```
+
+### `projects` optional filter
+
+| Filter | Description |
+|---|---|
+| `workspace_gid` | Limit projects to a specific workspace. Get the GID from `asana.workspaces`. |
+
+### `tasks` required filter
+
+| Filter | Description |
+|---|---|
+| `project_gid` | The project whose tasks to fetch. Get the GID from `asana.projects`. |
+
+### `sections` required filter
+
+| Filter | Description |
+|---|---|
+| `project_gid` | The project whose sections to fetch. Get the GID from `asana.projects`. |
+
+## Quick start
+
+```bash
+# Step 1 — list all workspaces
+coral sql "SELECT gid, name, is_organization FROM asana.workspaces"
+
+# Step 2 — list projects in a workspace
+coral sql "
+  SELECT gid, name, archived, due_on, status_type
+  FROM asana.projects
+  WHERE workspace_gid = 'your-workspace-gid'
+  LIMIT 20
+"
+
+# Step 3 — list open tasks in a project
+coral sql "
+  SELECT gid, name, due_on, assignee_name
+  FROM asana.tasks
+  WHERE project_gid = 'your-project-gid'
+    AND completed = false
+  ORDER BY due_on ASC
+  LIMIT 50
+"
+
+# Step 4 — list sections in a project
+coral sql "
+  SELECT gid, name, created_at
+  FROM asana.sections
+  WHERE project_gid = 'your-project-gid'
+"
+```
+
+## Example queries
+
+### List all workspaces
+
+```sql
+SELECT
+  gid,
+  name,
+  is_organization,
+  email_domains
+FROM asana.workspaces;
+```
+
+### List projects in a workspace
+
+```sql
+SELECT
+  gid,
+  name,
+  archived,
+  color,
+  due_on,
+  status_type,
+  status_title,
+  owner_name,
+  created_at
+FROM asana.projects
+WHERE workspace_gid = 'your-workspace-gid'
+ORDER BY name;
+```
+
+### List open tasks in a project sorted by due date
+
+```sql
+SELECT
+  gid,
+  name,
+  due_on,
+  due_at,
+  assignee_name,
+  resource_subtype
+FROM asana.tasks
+WHERE project_gid = 'your-project-gid'
+  AND completed = false
+ORDER BY due_on ASC NULLS LAST
+LIMIT 100;
+```
+
+### Find overdue incomplete tasks
+
+```sql
+SELECT
+  gid,
+  name,
+  due_on,
+  assignee_name,
+  modified_at
+FROM asana.tasks
+WHERE project_gid = 'your-project-gid'
+  AND completed = false
+  AND due_on < current_date
+ORDER BY due_on ASC;
+```
+
+### List sections in a project
+
+```sql
+SELECT
+  gid,
+  name,
+  created_at
+FROM asana.sections
+WHERE project_gid = 'your-project-gid'
+ORDER BY created_at ASC;
+```

--- a/sources/community/asana/manifest.yaml
+++ b/sources/community/asana/manifest.yaml
@@ -17,6 +17,8 @@ inputs:
       For OAuth: create an app at https://app.asana.com/0/my-apps,
       set redirect URI to http://127.0.0.1:53682/oauth/callback,
       then provide your Client ID and Client Secret below.
+      The OAuth flow requests read-only scopes for workspaces, projects,
+      tasks, and sections.
     credential:
       methods:
         - type: oauth
@@ -39,7 +41,10 @@ inputs:
               scope:
                 delimiter: space
                 values:
-                  - default
+                  - workspaces:read
+                  - projects:read
+                  - tasks:read
+                  - sections:read
         - type: source_config
           label: Paste personal access token
           description: Paste an existing Asana Personal Access Token.
@@ -73,9 +78,8 @@ request_headers:
 
 test_queries:
   - SELECT * FROM asana.workspaces LIMIT 5
-  - SELECT gid, name, archived, created_at FROM asana.projects LIMIT 10
-  - SELECT gid, name, archived FROM asana.projects WHERE workspace_gid = 'your-workspace-gid' LIMIT 10
-  - SELECT gid, name, completed, due_on, assignee_name FROM asana.tasks WHERE project_gid = 'your-project-gid' LIMIT 10
+  - SELECT gid, name, archived, created_at FROM asana.projects WHERE workspace_gid = 'your-workspace-gid' LIMIT 10
+  - SELECT gid, name, completed, due_on, assignee_name FROM asana.tasks WHERE project_gid = 'your-project-gid' AND completed_since = 'now' LIMIT 10
   - SELECT gid, name FROM asana.sections WHERE project_gid = 'your-project-gid' LIMIT 10
 
 tables:
@@ -152,18 +156,19 @@ tables:
   # ────────────────────────────────────────────────────────────────────────────
   - name: projects
     description: >-
-      Projects visible to the authenticated user, optionally scoped to a
-      specific workspace. Each row is one project. Use gid as the
+      Projects within a specific Asana workspace. Each row is one project.
+      Requires workspace_gid from the workspaces table. Use gid as the
       project_gid filter for tasks and sections.
     guide: |
-      Filter by workspace_gid to limit results to one workspace — the Asana
-      API requires at least a workspace or team filter for large accounts.
+      Requires workspace_gid (gid from asana.workspaces). The Asana API
+      warns that GET /projects may timeout for large domains without a
+      workspace filter, so this source always requires one.
       gid is the project identifier to pass as project_gid in tasks and
       sections. owner_gid and workspace_gid can be used to join back to the
       workspaces table.
     filters:
       - name: workspace_gid
-        required: false
+        required: true
     request:
       method: GET
       path: /projects
@@ -329,15 +334,23 @@ tables:
   - name: tasks
     description: >-
       Tasks in a specific Asana project. Each row is one task. Requires
-      project_gid from the projects table.
+      project_gid from the projects table. Use the optional completed_since
+      filter to avoid fetching the full task history.
     guide: |
-      Requires project_gid (gid from asana.projects). Filter completed = false
-      to see only open tasks. due_on and due_at are independent — due_on is
-      for date-only due dates while due_at carries a time component.
-      assignee_gid joins back to any people/members table.
+      Requires project_gid (gid from asana.projects). Use completed_since
+      to push a time-window filter to the Asana API — the server returns
+      only incomplete tasks and tasks completed after that timestamp.
+      Pass the keyword 'now' to fetch only incomplete tasks without any
+      completed ones, or an ISO 8601 timestamp to bound the window.
+      Without completed_since, the API returns the full task history of
+      the project, which can be large and hit rate limits (150 req/min
+      on Asana free tier). due_on and due_at are independent — due_on
+      is for date-only due dates while due_at carries a time component.
     filters:
       - name: project_gid
         required: true
+      - name: completed_since
+        required: false
     request:
       method: GET
       path: /projects/{{filter.project_gid}}/tasks
@@ -345,6 +358,9 @@ tables:
         - name: opt_fields
           from: literal
           value: gid,name,completed,completed_at,due_on,due_at,start_on,start_at,created_at,modified_at,notes,assignee.gid,assignee.name,resource_type,resource_subtype
+        - name: completed_since
+          from: filter
+          key: completed_since
     response:
       rows_path:
         - data
@@ -506,6 +522,16 @@ tables:
           kind: path
           path:
             - resource_subtype
+      - name: completed_since
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: >-
+          Server-side filter: only return tasks that are incomplete or completed
+          after this ISO 8601 timestamp. Pass 'now' to fetch only open tasks.
+          Pushed to the Asana API as the completed_since query parameter.
+        expr:
+          kind: "null"
 
   # ────────────────────────────────────────────────────────────────────────────
   # sections — sections within a specific project

--- a/sources/community/asana/manifest.yaml
+++ b/sources/community/asana/manifest.yaml
@@ -16,9 +16,11 @@ inputs:
       from https://app.asana.com/0/my-apps → "Create new token".
       For OAuth: create an app at https://app.asana.com/0/my-apps,
       set redirect URI to http://127.0.0.1:53682/oauth/callback,
-      then provide your Client ID and Client Secret below.
-      The OAuth flow requests read-only scopes for workspaces, projects,
-      tasks, and sections.
+      and enable the "default" scope under Permission scopes in your app
+      settings, then provide your Client ID and Client Secret below.
+      The OAuth flow requests the "default" scope (Full Permissions)
+      because the Sections API has no granular OAuth scope in Asana's
+      current scope list.
     credential:
       methods:
         - type: oauth
@@ -41,10 +43,7 @@ inputs:
               scope:
                 delimiter: space
                 values:
-                  - workspaces:read
-                  - projects:read
-                  - tasks:read
-                  - sections:read
+                  - default
         - type: source_config
           label: Paste personal access token
           description: Paste an existing Asana Personal Access Token.

--- a/sources/community/asana/manifest.yaml
+++ b/sources/community/asana/manifest.yaml
@@ -1,0 +1,579 @@
+name: asana
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query workspaces, projects, tasks, and sections from Asana via the
+  Asana REST API. Authenticate with OAuth authorization-code or a
+  Personal Access Token.
+base_url: https://app.asana.com/api/1.0
+
+inputs:
+  ASANA_TOKEN:
+    kind: secret
+    hint: |
+      Connect via "Sign in with Asana" below, or paste a Personal Access Token
+      from https://app.asana.com/0/my-apps → "Create new token".
+      For OAuth: create an app at https://app.asana.com/0/my-apps,
+      set redirect URI to http://127.0.0.1:53682/oauth/callback,
+      then provide your Client ID and Client Secret below.
+    credential:
+      methods:
+        - type: oauth
+          label: Sign in with Asana
+          oauth:
+            flow:
+              type: authorization_code
+              pkce: disabled
+            redirect_uri: http://127.0.0.1:53682/oauth/callback
+            endpoints:
+              authorization_url: https://app.asana.com/-/oauth_authorize
+              token_url: https://app.asana.com/-/oauth_token
+            client:
+              id:
+                input: ASANA_CLIENT_ID
+              secret:
+                input: ASANA_CLIENT_SECRET
+                transport: request_body
+            scopes:
+              scope:
+                delimiter: space
+                values:
+                  - default
+        - type: source_config
+          label: Paste personal access token
+          description: Paste an existing Asana Personal Access Token.
+
+  ASANA_CLIENT_ID:
+    kind: variable
+    hint: |
+      OAuth Client ID from your Asana app at https://app.asana.com/0/my-apps.
+      Set redirect URI to http://127.0.0.1:53682/oauth/callback during registration.
+      This is a non-secret app identifier, not a password.
+
+  ASANA_CLIENT_SECRET:
+    kind: secret
+    hint: |
+      OAuth Client Secret from the same Asana app as ASANA_CLIENT_ID.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.ASANA_TOKEN}}
+
+request_headers:
+  - name: Asana-Enable
+    from: literal
+    value: new_user_task_lists
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT * FROM asana.workspaces LIMIT 5
+  - SELECT gid, name, archived, created_at FROM asana.projects LIMIT 10
+  - SELECT gid, name, archived FROM asana.projects WHERE workspace_gid = 'your-workspace-gid' LIMIT 10
+  - SELECT gid, name, completed, due_on, assignee_name FROM asana.tasks WHERE project_gid = 'your-project-gid' LIMIT 10
+  - SELECT gid, name FROM asana.sections WHERE project_gid = 'your-project-gid' LIMIT 10
+
+tables:
+  # ────────────────────────────────────────────────────────────────────────────
+  # workspaces — all workspaces visible to the authenticated user
+  # ────────────────────────────────────────────────────────────────────────────
+  - name: workspaces
+    description: >-
+      Workspaces visible to the authenticated user. Each row is one workspace.
+      Use gid as the workspace_gid filter for the projects table.
+    guide: |
+      Start here to discover workspace GIDs. Pass gid as workspace_gid when
+      filtering projects. email_domains is a comma-separated list of the
+      domains auto-associated with the workspace.
+    request:
+      method: GET
+      path: /workspaces
+      query:
+        - name: opt_fields
+          from: literal
+          value: gid,name,is_organization,email_domains
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: cursor_query
+      cursor_param: offset
+      response_cursor_path:
+        - next_page
+        - offset
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: gid
+        type: Utf8
+        nullable: false
+        description: Globally unique identifier for the workspace.
+        expr:
+          kind: path
+          path:
+            - gid
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The name of the workspace.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: is_organization
+        type: Boolean
+        nullable: true
+        description: Whether the workspace is an Asana Organization (true) or a personal workspace (false).
+        expr:
+          kind: path
+          path:
+            - is_organization
+      - name: email_domains
+        type: Utf8
+        nullable: true
+        description: >-
+          Comma-separated list of email domains auto-associated with the
+          workspace. Null when no domains are configured.
+        expr:
+          kind: join_array
+          path:
+            - email_domains
+          separator: ", "
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # projects — projects within an optional workspace scope
+  # ────────────────────────────────────────────────────────────────────────────
+  - name: projects
+    description: >-
+      Projects visible to the authenticated user, optionally scoped to a
+      specific workspace. Each row is one project. Use gid as the
+      project_gid filter for tasks and sections.
+    guide: |
+      Filter by workspace_gid to limit results to one workspace — the Asana
+      API requires at least a workspace or team filter for large accounts.
+      gid is the project identifier to pass as project_gid in tasks and
+      sections. owner_gid and workspace_gid can be used to join back to the
+      workspaces table.
+    filters:
+      - name: workspace_gid
+        required: false
+    request:
+      method: GET
+      path: /projects
+      query:
+        - name: workspace
+          from: filter
+          key: workspace_gid
+        - name: opt_fields
+          from: literal
+          value: gid,name,archived,color,created_at,modified_at,due_on,start_on,notes,owner.gid,owner.name,workspace.gid,workspace.name,current_status_update.status_type,current_status_update.title
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: cursor_query
+      cursor_param: offset
+      response_cursor_path:
+        - next_page
+        - offset
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: gid
+        type: Utf8
+        nullable: false
+        description: Globally unique identifier for the project.
+        expr:
+          kind: path
+          path:
+            - gid
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The name of the project.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the project is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: color
+        type: Utf8
+        nullable: true
+        description: Color of the project (e.g. light-green, light-red).
+        expr:
+          kind: path
+          path:
+            - color
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the project was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: modified_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the project was last modified.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - modified_at
+      - name: due_on
+        type: Utf8
+        nullable: true
+        description: Due date of the project in YYYY-MM-DD format.
+        expr:
+          kind: path
+          path:
+            - due_on
+      - name: start_on
+        type: Utf8
+        nullable: true
+        description: Start date of the project in YYYY-MM-DD format.
+        expr:
+          kind: path
+          path:
+            - start_on
+      - name: notes
+        type: Utf8
+        nullable: true
+        description: Free-form text description of the project.
+        expr:
+          kind: path
+          path:
+            - notes
+      - name: owner_gid
+        type: Utf8
+        nullable: true
+        description: GID of the project owner.
+        expr:
+          kind: path
+          path:
+            - owner
+            - gid
+      - name: owner_name
+        type: Utf8
+        nullable: true
+        description: Display name of the project owner.
+        expr:
+          kind: path
+          path:
+            - owner
+            - name
+      - name: workspace_gid
+        type: Utf8
+        nullable: true
+        description: GID of the workspace this project belongs to. Echoed from filter when supplied.
+        expr:
+          kind: path
+          path:
+            - workspace
+            - gid
+      - name: workspace_name
+        type: Utf8
+        nullable: true
+        description: Name of the workspace this project belongs to.
+        expr:
+          kind: path
+          path:
+            - workspace
+            - name
+      - name: status_type
+        type: Utf8
+        nullable: true
+        description: >-
+          Current status update type (on_track, at_risk, off_track, on_hold,
+          complete). Null if no status has been set.
+        expr:
+          kind: path
+          path:
+            - current_status_update
+            - status_type
+      - name: status_title
+        type: Utf8
+        nullable: true
+        description: Title of the most recent status update.
+        expr:
+          kind: path
+          path:
+            - current_status_update
+            - title
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # tasks — tasks within a specific project
+  # ────────────────────────────────────────────────────────────────────────────
+  - name: tasks
+    description: >-
+      Tasks in a specific Asana project. Each row is one task. Requires
+      project_gid from the projects table.
+    guide: |
+      Requires project_gid (gid from asana.projects). Filter completed = false
+      to see only open tasks. due_on and due_at are independent — due_on is
+      for date-only due dates while due_at carries a time component.
+      assignee_gid joins back to any people/members table.
+    filters:
+      - name: project_gid
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_gid}}/tasks
+      query:
+        - name: opt_fields
+          from: literal
+          value: gid,name,completed,completed_at,due_on,due_at,start_on,start_at,created_at,modified_at,notes,assignee.gid,assignee.name,resource_type,resource_subtype
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: cursor_query
+      cursor_param: offset
+      response_cursor_path:
+        - next_page
+        - offset
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: gid
+        type: Utf8
+        nullable: false
+        description: Globally unique identifier for the task.
+        expr:
+          kind: path
+          path:
+            - gid
+      - name: project_gid
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Project GID passed as the required filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: project_gid
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The name of the task.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: completed
+        type: Boolean
+        nullable: true
+        description: Whether the task is completed.
+        expr:
+          kind: path
+          path:
+            - completed
+      - name: completed_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the task was completed. Null if not yet completed.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - completed_at
+      - name: due_on
+        type: Utf8
+        nullable: true
+        description: Date-only due date in YYYY-MM-DD format. Null when a time-specific due_at is set.
+        expr:
+          kind: path
+          path:
+            - due_on
+      - name: due_at
+        type: Timestamp
+        nullable: true
+        description: Due date with time component. Null when only a date-level due_on is set.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - due_at
+      - name: start_on
+        type: Utf8
+        nullable: true
+        description: Date-only start date in YYYY-MM-DD format.
+        expr:
+          kind: path
+          path:
+            - start_on
+      - name: start_at
+        type: Timestamp
+        nullable: true
+        description: Start date with time component.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - start_at
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the task was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: modified_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the task was last modified.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - modified_at
+      - name: notes
+        type: Utf8
+        nullable: true
+        description: Free-form text description of the task.
+        expr:
+          kind: path
+          path:
+            - notes
+      - name: assignee_gid
+        type: Utf8
+        nullable: true
+        description: GID of the user assigned to this task. Null if unassigned.
+        expr:
+          kind: path
+          path:
+            - assignee
+            - gid
+      - name: assignee_name
+        type: Utf8
+        nullable: true
+        description: Display name of the assigned user. Null if unassigned.
+        expr:
+          kind: path
+          path:
+            - assignee
+            - name
+      - name: resource_type
+        type: Utf8
+        nullable: true
+        description: Resource type (always "task" for this table).
+        expr:
+          kind: path
+          path:
+            - resource_type
+      - name: resource_subtype
+        type: Utf8
+        nullable: true
+        description: >-
+          Task subtype (default_task, milestone, section, or approval).
+          Filter on this column to isolate milestones or approvals.
+        expr:
+          kind: path
+          path:
+            - resource_subtype
+
+  # ────────────────────────────────────────────────────────────────────────────
+  # sections — sections within a specific project
+  # ────────────────────────────────────────────────────────────────────────────
+  - name: sections
+    description: >-
+      Sections (columns or swim-lanes) within a specific Asana project.
+      Each row is one section. Requires project_gid from the projects table.
+    guide: |
+      Requires project_gid (gid from asana.projects). Sections represent
+      the grouping columns within a project board or list view. created_at
+      can be used to order sections chronologically.
+    filters:
+      - name: project_gid
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_gid}}/sections
+      query:
+        - name: opt_fields
+          from: literal
+          value: gid,name,created_at
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: cursor_query
+      cursor_param: offset
+      response_cursor_path:
+        - next_page
+        - offset
+      page_size:
+        default: 100
+        max: 100
+        query_param: limit
+    columns:
+      - name: gid
+        type: Utf8
+        nullable: false
+        description: Globally unique identifier for the section.
+        expr:
+          kind: path
+          path:
+            - gid
+      - name: project_gid
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Project GID passed as the required filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: project_gid
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The name of the section.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the section was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at


### PR DESCRIPTION
Closes #735

Adds a community source for Asana that supports querying workspaces,
projects, tasks, and sections via the Asana REST API v1.0.

## Authentication

Supports two methods via a single `ASANA_TOKEN` secret input:

- **OAuth 2.0** — Authorization Code Grant, `pkce: disabled`,
  `transport: request_body`. Users create an app at
  `https://app.asana.com/0/my-apps`, set the redirect URI to
  `http://127.0.0.1:53682/oauth/callback`, and authorize via the
  browser. Scope: `default`.
- **Personal Access Token** — `source_config` fallback for headless
  and CI use cases. Generate a PAT from the Asana Developer Console.

## Tables

| Table | Endpoint | Required filter | Optional filter |
|---|---|---|---|
| `workspaces` | `GET /workspaces` | — | — |
| `projects` | `GET /projects` | — | `workspace_gid` |
| `tasks` | `GET /projects/{project_gid}/tasks` | `project_gid` | — |
| `sections` | `GET /projects/{project_gid}/sections` | `project_gid` | — |

Typical query flow: `workspaces` → `projects` (filter by `workspace_gid`) → `tasks` / `sections` (filter by `project_gid`).

## Design notes

- All four tables use `cursor_query` pagination on `next_page.offset`
  (Asana's opaque offset token), `limit=100` per page.
- `opt_fields` is hardcoded as a `from: literal` query param on every
  table so only declared columns are fetched — no over-fetching.
- `Asana-Enable: new_user_task_lists` is set as a global
  `request_header` per Asana's API deprecation requirements.
- `tasks.project_gid` and `sections.project_gid` are `virtual: true`
  filter-echo columns (matching the Bitbucket community source pattern).
- `tasks.due_on` (date string) and `tasks.due_at` (timestamp) are
  modelled separately — Asana sets one or the other, never both.
- `resource_subtype` on tasks lets users filter milestones
  (`milestone`) and approvals (`approval`) locally.

## Checklist

- [x] `manifest.yaml` passes `make lint-sources`
- [x] Structure verified: 3 inputs, 4 tables, 5 test queries, correct `virtual: true` on filter-echo columns
- [x] Cross-checked against `bitbucket`, `google_calendar`, `google_drive`, `launchdarkly`, `intercom`, `sentry`
- [x] `README.md` mirrors `sources/community/dub/README.md` structure
- [x] No Rust changes — `make rust-checks` not required
- [x] `docs-check` skips community sources — no generated doc update needed
