### PR TITLE
feat(sources/community/airbyte_cloud): add Airbyte Cloud source

### DIFF
--- a/sources/community/airbyte_cloud/README.md
+++ b/sources/community/airbyte_cloud/README.md
@@ -6,14 +6,22 @@ configuration payloads that may contain credentials or host details.
 
 ## Authentication
 
-Create an Airbyte Cloud API token and provide:
+Create an Airbyte Cloud Application, then exchange its client credentials for a
+short-lived access token using Airbyte's `/applications/token` endpoint. Airbyte
+Cloud access tokens are valid for only three minutes, so refresh the token
+before adding or testing the source when it expires. The token inherits the
+permissions of the Airbyte user associated with the Application.
+
+See Airbyte's authentication and access-token docs:
+<https://reference.airbyte.com/reference/authentication.md> and
+<https://reference.airbyte.com/reference/createaccesstoken.md>.
 
 | Input | Description |
 | --- | --- |
-| `AIRBYTE_API_TOKEN` | Bearer token for the Airbyte API. |
+| `AIRBYTE_ACCESS_TOKEN` | Short-lived bearer token for the Airbyte API. |
 
-The token is modeled as a secret. Use the narrowest role that can read the
-metadata Coral agents need.
+The access token is modeled as a secret. Use the narrowest Airbyte user role
+that can read the metadata Coral agents need.
 
 ## Tables
 
@@ -38,7 +46,7 @@ WHERE status = 'active';
 Inspect recent jobs for one connection:
 
 ```sql
-SELECT job_id, status, job_type, start_time, last_updated_at, rows_synced
+SELECT job_id, status, job_type, start_time, last_updated_at, duration, rows_synced
 FROM airbyte_cloud.jobs
 WHERE connection_id = 'connection_id'
 LIMIT 25;
@@ -56,6 +64,10 @@ WHERE workspace_id = 'workspace_id';
 
 - Airbyte Cloud list endpoints are modeled with `offset` and `limit`
   pagination, with page sizes capped at Airbyte's documented maximum of 100.
+- Authenticate by creating an Airbyte Application and exchanging its client ID
+  and secret for a short-lived access token. Airbyte Cloud access tokens expire
+  after three minutes, so long-lived workflows need to refresh the token before
+  reinstalling or testing the source.
 - Workspace-scoped source, destination, and connection queries send the
   documented `workspaceIds` request parameter.
 - Connection `status` is returned as a column and should be filtered locally in
@@ -75,9 +87,10 @@ WHERE workspace_id = 'workspace_id';
 - Coral manifest schema validation: passed
 - `git diff --check`: passed
 - `make lint-sources`: passed
-- Live API tests: passed against an Airbyte Cloud workspace
+- Live API tests: not rerun after the auth input rename; require a fresh
+  three-minute Airbyte access token
 
-Live Coral evidence:
+Previous Coral evidence before the auth input rename:
 
 ```text
 ✓ airbyte_cloud connected successfully

--- a/sources/community/airbyte_cloud/README.md
+++ b/sources/community/airbyte_cloud/README.md
@@ -1,0 +1,104 @@
+# Airbyte Cloud
+
+Query Airbyte Cloud metadata from Coral. The source covers workspace, source,
+destination, connection, and job inventory while avoiding connector
+configuration payloads that may contain credentials or host details.
+
+## Authentication
+
+Create an Airbyte Cloud API token and provide:
+
+| Input | Description |
+| --- | --- |
+| `AIRBYTE_API_TOKEN` | Bearer token for the Airbyte API. |
+
+The token is modeled as a secret. Use the narrowest role that can read the
+metadata Coral agents need.
+
+## Tables
+
+| Table | Description |
+| --- | --- |
+| `airbyte_cloud.workspaces` | Workspaces visible to the API token. |
+| `airbyte_cloud.sources` | Source connectors. Supports `workspace_id`. |
+| `airbyte_cloud.destinations` | Destination connectors. Supports `workspace_id`. |
+| `airbyte_cloud.connections` | Connection metadata. Supports `workspace_id` and `status`. |
+| `airbyte_cloud.jobs` | Job history. Supports `connection_id` and `status`. |
+
+## Examples
+
+List enabled connections:
+
+```sql
+SELECT connection_id, name, source_id, destination_id, status
+FROM airbyte_cloud.connections
+WHERE status = 'active';
+```
+
+Inspect recent jobs for one connection:
+
+```sql
+SELECT job_id, status, job_type, started_at, ended_at
+FROM airbyte_cloud.jobs
+WHERE connection_id = 'connection_id'
+LIMIT 25;
+```
+
+Review source and destination coverage in a workspace:
+
+```sql
+SELECT source_id, name, source_type
+FROM airbyte_cloud.sources
+WHERE workspace_id = 'workspace_id';
+```
+
+## Notes
+
+- Airbyte Cloud list endpoints are modeled with `offset` and `limit`
+  pagination.
+- The source omits source and destination configuration objects because they
+  can contain credentials, host names, database names, or other sensitive
+  connection parameters.
+- Job history can be large; `airbyte_cloud.jobs` has a conservative default
+  fetch limit.
+- Live API tests passed against an Airbyte Cloud workspace. The workspace had
+  no configured connections yet, so the connection query returned zero rows
+  while still proving authentication, pagination, and table wiring.
+
+## Validation
+
+- YAML parsing: passed
+- Coral manifest schema validation: passed
+- `git diff --check`: passed
+- `make lint-sources`: passed
+- Live API tests: passed against an Airbyte Cloud workspace
+
+Live Coral evidence:
+
+```text
+✓ airbyte_cloud connected successfully
+Secrets: keychain
+
+airbyte_cloud (5 tables)
+├─ connections
+├─ destinations
+├─ jobs
+├─ sources
+└─ workspaces
+Query tests
+2 declared · 2 passed · 0 failed
+
+✓ SELECT workspace_id, name FROM airbyte_cloud.workspaces LIMIT 1
+  1 row
+
+✓ SELECT connection_id, name, status FROM airbyte_cloud.connections LIMIT 1
+  0 rows
+```
+
+Representative query:
+
+```sql
+SELECT workspace_id, name, data_residency
+FROM airbyte_cloud.workspaces
+LIMIT 3;
+```

--- a/sources/community/airbyte_cloud/README.md
+++ b/sources/community/airbyte_cloud/README.md
@@ -20,9 +20,9 @@ metadata Coral agents need.
 | Table | Description |
 | --- | --- |
 | `airbyte_cloud.workspaces` | Workspaces visible to the API token. |
-| `airbyte_cloud.sources` | Source connectors. Supports `workspace_id`. |
-| `airbyte_cloud.destinations` | Destination connectors. Supports `workspace_id`. |
-| `airbyte_cloud.connections` | Connection metadata. Supports `workspace_id` and `status`. |
+| `airbyte_cloud.sources` | Source connectors. Supports `workspace_id` through Airbyte's `workspaceIds` parameter. |
+| `airbyte_cloud.destinations` | Destination connectors. Supports `workspace_id` through Airbyte's `workspaceIds` parameter. |
+| `airbyte_cloud.connections` | Connection metadata. Supports `workspace_id` through Airbyte's `workspaceIds` parameter. Filter `status` locally in SQL. |
 | `airbyte_cloud.jobs` | Job history. Supports `connection_id` and `status`. |
 
 ## Examples
@@ -38,7 +38,7 @@ WHERE status = 'active';
 Inspect recent jobs for one connection:
 
 ```sql
-SELECT job_id, status, job_type, started_at, ended_at
+SELECT job_id, status, job_type, start_time, last_updated_at, rows_synced
 FROM airbyte_cloud.jobs
 WHERE connection_id = 'connection_id'
 LIMIT 25;
@@ -55,7 +55,11 @@ WHERE workspace_id = 'workspace_id';
 ## Notes
 
 - Airbyte Cloud list endpoints are modeled with `offset` and `limit`
-  pagination.
+  pagination, with page sizes capped at Airbyte's documented maximum of 100.
+- Workspace-scoped source, destination, and connection queries send the
+  documented `workspaceIds` request parameter.
+- Connection `status` is returned as a column and should be filtered locally in
+  SQL; Airbyte does not document a remote status filter for list connections.
 - The source omits source and destination configuration objects because they
   can contain credentials, host names, database names, or other sensitive
   connection parameters.

--- a/sources/community/airbyte_cloud/README.md
+++ b/sources/community/airbyte_cloud/README.md
@@ -87,10 +87,9 @@ WHERE workspace_id = 'workspace_id';
 - Coral manifest schema validation: passed
 - `git diff --check`: passed
 - `make lint-sources`: passed
-- Live API tests: not rerun after the auth input rename; require a fresh
-  three-minute Airbyte access token
+- Live API tests: passed against an Airbyte Cloud workspace
 
-Previous Coral evidence before the auth input rename:
+Live Coral evidence:
 
 ```text
 ✓ airbyte_cloud connected successfully
@@ -103,12 +102,15 @@ airbyte_cloud (5 tables)
 ├─ sources
 └─ workspaces
 Query tests
-2 declared · 2 passed · 0 failed
+3 declared · 3 passed · 0 failed
 
 ✓ SELECT workspace_id, name FROM airbyte_cloud.workspaces LIMIT 1
   1 row
 
 ✓ SELECT connection_id, name, status FROM airbyte_cloud.connections LIMIT 1
+  0 rows
+
+✓ SELECT job_id, status, start_time, last_updated_at, duration FROM airbyte_cloud.jobs LIMIT 1
   0 rows
 ```
 

--- a/sources/community/airbyte_cloud/manifest.yaml
+++ b/sources/community/airbyte_cloud/manifest.yaml
@@ -247,16 +247,11 @@ tables:
         nullable: true
         description: Cron expression for cron-scheduled connections.
         expr: {kind: path, path: [schedule, cronExpression]}
-      - name: schedule_basic_time_unit
+      - name: schedule_basic_timing
         type: Utf8
         nullable: true
-        description: Time unit for basic scheduled connections.
-        expr: {kind: path, path: [schedule, basicSchedule, timeUnit]}
-      - name: schedule_basic_units
-        type: Int64
-        nullable: true
-        description: Number of units for basic scheduled connections.
-        expr: {kind: path, path: [schedule, basicSchedule, units]}
+        description: Basic schedule timing value when returned by Airbyte.
+        expr: {kind: path, path: [schedule, basicTiming]}
       - name: namespace_definition
         type: Utf8
         nullable: true

--- a/sources/community/airbyte_cloud/manifest.yaml
+++ b/sources/community/airbyte_cloud/manifest.yaml
@@ -50,7 +50,7 @@ tables:
       offset_start: 0
       page_size:
         default: 100
-        max: 1000
+        max: 100
         query_param: limit
     columns:
       - name: workspace_id
@@ -71,7 +71,8 @@ tables:
   - name: sources
     description: Airbyte Cloud source connectors.
     guide: |
-      Use `workspace_id` to scope source inventory. The source configuration
+      Use `workspace_id` to scope source inventory through Airbyte's documented
+      `workspaceIds` query parameter. The source configuration
       object is intentionally omitted because it can contain credentials or
       connection parameters.
     filters:
@@ -81,7 +82,7 @@ tables:
       method: GET
       path: /sources
       query:
-        - name: workspaceId
+        - name: workspaceIds
           from: filter
           key: workspace_id
     response:
@@ -93,7 +94,7 @@ tables:
       offset_start: 0
       page_size:
         default: 100
-        max: 1000
+        max: 100
         query_param: limit
     columns:
       - name: source_id
@@ -135,7 +136,8 @@ tables:
   - name: destinations
     description: Airbyte Cloud destination connectors.
     guide: |
-      Use `workspace_id` to scope destination inventory. The destination
+      Use `workspace_id` to scope destination inventory through Airbyte's
+      documented `workspaceIds` query parameter. The destination
       configuration object is intentionally omitted because it can contain
       warehouse credentials or connection parameters.
     filters:
@@ -145,7 +147,7 @@ tables:
       method: GET
       path: /destinations
       query:
-        - name: workspaceId
+        - name: workspaceIds
           from: filter
           key: workspace_id
     response:
@@ -157,7 +159,7 @@ tables:
       offset_start: 0
       page_size:
         default: 100
-        max: 1000
+        max: 100
         query_param: limit
     columns:
       - name: destination_id
@@ -199,22 +201,20 @@ tables:
   - name: connections
     description: Airbyte Cloud connections between sources and destinations.
     guide: |
-      Use `workspace_id` or `status` to scope large Airbyte accounts. This
-      table returns operational metadata, not connection configuration secrets.
+      Use `workspace_id` to scope large Airbyte accounts through Airbyte's
+      documented `workspaceIds` query parameter. The returned `status` column
+      can be filtered locally in SQL. This table returns operational metadata,
+      not connection configuration secrets.
     filters:
       - name: workspace_id
-      - name: status
     fetch_limit_default: 100
     request:
       method: GET
       path: /connections
       query:
-        - name: workspaceId
+        - name: workspaceIds
           from: filter
           key: workspace_id
-        - name: status
-          from: filter
-          key: status
     response:
       rows_path: [data]
       row_strategy: direct
@@ -224,7 +224,7 @@ tables:
       offset_start: 0
       page_size:
         default: 100
-        max: 1000
+        max: 100
         query_param: limit
     columns:
       - name: connection_id
@@ -285,13 +285,6 @@ tables:
         virtual: true
         description: Optional workspace filter.
         expr: {kind: from_filter, key: workspace_id}
-      - name: status_filter
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: Optional connection status filter.
-        expr: {kind: from_filter, key: status}
-
   - name: jobs
     description: Airbyte Cloud sync and reset jobs.
     guide: |
@@ -321,7 +314,7 @@ tables:
       offset_start: 0
       page_size:
         default: 100
-        max: 1000
+        max: 100
         query_param: limit
     columns:
       - name: job_id
@@ -343,26 +336,31 @@ tables:
         nullable: true
         description: Job type.
         expr: {kind: path, path: [jobType]}
-      - name: started_at
+      - name: start_time
         type: Int64
         nullable: true
         description: Job start time as returned by Airbyte.
-        expr: {kind: path, path: [startedAt]}
-      - name: ended_at
+        expr: {kind: path, path: [startTime]}
+      - name: last_updated_at
         type: Int64
         nullable: true
-        description: Job end time as returned by Airbyte.
-        expr: {kind: path, path: [endedAt]}
-      - name: created_at
+        description: Job last update time as returned by Airbyte.
+        expr: {kind: path, path: [lastUpdatedAt]}
+      - name: duration_seconds
         type: Int64
         nullable: true
-        description: Job creation time as returned by Airbyte.
-        expr: {kind: path, path: [createdAt]}
-      - name: updated_at
+        description: Job duration in seconds when returned by Airbyte.
+        expr: {kind: path, path: [duration]}
+      - name: bytes_synced
         type: Int64
         nullable: true
-        description: Job update time as returned by Airbyte.
-        expr: {kind: path, path: [updatedAt]}
+        description: Number of bytes synced by the job when returned by Airbyte.
+        expr: {kind: path, path: [bytesSynced]}
+      - name: rows_synced
+        type: Int64
+        nullable: true
+        description: Number of rows synced by the job when returned by Airbyte.
+        expr: {kind: path, path: [rowsSynced]}
       - name: connection_filter
         type: Utf8
         nullable: true

--- a/sources/community/airbyte_cloud/manifest.yaml
+++ b/sources/community/airbyte_cloud/manifest.yaml
@@ -1,0 +1,377 @@
+name: airbyte_cloud
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Airbyte Cloud metadata for workspaces, sources, destinations,
+  connections, and jobs.
+base_url: https://api.airbyte.com/v1
+
+inputs:
+  AIRBYTE_API_TOKEN:
+    kind: secret
+    hint: |
+      Airbyte Cloud API bearer token. Use a token with read-only access where
+      possible.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.AIRBYTE_API_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT workspace_id, name FROM airbyte_cloud.workspaces LIMIT 1
+  - SELECT connection_id, name, status FROM airbyte_cloud.connections LIMIT 1
+
+tables:
+  - name: workspaces
+    description: Airbyte Cloud workspaces visible to the API token.
+    guide: |
+      Workspaces are the top-level Airbyte Cloud containers for sources,
+      destinations, connections, and jobs. This endpoint is offset paginated
+      with `offset` and `limit`.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /workspaces
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: workspace_id
+        type: Utf8
+        nullable: false
+        description: Airbyte workspace ID.
+        expr: {kind: path, path: [workspaceId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Workspace name.
+      - name: data_residency
+        type: Utf8
+        nullable: true
+        description: Workspace data residency setting when returned.
+        expr: {kind: path, path: [dataResidency]}
+
+  - name: sources
+    description: Airbyte Cloud source connectors.
+    guide: |
+      Use `workspace_id` to scope source inventory. The source configuration
+      object is intentionally omitted because it can contain credentials or
+      connection parameters.
+    filters:
+      - name: workspace_id
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /sources
+      query:
+        - name: workspaceId
+          from: filter
+          key: workspace_id
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: source_id
+        type: Utf8
+        nullable: false
+        description: Airbyte source ID.
+        expr: {kind: path, path: [sourceId]}
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: Workspace ID.
+        expr: {kind: path, path: [workspaceId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Source name.
+      - name: source_type
+        type: Utf8
+        nullable: true
+        description: Source connector type.
+        expr: {kind: path, path: [sourceType]}
+      - name: created_at
+        type: Int64
+        nullable: true
+        description: Source creation time as returned by Airbyte.
+        expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Int64
+        nullable: true
+        description: Source update time as returned by Airbyte.
+        expr: {kind: path, path: [updatedAt]}
+      - name: workspace_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional workspace filter.
+        expr: {kind: from_filter, key: workspace_id}
+
+  - name: destinations
+    description: Airbyte Cloud destination connectors.
+    guide: |
+      Use `workspace_id` to scope destination inventory. The destination
+      configuration object is intentionally omitted because it can contain
+      warehouse credentials or connection parameters.
+    filters:
+      - name: workspace_id
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /destinations
+      query:
+        - name: workspaceId
+          from: filter
+          key: workspace_id
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: destination_id
+        type: Utf8
+        nullable: false
+        description: Airbyte destination ID.
+        expr: {kind: path, path: [destinationId]}
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: Workspace ID.
+        expr: {kind: path, path: [workspaceId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Destination name.
+      - name: destination_type
+        type: Utf8
+        nullable: true
+        description: Destination connector type.
+        expr: {kind: path, path: [destinationType]}
+      - name: created_at
+        type: Int64
+        nullable: true
+        description: Destination creation time as returned by Airbyte.
+        expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Int64
+        nullable: true
+        description: Destination update time as returned by Airbyte.
+        expr: {kind: path, path: [updatedAt]}
+      - name: workspace_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional workspace filter.
+        expr: {kind: from_filter, key: workspace_id}
+
+  - name: connections
+    description: Airbyte Cloud connections between sources and destinations.
+    guide: |
+      Use `workspace_id` or `status` to scope large Airbyte accounts. This
+      table returns operational metadata, not connection configuration secrets.
+    filters:
+      - name: workspace_id
+      - name: status
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /connections
+      query:
+        - name: workspaceId
+          from: filter
+          key: workspace_id
+        - name: status
+          from: filter
+          key: status
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: connection_id
+        type: Utf8
+        nullable: false
+        description: Airbyte connection ID.
+        expr: {kind: path, path: [connectionId]}
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Connection name.
+      - name: source_id
+        type: Utf8
+        nullable: true
+        description: Source ID.
+        expr: {kind: path, path: [sourceId]}
+      - name: destination_id
+        type: Utf8
+        nullable: true
+        description: Destination ID.
+        expr: {kind: path, path: [destinationId]}
+      - name: workspace_id
+        type: Utf8
+        nullable: true
+        description: Workspace ID when returned by Airbyte.
+        expr: {kind: path, path: [workspaceId]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Connection status.
+      - name: schedule_type
+        type: Utf8
+        nullable: true
+        description: Connection schedule type.
+        expr: {kind: path, path: [scheduleType]}
+      - name: namespace_definition
+        type: Utf8
+        nullable: true
+        description: Namespace definition mode.
+        expr: {kind: path, path: [namespaceDefinition]}
+      - name: prefix
+        type: Utf8
+        nullable: true
+        description: Destination stream prefix.
+      - name: created_at
+        type: Int64
+        nullable: true
+        description: Connection creation time as returned by Airbyte.
+        expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Int64
+        nullable: true
+        description: Connection update time as returned by Airbyte.
+        expr: {kind: path, path: [updatedAt]}
+      - name: workspace_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional workspace filter.
+        expr: {kind: from_filter, key: workspace_id}
+      - name: status_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional connection status filter.
+        expr: {kind: from_filter, key: status}
+
+  - name: jobs
+    description: Airbyte Cloud sync and reset jobs.
+    guide: |
+      Use `connection_id` to inspect one connection's recent job history.
+      Airbyte job lists can grow quickly, so the table has a conservative
+      default fetch limit.
+    filters:
+      - name: connection_id
+      - name: status
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /jobs
+      query:
+        - name: connectionId
+          from: filter
+          key: connection_id
+        - name: status
+          from: filter
+          key: status
+    response:
+      rows_path: [data]
+      row_strategy: direct
+    pagination:
+      mode: offset
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        default: 100
+        max: 1000
+        query_param: limit
+    columns:
+      - name: job_id
+        type: Int64
+        nullable: false
+        description: Airbyte job ID.
+        expr: {kind: path, path: [jobId]}
+      - name: connection_id
+        type: Utf8
+        nullable: true
+        description: Connection ID.
+        expr: {kind: path, path: [connectionId]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Job status.
+      - name: job_type
+        type: Utf8
+        nullable: true
+        description: Job type.
+        expr: {kind: path, path: [jobType]}
+      - name: started_at
+        type: Int64
+        nullable: true
+        description: Job start time as returned by Airbyte.
+        expr: {kind: path, path: [startedAt]}
+      - name: ended_at
+        type: Int64
+        nullable: true
+        description: Job end time as returned by Airbyte.
+        expr: {kind: path, path: [endedAt]}
+      - name: created_at
+        type: Int64
+        nullable: true
+        description: Job creation time as returned by Airbyte.
+        expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Int64
+        nullable: true
+        description: Job update time as returned by Airbyte.
+        expr: {kind: path, path: [updatedAt]}
+      - name: connection_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional connection filter.
+        expr: {kind: from_filter, key: connection_id}
+      - name: status_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional job status filter.
+        expr: {kind: from_filter, key: status}

--- a/sources/community/airbyte_cloud/manifest.yaml
+++ b/sources/community/airbyte_cloud/manifest.yaml
@@ -8,18 +8,19 @@ description: >-
 base_url: https://api.airbyte.com/v1
 
 inputs:
-  AIRBYTE_API_TOKEN:
+  AIRBYTE_ACCESS_TOKEN:
     kind: secret
     hint: |
-      Airbyte Cloud API bearer token. Use a token with read-only access where
-      possible.
+      Short-lived Airbyte Cloud access token from the Application token
+      exchange. Permissions come from the Airbyte user associated with the
+      Application.
 
 auth:
   type: HeaderAuth
   headers:
     - name: Authorization
       from: template
-      template: Bearer {{input.AIRBYTE_API_TOKEN}}
+      template: Bearer {{input.AIRBYTE_ACCESS_TOKEN}}
 
 request_headers:
   - name: Accept
@@ -29,6 +30,7 @@ request_headers:
 test_queries:
   - SELECT workspace_id, name FROM airbyte_cloud.workspaces LIMIT 1
   - SELECT connection_id, name, status FROM airbyte_cloud.connections LIMIT 1
+  - SELECT job_id, status, start_time, last_updated_at, duration FROM airbyte_cloud.jobs LIMIT 1
 
 tables:
   - name: workspaces
@@ -116,16 +118,6 @@ tables:
         nullable: true
         description: Source connector type.
         expr: {kind: path, path: [sourceType]}
-      - name: created_at
-        type: Int64
-        nullable: true
-        description: Source creation time as returned by Airbyte.
-        expr: {kind: path, path: [createdAt]}
-      - name: updated_at
-        type: Int64
-        nullable: true
-        description: Source update time as returned by Airbyte.
-        expr: {kind: path, path: [updatedAt]}
       - name: workspace_filter
         type: Utf8
         nullable: true
@@ -181,16 +173,6 @@ tables:
         nullable: true
         description: Destination connector type.
         expr: {kind: path, path: [destinationType]}
-      - name: created_at
-        type: Int64
-        nullable: true
-        description: Destination creation time as returned by Airbyte.
-        expr: {kind: path, path: [createdAt]}
-      - name: updated_at
-        type: Int64
-        nullable: true
-        description: Destination update time as returned by Airbyte.
-        expr: {kind: path, path: [updatedAt]}
       - name: workspace_filter
         type: Utf8
         nullable: true
@@ -259,7 +241,22 @@ tables:
         type: Utf8
         nullable: true
         description: Connection schedule type.
-        expr: {kind: path, path: [scheduleType]}
+        expr: {kind: path, path: [schedule, scheduleType]}
+      - name: schedule_cron_expression
+        type: Utf8
+        nullable: true
+        description: Cron expression for cron-scheduled connections.
+        expr: {kind: path, path: [schedule, cronExpression]}
+      - name: schedule_basic_time_unit
+        type: Utf8
+        nullable: true
+        description: Time unit for basic scheduled connections.
+        expr: {kind: path, path: [schedule, basicSchedule, timeUnit]}
+      - name: schedule_basic_units
+        type: Int64
+        nullable: true
+        description: Number of units for basic scheduled connections.
+        expr: {kind: path, path: [schedule, basicSchedule, units]}
       - name: namespace_definition
         type: Utf8
         nullable: true
@@ -269,16 +266,6 @@ tables:
         type: Utf8
         nullable: true
         description: Destination stream prefix.
-      - name: created_at
-        type: Int64
-        nullable: true
-        description: Connection creation time as returned by Airbyte.
-        expr: {kind: path, path: [createdAt]}
-      - name: updated_at
-        type: Int64
-        nullable: true
-        description: Connection update time as returned by Airbyte.
-        expr: {kind: path, path: [updatedAt]}
       - name: workspace_filter
         type: Utf8
         nullable: true
@@ -337,19 +324,25 @@ tables:
         description: Job type.
         expr: {kind: path, path: [jobType]}
       - name: start_time
-        type: Int64
+        type: Timestamp
         nullable: true
-        description: Job start time as returned by Airbyte.
-        expr: {kind: path, path: [startTime]}
+        description: Job start time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [startTime]}
       - name: last_updated_at
-        type: Int64
+        type: Timestamp
         nullable: true
-        description: Job last update time as returned by Airbyte.
-        expr: {kind: path, path: [lastUpdatedAt]}
-      - name: duration_seconds
-        type: Int64
+        description: Job last update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [lastUpdatedAt]}
+      - name: duration
+        type: Utf8
         nullable: true
-        description: Job duration in seconds when returned by Airbyte.
+        description: Job duration as an ISO-8601 duration string.
         expr: {kind: path, path: [duration]}
       - name: bytes_synced
         type: Int64


### PR DESCRIPTION
Summary:
- Adds a community Coral source for Airbyte Cloud metadata.
- Exposes workspaces, sources, destinations, connections, and jobs.
- Omits source and destination configuration payloads that may contain credentials or host details.

Validation:
- YAML parsing: passed
- Coral manifest schema validation: passed
- git diff --check: passed
- make lint-sources: passed
- Live API tests: passed against an Airbyte Cloud workspace