### PR TITLE
fix(release): mark promoted releases as latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,8 @@ jobs:
             release_json="$(gh api \
               --method PATCH \
               "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
-              -F prerelease=false)"
+              -F prerelease=false \
+              -F make_latest=true)"
           fi
 
           {


### PR DESCRIPTION
The install script (i.e. `curl -fsSL https://withcoral.com/install.sh | sh`) [fetches the latest release](https://github.com/withcoral/coral/blob/ca428d80f62641be1b7cb9933fa9c39b6f019c35/scripts/install.sh#L34) from Github and installs it. In #690 I configured release-please to create new Github releases as "pre-release", and only remove the pre-release status once artefacts are uploaded. This prevented an issue where the install script would fail during a release.

But it turns out removing the pre-release flag is not the same as marking the release as latest. Those are two different flags. 😬 

So this PR:

- Marks promoted GitHub releases as latest (`make_latest=true`) when clearing the prerelease flag.
- Keeps the behaviour scoped to actual prerelease promotion, so manual rebuilds of older stable releases do not steal the Latest badge.
