### PR TITLE
feat(search): add sqlite search index foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "prost",
  "regex",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2187,6 +2188,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2509,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "heck"
@@ -3068,6 +3090,17 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -4238,6 +4271,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5344,6 +5391,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -22,6 +22,7 @@ opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true

--- a/crates/coral-app/src/search/index.rs
+++ b/crates/coral-app/src/search/index.rs
@@ -1,0 +1,301 @@
+//! Workspace-scoped `SQLite` storage for Universal Search retrieval.
+
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "foundation branch; the child branch wires this store into catalog metadata retrieval"
+    )
+)]
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rusqlite::Connection;
+
+use crate::state::AppStateLayout;
+use crate::storage::fs::ensure_dir;
+use crate::workspaces::WorkspaceName;
+
+pub(crate) const SEARCH_INDEX_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SearchIndexStore {
+    path: PathBuf,
+    capabilities: SqliteSearchCapabilities,
+}
+
+impl SearchIndexStore {
+    pub(crate) fn open_workspace(
+        layout: &AppStateLayout,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Self, SearchIndexError> {
+        Self::open(layout.search_index_file(workspace_name))
+    }
+
+    pub(crate) fn open(path: impl Into<PathBuf>) -> Result<Self, SearchIndexError> {
+        let path = path.into();
+        if let Some(parent) = path.parent() {
+            ensure_dir(parent)?;
+        }
+
+        let mut connection = Connection::open(&path)?;
+        configure_connection(&connection)?;
+        let capabilities = detect_capabilities(&connection)?;
+        ensure_supported(&capabilities)?;
+        migrate(&mut connection)?;
+
+        Ok(Self { path, capabilities })
+    }
+
+    pub(crate) fn connect(&self) -> Result<Connection, SearchIndexError> {
+        let connection = Connection::open(&self.path)?;
+        configure_connection(&connection)?;
+        Ok(connection)
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn capabilities(&self) -> &SqliteSearchCapabilities {
+        &self.capabilities
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SqliteSearchCapabilities {
+    pub(crate) sqlite_version: String,
+    pub(crate) fts5: bool,
+    pub(crate) trigram: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SearchIndexError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Sqlite(#[from] rusqlite::Error),
+    #[error("SQLite {sqlite_version} does not support required search feature: {feature}")]
+    UnsupportedCapability {
+        feature: &'static str,
+        sqlite_version: String,
+    },
+}
+
+fn configure_connection(connection: &Connection) -> Result<(), SearchIndexError> {
+    connection.busy_timeout(Duration::from_secs(5))?;
+    connection.pragma_update(None, "foreign_keys", "ON")?;
+    Ok(())
+}
+
+fn detect_capabilities(
+    connection: &Connection,
+) -> Result<SqliteSearchCapabilities, SearchIndexError> {
+    let sqlite_version =
+        connection.query_row("SELECT sqlite_version()", [], |row| row.get::<_, String>(0))?;
+    let fts5 = connection
+        .execute_batch(
+            "
+            CREATE VIRTUAL TABLE temp.coral_search_fts5_check USING fts5(value);
+            DROP TABLE temp.coral_search_fts5_check;
+            ",
+        )
+        .is_ok();
+    let trigram = connection
+        .execute_batch(
+            "
+            CREATE VIRTUAL TABLE temp.coral_search_trigram_check
+            USING fts5(value, tokenize = 'trigram');
+            DROP TABLE temp.coral_search_trigram_check;
+            ",
+        )
+        .is_ok();
+
+    Ok(SqliteSearchCapabilities {
+        sqlite_version,
+        fts5,
+        trigram,
+    })
+}
+
+fn ensure_supported(capabilities: &SqliteSearchCapabilities) -> Result<(), SearchIndexError> {
+    if !capabilities.fts5 {
+        return Err(SearchIndexError::UnsupportedCapability {
+            feature: "FTS5",
+            sqlite_version: capabilities.sqlite_version.clone(),
+        });
+    }
+    if !capabilities.trigram {
+        return Err(SearchIndexError::UnsupportedCapability {
+            feature: "FTS5 trigram tokenizer",
+            sqlite_version: capabilities.sqlite_version.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn migrate(connection: &mut Connection) -> Result<(), SearchIndexError> {
+    let transaction = connection.transaction()?;
+    transaction.execute_batch(
+        "
+        CREATE TABLE IF NOT EXISTS search_index_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL,
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );
+
+        INSERT INTO search_index_meta (key, value, updated_at)
+        VALUES ('schema_version', '1', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at;
+
+        CREATE TABLE IF NOT EXISTS catalog_entities (
+            workspace TEXT NOT NULL,
+            entity_key TEXT NOT NULL,
+            result_type TEXT NOT NULL,
+            surface_kind TEXT NOT NULL,
+            schema_name TEXT NOT NULL,
+            surface_name TEXT NOT NULL,
+            name TEXT NOT NULL,
+            data_type TEXT NOT NULL DEFAULT '',
+            is_required INTEGER NOT NULL DEFAULT 0,
+            description TEXT NOT NULL DEFAULT '',
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            PRIMARY KEY (workspace, entity_key)
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS catalog_entities_fts USING fts5(
+            workspace UNINDEXED,
+            entity_key UNINDEXED,
+            name,
+            qualified_name,
+            description,
+            searchable_text,
+            tokenize = 'trigram'
+        );
+
+        CREATE TABLE IF NOT EXISTS observed_values (
+            workspace TEXT NOT NULL,
+            source_name TEXT NOT NULL,
+            surface_kind TEXT NOT NULL,
+            surface_name TEXT NOT NULL,
+            column_name TEXT NOT NULL,
+            normalized_value_key TEXT NOT NULL,
+            display_value TEXT NOT NULL DEFAULT '',
+            sensitivity_tier TEXT NOT NULL DEFAULT 'low_risk',
+            suggested_operator TEXT NOT NULL DEFAULT 'exact',
+            first_observed_at TEXT NOT NULL,
+            last_observed_at TEXT NOT NULL,
+            observed_count INTEGER NOT NULL DEFAULT 1,
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            PRIMARY KEY (
+                workspace,
+                source_name,
+                surface_kind,
+                surface_name,
+                column_name,
+                normalized_value_key
+            )
+        );
+
+        CREATE INDEX IF NOT EXISTS observed_values_last_observed_idx
+            ON observed_values (workspace, last_observed_at);
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS observed_values_fts USING fts5(
+            workspace UNINDEXED,
+            source_name UNINDEXED,
+            surface_kind UNINDEXED,
+            surface_name UNINDEXED,
+            column_name UNINDEXED,
+            normalized_value_key UNINDEXED,
+            display_value,
+            searchable_text,
+            tokenize = 'trigram'
+        );
+
+        PRAGMA user_version = 1;
+        ",
+    )?;
+    transaction.commit()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::OptionalExtension as _;
+    use tempfile::tempdir;
+
+    use super::{SEARCH_INDEX_SCHEMA_VERSION, SearchIndexStore};
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
+
+    #[test]
+    fn open_workspace_creates_search_index_schema() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let store = SearchIndexStore::open_workspace(&layout, &workspace).expect("store");
+
+        assert_eq!(store.path(), layout.search_index_file(&workspace));
+        assert!(store.capabilities().fts5);
+        assert!(store.capabilities().trigram);
+
+        let connection = store.connect().expect("connect");
+        let user_version: u32 = connection
+            .query_row("PRAGMA user_version", [], |row| row.get(0))
+            .expect("user_version");
+        assert_eq!(user_version, SEARCH_INDEX_SCHEMA_VERSION);
+
+        let schema_version = connection
+            .query_row(
+                "SELECT value FROM search_index_meta WHERE key = 'schema_version'",
+                [],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .expect("schema_version query")
+            .expect("schema_version");
+        assert_eq!(schema_version, SEARCH_INDEX_SCHEMA_VERSION.to_string());
+    }
+
+    #[test]
+    fn catalog_fts_supports_bm25_trigram_matches() {
+        let temp = tempdir().expect("tempdir");
+        let store = SearchIndexStore::open(temp.path().join("search.sqlite")).expect("store");
+        let connection = store.connect().expect("connect");
+        connection
+            .execute(
+                "
+                INSERT INTO catalog_entities_fts (
+                    workspace,
+                    entity_key,
+                    name,
+                    qualified_name,
+                    description,
+                    searchable_text
+                )
+                VALUES ('default', 'function:github.search_commits', 'search_commits',
+                    'github.search_commits', 'Search commits', 'github commit sha')
+                ",
+                [],
+            )
+            .expect("insert fts row");
+
+        let row_count: u32 = connection
+            .query_row(
+                "
+                SELECT count(*)
+                FROM catalog_entities_fts
+                WHERE catalog_entities_fts MATCH '\"commit\"'
+                ORDER BY bm25(catalog_entities_fts)
+                ",
+                [],
+                |row| row.get(0),
+            )
+            .expect("fts query");
+        assert_eq!(row_count, 1);
+    }
+}

--- a/crates/coral-app/src/search/mod.rs
+++ b/crates/coral-app/src/search/mod.rs
@@ -1,3 +1,4 @@
 //! App-owned Universal Search behavior.
 
+pub(crate) mod index;
 pub(crate) mod service;

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -82,6 +82,14 @@ impl AppStateLayout {
         self.feedback_dir(workspace_name).join("reports.jsonl")
     }
 
+    pub(crate) fn search_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.workspace_dir(workspace_name).join("search")
+    }
+
+    pub(crate) fn search_index_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.search_dir(workspace_name).join("search.sqlite")
+    }
+
     pub(crate) fn source_dir(
         &self,
         workspace_name: &WorkspaceName,
@@ -150,6 +158,14 @@ mod tests {
                 .join("default")
                 .join("feedback")
                 .join("reports.jsonl")
+        );
+        assert_eq!(
+            layout.search_index_file(&workspace_name),
+            config_dir
+                .join("workspaces")
+                .join("default")
+                .join("search")
+                .join("search.sqlite")
         );
         assert_eq!(
             layout.local_trace_store_dir(),


### PR DESCRIPTION
## Summary

- Add a workspace-scoped SQLite search index at `workspaces/<workspace>/search/search.sqlite`.
- Add `SearchIndexStore` initialization, schema versioning, and FTS5/trigram capability checks.
- Create the initial catalog and observed-value tables/FTS tables needed by the follow-up retrieval providers.

## Tests

- `sqlite3 :memory: "select sqlite_version(); create virtual table fts_default using fts5(value); create virtual table fts_trigram using fts5(value, tokenize='trigram'); select 'fts5_trigram_ok';"`
- `cargo test -p coral-app search::index --all-features --locked`
- `cargo clippy -p coral-app --all-targets --all-features -- -D warnings`
- `make rust-checks` (run at stack tip)