### PR TITLE
feat(search): use sqlite catalog retrieval

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -47,7 +47,7 @@ use crate::feedback::publisher::{
 use crate::feedback::service::FeedbackService;
 use crate::query::manager::QueryManager;
 use crate::query::service::QueryService;
-use crate::search::service::SearchService;
+use crate::search::service::{SearchIndexRefresher, SearchService};
 use crate::sources::manager::SourceManager;
 use crate::sources::service::SourceService;
 use crate::state::{AppStateLayout, ConfigStore};
@@ -283,7 +283,7 @@ impl ServerBuilder {
             config_store,
             credential_manager,
             query_runtime_context,
-            layout,
+            layout.clone(),
             self.config.engine_extensions_providers,
         );
         let trace_service = if telemetry_config.trace_history.enabled {
@@ -296,6 +296,7 @@ impl ServerBuilder {
             query_manager,
             feedback_manager,
             trace_service,
+            layout,
             self.config.mode,
         )
         .await
@@ -377,11 +378,17 @@ async fn start_server(
     query_manager: QueryManager,
     feedback_manager: FeedbackManager,
     trace_service: Option<TraceService>,
+    layout: AppStateLayout,
     mode: ServerMode,
 ) -> Result<RunningServer, AppError> {
-    let source_service = SourceService::new(source_manager, query_manager.clone());
+    let search_index_refresher = SearchIndexRefresher::new(layout);
+    let source_service = SourceService::new(
+        source_manager,
+        query_manager.clone(),
+        search_index_refresher.clone(),
+    );
     let catalog_service = CatalogService::new(query_manager.clone());
-    let search_service = SearchService::new(query_manager.clone());
+    let search_service = SearchService::new(query_manager.clone(), search_index_refresher);
     let query_service = QueryService::new(query_manager);
     let feedback_service = FeedbackService::new(feedback_manager);
     let mut routes = Routes::default()
@@ -720,7 +727,7 @@ enabled = false
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let trace_service =
@@ -730,6 +737,7 @@ enabled = false
             query_manager,
             feedback_manager,
             Some(trace_service),
+            layout,
             ServerMode::NativeGrpc,
         )
         .await
@@ -1101,7 +1109,7 @@ tables:
                 home_dir: Some(fake_home.clone()),
                 ..QueryRuntimeContext::default()
             },
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let running = start_server(
@@ -1109,6 +1117,7 @@ tables:
             query_manager,
             feedback_manager,
             None,
+            layout,
             ServerMode::NativeGrpc,
         )
         .await
@@ -1200,7 +1209,7 @@ tables:
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let running = start_server(
@@ -1208,6 +1217,7 @@ tables:
             query_manager,
             feedback_manager,
             None,
+            layout,
             ServerMode::NativeGrpc,
         )
         .await
@@ -1299,7 +1309,7 @@ tables:
             config_store,
             credential_manager,
             QueryRuntimeContext::default(),
-            layout,
+            layout.clone(),
             vec![Arc::new(NoopEngineExtensionsProvider)],
         );
         let running = start_server(
@@ -1307,6 +1317,7 @@ tables:
             query_manager,
             feedback_manager,
             None,
+            layout,
             ServerMode::NativeGrpc,
         )
         .await

--- a/crates/coral-app/src/search/index.rs
+++ b/crates/coral-app/src/search/index.rs
@@ -1,17 +1,13 @@
 //! Workspace-scoped `SQLite` storage for Universal Search retrieval.
 
-#![cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "foundation branch; the child branch wires this store into catalog metadata retrieval"
-    )
-)]
-
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::Duration;
 
-use rusqlite::Connection;
+use coral_engine::{
+    CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
+    TableFunctionResultColumnInfo, TableInfo,
+};
+use rusqlite::{Connection, params};
 
 use crate::state::AppStateLayout;
 use crate::storage::fs::ensure_dir;
@@ -54,12 +50,188 @@ impl SearchIndexStore {
         Ok(connection)
     }
 
-    pub(crate) fn path(&self) -> &Path {
+    #[cfg(test)]
+    pub(crate) fn path(&self) -> &std::path::Path {
         &self.path
     }
 
     pub(crate) fn capabilities(&self) -> &SqliteSearchCapabilities {
         &self.capabilities
+    }
+
+    pub(crate) fn replace_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+    ) -> Result<(), SearchIndexError> {
+        let records = catalog_entity_records(catalog);
+        let mut connection = self.connect()?;
+        let transaction = connection.transaction()?;
+
+        transaction.execute(
+            "DELETE FROM catalog_entities_fts WHERE workspace = ?1",
+            params![workspace_name.as_str()],
+        )?;
+        transaction.execute(
+            "DELETE FROM catalog_entities WHERE workspace = ?1",
+            params![workspace_name.as_str()],
+        )?;
+
+        {
+            let mut entity_insert = transaction.prepare(
+                "
+                INSERT INTO catalog_entities (
+                    workspace,
+                    entity_key,
+                    result_type,
+                    surface_kind,
+                    schema_name,
+                    surface_name,
+                    name,
+                    data_type,
+                    is_required,
+                    description,
+                    updated_at
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
+                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                ",
+            )?;
+            let mut fts_insert = transaction.prepare(
+                "
+                INSERT INTO catalog_entities_fts (
+                    workspace,
+                    entity_key,
+                    name,
+                    qualified_name,
+                    description,
+                    searchable_text
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                ",
+            )?;
+
+            for record in records {
+                entity_insert.execute(params![
+                    workspace_name.as_str(),
+                    &record.entity_key,
+                    record.result_type.as_str(),
+                    record.surface_kind.as_str(),
+                    &record.schema_name,
+                    &record.surface_name,
+                    &record.name,
+                    &record.data_type,
+                    i64::from(record.required),
+                    &record.description,
+                ])?;
+                fts_insert.execute(params![
+                    workspace_name.as_str(),
+                    &record.entity_key,
+                    &record.name,
+                    &record.qualified_name,
+                    &record.description,
+                    &record.searchable_text,
+                ])?;
+            }
+        }
+
+        transaction.execute(
+            "
+            INSERT INTO search_index_meta (key, value, updated_at)
+            VALUES (?1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            ON CONFLICT(key) DO UPDATE SET
+                value = excluded.value,
+                updated_at = excluded.updated_at
+            ",
+            params![format!("catalog_refreshed_at:{}", workspace_name.as_str())],
+        )?;
+        transaction.commit()?;
+        Ok(())
+    }
+
+    pub(crate) fn search_catalog(
+        &self,
+        workspace_name: &WorkspaceName,
+        terms: &[String],
+        limit: usize,
+    ) -> Result<Vec<CatalogSearchHit>, SearchIndexError> {
+        let Some(match_query) = fts_match_query(terms) else {
+            return Ok(Vec::new());
+        };
+        let connection = self.connect()?;
+        let mut statement = connection.prepare(
+            "
+            SELECT
+                e.entity_key,
+                e.result_type,
+                e.surface_kind,
+                e.schema_name,
+                e.surface_name,
+                e.name,
+                e.data_type,
+                e.is_required,
+                e.description,
+                f.name,
+                f.qualified_name,
+                f.description,
+                f.searchable_text,
+                bm25(catalog_entities_fts, 4.0, 5.0, 2.0, 1.0) AS rank
+            FROM catalog_entities_fts f
+            JOIN catalog_entities e
+                ON e.workspace = f.workspace AND e.entity_key = f.entity_key
+            WHERE f.workspace = ?1 AND catalog_entities_fts MATCH ?2
+            ORDER BY rank ASC, e.result_type ASC, e.entity_key ASC
+            LIMIT ?3
+            ",
+        )?;
+        let rows = statement.query_map(
+            params![
+                workspace_name.as_str(),
+                match_query,
+                i64::try_from(limit).unwrap_or(i64::MAX),
+            ],
+            |row| {
+                let result_type_raw: String = row.get(1)?;
+                let surface_kind_raw: String = row.get(2)?;
+                let name_field: String = row.get(9)?;
+                let qualified_name: String = row.get(10)?;
+                let description_field: String = row.get(11)?;
+                let searchable_text: String = row.get(12)?;
+                Ok(CatalogSearchHit {
+                    entity_key: row.get(0)?,
+                    result_type: CatalogSearchResultType::from_str(&result_type_raw),
+                    surface_kind: CatalogSearchSurfaceKind::from_str(&surface_kind_raw),
+                    schema_name: row.get(3)?,
+                    surface_name: row.get(4)?,
+                    name: row.get(5)?,
+                    data_type: row.get(6)?,
+                    required: row.get::<_, i64>(7)? != 0,
+                    description: row.get(8)?,
+                    matched_fields: matched_fields(
+                        terms,
+                        [
+                            ("name", name_field.as_str()),
+                            ("qualified_name", qualified_name.as_str()),
+                            ("description", description_field.as_str()),
+                            ("searchable_text", searchable_text.as_str()),
+                        ],
+                    ),
+                    score: 0,
+                })
+            },
+        )?;
+
+        let mut hits = Vec::new();
+        for row in rows {
+            hits.push(row?);
+        }
+        let hit_count = u32::try_from(hits.len()).unwrap_or(u32::MAX);
+        for (position, hit) in hits.iter_mut().enumerate() {
+            let position = u32::try_from(position).unwrap_or(u32::MAX);
+            hit.score = hit_count.saturating_sub(position);
+        }
+        Ok(hits)
     }
 }
 
@@ -81,6 +253,88 @@ pub(crate) enum SearchIndexError {
         feature: &'static str,
         sqlite_version: String,
     },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CatalogSearchHit {
+    pub(crate) entity_key: String,
+    pub(crate) result_type: Option<CatalogSearchResultType>,
+    pub(crate) surface_kind: Option<CatalogSearchSurfaceKind>,
+    pub(crate) schema_name: String,
+    pub(crate) surface_name: String,
+    pub(crate) name: String,
+    pub(crate) data_type: String,
+    pub(crate) required: bool,
+    pub(crate) description: String,
+    pub(crate) matched_fields: Vec<String>,
+    pub(crate) score: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CatalogSearchResultType {
+    CatalogTable,
+    CatalogTableFunction,
+    ColumnHint,
+    NativeSearchPath,
+}
+
+impl CatalogSearchResultType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::CatalogTable => "catalog_table",
+            Self::CatalogTableFunction => "catalog_table_function",
+            Self::ColumnHint => "column_hint",
+            Self::NativeSearchPath => "native_search_path",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "catalog_table" => Some(Self::CatalogTable),
+            "catalog_table_function" => Some(Self::CatalogTableFunction),
+            "column_hint" => Some(Self::ColumnHint),
+            "native_search_path" => Some(Self::NativeSearchPath),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum CatalogSearchSurfaceKind {
+    Table,
+    TableFunction,
+}
+
+impl CatalogSearchSurfaceKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::TableFunction => "table_function",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "table" => Some(Self::Table),
+            "table_function" => Some(Self::TableFunction),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CatalogEntityRecord {
+    entity_key: String,
+    result_type: CatalogSearchResultType,
+    surface_kind: CatalogSearchSurfaceKind,
+    schema_name: String,
+    surface_name: String,
+    name: String,
+    qualified_name: String,
+    data_type: String,
+    required: bool,
+    description: String,
+    searchable_text: String,
 }
 
 fn configure_connection(connection: &Connection) -> Result<(), SearchIndexError> {
@@ -144,12 +398,6 @@ fn migrate(connection: &mut Connection) -> Result<(), SearchIndexError> {
             value TEXT NOT NULL,
             updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
         );
-
-        INSERT INTO search_index_meta (key, value, updated_at)
-        VALUES ('schema_version', '1', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-        ON CONFLICT(key) DO UPDATE SET
-            value = excluded.value,
-            updated_at = excluded.updated_at;
 
         CREATE TABLE IF NOT EXISTS catalog_entities (
             workspace TEXT NOT NULL,
@@ -215,19 +463,307 @@ fn migrate(connection: &mut Connection) -> Result<(), SearchIndexError> {
             tokenize = 'trigram'
         );
 
-        PRAGMA user_version = 1;
         ",
     )?;
+    transaction.execute(
+        "
+        INSERT INTO search_index_meta (key, value, updated_at)
+        SELECT 'schema_version', ?1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        WHERE NOT EXISTS (
+            SELECT 1 FROM search_index_meta
+            WHERE key = 'schema_version' AND value = ?1
+        )
+        ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            updated_at = excluded.updated_at
+        ",
+        params![SEARCH_INDEX_SCHEMA_VERSION.to_string()],
+    )?;
+    let user_version: u32 = transaction.query_row("PRAGMA user_version", [], |row| row.get(0))?;
+    if user_version != SEARCH_INDEX_SCHEMA_VERSION {
+        transaction.pragma_update(None, "user_version", SEARCH_INDEX_SCHEMA_VERSION)?;
+    }
     transaction.commit()?;
     Ok(())
 }
 
+fn catalog_entity_records(catalog: &CatalogInfo) -> Vec<CatalogEntityRecord> {
+    let mut records = Vec::new();
+    for table in &catalog.tables {
+        table_entity_records(table, &mut records);
+    }
+    for function in &catalog.table_functions {
+        table_function_entity_records(function, &mut records);
+    }
+    records
+}
+
+fn table_entity_records(table: &TableInfo, records: &mut Vec<CatalogEntityRecord>) {
+    let qualified_name = qualified_name(&table.schema_name, &table.table_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("catalog:table:{qualified_name}"),
+        result_type: CatalogSearchResultType::CatalogTable,
+        surface_kind: CatalogSearchSurfaceKind::Table,
+        schema_name: table.schema_name.clone(),
+        surface_name: table.table_name.clone(),
+        name: table.table_name.clone(),
+        qualified_name: qualified_name.clone(),
+        data_type: String::new(),
+        required: false,
+        description: table.description.clone(),
+        searchable_text: join_search_text([
+            table.schema_name.as_str(),
+            table.table_name.as_str(),
+            qualified_name.as_str(),
+            table.description.as_str(),
+            table.guide.as_str(),
+            table.required_filters.join(" ").as_str(),
+        ]),
+    });
+
+    for column in &table.columns {
+        table_column_record(table, column, records);
+    }
+    for filter in &table.required_filters {
+        table_required_filter_record(table, filter, records);
+    }
+}
+
+fn table_column_record(
+    table: &TableInfo,
+    column: &ColumnInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&table.schema_name, &table.table_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("column:table:{surface_name}:{}", column.name),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::Table,
+        schema_name: table.schema_name.clone(),
+        surface_name: table.table_name.clone(),
+        name: column.name.clone(),
+        qualified_name: format!("{surface_name}.{}", column.name),
+        data_type: column.data_type.clone(),
+        required: column.is_required_filter,
+        description: column.description.clone(),
+        searchable_text: join_search_text([
+            table.schema_name.as_str(),
+            table.table_name.as_str(),
+            column.name.as_str(),
+            column.data_type.as_str(),
+            column.description.as_str(),
+        ]),
+    });
+}
+
+fn table_required_filter_record(
+    table: &TableInfo,
+    filter: &str,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&table.schema_name, &table.table_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("filter:table:{surface_name}:{filter}"),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::Table,
+        schema_name: table.schema_name.clone(),
+        surface_name: table.table_name.clone(),
+        name: filter.to_string(),
+        qualified_name: format!("{surface_name}.{filter}"),
+        data_type: String::new(),
+        required: true,
+        description: "Required table filter".to_string(),
+        searchable_text: join_search_text([
+            table.schema_name.as_str(),
+            table.table_name.as_str(),
+            filter,
+            "required table filter",
+        ]),
+    });
+}
+
+fn table_function_entity_records(
+    function: &TableFunctionInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let qualified_name = qualified_name(&function.schema_name, &function.function_name);
+    let arguments = function
+        .arguments
+        .iter()
+        .map(|argument| argument.name.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    let result_columns = function
+        .result_columns
+        .iter()
+        .map(|column| column.name.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    records.push(CatalogEntityRecord {
+        entity_key: format!("catalog:function:{qualified_name}"),
+        result_type: CatalogSearchResultType::CatalogTableFunction,
+        surface_kind: CatalogSearchSurfaceKind::TableFunction,
+        schema_name: function.schema_name.clone(),
+        surface_name: function.function_name.clone(),
+        name: function.function_name.clone(),
+        qualified_name: qualified_name.clone(),
+        data_type: String::new(),
+        required: false,
+        description: function.description.clone(),
+        searchable_text: join_search_text([
+            function.schema_name.as_str(),
+            function.function_name.as_str(),
+            qualified_name.as_str(),
+            function.description.as_str(),
+            function.kind.as_str(),
+            arguments.as_str(),
+            result_columns.as_str(),
+        ]),
+    });
+
+    if function.kind == "search" {
+        records.push(CatalogEntityRecord {
+            entity_key: format!("native_search:{qualified_name}"),
+            result_type: CatalogSearchResultType::NativeSearchPath,
+            surface_kind: CatalogSearchSurfaceKind::TableFunction,
+            schema_name: function.schema_name.clone(),
+            surface_name: function.function_name.clone(),
+            name: function.function_name.clone(),
+            qualified_name: qualified_name.clone(),
+            data_type: String::new(),
+            required: false,
+            description: function.description.clone(),
+            searchable_text: join_search_text([
+                function.schema_name.as_str(),
+                function.function_name.as_str(),
+                qualified_name.as_str(),
+                function.description.as_str(),
+                "native search path source scoped table function",
+                arguments.as_str(),
+                result_columns.as_str(),
+            ]),
+        });
+    }
+
+    for argument in &function.arguments {
+        table_function_argument_record(function, argument, records);
+    }
+    for column in &function.result_columns {
+        table_function_result_column_record(function, column, records);
+    }
+}
+
+fn table_function_argument_record(
+    function: &TableFunctionInfo,
+    argument: &TableFunctionArgumentInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&function.schema_name, &function.function_name);
+    let values = argument.values.join(" ");
+    records.push(CatalogEntityRecord {
+        entity_key: format!("argument:function:{surface_name}:{}", argument.name),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::TableFunction,
+        schema_name: function.schema_name.clone(),
+        surface_name: function.function_name.clone(),
+        name: argument.name.clone(),
+        qualified_name: format!("{surface_name}.{}", argument.name),
+        data_type: String::new(),
+        required: argument.required,
+        description: "Table function argument".to_string(),
+        searchable_text: join_search_text([
+            function.schema_name.as_str(),
+            function.function_name.as_str(),
+            argument.name.as_str(),
+            values.as_str(),
+            "table function argument",
+        ]),
+    });
+}
+
+fn table_function_result_column_record(
+    function: &TableFunctionInfo,
+    column: &TableFunctionResultColumnInfo,
+    records: &mut Vec<CatalogEntityRecord>,
+) {
+    let surface_name = qualified_name(&function.schema_name, &function.function_name);
+    records.push(CatalogEntityRecord {
+        entity_key: format!("result_column:function:{surface_name}:{}", column.name),
+        result_type: CatalogSearchResultType::ColumnHint,
+        surface_kind: CatalogSearchSurfaceKind::TableFunction,
+        schema_name: function.schema_name.clone(),
+        surface_name: function.function_name.clone(),
+        name: column.name.clone(),
+        qualified_name: format!("{surface_name}.{}", column.name),
+        data_type: column.data_type.clone(),
+        required: false,
+        description: column.description.clone(),
+        searchable_text: join_search_text([
+            function.schema_name.as_str(),
+            function.function_name.as_str(),
+            column.name.as_str(),
+            column.data_type.as_str(),
+            column.description.as_str(),
+            "table function result column",
+        ]),
+    });
+}
+
+fn qualified_name(schema_name: &str, surface_name: &str) -> String {
+    format!("{schema_name}.{surface_name}")
+}
+
+fn join_search_text<const N: usize>(parts: [&str; N]) -> String {
+    parts
+        .into_iter()
+        .filter(|part| !part.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn fts_match_query(terms: &[String]) -> Option<String> {
+    let phrases = terms
+        .iter()
+        .filter(|term| term.chars().count() >= 3)
+        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .collect::<Vec<_>>();
+    if phrases.is_empty() {
+        None
+    } else {
+        Some(phrases.join(" OR "))
+    }
+}
+
+fn matched_fields<const N: usize>(
+    terms: &[String],
+    fields: [(&'static str, &str); N],
+) -> Vec<String> {
+    let mut matched = fields
+        .into_iter()
+        .filter_map(|(field, value)| {
+            let normalized = value.to_ascii_lowercase();
+            terms
+                .iter()
+                .any(|term| normalized.contains(term.as_str()))
+                .then_some(field.to_string())
+        })
+        .collect::<Vec<_>>();
+    matched.sort();
+    matched.dedup();
+    matched
+}
+
 #[cfg(test)]
 mod tests {
+    use coral_engine::{
+        CatalogInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
+    };
     use rusqlite::OptionalExtension as _;
     use tempfile::tempdir;
 
-    use super::{SEARCH_INDEX_SCHEMA_VERSION, SearchIndexStore};
+    use super::{
+        CatalogSearchResultType, SEARCH_INDEX_SCHEMA_VERSION, SearchIndexStore, fts_match_query,
+    };
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
 
@@ -297,5 +833,81 @@ mod tests {
             )
             .expect("fts query");
         assert_eq!(row_count, 1);
+    }
+
+    #[test]
+    fn replace_catalog_indexes_function_metadata() {
+        let temp = tempdir().expect("tempdir");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let store = SearchIndexStore::open(temp.path().join("search.sqlite")).expect("store");
+        store
+            .replace_catalog(&workspace, &catalog_with_search_function())
+            .expect("replace catalog");
+
+        let hits = store
+            .search_catalog(
+                &workspace,
+                &[
+                    "github".to_string(),
+                    "deployments".to_string(),
+                    "sha".to_string(),
+                ],
+                10,
+            )
+            .expect("search catalog");
+
+        assert!(hits.iter().any(|hit| hit.result_type
+            == Some(CatalogSearchResultType::NativeSearchPath)
+            && hit.surface_name == "search_deployments"));
+        assert!(hits.iter().any(|hit| hit.result_type
+            == Some(CatalogSearchResultType::ColumnHint)
+            && hit.name == "sha"));
+
+        store
+            .replace_catalog(
+                &workspace,
+                &CatalogInfo {
+                    tables: Vec::new(),
+                    table_functions: Vec::new(),
+                },
+            )
+            .expect("replace empty catalog");
+        let hits = store
+            .search_catalog(&workspace, &["github".to_string()], 10)
+            .expect("search empty catalog");
+        assert!(hits.is_empty());
+    }
+
+    #[test]
+    fn fts_match_query_quotes_technical_terms() {
+        assert_eq!(
+            fts_match_query(&["github.search_commits".to_string(), "id".to_string()])
+                .expect("query"),
+            "\"github.search_commits\""
+        );
+    }
+
+    fn catalog_with_search_function() -> CatalogInfo {
+        CatalogInfo {
+            tables: Vec::new(),
+            table_functions: vec![TableFunctionInfo {
+                schema_name: "github".to_string(),
+                function_name: "search_deployments".to_string(),
+                description: "Search GitHub deployments".to_string(),
+                arguments: vec![TableFunctionArgumentInfo {
+                    name: "q".to_string(),
+                    required: true,
+                    values: Vec::new(),
+                }],
+                result_columns: vec![TableFunctionResultColumnInfo {
+                    name: "sha".to_string(),
+                    data_type: "Utf8".to_string(),
+                    nullable: false,
+                    description: "Deployment commit SHA".to_string(),
+                }],
+                kind: "search".to_string(),
+                search_limits_json: None,
+            }],
+        }
     }
 }

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -2,6 +2,7 @@
 
 use std::cmp::Reverse;
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 
 use coral_api::v1::search_result::Payload;
 use coral_api::v1::search_service_server::SearchService as SearchServiceApi;
@@ -10,19 +11,22 @@ use coral_api::v1::{
     SearchRequest, SearchResponse, SearchResult, SearchResultTruncation, SearchResultType,
     SearchSurfaceKind,
 };
-use coral_engine::{
-    CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
-    TableFunctionResultColumnInfo, TableInfo,
-};
+use coral_engine::{CatalogInfo, TableFunctionInfo, TableInfo};
 use tonic::{Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
 use crate::query::manager::{QueryManager, QueryManagerError};
+use crate::search::index::{
+    CatalogSearchHit, CatalogSearchResultType, CatalogSearchSurfaceKind, SearchIndexError,
+    SearchIndexStore,
+};
+use crate::state::AppStateLayout;
 use crate::transport::{
     catalog_item_to_proto, grpc_span, instrument_grpc, query_status, table_function_to_proto,
     workspace_name_from_proto, workspace_to_proto,
 };
 use crate::workspaces::WorkspaceName;
+use tokio::sync::Mutex;
 
 const DEFAULT_SEARCH_LIMIT: u32 = 10;
 const MAX_SEARCH_LIMIT: u32 = 50;
@@ -35,10 +39,46 @@ pub(crate) struct SearchService {
 }
 
 impl SearchService {
-    pub(crate) fn new(query_manager: QueryManager) -> Self {
+    pub(crate) fn new(query_manager: QueryManager, indexes: SearchIndexRefresher) -> Self {
         Self {
-            search: UniversalSearch::new(query_manager),
+            search: UniversalSearch::new(query_manager, indexes),
         }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SearchIndexRefresher {
+    layout: AppStateLayout,
+    refreshed_workspaces: Arc<Mutex<BTreeSet<WorkspaceName>>>,
+}
+
+impl SearchIndexRefresher {
+    pub(crate) fn new(layout: AppStateLayout) -> Self {
+        Self {
+            layout,
+            refreshed_workspaces: Arc::new(Mutex::new(BTreeSet::new())),
+        }
+    }
+
+    async fn refresh_catalog_if_needed(
+        &self,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+    ) -> Result<SearchIndexStore, SearchIndexError> {
+        let mut refreshed_workspaces = self.refreshed_workspaces.lock().await;
+        let index = SearchIndexStore::open_workspace(&self.layout, workspace_name)?;
+        if !refreshed_workspaces.contains(workspace_name) {
+            index.replace_catalog(workspace_name, catalog)?;
+            refreshed_workspaces.insert(workspace_name.clone());
+        }
+        Ok(index)
+    }
+
+    pub(crate) async fn mark_catalog_dirty(&self, workspace_name: &WorkspaceName) {
+        self.refreshed_workspaces
+            .lock()
+            .await
+            .remove(workspace_name);
     }
 }
 
@@ -67,12 +107,14 @@ impl SearchServiceApi for SearchService {
 #[derive(Clone)]
 struct UniversalSearch {
     queries: QueryManager,
+    indexes: SearchIndexRefresher,
 }
 
 impl UniversalSearch {
-    fn new(query_manager: QueryManager) -> Self {
+    fn new(query_manager: QueryManager, indexes: SearchIndexRefresher) -> Self {
         Self {
             queries: query_manager,
+            indexes,
         }
     }
 
@@ -84,8 +126,9 @@ impl UniversalSearch {
     ) -> Result<SearchResponse, QueryManagerError> {
         let terms = query_terms(query).map_err(QueryManagerError::App)?;
         let catalog = self.queries.list_catalog(workspace_name, None).await?;
-        let mut candidates =
-            dedupe_candidates(catalog_candidates(workspace_name, &catalog, &terms));
+        let (mut candidates, catalog_status) = self
+            .catalog_metadata_candidates(workspace_name, &catalog, &terms, limit)
+            .await;
         candidates.sort();
 
         let total_count = candidates.len();
@@ -97,19 +140,13 @@ impl UniversalSearch {
             .map(|candidate| candidate.result)
             .collect::<Vec<_>>();
         let returned_count = u32::try_from(results.len()).unwrap_or(u32::MAX);
-        let provider_state = if total_count == 0 {
-            SearchProviderState::Empty
-        } else {
-            SearchProviderState::ResultsFound
-        };
-
         Ok(SearchResponse {
             results,
             provider_statuses: vec![
                 SearchProviderStatus {
                     provider: SearchProvider::CatalogMetadata as i32,
-                    state: provider_state as i32,
-                    note: catalog_provider_note(provider_state, total_count),
+                    state: catalog_status.state as i32,
+                    note: catalog_status.note,
                 },
                 SearchProviderStatus {
                     provider: SearchProvider::ObservedValues as i32,
@@ -125,6 +162,53 @@ impl UniversalSearch {
             }),
         })
     }
+
+    async fn catalog_metadata_candidates(
+        &self,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+        terms: &QueryTerms,
+        limit: u32,
+    ) -> (Vec<Candidate>, CatalogProviderStatus) {
+        let index = match self
+            .indexes
+            .refresh_catalog_if_needed(workspace_name, catalog)
+            .await
+        {
+            Ok(index) => index,
+            Err(error) => return (Vec::new(), catalog_index_error_status(&error)),
+        };
+        let capabilities = index.capabilities();
+        tracing::debug!(
+            workspace = %workspace_name,
+            sqlite_version = %capabilities.sqlite_version,
+            fts5 = capabilities.fts5,
+            trigram = capabilities.trigram,
+            "using SQLite catalog search index"
+        );
+        let search_limit = usize::try_from(limit)
+            .unwrap_or(usize::MAX)
+            .saturating_mul(5)
+            .max(25);
+        let hits = match index.search_catalog(workspace_name, &terms.terms, search_limit) {
+            Ok(hits) => hits,
+            Err(error) => return (Vec::new(), catalog_index_error_status(&error)),
+        };
+        let candidates =
+            dedupe_candidates(catalog_candidates_from_hits(workspace_name, catalog, hits));
+        let state = if candidates.is_empty() {
+            SearchProviderState::Empty
+        } else {
+            SearchProviderState::ResultsFound
+        };
+        let note = catalog_provider_note(state, candidates.len());
+        (candidates, CatalogProviderStatus { state, note })
+    }
+}
+
+struct CatalogProviderStatus {
+    state: SearchProviderState,
+    note: String,
 }
 
 #[derive(Clone)]
@@ -176,7 +260,6 @@ fn dedupe_candidates(candidates: Vec<Candidate>) -> Vec<Candidate> {
 
 #[derive(Clone, Debug)]
 struct QueryTerms {
-    normalized_query: String,
     terms: Vec<String>,
 }
 
@@ -219,10 +302,7 @@ fn query_terms(query: &str) -> Result<QueryTerms, AppError> {
     terms.sort();
     terms.dedup();
 
-    Ok(QueryTerms {
-        normalized_query,
-        terms,
-    })
+    Ok(QueryTerms { terms })
 }
 
 fn is_query_token_char(ch: char) -> bool {
@@ -233,223 +313,97 @@ fn normalize(value: &str) -> String {
     value.trim().to_ascii_lowercase()
 }
 
-fn catalog_candidates(
+fn catalog_candidates_from_hits(
     workspace_name: &WorkspaceName,
     catalog: &CatalogInfo,
-    terms: &QueryTerms,
+    hits: Vec<CatalogSearchHit>,
 ) -> Vec<Candidate> {
     let mut candidates = Vec::new();
-    for table in &catalog.tables {
-        table_candidates(workspace_name, table, terms, &mut candidates);
+    let mut column_hints_by_surface =
+        BTreeMap::<(CatalogSearchSurfaceKind, String, String), usize>::new();
+    for hit in hits {
+        match hit.result_type {
+            Some(CatalogSearchResultType::CatalogTable) => {
+                if let Some(table) = find_table(catalog, &hit.schema_name, &hit.surface_name) {
+                    candidates.push(Candidate {
+                        key: hit.entity_key,
+                        score: hit.score,
+                        type_order: 1,
+                        result: SearchResult {
+                            r#type: SearchResultType::CatalogItem as i32,
+                            payload: Some(Payload::CatalogItem(catalog_item_to_proto(
+                                workspace_name,
+                                crate::catalog::discovery::CatalogItem::Table(table_summary(table)),
+                            ))),
+                        },
+                    });
+                }
+            }
+            Some(CatalogSearchResultType::CatalogTableFunction) => {
+                if let Some(function) = find_function(catalog, &hit.schema_name, &hit.surface_name)
+                {
+                    candidates.push(Candidate {
+                        key: hit.entity_key,
+                        score: hit.score,
+                        type_order: 1,
+                        result: SearchResult {
+                            r#type: SearchResultType::CatalogItem as i32,
+                            payload: Some(Payload::CatalogItem(catalog_item_to_proto(
+                                workspace_name,
+                                crate::catalog::discovery::CatalogItem::TableFunction(
+                                    function.clone(),
+                                ),
+                            ))),
+                        },
+                    });
+                }
+            }
+            Some(CatalogSearchResultType::ColumnHint) => {
+                let Some(surface_kind) = hit.surface_kind else {
+                    continue;
+                };
+                let count_key = (
+                    surface_kind,
+                    hit.schema_name.clone(),
+                    hit.surface_name.clone(),
+                );
+                let count = column_hints_by_surface.entry(count_key).or_default();
+                if *count >= MAX_COLUMN_HINTS_PER_SURFACE {
+                    continue;
+                }
+                candidates.push(column_hint_candidate(
+                    ColumnHintCandidate {
+                        workspace_name,
+                        schema_name: &hit.schema_name,
+                        surface_name: &hit.surface_name,
+                        surface_kind: surface_kind.to_proto(),
+                        name: &hit.name,
+                        data_type: &hit.data_type,
+                        required: hit.required,
+                        description: &hit.description,
+                        matched_fields: hit.matched_fields,
+                    },
+                    hit.score,
+                ));
+                *count += 1;
+            }
+            Some(CatalogSearchResultType::NativeSearchPath) => {
+                if let Some(function) = find_function(catalog, &hit.schema_name, &hit.surface_name)
+                    && function.kind == "search"
+                {
+                    candidates.push(native_search_path_candidate(
+                        workspace_name,
+                        function,
+                        hit.matched_fields,
+                        hit.score,
+                    ));
+                }
+            }
+            None => {}
+        }
     }
-    for function in &catalog.table_functions {
-        table_function_candidates(workspace_name, function, terms, &mut candidates);
-    }
+
     candidates
-}
-
-fn table_candidates(
-    workspace_name: &WorkspaceName,
-    table: &TableInfo,
-    terms: &QueryTerms,
-    candidates: &mut Vec<Candidate>,
-) {
-    let name = qualified_name(&table.schema_name, &table.table_name);
-    let fields = [
-        ("schema_name", table.schema_name.as_str(), 2),
-        ("table_name", table.table_name.as_str(), 4),
-        ("name", name.as_str(), 4),
-        ("description", table.description.as_str(), 2),
-        ("guide", table.guide.as_str(), 1),
-    ];
-    if let Some((score, _matched_fields)) = score_fields(terms, fields) {
-        candidates.push(Candidate {
-            key: format!("catalog:table:{}.{}", table.schema_name, table.table_name),
-            score,
-            type_order: 1,
-            result: SearchResult {
-                r#type: SearchResultType::CatalogItem as i32,
-                payload: Some(Payload::CatalogItem(catalog_item_to_proto(
-                    workspace_name,
-                    crate::catalog::discovery::CatalogItem::Table(table_summary(table)),
-                ))),
-            },
-        });
-    }
-
-    let mut hints_for_surface = 0usize;
-    for column in &table.columns {
-        if hints_for_surface >= MAX_COLUMN_HINTS_PER_SURFACE {
-            break;
-        }
-        let fields = [
-            ("column_name", column.name.as_str(), 4),
-            ("description", column.description.as_str(), 2),
-            ("data_type", column.data_type.as_str(), 1),
-        ];
-        if let Some((score, matched_fields)) = score_fields(terms, fields) {
-            candidates.push(column_hint_candidate(
-                ColumnHintCandidate {
-                    workspace_name,
-                    schema_name: &table.schema_name,
-                    surface_name: &table.table_name,
-                    surface_kind: SearchSurfaceKind::Table,
-                    name: &column.name,
-                    data_type: &column.data_type,
-                    required: column.is_required_filter,
-                    description: &column.description,
-                    matched_fields,
-                },
-                score + required_filter_boost(column),
-            ));
-            hints_for_surface += 1;
-        }
-    }
-
-    for filter in &table.required_filters {
-        if hints_for_surface >= MAX_COLUMN_HINTS_PER_SURFACE {
-            break;
-        }
-        let fields = [("required_filter", filter.as_str(), 5)];
-        if let Some((score, matched_fields)) = score_fields(terms, fields) {
-            candidates.push(column_hint_candidate(
-                ColumnHintCandidate {
-                    workspace_name,
-                    schema_name: &table.schema_name,
-                    surface_name: &table.table_name,
-                    surface_kind: SearchSurfaceKind::Table,
-                    name: filter,
-                    data_type: "",
-                    required: true,
-                    description: "Required table filter",
-                    matched_fields,
-                },
-                score + 2,
-            ));
-            hints_for_surface += 1;
-        }
-    }
-}
-
-fn table_function_candidates(
-    workspace_name: &WorkspaceName,
-    function: &TableFunctionInfo,
-    terms: &QueryTerms,
-    candidates: &mut Vec<Candidate>,
-) {
-    let name = qualified_name(&function.schema_name, &function.function_name);
-    let fields = [
-        ("schema_name", function.schema_name.as_str(), 2),
-        ("function_name", function.function_name.as_str(), 5),
-        ("name", name.as_str(), 5),
-        ("description", function.description.as_str(), 2),
-        ("kind", function.kind.as_str(), 2),
-    ];
-    if let Some((score, matched_fields)) = score_fields(terms, fields) {
-        candidates.push(Candidate {
-            key: format!(
-                "catalog:function:{}.{}",
-                function.schema_name, function.function_name
-            ),
-            score,
-            type_order: 1,
-            result: SearchResult {
-                r#type: SearchResultType::CatalogItem as i32,
-                payload: Some(Payload::CatalogItem(catalog_item_to_proto(
-                    workspace_name,
-                    crate::catalog::discovery::CatalogItem::TableFunction(function.clone()),
-                ))),
-            },
-        });
-
-        if function.kind == "search" {
-            candidates.push(native_search_path_candidate(
-                workspace_name,
-                function,
-                matched_fields,
-                score + 4,
-            ));
-        }
-    }
-
-    let mut hints_for_surface = 0usize;
-    for argument in &function.arguments {
-        if hints_for_surface >= MAX_COLUMN_HINTS_PER_SURFACE {
-            break;
-        }
-        if let Some(candidate) = argument_hint_candidate(workspace_name, function, argument, terms)
-        {
-            candidates.push(candidate);
-            hints_for_surface += 1;
-        }
-    }
-    for column in &function.result_columns {
-        if hints_for_surface >= MAX_COLUMN_HINTS_PER_SURFACE {
-            break;
-        }
-        if let Some(candidate) =
-            result_column_hint_candidate(workspace_name, function, column, terms)
-        {
-            candidates.push(candidate);
-            hints_for_surface += 1;
-        }
-    }
-}
-
-fn argument_hint_candidate(
-    workspace_name: &WorkspaceName,
-    function: &TableFunctionInfo,
-    argument: &TableFunctionArgumentInfo,
-    terms: &QueryTerms,
-) -> Option<Candidate> {
-    let values = argument.values.join(" ");
-    let fields = [
-        ("argument", argument.name.as_str(), 5),
-        ("allowed_values", values.as_str(), 2),
-    ];
-    let (score, matched_fields) = score_fields(terms, fields)?;
-    Some(column_hint_candidate(
-        ColumnHintCandidate {
-            workspace_name,
-            schema_name: &function.schema_name,
-            surface_name: &function.function_name,
-            surface_kind: SearchSurfaceKind::TableFunction,
-            name: &argument.name,
-            data_type: "",
-            required: argument.required,
-            description: "Table function argument",
-            matched_fields,
-        },
-        score + u32::from(argument.required),
-    ))
-}
-
-fn result_column_hint_candidate(
-    workspace_name: &WorkspaceName,
-    function: &TableFunctionInfo,
-    column: &TableFunctionResultColumnInfo,
-    terms: &QueryTerms,
-) -> Option<Candidate> {
-    let fields = [
-        ("result_column", column.name.as_str(), 4),
-        ("description", column.description.as_str(), 2),
-        ("data_type", column.data_type.as_str(), 1),
-    ];
-    let (score, matched_fields) = score_fields(terms, fields)?;
-    Some(column_hint_candidate(
-        ColumnHintCandidate {
-            workspace_name,
-            schema_name: &function.schema_name,
-            surface_name: &function.function_name,
-            surface_kind: SearchSurfaceKind::TableFunction,
-            name: &column.name,
-            data_type: &column.data_type,
-            required: false,
-            description: &column.description,
-            matched_fields,
-        },
-        score,
-    ))
 }
 
 struct ColumnHintCandidate<'a> {
@@ -462,6 +416,15 @@ struct ColumnHintCandidate<'a> {
     required: bool,
     description: &'a str,
     matched_fields: Vec<String>,
+}
+
+impl CatalogSearchSurfaceKind {
+    fn to_proto(self) -> SearchSurfaceKind {
+        match self {
+            Self::Table => SearchSurfaceKind::Table,
+            Self::TableFunction => SearchSurfaceKind::TableFunction,
+        }
+    }
 }
 
 fn column_hint_candidate(input: ColumnHintCandidate<'_>, score: u32) -> Candidate {
@@ -516,52 +479,10 @@ fn native_search_path_candidate(
     }
 }
 
-fn score_fields<const N: usize>(
-    terms: &QueryTerms,
-    fields: [(&'static str, &str, u32); N],
-) -> Option<(u32, Vec<String>)> {
-    let mut score = 0u32;
-    let mut matched_fields = BTreeSet::<&'static str>::new();
-    for (field, value, weight) in fields {
-        if value.trim().is_empty() {
-            continue;
-        }
-        let normalized = normalize(value);
-        let exact_bonus = u32::from(normalized == terms.normalized_query) * weight * 2;
-        let matched_term_count = terms
-            .terms
-            .iter()
-            .filter(|term| normalized.contains(term.as_str()))
-            .count();
-        let term_score = u32::try_from(matched_term_count).unwrap_or(u32::MAX) * weight;
-        if exact_bonus > 0 || term_score > 0 {
-            score += exact_bonus + term_score;
-            matched_fields.insert(field);
-        }
-    }
-    (score > 0).then(|| {
-        (
-            score,
-            matched_fields
-                .into_iter()
-                .map(str::to_string)
-                .collect::<Vec<_>>(),
-        )
-    })
-}
-
 fn table_summary(table: &TableInfo) -> TableInfo {
     let mut table = table.clone();
     table.columns.clear();
     table
-}
-
-fn required_filter_boost(column: &ColumnInfo) -> u32 {
-    if column.is_required_filter { 2 } else { 0 }
-}
-
-fn qualified_name(schema_name: &str, name: &str) -> String {
-    format!("{schema_name}.{name}")
 }
 
 fn sql_call_example(function: &TableFunctionInfo) -> String {
@@ -579,6 +500,27 @@ fn sql_call_example(function: &TableFunctionInfo) -> String {
     )
 }
 
+fn find_table<'a>(
+    catalog: &'a CatalogInfo,
+    schema_name: &str,
+    table_name: &str,
+) -> Option<&'a TableInfo> {
+    catalog
+        .tables
+        .iter()
+        .find(|table| table.schema_name == schema_name && table.table_name == table_name)
+}
+
+fn find_function<'a>(
+    catalog: &'a CatalogInfo,
+    schema_name: &str,
+    function_name: &str,
+) -> Option<&'a TableFunctionInfo> {
+    catalog.table_functions.iter().find(|function| {
+        function.schema_name == schema_name && function.function_name == function_name
+    })
+}
+
 fn catalog_provider_note(state: SearchProviderState, total_count: usize) -> String {
     match state {
         SearchProviderState::ResultsFound => {
@@ -586,6 +528,17 @@ fn catalog_provider_note(state: SearchProviderState, total_count: usize) -> Stri
         }
         SearchProviderState::Empty => "Catalog metadata returned no search hints".to_string(),
         _ => String::new(),
+    }
+}
+
+fn catalog_index_error_status(error: &SearchIndexError) -> CatalogProviderStatus {
+    let state = match error {
+        SearchIndexError::UnsupportedCapability { .. } => SearchProviderState::Partial,
+        SearchIndexError::Io(_) | SearchIndexError::Sqlite(_) => SearchProviderState::Error,
+    };
+    CatalogProviderStatus {
+        state,
+        note: format!("Catalog metadata search index is unavailable: {error}"),
     }
 }
 
@@ -600,8 +553,12 @@ fn truncation_note(truncated: bool, total_count: usize, max_results: usize) -> S
 #[cfg(test)]
 mod tests {
     use coral_api::v1::SearchSurfaceKind;
+    use coral_engine::{CatalogInfo, TableInfo};
+    use tempfile::tempdir;
 
-    use super::{query_terms, score_fields};
+    use super::{SearchIndexRefresher, query_terms};
+    use crate::state::AppStateLayout;
+    use crate::workspaces::WorkspaceName;
 
     #[test]
     fn query_terms_preserve_identifier_punctuation() {
@@ -613,23 +570,69 @@ mod tests {
     }
 
     #[test]
-    fn score_fields_matches_terms_and_exact_query() {
-        let terms = query_terms("issue title").expect("terms");
-        let (score, fields) = score_fields(
-            &terms,
-            [("name", "title", 4), ("description", "Issue title", 2)],
-        )
-        .expect("score");
-
-        assert!(score >= 8);
-        assert_eq!(fields, vec!["description", "name"]);
-    }
-
-    #[test]
     fn surface_kind_has_stable_proto_names() {
         assert_eq!(
             SearchSurfaceKind::Table.as_str_name(),
             "SEARCH_SURFACE_KIND_TABLE"
         );
+    }
+
+    #[tokio::test]
+    async fn search_index_refresher_only_refreshes_once_until_forced() {
+        let temp = tempdir().expect("tempdir");
+        let layout =
+            AppStateLayout::discover(Some(temp.path().join("coral-config"))).expect("layout");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let refresher = SearchIndexRefresher::new(layout);
+
+        let first_catalog = catalog_with_table("messages", "Fixture messages");
+        let second_catalog = catalog_with_table("tasks", "Fixture tasks");
+
+        let index = refresher
+            .refresh_catalog_if_needed(&workspace, &first_catalog)
+            .await
+            .expect("initial refresh");
+        assert!(catalog_has_surface(&index, &workspace, "messages"));
+
+        let index = refresher
+            .refresh_catalog_if_needed(&workspace, &second_catalog)
+            .await
+            .expect("skipped refresh");
+        assert!(catalog_has_surface(&index, &workspace, "messages"));
+        assert!(!catalog_has_surface(&index, &workspace, "tasks"));
+
+        refresher.mark_catalog_dirty(&workspace).await;
+        let index = refresher
+            .refresh_catalog_if_needed(&workspace, &second_catalog)
+            .await
+            .expect("dirty refresh");
+        assert!(!catalog_has_surface(&index, &workspace, "messages"));
+        assert!(catalog_has_surface(&index, &workspace, "tasks"));
+    }
+
+    fn catalog_with_table(table_name: &str, description: &str) -> CatalogInfo {
+        CatalogInfo {
+            tables: vec![TableInfo {
+                schema_name: "fixture".to_string(),
+                table_name: table_name.to_string(),
+                description: description.to_string(),
+                guide: String::new(),
+                columns: Vec::new(),
+                required_filters: Vec::new(),
+            }],
+            table_functions: Vec::new(),
+        }
+    }
+
+    fn catalog_has_surface(
+        index: &crate::search::index::SearchIndexStore,
+        workspace: &WorkspaceName,
+        surface_name: &str,
+    ) -> bool {
+        index
+            .search_catalog(workspace, &[surface_name.to_string()], 10)
+            .expect("search catalog")
+            .iter()
+            .any(|hit| hit.surface_name == surface_name)
     }
 }

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -32,6 +32,7 @@ use tonic::{Request, Response, Status};
 
 use crate::bootstrap::{AppError, app_status};
 use crate::query::manager::QueryManager;
+use crate::search::service::SearchIndexRefresher;
 use crate::sources::SourceName;
 use crate::sources::manager::{
     CreateBundledSourceCommand, CreateBundledSourceWithOAuthCommand, ImportSourceCommand,
@@ -53,13 +54,19 @@ use tokio_stream::StreamExt as _;
 pub(crate) struct SourceService {
     sources: SourceManager,
     queries: QueryManager,
+    search_indexes: SearchIndexRefresher,
 }
 
 impl SourceService {
-    pub(crate) fn new(source_manager: SourceManager, query_manager: QueryManager) -> Self {
+    pub(crate) fn new(
+        source_manager: SourceManager,
+        query_manager: QueryManager,
+        search_indexes: SearchIndexRefresher,
+    ) -> Self {
         Self {
             sources: source_manager,
             queries: query_manager,
+            search_indexes,
         }
     }
 }
@@ -155,6 +162,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -166,6 +174,7 @@ impl SourceServiceApi for SourceService {
             let installed = sources
                 .create_bundled_source(&workspace_name, &command)
                 .map_err(app_status)?;
+            search_indexes.mark_catalog_dirty(&workspace_name).await;
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(&workspace_name, installed)),
             }))
@@ -179,6 +188,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -196,14 +206,16 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
                             )
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        search_indexes.mark_catalog_dirty(&workspace_name).await;
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {
@@ -220,6 +232,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::ImportSourceStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -232,6 +245,7 @@ impl SourceServiceApi for SourceService {
                 let installed = sources
                     .import_source(&workspace_name, &command)
                     .map_err(app_status)?;
+                search_indexes.mark_catalog_dirty(&workspace_name).await;
                 let response = ImportSourceResponse {
                     event: Some(import_source_response::Event::Source(
                         installed_source_to_proto(&response_workspace_name, installed),
@@ -254,10 +268,12 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .import_source_with_credentials(&workspace_name, command, event_sender)
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        search_indexes.mark_catalog_dirty(&workspace_name).await;
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(stream))
@@ -271,6 +287,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<DeleteSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let search_indexes = self.search_indexes.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -278,6 +295,7 @@ impl SourceServiceApi for SourceService {
             sources
                 .delete_source(&workspace_name, &source_name)
                 .map_err(app_status)?;
+            search_indexes.mark_catalog_dirty(&workspace_name).await;
             Ok(Response::new(DeleteSourceResponse {}))
         })
         .await

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -5,9 +5,11 @@
 
 use coral_api::v1::search_result::Payload;
 use coral_api::v1::{
-    SearchProvider, SearchProviderState, SearchRequest, SearchResultType, SearchSurfaceKind,
+    DeleteSourceRequest, SearchProvider, SearchProviderState, SearchRequest, SearchResultType,
+    SearchSurfaceKind,
 };
 use coral_client::default_workspace;
+use rusqlite::Connection;
 use tonic::Request;
 
 use super::harness::{GrpcHarness, fixture_manifest_with_functions_yaml};
@@ -45,6 +47,16 @@ async fn search_returns_typed_metadata_and_native_search_results() {
         SearchProviderState::NotEnabled,
     );
     assert!(!response.truncation.expect("truncation").truncated);
+    assert!(
+        harness
+            .config_dir()
+            .join("workspaces")
+            .join("default")
+            .join("search")
+            .join("search.sqlite")
+            .exists(),
+        "search should create the workspace SQLite search index"
+    );
     assert!(response.results.iter().any(|result| result.r#type
         == SearchResultType::NativeSearchPath as i32
         && matches!(
@@ -137,6 +149,55 @@ async fn search_applies_limit_and_reports_truncation() {
     assert_eq!(truncation.max_results, 1);
 }
 
+#[tokio::test]
+async fn source_mutations_mark_catalog_search_index_dirty() {
+    let harness = GrpcHarness::new().await;
+    let manifest_yaml = fixture_manifest_with_functions_yaml();
+    harness
+        .import_source(manifest_yaml.clone(), Vec::new(), Vec::new())
+        .await;
+
+    assert!(!search_index_path(&harness).exists());
+    search(&harness, "issue search title").await;
+    assert!(catalog_entity_count(&harness, "search_issues") > 0);
+
+    let updated_manifest_yaml = manifest_yaml.replace("search_issues", "search_tasks");
+    harness
+        .import_source(updated_manifest_yaml, Vec::new(), Vec::new())
+        .await;
+    assert!(catalog_entity_count(&harness, "search_issues") > 0);
+    assert_eq!(catalog_entity_count(&harness, "search_tasks"), 0);
+
+    search(&harness, "task search title").await;
+    assert_eq!(catalog_entity_count(&harness, "search_issues"), 0);
+    assert!(catalog_entity_count(&harness, "search_tasks") > 0);
+
+    harness
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: "searchy".to_string(),
+        }))
+        .await
+        .expect("delete source");
+    assert!(total_catalog_entity_count(&harness) > 0);
+
+    search(&harness, "task search title").await;
+    assert_eq!(total_catalog_entity_count(&harness), 0);
+}
+
+async fn search(harness: &GrpcHarness, query: &str) {
+    harness
+        .search_client()
+        .search(Request::new(SearchRequest {
+            workspace: Some(default_workspace()),
+            query: query.to_string(),
+            limit: 10,
+        }))
+        .await
+        .expect("search");
+}
+
 fn assert_provider_state(
     response: &coral_api::v1::SearchResponse,
     provider: SearchProvider,
@@ -148,4 +209,35 @@ fn assert_provider_state(
         .find(|status| status.provider == provider as i32)
         .expect("provider status");
     assert_eq!(status.state, state as i32);
+}
+
+fn catalog_entity_count(harness: &GrpcHarness, surface_name: &str) -> u32 {
+    let connection = Connection::open(search_index_path(harness)).expect("open search index");
+    connection
+        .query_row(
+            "SELECT count(*) FROM catalog_entities WHERE workspace = 'default' AND surface_name = ?1",
+            [surface_name],
+            |row| row.get(0),
+        )
+        .expect("catalog entity count")
+}
+
+fn total_catalog_entity_count(harness: &GrpcHarness) -> u32 {
+    let connection = Connection::open(search_index_path(harness)).expect("open search index");
+    connection
+        .query_row(
+            "SELECT count(*) FROM catalog_entities WHERE workspace = 'default'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("total catalog entity count")
+}
+
+fn search_index_path(harness: &GrpcHarness) -> std::path::PathBuf {
+    harness
+        .config_dir()
+        .join("workspaces")
+        .join("default")
+        .join("search")
+        .join("search.sqlite")
 }


### PR DESCRIPTION
## Summary

- Refresh catalog metadata into the workspace SQLite search index on the first Universal Search call in a server session, then reuse the session-fresh index for later searches.
- Mark the workspace catalog index dirty after successful source create/import/reconfigure/delete actions so the next `search` refreshes it lazily; source mutations do not synchronously rebuild the index.
- Replace Universal Search catalog metadata retrieval with SQLite FTS5/BM25/trigram lookup while preserving typed `catalog_item`, `column_hint`, and `native_search_path` results.
- Preserve provider statuses, truncation, and the single `search(query)` surface; observed values remain reported as `not_enabled`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p coral-app search --all-features --locked`
- `cargo test -p coral-app --test grpc source_mutations_mark_catalog_search_index_dirty --all-features --locked`
- `cargo test -p coral-cli --test cli_e2e --all-features --locked search_command`
- `cargo test -p coral-mcp --all-features --locked`
- `cargo clippy -p coral-app --all-targets --all-features -- -D warnings`
- `cargo build -p coral-cli --all-features --locked`
- `hyperfine --warmup 2 --runs 10 ... coral source list ...`: `1.068 s ± 0.015 s`
- `hyperfine --warmup 2 --runs 10 ... coral search "github deployments sha" --json ...`: `2.706 s ± 0.153 s` for one-shot CLI sessions
- MCP same-process local config measurement, 5 sessions with two searches each: first search `2.554 s ± 0.163 s`, second search `1.355 s ± 0.056 s`
