### PR TITLE
feat(sources/community/open-notify): add Open Notify (ISS) source

### DIFF
--- a/sources/community/open-notify/README.md
+++ b/sources/community/open-notify/README.md
@@ -1,0 +1,40 @@
+# Open Notify (ISS)
+
+Real-time data about the International Space Station and astronauts in space from [Open Notify](http://open-notify.org/Open-Notify-API/).
+
+## Setup
+
+No authentication is required. Add the source:
+
+```bash
+coral source add --file sources/community/open-notify/manifest.yaml
+```
+
+## Local Testing
+
+```bash
+coral sql "
+  SELECT name, craft 
+  FROM open_notify.astronauts 
+  LIMIT 5
+"
+
+/*
++----------------------+-------+
+| name                 | craft |
++----------------------+-------+
+| Oleg Kononenko       | ISS   |
+| Nikolai Chub         | ISS   |
+| Tracy Caldwell Dyson | ISS   |
+| Matthew Dominick     | ISS   |
+| Michael Barratt      | ISS   |
++----------------------+-------+
+*/
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `iss_position` | Current geographic location of the International Space Station. |
+| `astronauts` | List of astronauts currently in space. |

--- a/sources/community/open-notify/manifest.yaml
+++ b/sources/community/open-notify/manifest.yaml
@@ -1,0 +1,73 @@
+name: open_notify
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Real-time data about the International Space Station and astronauts in space from Open Notify.
+base_url: http://api.open-notify.org
+test_queries:
+  - SELECT latitude, longitude FROM open_notify.iss_position LIMIT 1
+  - SELECT name, craft FROM open_notify.astronauts LIMIT 5
+tables:
+  - name: iss_position
+    description: Current geographic location of the International Space Station.
+    request:
+      method: GET
+      path: /iss-now.json
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: timestamp
+        type: Int64
+        nullable: false
+        description: Unix timestamp of the position data.
+        expr:
+          kind: path
+          path:
+            - timestamp
+      - name: latitude
+        type: Utf8
+        nullable: false
+        description: Current latitude of the ISS.
+        expr:
+          kind: path
+          path:
+            - iss_position
+            - latitude
+      - name: longitude
+        type: Utf8
+        nullable: false
+        description: Current longitude of the ISS.
+        expr:
+          kind: path
+          path:
+            - iss_position
+            - longitude
+
+  - name: astronauts
+    description: List of astronauts currently in space.
+    request:
+      method: GET
+      path: /astros.json
+    response:
+      rows_path:
+        - people
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Name of the astronaut.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: craft
+        type: Utf8
+        nullable: false
+        description: Spacecraft the astronaut is aboard.
+        expr:
+          kind: path
+          path:
+            - craft

--- a/sources/community/open-notify/manifest.yaml
+++ b/sources/community/open-notify/manifest.yaml
@@ -26,7 +26,7 @@ tables:
           path:
             - timestamp
       - name: latitude
-        type: Utf8
+        type: Float64
         nullable: false
         description: Current latitude of the ISS.
         expr:
@@ -35,7 +35,7 @@ tables:
             - iss_position
             - latitude
       - name: longitude
-        type: Utf8
+        type: Float64
         nullable: false
         description: Current longitude of the ISS.
         expr:


### PR DESCRIPTION
## Summary
This PR adds a new community source for **Open Notify**, an API that provides real-time data about the International Space Station (ISS) and astronauts currently in space.

## Tables Added
- **`iss_position`**: Retrieves the current latitude and longitude of the ISS, along with a UNIX timestamp. The API endpoint (`/iss-now.json`) returns a single JSON object rather than a list, which Coral correctly processes into a single row using `response: {}` and `pagination: mode: none`.
- **`astronauts`**: Retrieves a list of astronauts currently in space, including their name and the spacecraft they are aboard (e.g., "ISS"). This endpoint (`/astros.json`) maps the `people` array via `rows_path: [people]`.

## Implementation Details
- **Authentication**: No authentication is required for this API.
- **Pagination**: Set to `mode: none` since the API only returns a real-time snapshot of current data without paginated lists.
- **Testing**: SQL queries were declared in `test_queries` to ensure both tables execute properly.

## Verification
Locally tested and linted with `coral source lint` and `coral source test`. The source was successfully added and verified via CLI:
```sql
SELECT name, craft FROM open_notify.astronauts LIMIT 5;
```
```text
+----------------------+-------+
| name                 | craft |
+----------------------+-------+
| Oleg Kononenko       | ISS   |
| Nikolai Chub         | ISS   |
| Tracy Caldwell Dyson | ISS   |
| Matthew Dominick     | ISS   |
| Michael Barratt      | ISS   |
+----------------------+-------+
```