### PR TITLE
fix(catalog): rank search results by relevance

### DIFF
--- a/crates/coral-app/src/catalog/discovery.rs
+++ b/crates/coral-app/src/catalog/discovery.rs
@@ -223,7 +223,7 @@ impl CatalogDiscovery {
         pagination: Pagination,
     ) -> Result<Page<CatalogSearchResult>, QueryManagerError> {
         let regex = compile_metadata_regex(pattern, ignore_case).map_err(QueryManagerError::App)?;
-        let matches = self
+        let mut matches = self
             .catalog_items(workspace_name, schema_name, kind)
             .await?
             .into_iter()
@@ -234,7 +234,8 @@ impl CatalogDiscovery {
                     matched_fields,
                 })
             })
-            .collect();
+            .collect::<Vec<_>>();
+        sort_catalog_search_results(&mut matches, &regex);
         Ok(page_items(matches, pagination))
     }
 
@@ -379,6 +380,62 @@ fn catalog_item_sort_key(item: &CatalogItem) -> (&str, &str, &'static str) {
             &function.function_name,
             "table_function",
         ),
+    }
+}
+
+fn sort_catalog_search_results(matches: &mut [CatalogSearchResult], regex: &Regex) {
+    matches.sort_by(|left, right| {
+        catalog_search_relevance(right, regex)
+            .cmp(&catalog_search_relevance(left, regex))
+            .then_with(|| {
+                catalog_item_sort_key(&left.item).cmp(&catalog_item_sort_key(&right.item))
+            })
+    });
+}
+
+fn catalog_search_relevance(result: &CatalogSearchResult, regex: &Regex) -> (usize, u16, u16) {
+    let best_identifier_match_len = regex
+        .find_iter(catalog_item_bare_name(&result.item))
+        .map(|matched| matched.len())
+        .max()
+        .unwrap_or_default();
+    let best_field_weight = result
+        .matched_fields
+        .iter()
+        .copied()
+        .map(catalog_field_weight)
+        .max()
+        .unwrap_or_default();
+    let total_field_weight = result
+        .matched_fields
+        .iter()
+        .copied()
+        .map(catalog_field_weight)
+        .sum();
+    (
+        best_identifier_match_len,
+        best_field_weight,
+        total_field_weight,
+    )
+}
+
+fn catalog_item_bare_name(item: &CatalogItem) -> &str {
+    match item {
+        CatalogItem::Table(table) => &table.table_name,
+        CatalogItem::TableFunction(function) => &function.function_name,
+    }
+}
+
+fn catalog_field_weight(field: CatalogMetadataField) -> u16 {
+    match field {
+        CatalogMetadataField::TableName | CatalogMetadataField::FunctionName => 100,
+        CatalogMetadataField::Name => 90,
+        CatalogMetadataField::SchemaName => 60,
+        CatalogMetadataField::RequiredFilters
+        | CatalogMetadataField::Arguments
+        | CatalogMetadataField::ResultColumns => 45,
+        CatalogMetadataField::Description => 25,
+        CatalogMetadataField::Guide => 10,
     }
 }
 
@@ -611,7 +668,10 @@ pub(crate) fn page_items<T>(items: Vec<T>, pagination: Pagination) -> Page<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{CatalogMetadataField, compile_metadata_regex, table_matched_fields};
+    use super::{
+        CatalogItem, CatalogMetadataField, CatalogSearchResult, compile_metadata_regex,
+        sort_catalog_search_results, table_matched_fields,
+    };
     use coral_engine::TableInfo;
 
     fn table(required_filters: Vec<String>) -> TableInfo {
@@ -625,6 +685,33 @@ mod tests {
         }
     }
 
+    fn table_result(
+        schema_name: &str,
+        table_name: &str,
+        matched_fields: Vec<CatalogMetadataField>,
+    ) -> CatalogSearchResult {
+        CatalogSearchResult {
+            item: CatalogItem::Table(TableInfo {
+                schema_name: schema_name.to_string(),
+                table_name: table_name.to_string(),
+                description: String::new(),
+                guide: String::new(),
+                columns: Vec::new(),
+                required_filters: Vec::new(),
+            }),
+            matched_fields,
+        }
+    }
+
+    fn result_name(result: &CatalogSearchResult) -> String {
+        match &result.item {
+            CatalogItem::Table(table) => format!("{}.{}", table.schema_name, table.table_name),
+            CatalogItem::TableFunction(function) => {
+                format!("{}.{}", function.schema_name, function.function_name)
+            }
+        }
+    }
+
     #[test]
     fn required_filters_match_each_filter_independently() {
         let summary = table(vec!["owner".to_string(), "repo".to_string()]);
@@ -635,6 +722,57 @@ mod tests {
         );
         assert!(
             table_matched_fields(&summary, &regex::Regex::new("r.r").expect("regex")).is_empty()
+        );
+    }
+
+    #[test]
+    fn catalog_search_ranks_identifier_matches_before_weak_metadata_matches() {
+        let mut results = vec![
+            table_result("datadog", "dashboards", vec![CatalogMetadataField::Guide]),
+            table_result("github", "zebra", vec![CatalogMetadataField::SchemaName]),
+            table_result(
+                "github",
+                "enterprise_teams",
+                vec![
+                    CatalogMetadataField::SchemaName,
+                    CatalogMetadataField::TableName,
+                    CatalogMetadataField::Name,
+                    CatalogMetadataField::Description,
+                    CatalogMetadataField::Guide,
+                    CatalogMetadataField::RequiredFilters,
+                ],
+            ),
+            table_result(
+                "github",
+                "pulls",
+                vec![
+                    CatalogMetadataField::SchemaName,
+                    CatalogMetadataField::TableName,
+                    CatalogMetadataField::Name,
+                ],
+            ),
+            table_result("github", "attempts", vec![CatalogMetadataField::Guide]),
+            table_result(
+                "jira",
+                "pulls",
+                vec![CatalogMetadataField::TableName, CatalogMetadataField::Name],
+            ),
+        ];
+
+        let regex = regex::Regex::new("github|pull|review|pr").expect("regex");
+        sort_catalog_search_results(&mut results, &regex);
+
+        let names = results.iter().map(result_name).collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "github.pulls",
+                "jira.pulls",
+                "github.enterprise_teams",
+                "github.zebra",
+                "datadog.dashboards",
+                "github.attempts",
+            ]
         );
     }
 

--- a/crates/coral-mcp/src/surface/tools.rs
+++ b/crates/coral-mcp/src/surface/tools.rs
@@ -488,7 +488,7 @@ fn sql_tool_description() -> &'static str {
 }
 
 fn search_catalog_description() -> &'static str {
-    "Search compact database catalog summaries for currently configured sources with a Rust regex. Use this before list_catalog when you know the entity or task; use detail='full' only for small result sets."
+    "Search compact database catalog summaries for currently configured sources with a Rust regex. Strong identifier matches are ranked first. Use this before list_catalog when you know the entity or task; use detail='full' only for small result sets."
 }
 
 fn sql_output_schema() -> Arc<Map<String, Value>> {

--- a/docs/guides/use-coral-over-mcp.mdx
+++ b/docs/guides/use-coral-over-mcp.mdx
@@ -45,6 +45,7 @@ Agents should treat the discovery tools as catalog helpers, not as replacement p
 **`search_catalog`**: deterministic regex matching over database catalog metadata.
 
 - Arguments: required `pattern` plus optional `schema`, `kind`, `detail`, `ignore_case`, `limit`, `offset`.
+- Results are ranked before pagination. Matches on exact catalog identifiers such as table or function names appear ahead of weaker prose matches in descriptions, guides, arguments, or result columns.
 - The default `detail: "summary"` is intended for normal agent discovery. Use `detail: "full"` only for small result sets.
 - `limit` accepts `1` through `50`.
 

--- a/docs/reference/cli-reference.mdx
+++ b/docs/reference/cli-reference.mdx
@@ -224,6 +224,8 @@ This server exposes:
 | Resource | `coral://guide`  | Database workflow guide for agents |
 | Resource | `coral://tables` | Database table summaries         |
 
+`search_catalog` ranks strong identifier matches before weaker prose matches before applying pagination, so exact table and function name hits appear ahead of description or guide-only matches.
+
 ## `coral completion <SHELL>`
 
 Generate a shell completion script and write it to standard output. Supported shells are `bash`, `zsh`, `fish`, `elvish`, and `powershell`.

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -37,7 +37,7 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 - Use each table's `sql_reference`; write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Use each table function's `sql_call_example`, filling in required arguments before querying it.
 - Use the `sql` result's `row_count` and `columns` before issuing extra count or schema-discovery calls. Treat `row_count` as rows returned by the statement, not total rows beyond a `LIMIT`.
-- Keep metadata discovery bounded: prefer compact catalog summaries, focused `search_catalog` patterns, `search_columns` for cross-table field discovery, `describe_table`, and filtered `list_columns`; add `LIMIT` when reading broad metadata directly.
+- Keep metadata discovery bounded: prefer compact catalog summaries, focused `search_catalog` patterns, `search_columns` for cross-table field discovery, `describe_table`, and filtered `list_columns`; `search_catalog` ranks strong identifier matches first, so inspect early hits before broadening the search. Add `LIMIT` when reading broad metadata directly.
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.
 - Required filters must appear in `WHERE`; inspect `required_filters` and `is_required_filter`.
 - Secret inputs always return `value = NULL`; use `is_set`.


### PR DESCRIPTION
## Summary
- Rank `search_catalog` results before pagination using generic catalog relevance signals.
- Prefer longer bare table/function identifier matches, then stronger matched metadata fields, then stable lexical ordering.
- Update the MCP tool description, docs, and maintained Coral skill so agents know early search results are relevance-ranked.

## Rationale
The bad session `019e6a48-f3eb-7512-96d1-f3e030798608` searched `pattern="github|pull|review|pr"` with no schema. The first page returned `codex.events` and Datadog entries that matched weak prose fields like `guide`, `arguments`, or `result_columns`, even though the user task was clearly about GitHub pull/review data.

The same session later searched `schema="github"` for `pulls|pull_request|review_requests|requested_reviewers|reviews|requested`. The first result was `github.attempts` from a weak guide match, ahead of name matches such as `github.pulls`, `github.pulls_list_review_comments`, and `github.requested_reviewers`. That is a Coral affordance failure: the app filtered the catalog and then returned lexical order instead of ranking high-signal targets first.

## Expected improvement
This should remove at least 1-2 repeated catalog-discovery calls for broad task/entity searches by putting plausible table/function targets on the first page. It is intentionally generic: no GitHub-specific shortcut, no provider-specific source logic, and no prompt-only fix.

Fresh replay on current code with the bad broad pattern returned GitHub pull/review identifier matches first: `github.pulls_list_review_comments`, `github.repo_pull_review_comments`, `github.requested_reviewers`, `github.reviews`, and `github.github_owned`. The old session returned Codex/Datadog weak matches first.

Fresh replay of the schema-scoped bad pattern now starts with `github.requested_reviewers`, `github.required_pull_request_reviews`, `github.reviews`, `github.pulls`, and `github.pulls_list_review_comments`; the old session started with `github.attempts` from a guide-only hit.

Replay trace: `a178b7b7ceaa48f640c19356c1dbe9bc`.

## Verification
- `cargo test -p coral-app catalog::discovery::tests::catalog_search_ranks_identifier_matches_before_weak_metadata_matches -- --nocapture`
- `cargo test -p coral-app --test grpc search_catalog_matches_metadata_and_paginates_after_filtering -- --nocapture`
- `cargo test -p coral-mcp list_catalog_surfaces_table_functions -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `make docs-check`
- `make rust-checks` (nextest: 850 tests passed; rustdoc passed with warnings denied)