### PR TITLE
feat(mcp): compact catalog discovery output

### DIFF
--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -74,6 +74,6 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
 - `list_catalog` shows queryable tables and parameterized table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
 - `search_catalog` searches table and table-function names, descriptions, arguments, result columns, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the catalog item you need.
-- `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
+- `describe_table` returns one compact table detail with guide text, required filters, column count, and up to 50 compact columns; use `list_columns` or `coral.columns` when you need filtered or exhaustive column details.
 - `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively. Existing tables return paginated `columns` plus `total`, `has_more`, and optional `next_offset`; regex matches add `matched_fields` per column. Missing tables return `found: false` with suggested recovery calls instead of an empty page.
 - `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -304,7 +304,7 @@ impl CoralMcpServer {
                 }),
             }))
             .await
-            .map(|response| search_catalog_value(&response.into_inner()))
+            .map(|response| search_catalog_value(&response.into_inner(), arguments.detail))
         {
             Ok(value) => Ok(ToolCallOutcome::Success(value)),
             Err(status) if status.code() == tonic::Code::InvalidArgument => {
@@ -334,7 +334,7 @@ impl CoralMcpServer {
                 }),
             }))
             .await
-            .map(|response| list_catalog_value(&response.into_inner()));
+            .map(|response| list_catalog_value(&response.into_inner(), arguments.detail));
         Ok(ToolCallOutcome::from_value_result(
             "Catalog listing",
             result,

--- a/crates/coral-mcp/src/surface/catalog.rs
+++ b/crates/coral-mcp/src/surface/catalog.rs
@@ -8,10 +8,13 @@ use coral_api::v1::{
 use serde::Serialize;
 use serde_json::{Map, Value};
 
+use super::tools::CatalogToolDetail;
 use super::values::{
     format_schema_table_equivalent, format_sql_identifier, insert_pagination_fields,
     missing_table_summary_value, paged_collection_value,
 };
+
+const DESCRIBE_TABLE_COLUMN_LIMIT: usize = 50;
 
 pub(crate) fn describe_table_value(
     schema: &str,
@@ -91,32 +94,47 @@ fn describe_missing_table_value(
     .expect("missing table value serializes")
 }
 
-pub(crate) fn search_catalog_value(response: &SearchCatalogResponse) -> Value {
+pub(crate) fn search_catalog_value(
+    response: &SearchCatalogResponse,
+    detail: CatalogToolDetail,
+) -> Value {
     let pagination = response.pagination.unwrap_or_default();
     let items = response
         .items
         .iter()
-        .filter_map(catalog_search_result_value)
+        .filter_map(|result| catalog_search_result_value(result, detail))
         .collect::<Vec<_>>();
     paged_collection_value("items", items, &pagination)
 }
 
-pub(crate) fn list_catalog_value(response: &ListCatalogResponse) -> Value {
+pub(crate) fn list_catalog_value(
+    response: &ListCatalogResponse,
+    detail: CatalogToolDetail,
+) -> Value {
     let pagination = response.pagination.unwrap_or_default();
     let items = response
         .items
         .iter()
-        .filter_map(catalog_item_value)
+        .filter_map(|item| catalog_item_value(item, detail))
         .collect::<Vec<_>>();
     paged_collection_value("items", items, &pagination)
 }
 
-fn catalog_item_value(item: &coral_api::v1::CatalogItem) -> Option<Value> {
-    match item.item.as_ref()? {
-        catalog_item::Item::Table(table) => {
+fn catalog_item_value(
+    item: &coral_api::v1::CatalogItem,
+    detail: CatalogToolDetail,
+) -> Option<Value> {
+    match (item.item.as_ref()?, detail) {
+        (catalog_item::Item::Table(table), CatalogToolDetail::Summary) => {
+            serde_json::to_value(CatalogTableSummaryItemValue::from(table)).ok()
+        }
+        (catalog_item::Item::Table(table), CatalogToolDetail::Full) => {
             serde_json::to_value(CatalogTableItemValue::from(table)).ok()
         }
-        catalog_item::Item::TableFunction(function) => {
+        (catalog_item::Item::TableFunction(function), CatalogToolDetail::Summary) => {
+            serde_json::to_value(CatalogTableFunctionSummaryItemValue::from(function)).ok()
+        }
+        (catalog_item::Item::TableFunction(function), CatalogToolDetail::Full) => {
             serde_json::to_value(CatalogTableFunctionItemValue::from(function)).ok()
         }
     }
@@ -134,8 +152,11 @@ fn minimal_table_function_call_example(function: &ProtoTableFunction) -> String 
     format!("{reference}({required_arguments})")
 }
 
-fn catalog_search_result_value(result: &coral_api::v1::CatalogSearchResult) -> Option<Value> {
-    let mut value = catalog_item_value(result.item.as_ref()?)?;
+fn catalog_search_result_value(
+    result: &coral_api::v1::CatalogSearchResult,
+    detail: CatalogToolDetail,
+) -> Option<Value> {
+    let mut value = catalog_item_value(result.item.as_ref()?, detail)?;
     value.as_object_mut()?.insert(
         "matched_fields".to_string(),
         serde_json::to_value(&result.matched_fields).ok()?,
@@ -187,6 +208,8 @@ struct FoundTableValue<'a> {
     guide: &'a str,
     required_filters: &'a [String],
     column_count: usize,
+    columns_returned: usize,
+    columns: Vec<DescribeColumnValue<'a>>,
     columns_hint: &'static str,
 }
 
@@ -201,7 +224,14 @@ impl<'a> From<&'a ProtoTable> for FoundTableValue<'a> {
             guide: &table.guide,
             required_filters: &table.required_filters,
             column_count: table.columns.len(),
-            columns_hint: "Use list_columns with this schema/table to inspect columns.",
+            columns_returned: table.columns.len().min(DESCRIBE_TABLE_COLUMN_LIMIT),
+            columns: table
+                .columns
+                .iter()
+                .take(DESCRIBE_TABLE_COLUMN_LIMIT)
+                .map(DescribeColumnValue::from)
+                .collect(),
+            columns_hint: "Columns are compact and capped. Use list_columns with pattern, required_only, or pagination when you need filtered or exhaustive column discovery.",
         }
     }
 }
@@ -241,6 +271,29 @@ struct SuggestedCallArguments<'a> {
 }
 
 #[derive(Serialize)]
+struct CatalogTableSummaryItemValue<'a> {
+    kind: &'static str,
+    schema_name: &'a str,
+    name: String,
+    sql_reference: String,
+    description: &'a str,
+    required_filters: &'a [String],
+}
+
+impl<'a> From<&'a ProtoTableSummary> for CatalogTableSummaryItemValue<'a> {
+    fn from(table: &'a ProtoTableSummary) -> Self {
+        Self {
+            kind: "table",
+            schema_name: &table.schema_name,
+            name: format!("{}.{}", table.schema_name, table.name),
+            sql_reference: format_schema_table_equivalent(&table.schema_name, &table.name),
+            description: &table.description,
+            required_filters: &table.required_filters,
+        }
+    }
+}
+
+#[derive(Serialize)]
 struct CatalogTableItemValue<'a> {
     kind: &'static str,
     schema_name: &'a str,
@@ -272,6 +325,37 @@ struct CatalogTableValue<'a> {
     table_name: &'a str,
     guide: &'a str,
     required_filters: &'a [String],
+}
+
+#[derive(Serialize)]
+struct CatalogTableFunctionSummaryItemValue<'a> {
+    kind: &'static str,
+    schema_name: &'a str,
+    name: String,
+    sql_reference: String,
+    sql_call_example: String,
+    description: &'a str,
+    arguments: Vec<TableFunctionArgumentValue<'a>>,
+    result_column_count: usize,
+}
+
+impl<'a> From<&'a ProtoTableFunction> for CatalogTableFunctionSummaryItemValue<'a> {
+    fn from(function: &'a ProtoTableFunction) -> Self {
+        Self {
+            kind: "table_function",
+            schema_name: &function.schema_name,
+            name: format!("{}.{}", function.schema_name, function.name),
+            sql_reference: format_schema_table_equivalent(&function.schema_name, &function.name),
+            sql_call_example: minimal_table_function_call_example(function),
+            description: &function.description,
+            arguments: function
+                .arguments
+                .iter()
+                .map(TableFunctionArgumentValue::from)
+                .collect(),
+            result_column_count: function.result_columns.len(),
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -350,6 +434,25 @@ impl<'a> From<&'a ProtoTableFunctionResultColumn> for TableFunctionResultColumnV
             data_type: &column.data_type,
             is_nullable: column.nullable,
             description: &column.description,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct DescribeColumnValue<'a> {
+    column_name: &'a str,
+    data_type: &'a str,
+    is_virtual: bool,
+    is_required_filter: bool,
+}
+
+impl<'a> From<&'a coral_api::v1::Column> for DescribeColumnValue<'a> {
+    fn from(column: &'a coral_api::v1::Column) -> Self {
+        Self {
+            column_name: &column.name,
+            data_type: &column.data_type,
+            is_virtual: column.is_virtual,
+            is_required_filter: column.is_required_filter,
         }
     }
 }

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -12,6 +12,7 @@ use super::{Pagination, parse_pagination, parse_pagination_with_limits};
 pub(crate) struct ListCatalogArguments {
     pub(crate) schema: Option<String>,
     pub(crate) kind: Option<CatalogToolKind>,
+    pub(crate) detail: CatalogToolDetail,
     pub(crate) pagination: Pagination,
 }
 
@@ -19,6 +20,7 @@ pub(crate) struct SearchCatalogArguments {
     pub(crate) pattern: String,
     pub(crate) schema: Option<String>,
     pub(crate) kind: Option<CatalogToolKind>,
+    pub(crate) detail: CatalogToolDetail,
     pub(crate) ignore_case: bool,
     pub(crate) pagination: Pagination,
 }
@@ -27,6 +29,12 @@ pub(crate) struct SearchCatalogArguments {
 pub(crate) enum CatalogToolKind {
     Table,
     TableFunction,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CatalogToolDetail {
+    Summary,
+    Full,
 }
 
 pub(crate) struct DescribeTableArguments {
@@ -71,7 +79,7 @@ pub(crate) fn list_catalog_tool(visible_table_count: usize, visible_function_cou
     Tool::new(
         "list_catalog",
         format!(
-            "List database catalog items. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
+            "List compact database catalog summaries. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible. Prefer search_catalog when you know the entity or task; use detail='full' only for small result sets that need guides, function result columns, or full argument metadata."
         ),
         json_object_schema(&json!({
             "type": "object",
@@ -92,11 +100,17 @@ pub(crate) fn list_catalog_tool(visible_table_count: usize, visible_function_cou
                         }
                     ]
                 },
+                "detail": {
+                    "type": "string",
+                    "description": "Output detail level. Defaults to compact summaries. Use 'full' only with a narrow schema/kind/limit when bulky guides, function result columns, and full argument metadata are required.",
+                    "enum": ["summary", "full"],
+                    "default": "summary"
+                },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum catalog items to return, from 1 to 200. Defaults to 50.",
+                    "description": "Maximum catalog items to return, from 1 to 50. Defaults to 50.",
                     "minimum": 1,
-                    "maximum": 200,
+                    "maximum": 50,
                     "default": 50
                 },
                 "offset": {
@@ -150,15 +164,21 @@ pub(crate) fn search_catalog_tool(
                         }
                     ]
                 },
+                "detail": {
+                    "type": "string",
+                    "description": "Output detail level. Defaults to compact summaries. Use 'full' only for small result sets that need guides, function result columns, or full argument metadata.",
+                    "enum": ["summary", "full"],
+                    "default": "summary"
+                },
                 "ignore_case": {
                     "type": "boolean",
                     "description": "Whether regex matching is case-insensitive. Defaults to true."
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum catalog items to return, from 1 to 100. Defaults to 20.",
+                    "description": "Maximum catalog items to return, from 1 to 50. Defaults to 20.",
                     "minimum": 1,
-                    "maximum": 100,
+                    "maximum": 50,
                     "default": 20
                 },
                 "offset": {
@@ -184,7 +204,7 @@ pub(crate) fn search_catalog_tool(
 pub(crate) fn describe_table_tool() -> Tool {
     Tool::new(
         "describe_table",
-        "Describe one database table without returning full column definitions.",
+        "Describe one database table, including required filters and compact column metadata.",
         json_object_schema(&json!({
             "type": "object",
             "required": ["schema", "table"],
@@ -317,7 +337,8 @@ pub(crate) fn list_catalog_arguments(
     Ok(ListCatalogArguments {
         schema: optional_string_argument(arguments, "schema")?,
         kind: optional_catalog_kind_argument(arguments)?,
-        pagination: parse_pagination(arguments)?,
+        detail: optional_catalog_detail_argument(arguments)?,
+        pagination: parse_pagination_with_limits(arguments, 50, 50)?,
     })
 }
 
@@ -328,8 +349,9 @@ pub(crate) fn search_catalog_arguments(
         pattern: required_string_argument(arguments, "pattern")?,
         schema: optional_string_argument(arguments, "schema")?,
         kind: optional_catalog_kind_argument(arguments)?,
+        detail: optional_catalog_detail_argument(arguments)?,
         ignore_case: optional_bool_argument(arguments, "ignore_case", true)?,
-        pagination: parse_pagination_with_limits(arguments, 20, 100)?,
+        pagination: parse_pagination_with_limits(arguments, 20, 50)?,
     })
 }
 
@@ -344,6 +366,22 @@ fn optional_catalog_kind_argument(
         "table_function" => Ok(Some(CatalogToolKind::TableFunction)),
         _ => Err(ErrorData::invalid_params(
             "argument 'kind' must be 'table' or 'table_function'",
+            None,
+        )),
+    }
+}
+
+fn optional_catalog_detail_argument(
+    arguments: Option<&Map<String, Value>>,
+) -> Result<CatalogToolDetail, ErrorData> {
+    let Some(detail) = optional_string_argument(arguments, "detail")? else {
+        return Ok(CatalogToolDetail::Summary);
+    };
+    match detail.as_str() {
+        "summary" => Ok(CatalogToolDetail::Summary),
+        "full" => Ok(CatalogToolDetail::Full),
+        _ => Err(ErrorData::invalid_params(
+            "argument 'detail' must be 'summary' or 'full'",
             None,
         )),
     }
@@ -392,7 +430,7 @@ fn sql_tool_description(_sources: &[Source], visible_table_count: usize) -> Stri
 
 fn search_catalog_description(visible_table_count: usize, visible_function_count: usize) -> String {
     format!(
-        "Search database catalog metadata with a Rust regex. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible."
+        "Search compact database catalog summaries with a Rust regex. {visible_table_count} table(s) and {visible_function_count} table function(s) are currently visible. Use this before list_catalog when you know the entity or task; use detail='full' only for small result sets."
     )
 }
 
@@ -435,7 +473,7 @@ fn list_catalog_output_schema() -> Arc<Map<String, Value>> {
 fn catalog_table_item_output_schema() -> Value {
     json!({
         "type": "object",
-        "required": ["kind", "schema_name", "name", "sql_reference", "description", "table"],
+        "required": ["kind", "schema_name", "name", "sql_reference", "description"],
         "additionalProperties": false,
         "properties": {
             "kind": { "enum": ["table"] },
@@ -443,6 +481,10 @@ fn catalog_table_item_output_schema() -> Value {
             "name": { "type": "string" },
             "sql_reference": { "type": "string" },
             "description": { "type": "string" },
+            "required_filters": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
             "table": {
                 "type": "object",
                 "required": ["table_name", "guide", "required_filters"],
@@ -469,8 +511,7 @@ fn catalog_table_function_item_output_schema() -> Value {
             "name",
             "sql_reference",
             "sql_call_example",
-            "description",
-            "table_function"
+            "description"
         ],
         "additionalProperties": false,
         "properties": {
@@ -480,6 +521,14 @@ fn catalog_table_function_item_output_schema() -> Value {
             "sql_reference": { "type": "string" },
             "sql_call_example": { "type": "string" },
             "description": { "type": "string" },
+            "arguments": {
+                "type": "array",
+                "items": table_function_argument_output_schema()
+            },
+            "result_column_count": {
+                "type": "integer",
+                "minimum": 0
+            },
             "table_function": {
                 "type": "object",
                 "required": ["function_name", "arguments", "result_columns"],
@@ -488,19 +537,7 @@ fn catalog_table_function_item_output_schema() -> Value {
                     "function_name": { "type": "string" },
                     "arguments": {
                         "type": "array",
-                        "items": {
-                            "type": "object",
-                            "required": ["name", "required", "values"],
-                            "additionalProperties": false,
-                            "properties": {
-                                "name": { "type": "string" },
-                                "required": { "type": "boolean" },
-                                "values": {
-                                    "type": "array",
-                                    "items": { "type": "string" }
-                                }
-                            }
-                        }
+                        "items": table_function_argument_output_schema()
                     },
                     "result_columns": {
                         "type": "array",
@@ -517,6 +554,22 @@ fn catalog_table_function_item_output_schema() -> Value {
                         }
                     }
                 }
+            }
+        }
+    })
+}
+
+fn table_function_argument_output_schema() -> Value {
+    json!({
+        "type": "object",
+        "required": ["name", "required", "values"],
+        "additionalProperties": false,
+        "properties": {
+            "name": { "type": "string" },
+            "required": { "type": "boolean" },
+            "values": {
+                "type": "array",
+                "items": { "type": "string" }
             }
         }
     })
@@ -802,7 +855,7 @@ fn json_object_schema(value: &Value) -> Arc<Map<String, Value>> {
 mod tests {
     use serde_json::{Map, Value};
 
-    use super::{list_catalog_arguments, search_catalog_arguments};
+    use super::{CatalogToolDetail, list_catalog_arguments, search_catalog_arguments};
 
     #[test]
     fn catalog_kind_argument_accepts_null_as_all_kinds() {
@@ -810,9 +863,15 @@ mod tests {
         arguments.insert("kind".to_string(), Value::Null);
         let list = list_catalog_arguments(Some(&arguments)).expect("list arguments");
         assert_eq!(list.kind, None);
+        assert_eq!(list.detail, CatalogToolDetail::Summary);
 
         arguments.insert("pattern".to_string(), Value::String("issue".to_string()));
         let search = search_catalog_arguments(Some(&arguments)).expect("search arguments");
         assert_eq!(search.kind, None);
+        assert_eq!(search.detail, CatalogToolDetail::Summary);
+
+        arguments.insert("detail".to_string(), Value::String("full".to_string()));
+        let search = search_catalog_arguments(Some(&arguments)).expect("full search arguments");
+        assert_eq!(search.detail, CatalogToolDetail::Full);
     }
 }

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -433,7 +433,13 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         catalog["items"][0]["sql_reference"],
         "local_messages.events"
     );
-    assert_eq!(catalog["items"][0]["table"]["table_name"], "events");
+    assert!(
+        catalog["items"][0]["required_filters"]
+            .as_array()
+            .expect("summary required filters")
+            .is_empty()
+    );
+    assert!(catalog["items"][0]["table"].is_null());
     assert_matches_output_schema(list_catalog_tool, &catalog);
 
     let catalog_page = client
@@ -514,10 +520,7 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
         search["items"][0]["sql_reference"],
         "local_messages.messages"
     );
-    assert!(
-        search["items"][0]["table"]["guide"].is_string(),
-        "search results should always expose guide text, even when empty"
-    );
+    assert!(search["items"][0]["table"].is_null());
     assert!(
         search["items"][0]["matched_fields"]
             .as_array()
@@ -566,8 +569,10 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
     assert_eq!(described["found"], true);
     assert_eq!(described["name"], "local_messages.messages");
     assert_eq!(described["column_count"], 3);
+    assert_eq!(described["columns_returned"], 3);
     assert!(described["columns_hint"].as_str().is_some());
-    assert!(described["columns"].is_null());
+    assert_eq!(described["columns"][0]["column_name"], "type");
+    assert_eq!(described["columns"][0]["data_type"], "Utf8");
 
     let missing_table = client
         .call_tool(
@@ -785,6 +790,10 @@ async fn mcp_surface_refreshes_and_renders_dynamic_guide() {
 }
 
 #[tokio::test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "This catalog coverage exercises summary and full table-function renderings in one session."
+)]
 async fn list_catalog_surfaces_table_functions() {
     let temp = TempDir::new().expect("temp dir");
     let manifest_path = write_function_fixture_manifest(temp.path());
@@ -821,17 +830,30 @@ async fn list_catalog_surfaces_table_functions() {
         catalog["items"][0]["sql_call_example"],
         "searchy.lookup_issue(number => '<value>')"
     );
-    assert_eq!(
-        catalog["items"][0]["table_function"]["arguments"][0]["name"],
-        "number"
-    );
-    assert_eq!(
-        catalog["items"][0]["table_function"]["result_columns"][0]["column_name"],
-        "title"
-    );
+    assert_eq!(catalog["items"][0]["arguments"][0]["name"], "number");
+    assert_eq!(catalog["items"][0]["result_column_count"], 1);
+    assert!(catalog["items"][0]["table_function"].is_null());
     assert_eq!(catalog["items"][1]["kind"], "table");
     assert_eq!(catalog["items"][1]["name"], "searchy.placeholder");
     assert_matches_output_schema(catalog_tool, &catalog);
+
+    let full_functions = client
+        .call_tool(
+            CallToolRequestParams::new("list_catalog").with_arguments(json_object(&json!({
+                "kind": "table_function",
+                "detail": "full",
+                "limit": 1
+            }))),
+        )
+        .await
+        .expect("list full table functions")
+        .structured_content
+        .expect("structured full functions");
+    assert_eq!(
+        full_functions["items"][0]["table_function"]["result_columns"][0]["column_name"],
+        "title"
+    );
+    assert_matches_output_schema(catalog_tool, &full_functions);
 
     let functions = client
         .call_tool(
@@ -870,6 +892,7 @@ async fn list_catalog_surfaces_table_functions() {
     assert_eq!(search["total"], 1);
     assert_eq!(search["items"][0]["kind"], "table_function");
     assert_eq!(search["items"][0]["name"], "searchy.search_issues");
+    assert_eq!(search["items"][0]["result_column_count"], 2);
     assert!(
         search["items"][0]["matched_fields"]
             .as_array()

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -15,8 +15,8 @@ Before setting up a client, make sure you have [connected at least one source](/
 | Type     | Name             | Description                                             |
 | -------- | ---------------- | ------------------------------------------------------- |
 | Tool     | `sql`            | Execute read-only SQL against the Coral database        |
-| Tool     | `list_catalog`   | List database tables and table functions with pagination |
-| Tool     | `search_catalog` | Search database catalog metadata with a Rust regex      |
+| Tool     | `list_catalog`   | List compact table and table-function summaries with pagination |
+| Tool     | `search_catalog` | Search compact catalog summaries with a Rust regex      |
 | Tool     | `describe_table` | Show compact metadata for one database table            |
 | Tool     | `list_columns`   | List columns for one database table with pagination     |
 | Resource | `coral://guide`  | Database workflow guide for agents                     |
@@ -28,21 +28,25 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 
 ### Discovery tools
 
-**`list_catalog`**: paginated list of database tables and parameterized table functions.
+**`list_catalog`**: paginated list of compact database table and parameterized table-function summaries.
 
-- Arguments: optional `schema`, `kind`, `limit`, `offset`. Omit `kind` (or pass `null`) to include both `"table"` and `"table_function"` items.
+- Arguments: optional `schema`, `kind`, `detail`, `limit`, `offset`. Omit `kind` (or pass `null`) to include both `"table"` and `"table_function"` items.
+- The default `detail: "summary"` omits bulky guides and table-function result-column lists. Use `detail: "full"` only with a narrow `schema`, `kind`, and `limit` when that metadata is required.
+- `limit` accepts `1` through `50`.
 - For tables, use `sql_reference` in `FROM` and `JOIN` clauses.
 - For table functions, use `sql_call_example` and fill in the required arguments.
 - Do not quote the whole `schema.item` string: write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 
 **`search_catalog`**: deterministic regex matching over database catalog metadata.
 
-- Arguments: required `pattern` plus optional `schema`, `kind`, `ignore_case`, `limit`, `offset`.
+- Arguments: required `pattern` plus optional `schema`, `kind`, `detail`, `ignore_case`, `limit`, `offset`.
+- The default `detail: "summary"` is intended for normal agent discovery. Use `detail: "full"` only for small result sets.
+- `limit` accepts `1` through `50`.
 
 **`describe_table`**: compact metadata for one table.
 
 - Arguments: exact `schema` and `table`.
-- Returns guide text, required filters, and a column count without dumping full columns.
+- Returns guide text, required filters, column count, and up to 50 compact column summaries. Use `list_columns` when you need regex filtering, `required_only`, or pagination over a wide table.
 
 **`list_columns`**: paginated columns for one table.
 

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -23,11 +23,11 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 ## Workflow
 
 1. Identify the needed source, entity, and scope from the user request.
-2. Discover tables and table functions with `list_catalog` or `search_catalog`; page large catalogs and narrow by schema or kind when useful.
-3. Read `list_catalog` or `search_catalog` for `sql_reference`, `sql_call_example`, and `required_filters`; use `coral://guide` for query patterns and `coral://tables` for table summaries.
-4. Inspect `coral.columns` for table columns, required filters, virtual columns, and descriptions.
-5. Inspect `coral.table_functions` for source-scoped function arguments and result columns.
-6. Inspect `coral.inputs` when source configuration affects the answer.
+2. Prefer `search_catalog` with a focused pattern, `schema`, and `kind` when the task names an entity; use `list_catalog` only for broad browsing. Both return compact summaries by default.
+3. Read summary results for `sql_reference`, `sql_call_example`, and `required_filters`; request `detail: "full"` only for a small catalog result set that needs guides or table-function result columns.
+4. For a candidate table, call `describe_table` first; it includes up to 50 compact column summaries. Call `list_columns` only for needed columns using `pattern`, `required_only`, and pagination.
+5. Query `coral.columns`, `coral.table_functions`, `coral.filters`, or `coral.inputs` only for deeper multi-table introspection, filter modes, source configuration, or full table-function JSON.
+6. Use `coral://guide` for query patterns and `coral://tables` for table summaries when tool discovery is not enough.
 7. Query with `sql`: select useful columns, include required filters or function arguments, and add `LIMIT` unless complete output is requested.
 8. Summarize evidence, gaps, and next action. If editing code, use the Coral result to guide changes.
 
@@ -35,7 +35,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 
 - Use each table's `sql_reference`; write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Use each table function's `sql_call_example`, filling in required arguments before querying it.
-- Keep metadata discovery bounded: page catalog discovery, query `coral.columns` for one table or `coral.table_functions` for one source when possible, and add `LIMIT` when reading broad metadata directly.
+- Keep metadata discovery bounded: prefer compact catalog summaries, focused `search_catalog` patterns, `describe_table`, and filtered `list_columns`; add `LIMIT` when reading broad metadata directly.
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.
 - Required filters must appear in `WHERE`; inspect `required_filters` and `is_required_filter`.
 - Secret inputs always return `value = NULL`; use `is_set`.


### PR DESCRIPTION
Reduce agent metadata-discovery cost by making list_catalog and search_catalog compact by default with explicit detail=full for bulky guides/result columns.

Also return bounded compact columns from describe_table so known-table discovery can avoid a follow-up list_columns call. Measured against the seed session class: old broad list_catalog(github, limit=200) was 194,056 bytes; new largest valid page is 26,216 bytes, and old describe_table+list_columns for github.pulls was 39,585 bytes versus 15,802 bytes for the compact describe_table path.

Verification: cargo fmt --check; make docs-check; git diff --check; cargo test -p coral-mcp -- --nocapture.