### PR TITLE
feat(sources/community/buildkite): add buildkite community source

### DIFF
--- a/sources/community/buildkite/README.md
+++ b/sources/community/buildkite/README.md
@@ -1,0 +1,266 @@
+# Buildkite (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Buildkite REST API v2)
+**Tables:** 5
+**Base URL:** `https://api.buildkite.com/v2`
+
+Query organizations, pipelines, builds, and agents from Buildkite via SQL.
+Designed for CI/CD analytics: build cycle times, pipeline success rates, and
+agent infrastructure monitoring. Pairs naturally with the bundled **GitHub**
+and **Bitbucket** sources for cross-source engineering metrics.
+
+## Setup
+
+### 1. Create a Buildkite API access token
+
+1. Go to [https://buildkite.com/user/api-access-tokens](https://buildkite.com/user/api-access-tokens)
+2. Click **New API Access Token**
+3. Give it a description and select the following scopes:
+   - `read_organizations`
+   - `read_pipelines`
+   - `read_builds`
+   - `read_agents`
+4. Copy the token.
+
+### 2. Set your token
+
+```sh
+export BUILDKITE_TOKEN="<your-api-token>"
+```
+
+### 3. Add the source
+
+```sh
+cargo run -p coral-cli -- source add --file sources/community/buildkite/manifest.yaml
+```
+
+### 4. Verify
+
+```sh
+cargo run -p coral-cli -- sql "SELECT slug, name FROM buildkite.organizations LIMIT 5"
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `buildkite.organizations` | Organizations accessible by the token | — |
+| `buildkite.pipelines` | Pipelines in an organization | `org_slug` |
+| `buildkite.builds` | Builds for a specific pipeline | `org_slug`, `pipeline_slug` |
+| `buildkite.org_builds` | Builds across all pipelines in an org | `org_slug` |
+| `buildkite.agents` | Agents connected to an organization | `org_slug` |
+
+All tables are read-only. This source does not create, modify, or delete any
+Buildkite data.
+
+### `organizations`
+
+Lists all organizations accessible by the API token. Use `slug` as `org_slug`
+in all other tables. Start here to discover your organization slug.
+
+### `pipelines`
+
+Lists all pipelines in an organization. Use `slug` as `pipeline_slug` in the
+`builds` table. `repository` shows the connected source repository.
+
+### `builds`
+
+Lists builds for a specific pipeline. Requires both `org_slug` and
+`pipeline_slug`. Use `state` to filter results locally:
+
+| Value | Meaning |
+|---|---|
+| `passed` | Build completed successfully |
+| `failed` | Build failed |
+| `running` | Build is currently running |
+| `scheduled` | Build is waiting to run |
+| `blocked` | Build is blocked on a manual step |
+| `canceled` | Build was canceled |
+| `skipped` | Build was skipped |
+
+`pipeline_slug` and `pipeline_name` are sourced from the nested `pipeline`
+object in the API response.
+
+### `org_builds`
+
+Lists builds across all pipelines in an organization. Requires only `org_slug`.
+Use when you need a cross-pipeline view. For pipeline-specific queries, prefer
+`buildkite.builds` which is more targeted and efficient.
+
+### `agents`
+
+Lists agents connected to an organization. Use `connection_state` to monitor
+agent availability. `hostname` and `ip_address` identify the machine running
+the agent.
+
+## Filters and pagination
+
+All tables use page-based pagination (`page`, `per_page`). The default page
+size is 30; the maximum is 100. Always use `LIMIT` when querying organizations
+with many pipelines or builds.
+
+## Example queries
+
+List your organizations:
+
+```sql
+SELECT slug, name, created_at
+FROM buildkite.organizations
+LIMIT 10;
+```
+
+List pipelines in an organization:
+
+```sql
+SELECT slug, name, default_branch, repository, created_at
+FROM buildkite.pipelines
+WHERE org_slug = 'my-org'
+ORDER BY name
+LIMIT 20;
+```
+
+Recent builds for a pipeline:
+
+```sql
+SELECT number, state, branch, commit, creator_name, created_at, finished_at
+FROM buildkite.builds
+WHERE org_slug = 'my-org'
+  AND pipeline_slug = 'my-pipeline'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+Failed builds for a pipeline:
+
+```sql
+SELECT number, branch, commit, creator_name, created_at, finished_at
+FROM buildkite.builds
+WHERE org_slug = 'my-org'
+  AND pipeline_slug = 'my-pipeline'
+  AND state = 'failed'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+Builds across all pipelines in an org:
+
+```sql
+SELECT number, pipeline_slug, pipeline_name, state, branch, created_at
+FROM buildkite.org_builds
+WHERE org_slug = 'my-org'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+Connected agents:
+
+```sql
+SELECT name, connection_state, hostname, version, os
+FROM buildkite.agents
+WHERE org_slug = 'my-org'
+  AND connection_state = 'connected'
+ORDER BY name
+LIMIT 20;
+```
+
+Build cycle times for a pipeline (passed builds only):
+
+```sql
+SELECT
+  number,
+  branch,
+  creator_name,
+  created_at,
+  started_at,
+  finished_at
+FROM buildkite.builds
+WHERE org_slug = 'my-org'
+  AND pipeline_slug = 'my-pipeline'
+  AND state = 'passed'
+ORDER BY finished_at DESC
+LIMIT 50;
+```
+
+Cross-source: Buildkite builds alongside Bitbucket pull requests:
+
+```sql
+SELECT
+  b.number      AS build_number,
+  b.state       AS build_state,
+  b.branch,
+  b.created_at  AS build_started,
+  pr.title      AS pr_title,
+  pr.author_nickname
+FROM buildkite.builds b
+LEFT JOIN bitbucket.pull_requests pr
+  ON b.branch = pr.source_branch
+  AND pr.workspace = 'my-workspace'
+  AND pr.repo_slug = 'my-repo'
+WHERE b.org_slug = 'my-org'
+  AND b.pipeline_slug = 'my-pipeline'
+ORDER BY b.created_at DESC
+LIMIT 20;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/buildkite/manifest.yaml
+```
+
+Add the source and validate each table:
+
+```sh
+export BUILDKITE_TOKEN="<your-api-token>"
+cargo run -p coral-cli -- source add --file sources/community/buildkite/manifest.yaml
+
+# organizations — no required filters
+cargo run -p coral-cli -- sql "SELECT slug, name, created_at FROM buildkite.organizations LIMIT 5"
+
+# pipelines — requires org_slug
+cargo run -p coral-cli -- sql "SELECT slug, name, default_branch FROM buildkite.pipelines WHERE org_slug = 'your-org' LIMIT 5"
+
+# builds — requires org_slug and pipeline_slug
+cargo run -p coral-cli -- sql "SELECT number, state, branch, created_at, finished_at FROM buildkite.builds WHERE org_slug = 'your-org' AND pipeline_slug = 'your-pipeline' LIMIT 5"
+
+# org_builds — requires org_slug only
+cargo run -p coral-cli -- sql "SELECT number, pipeline_slug, state, created_at FROM buildkite.org_builds WHERE org_slug = 'your-org' LIMIT 5"
+
+# agents — requires org_slug
+cargo run -p coral-cli -- sql "SELECT name, connection_state, hostname, version FROM buildkite.agents WHERE org_slug = 'your-org' LIMIT 5"
+```
+
+Inspect registered tables and columns:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'buildkite'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'buildkite' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- **API token scopes:** create the token with `read_organizations`,
+  `read_pipelines`, `read_builds`, and `read_agents` scopes. The token
+  is sent as `Authorization: Bearer`.
+- **`pipeline_slug` and `pipeline_name`** in `builds` and `org_builds` are
+  sourced from the nested `pipeline.slug` and `pipeline.name` fields in the
+  Buildkite API response, not top-level fields.
+- **`creator_name` and `creator_email`** are sourced from the nested
+  `creator.name` and `creator.email` fields in the API response.
+- **`builds` vs `org_builds`:** use `builds` when you know the pipeline slug
+  for targeted queries; use `org_builds` for cross-pipeline views.
+- **Page-based pagination:** all tables paginate by `page` and `per_page`.
+  Always use `LIMIT` on large organizations.
+- **Rate limits:** the Buildkite API enforces rate limits per token. Reduce
+  query frequency if you hit limits.
+
+## Out of scope for v1
+
+- Jobs table (requires `org_slug`, `pipeline_slug`, and `build_number`)
+- Annotations
+- Artifacts
+- Teams and team members
+- Write operations of any kind

--- a/sources/community/buildkite/manifest.yaml
+++ b/sources/community/buildkite/manifest.yaml
@@ -1,0 +1,623 @@
+name: buildkite
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query organizations, pipelines, builds, and agents from Buildkite
+  via the Buildkite REST API v2.
+base_url: https://api.buildkite.com/v2
+
+inputs:
+  BUILDKITE_TOKEN:
+    kind: secret
+    hint: |
+      Buildkite API access token. Create one at
+      https://buildkite.com/user/api-access-tokens with the following
+      scopes: read_organizations, read_pipelines, read_builds,
+      read_agents. The token is sent as Authorization: Bearer.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.BUILDKITE_TOKEN}}
+
+test_queries:
+  - SELECT slug, name, created_at FROM buildkite.organizations LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────────
+  # organizations — orgs accessible by the token
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: organizations
+    description: >-
+      Buildkite organizations accessible by the API token. Each row is
+      one organization. Use slug as org_slug in pipelines, builds,
+      org_builds, and agents.
+    guide: |
+      No required filters. Use `slug` as `org_slug` in all other tables.
+      Start here to discover your organization slug before querying
+      pipelines or builds.
+    request:
+      method: GET
+      path: /organizations
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: >-
+          Organization slug. Use as org_slug in pipelines, builds,
+          org_builds, and agents tables.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Organization display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: web_url
+        type: Utf8
+        nullable: true
+        description: URL of the organization in the Buildkite web interface.
+        expr:
+          kind: path
+          path:
+            - web_url
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the organization was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # pipelines — pipelines in an organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: pipelines
+    description: >-
+      Pipelines in a Buildkite organization. Each row is one pipeline.
+      Use slug as pipeline_slug in the builds table.
+    guide: |
+      Requires `org_slug`. Use `slug` as `pipeline_slug` in the builds
+      table. Join with `buildkite.builds` on `org_slug` and
+      `pipeline_slug = slug` for build analytics.
+    filters:
+      - name: org_slug
+        required: true
+    request:
+      method: GET
+      path: /organizations/{{filter.org_slug}}/pipelines
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: slug
+        type: Utf8
+        nullable: false
+        description: Pipeline slug. Use as pipeline_slug in the builds table.
+        expr:
+          kind: path
+          path:
+            - slug
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Pipeline display name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Pipeline description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: repository
+        type: Utf8
+        nullable: true
+        description: Repository URL the pipeline is connected to.
+        expr:
+          kind: path
+          path:
+            - repository
+      - name: default_branch
+        type: Utf8
+        nullable: true
+        description: Default branch for the pipeline.
+        expr:
+          kind: path
+          path:
+            - default_branch
+      - name: web_url
+        type: Utf8
+        nullable: true
+        description: URL of the pipeline in the Buildkite web interface.
+        expr:
+          kind: path
+          path:
+            - web_url
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the pipeline was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: org_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Organization slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: org_slug
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # builds — builds for a specific pipeline
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: builds
+    description: >-
+      Builds for a specific pipeline in a Buildkite organization. Each
+      row is one build. Use state to filter by build outcome.
+    guide: |
+      Requires `org_slug` and `pipeline_slug`. Use `state` to filter
+      results locally: passed, failed, running, scheduled, blocked,
+      canceled, or skipped. Use `created_at` and `finished_at` for
+      build cycle-time analytics. Join with `buildkite.pipelines` on
+      `org_slug` and `pipeline_slug = slug`.
+    filters:
+      - name: org_slug
+        required: true
+      - name: pipeline_slug
+        required: true
+    request:
+      method: GET
+      path: /organizations/{{filter.org_slug}}/pipelines/{{filter.pipeline_slug}}/builds
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: number
+        type: Int64
+        nullable: false
+        description: Build number within the pipeline.
+        expr:
+          kind: path
+          path:
+            - number
+      - name: state
+        type: Utf8
+        nullable: true
+        description: >-
+          Build state: running, scheduled, passed, failed, blocked,
+          canceled, or skipped.
+        expr:
+          kind: path
+          path:
+            - state
+      - name: branch
+        type: Utf8
+        nullable: true
+        description: Branch the build ran against.
+        expr:
+          kind: path
+          path:
+            - branch
+      - name: commit
+        type: Utf8
+        nullable: true
+        description: Git commit SHA for the build.
+        expr:
+          kind: path
+          path:
+            - commit
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Commit message for the build.
+        expr:
+          kind: path
+          path:
+            - message
+      - name: web_url
+        type: Utf8
+        nullable: true
+        description: URL of the build in the Buildkite web interface.
+        expr:
+          kind: path
+          path:
+            - web_url
+      - name: pipeline_slug
+        type: Utf8
+        nullable: true
+        description: Slug of the pipeline this build belongs to (from pipeline.slug).
+        expr:
+          kind: path
+          path:
+            - pipeline
+            - slug
+      - name: pipeline_name
+        type: Utf8
+        nullable: true
+        description: Display name of the pipeline (from pipeline.name).
+        expr:
+          kind: path
+          path:
+            - pipeline
+            - name
+      - name: creator_name
+        type: Utf8
+        nullable: true
+        description: Name of the user who created the build (from creator.name).
+        expr:
+          kind: path
+          path:
+            - creator
+            - name
+      - name: creator_email
+        type: Utf8
+        nullable: true
+        description: Email of the user who created the build (from creator.email).
+        expr:
+          kind: path
+          path:
+            - creator
+            - email
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the build was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the build started running.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - started_at
+      - name: finished_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the build finished.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - finished_at
+      - name: org_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Organization slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: org_slug
+      - name: pipeline_slug_filter
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Pipeline slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: pipeline_slug
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # org_builds — builds across all pipelines in an organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: org_builds
+    description: >-
+      Builds across all pipelines in a Buildkite organization. Each row
+      is one build. Use when you need a cross-pipeline view without
+      knowing specific pipeline slugs.
+    guide: |
+      Requires `org_slug` only. Returns builds across all pipelines,
+      newest first. Use `pipeline_slug` and `pipeline_name` columns to
+      identify which pipeline each build belongs to. For pipeline-specific
+      queries, prefer `buildkite.builds` which is more targeted.
+    filters:
+      - name: org_slug
+        required: true
+    request:
+      method: GET
+      path: /organizations/{{filter.org_slug}}/builds
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: number
+        type: Int64
+        nullable: false
+        description: Build number within the pipeline.
+        expr:
+          kind: path
+          path:
+            - number
+      - name: state
+        type: Utf8
+        nullable: true
+        description: >-
+          Build state: running, scheduled, passed, failed, blocked,
+          canceled, or skipped.
+        expr:
+          kind: path
+          path:
+            - state
+      - name: branch
+        type: Utf8
+        nullable: true
+        description: Branch the build ran against.
+        expr:
+          kind: path
+          path:
+            - branch
+      - name: commit
+        type: Utf8
+        nullable: true
+        description: Git commit SHA for the build.
+        expr:
+          kind: path
+          path:
+            - commit
+      - name: message
+        type: Utf8
+        nullable: true
+        description: Commit message for the build.
+        expr:
+          kind: path
+          path:
+            - message
+      - name: web_url
+        type: Utf8
+        nullable: true
+        description: URL of the build in the Buildkite web interface.
+        expr:
+          kind: path
+          path:
+            - web_url
+      - name: pipeline_slug
+        type: Utf8
+        nullable: true
+        description: Slug of the pipeline this build belongs to (from pipeline.slug).
+        expr:
+          kind: path
+          path:
+            - pipeline
+            - slug
+      - name: pipeline_name
+        type: Utf8
+        nullable: true
+        description: Display name of the pipeline (from pipeline.name).
+        expr:
+          kind: path
+          path:
+            - pipeline
+            - name
+      - name: creator_name
+        type: Utf8
+        nullable: true
+        description: Name of the user who created the build (from creator.name).
+        expr:
+          kind: path
+          path:
+            - creator
+            - name
+      - name: creator_email
+        type: Utf8
+        nullable: true
+        description: Email of the user who created the build (from creator.email).
+        expr:
+          kind: path
+          path:
+            - creator
+            - email
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the build was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the build started running.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - started_at
+      - name: finished_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the build finished.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - finished_at
+      - name: org_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Organization slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: org_slug
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # agents — agents connected to an organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: agents
+    description: >-
+      Agents connected to a Buildkite organization. Each row is one
+      agent. Use connection_state to monitor agent availability.
+    guide: |
+      Requires `org_slug`. Use `connection_state` to filter connected
+      vs disconnected agents. `hostname` identifies the machine running
+      the agent. Use for infrastructure monitoring and capacity planning.
+    filters:
+      - name: org_slug
+        required: true
+    request:
+      method: GET
+      path: /organizations/{{filter.org_slug}}/agents
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Agent ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Agent name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: connection_state
+        type: Utf8
+        nullable: true
+        description: "Agent connection state: connected, disconnected, or lost."
+        expr:
+          kind: path
+          path:
+            - connection_state
+      - name: hostname
+        type: Utf8
+        nullable: true
+        description: Hostname of the machine running the agent.
+        expr:
+          kind: path
+          path:
+            - hostname
+      - name: ip_address
+        type: Utf8
+        nullable: true
+        description: IP address of the machine running the agent.
+        expr:
+          kind: path
+          path:
+            - ip_address
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Buildkite agent version.
+        expr:
+          kind: path
+          path:
+            - version
+      - name: os
+        type: Utf8
+        nullable: true
+        description: Operating system of the machine running the agent.
+        expr:
+          kind: path
+          path:
+            - os
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the agent was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: org_slug
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Organization slug passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: org_slug


### PR DESCRIPTION
Fixes #870 

Adds a new Buildkite community source that enables Coral to query Buildkite organizations, pipelines, builds, and agents through SQL. This enables CI/CD analytics such as build cycle times, pipeline success rates, agent monitoring, and cross-source joins with bundled GitHub and Bitbucket sources.

This change is manifest-only and uses Coral's existing HTTP source-spec model with a Bearer API token. It is read-only and introduces no CLI, MCP, config, or runtime changes.

---

## What Changed

Added:

- `sources/community/buildkite/manifest.yaml`
- `sources/community/buildkite/README.md`

---

## Source Scope

### Inputs

- `BUILDKITE_TOKEN` — API access token (secret), sent as `Authorization: Bearer`

---

## Tables

### `buildkite.organizations`

- **Endpoint:** `GET /v2/organizations`
- **Required filters:** none (used for test queries)
- **Pagination:** page-based, page size up to 100

**Columns:**
- slug
- name
- web_url
- created_at

---

### `buildkite.pipelines`

- **Endpoint:** `GET /v2/organizations/{org_slug}/pipelines`
- **Required filter:** org_slug
- **Pagination:** page-based, page size up to 100

**Columns:**
- slug
- name
- description
- repository
- default_branch
- web_url
- created_at
- org_slug

---

### `buildkite.builds`

- **Endpoint:** `GET /v2/organizations/{org_slug}/pipelines/{pipeline_slug}/builds`
- **Required filters:** org_slug, pipeline_slug
- **Pagination:** page-based, page size up to 100

**Columns:**
- number
- state
- branch
- commit
- message
- web_url
- pipeline_slug
- pipeline_name
- creator_name
- creator_email
- created_at
- started_at
- finished_at
- org_slug
- pipeline_slug_filter

Notes:
- `pipeline_slug` and `pipeline_name` are sourced from nested `pipeline.slug` and `pipeline.name`
- `creator_name` and `creator_email` are sourced from nested `creator.name` and `creator.email`

---

### `buildkite.org_builds`

- **Endpoint:** `GET /v2/organizations/{org_slug}/builds`
- **Required filter:** org_slug only (cross-pipeline builds)
- **Pagination:** page-based, page size up to 100

**Columns:**
- same schema as `builds` minus `pipeline_slug_filter`

---

### `buildkite.agents`

- **Endpoint:** `GET /v2/organizations/{org_slug}/agents`
- **Required filter:** org_slug
- **Pagination:** page-based, page size up to 100

**Columns:**
- id
- name
- connection_state
- hostname
- ip_address
- version
- os
- created_at
- org_slug

---

## Implementation Notes

- **Auth:** `Authorization: Bearer {{input.BUILDKITE_TOKEN}}` via HeaderAuth
- Buildkite returns top-level JSON arrays for all list endpoints (no wrapper key)
- Handled using `row_strategy: direct` with no `rows_path`
- Pagination uses `page` and `per_page` query params
- Buildkite supports Link headers, but page-based pagination works correctly
- All timestamps use `iso8601` format

### Data Model Notes

- `builds` and `org_builds` share identical schemas
- `builds` = pipeline-scoped (filtered)
- `org_builds` = cross-pipeline aggregation

---

## Out of Scope (v1)

Not included in this version:

- Jobs table (requires org_slug, pipeline_slug, build_number)
- Annotations and artifacts
- Teams and team members
- Any write operations

## Live-testing evidence

Add source:

<img width="916" height="389" alt="Screenshot 2026-05-27 142407" src="https://github.com/user-attachments/assets/136da005-e86c-4097-a28f-5f111e49e5d4" />


Organizations:

<img width="910" height="144" alt="Screenshot 2026-05-27 142417" src="https://github.com/user-attachments/assets/6108e346-ed07-42c7-9fad-096ee283e48d" />


Pipelines:

<img width="1349" height="158" alt="Screenshot 2026-05-27 142435" src="https://github.com/user-attachments/assets/44e419e8-fa89-46c3-a590-d96abcf26d06" />


Builds:

<img width="1419" height="159" alt="Screenshot 2026-05-27 142451" src="https://github.com/user-attachments/assets/9e38eea6-2655-47b3-acc6-b9a289b2ed29" />


Agents (CI runners monitoring):

<img width="1419" height="140" alt="Screenshot 2026-05-27 144029" src="https://github.com/user-attachments/assets/a4341766-fa60-4693-aa93-a50151f8700b" />


The query executes successfully but returns no rows since no Buildkite agents are currently connected in the `nancy-workspace` org. This is expected behavior given the absence of active agents.


Organization-wide builds:

<img width="1436" height="208" alt="Screenshot 2026-05-27 142507" src="https://github.com/user-attachments/assets/ba241e97-07bb-4a25-a803-1ce384fa00fc" />


