### PR TITLE
feat(sources/community/jsonplaceholder): add JSONPlaceholder source

### DIFF
--- a/sources/community/jsonplaceholder/README.md
+++ b/sources/community/jsonplaceholder/README.md
@@ -1,0 +1,75 @@
+# JSONPlaceholder
+
+Query fake JSON data from [JSONPlaceholder](https://jsonplaceholder.typicode.com/). This source is useful for testing, prototyping, and demonstrating SQL capabilities with a simple REST API.
+
+## Tables
+
+| Table      | Description                                                                 |
+| ---------- | --------------------------------------------------------------------------- |
+| `users`    | Retrieve a list of 10 fake users.                                           |
+| `posts`    | Retrieve 100 fake posts. Can be filtered by `user_id_filter`.               |
+| `todos`    | Retrieve 200 fake todos. Can be filtered by `user_id_filter`.               |
+
+## Filters
+
+| Filter             | Required | Description                                     |
+| ------------------ | -------- | ----------------------------------------------- |
+| `user_id_filter`   | No       | Filter posts or todos by a specific `userId`.   |
+
+## Example queries
+
+```sql
+-- Retrieve the first 5 users
+SELECT id, name, username, email 
+FROM jsonplaceholder.users 
+LIMIT 5;
+
+/*
++----+------------------+-----------+---------------------------+
+| id | name             | username  | email                     |
++----+------------------+-----------+---------------------------+
+| 1  | Leanne Graham    | Bret      | Sincere@april.biz         |
+| 2  | Ervin Howell     | Antonette | Shanna@melissa.tv         |
+| 3  | Clementine Bauch | Samantha  | Nathan@yesenia.net        |
+| 4  | Patricia Lebsack | Karianne  | Julianne.OConner@kory.org |
+| 5  | Chelsey Dietrich | Kamren    | Lucio_Hettinger@annie.ca  |
++----+------------------+-----------+---------------------------+
+*/
+
+-- Retrieve posts for a specific user
+SELECT id, title, body 
+FROM jsonplaceholder.posts 
+WHERE user_id_filter = 2 
+LIMIT 2;
+
+/*
++----+---------------------------------------+-----------------------------------------------------------------------------+
+| id | title                                 | body                                                                        |
++----+---------------------------------------+-----------------------------------------------------------------------------+
+| 11 | et ea vero quia laudantium autem      | delectus reiciendis molestiae occaecati non minima eveniet qui voluptatibus |
+|    |                                       | accusamus in eum beatae sit                                                 |
+|    |                                       | vel qui neque voluptates ut commodi qui incidunt                            |
+|    |                                       | ut animi commodi                                                            |
+| 12 | in quibusdam tempore odit est dolorem | itaque id aut magnam                                                        |
+|    |                                       | praesentium quia et ea odit et ea voluptas et                               |
+|    |                                       | sapiente quia nihil amet occaecati quia id voluptatem                       |
+|    |                                       | incidunt ea est distinctio odio                                             |
++----+---------------------------------------+-----------------------------------------------------------------------------+
+*/
+
+-- Retrieve todos for a specific user
+SELECT id, title, completed 
+FROM jsonplaceholder.todos 
+WHERE user_id_filter = 1 
+LIMIT 3;
+
+/*
++----+------------------------------------+-----------+
+| id | title                              | completed |
++----+------------------------------------+-----------+
+| 1  | delectus aut autem                 | false     |
+| 2  | quis ut nam facilis et officia qui | false     |
+| 3  | fugiat veniam minus                | false     |
++----+------------------------------------+-----------+
+*/
+```

--- a/sources/community/jsonplaceholder/README.md
+++ b/sources/community/jsonplaceholder/README.md
@@ -2,19 +2,25 @@
 
 Query fake JSON data from [JSONPlaceholder](https://jsonplaceholder.typicode.com/). This source is useful for testing, prototyping, and demonstrating SQL capabilities with a simple REST API.
 
+```bash
+coral source add --file sources/community/jsonplaceholder/manifest.yaml
+```
+
 ## Tables
 
 | Table      | Description                                                                 |
 | ---------- | --------------------------------------------------------------------------- |
 | `users`    | Retrieve a list of 10 fake users.                                           |
 | `posts`    | Retrieve 100 fake posts. Can be filtered by `user_id_filter`.               |
+| `comments` | Retrieve fake comments. Can be filtered by `post_id_filter`.                |
 | `todos`    | Retrieve 200 fake todos. Can be filtered by `user_id_filter`.               |
 
 ## Filters
 
 | Filter             | Required | Description                                     |
 | ------------------ | -------- | ----------------------------------------------- |
-| `user_id_filter`   | No       | Filter posts or todos by a specific `userId`.   |
+| `user_id_filter`   | No       | Filter posts or todos by a specific `userId`. Note: this is an echoed filter column, not a provider field. |
+| `post_id_filter`   | No       | Filter comments by a specific `postId`. Note: this is an echoed filter column, not a provider field. |
 
 ## Example queries
 
@@ -72,4 +78,59 @@ LIMIT 3;
 | 3  | fugiat veniam minus                | false     |
 +----+------------------------------------+-----------+
 */
+```
+
+## Local Testing
+
+```bash
+coral source add --file sources/community/jsonplaceholder/manifest.yaml
+# Added source jsonplaceholder
+# 
+#   ✓ jsonplaceholder connected successfully
+# 
+#     jsonplaceholder (4 tables)
+#     ├─ comments
+#     ├─ posts
+#     ├─ todos
+#     └─ users
+#     Query tests
+#     3 declared · 3 passed · 0 failed
+# 
+#     ✓ SELECT id, name, email FROM jsonplaceholder.users LIMIT 1
+#       1 row
+# 
+#     ✓ SELECT id, title, completed FROM jsonplaceholder.todos WHERE user_id_filter = 1 LIMIT 1
+#       1 row
+# 
+#     ✓ SELECT id, name, email FROM jsonplaceholder.comments WHERE post_id_filter = 1 LIMIT 1
+#       1 row
+
+coral source test jsonplaceholder
+#   ✓ jsonplaceholder connected successfully
+# 
+#     jsonplaceholder (4 tables)
+#     ├─ comments
+#     ├─ posts
+#     ├─ todos
+#     └─ users
+#     Query tests
+#     3 declared · 3 passed · 0 failed
+# 
+#     ✓ SELECT id, name, email FROM jsonplaceholder.users LIMIT 1
+#       1 row
+# 
+#     ✓ SELECT id, title, completed FROM jsonplaceholder.todos WHERE user_id_filter = 1 LIMIT 1
+#       1 row
+# 
+#     ✓ SELECT id, name, email FROM jsonplaceholder.comments WHERE post_id_filter = 1 LIMIT 1
+#       1 row
+
+coral sql "SELECT id, title, completed FROM jsonplaceholder.todos WHERE user_id_filter = 1 LIMIT 3"
+# +----+------------------------------------+-----------+
+# | id | title                              | completed |
+# +----+------------------------------------+-----------+
+# | 1  | delectus aut autem                 | false     |
+# | 2  | quis ut nam facilis et officia qui | false     |
+# | 3  | fugiat veniam minus                | false     |
+# +----+------------------------------------+-----------+
 ```

--- a/sources/community/jsonplaceholder/manifest.yaml
+++ b/sources/community/jsonplaceholder/manifest.yaml
@@ -1,0 +1,127 @@
+name: jsonplaceholder
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query fake data from JSONPlaceholder (jsonplaceholder.typicode.com).
+  Provides users, posts, comments, and todos.
+base_url: https://jsonplaceholder.typicode.com
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name, email FROM jsonplaceholder.users LIMIT 1
+  - SELECT id, title, completed FROM jsonplaceholder.todos WHERE user_id_filter = 1 LIMIT 1
+
+tables:
+  # ─────────────────────────────────────────────────────────────
+  # users
+  # ─────────────────────────────────────────────────────────────
+  - name: users
+    description: Get all users. Returns 10 fake users.
+    fetch_limit_default: 10
+    request:
+      method: GET
+      path: /users
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+      - name: name
+        type: Utf8
+      - name: username
+        type: Utf8
+      - name: email
+        type: Utf8
+      - name: phone
+        type: Utf8
+      - name: website
+        type: Utf8
+
+  # ─────────────────────────────────────────────────────────────
+  # posts
+  # ─────────────────────────────────────────────────────────────
+  - name: posts
+    description: Get fake posts. Use user_id_filter to filter by user.
+    fetch_limit_default: 10
+    filters:
+      - name: user_id_filter
+    request:
+      method: GET
+      path: /posts
+      query:
+        - name: userId
+          from: filter
+          key: user_id_filter
+    pagination:
+      mode: page
+      page_param: _page
+      page_size:
+        default: 10
+        max: 100
+        query_param: _limit
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+      - name: user_id
+        type: Int64
+        expr:
+          kind: path
+          path: [userId]
+      - name: title
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: user_id_filter
+        type: Int64
+        virtual: true
+        description: Echoes the user_id filter value.
+        expr:
+          kind: from_filter
+          key: user_id_filter
+
+  # ─────────────────────────────────────────────────────────────
+  # todos
+  # ─────────────────────────────────────────────────────────────
+  - name: todos
+    description: Get fake todos. Use user_id_filter to filter by user.
+    fetch_limit_default: 10
+    filters:
+      - name: user_id_filter
+    request:
+      method: GET
+      path: /todos
+      query:
+        - name: userId
+          from: filter
+          key: user_id_filter
+    pagination:
+      mode: page
+      page_param: _page
+      page_size:
+        default: 10
+        max: 100
+        query_param: _limit
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+      - name: user_id
+        type: Int64
+        expr:
+          kind: path
+          path: [userId]
+      - name: title
+        type: Utf8
+      - name: completed
+        type: Boolean
+      - name: user_id_filter
+        type: Int64
+        virtual: true
+        description: Echoes the user_id filter value.
+        expr:
+          kind: from_filter
+          key: user_id_filter

--- a/sources/community/jsonplaceholder/manifest.yaml
+++ b/sources/community/jsonplaceholder/manifest.yaml
@@ -14,6 +14,7 @@ request_headers:
 test_queries:
   - SELECT id, name, email FROM jsonplaceholder.users LIMIT 1
   - SELECT id, title, completed FROM jsonplaceholder.todos WHERE user_id_filter = 1 LIMIT 1
+  - SELECT id, name, email FROM jsonplaceholder.comments WHERE post_id_filter = 1 LIMIT 1
 
 tables:
   # ─────────────────────────────────────────────────────────────
@@ -57,6 +58,7 @@ tables:
           key: user_id_filter
     pagination:
       mode: page
+      page_start: 1
       page_param: _page
       page_size:
         default: 10
@@ -84,6 +86,52 @@ tables:
           key: user_id_filter
 
   # ─────────────────────────────────────────────────────────────
+  # comments
+  # ─────────────────────────────────────────────────────────────
+  - name: comments
+    description: Get fake comments. Use post_id_filter to filter by post.
+    fetch_limit_default: 10
+    filters:
+      - name: post_id_filter
+    request:
+      method: GET
+      path: /comments
+      query:
+        - name: postId
+          from: filter
+          key: post_id_filter
+    pagination:
+      mode: page
+      page_start: 1
+      page_param: _page
+      page_size:
+        default: 10
+        max: 100
+        query_param: _limit
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+      - name: post_id
+        type: Int64
+        expr:
+          kind: path
+          path: [postId]
+      - name: name
+        type: Utf8
+      - name: email
+        type: Utf8
+      - name: body
+        type: Utf8
+      - name: post_id_filter
+        type: Int64
+        virtual: true
+        description: Echoes the post_id filter value.
+        expr:
+          kind: from_filter
+          key: post_id_filter
+
+  # ─────────────────────────────────────────────────────────────
   # todos
   # ─────────────────────────────────────────────────────────────
   - name: todos
@@ -100,6 +148,7 @@ tables:
           key: user_id_filter
     pagination:
       mode: page
+      page_start: 1
       page_param: _page
       page_size:
         default: 10


### PR DESCRIPTION
## Overview

This pull request introduces **JSONPlaceholder** as a new community source for Coral. JSONPlaceholder is a popular free fake REST API for testing and prototyping. Adding this source provides users with a zero-setup, zero-auth environment to explore Coral's capabilities and test standard SQL queries over REST endpoints.

Fixes #839

## Key Changes

* **Source Manifest (`manifest.yaml`)**:
  * Implemented mapping for 3 core JSONPlaceholder entities: `users` (10 rows), `posts` (100 rows), and `todos` (200 rows).
  * **Filter Pushdown**: Mapped `user_id_filter` for both the `posts` and `todos` endpoints to seamlessly push queries down to the API's `?userId=` query parameter filtering.
  * **Pagination Support**: Fully integrated pagination for API parity using the native `_page` and `_limit` query parameters via Coral's `page` mode.
* **Documentation (`README.md`)**:
  * Provided an overview of the mapped endpoints.
  * Included sample SQL queries demonstrating filter use and limit enforcement.
  * Authored sample output tables mapped exactly from CLI `coral sql` execution for transparent output visualization.

## Testing Performed

* **Local Validation**: Verified using `coral source lint` via the WSL environment; all schema and structure checks returned completely valid.
* **Query Execution**: Successfully connected the source via `coral source add` and executed complex queries via `coral sql`. All filter bindings and payload extraction tests succeeded efficiently.