### PR TITLE
feat(sources/community/dog-ceo): add Dog CEO source

### DIFF
--- a/sources/community/dog-ceo/README.md
+++ b/sources/community/dog-ceo/README.md
@@ -1,0 +1,39 @@
+# Dog CEO
+
+Fetch random dog images and filter by breed using the [Dog CEO API](https://dog.ceo/dog-api/).
+
+## Setup
+
+No authentication is required. Add the source:
+
+```bash
+coral source add --file sources/community/dog-ceo/manifest.yaml
+```
+
+## Local Testing
+
+```bash
+coral sql "
+  SELECT image_url 
+  FROM dog_ceo.breed_images 
+  WHERE breed = 'hound' AND count = 2 
+  LIMIT 2
+"
+
+/*
++---------------------------------------------------------------+
+| image_url                                                     |
++---------------------------------------------------------------+
+| https://images.dog.ceo/breeds/hound-blood/n02088466_10408.jpg |
+| https://images.dog.ceo/breeds/hound-ibizan/n02091244_1340.jpg |
++---------------------------------------------------------------+
+*/
+```
+
+## Tables
+
+| Table | Description |
+|-------|-------------|
+| `random_image` | Get a single random dog image. |
+| `random_images` | Get an array of random dog images. Requires the `count` filter. |
+| `breed_images` | Get an array of random images for a specific breed. Requires `breed` and `count` filters. |

--- a/sources/community/dog-ceo/manifest.yaml
+++ b/sources/community/dog-ceo/manifest.yaml
@@ -1,0 +1,105 @@
+name: dog_ceo
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Fetch random dog images and filter by breed using the Dog CEO API.
+base_url: https://dog.ceo/api
+test_queries:
+  - SELECT image_url FROM dog_ceo.random_image LIMIT 1
+  - SELECT image_url FROM dog_ceo.random_images WHERE count = 2 LIMIT 2
+  - SELECT image_url FROM dog_ceo.breed_images WHERE breed = 'hound' AND count = 1 LIMIT 1
+tables:
+  - name: random_image
+    description: Get a single random dog image.
+    request:
+      method: GET
+      path: /breeds/image/random
+    response:
+      rows_path: []
+    pagination:
+      mode: none
+    columns:
+      - name: image_url
+        type: Utf8
+        nullable: false
+        description: The image URL.
+        expr:
+          kind: path
+          path:
+            - message
+      - name: status
+        type: Utf8
+        nullable: false
+        description: The API status.
+        expr:
+          kind: path
+          path:
+            - status
+
+  - name: random_images
+    description: Get multiple random dog images.
+    filters:
+      - name: count
+        required: true
+    request:
+      method: GET
+      path: /breeds/image/random/{{filter.count}}
+    response:
+      rows_path:
+        - message
+    pagination:
+      mode: none
+    columns:
+      - name: count
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Number of images requested.
+        expr:
+          kind: from_filter
+          key: count
+      - name: image_url
+        type: Utf8
+        nullable: false
+        description: The image URL.
+        expr:
+          kind: current_row
+
+  - name: breed_images
+    description: Get random images for a specific breed.
+    filters:
+      - name: breed
+        required: true
+      - name: count
+        required: true
+    request:
+      method: GET
+      path: /breed/{{filter.breed}}/images/random/{{filter.count}}
+    response:
+      rows_path:
+        - message
+    pagination:
+      mode: none
+    columns:
+      - name: breed
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: The breed.
+        expr:
+          kind: from_filter
+          key: breed
+      - name: count
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Number of images requested.
+        expr:
+          kind: from_filter
+          key: count
+      - name: image_url
+        type: Utf8
+        nullable: false
+        description: The image URL.
+        expr:
+          kind: current_row


### PR DESCRIPTION
## Summary
This PR adds a new community source for **Dog CEO**, which interacts with the Dog API to provide random dog images and breed-specific images.

## Tables Added
- **`random_image`**: Retrieves a single random dog image URL. The `message` property is mapped to the `image_url` column.
- **`random_images`**: Retrieves an array of random dog images. Requires the `count` filter dynamically injected into the path. The response array inside `message` is unwrapped by `rows_path: [message]`, and each array element is assigned to `image_url` via the `kind: current_row` expression.
- **`breed_images`**: Retrieves an array of images filtered by specific breed. Requires `breed` and `count` filters dynamically injected into the endpoint. Also utilizes `rows_path: [message]` and `current_row` to map the string array cleanly into individual records.

## Implementation Details
- **Authentication**: No authentication required.
- **Array Parsing**: Successfully handled the `{"message": ["url1", "url2"]}` structure by combining `rows_path` with `current_row` mapping since the array contains raw strings rather than objects.
- **Testing**: `test_queries` are provided for all three tables, effectively asserting the filter mechanisms logic locally.

## Verification
Locally tested and linted with `coral source lint` and `coral source test`. Here is an example query showing live fetched results from the `breed_images` table:
```sql
SELECT image_url FROM dog_ceo.breed_images WHERE breed = 'hound' AND count = 2 LIMIT 2;
```
```text
+---------------------------------------------------------------+
| image_url                                                     |
+---------------------------------------------------------------+
| https://images.dog.ceo/breeds/hound-blood/n02088466_10408.jpg |
| https://images.dog.ceo/breeds/hound-ibizan/n02091244_1340.jpg |
+---------------------------------------------------------------+
```