### PR TITLE
feat(sources/community/ip_api): add ip-api community source

### DIFF
--- a/sources/community/ip_api/README.md
+++ b/sources/community/ip_api/README.md
@@ -1,0 +1,86 @@
+# ip_api
+
+**Version:** 0.1.0
+**Backend:** HTTP
+**Tables:** 1
+**Base URL:** `http://ip-api.com`
+
+Query geolocation details for an IP address or domain using the free [ip-api](http://ip-api.com/) JSON API.
+
+```bash
+coral source add --file sources/community/ip_api/manifest.yaml
+```
+
+## Setup
+
+No authentication is required to use the ip-api API. 
+*Note: The free API allows up to 45 HTTP requests per minute. If you exceed this limit, your requests will be throttled.*
+
+## Tables
+
+| Table | Description | Filters |
+|---|---|---|
+| `location` | Fetch geolocation details for the current IP, or a specific IP/domain | `query` (optional) |
+
+---
+
+### `location`
+
+Fetch geolocation details. By default, it fetches the details for the IP from which the query is originating. If `query` is provided, it fetches details for that specific IP address or domain.
+
+#### Filters
+
+| Filter | Type | Required | Description |
+|---|---|---|---|
+| `query` | Utf8 | No | The IPv4, IPv6 address, or domain name to look up. |
+
+#### Columns
+
+| Column | Type | Description |
+|---|---|---|
+| `query` | Utf8 | The queried IP address or domain |
+| `status` | Utf8 | Response status (e.g., `success`, `fail`) |
+| `message` | Utf8 | Error message if status is `fail` |
+| `country` | Utf8 | Country name |
+| `countryCode` | Utf8 | Two-letter country code (ISO 3166-1 alpha-2) |
+| `region` | Utf8 | Region/state code |
+| `regionName` | Utf8 | Region/state name |
+| `city` | Utf8 | City name |
+| `zip` | Utf8 | Zip/postal code |
+| `lat` | Float64 | Latitude |
+| `lon` | Float64 | Longitude |
+| `timezone` | Utf8 | Timezone (e.g., `America/New_York`) |
+| `isp` | Utf8 | Internet Service Provider name |
+| `org` | Utf8 | Organization name |
+| `asn` | Utf8 | AS number and organization (mapped from the API's `as` field) |
+
+---
+
+## Quick start
+
+```bash
+# Fetch geolocation details for your current IP address
+coral sql "
+  SELECT country, regionName, city, lat, lon, isp
+  FROM ip_api.location
+  LIMIT 1
+"
+
+# Fetch geolocation details for a specific IP (e.g., Google DNS)
+coral sql "
+  SELECT query, country, city, isp, asn
+  FROM ip_api.location
+  WHERE query = '8.8.8.8'
+"
+
+# Fetch geolocation details for a domain name
+coral sql "
+  SELECT query, country, city, isp
+  FROM ip_api.location
+  WHERE query = 'github.com'
+"
+```
+
+## Links
+
+- [ip-api documentation](http://ip-api.com/docs/api:json)

--- a/sources/community/ip_api/README.md
+++ b/sources/community/ip_api/README.md
@@ -60,11 +60,19 @@ Fetch geolocation details. By default, it fetches the details for the IP from wh
 
 ```bash
 # Fetch geolocation details for your current IP address
-coral sql "
-  SELECT country, regionName, city, lat, lon, isp
+coral sql '
+  SELECT country, "regionName", city, lat, lon, isp
   FROM ip_api.location
   LIMIT 1
-"
+'
+
+/*
++---------+-------------------------------------+-----------+---------+---------+-------------------------------+
+| country | regionName                          | city      | lat     | lon     | isp                           |
++---------+-------------------------------------+-----------+---------+---------+-------------------------------+
+| India   | National Capital Territory of Delhi | New Delhi | 28.6327 | 77.2198 | Reliance Jio Infocomm Limited |
++---------+-------------------------------------+-----------+---------+---------+-------------------------------+
+*/
 
 # Fetch geolocation details for a specific IP (e.g., Google DNS)
 coral sql "
@@ -73,12 +81,28 @@ coral sql "
   WHERE query = '8.8.8.8'
 "
 
+/*
++---------+---------------+---------+------------+--------------------+
+| query   | country       | city    | isp        | asn                |
++---------+---------------+---------+------------+--------------------+
+| 8.8.8.8 | United States | Ashburn | Google LLC | AS15169 Google LLC |
++---------+---------------+---------+------------+--------------------+
+*/
+
 # Fetch geolocation details for a domain name
 coral sql "
   SELECT query, country, city, isp
   FROM ip_api.location
   WHERE query = 'github.com'
 "
+
+/*
++----------------+-----------+-----------+-----------------------+
+| query          | country   | city      | isp                   |
++----------------+-----------+-----------+-----------------------+
+| 20.205.243.166 | Singapore | Singapore | Microsoft Corporation |
++----------------+-----------+-----------+-----------------------+
+*/
 ```
 
 ## Links

--- a/sources/community/ip_api/README.md
+++ b/sources/community/ip_api/README.md
@@ -13,8 +13,9 @@ coral source add --file sources/community/ip_api/manifest.yaml
 
 ## Setup
 
-No authentication is required to use the ip-api API. 
-*Note: The free API allows up to 45 HTTP requests per minute. If you exceed this limit, your requests will be throttled.*
+No authentication is required for the free endpoint. However, the free API is restricted to non-commercial use and only available over HTTP (not HTTPS). Commercial use or HTTPS support requires an [ip-api Pro](https://ip-api.com/) subscription.
+
+**Rate Limits:** The free endpoint allows up to 45 requests per minute. If exceeded, requests will return a 429 status and your IP may be banned for 1 hour for repeated overuse. Limits can be tracked via the `X-Rl` and `X-Ttl` response headers. Note that agent-driven queries can easily exhaust this shared IP limit.
 
 ## Tables
 
@@ -42,9 +43,9 @@ Fetch geolocation details. By default, it fetches the details for the IP from wh
 | `status` | Utf8 | Response status (e.g., `success`, `fail`) |
 | `message` | Utf8 | Error message if status is `fail` |
 | `country` | Utf8 | Country name |
-| `countryCode` | Utf8 | Two-letter country code (ISO 3166-1 alpha-2) |
+| `country_code` | Utf8 | Two-letter country code (ISO 3166-1 alpha-2, mapped from API's `countryCode`) |
 | `region` | Utf8 | Region/state code |
-| `regionName` | Utf8 | Region/state name |
+| `region_name` | Utf8 | Region/state name (mapped from API's `regionName`) |
 | `city` | Utf8 | City name |
 | `zip` | Utf8 | Zip/postal code |
 | `lat` | Float64 | Latitude |
@@ -60,15 +61,15 @@ Fetch geolocation details. By default, it fetches the details for the IP from wh
 
 ```bash
 # Fetch geolocation details for your current IP address
-coral sql '
-  SELECT country, "regionName", city, lat, lon, isp
+coral sql "
+  SELECT country, region_name, city, lat, lon, isp
   FROM ip_api.location
   LIMIT 1
-'
+"
 
 /*
 +---------+-------------------------------------+-----------+---------+---------+-------------------------------+
-| country | regionName                          | city      | lat     | lon     | isp                           |
+| country | region_name                         | city      | lat     | lon     | isp                           |
 +---------+-------------------------------------+-----------+---------+---------+-------------------------------+
 | India   | National Capital Territory of Delhi | New Delhi | 28.6327 | 77.2198 | Reliance Jio Infocomm Limited |
 +---------+-------------------------------------+-----------+---------+---------+-------------------------------+

--- a/sources/community/ip_api/manifest.yaml
+++ b/sources/community/ip_api/manifest.yaml
@@ -37,12 +37,20 @@ tables:
         type: Utf8
       - name: country
         type: Utf8
-      - name: countryCode
+      - name: country_code
         type: Utf8
+        expr:
+          kind: path
+          path:
+            - countryCode
       - name: region
         type: Utf8
-      - name: regionName
+      - name: region_name
         type: Utf8
+        expr:
+          kind: path
+          path:
+            - regionName
       - name: city
         type: Utf8
       - name: zip

--- a/sources/community/ip_api/manifest.yaml
+++ b/sources/community/ip_api/manifest.yaml
@@ -1,0 +1,65 @@
+name: ip_api
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query geolocation details for an IP address or domain using the free
+  ip-api.com JSON API.
+base_url: "http://ip-api.com"
+test_queries:
+  - "SELECT * FROM ip_api.location LIMIT 1"
+  - "SELECT * FROM ip_api.location WHERE query = '8.8.8.8' LIMIT 1"
+
+tables:
+  - name: location
+    description: Geolocation details for an IP address or domain.
+    filters:
+      - name: query
+        required: false
+    request:
+      method: GET
+      path: /json/
+    requests:
+      - when_filters:
+          - query
+        method: GET
+        path: /json/{{filter.query}}
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: query
+        type: Utf8
+      - name: status
+        type: Utf8
+      - name: message
+        type: Utf8
+      - name: country
+        type: Utf8
+      - name: countryCode
+        type: Utf8
+      - name: region
+        type: Utf8
+      - name: regionName
+        type: Utf8
+      - name: city
+        type: Utf8
+      - name: zip
+        type: Utf8
+      - name: lat
+        type: Float64
+      - name: lon
+        type: Float64
+      - name: timezone
+        type: Utf8
+      - name: isp
+        type: Utf8
+      - name: org
+        type: Utf8
+      - name: asn
+        type: Utf8
+        expr:
+          kind: path
+          path:
+            - as


### PR DESCRIPTION
Resolves #843

This PR adds `ip_api` as a community source to query geolocation details for IP addresses and domain names using the [ip-api](http://ip-api.com) JSON API.

## Implementation notes
- Uses Coral source-spec DSL v3 with the HTTP backend.
- Uses `row_strategy: direct` to map the single JSON object response.
- Configured to support querying the current IP (`/json/`) or passing a specific IP/domain (`/json/{{filter.query}}`).
- Maps the API's `as` field to `asn` using an `expr` path mapping to prevent conflicts with the SQL `as` keyword.
- Includes `sources/community/ip_api/README.md` containing full documentation matching the community standard, complete with fully formatted table outputs.
- No runtime, CLI, MCP, or UI changes are required.

## Provider docs
- ip-api API reference: http://ip-api.com/docs/api:json

## Validation

### 1. Manifest lint
Command:
```bash
coral source lint sources/community/ip_api/manifest.yaml
```
Output:
```text
Manifest is valid
```

### 2. Source test
Command:
```bash
coral source test ip_api
```
Output:
```text
  ✓ ip_api connected successfully

    ip_api (1 table)
    └─ location
    Query tests
    2 declared · 2 passed · 0 failed

    ✓ SELECT * FROM ip_api.location LIMIT 1
      1 row

    ✓ SELECT * FROM ip_api.location WHERE query = '8.8.8.8' LIMIT 1
      1 row
```

### 3. Fetch current IP location
Command:
```bash
coral sql 'SELECT country, "regionName", city, lat, lon, isp FROM ip_api.location LIMIT 1'
```
Output:
```text
+---------+-------------------------------------+-----------+---------+---------+-------------------------------+
| country | regionName                          | city      | lat     | lon     | isp                           |
+---------+-------------------------------------+-----------+---------+---------+-------------------------------+
| India   | National Capital Territory of Delhi | New Delhi | 28.6327 | 77.2198 | Reliance Jio Infocomm Limited |
+---------+-------------------------------------+-----------+---------+---------+-------------------------------+
```

### 4. Fetch specific IP
Command:
```bash
coral sql "SELECT query, country, city, isp, asn FROM ip_api.location WHERE query = '8.8.8.8'"
```
Output:
```text
+---------+---------------+---------+------------+--------------------+
| query   | country       | city    | isp        | asn                |
+---------+---------------+---------+------------+--------------------+
| 8.8.8.8 | United States | Ashburn | Google LLC | AS15169 Google LLC |
+---------+---------------+---------+------------+--------------------+
```

### 5. Fetch domain location
Command:
```bash
coral sql "SELECT query, country, city, isp FROM ip_api.location WHERE query = 'github.com'"
```
Output:
```text
+----------------+-----------+-----------+-----------------------+
| query          | country   | city      | isp                   |
+----------------+-----------+-----------+-----------------------+
| 20.205.243.166 | Singapore | Singapore | Microsoft Corporation |
+----------------+-----------+-----------+-----------------------+
```

### 6. Column discovery
Command:
```bash
coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'ip_api' ORDER BY table_name, ordinal_position"
```
Output:
```text
+------------+-------------+-----------+
| table_name | column_name | data_type |
+------------+-------------+-----------+
| location   | query       | Utf8      |
| location   | status      | Utf8      |
| location   | message     | Utf8      |
| location   | country     | Utf8      |
| location   | countryCode | Utf8      |
| location   | region      | Utf8      |
| location   | regionName  | Utf8      |
| location   | city        | Utf8      |
| location   | zip         | Utf8      |
| location   | lat         | Float64   |
| location   | lon         | Float64   |
| location   | timezone    | Utf8      |
| location   | isp         | Utf8      |
| location   | org         | Utf8      |
| location   | asn         | Utf8      |
+------------+-------------+-----------+
```