### PR TITLE
feat(sources/community/cat-facts): add Cat Facts source

### DIFF
--- a/sources/community/cat-facts/README.md
+++ b/sources/community/cat-facts/README.md
@@ -1,0 +1,36 @@
+# Cat Facts
+
+Fetch random and paginated cat facts from the [CatFact.ninja API](https://catfact.ninja/).
+
+## Setup
+
+No authentication is required. Add the source:
+
+```bash
+coral source add --file sources/community/cat-facts/manifest.yaml
+```
+
+## Local Testing
+
+```bash
+coral sql "
+  SELECT fact, length 
+  FROM cat_facts.random_fact 
+  LIMIT 1
+"
+
+/*
++-----------------------------------------------------------------------------+--------+
+| fact                                                                        | length |
++-----------------------------------------------------------------------------+--------+
+| In multi-cat households, cats of the opposite sex usually get along better. | 75     |
++-----------------------------------------------------------------------------+--------+
+*/
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `random_fact` | Get a single random cat fact. |
+| `facts` | List paginated cat facts. Supports querying up to maximum facts available. |

--- a/sources/community/cat-facts/manifest.yaml
+++ b/sources/community/cat-facts/manifest.yaml
@@ -1,0 +1,69 @@
+name: cat_facts
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Fetch random cat facts and list paginated facts from CatFact.ninja.
+base_url: https://catfact.ninja
+test_queries:
+  - SELECT fact, length FROM cat_facts.random_fact LIMIT 1
+  - SELECT fact, length FROM cat_facts.facts LIMIT 10
+tables:
+  - name: random_fact
+    description: Get a single random cat fact.
+    request:
+      method: GET
+      path: /fact
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: fact
+        type: Utf8
+        nullable: false
+        description: The cat fact.
+        expr:
+          kind: path
+          path:
+            - fact
+      - name: length
+        type: Int64
+        nullable: false
+        description: The character length of the fact.
+        expr:
+          kind: path
+          path:
+            - length
+
+  - name: facts
+    description: List paginated cat facts.
+    request:
+      method: GET
+      path: /facts
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: page
+      page_param: page
+      page_size:
+        default: 10
+        max: 100
+        query_param: limit
+    columns:
+      - name: fact
+        type: Utf8
+        nullable: false
+        description: The cat fact.
+        expr:
+          kind: path
+          path:
+            - fact
+      - name: length
+        type: Int64
+        nullable: false
+        description: The character length of the fact.
+        expr:
+          kind: path
+          path:
+            - length

--- a/sources/community/cat-facts/manifest.yaml
+++ b/sources/community/cat-facts/manifest.yaml
@@ -6,7 +6,7 @@ description: Fetch random cat facts and list paginated facts from CatFact.ninja.
 base_url: https://catfact.ninja
 test_queries:
   - SELECT fact, length FROM cat_facts.random_fact LIMIT 1
-  - SELECT fact, length FROM cat_facts.facts LIMIT 10
+  - SELECT fact, length FROM cat_facts.facts LIMIT 15
 tables:
   - name: random_fact
     description: Get a single random cat fact.
@@ -46,6 +46,7 @@ tables:
     pagination:
       mode: page
       page_param: page
+      page_start: 1
       page_size:
         default: 10
         max: 100


### PR DESCRIPTION
## Summary
This PR adds a new community source for **Cat Facts**, which interacts with the CatFact.ninja API to provide random and paginated cat facts.

## Tables Added
- **`random_fact`**: Retrieves a single random cat fact from the `/fact` endpoint. Pagination is disabled (`mode: none`) and `rows_path` is explicitly `[]` since the API returns a single JSON object.
- **`facts`**: Lists paginated cat facts from the `/facts` endpoint. Uses `rows_path: [data]` to unwrap the internal array, and configures pagination using `mode: page` via the `page` query parameter mapping seamlessly into the API's pagination behavior.

## Implementation Details
- **Authentication**: No authentication required.
- **Testing**: `test_queries` are provided to locally validate both the random and paginated endpoints. 

## Verification
Locally tested and linted with `coral source lint` and `coral source test`. Here is an example query showing live fetched results from the `random_fact` table:
```sql
SELECT fact, length FROM cat_facts.random_fact LIMIT 1;
```
```text
+-----------------------------------------------------------------------------+--------+
| fact                                                                        | length |
+-----------------------------------------------------------------------------+--------+
| In multi-cat households, cats of the opposite sex usually get along better. | 75     |
+-----------------------------------------------------------------------------+--------+
```