### PR TITLE
feat(sources/community/country-state-city): add Country State City source

### DIFF
--- a/sources/community/country-state-city/README.md
+++ b/sources/community/country-state-city/README.md
@@ -1,0 +1,41 @@
+# Country State City
+
+Retrieve geographic data about countries, states, and cities worldwide using the [Country State City API](https://countrystatecity.in/).
+
+## Setup
+
+This source requires a free API key from countrystatecity.in.
+Provide it during setup:
+
+```bash
+coral source add --file sources/community/country-state-city/manifest.yaml --interactive
+```
+*(When prompted for `api_key`, paste your `X-CSCAPI-KEY` value.)*
+
+## Local Testing
+
+```bash
+coral sql "
+  SELECT name 
+  FROM country_state_city.cities 
+  WHERE ciso = 'US' AND siso = 'CA' 
+  LIMIT 2
+"
+
+/*
++----------------+
+| name           |
++----------------+
+| Acalanes Ridge |
+| Acton          |
++----------------+
+*/
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `countries` | List of all countries globally. |
+| `states` | List of states for a specific country (filtered by `ciso`). |
+| `cities` | List of cities for a specific state and country (filtered by `ciso` and `siso`). |

--- a/sources/community/country-state-city/manifest.yaml
+++ b/sources/community/country-state-city/manifest.yaml
@@ -1,0 +1,168 @@
+name: country_state_city
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Retrieve countries, states, and cities using the Country State City API.
+base_url: https://api.countrystatecity.in/v1
+inputs:
+  api_key:
+    kind: secret
+    hint: Free API key from countrystatecity.in (X-CSCAPI-KEY).
+test_queries:
+  - SELECT name, iso2 FROM country_state_city.countries LIMIT 1
+  - SELECT name, iso2 FROM country_state_city.states WHERE ciso = 'US' LIMIT 1
+  - SELECT name FROM country_state_city.cities WHERE ciso = 'US' AND siso = 'CA' LIMIT 1
+tables:
+  - name: countries
+    description: List of all countries.
+    request:
+      method: GET
+      path: /countries
+      headers:
+        - name: X-CSCAPI-KEY
+          from: input
+          key: api_key
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique country ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Country name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: iso2
+        type: Utf8
+        nullable: false
+        description: Country ISO2 code.
+        expr:
+          kind: path
+          path:
+            - iso2
+      - name: currency
+        type: Utf8
+        nullable: true
+        description: Country currency code.
+        expr:
+          kind: path
+          path:
+            - currency
+      - name: emoji
+        type: Utf8
+        nullable: true
+        description: Country flag emoji.
+        expr:
+          kind: path
+          path:
+            - emoji
+
+  - name: states
+    description: List of states for a specific country.
+    filters:
+      - name: ciso
+        required: true
+    request:
+      method: GET
+      path: /countries/{{filter.ciso}}/states
+      headers:
+        - name: X-CSCAPI-KEY
+          from: input
+          key: api_key
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique state ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: State name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: iso2
+        type: Utf8
+        nullable: false
+        description: State ISO2 code.
+        expr:
+          kind: path
+          path:
+            - iso2
+      - name: ciso
+        type: Utf8
+        nullable: false
+        description: Country ISO code.
+        expr:
+          kind: from_filter
+          key: ciso
+
+  - name: cities
+    description: List of cities for a specific state and country.
+    filters:
+      - name: ciso
+        required: true
+      - name: siso
+        required: true
+    request:
+      method: GET
+      path: /countries/{{filter.ciso}}/states/{{filter.siso}}/cities
+      headers:
+        - name: X-CSCAPI-KEY
+          from: input
+          key: api_key
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Unique city ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: false
+        description: City name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: ciso
+        type: Utf8
+        nullable: false
+        description: Country ISO code.
+        expr:
+          kind: from_filter
+          key: ciso
+      - name: siso
+        type: Utf8
+        nullable: false
+        description: State ISO code.
+        expr:
+          kind: from_filter
+          key: siso


### PR DESCRIPTION
## Summary
This PR adds a new community source for **Country State City**, which provides geographical data including countries, states, and cities worldwide via the Country State City API.

## Tables Added
- **`countries`**: Lists all countries globally, mapping top-level `id`, `name`, `iso2`, `currency`, and `emoji`.
- **`states`**: Lists states for a specific country. Requires the `ciso` (Country ISO2) filter, seamlessly injected into the `/v1/countries/{{filter.ciso}}/states` endpoint.
- **`cities`**: Lists cities for a specific state. Requires both `ciso` and `siso` (State ISO2) filters, injected into the `/v1/countries/{{filter.ciso}}/states/{{filter.siso}}/cities` endpoint.

## Implementation Details
- **Authentication**: Requires a free API key provided via the `X-CSCAPI-KEY` header. Implemented using a `secret` input variable in Coral's `inputs` schema configuration.
- **Data Shape**: Endpoints return simple top-level JSON arrays `[...]`, handled with `rows_path: []`. Pagination uses `mode: none` as the data is served comprehensively.
- **Testing**: `test_queries` have been rigorously defined covering all tables to ensure filters function correctly.

## Verification
Locally tested and linted with `coral source lint` and `coral source test`. Here is an example query showing live fetched results:
```sql
SELECT name FROM country_state_city.cities WHERE ciso = 'US' AND siso = 'CA' LIMIT 2;
```
```text
+----------------+
| name           |
+----------------+
| Acalanes Ridge |
| Acton          |
+----------------+
```