### PR TITLE
feat(sources/community/universities): add Universities List source

### DIFF
--- a/sources/community/universities/README.md
+++ b/sources/community/universities/README.md
@@ -1,0 +1,37 @@
+# Universities List
+
+Search universities worldwide by name or country via the [HipoLabs Universities API](https://github.com/Hipo/university-domains-list).
+
+## Setup
+
+No authentication is required. Add the source:
+
+```bash
+coral source add --file sources/community/universities/manifest.yaml
+```
+
+## Local Testing
+
+```bash
+coral sql "
+  SELECT name, country 
+  FROM universities.universities 
+  WHERE country = 'United States' 
+  LIMIT 2
+"
+
+/*
++-----------------------+---------------+
+| name                  | country       |
++-----------------------+---------------+
+| Marywood University   | United States |
+| Lindenwood University | United States |
++-----------------------+---------------+
+*/
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `universities` | List of universities filtered by `name` or `country`. |

--- a/sources/community/universities/manifest.yaml
+++ b/sources/community/universities/manifest.yaml
@@ -25,7 +25,12 @@ tables:
     response:
       rows_path: []
     pagination:
-      mode: none
+      mode: offset
+      offset_param: offset
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
     columns:
       - name: name
         type: Utf8

--- a/sources/community/universities/manifest.yaml
+++ b/sources/community/universities/manifest.yaml
@@ -1,0 +1,77 @@
+name: universities
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Search universities worldwide by name or country via the HipoLabs Universities API.
+base_url: http://universities.hipolabs.com
+test_queries:
+  - SELECT name, country FROM universities.universities WHERE country = 'United States' LIMIT 1
+tables:
+  - name: universities
+    description: List of universities filtered by name or country.
+    filters:
+      - name: name
+      - name: country
+    request:
+      method: GET
+      path: /search
+      query:
+        - name: name
+          from: filter
+          key: name
+        - name: country
+          from: filter
+          key: country
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Name of the university.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: country
+        type: Utf8
+        nullable: false
+        description: Country where the university is located.
+        expr:
+          kind: path
+          path:
+            - country
+      - name: alpha_two_code
+        type: Utf8
+        nullable: false
+        description: Two-letter country code (ISO 3166-1 alpha-2).
+        expr:
+          kind: path
+          path:
+            - alpha_two_code
+      - name: state_province
+        type: Utf8
+        nullable: true
+        description: State or province where the university is located.
+        expr:
+          kind: path
+          path:
+            - state-province
+      - name: domains
+        type: Utf8
+        nullable: true
+        description: Comma-separated list of domains belonging to the university.
+        expr:
+          kind: join_array
+          path:
+            - domains
+      - name: web_pages
+        type: Utf8
+        nullable: true
+        description: Comma-separated list of web pages for the university.
+        expr:
+          kind: join_array
+          path:
+            - web_pages


### PR DESCRIPTION
## Summary
This PR adds a new community source for **Universities List**, which provides a searchable directory of universities worldwide via the HipoLabs Universities API.

## Tables Added
- **`universities`**: Provides a list of universities, returning properties such as `name`, `country`, `alpha_two_code`, `domains`, and `web_pages`. It supports two optional URL query parameters natively integrated as filters:
  - `name`: Filter the dataset by university name.
  - `country`: Filter the dataset by country name.

## Implementation Details
- **Authentication**: No API keys or authentication required.
- **Array Parsing**: The API returns a direct JSON array `[...]` at the root, so `rows_path` is explicitly set to `[]`.
- **List Joining**: Array properties like `domains` and `web_pages` are serialized into strings using the `join_array` expression kind for robust SQL operability.
- **Testing**: A `test_queries` definition ensures the table schemas and connections are validated locally during development.

## Verification
Locally tested and linted with `coral source lint` and `coral source test`. Here is an example query showing live fetched results:
```sql
SELECT name, country FROM universities.universities WHERE country = 'United States' LIMIT 2;
```
```text
+-----------------------+---------------+
| name                  | country       |
+-----------------------+---------------+
| Marywood University   | United States |
| Lindenwood University | United States |
+-----------------------+---------------+
```