### PR TITLE
feat(sources/community/advice-slip): add Advice Slip source

### DIFF
--- a/sources/community/advice-slip/README.md
+++ b/sources/community/advice-slip/README.md
@@ -1,0 +1,37 @@
+# Advice Slip
+
+Generate random advice or search for specific advice using the [Advice Slip API](https://api.adviceslip.com/).
+
+## Setup
+
+No authentication is required. Add the source:
+
+```bash
+coral source add --file sources/community/advice-slip/manifest.yaml
+```
+
+## Local Testing
+
+```bash
+coral sql "
+  SELECT id, advice 
+  FROM advice_slip.advices 
+  WHERE query = 'spiders' 
+  LIMIT 1
+"
+
+/*
++----+---------------------------------------------------------------------+
+| id | advice                                                              |
++----+---------------------------------------------------------------------+
+| 1  | Remember that spiders are more afraid of you, than you are of them. |
++----+---------------------------------------------------------------------+
+*/
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `random_advice` | Get a single random piece of advice. |
+| `advices` | Search for advice containing a specific keyword via the `query` filter. |

--- a/sources/community/advice-slip/manifest.yaml
+++ b/sources/community/advice-slip/manifest.yaml
@@ -1,0 +1,83 @@
+name: advice_slip
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Generate random advice or search for specific advice using the Advice Slip API.
+base_url: https://api.adviceslip.com
+test_queries:
+  - SELECT id, advice FROM advice_slip.random_advice LIMIT 1
+  - SELECT id, advice, date FROM advice_slip.advices WHERE query = 'spiders' LIMIT 1
+tables:
+  - name: random_advice
+    description: Get a single random piece of advice.
+    request:
+      method: GET
+      path: /advice
+    response: {}
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique ID of the advice slip.
+        expr:
+          kind: path
+          path:
+            - slip
+            - id
+      - name: advice
+        type: Utf8
+        nullable: false
+        description: The advice text.
+        expr:
+          kind: path
+          path:
+            - slip
+            - advice
+
+  - name: advices
+    description: Search for advice containing a specific keyword.
+    filters:
+      - name: query
+        required: true
+    request:
+      method: GET
+      path: /advice/search/{{filter.query}}
+    response:
+      rows_path:
+        - slips
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique ID of the advice slip.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: advice
+        type: Utf8
+        nullable: false
+        description: The advice text.
+        expr:
+          kind: path
+          path:
+            - advice
+      - name: date
+        type: Utf8
+        nullable: true
+        description: Date the advice was added (YYYY-MM-DD).
+        expr:
+          kind: path
+          path:
+            - date
+      - name: query
+        type: Utf8
+        nullable: true
+        description: The query used to search for this advice.
+        expr:
+          kind: from_filter
+          key: query


### PR DESCRIPTION
## Summary
This PR adds a new community source for **Advice Slip**, an API that provides random pieces of advice and allows searching for advice by keyword.

## Tables Added
- **`random_advice`**: Retrieves a single, random piece of advice. The API endpoint (`/advice`) returns a single object containing an `id` and `advice` string, mapped directly to columns.
- **`advices`**: Allows searching for advice using the `query` filter. The endpoint (`/advice/search/{query}`) returns an array of matching slips. The query filter is dynamically injected into the request path.

## Implementation Details
- **Authentication**: No authentication is required for this API.
- **Pagination**: Set to `mode: none` as the search endpoint returns the full set of matches at once (or up to its internal limit) without cursor/page structures.
- **Testing**: SQL queries were declared in `test_queries` for both endpoints to ensure robust structural validation.

## Verification
Locally tested and linted with `coral source lint` and `coral source test`. Here is an example of the query output validating the search functionality:
```sql
SELECT id, advice FROM advice_slip.advices WHERE query = 'spiders' LIMIT 1;
```
```text
+----+---------------------------------------------------------------------+
| id | advice                                                              |
+----+---------------------------------------------------------------------+
| 1  | Remember that spiders are more afraid of you, than you are of them. |
+----+---------------------------------------------------------------------+
```