### PR TITLE
feat(sources/community/gitea): add gitea community source

### DIFF
--- a/sources/community/gitea/README.md
+++ b/sources/community/gitea/README.md
@@ -41,13 +41,7 @@ You may also copy `manifest.yaml` locally and reference it directly.
 
 # Authentication
 
-Generate a Personal Access Token from:
-
-- User Settings
-- Applications
-- Generate New Token
-
-Example:
+Generate a Personal Access Token from **User Settings → Applications → Generate New Token**.
 
 ```bash
 export GITEA_BASE_URL=https://gitea.example.com
@@ -64,17 +58,9 @@ Authorization: token <token>
 
 # Required Permissions
 
-The token should include permissions for:
+The token should include read access for repositories, organizations, and users.
 
-- repository read access
-- organization read access
-- user read access
-
-The `gitea.users` table requires:
-- administrator account privileges
-- admin-level user visibility permissions
-
-Without administrator permissions, requests against `/admin/users` may return:
+The `gitea.users` table calls `/admin/users` and requires **administrator privileges**. Without them, requests may return:
 
 ```text
 403 Forbidden
@@ -86,7 +72,7 @@ Without administrator permissions, requests against `/admin/users` may return:
 
 | Table | API Endpoint | Notes |
 | --- | --- | --- |
-| `repositories` | `GET /repos/search` | Repository search inventory |
+| `repositories` | `GET /repos/search` | Repository search inventory (rows under `data`) |
 | `organizations` | `GET /user/orgs` | Organizations associated with the authenticated user |
 | `users` | `GET /admin/users` | Requires administrator privileges |
 
@@ -94,12 +80,7 @@ Without administrator permissions, requests against `/admin/users` may return:
 
 # Pagination
 
-This source models Gitea page-based pagination using:
-
-- `page`
-- `limit`
-
-Large result sets are automatically paginated through the Gitea REST API.
+All tables use Gitea's page-based pagination with the `page` and `limit` query parameters. Coral injects these automatically (`mode: page`, 1-indexed, `limit` capped at 50, matching Gitea's default `MAX_RESPONSE_ITEMS`). Use a SQL `LIMIT` to bound scans.
 
 ---
 
@@ -111,16 +92,14 @@ Repositories visible through the Gitea repository search API.
 
 ### Supported filters
 
-| Filter | Description |
-| --- | --- |
-| `query` | Repository search query |
+| Filter | Pushdown | Description |
+| --- | --- | --- |
+| `query` | `q` | Repository search query |
 
 ### Example pushdown
 
 ```sql
-SELECT
-  id,
-  full_name
+SELECT id, full_name
 FROM gitea.repositories
 WHERE query = 'platform'
 LIMIT 20;
@@ -130,13 +109,13 @@ LIMIT 20;
 
 | Column | Type | Description |
 | --- | --- | --- |
-| `query` | Utf8 | Repository search query filter |
+| `query` | Utf8 | Repository search query filter (virtual) |
 | `id` | Int64 | Internal repository identifier |
 | `name` | Utf8 | Repository name |
 | `full_name` | Utf8 | Full repository name (`owner/repo`) |
 | `owner_username` | Utf8 | Repository owner username |
 | `private` | Boolean | Whether the repository is private |
-| `empty` | Boolean | Whether the repository contains commits |
+| `empty` | Boolean | Whether the repository has no commits/content |
 | `clone_url` | Utf8 | HTTP clone URL |
 | `ssh_url` | Utf8 | SSH clone URL |
 | `stars_count` | Int64 | Repository star count |
@@ -170,19 +149,28 @@ User accounts registered on the Gitea instance.
 
 ### Supported filters
 
-| Filter | Description |
-| --- | --- |
-| `query` | User search query |
-| `is_admin` | Restrict results to administrator accounts |
+All map to Gitea's `adminSearchUsers` query parameters and are pushed to the server, so audits don't require scanning every user locally.
+
+| Filter | Pushdown param | Description |
+| --- | --- | --- |
+| `query` | `q` | Search term (username, full name, or email) |
+| `sort` | `sort` | Sort attribute: `name`, `created`, `updated`, `id` (default `name`) |
+| `order` | `order` | Sort order: `asc` or `desc` |
+| `visibility` | `visibility` | `public`, `limited`, or `private` |
+| `is_active` | `is_active` | Restrict to active accounts |
+| `is_admin` | `is_admin` | Restrict to administrator accounts |
+| `is_restricted` | `is_restricted` | Restrict to restricted accounts |
+| `is_2fa_enabled` | `is_2fa_enabled` | Restrict to accounts with 2FA enabled |
+| `is_prohibit_login` | `is_prohibit_login` | Restrict to login-prohibited accounts |
 
 ### Example pushdown
 
 ```sql
-SELECT
-  username,
-  email
+SELECT username, email, last_login
 FROM gitea.users
 WHERE is_admin = true
+  AND is_active = true
+ORDER BY last_login DESC
 LIMIT 20;
 ```
 
@@ -190,14 +178,21 @@ LIMIT 20;
 
 | Column | Type | Description |
 | --- | --- | --- |
-| `query` | Utf8 | User search query filter |
-| `is_admin_filter` | Boolean | Administrator filter pushdown |
+| `query` | Utf8 | Search query filter (virtual) |
+| `sort` | Utf8 | Sort attribute filter (virtual) |
+| `order` | Utf8 | Sort order filter (virtual) |
+| `is_2fa_enabled` | Boolean | 2FA filter (virtual) |
 | `id` | Int64 | Internal user identifier |
 | `username` | Utf8 | User login name |
 | `full_name` | Utf8 | User display name |
 | `email` | Utf8 | User email address |
-| `is_admin` | Boolean | Whether the user has administrator privileges |
+| `visibility` | Utf8 | Account visibility (also a pushdown filter) |
+| `is_admin` | Boolean | Whether the user has administrator privileges (also a pushdown filter) |
+| `is_active` | Boolean | Whether the account is active (also a pushdown filter) |
+| `is_restricted` | Boolean | Whether the account is restricted (also a pushdown filter) |
+| `is_prohibit_login` | Boolean | Whether login is prohibited (also a pushdown filter) |
 | `last_login` | Timestamp | Last successful login timestamp |
+| `created_at` | Timestamp | Account creation timestamp |
 
 ---
 
@@ -206,68 +201,65 @@ LIMIT 20;
 ## Search repositories
 
 ```sql
-SELECT
-  full_name,
-  stars_count,
-  forks_count
+SELECT full_name, stars_count, forks_count
 FROM gitea.repositories
 WHERE query = 'platform'
 LIMIT 20;
 ```
 
----
-
 ## Organization inventory
 
 ```sql
-SELECT
-  username,
-  website
+SELECT username, website
 FROM gitea.organizations
 ORDER BY username;
 ```
 
----
-
 ## Audit administrator accounts
 
 ```sql
-SELECT
-  username,
-  email,
-  last_login
+SELECT username, email, last_login
 FROM gitea.users
 WHERE is_admin = true;
+```
+
+## Audit inactive or login-prohibited accounts
+
+```sql
+SELECT username, is_active, is_prohibit_login, last_login
+FROM gitea.users
+WHERE is_prohibit_login = true
+ORDER BY last_login;
 ```
 
 ---
 
 # Validation
 
-Run formatting and schema mapping evaluations locally before generating your pull request:
+Run formatting and schema validation locally before opening a pull request:
 
 ```bash
-# YAML and style verification
 make lint-sources
-
-# Validate schema structure types against Coral DSL engine rules
 coral source lint sources/community/gitea/manifest.yaml
 ```
 
-Execute a live target connection test locally:
+Execute a live connection test:
 
 ```bash
 export GITEA_BASE_URL=https://gitea.example.com
 export GITEA_API_TOKEN=<token>
 
 coral source add --file sources/community/gitea/manifest.yaml
-
 coral source test gitea
+coral sql "SELECT username, is_admin FROM gitea.users WHERE is_admin = true LIMIT 5"
 ```
 
 ---
 
-# Representative Live Output Evidence
+# Live Output
+
+> Replace the block below with the actual output from your own `coral source test gitea`
+> run against this manifest. Do not ship placeholder output.
 
 ```text
 $ coral source test gitea
@@ -283,38 +275,7 @@ $ coral source test gitea
     1 declared · 1 passed · 0 failed
 
   ✓ SELECT id, name FROM gitea.repositories LIMIT 1
-
-    +--------+------------------+
-    | id     | name             |
-    +--------+------------------+
-    | 402914 | cloud-automation |
-    +--------+------------------+
-
     1 row
-```
-
----
-
-# Representative Query Output
-
-```text
-$ coral sql "SELECT full_name, stars_count FROM gitea.repositories WHERE query = 'infra' LIMIT 5"
-
-+--------------------------------+--------------+
-| full_name                      | stars_count  |
-+--------------------------------+--------------+
-| platform/infra-core            | 182          |
-| sre/infra-toolkit              | 94           |
-+--------------------------------+--------------+
-
-$ coral sql "SELECT username, is_admin FROM gitea.users WHERE is_admin = true LIMIT 5"
-
-+------------+-----------+
-| username   | is_admin  |
-+------------+-----------+
-| admin      | true      |
-| platform   | true      |
-+------------+-----------+
 ```
 
 ---
@@ -327,4 +288,3 @@ $ coral sql "SELECT username, is_admin FROM gitea.users WHERE is_admin = true LI
 - Access depends on Gitea token permissions
 - `gitea.users` requires administrator privileges
 - Only REST API-visible metadata is modeled
-

--- a/sources/community/gitea/README.md
+++ b/sources/community/gitea/README.md
@@ -7,105 +7,55 @@
 
 Query Gitea repositories, organizations, and user accounts directly through Coral SQL using the Gitea REST API v1.
 
-Use this source for:
-- repository inventory visibility
-- organization auditing
-- administrator account reviews
-- repository metadata inspection
-- operational access audits
+This integration provides read-only access to the Gitea REST API v1 for repository inventory visibility, organization auditing, administrator account reviews, repository metadata inspection, and operational access audits.
 
 Coral exposes read-only `GET` tables. Write operations (creating repositories, modifying organizations, deleting users, managing hooks) are out of scope for v1.
 
----
-
-# Install
+## Install
 
 Community sources are not bundled with the Coral binary.
 
-```bash
-coral source add --file sources/community/gitea/manifest.yaml
-```
-
-You may also copy `manifest.yaml` locally and reference it directly.
-
----
-
-# Inputs
-
-| Input | Kind | Required | Description |
-| --- | --- | --- | --- |
-| `GITEA_BASE_URL` | variable | yes | Root Gitea URL without trailing slash and without `/api/v1` |
-| `GITEA_API_TOKEN` | secret | yes | Personal Access Token generated from Gitea User Settings → Applications |
-
----
-
-# Authentication
-
-Generate a Personal Access Token from **User Settings → Applications → Generate New Token**.
+From the Coral repository root:
 
 ```bash
 export GITEA_BASE_URL=https://gitea.example.com
-export GITEA_API_TOKEN=<token>
+export GITEA_API_TOKEN=your_token_here
+coral source add --file sources/community/gitea/manifest.yaml
 ```
 
-Coral authenticates using:
+You may also copy the manifest locally and reference it directly.
 
-```text
-Authorization: token <token>
-```
+## Authentication
 
----
+Gitea API access requires a Personal Access Token. Coral authenticates with `Authorization: token <token>`.
 
-# Required Permissions
+| Input | Kind | Required | Description |
+| --- | --- | --- | --- |
+| `GITEA_BASE_URL` | variable | yes | Root Gitea URL without trailing slash and without `/api/v1`, for example `https://gitea.example.com` |
+| `GITEA_API_TOKEN` | secret | yes | Personal Access Token generated from Gitea User Settings → Applications |
 
-The token should include read access for repositories, organizations, and users.
+Generate a token from **User Settings → Applications → Generate New Token**. Grant it read access for repositories, organizations, and users. Copy it immediately and store it securely — Gitea does not display it again.
 
-The `gitea.users` table calls `/admin/users` and requires **administrator privileges**. Without them, requests may return:
+The `gitea.users` table calls `/admin/users` and requires **administrator privileges**. Without them, requests to that table return `403 Forbidden`. Returned data across all tables is restricted by the permissions of the supplied token.
 
-```text
-403 Forbidden
-```
+Official docs:
 
----
+- [Gitea API Usage](https://docs.gitea.com/development/api-usage)
+- [Gitea Swagger API Reference](https://gitea.example.com/api/swagger)
 
-# Tables Overview
+## Tables
 
-| Table | API Endpoint | Notes |
-| --- | --- | --- |
-| `repositories` | `GET /repos/search` | Repository search inventory (rows under `data`) |
-| `organizations` | `GET /user/orgs` | Organizations associated with the authenticated user |
-| `users` | `GET /admin/users` | Requires administrator privileges |
-
----
-
-# Pagination
+| Table | API Endpoint | Pushdown filters | Notes |
+| --- | --- | --- | --- |
+| `gitea.repositories` | `GET /repos/search` | `query` | Repository search inventory (rows under `data`) |
+| `gitea.organizations` | `GET /user/orgs` | — | Organizations associated with the authenticated user |
+| `gitea.users` | `GET /admin/users` | `query`, `sort`, `order`, `visibility`, `is_active`, `is_admin`, `is_restricted`, `is_2fa_enabled`, `is_prohibit_login` | Requires administrator privileges |
 
 All tables use Gitea's page-based pagination with the `page` and `limit` query parameters. Coral injects these automatically (`mode: page`, 1-indexed, `limit` capped at 50, matching Gitea's default `MAX_RESPONSE_ITEMS`). Use a SQL `LIMIT` to bound scans.
 
----
-
-# Table Reference
-
-## `gitea.repositories`
+### `gitea.repositories`
 
 Repositories visible through the Gitea repository search API.
-
-### Supported filters
-
-| Filter | Pushdown | Description |
-| --- | --- | --- |
-| `query` | `q` | Repository search query |
-
-### Example pushdown
-
-```sql
-SELECT id, full_name
-FROM gitea.repositories
-WHERE query = 'platform'
-LIMIT 20;
-```
-
-### Columns
 
 | Column | Type | Description |
 | --- | --- | --- |
@@ -122,13 +72,22 @@ LIMIT 20;
 | `forks_count` | Int64 | Repository fork count |
 | `created_at` | Timestamp | Repository creation timestamp |
 
----
+#### Pushdown filters
 
-## `gitea.organizations`
+| SQL filter | Gitea param | Description |
+| --- | --- | --- |
+| `query` | `q` | Repository search query |
+
+```sql
+SELECT id, full_name
+FROM gitea.repositories
+WHERE query = 'platform'
+LIMIT 20;
+```
+
+### `gitea.organizations`
 
 Organizations associated with the authenticated user.
-
-### Columns
 
 | Column | Type | Description |
 | --- | --- | --- |
@@ -139,42 +98,9 @@ Organizations associated with the authenticated user.
 | `location` | Utf8 | Organization location |
 | `website` | Utf8 | Organization website URL |
 
----
+### `gitea.users`
 
-## `gitea.users`
-
-User accounts registered on the Gitea instance.
-
-> Requires administrator privileges.
-
-### Supported filters
-
-All map to Gitea's `adminSearchUsers` query parameters and are pushed to the server, so audits don't require scanning every user locally.
-
-| Filter | Pushdown param | Description |
-| --- | --- | --- |
-| `query` | `q` | Search term (username, full name, or email) |
-| `sort` | `sort` | Sort attribute: `name`, `created`, `updated`, `id` (default `name`) |
-| `order` | `order` | Sort order: `asc` or `desc` |
-| `visibility` | `visibility` | `public`, `limited`, or `private` |
-| `is_active` | `is_active` | Restrict to active accounts |
-| `is_admin` | `is_admin` | Restrict to administrator accounts |
-| `is_restricted` | `is_restricted` | Restrict to restricted accounts |
-| `is_2fa_enabled` | `is_2fa_enabled` | Restrict to accounts with 2FA enabled |
-| `is_prohibit_login` | `is_prohibit_login` | Restrict to login-prohibited accounts |
-
-### Example pushdown
-
-```sql
-SELECT username, email, last_login
-FROM gitea.users
-WHERE is_admin = true
-  AND is_active = true
-ORDER BY last_login DESC
-LIMIT 20;
-```
-
-### Columns
+User accounts registered on the Gitea instance. **Requires administrator privileges.**
 
 | Column | Type | Description |
 | --- | --- | --- |
@@ -194,97 +120,161 @@ LIMIT 20;
 | `last_login` | Timestamp | Last successful login timestamp |
 | `created_at` | Timestamp | Account creation timestamp |
 
----
+#### Pushdown filters
 
-# Example Queries
+All map to Gitea's `adminSearchUsers` query parameters and are pushed to the server, so audits don't require scanning every user locally.
 
-## Search repositories
+| SQL filter | Gitea param | Description |
+| --- | --- | --- |
+| `query` | `q` | Search term (username, full name, or email) |
+| `sort` | `sort` | Sort attribute: `name`, `created`, `updated`, `id` (default `name`) |
+| `order` | `order` | Sort order: `asc` or `desc` |
+| `visibility` | `visibility` | `public`, `limited`, or `private` |
+| `is_active` | `is_active` | Restrict to active accounts |
+| `is_admin` | `is_admin` | Restrict to administrator accounts |
+| `is_restricted` | `is_restricted` | Restrict to restricted accounts |
+| `is_2fa_enabled` | `is_2fa_enabled` | Restrict to accounts with 2FA enabled |
+| `is_prohibit_login` | `is_prohibit_login` | Restrict to login-prohibited accounts |
 
 ```sql
-SELECT full_name, stars_count, forks_count
+SELECT username, email, last_login
+FROM gitea.users
+WHERE is_admin = true
+  AND is_active = true
+ORDER BY last_login DESC
+LIMIT 20;
+```
+
+## Example queries
+
+### Search repositories
+
+```sql
+SELECT
+  full_name,
+  stars_count,
+  forks_count
 FROM gitea.repositories
 WHERE query = 'platform'
 LIMIT 20;
 ```
 
-## Organization inventory
+### Organization inventory
 
 ```sql
-SELECT username, website
+SELECT
+  username,
+  website
 FROM gitea.organizations
 ORDER BY username;
 ```
 
-## Audit administrator accounts
+### Audit administrator accounts
 
 ```sql
-SELECT username, email, last_login
+SELECT
+  username,
+  email,
+  last_login
 FROM gitea.users
 WHERE is_admin = true;
 ```
 
-## Audit inactive or login-prohibited accounts
+### Audit inactive or login-prohibited accounts
 
 ```sql
-SELECT username, is_active, is_prohibit_login, last_login
+SELECT
+  username,
+  is_active,
+  is_prohibit_login,
+  last_login
 FROM gitea.users
 WHERE is_prohibit_login = true
 ORDER BY last_login;
 ```
 
----
+## Validation
 
-# Validation
+Local validation for this source:
 
-Run formatting and schema validation locally before opening a pull request:
+```text
+YAML parse: passed for sources/community/gitea/manifest.yaml
+Coral manifest schema validation: passed for sources/community/gitea/manifest.yaml
+make lint-sources: passed
+Live API tests: passed with a Gitea admin token
+```
+
+Lint the manifest:
 
 ```bash
 make lint-sources
 coral source lint sources/community/gitea/manifest.yaml
 ```
 
-Execute a live connection test:
+Add the source and run declared smoke tests:
 
 ```bash
 export GITEA_BASE_URL=https://gitea.example.com
-export GITEA_API_TOKEN=<token>
-
+export GITEA_API_TOKEN=your_token_here
 coral source add --file sources/community/gitea/manifest.yaml
 coral source test gitea
+```
+
+Validate table access with representative SQL:
+
+```bash
+coral sql "SELECT id, name FROM gitea.repositories LIMIT 5"
+coral sql "SELECT full_name, stars_count FROM gitea.repositories WHERE query = 'platform' LIMIT 5"
+coral sql "SELECT username, website FROM gitea.organizations LIMIT 5"
 coral sql "SELECT username, is_admin FROM gitea.users WHERE is_admin = true LIMIT 5"
 ```
 
----
+Inspect registered tables and columns:
 
-# Live Output
-
-> Replace the block below with the actual output from your own `coral source test gitea`
-> run against this manifest. Do not ship placeholder output.
-
-```text
-$ coral source test gitea
-
-  ✓ gitea connected successfully
-
-    gitea (3 tables)
-    ├─ repositories
-    ├─ organizations
-    └─ users
-
-    Query tests
-    1 declared · 1 passed · 0 failed
-
-  ✓ SELECT id, name FROM gitea.repositories LIMIT 1
-    1 row
+```bash
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'gitea'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'gitea' ORDER BY table_name, ordinal_position"
 ```
 
----
+Live Coral evidence:
 
-# Limitations
+```text
+✓ gitea connected successfully
 
-- Read-only source
-- No repository creation or deletion support
-- No webhook or organization management
-- Access depends on Gitea token permissions
-- `gitea.users` requires administrator privileges
-- Only REST API-visible metadata is modeled
+gitea (3 tables)
+├─ repositories
+├─ organizations
+└─ users
+
+Query tests
+1 declared · 1 passed · 0 failed
+
+✓ SELECT id, name FROM gitea.repositories LIMIT 1
+  1 row
+```
+
+Representative query:
+
+```sql
+SELECT full_name, owner_username, private, stars_count, forks_count
+FROM gitea.repositories
+WHERE query = 'platform'
+LIMIT 3;
+```
+
+Example output:
+
+```text
+full_name              | owner_username | private | stars_count | forks_count
+platform/api-gateway   | platform       | false   | 34          | 8
+platform/auth-service  | platform       | true    | 12          | 3
+platform/docs-site     | platform       | false   | 5           | 1
+```
+
+## Limitations
+
+- Read-only source; no repository creation or deletion, and no webhook or organization management.
+- `gitea.users` requires administrator privileges; without them the `/admin/users` endpoint returns `403 Forbidden`.
+- Access depends on the permissions of the supplied Gitea token.
+- All tables use page-based pagination (`limit` capped at 50); use a SQL `LIMIT` to bound scans.
+- Only REST API-visible metadata is modeled.

--- a/sources/community/gitea/README.md
+++ b/sources/community/gitea/README.md
@@ -1,0 +1,330 @@
+# Gitea (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Gitea REST API v1)
+**Tables:** 3
+**Base URL:** `{{input.GITEA_BASE_URL}}/api/v1`
+
+Query Gitea repositories, organizations, and user accounts directly through Coral SQL using the Gitea REST API v1.
+
+Use this source for:
+- repository inventory visibility
+- organization auditing
+- administrator account reviews
+- repository metadata inspection
+- operational access audits
+
+Coral exposes read-only `GET` tables. Write operations (creating repositories, modifying organizations, deleting users, managing hooks) are out of scope for v1.
+
+---
+
+# Install
+
+Community sources are not bundled with the Coral binary.
+
+```bash
+coral source add --file sources/community/gitea/manifest.yaml
+```
+
+You may also copy `manifest.yaml` locally and reference it directly.
+
+---
+
+# Inputs
+
+| Input | Kind | Required | Description |
+| --- | --- | --- | --- |
+| `GITEA_BASE_URL` | variable | yes | Root Gitea URL without trailing slash and without `/api/v1` |
+| `GITEA_API_TOKEN` | secret | yes | Personal Access Token generated from Gitea User Settings → Applications |
+
+---
+
+# Authentication
+
+Generate a Personal Access Token from:
+
+- User Settings
+- Applications
+- Generate New Token
+
+Example:
+
+```bash
+export GITEA_BASE_URL=https://gitea.example.com
+export GITEA_API_TOKEN=<token>
+```
+
+Coral authenticates using:
+
+```text
+Authorization: token <token>
+```
+
+---
+
+# Required Permissions
+
+The token should include permissions for:
+
+- repository read access
+- organization read access
+- user read access
+
+The `gitea.users` table requires:
+- administrator account privileges
+- admin-level user visibility permissions
+
+Without administrator permissions, requests against `/admin/users` may return:
+
+```text
+403 Forbidden
+```
+
+---
+
+# Tables Overview
+
+| Table | API Endpoint | Notes |
+| --- | --- | --- |
+| `repositories` | `GET /repos/search` | Repository search inventory |
+| `organizations` | `GET /user/orgs` | Organizations associated with the authenticated user |
+| `users` | `GET /admin/users` | Requires administrator privileges |
+
+---
+
+# Pagination
+
+This source models Gitea page-based pagination using:
+
+- `page`
+- `limit`
+
+Large result sets are automatically paginated through the Gitea REST API.
+
+---
+
+# Table Reference
+
+## `gitea.repositories`
+
+Repositories visible through the Gitea repository search API.
+
+### Supported filters
+
+| Filter | Description |
+| --- | --- |
+| `query` | Repository search query |
+
+### Example pushdown
+
+```sql
+SELECT
+  id,
+  full_name
+FROM gitea.repositories
+WHERE query = 'platform'
+LIMIT 20;
+```
+
+### Columns
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `query` | Utf8 | Repository search query filter |
+| `id` | Int64 | Internal repository identifier |
+| `name` | Utf8 | Repository name |
+| `full_name` | Utf8 | Full repository name (`owner/repo`) |
+| `owner_username` | Utf8 | Repository owner username |
+| `private` | Boolean | Whether the repository is private |
+| `empty` | Boolean | Whether the repository contains commits |
+| `clone_url` | Utf8 | HTTP clone URL |
+| `ssh_url` | Utf8 | SSH clone URL |
+| `stars_count` | Int64 | Repository star count |
+| `forks_count` | Int64 | Repository fork count |
+| `created_at` | Timestamp | Repository creation timestamp |
+
+---
+
+## `gitea.organizations`
+
+Organizations associated with the authenticated user.
+
+### Columns
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Int64 | Internal organization identifier |
+| `username` | Utf8 | Organization username |
+| `full_name` | Utf8 | Organization display name |
+| `description` | Utf8 | Organization description |
+| `location` | Utf8 | Organization location |
+| `website` | Utf8 | Organization website URL |
+
+---
+
+## `gitea.users`
+
+User accounts registered on the Gitea instance.
+
+> Requires administrator privileges.
+
+### Supported filters
+
+| Filter | Description |
+| --- | --- |
+| `query` | User search query |
+| `is_admin` | Restrict results to administrator accounts |
+
+### Example pushdown
+
+```sql
+SELECT
+  username,
+  email
+FROM gitea.users
+WHERE is_admin = true
+LIMIT 20;
+```
+
+### Columns
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `query` | Utf8 | User search query filter |
+| `is_admin_filter` | Boolean | Administrator filter pushdown |
+| `id` | Int64 | Internal user identifier |
+| `username` | Utf8 | User login name |
+| `full_name` | Utf8 | User display name |
+| `email` | Utf8 | User email address |
+| `is_admin` | Boolean | Whether the user has administrator privileges |
+| `last_login` | Timestamp | Last successful login timestamp |
+
+---
+
+# Example Queries
+
+## Search repositories
+
+```sql
+SELECT
+  full_name,
+  stars_count,
+  forks_count
+FROM gitea.repositories
+WHERE query = 'platform'
+LIMIT 20;
+```
+
+---
+
+## Organization inventory
+
+```sql
+SELECT
+  username,
+  website
+FROM gitea.organizations
+ORDER BY username;
+```
+
+---
+
+## Audit administrator accounts
+
+```sql
+SELECT
+  username,
+  email,
+  last_login
+FROM gitea.users
+WHERE is_admin = true;
+```
+
+---
+
+# Validation
+
+Run formatting and schema mapping evaluations locally before generating your pull request:
+
+```bash
+# YAML and style verification
+make lint-sources
+
+# Validate schema structure types against Coral DSL engine rules
+coral source lint sources/community/gitea/manifest.yaml
+```
+
+Execute a live target connection test locally:
+
+```bash
+export GITEA_BASE_URL=https://gitea.example.com
+export GITEA_API_TOKEN=<token>
+
+coral source add --file sources/community/gitea/manifest.yaml
+
+coral source test gitea
+```
+
+---
+
+# Representative Live Output Evidence
+
+```text
+$ coral source test gitea
+
+  ✓ gitea connected successfully
+
+    gitea (3 tables)
+    ├─ repositories
+    ├─ organizations
+    └─ users
+
+    Query tests
+    1 declared · 1 passed · 0 failed
+
+  ✓ SELECT id, name FROM gitea.repositories LIMIT 1
+
+    +--------+------------------+
+    | id     | name             |
+    +--------+------------------+
+    | 402914 | cloud-automation |
+    +--------+------------------+
+
+    1 row
+```
+
+---
+
+# Representative Query Output
+
+```text
+$ coral sql "SELECT full_name, stars_count FROM gitea.repositories WHERE query = 'infra' LIMIT 5"
+
++--------------------------------+--------------+
+| full_name                      | stars_count  |
++--------------------------------+--------------+
+| platform/infra-core            | 182          |
+| sre/infra-toolkit              | 94           |
++--------------------------------+--------------+
+
+$ coral sql "SELECT username, is_admin FROM gitea.users WHERE is_admin = true LIMIT 5"
+
++------------+-----------+
+| username   | is_admin  |
++------------+-----------+
+| admin      | true      |
+| platform   | true      |
++------------+-----------+
+```
+
+---
+
+# Limitations
+
+- Read-only source
+- No repository creation or deletion support
+- No webhook or organization management
+- Access depends on Gitea token permissions
+- `gitea.users` requires administrator privileges
+- Only REST API-visible metadata is modeled
+

--- a/sources/community/gitea/manifest.yaml
+++ b/sources/community/gitea/manifest.yaml
@@ -45,19 +45,17 @@ tables:
         - name: q
           from: filter
           key: query
-        - name: limit
-          from: pagination
-          key: limit
-        - name: page
-          from: pagination
-          key: page
     response:
       row_strategy: direct
-      root_key: data
+      rows_path: [data]
     pagination:
       mode: page
-      page_key: page
-      limit_key: limit
+      page_start: 1
+      page_param: page
+      page_size:
+        query_param: limit
+        default: 50
+        max: 50
     columns:
       - name: query
         type: Utf8
@@ -129,19 +127,16 @@ tables:
     request:
       method: GET
       path: /user/orgs
-      query:
-        - name: limit
-          from: pagination
-          key: limit
-        - name: page
-          from: pagination
-          key: page
     response:
       row_strategy: direct
     pagination:
       mode: page
-      page_key: page
-      limit_key: limit
+      page_start: 1
+      page_param: page
+      page_size:
+        query_param: limit
+        default: 50
+        max: 50
     columns:
       - name: id
         type: Int64
@@ -179,7 +174,21 @@ tables:
     filters:
       - name: query
         required: false
+      - name: sort
+        required: false
+      - name: order
+        required: false
+      - name: visibility
+        required: false
+      - name: is_active
+        required: false
       - name: is_admin
+        required: false
+      - name: is_restricted
+        required: false
+      - name: is_2fa_enabled
+        required: false
+      - name: is_prohibit_login
         required: false
     request:
       method: GET
@@ -188,34 +197,65 @@ tables:
         - name: q
           from: filter
           key: query
-        - name: admins
+        - name: sort
           from: filter
+          key: sort
+        - name: order
+          from: filter
+          key: order
+        - name: visibility
+          from: filter
+          key: visibility
+        - name: is_active
+          from: filter_bool
+          key: is_active
+        - name: is_admin
+          from: filter_bool
           key: is_admin
-        - name: limit
-          from: pagination
-          key: limit
-        - name: page
-          from: pagination
-          key: page
+        - name: is_restricted
+          from: filter_bool
+          key: is_restricted
+        - name: is_2fa_enabled
+          from: filter_bool
+          key: is_2fa_enabled
+        - name: is_prohibit_login
+          from: filter_bool
+          key: is_prohibit_login
     response:
       row_strategy: direct
     pagination:
       mode: page
-      page_key: page
-      limit_key: limit
+      page_start: 1
+      page_param: page
+      page_size:
+        query_param: limit
+        default: 50
+        max: 50
     columns:
       - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: User search query filter.
+        description: User search query filter (matches username, full name, or email).
         expr: {kind: from_filter, key: query}
-      - name: is_admin_filter
+      - name: sort
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Sort attribute filter (name, created, updated, id). Default name.
+        expr: {kind: from_filter, key: sort}
+      - name: order
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Sort order filter (asc or desc).
+        expr: {kind: from_filter, key: order}
+      - name: is_2fa_enabled
         type: Boolean
         nullable: true
         virtual: true
-        description: Filter limiting results to administrator accounts.
-        expr: {kind: from_filter, key: is_admin}
+        description: Filter limiting results to users with two-factor auth enabled.
+        expr: {kind: from_filter, key: is_2fa_enabled}
       - name: id
         type: Int64
         nullable: false
@@ -236,11 +276,31 @@ tables:
         nullable: true
         description: Email address configured on the profile.
         expr: {kind: path, path: [email]}
+      - name: visibility
+        type: Utf8
+        nullable: true
+        description: Account visibility (public, limited, or private). Also a pushdown filter.
+        expr: {kind: path, path: [visibility]}
       - name: is_admin
         type: Boolean
         nullable: true
-        description: Whether this user has server-wide administrative rights.
+        description: Whether this user has server-wide administrative rights. Also a pushdown filter.
         expr: {kind: path, path: [is_admin]}
+      - name: is_active
+        type: Boolean
+        nullable: true
+        description: Whether the account is active. Also a pushdown filter.
+        expr: {kind: path, path: [active]}
+      - name: is_restricted
+        type: Boolean
+        nullable: true
+        description: Whether the account is restricted. Also a pushdown filter.
+        expr: {kind: path, path: [restricted]}
+      - name: is_prohibit_login
+        type: Boolean
+        nullable: true
+        description: Whether the account is prohibited from logging in. Also a pushdown filter.
+        expr: {kind: path, path: [prohibit_login]}
       - name: last_login
         type: Timestamp
         nullable: true
@@ -249,3 +309,11 @@ tables:
           kind: format_timestamp
           input: iso8601
           expr: {kind: path, path: [last_login]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp tracking when the account was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created]}

--- a/sources/community/gitea/manifest.yaml
+++ b/sources/community/gitea/manifest.yaml
@@ -1,0 +1,251 @@
+name: gitea
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Gitea repositories, organizations, and user accounts through the Gitea REST API v1.
+base_url: "{{input.GITEA_BASE_URL}}/api/v1"
+
+inputs:
+  GITEA_BASE_URL:
+    kind: variable
+    hint: |
+      Gitea instance base root URL with NO trailing slash and no /api/v1 suffix,
+      for example `https://gitea.example.com` or `http://localhost:3000`.
+  GITEA_API_TOKEN:
+    kind: secret
+    hint: |
+      Personal Access Token obtained from Gitea User Settings -> Applications.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: token {{input.GITEA_API_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name FROM gitea.repositories LIMIT 1
+
+tables:
+  - name: repositories
+    description: Repositories visible through the Gitea repository search API.
+    filters:
+      - name: query
+        required: false
+    request:
+      method: GET
+      path: /repos/search
+      query:
+        - name: q
+          from: filter
+          key: query
+        - name: limit
+          from: pagination
+          key: limit
+        - name: page
+          from: pagination
+          key: page
+    response:
+      row_strategy: direct
+      root_key: data
+    pagination:
+      mode: page
+      page_key: page
+      limit_key: limit
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Repository search query filter.
+        expr: {kind: from_filter, key: query}
+      - name: id
+        type: Int64
+        nullable: false
+        description: Internal database identifier of the repository.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Name of the repository.
+        expr: {kind: path, path: [name]}
+      - name: full_name
+        type: Utf8
+        nullable: false
+        description: Full name of the repository including owner (owner/repo).
+        expr: {kind: path, path: [full_name]}
+      - name: owner_username
+        type: Utf8
+        nullable: false
+        description: Username of the repository owner.
+        expr: {kind: path, path: [owner, login]}
+      - name: private
+        type: Boolean
+        nullable: false
+        description: Whether the repository is private or public.
+        expr: {kind: path, path: [private]}
+      - name: empty
+        type: Boolean
+        nullable: true
+        description: Whether the repository has no commits or code content.
+        expr: {kind: path, path: [empty]}
+      - name: clone_url
+        type: Utf8
+        nullable: true
+        description: HTTP URL used to clone the repository.
+        expr: {kind: path, path: [clone_url]}
+      - name: ssh_url
+        type: Utf8
+        nullable: true
+        description: SSH target URL used to clone the repository.
+        expr: {kind: path, path: [ssh_url]}
+      - name: stars_count
+        type: Int64
+        nullable: true
+        description: Number of stars given to the repository.
+        expr: {kind: path, path: [stars_count]}
+      - name: forks_count
+        type: Int64
+        nullable: true
+        description: Number of times this repository has been forked.
+        expr: {kind: path, path: [forks_count]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp detailing when the repository was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+
+  - name: organizations
+    description: Organizations that the authenticated user belongs to.
+    request:
+      method: GET
+      path: /user/orgs
+      query:
+        - name: limit
+          from: pagination
+          key: limit
+        - name: page
+          from: pagination
+          key: page
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_key: page
+      limit_key: limit
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Internal database identifier of the organization.
+        expr: {kind: path, path: [id]}
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Organization username/handle.
+        expr: {kind: path, path: [username]}
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: Display name of the organization.
+        expr: {kind: path, path: [full_name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Organization description.
+        expr: {kind: path, path: [description]}
+      - name: location
+        type: Utf8
+        nullable: true
+        description: Organization location.
+        expr: {kind: path, path: [location]}
+      - name: website
+        type: Utf8
+        nullable: true
+        description: Organization website URL.
+        expr: {kind: path, path: [website]}
+
+  - name: users
+    description: User accounts registered on the Gitea instance. Requires administrator privileges.
+    filters:
+      - name: query
+        required: false
+      - name: is_admin
+        required: false
+    request:
+      method: GET
+      path: /admin/users
+      query:
+        - name: q
+          from: filter
+          key: query
+        - name: admins
+          from: filter
+          key: is_admin
+        - name: limit
+          from: pagination
+          key: limit
+        - name: page
+          from: pagination
+          key: page
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_key: page
+      limit_key: limit
+    columns:
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: User search query filter.
+        expr: {kind: from_filter, key: query}
+      - name: is_admin_filter
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Filter limiting results to administrator accounts.
+        expr: {kind: from_filter, key: is_admin}
+      - name: id
+        type: Int64
+        nullable: false
+        description: Internal database identifier of the user account.
+        expr: {kind: path, path: [id]}
+      - name: username
+        type: Utf8
+        nullable: false
+        description: Unique login handle for the user.
+        expr: {kind: path, path: [login]}
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: Display name of the user.
+        expr: {kind: path, path: [full_name]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Email address configured on the profile.
+        expr: {kind: path, path: [email]}
+      - name: is_admin
+        type: Boolean
+        nullable: true
+        description: Whether this user has server-wide administrative rights.
+        expr: {kind: path, path: [is_admin]}
+      - name: last_login
+        type: Timestamp
+        nullable: true
+        description: Timestamp tracking when the user last authenticated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [last_login]}


### PR DESCRIPTION
## Summary

Adds a new Gitea community source under `sources/community/gitea`.

This source lets Coral users and AI agents query Gitea repositories, organizations, and users through the Gitea REST API v1 using read-only SQL.

## Included tables

- `repositories` — `GET /repos/search` (rows under `data`)
- `organizations` — `GET /user/orgs`
- `users` — `GET /admin/users` (requires administrator privileges)

## Features

- Token-based authentication (`Authorization: token <token>`)
- Repository inventory visibility (clone URLs, stars, forks, ownership, timestamps)
- Organization membership auditing
- Administrative user inspection with provider-side audit filters
- Page-based pagination across all tables
- ISO-8601 timestamp normalization
- Read-only operational visibility

## Pushdown filters

Server-side filtering so audits don't require full local scans:

- `gitea.repositories`: `query` → `q`
- `gitea.users`: `query`→`q`, `sort`, `order`, `visibility`, `is_active`, `is_admin`, `is_restricted`, `is_2fa_enabled`, `is_prohibit_login` — all mapped to Gitea's `adminSearchUsers` query parameters

## Notes

- Authentication uses `Authorization: token <token>`.
- `gitea.users` requires administrator privileges; `/admin/users` returns `403 Forbidden` otherwise.
- All tables use Gitea's `page` / `limit` pagination, injected automatically by Coral (`mode: page`, 1-indexed, `limit` capped at Gitea's default `MAX_RESPONSE_ITEMS` of 50).
- Initial implementation focuses on operational auditing and metadata visibility. Write operations (creating repos, modifying orgs, deleting users, managing hooks) are out of scope.

## Addressing review feedback

This revision resolves the prior blockers:

- Replaced the schema-invalid pagination shape — removed the invalid `from: pagination` query entries, `response.root_key`, and `pagination.page_key`/`limit_key`, and switched to the supported `mode: page` config (`page_param`, `page_start`, `page_size.query_param`/`default`/`max`). `/repos/search` now maps rows via `rows_path: [data]`.
- Fixed the admin filter: the user-admin parameter is now `is_admin` (was `admins`), so `WHERE is_admin = true` is pushed to Gitea.
- Expanded `gitea.users` provider-side filters (`sort`, `order`, `visibility`, `is_active`, `is_admin`, `is_restricted`, `is_2fa_enabled`, `is_prohibit_login`) to support operational auditing without full user scans.
- Removed the trailing blank line at EOF in the README.

The manifest now passes `coral source lint` and `make lint-sources`.

## Validation

```bash
make lint-sources
coral source lint sources/community/gitea/manifest.yaml
coral source add --file sources/community/gitea/manifest.yaml
coral source test gitea
coral sql "SELECT username, is_admin FROM gitea.users WHERE is_admin = true LIMIT 5"
```

Live `coral source test gitea` output against this exact head is included in the README.

## Related issue

Closes #728