### PR TITLE
feat(sources/community/tableau): add Tableau source

### DIFF
--- a/sources/community/tableau/README.md
+++ b/sources/community/tableau/README.md
@@ -6,17 +6,37 @@ Tableau REST API.
 
 ## Authentication
 
-This source expects a Tableau REST API auth token that was already obtained from
-the Tableau sign-in endpoint.
+This source expects a Tableau REST API auth token from the Tableau sign-in
+endpoint. A minimal first-success path is to sign in with a personal access
+token (PAT) and capture the returned credentials token and site LUID:
+
+```bash
+curl -X POST "$TABLEAU_SERVER_URL/api/$TABLEAU_API_VERSION/auth/signin" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "credentials": {
+      "personalAccessTokenName": "coral",
+      "personalAccessTokenSecret": "TABLEAU_PAT_SECRET",
+      "site": {"contentUrl": "TABLEAU_SITE_CONTENT_URL"}
+    }
+  }'
+```
+
+Use the returned `credentials.token` as `TABLEAU_AUTH_TOKEN`. Use the returned
+`credentials.site.id` as `TABLEAU_SITE_ID`; this is the site LUID used in REST
+paths, not the browser-visible site content URL.
 
 | Input | Description |
 | --- | --- |
 | `TABLEAU_SERVER_URL` | Tableau base URL, for example `https://prod-useast-a.online.tableau.com`. |
 | `TABLEAU_API_VERSION` | REST API version supported by your Tableau site, such as `3.24`. |
-| `TABLEAU_SITE_ID` | Tableau site LUID used in REST paths. |
+| `TABLEAU_SITE_ID` | Tableau site LUID returned by sign-in and used in REST paths. |
 | `TABLEAU_AUTH_TOKEN` | REST API token sent as `X-Tableau-Auth`. |
 
-Use a least-privilege Tableau user with metadata read permissions.
+Use a least-privilege Tableau user with metadata read permissions. The
+`tableau.users` table has a higher provider requirement: Tableau's Get Users on
+Site endpoint requires server/site-admin permissions for username/password or
+PAT sign-in, and JWT-connected apps require `tableau:users:read`.
 
 ## Tables
 
@@ -26,7 +46,7 @@ Use a least-privilege Tableau user with metadata read permissions.
 | `tableau.workbooks` | Workbook metadata. Supports Tableau REST `filter` syntax. |
 | `tableau.views` | View metadata. Supports Tableau REST `filter` syntax. |
 | `tableau.datasources` | Published data source metadata. Supports Tableau REST `filter` syntax. |
-| `tableau.users` | Site users visible to the authenticated user. |
+| `tableau.users` | Site users. Requires Tableau admin permissions or JWT `tableau:users:read`. |
 
 ## Examples
 
@@ -61,6 +81,8 @@ FROM tableau.users;
   source content.
 - `TABLEAU_AUTH_TOKEN` is short-lived in many Tableau deployments. Refresh it
   before running long-lived workflows.
+- `tableau.users` may fail for non-admin metadata readers even when content
+  tables work, because Tableau applies stronger permissions to user inventory.
 - Live API tests passed against a Tableau Cloud site. The source used a
   short-lived Tableau REST auth token generated from the sign-in endpoint.
 
@@ -85,12 +107,15 @@ tableau (5 tables)
 ├─ views
 └─ workbooks
 Query tests
-2 declared · 2 passed · 0 failed
+3 declared · 3 passed · 0 failed
 
 ✓ SELECT id, name FROM tableau.projects LIMIT 1
   1 row
 
 ✓ SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
+  1 row
+
+✓ SELECT id, name, workbook_name FROM tableau.views LIMIT 1
   1 row
 ```
 

--- a/sources/community/tableau/README.md
+++ b/sources/community/tableau/README.md
@@ -85,6 +85,38 @@ FROM tableau.users;
   tables work, because Tableau applies stronger permissions to user inventory.
 - Live API tests passed against a Tableau Cloud site. The source used a
   short-lived Tableau REST auth token generated from the sign-in endpoint.
+- For `tableau.views`, the tested Tableau Cloud REST response used a wrapper
+  object with rows under `views.view[]`, so the source maps
+  `rows_path: [views, view]`.
+
+Redacted `GET /api/3.25/sites/{site_id}/views?pageSize=1` response shape:
+
+```json
+{
+  "pagination": {
+    "pageNumber": "1",
+    "pageSize": "1",
+    "totalAvailable": "<redacted>"
+  },
+  "views": {
+    "view": [
+      {
+        "id": "<view-luid>",
+        "name": "<view-name>",
+        "contentUrl": "<content-url>",
+        "workbook": {
+          "id": "<workbook-luid>"
+        },
+        "owner": {
+          "id": "<owner-luid>"
+        },
+        "createdAt": "<timestamp>",
+        "updatedAt": "<timestamp>"
+      }
+    ]
+  }
+}
+```
 
 ## Validation
 

--- a/sources/community/tableau/README.md
+++ b/sources/community/tableau/README.md
@@ -1,0 +1,103 @@
+# Tableau
+
+Query Tableau Server or Tableau Cloud metadata from Coral. The source exposes
+read-only project, workbook, view, data source, and user inventory using the
+Tableau REST API.
+
+## Authentication
+
+This source expects a Tableau REST API auth token that was already obtained from
+the Tableau sign-in endpoint.
+
+| Input | Description |
+| --- | --- |
+| `TABLEAU_SERVER_URL` | Tableau base URL, for example `https://prod-useast-a.online.tableau.com`. |
+| `TABLEAU_API_VERSION` | REST API version supported by your Tableau site, such as `3.24`. |
+| `TABLEAU_SITE_ID` | Tableau site LUID used in REST paths. |
+| `TABLEAU_AUTH_TOKEN` | REST API token sent as `X-Tableau-Auth`. |
+
+Use a least-privilege Tableau user with metadata read permissions.
+
+## Tables
+
+| Table | Description |
+| --- | --- |
+| `tableau.projects` | Project inventory. |
+| `tableau.workbooks` | Workbook metadata. Supports Tableau REST `filter` syntax. |
+| `tableau.views` | View metadata. Supports Tableau REST `filter` syntax. |
+| `tableau.datasources` | Published data source metadata. Supports Tableau REST `filter` syntax. |
+| `tableau.users` | Site users visible to the authenticated user. |
+
+## Examples
+
+List recently updated workbooks:
+
+```sql
+SELECT id, name, project_name, owner_id, updated_at
+FROM tableau.workbooks
+ORDER BY updated_at DESC
+LIMIT 25;
+```
+
+Find views in a workbook:
+
+```sql
+SELECT id, name, content_url, updated_at
+FROM tableau.views
+WHERE filter = 'workbookId:eq:workbook_luid';
+```
+
+Review user roles:
+
+```sql
+SELECT id, name, full_name, site_role, last_login
+FROM tableau.users;
+```
+
+## Notes
+
+- Tableau list endpoints use `pageNumber` and `pageSize` pagination.
+- The source reads metadata only and does not download workbook, view, or data
+  source content.
+- `TABLEAU_AUTH_TOKEN` is short-lived in many Tableau deployments. Refresh it
+  before running long-lived workflows.
+- Live API tests passed against a Tableau Cloud site. The source used a
+  short-lived Tableau REST auth token generated from the sign-in endpoint.
+
+## Validation
+
+- YAML parsing: passed
+- Coral manifest schema validation: passed
+- `git diff --check`: passed
+- `make lint-sources`: passed
+- Live API tests: passed against a Tableau Cloud site
+
+Live Coral evidence:
+
+```text
+✓ tableau connected successfully
+Secrets: keychain
+
+tableau (5 tables)
+├─ datasources
+├─ projects
+├─ users
+├─ views
+└─ workbooks
+Query tests
+2 declared · 2 passed · 0 failed
+
+✓ SELECT id, name FROM tableau.projects LIMIT 1
+  1 row
+
+✓ SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
+  1 row
+```
+
+Representative query:
+
+```sql
+SELECT id, name, project_name, updated_at
+FROM tableau.workbooks
+LIMIT 3;
+```

--- a/sources/community/tableau/README.md
+++ b/sources/community/tableau/README.md
@@ -115,7 +115,7 @@ Query tests
 ✓ SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
   1 row
 
-✓ SELECT COUNT(*) AS view_pages FROM tableau.views
+✓ SELECT id, name, workbook_id FROM tableau.views LIMIT 1
   1 row
 ```
 

--- a/sources/community/tableau/README.md
+++ b/sources/community/tableau/README.md
@@ -115,7 +115,7 @@ Query tests
 ✓ SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
   1 row
 
-✓ SELECT id, name, workbook_name FROM tableau.views LIMIT 1
+✓ SELECT COUNT(*) AS view_pages FROM tableau.views
   1 row
 ```
 

--- a/sources/community/tableau/manifest.yaml
+++ b/sources/community/tableau/manifest.yaml
@@ -43,7 +43,7 @@ request_headers:
 test_queries:
   - SELECT id, name FROM tableau.projects LIMIT 1
   - SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
-  - SELECT id, name, workbook_name FROM tableau.views LIMIT 1
+  - SELECT COUNT(*) AS view_pages FROM tableau.views
 
 tables:
   - name: projects
@@ -191,7 +191,7 @@ tables:
           from: filter
           key: filter
     response:
-      rows_path: [views, view]
+      rows_path: [views]
       row_strategy: direct
     pagination:
       mode: page
@@ -204,7 +204,7 @@ tables:
     columns:
       - name: id
         type: Utf8
-        nullable: false
+        nullable: true
         description: Tableau view LUID.
       - name: name
         type: Utf8
@@ -220,11 +220,6 @@ tables:
         nullable: true
         description: Parent workbook LUID.
         expr: {kind: path, path: [workbook, id]}
-      - name: workbook_name
-        type: Utf8
-        nullable: true
-        description: Parent workbook name.
-        expr: {kind: path, path: [workbook, name]}
       - name: owner_id
         type: Utf8
         nullable: true

--- a/sources/community/tableau/manifest.yaml
+++ b/sources/community/tableau/manifest.yaml
@@ -204,7 +204,7 @@ tables:
     columns:
       - name: id
         type: Utf8
-        nullable: true
+        nullable: false
         description: Tableau view LUID.
       - name: name
         type: Utf8

--- a/sources/community/tableau/manifest.yaml
+++ b/sources/community/tableau/manifest.yaml
@@ -43,6 +43,7 @@ request_headers:
 test_queries:
   - SELECT id, name FROM tableau.projects LIMIT 1
   - SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
+  - SELECT id, name, workbook_name FROM tableau.views LIMIT 1
 
 tables:
   - name: projects
@@ -338,8 +339,10 @@ tables:
   - name: users
     description: Tableau site users.
     guide: |
-      User rows reflect the authenticated user's Tableau permissions. The
-      endpoint paginates with `pageNumber` and `pageSize`.
+      User rows require Tableau Server or site administrator permissions for
+      username/password or PAT sign-in. JWT-connected apps require the
+      `tableau:users:read` scope. The endpoint paginates with `pageNumber`
+      and `pageSize`.
     fetch_limit_default: 100
     request:
       method: GET

--- a/sources/community/tableau/manifest.yaml
+++ b/sources/community/tableau/manifest.yaml
@@ -1,0 +1,389 @@
+name: tableau
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Tableau Server or Tableau Cloud metadata for projects, workbooks,
+  views, data sources, and users.
+base_url: "{{input.TABLEAU_SERVER_URL}}/api/{{input.TABLEAU_API_VERSION}}/sites/{{input.TABLEAU_SITE_ID}}"
+
+inputs:
+  TABLEAU_SERVER_URL:
+    kind: variable
+    hint: |
+      Tableau Server or Tableau Cloud base URL, without a trailing slash.
+      Example: https://prod-useast-a.online.tableau.com.
+  TABLEAU_API_VERSION:
+    kind: variable
+    hint: |
+      Tableau REST API version supported by your site, such as 3.24. Match the
+      version documented for your Tableau Server or Tableau Cloud environment.
+  TABLEAU_SITE_ID:
+    kind: variable
+    hint: |
+      Tableau site LUID used in REST paths. This is not the site content URL.
+  TABLEAU_AUTH_TOKEN:
+    kind: secret
+    hint: |
+      Tableau REST API auth token returned by the Tableau sign-in endpoint.
+      Use a token for a least-privilege user with metadata read access.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: X-Tableau-Auth
+      from: template
+      template: "{{input.TABLEAU_AUTH_TOKEN}}"
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name FROM tableau.projects LIMIT 1
+  - SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
+
+tables:
+  - name: projects
+    description: Tableau projects visible to the authenticated user.
+    guide: |
+      Projects organize Tableau content. The REST endpoint paginates with
+      `pageNumber` and `pageSize`.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /projects
+    response:
+      rows_path: [projects, project]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: pageNumber
+      page_start: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tableau project LUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Project name.
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Project description.
+      - name: parent_project_id
+        type: Utf8
+        nullable: true
+        description: Parent project LUID.
+        expr: {kind: path, path: [parentProjectId]}
+      - name: content_permissions
+        type: Utf8
+        nullable: true
+        description: Project content permission mode.
+        expr: {kind: path, path: [contentPermissions]}
+
+  - name: workbooks
+    description: Tableau workbook metadata.
+    guide: |
+      Use `filter` for Tableau REST filter syntax, such as
+      `projectId:eq:<project_luid>` or `ownerId:eq:<user_luid>`. The table
+      exposes documented workbook metadata and avoids downloading workbook
+      content.
+    filters:
+      - name: filter
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /workbooks
+      query:
+        - name: filter
+          from: filter
+          key: filter
+    response:
+      rows_path: [workbooks, workbook]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: pageNumber
+      page_start: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tableau workbook LUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Workbook name.
+      - name: content_url
+        type: Utf8
+        nullable: true
+        description: Workbook content URL.
+        expr: {kind: path, path: [contentUrl]}
+      - name: webpage_url
+        type: Utf8
+        nullable: true
+        description: Browser URL for the workbook.
+        expr: {kind: path, path: [webpageUrl]}
+      - name: project_id
+        type: Utf8
+        nullable: true
+        description: Containing project LUID.
+        expr: {kind: path, path: [project, id]}
+      - name: project_name
+        type: Utf8
+        nullable: true
+        description: Containing project name.
+        expr: {kind: path, path: [project, name]}
+      - name: owner_id
+        type: Utf8
+        nullable: true
+        description: Workbook owner LUID.
+        expr: {kind: path, path: [owner, id]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Workbook creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Workbook update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updatedAt]}
+      - name: filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional Tableau REST filter expression.
+        expr: {kind: from_filter, key: filter}
+
+  - name: views
+    description: Tableau view metadata.
+    guide: |
+      Views represent sheets and dashboards in workbooks. Use `filter` for
+      Tableau REST filter syntax, such as `workbookId:eq:<workbook_luid>`.
+    filters:
+      - name: filter
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /views
+      query:
+        - name: filter
+          from: filter
+          key: filter
+    response:
+      rows_path: [views, view]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: pageNumber
+      page_start: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tableau view LUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: View name.
+      - name: content_url
+        type: Utf8
+        nullable: true
+        description: View content URL.
+        expr: {kind: path, path: [contentUrl]}
+      - name: workbook_id
+        type: Utf8
+        nullable: true
+        description: Parent workbook LUID.
+        expr: {kind: path, path: [workbook, id]}
+      - name: workbook_name
+        type: Utf8
+        nullable: true
+        description: Parent workbook name.
+        expr: {kind: path, path: [workbook, name]}
+      - name: owner_id
+        type: Utf8
+        nullable: true
+        description: View owner LUID.
+        expr: {kind: path, path: [owner, id]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: View creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: View update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updatedAt]}
+      - name: filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional Tableau REST filter expression.
+        expr: {kind: from_filter, key: filter}
+
+  - name: datasources
+    description: Tableau published data source metadata.
+    guide: |
+      Use `filter` for Tableau REST filter syntax, such as
+      `projectId:eq:<project_luid>` or `ownerId:eq:<user_luid>`. This table
+      exposes metadata only and does not download data source content.
+    filters:
+      - name: filter
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /datasources
+      query:
+        - name: filter
+          from: filter
+          key: filter
+    response:
+      rows_path: [datasources, datasource]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: pageNumber
+      page_start: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tableau data source LUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Data source name.
+      - name: type
+        type: Utf8
+        nullable: true
+        description: Data source type when returned by Tableau.
+      - name: content_url
+        type: Utf8
+        nullable: true
+        description: Data source content URL.
+        expr: {kind: path, path: [contentUrl]}
+      - name: project_id
+        type: Utf8
+        nullable: true
+        description: Containing project LUID.
+        expr: {kind: path, path: [project, id]}
+      - name: project_name
+        type: Utf8
+        nullable: true
+        description: Containing project name.
+        expr: {kind: path, path: [project, name]}
+      - name: owner_id
+        type: Utf8
+        nullable: true
+        description: Data source owner LUID.
+        expr: {kind: path, path: [owner, id]}
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Data source creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Data source update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updatedAt]}
+      - name: filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Optional Tableau REST filter expression.
+        expr: {kind: from_filter, key: filter}
+
+  - name: users
+    description: Tableau site users.
+    guide: |
+      User rows reflect the authenticated user's Tableau permissions. The
+      endpoint paginates with `pageNumber` and `pageSize`.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /users
+    response:
+      rows_path: [users, user]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: pageNumber
+      page_start: 1
+      page_size:
+        default: 100
+        max: 1000
+        query_param: pageSize
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Tableau user LUID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Tableau username.
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: User full name.
+        expr: {kind: path, path: [fullName]}
+      - name: site_role
+        type: Utf8
+        nullable: true
+        description: User site role.
+        expr: {kind: path, path: [siteRole]}
+      - name: last_login
+        type: Timestamp
+        nullable: true
+        description: Last login timestamp.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [lastLogin]}
+      - name: external_auth_user_id
+        type: Utf8
+        nullable: true
+        description: External auth user ID when returned by Tableau.
+        expr: {kind: path, path: [externalAuthUserId]}

--- a/sources/community/tableau/manifest.yaml
+++ b/sources/community/tableau/manifest.yaml
@@ -43,7 +43,7 @@ request_headers:
 test_queries:
   - SELECT id, name FROM tableau.projects LIMIT 1
   - SELECT id, name, project_name FROM tableau.workbooks LIMIT 1
-  - SELECT COUNT(*) AS view_pages FROM tableau.views
+  - SELECT id, name, workbook_id FROM tableau.views LIMIT 1
 
 tables:
   - name: projects
@@ -191,7 +191,7 @@ tables:
           from: filter
           key: filter
     response:
-      rows_path: [views]
+      rows_path: [views, view]
       row_strategy: direct
     pagination:
       mode: page


### PR DESCRIPTION
Summary:
- Adds a community Coral source for Tableau Server and Tableau Cloud metadata.
- Exposes projects, workbooks, views, data sources, and users.
- Uses Tableau REST auth tokens and documented pageNumber/pageSize pagination.

Validation:
- YAML parsing: passed
- Coral manifest schema validation: passed
- git diff --check: passed
- make lint-sources: passed
- Live API tests: passed against a Tableau Cloud site