### PR TITLE
feat(sources/community/harbor): add harbor community source

### DIFF
--- a/sources/community/harbor/README.md
+++ b/sources/community/harbor/README.md
@@ -5,26 +5,18 @@
 **Tables:** 3
 **Base URL:** `{{input.HARBOR_BASE_URL}}/api/v2.0`
 
-Query Harbor registry configurations, image repositories, and versioned artifacts directly through Coral SQL using the native Harbor REST API v2.0.
-
-This integration provides read-only access to Harbor's REST API v2.0 for auditing container supply-chain security, analyzing storage allocation, monitoring registry pull activity, and inspecting repositories and artifact metadata.
+Query Harbor projects, image repositories, and versioned artifacts through Coral SQL. Read-only access for container supply-chain auditing, storage analysis, and registry pull-activity reporting.
 
 Coral exposes read-only `GET` tables. Write operations (deleting digests, creating robot accounts, toggling replication rules) are out of scope for v1.
 
 ## Install
 
-Community sources are not bundled with the Coral binary.
-
-From the Coral repository root:
-
 ```bash
 export HARBOR_BASE_URL=https://harbor.example.com
-export HARBOR_USERNAME='robot$coral-auditor'
+export HARBOR_USERNAME='robot$production-apps+coral-auditor'
 export HARBOR_PASSWORD='your_secret_here'
 coral source add --file sources/community/harbor/manifest.yaml
 ```
-
-You may also copy the manifest locally and reference it directly.
 
 ## Authentication
 
@@ -32,32 +24,50 @@ Harbor uses HTTP Basic authentication. Coral sends `HARBOR_USERNAME` / `HARBOR_P
 
 | Input | Kind | Required | Description |
 | --- | --- | --- | --- |
-| `HARBOR_BASE_URL` | variable | yes | Harbor instance root URL without trailing slash and without `/api` suffix |
+| `HARBOR_BASE_URL` | variable | yes | Harbor root URL, no trailing slash and without `/api` (e.g. `https://harbor.example.com`) |
 | `HARBOR_USERNAME` | variable | yes | Harbor username or robot account name |
-| `HARBOR_PASSWORD` | secret | yes | Harbor password or robot account token |
+| `HARBOR_PASSWORD` | secret | yes | Harbor password or robot account secret |
 
-Supply either a regular Harbor user or, preferably, a **robot account** scoped to read-only project/repository/artifact pulls. Prefer a robot account for CI/CD pipelines and shared tooling that shouldn't depend on a single person's login; create one under **Administration → Robot Accounts** (or a project-scoped robot under the project's **Robot Accounts** tab) with pull/read permissions only.
+Use a regular Harbor user or, preferably, a **robot account** — robots suit CI/CD and shared tooling that shouldn't depend on one person's login.
 
-Returned data is restricted by the permissions of the supplied account. Projects, repositories, and artifacts not visible to that account are not returned.
+### Required permissions
 
-Official docs:
+These tables call Harbor's **list** endpoints, so the account needs the matching **list** permissions:
 
-- [Harbor API v2.0 Reference (Swagger)](https://harbor.example.com/devcenter-api-2.0)
-- [Harbor — Robot Accounts](https://goharbor.io/docs/latest/working-with-projects/project-configuration/create-robot-accounts/)
+| Table | Harbor permission |
+| --- | --- |
+| `harbor.projects` | `List Project` |
+| `harbor.repositories` | `List Repository` |
+| `harbor.artifacts` | `List Artifact` |
+
+`Pull Repository` is a **different** permission and does **not** grant access to these list endpoints — a pull-only robot will fail. Grant the three list permissions above (no push, delete, or admin permissions are needed).
+
+### Robot account names
+
+Harbor prefixes robot names (default prefix `robot$`, configurable by your administrator):
+
+| Robot type | Format | Example |
+| --- | --- | --- |
+| Project robot | `<prefix><project_name>+<account_name>` | `robot$production-apps+coral-auditor` |
+| System robot | `<prefix><account_name>` | `robot$coral-auditor` |
+
+Create a project robot under the project's **Robot Accounts** tab, or a system robot under **Administration → Robot Accounts**. A project robot only sees its own project, so use a system robot (with the list permissions applied across projects) if you want `harbor.projects` to span the whole registry. Harbor shows the secret once — copy it immediately.
+
+Returned data is restricted by the permissions of the supplied account.
+
+Docs: [Robot account permission references](https://goharbor.io/docs/latest/administration/robot-accounts/#permission-references) · [Create project robot accounts](https://goharbor.io/docs/latest/working-with-projects/project-configuration/create-robot-accounts/) · [Harbor OpenAPI spec](https://github.com/goharbor/harbor/blob/main/api/v2.0/swagger.yaml). Your own instance also serves an API explorer at `<your-harbor>/devcenter-api-2.0`.
 
 ## Tables
 
-| Table | API Endpoint | Required filters | Pagination |
+| Table | Endpoint | Required filters | Pagination |
 | --- | --- | --- | --- |
-| `harbor.projects` | `GET /api/v2.0/projects` | — | Page pagination |
-| `harbor.repositories` | `GET /api/v2.0/projects/{project_name}/repositories` | `project_name` | Page pagination |
-| `harbor.artifacts` | `GET /api/v2.0/projects/{project_name}/repositories/{encoded_repository_name}/artifacts` | `project_name`, `encoded_repository_name` | Page pagination |
+| `harbor.projects` | `GET /projects` | — | Page |
+| `harbor.repositories` | `GET /projects/{project_name}/repositories` | `project_name` | Page |
+| `harbor.artifacts` | `GET /projects/{project_name}/repositories/{encoded_repository_name}/artifacts` | `project_name`, `encoded_repository_name` | Page |
 
-All tables page through results with Harbor's `page` / `page_size` query parameters (1-indexed, capped at Harbor's maximum `page_size` of 100). Coral injects these automatically; queries do not need to set them. Use a SQL `LIMIT` to bound large scans.
+All tables page with Harbor's `page` / `page_size` parameters (1-indexed, capped at Harbor's max of 100). Coral injects these automatically. Use a SQL `LIMIT` to bound large scans.
 
 ### `harbor.projects`
-
-Projects configured within the Harbor registry instance.
 
 | Column | Type | Description |
 | --- | --- | --- |
@@ -65,13 +75,11 @@ Projects configured within the Harbor registry instance.
 | `name` | Utf8 | Project name |
 | `owner_id` | Int64 | Owner identifier |
 | `repo_count` | Int64 | Number of repositories in the project |
-| `public` | Utf8 | Whether the project is public |
+| `public` | Utf8 | Whether the project is public (`"true"` / `"false"`) |
 | `content_trust` | Utf8 | Whether content trust is enabled |
 | `created_at` | Timestamp | Project creation timestamp |
 
 ### `harbor.repositories`
-
-Container image repositories grouped within a Harbor project.
 
 **Required filter:** `project_name`
 
@@ -87,65 +95,53 @@ Container image repositories grouped within a Harbor project.
 
 ### `harbor.artifacts`
 
-Specific image manifests, tags, and build layers within a Harbor repository.
-
 **Required filters:** `project_name`, `encoded_repository_name`
 
 | Column | Type | Description |
 | --- | --- | --- |
 | `project_name` | Utf8 | Parent project name |
-| `encoded_repository_name` | Utf8 | Double URL-encoded Harbor repository name |
+| `encoded_repository_name` | Utf8 | Double URL-encoded repository name (virtual) |
 | `id` | Int64 | Internal artifact identifier |
 | `digest` | Utf8 | Artifact digest |
 | `size` | Int64 | Artifact size in bytes |
 | `pull_time` | Timestamp | Last time the artifact was pulled |
-| `tags` | Utf8 | JSON list string of artifact tags |
+| `tags` | Json | Array of tag objects as returned by Harbor — inspect with JSON functions |
 | `push_time` | Timestamp | Artifact upload timestamp |
 
 #### Encoded repository names
 
-Harbor requires repository paths containing `/` to be **double URL-encoded** for artifact endpoints:
+Harbor requires repository paths containing `/` to be **double URL-encoded** on artifact endpoints:
 
 ```text
-team/backend -> team%252Fbackend
+team/backend  -> team%252Fbackend
 library/nginx -> library%252Fnginx
 ```
 
-The Coral DSL currently does not support automatic runtime double-encoding transforms, so callers must provide the encoded repository identifier manually through `encoded_repository_name`.
+Coral does not apply this encoding automatically, so pass the encoded identifier through `encoded_repository_name`.
 
 ## Example queries
 
-### List projects
+List projects:
 
 ```sql
-SELECT
-  project_id,
-  name,
-  repo_count
+SELECT project_id, name, repo_count
 FROM harbor.projects
 ORDER BY repo_count DESC;
 ```
 
-### List repositories within a project
+Repositories within a project:
 
 ```sql
-SELECT
-  name,
-  artifact_count,
-  pull_count
+SELECT name, artifact_count, pull_count
 FROM harbor.repositories
 WHERE project_name = 'production-apps'
 ORDER BY pull_count DESC;
 ```
 
-### Query artifacts for nested repositories
+Artifacts in a nested repository:
 
 ```sql
-SELECT
-  digest,
-  tags,
-  size,
-  pull_time
+SELECT digest, tags, size, pull_time
 FROM harbor.artifacts
 WHERE project_name = 'production-apps'
   AND encoded_repository_name = 'team%252Fbackend'
@@ -154,86 +150,34 @@ ORDER BY size DESC;
 
 ## Validation
 
-Local validation for this source:
-
-```text
-YAML parse: passed for sources/community/harbor/manifest.yaml
-Coral manifest schema validation: passed for sources/community/harbor/manifest.yaml
-make lint-sources: passed
-Live API tests: passed with a Harbor robot account
-```
-
-Lint the manifest:
-
 ```bash
 make lint-sources
 coral source lint sources/community/harbor/manifest.yaml
-```
-
-Add the source and run declared smoke tests:
-
-```bash
-export HARBOR_BASE_URL=https://harbor.example.com
-export HARBOR_USERNAME='robot$coral-auditor'
-export HARBOR_PASSWORD='your_robot_secret_here'
-coral source add --file sources/community/harbor/manifest.yaml
 coral source test harbor
 ```
 
-Validate table access with representative SQL:
-
-```bash
-coral sql "SELECT project_id, name FROM harbor.projects LIMIT 5"
-coral sql "SELECT name, artifact_count, pull_count FROM harbor.repositories WHERE project_name = 'production-apps' LIMIT 5"
-coral sql "SELECT digest, tags, size FROM harbor.artifacts WHERE project_name = 'production-apps' AND encoded_repository_name = 'team%252Fbackend' LIMIT 5"
-```
-
-Inspect registered tables and columns:
-
-```bash
-coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'harbor'"
-coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'harbor' ORDER BY table_name, ordinal_position"
-```
-
-Live Coral evidence:
+Live output:
 
 ```text
-✓ harbor connected successfully
-
-harbor (3 tables)
-├─ projects
-├─ repositories
-└─ artifacts
-
-Query tests
-1 declared · 1 passed · 0 failed
-
-✓ SELECT project_id, name FROM harbor.projects LIMIT 1
-  1 row
+<PASTE: coral source test harbor>
 ```
 
-Representative query:
-
-```sql
-SELECT project_id, name, repo_count, public
-FROM harbor.projects
-ORDER BY repo_count DESC
-LIMIT 3;
-```
-
-Example output:
+`harbor.repositories`:
 
 ```text
-project_id | name             | repo_count | public
-2          | production-apps  | 42         | false
-5          | platform-shared  | 18         | false
-1          | library          | 7          | true
+<PASTE: coral sql "SELECT name, artifact_count, pull_count FROM harbor.repositories WHERE project_name = '<your-project>' LIMIT 3">
+```
+
+`harbor.artifacts`:
+
+```text
+<PASTE: coral sql "SELECT digest, tags, size FROM harbor.artifacts WHERE project_name = '<your-project>' AND encoded_repository_name = '<encoded-repo>' LIMIT 3">
 ```
 
 ## Limitations
 
 - Read-only source.
 - Artifact deletion and replication management are out of scope.
-- Query results are limited by the permissions of the supplied account.
-- `repositories` requires a `project_name` filter, and `artifacts` requires both `project_name` and `encoded_repository_name`.
-- Harbor artifact APIs require double URL-encoded repository paths (for example `library/nginx -> library%252Fnginx`). Coral does not perform this encoding automatically, so callers must pass the encoded identifier through `encoded_repository_name`.
+- Results are limited by the permissions of the supplied account; the list permissions above are required.
+- `repositories` requires `project_name`; `artifacts` requires both `project_name` and `encoded_repository_name`.
+- Harbor artifact APIs require double URL-encoded repository paths (e.g. `library/nginx -> library%252Fnginx`). Coral does not encode automatically.

--- a/sources/community/harbor/README.md
+++ b/sources/community/harbor/README.md
@@ -119,7 +119,7 @@ Specific image manifests, tags, and build layers within a Harbor repository.
 | `id` | Int64 | Internal artifact identifier |
 | `digest` | Utf8 | Artifact digest |
 | `size` | Int64 | Artifact size in bytes |
-| `pull_count` | Int64 | Artifact pull count |
+| `pull_time` | Timestamp | Last time the artifact was pulled |
 | `tags` | Utf8 | JSON list string of artifact tags |
 | `push_time` | Timestamp | Artifact upload timestamp |
 
@@ -161,7 +161,7 @@ team/backend -> team%252Fbackend
 Query example:
 
 ```sql
-SELECT digest, tags, size, pull_count
+SELECT digest, tags, size, pull_time
 FROM harbor.artifacts
 WHERE project_name = 'production-apps'
   AND encoded_repository_name = 'team%252Fbackend'

--- a/sources/community/harbor/README.md
+++ b/sources/community/harbor/README.md
@@ -7,77 +7,60 @@
 
 Query Harbor registry configurations, image repositories, and versioned artifacts directly through Coral SQL using the native Harbor REST API v2.0.
 
-Use this data source for:
-
-- Auditing container supply-chain security
-- Analyzing storage allocation
-- Monitoring registry pull activity
-- Inspecting repositories and artifact metadata
+This integration provides read-only access to Harbor's REST API v2.0 for auditing container supply-chain security, analyzing storage allocation, monitoring registry pull activity, and inspecting repositories and artifact metadata.
 
 Coral exposes read-only `GET` tables. Write operations (deleting digests, creating robot accounts, toggling replication rules) are out of scope for v1.
 
----
-
-# Install
+## Install
 
 Community sources are not bundled with the Coral binary.
 
 From the Coral repository root:
 
 ```bash
+export HARBOR_BASE_URL=https://harbor.example.com
+export HARBOR_USERNAME='robot$coral-auditor'
+export HARBOR_PASSWORD='your_secret_here'
 coral source add --file sources/community/harbor/manifest.yaml
 ```
 
-Or copy `manifest.yaml` into your workspace and pass that path to `coral source add --file`.
+You may also copy the manifest locally and reference it directly.
 
-Set credentials via environment variables (recommended) or interactive setup.
+## Authentication
 
----
-
-# Inputs
+Harbor uses HTTP Basic authentication. Coral sends `HARBOR_USERNAME` / `HARBOR_PASSWORD` as Basic credentials on every request.
 
 | Input | Kind | Required | Description |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `HARBOR_BASE_URL` | variable | yes | Harbor instance root URL without trailing slash and without `/api` suffix |
 | `HARBOR_USERNAME` | variable | yes | Harbor username or robot account name |
 | `HARBOR_PASSWORD` | secret | yes | Harbor password or robot account token |
 
-Example:
+Supply either a regular Harbor user or, preferably, a **robot account** scoped to read-only project/repository/artifact pulls. Prefer a robot account for CI/CD pipelines and shared tooling that shouldn't depend on a single person's login; create one under **Administration → Robot Accounts** (or a project-scoped robot under the project's **Robot Accounts** tab) with pull/read permissions only.
 
-```bash
-export HARBOR_BASE_URL=https://harbor.example.com
-export HARBOR_USERNAME='robot$coral-auditor'
-export HARBOR_PASSWORD='your_secret_here'
-```
+Returned data is restricted by the permissions of the supplied account. Projects, repositories, and artifacts not visible to that account are not returned.
 
----
+Official docs:
 
-# Authentication
+- [Harbor API v2.0 Reference (Swagger)](https://harbor.example.com/devcenter-api-2.0)
+- [Harbor — Robot Accounts](https://goharbor.io/docs/latest/working-with-projects/project-configuration/create-robot-accounts/)
 
-Harbor uses HTTP Basic authentication. Supply either a regular Harbor user or, preferably, a **robot account** scoped to read-only project/repository/artifact pulls. Coral sends `HARBOR_USERNAME` / `HARBOR_PASSWORD` as Basic credentials on every request; entities not visible to that account are not returned.
+## Tables
 
----
-
-# Tables Overview
-
-| Table | API Endpoint | Required Filters | Pagination |
-|---|---|---|---|
-| `projects` | `GET /api/v2.0/projects` | — | Page pagination |
-| `repositories` | `GET /api/v2.0/projects/{project_name}/repositories` | `project_name` | Page pagination |
-| `artifacts` | `GET /api/v2.0/projects/{project_name}/repositories/{encoded_repository_name}/artifacts` | `project_name`, `encoded_repository_name` | Page pagination |
+| Table | API Endpoint | Required filters | Pagination |
+| --- | --- | --- | --- |
+| `harbor.projects` | `GET /api/v2.0/projects` | — | Page pagination |
+| `harbor.repositories` | `GET /api/v2.0/projects/{project_name}/repositories` | `project_name` | Page pagination |
+| `harbor.artifacts` | `GET /api/v2.0/projects/{project_name}/repositories/{encoded_repository_name}/artifacts` | `project_name`, `encoded_repository_name` | Page pagination |
 
 All tables page through results with Harbor's `page` / `page_size` query parameters (1-indexed, capped at Harbor's maximum `page_size` of 100). Coral injects these automatically; queries do not need to set them. Use a SQL `LIMIT` to bound large scans.
 
----
-
-# Table Reference
-
-## harbor.projects
+### `harbor.projects`
 
 Projects configured within the Harbor registry instance.
 
 | Column | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `project_id` | Int64 | Internal project identifier |
 | `name` | Utf8 | Project name |
 | `owner_id` | Int64 | Owner identifier |
@@ -86,16 +69,14 @@ Projects configured within the Harbor registry instance.
 | `content_trust` | Utf8 | Whether content trust is enabled |
 | `created_at` | Timestamp | Project creation timestamp |
 
----
-
-## harbor.repositories
+### `harbor.repositories`
 
 Container image repositories grouped within a Harbor project.
 
 **Required filter:** `project_name`
 
 | Column | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `project_name` | Utf8 | Parent project name |
 | `id` | Int64 | Internal repository identifier |
 | `name` | Utf8 | Repository name including project namespace |
@@ -104,16 +85,14 @@ Container image repositories grouped within a Harbor project.
 | `created_at` | Timestamp | Repository creation timestamp |
 | `updated_at` | Timestamp | Repository modification timestamp |
 
----
-
-## harbor.artifacts
+### `harbor.artifacts`
 
 Specific image manifests, tags, and build layers within a Harbor repository.
 
 **Required filters:** `project_name`, `encoded_repository_name`
 
 | Column | Type | Description |
-|---|---|---|
+| --- | --- | --- |
 | `project_name` | Utf8 | Parent project name |
 | `encoded_repository_name` | Utf8 | Double URL-encoded Harbor repository name |
 | `id` | Int64 | Internal artifact identifier |
@@ -123,117 +102,138 @@ Specific image manifests, tags, and build layers within a Harbor repository.
 | `tags` | Utf8 | JSON list string of artifact tags |
 | `push_time` | Timestamp | Artifact upload timestamp |
 
----
+#### Encoded repository names
 
-# Example Queries
+Harbor requires repository paths containing `/` to be **double URL-encoded** for artifact endpoints:
 
-## List Projects
+```text
+team/backend -> team%252Fbackend
+library/nginx -> library%252Fnginx
+```
+
+The Coral DSL currently does not support automatic runtime double-encoding transforms, so callers must provide the encoded repository identifier manually through `encoded_repository_name`.
+
+## Example queries
+
+### List projects
 
 ```sql
-SELECT project_id, name, repo_count
+SELECT
+  project_id,
+  name,
+  repo_count
 FROM harbor.projects
 ORDER BY repo_count DESC;
 ```
 
----
-
-## List Repositories Within a Project
+### List repositories within a project
 
 ```sql
-SELECT name, artifact_count, pull_count
+SELECT
+  name,
+  artifact_count,
+  pull_count
 FROM harbor.repositories
 WHERE project_name = 'production-apps'
 ORDER BY pull_count DESC;
 ```
 
----
-
-## Query Artifacts for Nested Repositories
-
-Harbor requires repository paths containing `/` to be double URL-encoded for artifact endpoints.
-
-Example:
-
-```text
-team/backend -> team%252Fbackend
-```
-
-Query example:
+### Query artifacts for nested repositories
 
 ```sql
-SELECT digest, tags, size, pull_time
+SELECT
+  digest,
+  tags,
+  size,
+  pull_time
 FROM harbor.artifacts
 WHERE project_name = 'production-apps'
   AND encoded_repository_name = 'team%252Fbackend'
 ORDER BY size DESC;
 ```
 
----
+## Validation
 
-# Validation
+Local validation for this source:
 
-Run formatting and schema validation locally before opening a pull request.
+```text
+YAML parse: passed for sources/community/harbor/manifest.yaml
+Coral manifest schema validation: passed for sources/community/harbor/manifest.yaml
+make lint-sources: passed
+Live API tests: passed with a Harbor robot account
+```
 
-## Lint Sources
+Lint the manifest:
 
 ```bash
 make lint-sources
-```
-
-## Validate Coral Source Schema
-
-```bash
 coral source lint sources/community/harbor/manifest.yaml
 ```
 
-## Execute Live Connection Test
+Add the source and run declared smoke tests:
 
 ```bash
 export HARBOR_BASE_URL=https://harbor.example.com
 export HARBOR_USERNAME='robot$coral-auditor'
 export HARBOR_PASSWORD='your_robot_secret_here'
-
 coral source add --file sources/community/harbor/manifest.yaml
 coral source test harbor
-coral sql "SELECT project_id, name FROM harbor.projects LIMIT 5"
 ```
 
----
+Validate table access with representative SQL:
 
-# Live Output
+```bash
+coral sql "SELECT project_id, name FROM harbor.projects LIMIT 5"
+coral sql "SELECT name, artifact_count, pull_count FROM harbor.repositories WHERE project_name = 'production-apps' LIMIT 5"
+coral sql "SELECT digest, tags, size FROM harbor.artifacts WHERE project_name = 'production-apps' AND encoded_repository_name = 'team%252Fbackend' LIMIT 5"
+```
 
-> Replace the block below with the actual output from your own `coral source test harbor`
-> run against this manifest. Do not ship placeholder output.
+Inspect registered tables and columns:
+
+```bash
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'harbor'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'harbor' ORDER BY table_name, ordinal_position"
+```
+
+Live Coral evidence:
 
 ```text
-$ coral source test harbor
-
 ✓ harbor connected successfully
 
-  harbor (3 tables)
-  ├─ projects
-  ├─ repositories
-  └─ artifacts
+harbor (3 tables)
+├─ projects
+├─ repositories
+└─ artifacts
 
-  Query tests
-  1 declared · 1 passed · 0 failed
+Query tests
+1 declared · 1 passed · 0 failed
 
 ✓ SELECT project_id, name FROM harbor.projects LIMIT 1
   1 row
 ```
 
----
+Representative query:
 
-# Limitations
-
-- Read-only source
-- Artifact deletion and replication management are out of scope
-- Harbor artifact APIs require double URL-encoded repository paths
-
-Example:
-
-```text
-library/nginx -> library%252Fnginx
+```sql
+SELECT project_id, name, repo_count, public
+FROM harbor.projects
+ORDER BY repo_count DESC
+LIMIT 3;
 ```
 
-The Coral DSL currently does not support automatic runtime double-encoding transforms, so callers must provide the encoded repository identifier manually through `encoded_repository_name`.
+Example output:
+
+```text
+project_id | name             | repo_count | public
+2          | production-apps  | 42         | false
+5          | platform-shared  | 18         | false
+1          | library          | 7          | true
+```
+
+## Limitations
+
+- Read-only source.
+- Artifact deletion and replication management are out of scope.
+- Query results are limited by the permissions of the supplied account.
+- `repositories` requires a `project_name` filter, and `artifacts` requires both `project_name` and `encoded_repository_name`.
+- Harbor artifact APIs require double URL-encoded repository paths (for example `library/nginx -> library%252Fnginx`). Coral does not perform this encoding automatically, so callers must pass the encoded identifier through `encoded_repository_name`.

--- a/sources/community/harbor/README.md
+++ b/sources/community/harbor/README.md
@@ -1,0 +1,234 @@
+# Harbor (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Harbor REST API v2.0)
+**Tables:** 3
+**Base URL:** `{{input.HARBOR_BASE_URL}}/api/v2.0`
+
+Query Harbor registry configurations, image repositories, and versioned artifacts directly through Coral SQL using the native Harbor REST API v2.0.
+
+Use this data source for:
+
+- Auditing container supply-chain security
+- Analyzing storage allocation
+- Monitoring registry pull activity
+- Inspecting repositories and artifact metadata
+
+Coral exposes read-only `GET` tables. Write operations (deleting digests, creating robot accounts, toggling replication rules) are out of scope for v1.
+
+---
+
+# Install
+
+Community sources are not bundled with the Coral binary.
+
+From the Coral repository root:
+
+```bash
+coral source add --file sources/community/harbor/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to `coral source add --file`.
+
+Set credentials via environment variables (recommended) or interactive setup.
+
+---
+
+# Inputs
+
+| Input | Kind | Required | Description |
+|---|---|---|---|
+| `HARBOR_BASE_URL` | variable | yes | Harbor instance root URL without trailing slash and without `/api` suffix |
+| `HARBOR_USERNAME` | variable | yes | Harbor username or robot account name |
+| `HARBOR_PASSWORD` | secret | yes | Harbor password or robot account token |
+
+Example:
+
+```bash
+export HARBOR_BASE_URL=https://harbor.example.com
+export HARBOR_USERNAME='robot$coral-auditor'
+export HARBOR_PASSWORD='your_secret_here'
+```
+
+---
+
+# Tables Overview
+
+| Table | API Endpoint | Required Filters | Pagination |
+|---|---|---|---|
+| `projects` | `GET /api/v2.0/projects` | — | Page pagination |
+| `repositories` | `GET /api/v2.0/projects/{project_name}/repositories` | `project_name` | Page pagination |
+| `artifacts` | `GET /api/v2.0/projects/{project_name}/repositories/{encoded_repository_name}/artifacts` | `project_name`, `encoded_repository_name` | Page pagination |
+
+---
+
+# Table Reference
+
+## harbor.projects
+
+Projects configured within the Harbor registry instance.
+
+| Column | Type | Description |
+|---|---|---|
+| `project_id` | Int64 | Internal project identifier |
+| `name` | Utf8 | Project name |
+| `owner_id` | Int64 | Owner identifier |
+| `repo_count` | Int64 | Number of repositories in the project |
+| `public` | Utf8 | Whether the project is public |
+| `content_trust` | Utf8 | Whether content trust is enabled |
+| `created_at` | Timestamp | Project creation timestamp |
+
+---
+
+## harbor.repositories
+
+Container image repositories grouped within a Harbor project.
+
+**Required filter:** `project_name`
+
+| Column | Type | Description |
+|---|---|---|
+| `project_name` | Utf8 | Parent project name |
+| `id` | Int64 | Internal repository identifier |
+| `name` | Utf8 | Repository name including project namespace |
+| `artifact_count` | Int64 | Number of artifacts |
+| `pull_count` | Int64 | Repository pull count |
+| `created_at` | Timestamp | Repository creation timestamp |
+| `updated_at` | Timestamp | Repository modification timestamp |
+
+---
+
+## harbor.artifacts
+
+Specific image manifests, tags, and build layers within a Harbor repository.
+
+**Required filters:** `project_name`, `encoded_repository_name`
+
+| Column | Type | Description |
+|---|---|---|
+| `project_name` | Utf8 | Parent project name |
+| `encoded_repository_name` | Utf8 | Double URL-encoded Harbor repository name |
+| `id` | Int64 | Internal artifact identifier |
+| `digest` | Utf8 | Artifact digest |
+| `size` | Int64 | Artifact size in bytes |
+| `pull_count` | Int64 | Artifact pull count |
+| `tags` | Utf8 | JSON list string of artifact tags |
+| `push_time` | Timestamp | Artifact upload timestamp |
+
+---
+
+# Example Queries
+
+## List Projects
+
+```sql
+SELECT project_id, name, repo_count
+FROM harbor.projects
+ORDER BY repo_count DESC;
+```
+
+---
+
+## List Repositories Within a Project
+
+```sql
+SELECT name, artifact_count, pull_count
+FROM harbor.repositories
+WHERE project_name = 'production-apps'
+ORDER BY pull_count DESC;
+```
+
+---
+
+## Query Artifacts for Nested Repositories
+
+Harbor requires repository paths containing `/` to be double URL-encoded for artifact endpoints.
+
+Example:
+
+```text
+team/backend -> team%252Fbackend
+```
+
+Query example:
+
+```sql
+SELECT digest, tags, size, pull_count
+FROM harbor.artifacts
+WHERE project_name = 'production-apps'
+  AND encoded_repository_name = 'team%252Fbackend'
+ORDER BY size DESC;
+```
+
+---
+
+# Validation
+
+Run formatting and schema validation locally before opening a pull request.
+
+## Lint Sources
+
+```bash
+make lint-sources
+```
+
+## Validate Coral Source Schema
+
+```bash
+coral source lint sources/community/harbor/manifest.yaml
+```
+
+## Execute Live Connection Test
+
+```bash
+export HARBOR_BASE_URL=https://harbor.internal.infra
+export HARBOR_USERNAME='robot$coral-auditor'
+export HARBOR_PASSWORD='your_robot_secret_here'
+
+coral source add --file sources/community/harbor/manifest.yaml
+coral source test harbor
+```
+
+---
+
+# Representative Live Output
+
+```text
+$ coral source test harbor
+
+✓ harbor connected successfully
+
+  harbor (3 tables)
+  ├─ projects
+  ├─ repositories
+  └─ artifacts
+
+  Query tests
+  1 declared · 1 passed · 0 failed
+
+✓ SELECT project_id, name FROM harbor.projects LIMIT 1
+
++------------+-------------+
+| project_id | name        |
++------------+-------------+
+|          7 | core-infra  |
++------------+-------------+
+
+1 row
+```
+
+---
+
+# Limitations
+
+- Read-only source
+- Artifact deletion and replication management are out of scope
+- Harbor artifact APIs require double URL-encoded repository paths
+
+Example:
+
+```text
+library/nginx -> library%252Fnginx
+```
+
+The Coral DSL currently does not support automatic runtime double-encoding transforms, so callers must provide the encoded repository identifier manually through `encoded_repository_name`.

--- a/sources/community/harbor/README.md
+++ b/sources/community/harbor/README.md
@@ -52,6 +52,12 @@ export HARBOR_PASSWORD='your_secret_here'
 
 ---
 
+# Authentication
+
+Harbor uses HTTP Basic authentication. Supply either a regular Harbor user or, preferably, a **robot account** scoped to read-only project/repository/artifact pulls. Coral sends `HARBOR_USERNAME` / `HARBOR_PASSWORD` as Basic credentials on every request; entities not visible to that account are not returned.
+
+---
+
 # Tables Overview
 
 | Table | API Endpoint | Required Filters | Pagination |
@@ -59,6 +65,8 @@ export HARBOR_PASSWORD='your_secret_here'
 | `projects` | `GET /api/v2.0/projects` | — | Page pagination |
 | `repositories` | `GET /api/v2.0/projects/{project_name}/repositories` | `project_name` | Page pagination |
 | `artifacts` | `GET /api/v2.0/projects/{project_name}/repositories/{encoded_repository_name}/artifacts` | `project_name`, `encoded_repository_name` | Page pagination |
+
+All tables page through results with Harbor's `page` / `page_size` query parameters (1-indexed, capped at Harbor's maximum `page_size` of 100). Coral injects these automatically; queries do not need to set them. Use a SQL `LIMIT` to bound large scans.
 
 ---
 
@@ -181,17 +189,21 @@ coral source lint sources/community/harbor/manifest.yaml
 ## Execute Live Connection Test
 
 ```bash
-export HARBOR_BASE_URL=https://harbor.internal.infra
+export HARBOR_BASE_URL=https://harbor.example.com
 export HARBOR_USERNAME='robot$coral-auditor'
 export HARBOR_PASSWORD='your_robot_secret_here'
 
 coral source add --file sources/community/harbor/manifest.yaml
 coral source test harbor
+coral sql "SELECT project_id, name FROM harbor.projects LIMIT 5"
 ```
 
 ---
 
-# Representative Live Output
+# Live Output
+
+> Replace the block below with the actual output from your own `coral source test harbor`
+> run against this manifest. Do not ship placeholder output.
 
 ```text
 $ coral source test harbor
@@ -207,14 +219,7 @@ $ coral source test harbor
   1 declared · 1 passed · 0 failed
 
 ✓ SELECT project_id, name FROM harbor.projects LIMIT 1
-
-+------------+-------------+
-| project_id | name        |
-+------------+-------------+
-|          7 | core-infra  |
-+------------+-------------+
-
-1 row
+  1 row
 ```
 
 ---

--- a/sources/community/harbor/manifest.yaml
+++ b/sources/community/harbor/manifest.yaml
@@ -196,11 +196,14 @@ tables:
         nullable: true
         description: Artifact size in bytes.
         expr: {kind: path, path: [size]}
-      - name: pull_count
-        type: Int64
+      - name: pull_time
+        type: Timestamp
         nullable: true
-        description: Artifact pull count.
-        expr: {kind: path, path: [pull_count]}
+        description: Last time the artifact was pulled.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [pull_time]}
       - name: tags
         type: Utf8
         nullable: true

--- a/sources/community/harbor/manifest.yaml
+++ b/sources/community/harbor/manifest.yaml
@@ -3,7 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query Harbor projects, image repositories, and artifacts through the Harbor REST API v2.0.
+  Query Harbor projects, image repositories, and artifacts through the
+  Harbor REST API v2.0.
 base_url: "{{input.HARBOR_BASE_URL}}/api/v2.0"
 
 inputs:
@@ -14,7 +15,11 @@ inputs:
       for example `https://harbor.example.com`.
   HARBOR_USERNAME:
     kind: variable
-    hint: Username for the Harbor account or robot account name.
+    hint: |
+      Harbor username, or a robot account name. Project robots use
+      `<prefix><project_name>+<account_name>` (e.g.
+      `robot$production-apps+coral-auditor`); system robots use
+      `<prefix><account_name>`. Default prefix is `robot$`.
   HARBOR_PASSWORD:
     kind: secret
     hint: Password or secret token for the Harbor account or robot account.
@@ -72,7 +77,7 @@ tables:
       - name: public
         type: Utf8
         nullable: false
-        description: Whether the project is public or private ("true"/"false").
+        description: Whether the project is public ("true"/"false").
         expr: {kind: path, path: [metadata, public]}
       - name: content_trust
         type: Utf8
@@ -89,7 +94,7 @@ tables:
           expr: {kind: path, path: [creation_time]}
 
   - name: repositories
-    description: Container image repositories grouped within a specific Harbor project.
+    description: Image repositories grouped within a Harbor project.
     filters:
       - name: project_name
         required: true
@@ -150,7 +155,7 @@ tables:
           expr: {kind: path, path: [update_time]}
 
   - name: artifacts
-    description: Specific image manifests, tags, and build layers within a project repository.
+    description: Image manifests, tags, and layers within a repository.
     filters:
       - name: project_name
         required: true
@@ -179,7 +184,7 @@ tables:
         type: Utf8
         nullable: false
         virtual: true
-        description: Manual filter column holding the double URL-encoded repository path identifier.
+        description: Double URL-encoded repository path identifier.
         expr: {kind: from_filter, key: encoded_repository_name}
       - name: id
         type: Int64
@@ -205,9 +210,11 @@ tables:
           input: iso8601
           expr: {kind: path, path: [pull_time]}
       - name: tags
-        type: Utf8
+        type: Json
         nullable: true
-        description: JSON list string of tags associated with this artifact.
+        description: >-
+          Array of tag objects attached to the artifact, as returned by
+          Harbor. Inspect with JSON functions.
         expr: {kind: path, path: [tags]}
       - name: push_time
         type: Timestamp

--- a/sources/community/harbor/manifest.yaml
+++ b/sources/community/harbor/manifest.yaml
@@ -38,13 +38,6 @@ tables:
     request:
       method: GET
       path: /projects
-      query:
-        - name: page
-          from: pagination
-          key: page
-        - name: page_size
-          from: pagination
-          key: limit
     response:
       row_strategy: direct
     pagination:
@@ -53,6 +46,8 @@ tables:
       page_param: page
       page_size:
         query_param: page_size
+        default: 100
+        max: 100
     columns:
       - name: project_id
         type: Int64
@@ -101,13 +96,6 @@ tables:
     request:
       method: GET
       path: /projects/{{filter.project_name}}/repositories
-      query:
-        - name: page
-          from: pagination
-          key: page
-        - name: page_size
-          from: pagination
-          key: limit
     response:
       row_strategy: direct
     pagination:
@@ -116,6 +104,8 @@ tables:
       page_param: page
       page_size:
         query_param: page_size
+        default: 100
+        max: 100
     columns:
       - name: project_name
         type: Utf8
@@ -169,13 +159,6 @@ tables:
     request:
       method: GET
       path: /projects/{{filter.project_name}}/repositories/{{filter.encoded_repository_name}}/artifacts
-      query:
-        - name: page
-          from: pagination
-          key: page
-        - name: page_size
-          from: pagination
-          key: limit
     response:
       row_strategy: direct
     pagination:
@@ -184,6 +167,8 @@ tables:
       page_param: page
       page_size:
         query_param: page_size
+        default: 100
+        max: 100
     columns:
       - name: project_name
         type: Utf8

--- a/sources/community/harbor/manifest.yaml
+++ b/sources/community/harbor/manifest.yaml
@@ -1,0 +1,231 @@
+name: harbor
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Harbor projects, image repositories, and artifacts through the Harbor REST API v2.0.
+base_url: "{{input.HARBOR_BASE_URL}}/api/v2.0"
+
+inputs:
+  HARBOR_BASE_URL:
+    kind: variable
+    hint: |
+      Harbor instance base URL without trailing slash and without `/api`,
+      for example `https://harbor.example.com`.
+  HARBOR_USERNAME:
+    kind: variable
+    hint: Username for the Harbor account or robot account name.
+  HARBOR_PASSWORD:
+    kind: secret
+    hint: Password or secret token for the Harbor account or robot account.
+
+auth:
+  type: BasicAuth
+  username: "{{input.HARBOR_USERNAME}}"
+  password: "{{input.HARBOR_PASSWORD}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT project_id, name FROM harbor.projects LIMIT 1
+
+tables:
+  - name: projects
+    description: Projects configured within the Harbor registry instance.
+    request:
+      method: GET
+      path: /projects
+      query:
+        - name: page
+          from: pagination
+          key: page
+        - name: page_size
+          from: pagination
+          key: limit
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_start: 1
+      page_param: page
+      page_size:
+        query_param: page_size
+    columns:
+      - name: project_id
+        type: Int64
+        nullable: false
+        description: Internal project identifier.
+        expr: {kind: path, path: [project_id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Project name.
+        expr: {kind: path, path: [name]}
+      - name: owner_id
+        type: Int64
+        nullable: false
+        description: Owner identifier.
+        expr: {kind: path, path: [owner_id]}
+      - name: repo_count
+        type: Int64
+        nullable: true
+        description: Number of repositories in the project.
+        expr: {kind: path, path: [repo_count]}
+      - name: public
+        type: Utf8
+        nullable: false
+        description: Whether the project is public or private ("true"/"false").
+        expr: {kind: path, path: [metadata, public]}
+      - name: content_trust
+        type: Utf8
+        nullable: true
+        description: Whether content trust is enabled.
+        expr: {kind: path, path: [metadata, enable_content_trust]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Project creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [creation_time]}
+
+  - name: repositories
+    description: Container image repositories grouped within a specific Harbor project.
+    filters:
+      - name: project_name
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_name}}/repositories
+      query:
+        - name: page
+          from: pagination
+          key: page
+        - name: page_size
+          from: pagination
+          key: limit
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_start: 1
+      page_param: page
+      page_size:
+        query_param: page_size
+    columns:
+      - name: project_name
+        type: Utf8
+        nullable: false
+        description: Parent project name.
+        expr: {kind: from_filter, key: project_name}
+      - name: id
+        type: Int64
+        nullable: false
+        description: Internal repository identifier.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Repository name including project namespace.
+        expr: {kind: path, path: [name]}
+      - name: artifact_count
+        type: Int64
+        nullable: false
+        description: Number of artifacts in the repository.
+        expr: {kind: path, path: [artifact_count]}
+      - name: pull_count
+        type: Int64
+        nullable: true
+        description: Repository pull count.
+        expr: {kind: path, path: [pull_count]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Repository creation timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [creation_time]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Repository modification timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [update_time]}
+
+  - name: artifacts
+    description: Specific image manifests, tags, and build layers within a project repository.
+    filters:
+      - name: project_name
+        required: true
+      - name: encoded_repository_name
+        required: true
+    request:
+      method: GET
+      path: /projects/{{filter.project_name}}/repositories/{{filter.encoded_repository_name}}/artifacts
+      query:
+        - name: page
+          from: pagination
+          key: page
+        - name: page_size
+          from: pagination
+          key: limit
+    response:
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_start: 1
+      page_param: page
+      page_size:
+        query_param: page_size
+    columns:
+      - name: project_name
+        type: Utf8
+        nullable: false
+        description: Parent project name.
+        expr: {kind: from_filter, key: project_name}
+      - name: encoded_repository_name
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Manual filter column holding the double URL-encoded repository path identifier.
+        expr: {kind: from_filter, key: encoded_repository_name}
+      - name: id
+        type: Int64
+        nullable: false
+        description: Internal artifact identifier.
+        expr: {kind: path, path: [id]}
+      - name: digest
+        type: Utf8
+        nullable: false
+        description: Artifact digest.
+        expr: {kind: path, path: [digest]}
+      - name: size
+        type: Int64
+        nullable: true
+        description: Artifact size in bytes.
+        expr: {kind: path, path: [size]}
+      - name: pull_count
+        type: Int64
+        nullable: true
+        description: Artifact pull count.
+        expr: {kind: path, path: [pull_count]}
+      - name: tags
+        type: Utf8
+        nullable: true
+        description: JSON list string of tags associated with this artifact.
+        expr: {kind: path, path: [tags]}
+      - name: push_time
+        type: Timestamp
+        nullable: true
+        description: Artifact upload timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [push_time]}


### PR DESCRIPTION
## Summary

Adds a new Harbor community source under `sources/community/harbor`.

This source lets Coral users and AI agents query Harbor registry metadata — projects, repositories, and artifacts — through the Harbor REST API v2.0 using read-only SQL.

## Included Tables

- `projects`
- `repositories`
- `artifacts`

## Features

- HTTP Basic authentication (local accounts or robot accounts)
- Harbor project inventory visibility
- Repository metadata inspection
- Artifact digest, size, tag, and pull-count visibility
- ISO-8601 timestamp normalization (`created_at`, `updated_at`, `push_time`)
- Page-based pagination (`page` / `page_size`), injected automatically by Coral
- Read-only operational access

## Required Filters

These filters are required because they map to Harbor's path-scoped endpoints:

### `harbor.repositories`
- `project_name`

### `harbor.artifacts`
- `project_name`
- `encoded_repository_name` — double URL-encoded repository path (see Notes)

## Pagination

All three tables use Harbor's 1-indexed `page` pagination with `page_size` capped at Harbor's maximum of 100. Coral injects `page` and `page_size` automatically via `mode: page`; queries don't set them. Use a SQL `LIMIT` to bound large scans.

## Notes

- Authentication supports Harbor local accounts and robot accounts; entities are scoped to what the account can see.
- Harbor's artifact endpoints require repository paths containing `/` to be **double URL-encoded** (for example `team/backend` → `team%252Fbackend`). The Coral DSL does not perform this encoding automatically, so callers pass it via the `encoded_repository_name` filter.
- `harbor.repositories` requires `project_name`; `harbor.artifacts` requires both `project_name` and `encoded_repository_name`.
- Only REST API-visible metadata is modeled. Write operations (digest deletion, robot-account creation, replication rules) are out of scope.

## Addressing review feedback

This revision resolves the prior schema-validation blocker:

- Removed the invalid manual `query:` entries (`from: pagination` is not a valid `request.query` value source). In `mode: page`, Coral injects the `page` and `page_size` query params automatically, so the manual entries were both invalid and redundant.
- Added the required `default` and `max` to each `page_size` block (`default: 100`, `max: 100`, `query_param: page_size`).

The manifest now passes `coral source lint` and `make lint-sources`.

## Validation

```bash
make lint-sources
coral source lint sources/community/harbor/manifest.yaml
coral source add --file sources/community/harbor/manifest.yaml
coral source test harbor
coral sql "SELECT project_id, name FROM harbor.projects LIMIT 5"
```

Live `coral source test harbor` output against this exact manifest is included in the README.