### PR TITLE
feat(sources/community/servicenow): add ServiceNow source

### DIFF
--- a/sources/community/servicenow/README.md
+++ b/sources/community/servicenow/README.md
@@ -11,13 +11,22 @@ It does not create, update, or delete ServiceNow records.
 ## Authentication
 
 Use a least-privilege ServiceNow integration user with read access to the
-tables you want Coral to inspect.
+tables you want Coral to inspect. This manifest currently supports ServiceNow
+Basic authentication only. If your instance requires OAuth or another auth
+scheme, use a separate source variant rather than pasting bearer tokens into
+the password input.
 
 | Input | Kind | Description |
 |---|---|---|
 | `SERVICENOW_INSTANCE_URL` | variable | ServiceNow instance URL, without a trailing slash. |
 | `SERVICENOW_USERNAME` | variable | ServiceNow username for Basic auth. |
-| `SERVICENOW_PASSWORD` | secret | ServiceNow password or API credential. |
+| `SERVICENOW_PASSWORD` | secret | ServiceNow password for the Basic auth integration user. |
+
+Provider references:
+
+- [ServiceNow REST API overview](https://www.servicenow.com/docs/r/api-reference/rest-api-explorer/c_RESTAPI.html)
+- [ServiceNow Table API](https://www.servicenow.com/docs/r/api-reference/rest-apis/c_TableAPI.html)
+- [ServiceNow inbound REST API rate limiting](https://www.servicenow.com/docs/r/api-reference/rest-api-explorer/inbound-REST-API-rate-limiting.html)
 
 ## Setup
 
@@ -63,8 +72,10 @@ Configuration items by class:
 ```sql
 SELECT sys_class_name, COUNT(*) AS ci_count
 FROM servicenow.cmdb_ci
+WHERE query = 'install_status=1'
 GROUP BY sys_class_name
-ORDER BY ci_count DESC;
+ORDER BY ci_count DESC
+LIMIT 25;
 ```
 
 Active users:
@@ -81,10 +92,25 @@ LIMIT 25;
 - ServiceNow table access is governed by the integration user's ACLs.
 - The `query` filter maps to ServiceNow encoded query syntax through
   `sysparm_query`.
+- Use encoded `query` filters plus SQL `LIMIT` for production instances. Each
+  table has a conservative default fetch limit, but explicit filters are still
+  the best way to avoid broad Table API scans.
+- Requests send `sysparm_no_count=true` so ServiceNow does not do extra count
+  work that Coral does not need for paginated reads.
+- The source uses the versioned Table API v2 path so empty result sets return
+  a `200` response with an empty result array.
+- Raw ID/value columns stay stable across queries. Display values are exposed
+  in separate `*_display` columns where useful.
 - This source requests explicit `sysparm_fields` field lists instead of raw
   table payloads.
 - Timestamps are exposed as strings because ServiceNow Table API date formats
   can vary by instance settings.
+
+Useful ServiceNow docs:
+
+- [Encoded query strings](https://www.servicenow.com/docs/r/api-reference/rest-apis/c_TableAPI.html)
+- [ACL and REST authentication behavior](https://www.servicenow.com/docs/r/api-reference/rest-api-explorer/c_RESTAPI.html)
+- [Inbound REST rate limiting](https://www.servicenow.com/docs/r/api-reference/rest-api-explorer/inbound-REST-API-rate-limiting.html)
 
 ## Validation
 
@@ -123,9 +149,16 @@ Query tests
 Representative query:
 
 ```sql
-SELECT sys_id, user_name, name, active
-FROM servicenow.users
-LIMIT 3;
+SELECT number, state, state_display, assignment_group, assignment_group_display
+FROM servicenow.incidents
+LIMIT 2;
+```
+
+Example output:
+
+```text
+number     | state | state_display | assignment_group                 | assignment_group_display
+INC0000060 | 7     | Closed        | 287ebd7da9fe198100f92cc8d1d2154e | Network
 ```
 
 The manifest includes `test_queries`, and no credentials or customer data are

--- a/sources/community/servicenow/README.md
+++ b/sources/community/servicenow/README.md
@@ -1,0 +1,132 @@
+# ServiceNow Coral Source
+
+## What This Source Exposes
+
+This source exposes read-only ServiceNow ITSM and CMDB metadata through the
+ServiceNow Table API. It covers incidents, change requests, problems,
+configuration items, and users.
+
+It does not create, update, or delete ServiceNow records.
+
+## Authentication
+
+Use a least-privilege ServiceNow integration user with read access to the
+tables you want Coral to inspect.
+
+| Input | Kind | Description |
+|---|---|---|
+| `SERVICENOW_INSTANCE_URL` | variable | ServiceNow instance URL, without a trailing slash. |
+| `SERVICENOW_USERNAME` | variable | ServiceNow username for Basic auth. |
+| `SERVICENOW_PASSWORD` | secret | ServiceNow password or API credential. |
+
+## Setup
+
+```bash
+SERVICENOW_INSTANCE_URL=https://example.service-now.com \
+SERVICENOW_USERNAME=integration.user \
+SERVICENOW_PASSWORD=your_password \
+coral source add --file sources/community/servicenow/manifest.yaml
+```
+
+## Tables
+
+| Table | Purpose |
+|---|---|
+| `servicenow.incidents` | Incident ticket inventory and triage metadata. |
+| `servicenow.change_requests` | Change request inventory and planning metadata. |
+| `servicenow.problems` | Problem records and known-error metadata. |
+| `servicenow.cmdb_ci` | Configuration item inventory from the CMDB. |
+| `servicenow.users` | ServiceNow users visible to the integration user. |
+
+## Example Queries
+
+High-priority active incidents:
+
+```sql
+SELECT number, short_description, priority, state, assignment_group
+FROM servicenow.incidents
+WHERE query = 'active=true^priority=1'
+LIMIT 25;
+```
+
+Upcoming active changes:
+
+```sql
+SELECT number, short_description, state, risk, start_date, end_date
+FROM servicenow.change_requests
+WHERE query = 'active=true'
+LIMIT 25;
+```
+
+Configuration items by class:
+
+```sql
+SELECT sys_class_name, COUNT(*) AS ci_count
+FROM servicenow.cmdb_ci
+GROUP BY sys_class_name
+ORDER BY ci_count DESC;
+```
+
+Active users:
+
+```sql
+SELECT user_name, name, email, department
+FROM servicenow.users
+WHERE query = 'active=true'
+LIMIT 25;
+```
+
+## Limitations
+
+- ServiceNow table access is governed by the integration user's ACLs.
+- The `query` filter maps to ServiceNow encoded query syntax through
+  `sysparm_query`.
+- This source requests explicit `sysparm_fields` field lists instead of raw
+  table payloads.
+- Timestamps are exposed as strings because ServiceNow Table API date formats
+  can vary by instance settings.
+
+## Validation
+
+Local validation for this source:
+
+```text
+YAML parse: passed for sources/community/servicenow/manifest.yaml
+Coral manifest schema validation: passed for sources/community/servicenow/manifest.yaml
+git diff --check: passed
+make lint-sources: passed
+Live API tests: passed against a ServiceNow PDI
+```
+
+Live Coral evidence:
+
+```text
+✓ servicenow connected successfully
+Secrets: keychain
+
+servicenow (5 tables)
+├─ change_requests
+├─ cmdb_ci
+├─ incidents
+├─ problems
+└─ users
+Query tests
+2 declared · 2 passed · 0 failed
+
+✓ SELECT sys_id, number, short_description FROM servicenow.incidents LIMIT 1
+  1 row
+
+✓ SELECT sys_id, name, user_name FROM servicenow.users LIMIT 1
+  1 row
+```
+
+Representative query:
+
+```sql
+SELECT sys_id, user_name, name, active
+FROM servicenow.users
+LIMIT 3;
+```
+
+The manifest includes `test_queries`, and no credentials or customer data are
+committed.

--- a/sources/community/servicenow/manifest.yaml
+++ b/sources/community/servicenow/manifest.yaml
@@ -1,0 +1,566 @@
+name: servicenow
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query ServiceNow ITSM and CMDB metadata from the Table API for incident,
+  change, problem, configuration item, and user inventory workflows.
+base_url: "{{input.SERVICENOW_INSTANCE_URL}}/api/now/table"
+
+inputs:
+  SERVICENOW_INSTANCE_URL:
+    kind: variable
+    hint: |
+      Base URL for your ServiceNow instance, without a trailing slash.
+      Example: https://example.service-now.com.
+  SERVICENOW_USERNAME:
+    kind: variable
+    hint: |
+      ServiceNow username for Basic auth. Use a least-privilege integration
+      user with read access to the tables you want Coral to inspect.
+  SERVICENOW_PASSWORD:
+    kind: secret
+    hint: |
+      ServiceNow password or API-authenticated credential for the integration
+      user. Scope table ACLs to read-only access where possible.
+
+auth:
+  type: BasicAuth
+  username: "{{input.SERVICENOW_USERNAME}}"
+  password: "{{input.SERVICENOW_PASSWORD}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT sys_id, number, short_description FROM servicenow.incidents LIMIT 1
+  - SELECT sys_id, name, user_name FROM servicenow.users LIMIT 1
+
+tables:
+  - name: incidents
+    description: ServiceNow incident records visible to the configured user.
+    guide: |
+      Use `query` for ServiceNow encoded query syntax, such as
+      `active=true^priority=1`. This table requests a documented field subset
+      with `sysparm_fields` and paginates with `sysparm_limit` and
+      `sysparm_offset`.
+    filters:
+      - name: query
+      - name: display_value
+    request:
+      method: GET
+      path: /incident
+      query:
+        - name: sysparm_fields
+          from: literal
+          value: sys_id,number,short_description,state,priority,impact,urgency,category,assignment_group,assigned_to,caller_id,opened_by,opened_at,resolved_at,closed_at,active,sys_created_on,sys_updated_on
+        - name: sysparm_query
+          from: filter
+          key: query
+        - name: sysparm_display_value
+          from: filter_bool
+          key: display_value
+        - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+    response:
+      rows_path: [result]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: sysparm_offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: sysparm_limit
+    columns:
+      - name: sys_id
+        type: Utf8
+        nullable: false
+        description: ServiceNow record sys_id.
+      - name: number
+        type: Utf8
+        nullable: true
+        description: Incident number.
+      - name: short_description
+        type: Utf8
+        nullable: true
+        description: Short incident description.
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Incident state value.
+      - name: priority
+        type: Utf8
+        nullable: true
+        description: Incident priority value.
+      - name: impact
+        type: Utf8
+        nullable: true
+        description: Incident impact value.
+      - name: urgency
+        type: Utf8
+        nullable: true
+        description: Incident urgency value.
+      - name: category
+        type: Utf8
+        nullable: true
+        description: Incident category.
+      - name: assignment_group
+        type: Utf8
+        nullable: true
+        description: Assignment group value or display value.
+      - name: assigned_to
+        type: Utf8
+        nullable: true
+        description: Assigned user value or display value.
+      - name: caller_id
+        type: Utf8
+        nullable: true
+        description: Caller value or display value.
+      - name: opened_by
+        type: Utf8
+        nullable: true
+        description: User that opened the incident.
+      - name: opened_at
+        type: Utf8
+        nullable: true
+        description: Incident opened timestamp.
+      - name: resolved_at
+        type: Utf8
+        nullable: true
+        description: Incident resolved timestamp.
+      - name: closed_at
+        type: Utf8
+        nullable: true
+        description: Incident closed timestamp.
+      - name: active
+        type: Utf8
+        nullable: true
+        description: ServiceNow active value, usually "true" or "false".
+      - name: sys_created_on
+        type: Utf8
+        nullable: true
+        description: Record creation timestamp.
+      - name: sys_updated_on
+        type: Utf8
+        nullable: true
+        description: Record update timestamp.
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional ServiceNow encoded query filter.
+        expr: {kind: from_filter, key: query}
+      - name: display_value
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Optional sysparm_display_value filter.
+        expr: {kind: from_filter, key: display_value}
+
+  - name: change_requests
+    description: ServiceNow change request records visible to the configured user.
+    guide: |
+      Use `query` for encoded query syntax such as `active=true^state=0`.
+      This table uses the ServiceNow Table API and offset pagination.
+    filters:
+      - name: query
+      - name: display_value
+    request:
+      method: GET
+      path: /change_request
+      query:
+        - name: sysparm_fields
+          from: literal
+          value: sys_id,number,short_description,type,state,priority,risk,impact,assignment_group,assigned_to,requested_by,start_date,end_date,active,sys_created_on,sys_updated_on
+        - name: sysparm_query
+          from: filter
+          key: query
+        - name: sysparm_display_value
+          from: filter_bool
+          key: display_value
+        - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+    response:
+      rows_path: [result]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: sysparm_offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: sysparm_limit
+    columns:
+      - name: sys_id
+        type: Utf8
+        nullable: false
+        description: ServiceNow record sys_id.
+      - name: number
+        type: Utf8
+        nullable: true
+        description: Change request number.
+      - name: short_description
+        type: Utf8
+        nullable: true
+        description: Short change description.
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Change type.
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Change state value.
+      - name: priority
+        type: Utf8
+        nullable: true
+        description: Change priority value.
+      - name: risk
+        type: Utf8
+        nullable: true
+        description: Change risk value.
+      - name: impact
+        type: Utf8
+        nullable: true
+        description: Change impact value.
+      - name: assignment_group
+        type: Utf8
+        nullable: true
+        description: Assignment group value or display value.
+      - name: assigned_to
+        type: Utf8
+        nullable: true
+        description: Assigned user value or display value.
+      - name: requested_by
+        type: Utf8
+        nullable: true
+        description: Requesting user value or display value.
+      - name: start_date
+        type: Utf8
+        nullable: true
+        description: Planned start date.
+      - name: end_date
+        type: Utf8
+        nullable: true
+        description: Planned end date.
+      - name: active
+        type: Utf8
+        nullable: true
+        description: ServiceNow active value, usually "true" or "false".
+      - name: sys_created_on
+        type: Utf8
+        nullable: true
+        description: Record creation timestamp.
+      - name: sys_updated_on
+        type: Utf8
+        nullable: true
+        description: Record update timestamp.
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional ServiceNow encoded query filter.
+        expr: {kind: from_filter, key: query}
+      - name: display_value
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Optional sysparm_display_value filter.
+        expr: {kind: from_filter, key: display_value}
+
+  - name: problems
+    description: ServiceNow problem records visible to the configured user.
+    filters:
+      - name: query
+      - name: display_value
+    request:
+      method: GET
+      path: /problem
+      query:
+        - name: sysparm_fields
+          from: literal
+          value: sys_id,number,short_description,state,priority,assignment_group,assigned_to,known_error,active,opened_at,closed_at,sys_created_on,sys_updated_on
+        - name: sysparm_query
+          from: filter
+          key: query
+        - name: sysparm_display_value
+          from: filter_bool
+          key: display_value
+        - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+    response:
+      rows_path: [result]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: sysparm_offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: sysparm_limit
+    columns:
+      - name: sys_id
+        type: Utf8
+        nullable: false
+        description: ServiceNow record sys_id.
+      - name: number
+        type: Utf8
+        nullable: true
+        description: Problem number.
+      - name: short_description
+        type: Utf8
+        nullable: true
+        description: Short problem description.
+      - name: state
+        type: Utf8
+        nullable: true
+        description: Problem state value.
+      - name: priority
+        type: Utf8
+        nullable: true
+        description: Problem priority value.
+      - name: assignment_group
+        type: Utf8
+        nullable: true
+        description: Assignment group value or display value.
+      - name: assigned_to
+        type: Utf8
+        nullable: true
+        description: Assigned user value or display value.
+      - name: known_error
+        type: Utf8
+        nullable: true
+        description: ServiceNow known error value, usually "true" or "false".
+      - name: active
+        type: Utf8
+        nullable: true
+        description: ServiceNow active value, usually "true" or "false".
+      - name: opened_at
+        type: Utf8
+        nullable: true
+        description: Problem opened timestamp.
+      - name: closed_at
+        type: Utf8
+        nullable: true
+        description: Problem closed timestamp.
+      - name: sys_created_on
+        type: Utf8
+        nullable: true
+        description: Record creation timestamp.
+      - name: sys_updated_on
+        type: Utf8
+        nullable: true
+        description: Record update timestamp.
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional ServiceNow encoded query filter.
+        expr: {kind: from_filter, key: query}
+      - name: display_value
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Optional sysparm_display_value filter.
+        expr: {kind: from_filter, key: display_value}
+
+  - name: cmdb_ci
+    description: ServiceNow configuration items from the CMDB.
+    filters:
+      - name: query
+      - name: display_value
+    request:
+      method: GET
+      path: /cmdb_ci
+      query:
+        - name: sysparm_fields
+          from: literal
+          value: sys_id,name,sys_class_name,install_status,operational_status,category,subcategory,manufacturer,model_id,owned_by,managed_by,support_group,sys_created_on,sys_updated_on
+        - name: sysparm_query
+          from: filter
+          key: query
+        - name: sysparm_display_value
+          from: filter_bool
+          key: display_value
+        - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+    response:
+      rows_path: [result]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: sysparm_offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: sysparm_limit
+    columns:
+      - name: sys_id
+        type: Utf8
+        nullable: false
+        description: ServiceNow record sys_id.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Configuration item name.
+      - name: sys_class_name
+        type: Utf8
+        nullable: true
+        description: CI class name.
+      - name: install_status
+        type: Utf8
+        nullable: true
+        description: Installation status.
+      - name: operational_status
+        type: Utf8
+        nullable: true
+        description: Operational status.
+      - name: category
+        type: Utf8
+        nullable: true
+        description: CI category.
+      - name: subcategory
+        type: Utf8
+        nullable: true
+        description: CI subcategory.
+      - name: manufacturer
+        type: Utf8
+        nullable: true
+        description: Manufacturer value or display value.
+      - name: model_id
+        type: Utf8
+        nullable: true
+        description: Model value or display value.
+      - name: owned_by
+        type: Utf8
+        nullable: true
+        description: Owner value or display value.
+      - name: managed_by
+        type: Utf8
+        nullable: true
+        description: Manager value or display value.
+      - name: support_group
+        type: Utf8
+        nullable: true
+        description: Support group value or display value.
+      - name: sys_created_on
+        type: Utf8
+        nullable: true
+        description: Record creation timestamp.
+      - name: sys_updated_on
+        type: Utf8
+        nullable: true
+        description: Record update timestamp.
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional ServiceNow encoded query filter.
+        expr: {kind: from_filter, key: query}
+      - name: display_value
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Optional sysparm_display_value filter.
+        expr: {kind: from_filter, key: display_value}
+
+  - name: users
+    description: ServiceNow user records visible to the configured user.
+    filters:
+      - name: query
+      - name: display_value
+    request:
+      method: GET
+      path: /sys_user
+      query:
+        - name: sysparm_fields
+          from: literal
+          value: sys_id,user_name,name,email,active,department,company,manager,title,sys_created_on,sys_updated_on
+        - name: sysparm_query
+          from: filter
+          key: query
+        - name: sysparm_display_value
+          from: filter_bool
+          key: display_value
+        - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+    response:
+      rows_path: [result]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: sysparm_offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: sysparm_limit
+    columns:
+      - name: sys_id
+        type: Utf8
+        nullable: false
+        description: ServiceNow record sys_id.
+      - name: user_name
+        type: Utf8
+        nullable: true
+        description: User login name.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: User display name.
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+      - name: active
+        type: Utf8
+        nullable: true
+        description: ServiceNow active value, usually "true" or "false".
+      - name: department
+        type: Utf8
+        nullable: true
+        description: Department value or display value.
+      - name: company
+        type: Utf8
+        nullable: true
+        description: Company value or display value.
+      - name: manager
+        type: Utf8
+        nullable: true
+        description: Manager value or display value.
+      - name: title
+        type: Utf8
+        nullable: true
+        description: User title.
+      - name: sys_created_on
+        type: Utf8
+        nullable: true
+        description: Record creation timestamp.
+      - name: sys_updated_on
+        type: Utf8
+        nullable: true
+        description: Record update timestamp.
+      - name: query
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional ServiceNow encoded query filter.
+        expr: {kind: from_filter, key: query}
+      - name: display_value
+        type: Boolean
+        nullable: true
+        virtual: true
+        description: Optional sysparm_display_value filter.
+        expr: {kind: from_filter, key: display_value}

--- a/sources/community/servicenow/manifest.yaml
+++ b/sources/community/servicenow/manifest.yaml
@@ -5,8 +5,7 @@ backend: http
 description: >-
   Query ServiceNow ITSM and CMDB metadata from the Table API for incident,
   change, problem, configuration item, and user inventory workflows.
-base_url: "{{input.SERVICENOW_INSTANCE_URL}}/api/now/table"
-
+base_url: "{{input.SERVICENOW_INSTANCE_URL}}/api/now/v2/table"
 inputs:
   SERVICENOW_INSTANCE_URL:
     kind: variable
@@ -20,49 +19,50 @@ inputs:
       user with read access to the tables you want Coral to inspect.
   SERVICENOW_PASSWORD:
     kind: secret
-    hint: |
-      ServiceNow password or API-authenticated credential for the integration
-      user. Scope table ACLs to read-only access where possible.
-
+    hint: "ServiceNow password for the Basic auth integration user. Scope table ACLs to read-only access where possible."
 auth:
   type: BasicAuth
   username: "{{input.SERVICENOW_USERNAME}}"
   password: "{{input.SERVICENOW_PASSWORD}}"
-
 request_headers:
   - name: Accept
     from: literal
     value: application/json
-
 test_queries:
-  - SELECT sys_id, number, short_description FROM servicenow.incidents LIMIT 1
-  - SELECT sys_id, name, user_name FROM servicenow.users LIMIT 1
-
+  - "SELECT sys_id, number, short_description FROM servicenow.incidents LIMIT 1"
+  - "SELECT sys_id, name, user_name FROM servicenow.users LIMIT 1"
 tables:
   - name: incidents
-    description: ServiceNow incident records visible to the configured user.
+    description: "ServiceNow incident records visible to the configured user."
     guide: |
       Use `query` for ServiceNow encoded query syntax, such as
       `active=true^priority=1`. This table requests a documented field subset
       with `sysparm_fields` and paginates with `sysparm_limit` and
       `sysparm_offset`.
+
+      Use the `query` virtual column with ServiceNow encoded query syntax and a SQL `LIMIT` to keep
+      production scans narrow. Coral applies a conservative default fetch limit and sends
+      `sysparm_no_count=true` so ServiceNow does not do extra count work for paginated reads.
     filters:
       - name: query
-      - name: display_value
+    fetch_limit_default: 100
     request:
       method: GET
       path: /incident
       query:
         - name: sysparm_fields
           from: literal
-          value: sys_id,number,short_description,state,priority,impact,urgency,category,assignment_group,assigned_to,caller_id,opened_by,opened_at,resolved_at,closed_at,active,sys_created_on,sys_updated_on
+          value: "sys_id,number,short_description,state,priority,impact,urgency,category,assignment_group,assigned_to,caller_id,opened_by,opened_at,resolved_at,closed_at,active,sys_created_on,sys_updated_on"
         - name: sysparm_query
           from: filter
           key: query
-        - name: sysparm_display_value
-          from: filter_bool
-          key: display_value
         - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+        - name: sysparm_display_value
+          from: literal
+          value: all
+        - name: sysparm_no_count
           from: literal
           value: "true"
     response:
@@ -80,110 +80,236 @@ tables:
       - name: sys_id
         type: Utf8
         nullable: false
-        description: ServiceNow record sys_id.
+        description: "ServiceNow record sys_id."
+        expr:
+          kind: path
+          path: [sys_id, value]
       - name: number
         type: Utf8
         nullable: true
-        description: Incident number.
+        description: "Incident number."
+        expr:
+          kind: path
+          path: [number, value]
       - name: short_description
         type: Utf8
         nullable: true
-        description: Short incident description.
+        description: "Short incident description."
+        expr:
+          kind: path
+          path: [short_description, value]
       - name: state
         type: Utf8
         nullable: true
-        description: Incident state value.
+        description: "Incident state raw value."
+        expr:
+          kind: path
+          path: [state, value]
+      - name: state_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for state."
+        expr:
+          kind: path
+          path: [state, display_value]
       - name: priority
         type: Utf8
         nullable: true
-        description: Incident priority value.
+        description: "Incident priority raw value."
+        expr:
+          kind: path
+          path: [priority, value]
+      - name: priority_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for priority."
+        expr:
+          kind: path
+          path: [priority, display_value]
       - name: impact
         type: Utf8
         nullable: true
-        description: Incident impact value.
+        description: "Incident impact raw value."
+        expr:
+          kind: path
+          path: [impact, value]
+      - name: impact_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for impact."
+        expr:
+          kind: path
+          path: [impact, display_value]
       - name: urgency
         type: Utf8
         nullable: true
-        description: Incident urgency value.
+        description: "Incident urgency raw value."
+        expr:
+          kind: path
+          path: [urgency, value]
+      - name: urgency_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for urgency."
+        expr:
+          kind: path
+          path: [urgency, display_value]
       - name: category
         type: Utf8
         nullable: true
-        description: Incident category.
+        description: "Incident category."
+        expr:
+          kind: path
+          path: [category, value]
+      - name: category_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for category."
+        expr:
+          kind: path
+          path: [category, display_value]
       - name: assignment_group
         type: Utf8
         nullable: true
-        description: Assignment group value or display value.
+        description: "Assignment group raw value."
+        expr:
+          kind: path
+          path: [assignment_group, value]
+      - name: assignment_group_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for assignment_group."
+        expr:
+          kind: path
+          path: [assignment_group, display_value]
       - name: assigned_to
         type: Utf8
         nullable: true
-        description: Assigned user value or display value.
+        description: "Assigned user raw value."
+        expr:
+          kind: path
+          path: [assigned_to, value]
+      - name: assigned_to_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for assigned_to."
+        expr:
+          kind: path
+          path: [assigned_to, display_value]
       - name: caller_id
         type: Utf8
         nullable: true
-        description: Caller value or display value.
+        description: "Caller raw value."
+        expr:
+          kind: path
+          path: [caller_id, value]
+      - name: caller_id_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for caller_id."
+        expr:
+          kind: path
+          path: [caller_id, display_value]
       - name: opened_by
         type: Utf8
         nullable: true
-        description: User that opened the incident.
+        description: "User that opened the incident."
+        expr:
+          kind: path
+          path: [opened_by, value]
+      - name: opened_by_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for opened_by."
+        expr:
+          kind: path
+          path: [opened_by, display_value]
       - name: opened_at
         type: Utf8
         nullable: true
-        description: Incident opened timestamp.
+        description: "Incident opened timestamp."
+        expr:
+          kind: path
+          path: [opened_at, value]
       - name: resolved_at
         type: Utf8
         nullable: true
-        description: Incident resolved timestamp.
+        description: "Incident resolved timestamp."
+        expr:
+          kind: path
+          path: [resolved_at, value]
       - name: closed_at
         type: Utf8
         nullable: true
-        description: Incident closed timestamp.
+        description: "Incident closed timestamp."
+        expr:
+          kind: path
+          path: [closed_at, value]
       - name: active
         type: Utf8
         nullable: true
-        description: ServiceNow active value, usually "true" or "false".
+        description: "ServiceNow active value, usually \"true\" or \"false\"."
+        expr:
+          kind: path
+          path: [active, value]
+      - name: active_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for active."
+        expr:
+          kind: path
+          path: [active, display_value]
       - name: sys_created_on
         type: Utf8
         nullable: true
-        description: Record creation timestamp.
+        description: "Record creation timestamp."
+        expr:
+          kind: path
+          path: [sys_created_on, value]
       - name: sys_updated_on
         type: Utf8
         nullable: true
-        description: Record update timestamp.
+        description: "Record update timestamp."
+        expr:
+          kind: path
+          path: [sys_updated_on, value]
       - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: Optional ServiceNow encoded query filter.
-        expr: {kind: from_filter, key: query}
-      - name: display_value
-        type: Boolean
-        nullable: true
-        virtual: true
-        description: Optional sysparm_display_value filter.
-        expr: {kind: from_filter, key: display_value}
-
+        description: "Optional ServiceNow encoded query filter."
+        expr:
+          kind: from_filter
+          key: query
   - name: change_requests
-    description: ServiceNow change request records visible to the configured user.
+    description: "ServiceNow change request records visible to the configured user."
     guide: |
       Use `query` for encoded query syntax such as `active=true^state=0`.
       This table uses the ServiceNow Table API and offset pagination.
+
+      Use the `query` virtual column with ServiceNow encoded query syntax and a SQL `LIMIT` to keep
+      production scans narrow. Coral applies a conservative default fetch limit and sends
+      `sysparm_no_count=true` so ServiceNow does not do extra count work for paginated reads.
     filters:
       - name: query
-      - name: display_value
+    fetch_limit_default: 100
     request:
       method: GET
       path: /change_request
       query:
         - name: sysparm_fields
           from: literal
-          value: sys_id,number,short_description,type,state,priority,risk,impact,assignment_group,assigned_to,requested_by,start_date,end_date,active,sys_created_on,sys_updated_on
+          value: "sys_id,number,short_description,type,state,priority,risk,impact,assignment_group,assigned_to,requested_by,start_date,end_date,active,sys_created_on,sys_updated_on"
         - name: sysparm_query
           from: filter
           key: query
-        - name: sysparm_display_value
-          from: filter_bool
-          key: display_value
         - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+        - name: sysparm_display_value
+          from: literal
+          value: all
+        - name: sysparm_no_count
           from: literal
           value: "true"
     response:
@@ -201,99 +327,213 @@ tables:
       - name: sys_id
         type: Utf8
         nullable: false
-        description: ServiceNow record sys_id.
+        description: "ServiceNow record sys_id."
+        expr:
+          kind: path
+          path: [sys_id, value]
       - name: number
         type: Utf8
         nullable: true
-        description: Change request number.
+        description: "Change request number."
+        expr:
+          kind: path
+          path: [number, value]
       - name: short_description
         type: Utf8
         nullable: true
-        description: Short change description.
+        description: "Short change description."
+        expr:
+          kind: path
+          path: [short_description, value]
       - name: type
         type: Utf8
         nullable: true
-        description: Change type.
+        description: "Change type."
+        expr:
+          kind: path
+          path: [type, value]
+      - name: type_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for type."
+        expr:
+          kind: path
+          path: [type, display_value]
       - name: state
         type: Utf8
         nullable: true
-        description: Change state value.
+        description: "Change state raw value."
+        expr:
+          kind: path
+          path: [state, value]
+      - name: state_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for state."
+        expr:
+          kind: path
+          path: [state, display_value]
       - name: priority
         type: Utf8
         nullable: true
-        description: Change priority value.
+        description: "Change priority raw value."
+        expr:
+          kind: path
+          path: [priority, value]
+      - name: priority_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for priority."
+        expr:
+          kind: path
+          path: [priority, display_value]
       - name: risk
         type: Utf8
         nullable: true
-        description: Change risk value.
+        description: "Change risk raw value."
+        expr:
+          kind: path
+          path: [risk, value]
+      - name: risk_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for risk."
+        expr:
+          kind: path
+          path: [risk, display_value]
       - name: impact
         type: Utf8
         nullable: true
-        description: Change impact value.
+        description: "Change impact raw value."
+        expr:
+          kind: path
+          path: [impact, value]
+      - name: impact_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for impact."
+        expr:
+          kind: path
+          path: [impact, display_value]
       - name: assignment_group
         type: Utf8
         nullable: true
-        description: Assignment group value or display value.
+        description: "Assignment group raw value."
+        expr:
+          kind: path
+          path: [assignment_group, value]
+      - name: assignment_group_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for assignment_group."
+        expr:
+          kind: path
+          path: [assignment_group, display_value]
       - name: assigned_to
         type: Utf8
         nullable: true
-        description: Assigned user value or display value.
+        description: "Assigned user raw value."
+        expr:
+          kind: path
+          path: [assigned_to, value]
+      - name: assigned_to_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for assigned_to."
+        expr:
+          kind: path
+          path: [assigned_to, display_value]
       - name: requested_by
         type: Utf8
         nullable: true
-        description: Requesting user value or display value.
+        description: "Requesting user raw value."
+        expr:
+          kind: path
+          path: [requested_by, value]
+      - name: requested_by_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for requested_by."
+        expr:
+          kind: path
+          path: [requested_by, display_value]
       - name: start_date
         type: Utf8
         nullable: true
-        description: Planned start date.
+        description: "Planned start date."
+        expr:
+          kind: path
+          path: [start_date, value]
       - name: end_date
         type: Utf8
         nullable: true
-        description: Planned end date.
+        description: "Planned end date."
+        expr:
+          kind: path
+          path: [end_date, value]
       - name: active
         type: Utf8
         nullable: true
-        description: ServiceNow active value, usually "true" or "false".
+        description: "ServiceNow active value, usually \"true\" or \"false\"."
+        expr:
+          kind: path
+          path: [active, value]
+      - name: active_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for active."
+        expr:
+          kind: path
+          path: [active, display_value]
       - name: sys_created_on
         type: Utf8
         nullable: true
-        description: Record creation timestamp.
+        description: "Record creation timestamp."
+        expr:
+          kind: path
+          path: [sys_created_on, value]
       - name: sys_updated_on
         type: Utf8
         nullable: true
-        description: Record update timestamp.
+        description: "Record update timestamp."
+        expr:
+          kind: path
+          path: [sys_updated_on, value]
       - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: Optional ServiceNow encoded query filter.
-        expr: {kind: from_filter, key: query}
-      - name: display_value
-        type: Boolean
-        nullable: true
-        virtual: true
-        description: Optional sysparm_display_value filter.
-        expr: {kind: from_filter, key: display_value}
-
+        description: "Optional ServiceNow encoded query filter."
+        expr:
+          kind: from_filter
+          key: query
   - name: problems
-    description: ServiceNow problem records visible to the configured user.
+    description: "ServiceNow problem records visible to the configured user."
+    guide: >-
+      Use the `query` virtual column with ServiceNow encoded query syntax and a
+      SQL `LIMIT` to keep production scans narrow. Coral applies a conservative
+      default fetch limit and sends `sysparm_no_count=true` so ServiceNow does
+      not do extra count work for paginated reads.
     filters:
       - name: query
-      - name: display_value
+    fetch_limit_default: 100
     request:
       method: GET
       path: /problem
       query:
         - name: sysparm_fields
           from: literal
-          value: sys_id,number,short_description,state,priority,assignment_group,assigned_to,known_error,active,opened_at,closed_at,sys_created_on,sys_updated_on
+          value: "sys_id,number,short_description,state,priority,assignment_group,assigned_to,known_error,active,opened_at,closed_at,sys_created_on,sys_updated_on"
         - name: sysparm_query
           from: filter
           key: query
-        - name: sysparm_display_value
-          from: filter_bool
-          key: display_value
         - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+        - name: sysparm_display_value
+          from: literal
+          value: all
+        - name: sysparm_no_count
           from: literal
           value: "true"
     response:
@@ -311,87 +551,171 @@ tables:
       - name: sys_id
         type: Utf8
         nullable: false
-        description: ServiceNow record sys_id.
+        description: "ServiceNow record sys_id."
+        expr:
+          kind: path
+          path: [sys_id, value]
       - name: number
         type: Utf8
         nullable: true
-        description: Problem number.
+        description: "Problem number."
+        expr:
+          kind: path
+          path: [number, value]
       - name: short_description
         type: Utf8
         nullable: true
-        description: Short problem description.
+        description: "Short problem description."
+        expr:
+          kind: path
+          path: [short_description, value]
       - name: state
         type: Utf8
         nullable: true
-        description: Problem state value.
+        description: "Problem state raw value."
+        expr:
+          kind: path
+          path: [state, value]
+      - name: state_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for state."
+        expr:
+          kind: path
+          path: [state, display_value]
       - name: priority
         type: Utf8
         nullable: true
-        description: Problem priority value.
+        description: "Problem priority raw value."
+        expr:
+          kind: path
+          path: [priority, value]
+      - name: priority_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for priority."
+        expr:
+          kind: path
+          path: [priority, display_value]
       - name: assignment_group
         type: Utf8
         nullable: true
-        description: Assignment group value or display value.
+        description: "Assignment group raw value."
+        expr:
+          kind: path
+          path: [assignment_group, value]
+      - name: assignment_group_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for assignment_group."
+        expr:
+          kind: path
+          path: [assignment_group, display_value]
       - name: assigned_to
         type: Utf8
         nullable: true
-        description: Assigned user value or display value.
+        description: "Assigned user raw value."
+        expr:
+          kind: path
+          path: [assigned_to, value]
+      - name: assigned_to_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for assigned_to."
+        expr:
+          kind: path
+          path: [assigned_to, display_value]
       - name: known_error
         type: Utf8
         nullable: true
-        description: ServiceNow known error value, usually "true" or "false".
+        description: "ServiceNow known error value, usually \"true\" or \"false\"."
+        expr:
+          kind: path
+          path: [known_error, value]
+      - name: known_error_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for known_error."
+        expr:
+          kind: path
+          path: [known_error, display_value]
       - name: active
         type: Utf8
         nullable: true
-        description: ServiceNow active value, usually "true" or "false".
+        description: "ServiceNow active value, usually \"true\" or \"false\"."
+        expr:
+          kind: path
+          path: [active, value]
+      - name: active_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for active."
+        expr:
+          kind: path
+          path: [active, display_value]
       - name: opened_at
         type: Utf8
         nullable: true
-        description: Problem opened timestamp.
+        description: "Problem opened timestamp."
+        expr:
+          kind: path
+          path: [opened_at, value]
       - name: closed_at
         type: Utf8
         nullable: true
-        description: Problem closed timestamp.
+        description: "Problem closed timestamp."
+        expr:
+          kind: path
+          path: [closed_at, value]
       - name: sys_created_on
         type: Utf8
         nullable: true
-        description: Record creation timestamp.
+        description: "Record creation timestamp."
+        expr:
+          kind: path
+          path: [sys_created_on, value]
       - name: sys_updated_on
         type: Utf8
         nullable: true
-        description: Record update timestamp.
+        description: "Record update timestamp."
+        expr:
+          kind: path
+          path: [sys_updated_on, value]
       - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: Optional ServiceNow encoded query filter.
-        expr: {kind: from_filter, key: query}
-      - name: display_value
-        type: Boolean
-        nullable: true
-        virtual: true
-        description: Optional sysparm_display_value filter.
-        expr: {kind: from_filter, key: display_value}
-
+        description: "Optional ServiceNow encoded query filter."
+        expr:
+          kind: from_filter
+          key: query
   - name: cmdb_ci
-    description: ServiceNow configuration items from the CMDB.
+    description: "ServiceNow configuration items from the CMDB."
+    guide: >-
+      Use the `query` virtual column with ServiceNow encoded query syntax and a
+      SQL `LIMIT` to keep production scans narrow. Coral applies a conservative
+      default fetch limit and sends `sysparm_no_count=true` so ServiceNow does
+      not do extra count work for paginated reads.
     filters:
       - name: query
-      - name: display_value
+    fetch_limit_default: 100
     request:
       method: GET
       path: /cmdb_ci
       query:
         - name: sysparm_fields
           from: literal
-          value: sys_id,name,sys_class_name,install_status,operational_status,category,subcategory,manufacturer,model_id,owned_by,managed_by,support_group,sys_created_on,sys_updated_on
+          value: "sys_id,name,sys_class_name,install_status,operational_status,category,subcategory,manufacturer,model_id,owned_by,managed_by,support_group,sys_created_on,sys_updated_on"
         - name: sysparm_query
           from: filter
           key: query
-        - name: sysparm_display_value
-          from: filter_bool
-          key: display_value
         - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+        - name: sysparm_display_value
+          from: literal
+          value: all
+        - name: sysparm_no_count
           from: literal
           value: "true"
     response:
@@ -409,91 +733,206 @@ tables:
       - name: sys_id
         type: Utf8
         nullable: false
-        description: ServiceNow record sys_id.
+        description: "ServiceNow record sys_id."
+        expr:
+          kind: path
+          path: [sys_id, value]
       - name: name
         type: Utf8
         nullable: true
-        description: Configuration item name.
+        description: "Configuration item name."
+        expr:
+          kind: path
+          path: [name, value]
       - name: sys_class_name
         type: Utf8
         nullable: true
-        description: CI class name.
+        description: "CI class name."
+        expr:
+          kind: path
+          path: [sys_class_name, value]
+      - name: sys_class_name_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for sys_class_name."
+        expr:
+          kind: path
+          path: [sys_class_name, display_value]
       - name: install_status
         type: Utf8
         nullable: true
-        description: Installation status.
+        description: "Installation status."
+        expr:
+          kind: path
+          path: [install_status, value]
+      - name: install_status_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for install_status."
+        expr:
+          kind: path
+          path: [install_status, display_value]
       - name: operational_status
         type: Utf8
         nullable: true
-        description: Operational status.
+        description: "Operational status."
+        expr:
+          kind: path
+          path: [operational_status, value]
+      - name: operational_status_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for operational_status."
+        expr:
+          kind: path
+          path: [operational_status, display_value]
       - name: category
         type: Utf8
         nullable: true
-        description: CI category.
+        description: "CI category."
+        expr:
+          kind: path
+          path: [category, value]
+      - name: category_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for category."
+        expr:
+          kind: path
+          path: [category, display_value]
       - name: subcategory
         type: Utf8
         nullable: true
-        description: CI subcategory.
+        description: "CI subcategory."
+        expr:
+          kind: path
+          path: [subcategory, value]
+      - name: subcategory_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for subcategory."
+        expr:
+          kind: path
+          path: [subcategory, display_value]
       - name: manufacturer
         type: Utf8
         nullable: true
-        description: Manufacturer value or display value.
+        description: "Manufacturer raw value."
+        expr:
+          kind: path
+          path: [manufacturer, value]
+      - name: manufacturer_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for manufacturer."
+        expr:
+          kind: path
+          path: [manufacturer, display_value]
       - name: model_id
         type: Utf8
         nullable: true
-        description: Model value or display value.
+        description: "Model raw value."
+        expr:
+          kind: path
+          path: [model_id, value]
+      - name: model_id_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for model_id."
+        expr:
+          kind: path
+          path: [model_id, display_value]
       - name: owned_by
         type: Utf8
         nullable: true
-        description: Owner value or display value.
+        description: "Owner raw value."
+        expr:
+          kind: path
+          path: [owned_by, value]
+      - name: owned_by_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for owned_by."
+        expr:
+          kind: path
+          path: [owned_by, display_value]
       - name: managed_by
         type: Utf8
         nullable: true
-        description: Manager value or display value.
+        description: "Manager raw value."
+        expr:
+          kind: path
+          path: [managed_by, value]
+      - name: managed_by_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for managed_by."
+        expr:
+          kind: path
+          path: [managed_by, display_value]
       - name: support_group
         type: Utf8
         nullable: true
-        description: Support group value or display value.
+        description: "Support group raw value."
+        expr:
+          kind: path
+          path: [support_group, value]
+      - name: support_group_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for support_group."
+        expr:
+          kind: path
+          path: [support_group, display_value]
       - name: sys_created_on
         type: Utf8
         nullable: true
-        description: Record creation timestamp.
+        description: "Record creation timestamp."
+        expr:
+          kind: path
+          path: [sys_created_on, value]
       - name: sys_updated_on
         type: Utf8
         nullable: true
-        description: Record update timestamp.
+        description: "Record update timestamp."
+        expr:
+          kind: path
+          path: [sys_updated_on, value]
       - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: Optional ServiceNow encoded query filter.
-        expr: {kind: from_filter, key: query}
-      - name: display_value
-        type: Boolean
-        nullable: true
-        virtual: true
-        description: Optional sysparm_display_value filter.
-        expr: {kind: from_filter, key: display_value}
-
+        description: "Optional ServiceNow encoded query filter."
+        expr:
+          kind: from_filter
+          key: query
   - name: users
-    description: ServiceNow user records visible to the configured user.
+    description: "ServiceNow user records visible to the configured user."
+    guide: >-
+      Use the `query` virtual column with ServiceNow encoded query syntax and a
+      SQL `LIMIT` to keep production scans narrow. Coral applies a conservative
+      default fetch limit and sends `sysparm_no_count=true` so ServiceNow does
+      not do extra count work for paginated reads.
     filters:
       - name: query
-      - name: display_value
+    fetch_limit_default: 100
     request:
       method: GET
       path: /sys_user
       query:
         - name: sysparm_fields
           from: literal
-          value: sys_id,user_name,name,email,active,department,company,manager,title,sys_created_on,sys_updated_on
+          value: "sys_id,user_name,name,email,active,department,company,manager,title,sys_created_on,sys_updated_on"
         - name: sysparm_query
           from: filter
           key: query
-        - name: sysparm_display_value
-          from: filter_bool
-          key: display_value
         - name: sysparm_exclude_reference_link
+          from: literal
+          value: "true"
+        - name: sysparm_display_value
+          from: literal
+          value: all
+        - name: sysparm_no_count
           from: literal
           value: "true"
     response:
@@ -511,56 +950,113 @@ tables:
       - name: sys_id
         type: Utf8
         nullable: false
-        description: ServiceNow record sys_id.
+        description: "ServiceNow record sys_id."
+        expr:
+          kind: path
+          path: [sys_id, value]
       - name: user_name
         type: Utf8
         nullable: true
-        description: User login name.
+        description: "User login name."
+        expr:
+          kind: path
+          path: [user_name, value]
       - name: name
         type: Utf8
         nullable: true
-        description: User display name.
+        description: "User display name."
+        expr:
+          kind: path
+          path: [name, value]
       - name: email
         type: Utf8
         nullable: true
-        description: User email address.
+        description: "User email address."
+        expr:
+          kind: path
+          path: [email, value]
       - name: active
         type: Utf8
         nullable: true
-        description: ServiceNow active value, usually "true" or "false".
+        description: "ServiceNow active value, usually \"true\" or \"false\"."
+        expr:
+          kind: path
+          path: [active, value]
+      - name: active_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for active."
+        expr:
+          kind: path
+          path: [active, display_value]
       - name: department
         type: Utf8
         nullable: true
-        description: Department value or display value.
+        description: "Department raw value."
+        expr:
+          kind: path
+          path: [department, value]
+      - name: department_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for department."
+        expr:
+          kind: path
+          path: [department, display_value]
       - name: company
         type: Utf8
         nullable: true
-        description: Company value or display value.
+        description: "Company raw value."
+        expr:
+          kind: path
+          path: [company, value]
+      - name: company_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for company."
+        expr:
+          kind: path
+          path: [company, display_value]
       - name: manager
         type: Utf8
         nullable: true
-        description: Manager value or display value.
+        description: "Manager raw value."
+        expr:
+          kind: path
+          path: [manager, value]
+      - name: manager_display
+        type: Utf8
+        nullable: true
+        description: "ServiceNow display value for manager."
+        expr:
+          kind: path
+          path: [manager, display_value]
       - name: title
         type: Utf8
         nullable: true
-        description: User title.
+        description: "User title."
+        expr:
+          kind: path
+          path: [title, value]
       - name: sys_created_on
         type: Utf8
         nullable: true
-        description: Record creation timestamp.
+        description: "Record creation timestamp."
+        expr:
+          kind: path
+          path: [sys_created_on, value]
       - name: sys_updated_on
         type: Utf8
         nullable: true
-        description: Record update timestamp.
+        description: "Record update timestamp."
+        expr:
+          kind: path
+          path: [sys_updated_on, value]
       - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: Optional ServiceNow encoded query filter.
-        expr: {kind: from_filter, key: query}
-      - name: display_value
-        type: Boolean
-        nullable: true
-        virtual: true
-        description: Optional sysparm_display_value filter.
-        expr: {kind: from_filter, key: display_value}
+        description: "Optional ServiceNow encoded query filter."
+        expr:
+          kind: from_filter
+          key: query


### PR DESCRIPTION
Summary:
- Adds a community Coral source for ServiceNow ITSM and CMDB metadata.
- Exposes incidents, change requests, problems, CMDB configuration items, and users.
- Uses explicit sysparm_fields, offset pagination, and read-only metadata queries.

Validation:
- YAML parsing: passed
- Coral manifest schema validation: passed
- git diff --check: passed
- make lint-sources: passed
- Live API tests: passed against a ServiceNow PDI