### PR TITLE
feat(mcp): return sql result metadata

### DIFF
--- a/crates/coral-cli/tests/mcp.rs
+++ b/crates/coral-cli/tests/mcp.rs
@@ -803,6 +803,10 @@ async fn assert_sql_tool(
     )
     .await?;
     assert_eq!(sql["rows"][0]["text"], "hello");
+    assert_eq!(sql["row_count"], 2);
+    assert_eq!(sql["columns"][0]["name"], "text");
+    assert_eq!(sql["columns"][0]["data_type"], "Utf8");
+    assert_eq!(sql["columns"][0]["is_nullable"], false);
     Ok(())
 }
 

--- a/crates/coral-mcp/src/server.rs
+++ b/crates/coral-mcp/src/server.rs
@@ -52,8 +52,17 @@ enum ToolCallOutcome {
 }
 
 #[derive(Serialize)]
-struct SqlRowsValue {
+struct SqlResultValue {
     rows: Vec<Value>,
+    row_count: usize,
+    columns: Vec<SqlColumnValue>,
+}
+
+#[derive(Serialize)]
+struct SqlColumnValue {
+    name: String,
+    data_type: String,
+    is_nullable: bool,
 }
 
 #[derive(Serialize)]
@@ -193,7 +202,7 @@ impl CoralMcpServer {
         Ok((sources, tables, table_function_schema_names))
     }
 
-    async fn query_rows(&self, sql: &str) -> Result<Vec<Value>, tonic::Status> {
+    async fn execute_sql_value(&self, sql: &str) -> Result<Value, tonic::Status> {
         let mut query_client = self.query.clone();
         let response = query_client
             .execute_sql(Request::new(ExecuteSqlRequest {
@@ -204,13 +213,23 @@ impl CoralMcpServer {
             .into_inner();
         let result = decode_execute_sql_response(&response)
             .map_err(|error| tonic::Status::internal(error.to_string()))?;
-        batches_to_json_rows(result.batches())
-            .map_err(|error| tonic::Status::internal(error.to_string()))
-    }
-
-    async fn execute_sql_value(&self, sql: &str) -> Result<Value, tonic::Status> {
-        serialize_tool_value(SqlRowsValue {
-            rows: self.query_rows(sql).await?,
+        let columns = result
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| SqlColumnValue {
+                name: field.name().clone(),
+                data_type: field.data_type().to_string(),
+                is_nullable: field.is_nullable(),
+            })
+            .collect();
+        let row_count = result.row_count();
+        let rows = batches_to_json_rows(result.batches())
+            .map_err(|error| tonic::Status::internal(error.to_string()))?;
+        serialize_tool_value(SqlResultValue {
+            rows,
+            row_count,
+            columns,
         })
     }
 

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -73,6 +73,7 @@ pub(crate) fn sql_tool() -> Tool {
             }
         })),
     )
+    .with_raw_output_schema(sql_output_schema())
     .with_annotations(
         ToolAnnotations::with_title("Run SQL")
             .read_only(true)
@@ -488,6 +489,41 @@ fn sql_tool_description() -> &'static str {
 
 fn search_catalog_description() -> &'static str {
     "Search compact database catalog summaries for currently configured sources with a Rust regex. Use this before list_catalog when you know the entity or task; use detail='full' only for small result sets."
+}
+
+fn sql_output_schema() -> Arc<Map<String, Value>> {
+    json_object_schema(&json!({
+        "type": "object",
+        "required": ["rows", "row_count", "columns"],
+        "additionalProperties": false,
+        "properties": {
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "additionalProperties": true
+                }
+            },
+            "row_count": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of rows returned by this SQL statement."
+            },
+            "columns": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["name", "data_type", "is_nullable"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": { "type": "string" },
+                        "data_type": { "type": "string" },
+                        "is_nullable": { "type": "boolean" }
+                    }
+                }
+            }
+        }
+    }))
 }
 
 fn list_catalog_output_schema() -> Arc<Map<String, Value>> {

--- a/crates/coral-mcp/src/tests.rs
+++ b/crates/coral-mcp/src/tests.rs
@@ -1095,6 +1095,9 @@ async fn mcp_tool_error_does_not_end_session() {
 
     add_demo_source(&mut session.source_client, manifest_yaml).await;
 
+    let tools = client.list_all_tools().await.expect("tools");
+    let sql_tool = tool_by_name(&tools, "sql");
+
     let sql = client
         .call_tool(
             CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
@@ -1103,11 +1106,32 @@ async fn mcp_tool_error_does_not_end_session() {
         )
         .await
         .expect("sql");
-    assert_eq!(
-        sql.structured_content.expect("structured content")["rows"][0]["text"],
-        "hello"
-    );
+    let sql_content = sql.structured_content.expect("structured content");
+    assert_eq!(sql_content["rows"][0]["text"], "hello");
+    assert_eq!(sql_content["row_count"], 2);
+    assert_eq!(sql_content["columns"][0]["name"], "text");
+    assert_eq!(sql_content["columns"][0]["data_type"], "Utf8");
+    assert_eq!(sql_content["columns"][0]["is_nullable"], true);
+    assert_matches_output_schema(sql_tool, &sql_content);
     assert_eq!(sql.is_error, Some(false));
+
+    let empty_sql = client
+        .call_tool(
+            CallToolRequestParams::new("sql").with_arguments(json_object(&json!({
+                "sql": "SELECT text FROM local_messages.messages WHERE text = 'missing'"
+            }))),
+        )
+        .await
+        .expect("empty sql");
+    let empty_sql_content = empty_sql
+        .structured_content
+        .expect("empty structured content");
+    assert_eq!(empty_sql_content["rows"].as_array().expect("rows").len(), 0);
+    assert_eq!(empty_sql_content["row_count"], 0);
+    assert_eq!(empty_sql_content["columns"][0]["name"], "text");
+    assert_eq!(empty_sql_content["columns"][0]["data_type"], "Utf8");
+    assert_eq!(empty_sql_content["columns"][0]["is_nullable"], true);
+    assert_matches_output_schema(sql_tool, &empty_sql_content);
 
     let invalid_sql = client
         .call_tool(

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -27,6 +27,8 @@ Clients see the same database catalog and query results as `coral sql`. You set 
 
 MCP tool and resource listings are static capability metadata. They do not count or load the current source catalog; use `list_catalog`, `search_catalog`, `coral://guide`, `coral://tables`, or the `coral.*` metadata tables when the agent needs live catalog state.
 
+Successful `sql` calls return structured content with `rows`, `row_count`, and `columns`. `row_count` is the number of rows returned by that SQL statement, so a limited query reports the returned rows rather than the total rows available beyond the `LIMIT`. `columns` contains the returned Arrow field names, data types, and nullability, including for empty result sets.
+
 Agents should treat the discovery tools as catalog helpers, not as replacement provider APIs. For data questions, prefer a single `sql` call using `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over multiple tool calls that fetch rows and combine them in the agent.
 
 ### Discovery tools

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -209,6 +209,8 @@ This command is intended to be launched by an MCP-capable client rather than use
 
 The MCP `tools/list` and `resources/list` responses are static capability metadata. Live source and catalog state is loaded only when a client calls a catalog tool, reads `coral://guide` or `coral://tables`, or queries the `coral.*` metadata tables.
 
+Successful MCP `sql` tool calls return structured content with `rows`, `row_count`, and `columns`. `row_count` is the number of rows returned by that SQL statement, not a total beyond a `LIMIT`; `columns` reports the returned Arrow field names, data types, and nullability.
+
 This server exposes:
 
 | Type     | Name             | Description                      |

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -36,6 +36,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 
 - Use each table's `sql_reference`; write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Use each table function's `sql_call_example`, filling in required arguments before querying it.
+- Use the `sql` result's `row_count` and `columns` before issuing extra count or schema-discovery calls. Treat `row_count` as rows returned by the statement, not total rows beyond a `LIMIT`.
 - Keep metadata discovery bounded: prefer compact catalog summaries, focused `search_catalog` patterns, `search_columns` for cross-table field discovery, `describe_table`, and filtered `list_columns`; add `LIMIT` when reading broad metadata directly.
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.
 - Required filters must appear in `WHERE`; inspect `required_filters` and `is_required_filter`.


### PR DESCRIPTION
## Summary
- Expose `row_count` and returned Arrow `columns` in MCP `sql` structured content instead of returning only `rows`.
- Advertise the new `sql` output schema so MCP clients can validate the contract.
- Update MCP docs and the maintained Coral skill so agents use the returned metadata before issuing extra count or schema probes.

## Rationale and measured impact
Coral already computes and transports this metadata: `ExecuteSqlResponse` carries `row_count`, and `coral-client` decodes and validates the Arrow schema plus row count. The MCP adapter was throwing that away.

Trace evidence:
- Seed session `019e69d3-2442-79d0-92cf-70952982b53a` issued a list query followed by count probes; ClickHouse showed the original list query already had `row_count=42`.
- Follow-up bad session `019e6a48-f3eb-7512-96d1-f3e030798608` had 12 SQL calls, including a review-request list query followed by a matching `COUNT(*)`; telemetry recorded `row_count=44` for the list query.
- Recent OTEL sample: 35 `execute_sql` spans in the last day, 34 with `row_count`, 14 count queries, and 19 limited queries.

Expected reduction: future agents can avoid the extra under-limit `COUNT(*)`/row-presence probes when the original SQL result already returned the needed row count. This does not remove legitimate total-count queries when an initial query hits a `LIMIT`; docs call that out explicitly.

## Verification
- `cargo test -p coral-mcp mcp_tool_error_does_not_end_session -- --nocapture`
- `cargo test -p coral-cli --all-features --test mcp mcp_stdio_sql_and_catalog_tools_return_structured_content -- --nocapture`
- `cargo test -p coral-cli --all-features --test mcp mcp_stdio_raw_tools_list_advertises_client_compatible_schemas -- --nocapture`
- Fresh MCP replay trace `ff8c477f4892ab21097f45ab7be969f6`: `SELECT 1 AS one` returned `rows`, `row_count=1`, and `columns=[{name: one, data_type: Int64, is_nullable: false}]`; ClickHouse recorded `coral.query operation=execute_sql row_count=1`.
- `cargo fmt --check`
- `git diff --check`
- `make docs-check`
- `make rust-checks` (`849` nextest tests passed; rustdoc passed with warnings denied)
