### PR TITLE
feat(skills): add coral-onboard skill and demonstrate workflow + JOIN

### DIFF
--- a/plugins/coral/skills/coral-onboard/SKILL.md
+++ b/plugins/coral/skills/coral-onboard/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: coral-onboard
+description: "Install Coral, register it as an MCP server, configure a first source, and run a first query. Use when Coral is not yet running on this machine, or is running but not connected to this agent."
+---
+
+# Coral Onboard
+
+## Overview
+
+Use this skill exactly once per machine to take a user from no Coral to a returned SQL result. After onboarding, hand off to the `coral` skill for ongoing queries.
+
+- This is the only Coral skill that uses the `coral` CLI as the primary surface.
+- Stop after the first query returns rows. Do not extend into analytical queries or spec authoring.
+- Do not run this skill on a machine where Coral is already installed, registered, and queryable.
+
+## Support Checks
+
+- Run before suggesting any step: `command -v coral`, `claude mcp list | grep -i coral`, `coral source list`.
+- Resume the workflow from the first step that is not already satisfied; skip the steps that are.
+- If the agent is not Claude Code, substitute the matching MCP config path (`.cursor/mcp.json`, `.vscode/mcp.json`, `claude_desktop_config.json`).
+
+## Workflow
+
+1. Detect state with the three commands in *Support Checks*.
+2. Install Coral if the binary is missing.
+   - macOS: `brew install withcoral/tap/coral`.
+   - macOS / Linux: `curl -fsSL https://withcoral.com/install.sh | sh`.
+   - Windows: download the latest release zip and place `coral.exe` on PATH.
+   - Verify with `coral --version`.
+3. Register the MCP server if the agent does not see it.
+   - Claude Code: `claude mcp add --scope user coral -- coral mcp-stdio`.
+   - Other agents: write the per-agent MCP config file pointing at `coral mcp-stdio`.
+   - Tell the user to restart the agent. The MCP tools are not visible until restart.
+4. Add a first source if `coral source list` is empty. Prefer the lowest-friction option that returns useful rows.
+   - Zero-config: `coral source add claude` (queries `~/.claude/` transcripts).
+   - Otherwise: whichever bundled source the user already has credentials for, via `coral source add --interactive <name>`.
+   - Confirm with `coral source list` and `coral source test <name>`.
+5. Run one verification query. Prefer the MCP `sql` tool once the agent has reconnected; otherwise `coral sql` directly. Use the smallest meaningful query for the chosen source.
+6. Hand off. Report the source name, the row count, and one example row. Direct the user to the `coral` skill for further queries.
+
+## Onboarding Rules
+
+- Default to the system package manager (Homebrew on macOS, `install.sh` elsewhere). Do not build from source.
+- After MCP registration, prompt for restart; do not assume auto-reload.
+- Never store credentials in shell history or commits. Prefer `--interactive` over inline env vars when the secret is sensitive.
+- If `claude mcp list` reports Coral as `Failed to connect`, re-add with the absolute binary path: `claude mcp add --scope user coral -- $(which coral) mcp-stdio`.
+- If OAuth setup hangs, offer the paste-a-token path instead.
+- One verification query is enough. Stop there.
+
+## Boundaries
+
+- Do not author custom source specs; defer to `coral-create-source-spec`.
+- Do not review source-spec PRs; defer to `coral-review-source-spec`.
+- Do not run multi-source queries, JOINs, or analytical workloads; defer to `coral`.
+- Do not pre-install sources beyond the first; let the user grow their configuration over time.

--- a/plugins/coral/skills/coral-onboard/agents/openai.yaml
+++ b/plugins/coral/skills/coral-onboard/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Coral Onboard"
+  short_description: "Install Coral, register the MCP server, and run a first query"
+  default_prompt: "Use $coral-onboard to install Coral and connect a first source."
+
+policy:
+  allow_implicit_invocation: true

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -31,6 +31,44 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 7. Query with `sql`: select useful columns, include required filters or function arguments, and add `LIMIT` unless complete output is requested.
 8. Summarize evidence, gaps, and next action. If editing code, use the Coral result to guide changes.
 
+## Worked Example
+
+The Workflow above, demonstrated for one canonical request.
+
+User: "What open issues are in `withcoral/coral` right now?"
+
+1. `search_catalog` with `query: "github issues"` → returns `github.issues`.
+2. `describe_table` with `name: "github.issues"` → reports required filters `owner`, `repo`.
+3. `sql`:
+   ```sql
+   SELECT number, title, html_url, created_at
+   FROM github.issues
+   WHERE owner = 'withcoral' AND repo = 'coral' AND state = 'open'
+   ORDER BY created_at DESC
+   LIMIT 20
+   ```
+4. Lead with count and most recent row; cite `github.issues`; omit the SQL unless the user wants to reuse it.
+
+## Cross-Source JOIN
+
+A single statement spans multiple installed sources; each source scans locally before the join executes. Provider-direct MCPs cannot reproduce this.
+
+Example — GitHub issues that still have no Linear attachment:
+
+```sql
+SELECT i.number, i.title, i.html_url
+FROM github.issues i
+LEFT JOIN linear.attachments l ON l.url = i.html_url
+WHERE i.owner = 'withcoral' AND i.repo = 'coral'
+  AND i.state = 'open'
+  AND l.id IS NULL
+```
+
+- Confirm each schema is installed (`coral.tables` per schema) before composing the join.
+- Apply the tightest filter on each side; sources scan independently before joining.
+- Use `LEFT JOIN ... WHERE B.id IS NULL` for "missing on the other side" reports; `INNER JOIN` for symmetric correlation on a stable identifier.
+- Reach for a cross-source JOIN when the user's question implies correlating two systems ("which X already has a Y", "which Y is missing an X"); do not synthesize across sources by running two queries and merging in prose.
+
 ## Query Rules
 
 - Use each table's `sql_reference`; write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
@@ -39,7 +77,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.
 - Required filters must appear in `WHERE`; inspect `required_filters` and `is_required_filter`.
 - Secret inputs always return `value = NULL`; use `is_set`.
-- Cross-source joins work and execute locally after source scans complete.
+- Cross-source joins work and execute locally after source scans complete; see *Cross-Source JOIN* above.
 - Keep answers compact: name the source, table, required filters, and query shape. Avoid exhaustive column dumps unless requested.
 - Lead with the answer or blocker. Include SQL only when it helps the user trust or reuse the result.
 


### PR DESCRIPTION
## What

Two additions to `plugins/coral/skills/`, scoped at agent activation:

1. **`coral/SKILL.md`** — add a `## Worked Example` section (one canonical `search_catalog` → `describe_table` → `sql` walkthrough) and a `## Cross-Source JOIN` section (one `LEFT JOIN` with shape rules). The existing Query Rules bullet about JOINs cross-references the new section. Pure documentation; no behavior change.
2. **`coral-onboard/`** — a fourth skill that takes a user from zero (Coral not installed, MCP not registered, no sources configured) to a returned SQL result in one agent conversation. Bounded: stops after the first query returns rows, hands off to `coral`.

## Why

Reading the three existing skills as an agent, two gaps stood out:

- The `coral` skill prescribes an 8-step workflow but never demonstrates it. Step 7 reads *"Query with `sql`"* with no example. Agents have to invent the query shape. A 20-line worked example removes that friction.
- Cross-source JOIN — the single capability that direct provider MCPs structurally cannot reproduce — appears as a single Query Rules bullet (*"Cross-source joins work and execute locally after source scans complete"*). It's the differentiating feature; surfacing one good example up front changes how an agent reads the rest of the skill.
- All three existing skills assume Coral is installed, MCP is registered, and at least one source is configured. Nothing scaffolds the first five minutes for a fresh user. A bounded `coral-onboard` skill closes that gap and keeps the other three skills focused on their actual jobs.

## User-visible impact

- Agents using the `coral` skill now have a worked example to crib from on first use, plus an obvious template for cross-source correlation.
- Agents on a machine without Coral can invoke `coral-onboard` and walk through install → MCP register → first source → verification query in one conversation.
- No behavior changes to existing skills' rules or boundaries.
- The auto-generated mirror README (`withcoral/skills`) picks up the new skill on the next sync — no manual README edit needed.

## Validation

```
$ cargo run --locked -p xtask -- export-skills --dest /tmp/validate
   Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.81s
xtask: exported 4 skills to /private/tmp/validate
```

3 existing skills + the new `coral-onboard` = 4 exported. Generated mirror README registers the new skill automatically.

## Follow-on work

I noted several other smaller improvements while reading the skills — a tighter `feedback` tool schema in `coral`, a virtual-column gotcha example, a common-mistakes section in `coral-create-source-spec`, a fully worked review example in `coral-review-source-spec`. Intentionally scoped out of this PR to keep it focused on activation. Happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)