### PR TITLE
feat(sources/github): add review-requested PR shortcut

### DIFF
--- a/crates/coral-app/src/sources/catalog.rs
+++ b/crates/coral-app/src/sources/catalog.rs
@@ -122,7 +122,7 @@ mod tests {
 
     use std::collections::BTreeSet;
 
-    use coral_spec::ManifestInputKind;
+    use coral_spec::{ManifestInputKind, ValueSourceSpec, parse_source_manifest_yaml};
 
     use super::{describe_manifest, list_bundled_sources, load_bundled_source};
     use crate::sources::SourceName;
@@ -143,6 +143,43 @@ mod tests {
                 .any(|source| source.name == SourceName::parse("stripe").expect("source"))
         );
         assert!(sources.iter().all(|source| !source.version.is_empty()));
+    }
+
+    #[test]
+    fn github_review_requested_prs_function_uses_current_review_search() {
+        let source_name = SourceName::parse("github").expect("source");
+        let source = load_bundled_source(&source_name).expect("github bundled source");
+        let manifest =
+            parse_source_manifest_yaml(&source.manifest_yaml).expect("parse github manifest");
+        let http = manifest.as_http().expect("github is an HTTP source");
+        let function = http
+            .functions
+            .iter()
+            .find(|function| function.name == "review_requested_prs")
+            .expect("review-requested PR shortcut");
+
+        assert!(function.args.is_empty());
+        assert!(function.description.contains("notifications"));
+        assert!(
+            function
+                .columns
+                .iter()
+                .any(|column| column.name == "repository_full_name")
+        );
+
+        let q = function
+            .request
+            .query
+            .iter()
+            .find(|param| param.name == "q")
+            .expect("q query param");
+        let ValueSourceSpec::Literal { value } = &q.value else {
+            panic!("review_requested_prs q must be a literal");
+        };
+        assert_eq!(
+            value.as_str(),
+            Some("is:pr is:open review-requested:@me archived:false")
+        );
     }
 
     #[test]

--- a/sources/core/github/README.md
+++ b/sources/core/github/README.md
@@ -249,10 +249,14 @@ Remaining ~104 org tables require the PAT to be scoped to the organization with 
 | `search_code` | `github.search_code(q => 'className repo:owner/repo')` |
 | `search_commits` | `github.search_commits(q => 'fix repo:owner/repo')` |
 | `search_issues` | `github.search_issues(q => 'repo:owner/repo is:issue bug')` |
+| `review_requested_prs` | `github.review_requested_prs()` |
 
 Note: `search_commits` requires actual search text.
 Qualifier-only queries such as `q => 'repo:owner/repo'` return 422.
 `search_issues` requires `is:issue` or `is:pull-request` in the query.
+Use `review_requested_prs` for open pull requests currently waiting on the
+authenticated user's review. Do not use `notifications` as the source of truth
+for that workflow; notification inbox state can be stale.
 
 #### Requires GitHub App JWT (19 tables)
 

--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 1.1.6
+version: 1.1.7
 dsl_version: 3
 backend: http
 description: >-
@@ -247,7 +247,9 @@ functions:
         nullable: true
         expr: {kind: path, path: [score]}
   - name: search_issues
-    description: Search GitHub issues and pull requests.
+    description: >-
+      Search GitHub issues and pull requests. For current PRs waiting on the
+      authenticated user's review, prefer github.review_requested_prs().
     args:
       - name: q
         required: true
@@ -329,6 +331,88 @@ functions:
         type: Utf8
         nullable: true
         expr: {kind: path, path: [repository_url]}
+  - name: review_requested_prs
+    description: >-
+      Open pull requests currently requesting review from the authenticated user.
+      Wraps GitHub issue search review-requested:@me, including team review
+      requests; prefer this over notifications for current review queues because
+      notifications are inbox state and can be stale.
+    request:
+      method: GET
+      path: /search/issues
+      query:
+        - name: q
+          from: literal
+          value: "is:pr is:open review-requested:@me archived:false"
+        - name: sort
+          from: literal
+          value: updated
+        - name: order
+          from: literal
+          value: desc
+    response:
+      rows_path: [items]
+      allow_404_empty: false
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_size:
+        default: 30
+        max: 100
+        query_param: per_page
+      page_param: page
+      page_start: 1
+      page_step: 1
+      offset_start: 0
+      link_header_require_results: false
+    columns:
+      - name: repository_full_name
+        type: Utf8
+        nullable: true
+        description: >-
+          Repository owner/name for GitHub Cloud. For Enterprise Server, use
+          repository_url if your API base differs from https://api.github.com.
+        expr:
+          kind: replace
+          expr: {kind: path, path: [repository_url]}
+          from: "https://api.github.com/repos/"
+          to: ""
+      - name: number
+        type: Int64
+        nullable: true
+        expr: {kind: path, path: [number]}
+      - name: title
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [title]}
+      - name: author_login
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [user, login]}
+      - name: html_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [html_url]}
+      - name: state
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [state]}
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [updated_at]}
+      - name: created_at
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [created_at]}
+      - name: repository_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [repository_url]}
+      - name: pull_request_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [pull_request, url]}
   - name: search_labels
     description: Search GitHub labels in a repository.
     args:
@@ -58664,11 +58748,13 @@ tables:
           path:
             - url
   - name: notifications
-    description: List notifications for the authenticated user
+    description: List GitHub notification inbox entries for the authenticated user
     guide: >
       Use this table to review the authenticated user's notifications. Works without WHERE filters.
       Start with owner/repo or all before paging busy inboxes; unread state changes as GitHub
-      updates the inbox.
+      updates the inbox. Do not use this table as the source of truth for current pull requests
+      waiting on your review; notification inbox state can be stale. Use github.review_requested_prs()
+      for current review queues.
     filters:
       - name: all
         required: false


### PR DESCRIPTION
Add github.review_requested_prs(), a task-oriented table function for the repeated 'PRs waiting for my review' workflow. It wraps the trace-proven GitHub search qualifier is:pr is:open review-requested:@me archived:false, returns compact PR fields, and warns agents away from github.notifications for current review queues because notification inbox state can be stale.

Evidence: Codex session 019e6a48-f3eb-7512-96d1-f3e030798608 spent 28 Coral MCP calls and 270.8s on this task. Three notification SQL detours consumed about 63.5s and were discarded. A live tagged query through the new function returned 45 rows with one HTTP span in about 2.1s.

Verification: make lint-sources; cargo run --locked -p coral-cli -- source lint sources/core/github/manifest.yaml; make docs-check; cargo test -p coral-app sources::catalog::tests::github_review_requested_prs_function_uses_current_review_search -- --nocapture; make rust-checks; git diff --check.