### PR TITLE
feat(sources/community/fivetran): add Fivetran source

### DIFF
--- a/sources/community/fivetran/README.md
+++ b/sources/community/fivetran/README.md
@@ -1,0 +1,93 @@
+# Fivetran
+
+Query Fivetran account metadata from Coral. The source covers group,
+destination, connection, user, and dbt transformation project inventory without
+returning connector or destination configuration payloads that may contain
+connection details.
+
+## Authentication
+
+Create a scoped Fivetran REST API key and provide:
+
+| Input | Description |
+| --- | --- |
+| `FIVETRAN_API_KEY` | Fivetran API key. |
+| `FIVETRAN_API_SECRET` | Fivetran API secret. |
+
+Both values are modeled as secrets. Use the narrowest RBAC scope that can read
+the metadata you want Coral agents to inspect.
+
+## Tables
+
+| Table | Description |
+| --- | --- |
+| `fivetran.groups` | Groups accessible to the API key. |
+| `fivetran.destinations` | Destination inventory. Supports `group_id`. |
+| `fivetran.connections` | Connection status and sync metadata. Supports `group_id` and `schema`. |
+| `fivetran.users` | Account users visible to the API key. |
+| `fivetran.transformation_projects` | dbt Core transformation project metadata. Supports `group_id`. |
+
+## Examples
+
+List paused or failing connections:
+
+```sql
+SELECT id, service, schema, paused, setup_state, sync_state, update_state
+FROM fivetran.connections
+WHERE paused = true OR sync_state <> 'succeeded';
+```
+
+Inspect connections in one group:
+
+```sql
+SELECT id, service, schema, succeeded_at, failed_at
+FROM fivetran.connections
+WHERE group_id = 'group_id';
+```
+
+Review destination coverage:
+
+```sql
+SELECT group_id, service, region, setup_status
+FROM fivetran.destinations;
+```
+
+## Notes
+
+- Fivetran list endpoints are cursor paginated with `cursor` and `limit`.
+- The source omits connector and destination `config` payloads to avoid
+  exposing source credentials, host names, or other connection parameters.
+- Fivetran API responses depend on the API key owner's RBAC permissions.
+- Live API tests passed against a Fivetran account. The account had no
+  configured groups or connections, so the declared queries returned zero rows
+  while still proving authentication, pagination, and table wiring.
+
+## Validation
+
+- YAML parsing: passed
+- Coral manifest schema validation: passed
+- `git diff --check`: passed
+- `make lint-sources`: passed
+- Live API tests: passed against a Fivetran account
+
+Live Coral evidence:
+
+```text
+✓ fivetran connected successfully
+Secrets: keychain
+
+fivetran (5 tables)
+├─ connections
+├─ destinations
+├─ groups
+├─ transformation_projects
+└─ users
+Query tests
+2 declared · 2 passed · 0 failed
+
+✓ SELECT id, name FROM fivetran.groups LIMIT 1
+  0 rows
+
+✓ SELECT id, service, group_id FROM fivetran.connections LIMIT 1
+  0 rows
+```

--- a/sources/community/fivetran/README.md
+++ b/sources/community/fivetran/README.md
@@ -1,31 +1,34 @@
 # Fivetran
 
 Query Fivetran account metadata from Coral. The source covers group,
-destination, connection, user, and dbt transformation project inventory without
+destination, connection, user, and transformation project inventory without
 returning connector or destination configuration payloads that may contain
 connection details.
 
 ## Authentication
 
-Create a scoped Fivetran REST API key and provide:
+Create a Fivetran REST API key from the Fivetran dashboard, usually under
+account settings and system/API keys. Follow Fivetran's official REST API
+getting started guide for the exact credential flow:
+<https://fivetran.com/docs/rest-api/getting-started>.
 
 | Input | Description |
 | --- | --- |
 | `FIVETRAN_API_KEY` | Fivetran API key. |
 | `FIVETRAN_API_SECRET` | Fivetran API secret. |
 
-Both values are modeled as secrets. Use the narrowest RBAC scope that can read
-the metadata you want Coral agents to inspect.
+Both values are modeled as secrets. Use a scoped system key or least-privilege
+API key that can read only the metadata Coral agents need to inspect.
 
 ## Tables
 
 | Table | Description |
 | --- | --- |
 | `fivetran.groups` | Groups accessible to the API key. |
-| `fivetran.destinations` | Destination inventory. Supports `group_id`. |
+| `fivetran.destinations` | Destination inventory. Filter returned `group_id` locally in SQL. |
 | `fivetran.connections` | Connection status and sync metadata. Supports `group_id` and `schema`. |
-| `fivetran.users` | Account users visible to the API key. |
-| `fivetran.transformation_projects` | dbt Core transformation project metadata. Supports `group_id`. |
+| `fivetran.users` | Account users visible to the API key. Requires `USER:READ`. |
+| `fivetran.transformation_projects` | Transformation project metadata. Filter returned `group_id` locally in SQL. |
 
 ## Examples
 
@@ -55,12 +58,18 @@ FROM fivetran.destinations;
 ## Notes
 
 - Fivetran list endpoints are cursor paginated with `cursor` and `limit`.
+- Fivetran can return HTTP 429 when account-level API quotas or rate limits are
+  reached. Coral honors provider responses, and callers should retry after the
+  server's `Retry-After` guidance when present:
+  <https://fivetran.com/docs/rest-api/getting-started/rate-limiting>.
 - The source omits connector and destination `config` payloads to avoid
   exposing source credentials, host names, or other connection parameters.
 - Fivetran API responses depend on the API key owner's RBAC permissions.
+- The users table requires Fivetran `USER:READ` permission. A scoped key without
+  that permission can still use the other inventory tables.
 - Live API tests passed against a Fivetran account. The account had no
-  configured groups or connections, so the declared queries returned zero rows
-  while still proving authentication, pagination, and table wiring.
+  configured inventory for several tables, so some declared queries returned
+  zero rows while still proving authentication, pagination, and table wiring.
 
 ## Validation
 
@@ -83,11 +92,22 @@ fivetran (5 tables)
 ├─ transformation_projects
 └─ users
 Query tests
-2 declared · 2 passed · 0 failed
+4 declared · 4 passed · 0 failed
 
 ✓ SELECT id, name FROM fivetran.groups LIMIT 1
   0 rows
 
 ✓ SELECT id, service, group_id FROM fivetran.connections LIMIT 1
   0 rows
+
+✓ SELECT id, group_id, service FROM fivetran.destinations LIMIT 1
+  0 rows
+
+✓ SELECT id, type, group_id FROM fivetran.transformation_projects LIMIT 1
+  0 rows
+
+Additional users-table check with the scoped test key:
+
+SELECT id, email FROM fivetran.users LIMIT 1
+403 Forbidden: required permission USER:READ
 ```

--- a/sources/community/fivetran/manifest.yaml
+++ b/sources/community/fivetran/manifest.yaml
@@ -1,0 +1,359 @@
+name: fivetran
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Fivetran account metadata for groups, destinations, connections, users,
+  and transformation projects.
+base_url: https://api.fivetran.com/v1
+
+inputs:
+  FIVETRAN_API_KEY:
+    kind: secret
+    hint: |
+      Fivetran REST API key. Use a scoped key with read-only access where
+      possible.
+  FIVETRAN_API_SECRET:
+    kind: secret
+    hint: |
+      Fivetran REST API secret paired with the API key.
+
+auth:
+  type: BasicAuth
+  username: "{{input.FIVETRAN_API_KEY}}"
+  password: "{{input.FIVETRAN_API_SECRET}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json;version=2
+
+test_queries:
+  - SELECT id, name FROM fivetran.groups LIMIT 1
+  - SELECT id, service, group_id FROM fivetran.connections LIMIT 1
+
+tables:
+  - name: groups
+    description: Fivetran groups accessible to the configured API key.
+    guide: |
+      Groups are top-level containers that map users and connections to
+      destinations. This table uses Fivetran cursor pagination with `cursor`
+      and `limit`.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /groups
+    response:
+      rows_path: [data, items]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path: [data, next_cursor]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Fivetran group ID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Group name.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Group creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+
+  - name: destinations
+    description: Destination metadata for Fivetran groups.
+    guide: |
+      Returns destination inventory without exposing the destination `config`
+      object because destination configuration can contain connection details.
+      Filter by `group_id` to inspect one group.
+    filters:
+      - name: group_id
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /destinations
+      query:
+        - name: group_id
+          from: filter
+          key: group_id
+    response:
+      rows_path: [data, items]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path: [data, next_cursor]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Fivetran destination ID.
+      - name: group_id
+        type: Utf8
+        nullable: true
+        description: Group associated with this destination.
+      - name: service
+        type: Utf8
+        nullable: true
+        description: Destination service type, such as snowflake or bigquery.
+      - name: region
+        type: Utf8
+        nullable: true
+        description: Destination region when returned by Fivetran.
+      - name: time_zone_offset
+        type: Utf8
+        nullable: true
+        description: Destination time zone offset when returned by Fivetran.
+        expr: {kind: path, path: [time_zone_offset]}
+      - name: setup_status
+        type: Utf8
+        nullable: true
+        description: Destination setup status when returned by Fivetran.
+        expr: {kind: path, path: [setup_status]}
+      - name: group_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional destination group filter.
+        expr: {kind: from_filter, key: group_id}
+
+  - name: connections
+    description: Fivetran connections accessible to the configured API key.
+    guide: |
+      Use `group_id` or `schema` filters to scope large accounts. This table
+      intentionally exposes status metadata but not connector `config`, which
+      may contain source-specific connection details.
+    filters:
+      - name: group_id
+      - name: schema
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /connections
+      query:
+        - name: group_id
+          from: filter
+          key: group_id
+        - name: schema
+          from: filter
+          key: schema
+    response:
+      rows_path: [data, items]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path: [data, next_cursor]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Fivetran connection ID.
+      - name: group_id
+        type: Utf8
+        nullable: true
+        description: Destination group ID for the connection.
+      - name: service
+        type: Utf8
+        nullable: true
+        description: Connector service type.
+      - name: schema
+        type: Utf8
+        nullable: true
+        description: Destination schema name.
+      - name: paused
+        type: Boolean
+        nullable: true
+        description: Whether the connection is paused.
+      - name: setup_state
+        type: Utf8
+        nullable: true
+        description: Connector setup state.
+        expr: {kind: path, path: [status, setup_state]}
+      - name: sync_state
+        type: Utf8
+        nullable: true
+        description: Current sync state.
+        expr: {kind: path, path: [status, sync_state]}
+      - name: update_state
+        type: Utf8
+        nullable: true
+        description: Connector update state.
+        expr: {kind: path, path: [status, update_state]}
+      - name: is_historical_sync
+        type: Boolean
+        nullable: true
+        description: Whether historical sync is in progress.
+        expr: {kind: path, path: [status, is_historical_sync]}
+      - name: succeeded_at
+        type: Timestamp
+        nullable: true
+        description: Last successful sync time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [succeeded_at]}
+      - name: failed_at
+        type: Timestamp
+        nullable: true
+        description: Last failed sync time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [failed_at]}
+      - name: sync_frequency
+        type: Int64
+        nullable: true
+        description: Sync frequency in minutes.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Connection creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: group_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional group filter.
+        expr: {kind: from_filter, key: group_id}
+      - name: schema_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional schema filter.
+        expr: {kind: from_filter, key: schema}
+
+  - name: users
+    description: Fivetran users visible to the configured API key.
+    guide: |
+      Lists account users with documented cursor pagination. Returned rows
+      depend on the API key owner's RBAC permissions.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /users
+    response:
+      rows_path: [data, items]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path: [data, next_cursor]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Fivetran user ID.
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+      - name: given_name
+        type: Utf8
+        nullable: true
+        description: User given name.
+      - name: family_name
+        type: Utf8
+        nullable: true
+        description: User family name.
+      - name: verified
+        type: Boolean
+        nullable: true
+        description: Whether the user is verified.
+      - name: role
+        type: Utf8
+        nullable: true
+        description: User role when returned by Fivetran.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: User creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+
+  - name: transformation_projects
+    description: Fivetran dbt Core transformation projects.
+    guide: |
+      Filter by `group_id` for large accounts. This table returns project
+      metadata only and does not expose repository credentials.
+    filters:
+      - name: group_id
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /dbt/projects
+      query:
+        - name: group_id
+          from: filter
+          key: group_id
+    response:
+      rows_path: [data, items]
+      row_strategy: direct
+    pagination:
+      mode: cursor_query
+      cursor_param: cursor
+      response_cursor_path: [data, next_cursor]
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Transformation project ID.
+      - name: group_id
+        type: Utf8
+        nullable: true
+        description: Fivetran group ID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Transformation project name.
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Transformation project type.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Project creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: group_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional group filter.
+        expr: {kind: from_filter, key: group_id}

--- a/sources/community/fivetran/manifest.yaml
+++ b/sources/community/fivetran/manifest.yaml
@@ -31,6 +31,8 @@ request_headers:
 test_queries:
   - SELECT id, name FROM fivetran.groups LIMIT 1
   - SELECT id, service, group_id FROM fivetran.connections LIMIT 1
+  - SELECT id, group_id, service FROM fivetran.destinations LIMIT 1
+  - SELECT id, type, group_id FROM fivetran.transformation_projects LIMIT 1
 
 tables:
   - name: groups
@@ -77,17 +79,13 @@ tables:
     guide: |
       Returns destination inventory without exposing the destination `config`
       object because destination configuration can contain connection details.
-      Filter by `group_id` to inspect one group.
-    filters:
-      - name: group_id
+      Filter `group_id` locally in SQL to inspect one group; Fivetran's list
+      destinations endpoint documents cursor pagination parameters, not a
+      remote `group_id` query filter.
     fetch_limit_default: 100
     request:
       method: GET
       path: /destinations
-      query:
-        - name: group_id
-          from: filter
-          key: group_id
     response:
       rows_path: [data, items]
       row_strategy: direct
@@ -116,6 +114,16 @@ tables:
         type: Utf8
         nullable: true
         description: Destination region when returned by Fivetran.
+      - name: networking_method
+        type: Utf8
+        nullable: true
+        description: Destination networking method when returned by Fivetran.
+        expr: {kind: path, path: [networking_method]}
+      - name: daylight_saving_time_enabled
+        type: Boolean
+        nullable: true
+        description: Whether daylight saving time adjustment is enabled.
+        expr: {kind: path, path: [daylight_saving_time_enabled]}
       - name: time_zone_offset
         type: Utf8
         nullable: true
@@ -126,13 +134,21 @@ tables:
         nullable: true
         description: Destination setup status when returned by Fivetran.
         expr: {kind: path, path: [setup_status]}
-      - name: group_filter
+      - name: private_link_id
         type: Utf8
         nullable: true
-        virtual: true
-        description: Optional destination group filter.
-        expr: {kind: from_filter, key: group_id}
-
+        description: Private Link ID associated with the destination, when present.
+        expr: {kind: path, path: [private_link_id]}
+      - name: proxy_agent_id
+        type: Utf8
+        nullable: true
+        description: Proxy agent ID associated with the destination, when present.
+        expr: {kind: path, path: [proxy_agent_id]}
+      - name: hybrid_deployment_agent_id
+        type: Utf8
+        nullable: true
+        description: Hybrid deployment agent ID associated with the destination, when present.
+        expr: {kind: path, path: [hybrid_deployment_agent_id]}
   - name: connections
     description: Fivetran connections accessible to the configured API key.
     guide: |
@@ -250,7 +266,8 @@ tables:
     description: Fivetran users visible to the configured API key.
     guide: |
       Lists account users with documented cursor pagination. Returned rows
-      depend on the API key owner's RBAC permissions.
+      depend on the API key owner's RBAC permissions and require Fivetran
+      `USER:READ` permission.
     fetch_limit_default: 100
     request:
       method: GET
@@ -303,18 +320,14 @@ tables:
   - name: transformation_projects
     description: Fivetran dbt Core transformation projects.
     guide: |
-      Filter by `group_id` for large accounts. This table returns project
-      metadata only and does not expose repository credentials.
-    filters:
-      - name: group_id
+      Returns documented transformation project metadata only. Filter
+      `group_id` locally in SQL; Fivetran's list transformation projects
+      endpoint documents cursor pagination parameters, not a remote `group_id`
+      query filter.
     fetch_limit_default: 100
     request:
       method: GET
-      path: /dbt/projects
-      query:
-        - name: group_id
-          from: filter
-          key: group_id
+      path: /transformation-projects
     response:
       rows_path: [data, items]
       row_strategy: direct
@@ -335,14 +348,14 @@ tables:
         type: Utf8
         nullable: true
         description: Fivetran group ID.
-      - name: name
-        type: Utf8
-        nullable: true
-        description: Transformation project name.
       - name: type
         type: Utf8
         nullable: true
         description: Transformation project type.
+      - name: created_by_id
+        type: Utf8
+        nullable: true
+        description: Actor ID that created the transformation project.
       - name: created_at
         type: Timestamp
         nullable: true
@@ -351,9 +364,3 @@ tables:
           kind: format_timestamp
           input: iso8601
           expr: {kind: path, path: [created_at]}
-      - name: group_filter
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Optional group filter.
-        expr: {kind: from_filter, key: group_id}


### PR DESCRIPTION
Summary:
- Adds a community Coral source for Fivetran account metadata.
- Exposes groups, destinations, connections, users, and transformation projects.
- Omits connector and destination config payloads that may contain connection details.

Validation:
- YAML parsing: passed
- Coral manifest schema validation: passed
- git diff --check: passed
- make lint-sources: passed
- Live API tests: passed against a Fivetran account