### PR TITLE
ci(release): advance docs branch to released commit on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,16 +266,16 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        if: github.event_name == 'release'
         with:
           ref: ${{ env.TAG_NAME }}
           fetch-depth: 0
           token: ${{ steps.github-app-token.outputs.token }}
           persist-credentials: false
 
-      # Force push targets `docs` only — never `main`.
+      # Force push targets `docs` only — never `main`. Runs on both the
+      # `release` event and manual `workflow_dispatch` against a tag, so docs
+      # can be (re)pointed at a shipped tag by re-running this workflow.
       - name: Point docs branch at released commit
-        if: github.event_name == 'release'
         env:
           GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,6 +265,26 @@ jobs:
             echo "__RELEASE_BODY__"
           } >> "$GITHUB_OUTPUT"
 
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        if: github.event_name == 'release'
+        with:
+          ref: ${{ env.TAG_NAME }}
+          fetch-depth: 0
+          token: ${{ steps.github-app-token.outputs.token }}
+          persist-credentials: false
+
+      # Force push targets `docs` only — never `main`.
+      - name: Point docs branch at released commit
+        if: github.event_name == 'release'
+        env:
+          GH_APP_TOKEN: ${{ steps.github-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          released_commit="$(git rev-parse "${TAG_NAME}^{commit}")"
+          git push --force \
+            "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "${released_commit}:refs/heads/docs"
+
       # Dispatch the tap workflow after publishing the release:
       # https://octokit.github.io/rest.js/v22/#repos-create-dispatch-event
       - name: Trigger Homebrew tap bump

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,11 @@
   Any PR may leave that generated page stale so unrelated changes do not fail
   on aggregate community catalog drift; keep docs freshness strict for bundled
   sources under `sources/core/**`, `docs/docs.json`, and the changelog.
+- The live docs site deploys from the long-lived `docs` branch, not `main`, so
+  the published catalog matches the latest released binary. `main` still owns
+  docs freshness, but merging to `main` no longer publishes the site by itself:
+  the release workflow advances `docs` after release artifacts are published.
+  See `docs/AGENTS.md` for the full publishing model.
 - Keep checked-in generated files marked in `.gitattributes` with
   `linguist-generated` so GitHub collapses them by default in PR diffs.
 - Source inputs that carry credentials must be `kind: secret`, never

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -28,6 +28,20 @@
   `docs/reference/community-sources.mdx`; any PR may leave that generated page
   stale so unrelated changes do not fail on aggregate community catalog drift.
 
+## Publishing (which branch Mintlify deploys)
+- The live docs site deploys from the long-lived `docs` branch, not `main`.
+  `docs` lags `main` and only advances to states that match a shipped release,
+  so the bundled-sources catalog never advertises a source the latest released
+  binary cannot run.
+- `main` still owns docs freshness: keep `docs/` aligned with the code as today,
+  and `make docs-check` still guards bundled-source/changelog freshness on `main`.
+  Merging to `main` no longer publishes to the live site by itself.
+- The release workflow force-resets `docs` to the released commit after the
+  binary actually ships from the `publish-version` job in
+  `.github/workflows/release.yml`. This reset is intentional and content-safe.
+- There is no separate immediate-publish path for doc-only fixes in this flow.
+  They reach the live site when the next release advances `docs`.
+
 ## Maintaining these instructions
 - Keep docs-specific agent rules here; keep repo-wide agent and contributor
   rules in the root `AGENTS.md`


### PR DESCRIPTION
## Summary

Today, when landing a PR, docs are updated immediately; our binary follows a different release cadence. This means docs can document things that aren't shipped yet.

In this PR:
Repoint the live docs site (which Mintlify deploys) to a long-lived `docs` branch that lags `main` and only advances to a shipped release. The publish-version job force-pushes the released tag commit to `docs` after the release is promoted, so the bundled-sources catalog never advertises a source the latest released binary cannot run. The docs-advance steps run in `publish-version` on both `release` events and manual `workflow_dispatch` runs against a tag, so `docs` can be (re)pointed at a shipped tag by re-running this workflow.

## Test plan

Nothing. We'll have to do some manual steps after this lands to make it actually work.