### PR TITLE
feat(sources/community): add World Bank Open Data source

### DIFF
--- a/sources/community/world_bank/README.md
+++ b/sources/community/world_bank/README.md
@@ -33,20 +33,45 @@ ORDER BY date DESC
 LIMIT 10
 ```
 
-### Compare poverty rates — most recent value per country
+### GDP for a specific year or year range
+
+```sql
+-- Single year (server-side filter — does not over-fetch)
+SELECT country_name, date, value AS gdp_usd
+FROM world_bank.data
+WHERE country = 'all' AND indicator = 'NY.GDP.MKTP.CD' AND date = '2023'
+  AND value IS NOT NULL
+ORDER BY value DESC
+LIMIT 20
+
+-- Year range
+SELECT date, value AS gdp_usd
+FROM world_bank.data
+WHERE country = 'US' AND indicator = 'NY.GDP.MKTP.CD' AND date = '2010:2023'
+ORDER BY date DESC
+```
+
+> Use the `date` filter to push the year predicate to the API. Without it,
+> a `WHERE date = '2023'` clause in SQL applies **after** the fetch, so
+> paginated requests may silently miss rows. Supported formats: `'2024'`
+> (single year) and `'2010:2020'` (inclusive range).
+
+### Compare poverty rates — latest non-null value per country
 
 ```sql
 SELECT country_name, date, value AS poverty_rate_pct
 FROM world_bank.data
 WHERE country = 'all' AND indicator = 'SI.POV.DDAY'
-  AND mrv = '1' AND value IS NOT NULL
+  AND mrnev = '1' AND value IS NOT NULL
 ORDER BY value DESC
 LIMIT 20
 ```
 
-> **`mrv = '1'`** (Most Recent Value) returns one row per country/region with
-> its latest published value — ideal for cross-country comparisons. Without it,
-> data for all years is returned interleaved per country.
+> **`mrnev = '1'`** (Most Recent Non-Empty Value) returns one row per
+> country/region with its latest **non-null** observation — essential for
+> sparse indicators like poverty rates where recent periods often have no
+> published data. Use `mrv = '1'` instead when you want the most recent
+> period regardless of whether data is null.
 
 ### Countries by income level
 
@@ -95,7 +120,7 @@ LIMIT 20
 SELECT country_name, date, value AS renewable_pct
 FROM world_bank.data
 WHERE country = 'all' AND indicator = 'EG.FEC.RNEW.ZS'
-  AND mrv = '1' AND value IS NOT NULL
+  AND mrnev = '1' AND value IS NOT NULL
 ORDER BY value DESC
 LIMIT 15
 ```
@@ -106,7 +131,7 @@ LIMIT 15
 SELECT country_name, date, value AS unemployment_pct
 FROM world_bank.data
 WHERE country = 'all' AND indicator = 'SL.UEM.TOTL.ZS'
-  AND mrv = '1' AND value IS NOT NULL
+  AND mrnev = '1' AND value IS NOT NULL
 ORDER BY value DESC
 LIMIT 10
 ```
@@ -120,7 +145,7 @@ LIMIT 10
 | `SP.POP.TOTL` | Population, total |
 | `FP.CPI.TOTL.ZG` | Inflation, consumer prices (annual %) |
 | `SL.UEM.TOTL.ZS` | Unemployment, total (% of labor force) |
-| `SI.POV.DDAY` | Poverty headcount ratio at $2.15/day (2017 PPP) % |
+| `SI.POV.DDAY` | Poverty headcount ratio at $3.00/day (2021 PPP) % |
 | `EN.ATM.CO2E.PC` | CO2 emissions (metric tons per capita) |
 | `EG.FEC.RNEW.ZS` | Renewable energy consumption (% of total final energy) |
 | `SH.DYN.MORT` | Mortality rate, under-5 (per 1,000 live births) |
@@ -141,10 +166,11 @@ Use `world_bank.countries` to look up codes for any country or region.
 
 ## Data Notes
 
-- **Annual data only:** The `date` column is a year string (e.g. `'2024'`), not a timestamp.
+- **Annual data only:** The `date` column is a year string (e.g. `'2024'`), not a timestamp. Use `WHERE date = '2024'` or `WHERE date = '2010:2020'` to push year filtering to the API — a SQL predicate on `date` without this filter applies after fetching and may silently miss rows when results are paginated.
+- **`mrv` vs `mrnev`:** `mrv = '1'` returns the most recent period per country (may be null). `mrnev = '1'` returns the most recent **non-null** period per country. For sparse indicators (poverty rates, hospital beds, etc.), prefer `mrnev`.
 - **Null values:** Many country/year combinations have no published data — always filter `WHERE value IS NOT NULL` unless you want to see coverage gaps.
 - **Aggregate regions:** Entries like `EAS` (East Asia & Pacific) or `SSA` (Sub-Saharan Africa) are valid country codes and return regional aggregates.
-- **Data freshness:** Varies by indicator. The `lastupdated` field in API metadata reflects the last database refresh. Most WDI indicators are updated annually.
+- **Data freshness:** Varies by indicator. Most WDI indicators are updated annually.
 
 ## Validation
 

--- a/sources/community/world_bank/README.md
+++ b/sources/community/world_bank/README.md
@@ -1,0 +1,162 @@
+# World Bank Open Data
+
+Query macroeconomic and development indicators from the [World Bank Open Data API](https://datahelpdesk.worldbank.org/knowledgebase/articles/889392-about-the-indicators-api-documentation). No authentication required.
+
+**Coverage:** 29,500+ time-series indicators across 200+ countries and regions, with annual observations typically from 1960 to the most recently published year.
+
+## Tables
+
+| Table | Description |
+|---|---|
+| `world_bank.data` | **Core query table.** Annual indicator values for a country/region and indicator code |
+| `world_bank.indicators` | Full catalog of 29,500+ indicator codes with names and source metadata |
+| `world_bank.topic_indicators` | Indicators filtered by thematic topic — for discovering codes by domain |
+| `world_bank.countries` | Country/region metadata: ISO codes, geographic region, income level, capital city |
+| `world_bank.topics` | The 21 thematic topic groups used to organize indicators |
+
+## Install
+
+```
+coral source add sources/community/world_bank/manifest.yaml
+```
+
+## Example Queries
+
+### GDP over time
+
+```sql
+SELECT date, value AS gdp_usd
+FROM world_bank.data
+WHERE country = 'US' AND indicator = 'NY.GDP.MKTP.CD'
+  AND value IS NOT NULL
+ORDER BY date DESC
+LIMIT 10
+```
+
+### Compare poverty rates — most recent value per country
+
+```sql
+SELECT country_name, date, value AS poverty_rate_pct
+FROM world_bank.data
+WHERE country = 'all' AND indicator = 'SI.POV.DDAY'
+  AND mrv = '1' AND value IS NOT NULL
+ORDER BY value DESC
+LIMIT 20
+```
+
+> **`mrv = '1'`** (Most Recent Value) returns one row per country/region with
+> its latest published value — ideal for cross-country comparisons. Without it,
+> data for all years is returned interleaved per country.
+
+### Countries by income level
+
+```sql
+SELECT id, name, region, income_level, capital_city
+FROM world_bank.countries
+WHERE income_level = 'Low income'
+ORDER BY name
+```
+
+### Discover CO2-related indicators by topic
+
+```sql
+-- Step 1: find the Environment topic id
+SELECT id, topic FROM world_bank.topics WHERE topic LIKE '%Environment%'
+-- Returns: id=6, topic=Environment
+
+-- Step 2: browse environment indicators
+SELECT id, name FROM world_bank.topic_indicators WHERE topic = '6' LIMIT 20
+```
+
+> The API does not support server-side text search on indicators. Use
+> `world_bank.topic_indicators` to browse by theme, or fetch with a high
+> `LIMIT` and filter client-side:
+> ```sql
+> SELECT id, name FROM world_bank.indicators LIMIT 500
+> -- then filter results in your SQL client
+> ```
+
+### Browse health indicators by topic
+
+```sql
+-- Step 1: find topic IDs
+SELECT id, topic FROM world_bank.topics
+
+-- Step 2: list health indicators (topic 8)
+SELECT id, name
+FROM world_bank.topic_indicators
+WHERE topic = '8'
+LIMIT 20
+```
+
+### Renewable energy adoption — top countries (most recent)
+
+```sql
+SELECT country_name, date, value AS renewable_pct
+FROM world_bank.data
+WHERE country = 'all' AND indicator = 'EG.FEC.RNEW.ZS'
+  AND mrv = '1' AND value IS NOT NULL
+ORDER BY value DESC
+LIMIT 15
+```
+
+### Unemployment rate — latest per country
+
+```sql
+SELECT country_name, date, value AS unemployment_pct
+FROM world_bank.data
+WHERE country = 'all' AND indicator = 'SL.UEM.TOTL.ZS'
+  AND mrv = '1' AND value IS NOT NULL
+ORDER BY value DESC
+LIMIT 10
+```
+
+## Commonly Used Indicator Codes
+
+| Code | Indicator |
+|---|---|
+| `NY.GDP.MKTP.CD` | GDP (current US$) |
+| `NY.GNP.PCAP.CD` | GNI per capita (current US$) |
+| `SP.POP.TOTL` | Population, total |
+| `FP.CPI.TOTL.ZG` | Inflation, consumer prices (annual %) |
+| `SL.UEM.TOTL.ZS` | Unemployment, total (% of labor force) |
+| `SI.POV.DDAY` | Poverty headcount ratio at $2.15/day (2017 PPP) % |
+| `EN.ATM.CO2E.PC` | CO2 emissions (metric tons per capita) |
+| `EG.FEC.RNEW.ZS` | Renewable energy consumption (% of total final energy) |
+| `SH.DYN.MORT` | Mortality rate, under-5 (per 1,000 live births) |
+| `SE.PRM.ENRR` | School enrollment, primary (% gross) |
+| `SH.MED.BEDS.ZS` | Hospital beds (per 1,000 people) |
+| `IT.NET.USER.ZS` | Individuals using the Internet (% of population) |
+
+Use `world_bank.indicators` or `world_bank.topic_indicators` to discover more codes.
+
+## Country Codes
+
+The `country` filter in `world_bank.data` accepts:
+- **ISO2 codes** (2-letter): `US`, `IN`, `CN`, `GB`, `DE`
+- **ISO3 codes** (3-letter): `USA`, `IND`, `CHN`, `GBR`, `DEU`
+- **`all`** — returns data for all countries in one result set (large)
+
+Use `world_bank.countries` to look up codes for any country or region.
+
+## Data Notes
+
+- **Annual data only:** The `date` column is a year string (e.g. `'2024'`), not a timestamp.
+- **Null values:** Many country/year combinations have no published data — always filter `WHERE value IS NOT NULL` unless you want to see coverage gaps.
+- **Aggregate regions:** Entries like `EAS` (East Asia & Pacific) or `SSA` (Sub-Saharan Africa) are valid country codes and return regional aggregates.
+- **Data freshness:** Varies by indicator. The `lastupdated` field in API metadata reflects the last database refresh. Most WDI indicators are updated annually.
+
+## Validation
+
+- `coral source lint`: ✅ passed
+- `coral source add`: ✅ connected, 5 tables, 5/5 test queries passed
+- Live queries verified:
+  - `world_bank.data` — US GDP (NY.GDP.MKTP.CD): annual data returned, nested `indicator.id` and `country.value` fields resolved correctly
+  - `world_bank.data` — India population (SP.POP.TOTL): 2025 null (not yet published), 2024 = 1,450,935,791 ✅
+  - `world_bank.data` — `country = 'all'`, `mrv = '1'`: one row per country, top result is World aggregate ✅
+  - `world_bank.indicators` — pagination working, 29,511 total indicators
+  - `world_bank.countries` — 296 countries and regions in single request, nested `region.value` and `incomeLevel.value` resolved correctly ✅
+  - `world_bank.topics` — all 21 topics with full `sourceNote` text returned ✅
+  - `world_bank.topic_indicators` — topic `3` (Economy & Growth): 306 indicators ✅
+  - Invalid country code: returns empty rows via `null` data array handling (no error) ✅
+  - `rows_path: ["1"]` navigates numeric index in root array — confirmed working ✅

--- a/sources/community/world_bank/README.md
+++ b/sources/community/world_bank/README.md
@@ -17,7 +17,7 @@ Query macroeconomic and development indicators from the [World Bank Open Data AP
 ## Install
 
 ```
-coral source add sources/community/world_bank/manifest.yaml
+coral source add --file sources/community/world_bank/manifest.yaml
 ```
 
 ## Example Queries

--- a/sources/community/world_bank/manifest.yaml
+++ b/sources/community/world_bank/manifest.yaml
@@ -11,7 +11,7 @@ base_url: https://api.worldbank.org/v2
 
 test_queries:
   - SELECT indicator_id, indicator_name, date, value FROM world_bank.data WHERE country = 'US' AND indicator = 'NY.GDP.MKTP.CD' LIMIT 5
-  - SELECT country_name, date, value FROM world_bank.data WHERE country = 'all' AND indicator = 'NY.GDP.MKTP.CD' AND mrv = '1' LIMIT 5
+  - SELECT country_name, date, value FROM world_bank.data WHERE country = 'all' AND indicator = 'SI.POV.DDAY' AND mrnev = '1' AND value IS NOT NULL LIMIT 10
   - SELECT id, name, region, income_level FROM world_bank.countries LIMIT 5
   - SELECT id, topic FROM world_bank.topics
   - SELECT id, name FROM world_bank.topic_indicators WHERE topic = '3' LIMIT 5
@@ -40,20 +40,28 @@ tables:
         country = 'US' or 'USA'     → United States
         country = 'IN' or 'IND'     → India
         country = 'all'             → all countries (returns data for each
-                                       country across all years; use mrv = 1
-                                       to get only the most recent value per
-                                       country for cross-country comparisons)
+                                       country across all years)
 
-      Use mrv (Most Recent Value) for cross-country snapshots:
-        WHERE country = 'all' AND indicator = 'NY.GDP.MKTP.CD' AND mrv = 1
-        returns one row per country with its most recently published value,
-        ordered by country. Without mrv, data for all years is returned
-        interleaved per country.
+      Filter by a single year or year range (pushed to the API):
+        WHERE date = '2024'           → single year only
+        WHERE date = '2010:2020'      → inclusive year range
+
+      Use mrnev for cross-country snapshots (latest non-empty value):
+        WHERE country = 'all' AND indicator = 'SI.POV.DDAY' AND mrnev = '1'
+        returns one row per country with its latest non-null observation.
+        Prefer mrnev for sparse indicators (poverty rates, hospital beds,
+        etc.) where recent periods may have no published data.
+
+      Use mrv for the N most recently published periods (may include nulls):
+        WHERE country = 'all' AND indicator = 'NY.GDP.MKTP.CD' AND mrv = '1'
+        returns one row per country for the most recent period regardless of
+        whether value is null. Without mrv or mrnev, data for all years is
+        returned interleaved per country.
 
       Commonly used indicators:
         NY.GDP.MKTP.CD    GDP (current US$)
         SP.POP.TOTL       Population total
-        SI.POV.DDAY       Poverty headcount ratio at $2.15/day (2017 PPP) %
+        SI.POV.DDAY       Poverty headcount ratio at $3.00/day (2021 PPP) %
         EN.ATM.CO2E.PC    CO2 emissions (metric tons per capita)
         SH.DYN.MORT       Mortality rate, under-5 (per 1,000 live births)
         SE.PRM.ENRR       School enrollment, primary (% gross)
@@ -72,7 +80,9 @@ tables:
         required: true
       - name: indicator
         required: true
+      - name: date
       - name: mrv
+      - name: mrnev
     request:
       method: GET
       path: /country/{{filter.country}}/indicator/{{filter.indicator}}
@@ -80,9 +90,15 @@ tables:
         - name: format
           from: literal
           value: json
+        - name: date
+          from: filter
+          key: date
         - name: mrv
           from: filter
           key: mrv
+        - name: mrnev
+          from: filter
+          key: mrnev
     response:
       rows_path:
         - "1"
@@ -192,13 +208,28 @@ tables:
         type: Utf8
         nullable: true
         description: >-
-          Echoes the mrv (Most Recent Value) filter. When set to '1', the API
-          returns only the single most recently published value per country,
-          making cross-country comparisons possible without fetching all years.
+          Echoes the mrv (Most Recent Value periods) filter. When set to '1',
+          the API returns one row per country for the most recently published
+          period — which may have a null value for sparse indicators. For
+          latest non-null observations use mrnev instead.
           Pass as a quoted string: WHERE mrv = '1'.
         expr:
           kind: from_filter
           key: mrv
+
+      - name: mrnev
+        type: Utf8
+        nullable: true
+        description: >-
+          Echoes the mrnev (Most Recent Non-Empty Values) filter. When set to
+          '1', the API returns one row per country with its latest non-null
+          observation, skipping periods with no published data. Preferred over
+          mrv for sparse indicators such as poverty rates, hospital beds, or
+          any indicator updated less than annually. Pass as a quoted string:
+          WHERE mrnev = '1'.
+        expr:
+          kind: from_filter
+          key: mrnev
 
   # ──────────────────────────────────────────────────────────────────────
   # world_bank.indicators — full catalog of 29,500+ indicator codes

--- a/sources/community/world_bank/manifest.yaml
+++ b/sources/community/world_bank/manifest.yaml
@@ -1,0 +1,638 @@
+name: world_bank
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query macroeconomic and development indicators from the World Bank Open Data
+  API. Covers 29,500+ time-series indicators — GDP, population, poverty rates,
+  CO2 emissions, school enrollment, life expectancy, inflation, and more —
+  across 200+ countries and regions. No authentication required.
+base_url: https://api.worldbank.org/v2
+
+test_queries:
+  - SELECT indicator_id, indicator_name, date, value FROM world_bank.data WHERE country = 'US' AND indicator = 'NY.GDP.MKTP.CD' LIMIT 5
+  - SELECT country_name, date, value FROM world_bank.data WHERE country = 'all' AND indicator = 'NY.GDP.MKTP.CD' AND mrv = '1' LIMIT 5
+  - SELECT id, name, region, income_level FROM world_bank.countries LIMIT 5
+  - SELECT id, topic FROM world_bank.topics
+  - SELECT id, name FROM world_bank.topic_indicators WHERE topic = '3' LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # world_bank.data — core time-series query table
+  # GET /v2/country/{country}/indicator/{indicator}?format=json
+  # Response: [meta, data_array] — rows at index 1 ("rows_path: ['1']")
+  # Pagination: page mode, "page" + "per_page" params
+  # ──────────────────────────────────────────────────────────────────────
+  - name: data
+    description: >-
+      Time-series indicator values for a country or region. Each row is one
+      year's observation for the given indicator and country combination.
+      Requires both `country` (ISO2 or ISO3 code, or "all" for all countries)
+      and `indicator` (World Bank indicator code, e.g. NY.GDP.MKTP.CD).
+      Values cover from 1960 to the most recently published year; some
+      years may have no data (value is null). Use world_bank.indicators to
+      discover indicator codes, and world_bank.countries for country codes.
+    guide: >-
+      Always supply both required filters:
+        WHERE country = '<ISO2 or ISO3>' AND indicator = '<code>'
+
+      Examples:
+        country = 'US' or 'USA'     → United States
+        country = 'IN' or 'IND'     → India
+        country = 'all'             → all countries (returns data for each
+                                       country across all years; use mrv = 1
+                                       to get only the most recent value per
+                                       country for cross-country comparisons)
+
+      Use mrv (Most Recent Value) for cross-country snapshots:
+        WHERE country = 'all' AND indicator = 'NY.GDP.MKTP.CD' AND mrv = 1
+        returns one row per country with its most recently published value,
+        ordered by country. Without mrv, data for all years is returned
+        interleaved per country.
+
+      Commonly used indicators:
+        NY.GDP.MKTP.CD    GDP (current US$)
+        SP.POP.TOTL       Population total
+        SI.POV.DDAY       Poverty headcount ratio at $2.15/day (2017 PPP) %
+        EN.ATM.CO2E.PC    CO2 emissions (metric tons per capita)
+        SH.DYN.MORT       Mortality rate, under-5 (per 1,000 live births)
+        SE.PRM.ENRR       School enrollment, primary (% gross)
+        FP.CPI.TOTL.ZG    Inflation, consumer prices (annual %)
+        NY.GNP.PCAP.CD    GNI per capita (current US$)
+        SL.UEM.TOTL.ZS    Unemployment, total (% of total labor force)
+        EG.FEC.RNEW.ZS    Renewable energy consumption (% of total)
+
+      `value` is null for years with no published data — filter with
+        WHERE value IS NOT NULL to exclude missing observations.
+      `date` is a year string (e.g. '2024') — not a timestamp.
+      Results are ordered newest-first by default.
+    fetch_limit_default: 100
+    filters:
+      - name: country
+        required: true
+      - name: indicator
+        required: true
+      - name: mrv
+    request:
+      method: GET
+      path: /country/{{filter.country}}/indicator/{{filter.indicator}}
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: mrv
+          from: filter
+          key: mrv
+    response:
+      rows_path:
+        - "1"
+      allow_404_empty: true
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 100
+      page_size:
+        default: 100
+        max: 1000
+        query_param: per_page
+    columns:
+      - name: indicator_id
+        type: Utf8
+        nullable: false
+        description: World Bank indicator code (e.g. NY.GDP.MKTP.CD).
+        expr:
+          kind: path
+          path:
+            - indicator
+            - id
+
+      - name: indicator_name
+        type: Utf8
+        nullable: false
+        description: Human-readable indicator name (e.g. "GDP (current US$)").
+        expr:
+          kind: path
+          path:
+            - indicator
+            - value
+
+      - name: country_id
+        type: Utf8
+        nullable: false
+        description: ISO2 country code as returned by the API (e.g. "US", "IN").
+        expr:
+          kind: path
+          path:
+            - country
+            - id
+
+      - name: country_name
+        type: Utf8
+        nullable: false
+        description: Full country or region name (e.g. "United States", "India").
+        expr:
+          kind: path
+          path:
+            - country
+            - value
+
+      - name: countryiso3code
+        type: Utf8
+        nullable: true
+        description: ISO3 country code (e.g. "USA", "IND"). May be empty for aggregate regions.
+
+      - name: date
+        type: Utf8
+        nullable: false
+        description: >-
+          Year of observation as a string (e.g. "2024"). World Bank data is
+          annual; this is not a timestamp. Use ORDER BY date DESC for newest first.
+
+      - name: value
+        type: Float64
+        nullable: true
+        description: >-
+          Indicator value for this country and year. Null when the World Bank
+          has not published data for this combination. Filter WHERE value IS NOT NULL
+          to exclude missing years.
+
+      - name: unit
+        type: Utf8
+        nullable: true
+        description: Unit of measurement, if specified by the indicator (often empty).
+
+      - name: obs_status
+        type: Utf8
+        nullable: true
+        description: Observation status flag (e.g. "E" for estimate). Often empty.
+
+      - name: decimal
+        type: Int64
+        nullable: true
+        description: Number of decimal places recommended for display by the World Bank.
+
+      - name: country
+        type: Utf8
+        nullable: true
+        description: Echoes the country filter used to query this row.
+        expr:
+          kind: from_filter
+          key: country
+
+      - name: indicator
+        type: Utf8
+        nullable: true
+        description: Echoes the indicator filter used to query this row.
+        expr:
+          kind: from_filter
+          key: indicator
+
+      - name: mrv
+        type: Utf8
+        nullable: true
+        description: >-
+          Echoes the mrv (Most Recent Value) filter. When set to '1', the API
+          returns only the single most recently published value per country,
+          making cross-country comparisons possible without fetching all years.
+          Pass as a quoted string: WHERE mrv = '1'.
+        expr:
+          kind: from_filter
+          key: mrv
+
+  # ──────────────────────────────────────────────────────────────────────
+  # world_bank.indicators — full catalog of 29,500+ indicator codes
+  # GET /v2/indicator?format=json&per_page=N&page=N
+  # Response: [meta, indicator_array] — rows at index 1
+  # Pagination: page mode
+  # ──────────────────────────────────────────────────────────────────────
+  - name: indicators
+    description: >-
+      Full catalog of all World Bank indicators. Each row is one indicator
+      with its code, name, source database, and thematic topics. Use this
+      table to discover indicator codes to pass to world_bank.data.
+      There are 29,500+ indicators — use LIMIT and search by name in your
+      SQL client, or use world_bank.topic_indicators to browse by topic.
+    guide: >-
+      Use this table to look up indicator codes for world_bank.data.
+      The API does not support server-side text search; results are returned
+      alphabetically by indicator ID. To find indicators by name, either:
+
+      1. Browse by topic with world_bank.topic_indicators — each topic returns
+         a much smaller scoped set of indicators (typically 100–500).
+
+      2. Use a high LIMIT to fetch more rows and apply a client-side filter:
+           SELECT id, name FROM world_bank.indicators
+           WHERE name LIKE '%CO2%' LIMIT 500
+
+         Note: the LIKE filter applies only to the rows fetched in this
+         request. Use a large LIMIT to scan more of the 29,500+ indicators.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /indicator
+      query:
+        - name: format
+          from: literal
+          value: json
+    response:
+      rows_path:
+        - "1"
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 300
+      page_size:
+        default: 100
+        max: 1000
+        query_param: per_page
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: >-
+          World Bank indicator code (e.g. NY.GDP.MKTP.CD, SP.POP.TOTL).
+          Pass this value as the `indicator` filter in world_bank.data.
+
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Human-readable indicator name.
+
+      - name: unit
+        type: Utf8
+        nullable: true
+        description: Unit of measurement, if specified. Often empty.
+
+      - name: source_id
+        type: Utf8
+        nullable: true
+        description: Numeric ID of the source database within the World Bank.
+        expr:
+          kind: path
+          path:
+            - source
+            - id
+
+      - name: source_name
+        type: Utf8
+        nullable: true
+        description: Name of the World Bank source database (e.g. "World Development Indicators").
+        expr:
+          kind: path
+          path:
+            - source
+            - value
+
+      - name: source_note
+        type: Utf8
+        nullable: true
+        description: >-
+          Detailed methodology note describing what the indicator measures
+          and how it is computed.
+        expr:
+          kind: path
+          path:
+            - sourceNote
+
+      - name: source_organization
+        type: Utf8
+        nullable: true
+        description: Organization that collects or compiles this indicator.
+        expr:
+          kind: path
+          path:
+            - sourceOrganization
+
+      - name: topics
+        type: Json
+        nullable: true
+        description: >-
+          Array of thematic topics this indicator belongs to.
+          Each element has an "id" (matches world_bank.topics.id) and a "value" (topic name).
+
+  # ──────────────────────────────────────────────────────────────────────
+  # world_bank.countries — country and region metadata
+  # GET /v2/country?format=json&per_page=300
+  # Response: [meta, country_array] — rows at index 1
+  # All 296 entries fit in a single page — pagination: none
+  # ──────────────────────────────────────────────────────────────────────
+  - name: countries
+    description: >-
+      Metadata for all 296 countries and aggregate regions tracked by the
+      World Bank. Includes ISO2 and ISO3 codes, geographic region,
+      income level classification, lending type, and capital city.
+      Use this table to look up country codes for world_bank.data.
+      Aggregate regions (e.g. "East Asia & Pacific") are also listed
+      and can be used with country = 'EAS' in world_bank.data.
+    guide: >-
+      Use this table to look up the country codes needed for world_bank.data:
+
+        SELECT id, iso2_code, name, region, income_level
+        FROM world_bank.countries
+        WHERE region = 'South Asia'
+
+      The `id` column is the ISO3 code (e.g. "USA", "IND", "EAS").
+      Both ISO2 (e.g. "US") and ISO3 codes work in world_bank.data filters.
+      Aggregate region entries have an empty `capital_city`.
+    fetch_limit_default: 296
+    request:
+      method: GET
+      path: /country
+      query:
+        - name: format
+          from: literal
+          value: json
+        - name: per_page
+          from: literal
+          value: "300"
+    response:
+      rows_path:
+        - "1"
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: >-
+          ISO3 country code (e.g. "USA", "IND") or aggregate region code
+          (e.g. "EAS" for East Asia & Pacific). Use as the `country` filter
+          in world_bank.data, or use the shorter ISO2 code from iso2_code.
+
+      - name: iso2_code
+        type: Utf8
+        nullable: true
+        description: ISO2 country code (e.g. "US", "IN"). Also accepted by world_bank.data.
+        expr:
+          kind: path
+          path:
+            - iso2Code
+
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Full country or region name (e.g. "United States", "East Asia & Pacific").
+
+      - name: region_id
+        type: Utf8
+        nullable: true
+        description: Region code (e.g. "NAC" for North America, "SAS" for South Asia).
+        expr:
+          kind: path
+          path:
+            - region
+            - id
+
+      - name: region
+        type: Utf8
+        nullable: true
+        description: Geographic region name (e.g. "North America", "South Asia").
+        expr:
+          kind: path
+          path:
+            - region
+            - value
+
+      - name: admin_region
+        type: Utf8
+        nullable: true
+        description: Administrative region name. Empty for high-income countries and aggregate regions.
+        expr:
+          kind: path
+          path:
+            - adminregion
+            - value
+
+      - name: income_level_id
+        type: Utf8
+        nullable: true
+        description: >-
+          Income level code (e.g. "HIC" = High income, "UMC" = Upper middle income,
+          "LMC" = Lower middle income, "LIC" = Low income).
+        expr:
+          kind: path
+          path:
+            - incomeLevel
+            - id
+
+      - name: income_level
+        type: Utf8
+        nullable: true
+        description: Income level classification (e.g. "High income", "Low income").
+        expr:
+          kind: path
+          path:
+            - incomeLevel
+            - value
+
+      - name: lending_type
+        type: Utf8
+        nullable: true
+        description: >-
+          World Bank lending type (e.g. "IBRD", "IDA", "Blend", "Not classified").
+          Relevant for understanding which countries qualify for different lending programs.
+        expr:
+          kind: path
+          path:
+            - lendingType
+            - value
+
+      - name: capital_city
+        type: Utf8
+        nullable: true
+        description: Capital city name. Empty for aggregate regions.
+        expr:
+          kind: path
+          path:
+            - capitalCity
+
+      - name: longitude
+        type: Utf8
+        nullable: true
+        description: Longitude of the country centroid as a string (e.g. "-77.032").
+
+      - name: latitude
+        type: Utf8
+        nullable: true
+        description: Latitude of the country centroid as a string (e.g. "38.8895").
+
+  # ──────────────────────────────────────────────────────────────────────
+  # world_bank.topics — 21 thematic topic groups
+  # GET /v2/topic?format=json
+  # Response: [meta, topic_array] — rows at index 1
+  # All 21 entries fit in one page — pagination: none
+  # ──────────────────────────────────────────────────────────────────────
+  - name: topics
+    description: >-
+      The 21 thematic topic groups used to organize World Bank indicators.
+      Examples: Agriculture & Rural Development, Economy & Growth, Education,
+      Environment, Health, Poverty, Social Development, and more.
+      Use the topic id with world_bank.topic_indicators to browse indicators
+      belonging to a specific theme.
+    guide: >-
+      Use topic ids with world_bank.topic_indicators to explore indicators
+      for a given theme:
+
+        -- List all themes
+        SELECT id, topic FROM world_bank.topics
+
+        -- Then browse indicators in theme 3 (Economy & Growth)
+        SELECT id, name FROM world_bank.topic_indicators WHERE topic = '3'
+    fetch_limit_default: 21
+    request:
+      method: GET
+      path: /topic
+      query:
+        - name: format
+          from: literal
+          value: json
+    response:
+      rows_path:
+        - "1"
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: >-
+          Numeric topic identifier (1–21). Pass as the `topic` filter
+          (as a string) in world_bank.topic_indicators.
+
+      - name: topic
+        type: Utf8
+        nullable: false
+        description: Topic name (e.g. "Economy & Growth", "Health", "Education").
+        expr:
+          kind: path
+          path:
+            - value
+
+      - name: source_note
+        type: Utf8
+        nullable: true
+        description: Description of what this thematic area covers.
+        expr:
+          kind: path
+          path:
+            - sourceNote
+
+  # ──────────────────────────────────────────────────────────────────────
+  # world_bank.topic_indicators — indicators filtered by topic
+  # GET /v2/topic/{topic}/indicator?format=json
+  # Response: [meta, indicator_array] — rows at index 1
+  # Pagination: page mode
+  # ──────────────────────────────────────────────────────────────────────
+  - name: topic_indicators
+    description: >-
+      Indicators belonging to a specific thematic topic. Requires the `topic`
+      filter (numeric topic ID from world_bank.topics, passed as a string).
+      Returns a subset of world_bank.indicators relevant to the chosen theme —
+      useful for discovering indicator codes within a domain without browsing
+      all 29,500+ indicators.
+    guide: >-
+      Use world_bank.topics first to find a topic id, then query here:
+
+        -- Economy & Growth indicators (topic 3)
+        SELECT id, name FROM world_bank.topic_indicators WHERE topic = '3'
+
+        -- Health indicators (topic 8)
+        SELECT id, name FROM world_bank.topic_indicators WHERE topic = '8'
+
+        -- Environment indicators (topic 6)
+        SELECT id, name FROM world_bank.topic_indicators WHERE topic = '6'
+
+      Topic IDs:
+        1=Agriculture, 2=Aid Effectiveness, 3=Economy & Growth, 4=Education,
+        5=Energy & Mining, 6=Environment, 7=Financial Sector, 8=Health,
+        9=Infrastructure, 10=Social Protection & Labor, 11=Poverty,
+        12=Private Sector, 13=Public Sector, 14=Science & Technology,
+        15=Social Development, 16=Trade, 17=Urban Development,
+        18=Gender, 19=Millenium Dev Goals, 20=Climate Change, 21=External Debt
+    fetch_limit_default: 100
+    filters:
+      - name: topic
+        required: true
+    request:
+      method: GET
+      path: /topic/{{filter.topic}}/indicator
+      query:
+        - name: format
+          from: literal
+          value: json
+    response:
+      rows_path:
+        - "1"
+      allow_404_empty: true
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      max_pages: 50
+      page_size:
+        default: 100
+        max: 1000
+        query_param: per_page
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: >-
+          World Bank indicator code (e.g. NY.GDP.MKTP.CD). Pass this as the
+          `indicator` filter in world_bank.data.
+
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Human-readable indicator name.
+
+      - name: unit
+        type: Utf8
+        nullable: true
+        description: Unit of measurement, if specified. Often empty.
+
+      - name: source_id
+        type: Utf8
+        nullable: true
+        description: Numeric ID of the source database within the World Bank.
+        expr:
+          kind: path
+          path:
+            - source
+            - id
+
+      - name: source_name
+        type: Utf8
+        nullable: true
+        description: Name of the World Bank source database.
+        expr:
+          kind: path
+          path:
+            - source
+            - value
+
+      - name: source_note
+        type: Utf8
+        nullable: true
+        description: Methodology note describing what the indicator measures.
+        expr:
+          kind: path
+          path:
+            - sourceNote
+
+      - name: topics
+        type: Json
+        nullable: true
+        description: >-
+          All topic tags for this indicator (may include additional topics beyond
+          the one filtered on). Each element has "id" and "value".
+
+      - name: topic
+        type: Utf8
+        nullable: true
+        description: Echoes the topic filter used to query this table.
+        expr:
+          kind: from_filter
+          key: topic

--- a/sources/community/world_bank/manifest.yaml
+++ b/sources/community/world_bank/manifest.yaml
@@ -11,7 +11,7 @@ base_url: https://api.worldbank.org/v2
 
 test_queries:
   - SELECT indicator_id, indicator_name, date, value FROM world_bank.data WHERE country = 'US' AND indicator = 'NY.GDP.MKTP.CD' LIMIT 5
-  - SELECT country_name, date, value FROM world_bank.data WHERE country = 'all' AND indicator = 'SI.POV.DDAY' AND mrnev = '1' AND value IS NOT NULL LIMIT 10
+  - SELECT country_name, date, value FROM world_bank.data WHERE country = 'all' AND indicator = 'SI.POV.DDAY' AND mrnev = '1' LIMIT 10
   - SELECT id, name, region, income_level FROM world_bank.countries LIMIT 5
   - SELECT id, topic FROM world_bank.topics
   - SELECT id, name FROM world_bank.topic_indicators WHERE topic = '3' LIMIT 5


### PR DESCRIPTION
## Summary

Adds a World Bank Open Data community source — the first macroeconomic and development-data source in the Coral ecosystem. No authentication required.

**5 tables:**

| Table | Description |
|---|---|
| `world_bank.data` | Core query table — annual indicator values for any country/region and indicator code |
| `world_bank.indicators` | Full catalog of 29,500+ indicator codes with names and source metadata |
| `world_bank.topic_indicators` | Indicators scoped to a thematic topic — for discovering codes by domain |
| `world_bank.countries` | Metadata for 296 countries and regions — ISO codes, region, income level, capital city |
| `world_bank.topics` | The 21 thematic topic groups used to organise indicators |

## Why this source?

- **Zero auth, zero config** — public World Bank Open Data API, no key needed; works immediately after install
- **Unique dataset** — no other Coral source covers macroeconomic or geopolitical data; fills a category gap entirely
- **Novel DSL pattern** — uses `rows_path: ["1"]` (numeric array index) to navigate the World Bank API's `[metadata, data_array]` double-array response shape, a pattern not previously used in community sources
- **`mrv` filter** — exposes the World Bank `mrv` (Most Recent Value) parameter so `country = 'all' AND mrv = '1'` returns exactly one row per country/region with its latest published value, enabling cross-country comparisons in a single query
- **Agent-building ready** — enables research agents to answer macroeconomic questions ("which low-income countries have the highest renewable energy adoption?") that no other Coral source can touch

## Example queries

```sql
-- US GDP over time
SELECT date, value FROM world_bank.data
WHERE country = 'US' AND indicator = 'NY.GDP.MKTP.CD'
ORDER BY date DESC LIMIT 10

-- Cross-country GDP ranking (most recent year, one row per country)
SELECT country_name, date, value AS gdp_usd
FROM world_bank.data
WHERE country = 'all' AND indicator = 'NY.GDP.MKTP.CD' AND mrv = '1'
  AND value IS NOT NULL
ORDER BY value DESC LIMIT 10

-- Browse Health indicators (topic 8)
SELECT id, name FROM world_bank.topic_indicators WHERE topic = '8' LIMIT 20

-- Low-income countries with region and capital
SELECT id, name, region, capital_city FROM world_bank.countries
WHERE income_level = 'Low income' ORDER BY name
```

## Validation

- `coral source lint`: ✅ passed
- `coral source add --file sources/community/world_bank/manifest.yaml`: ✅ connected, 5 tables, **5/5 test queries passed**

Live `coral sql` queries verified:

| Test | Result |
|---|---|
| US GDP (NY.GDP.MKTP.CD) — all field paths | ✅ 5 rows, nested `indicator.id` and `country.value` paths resolve correctly |
| India population (SP.POP.TOTL) via ISO3 code | ✅ 2025 null (not yet published), 2024 = 1,450,935,791 |
| `country = 'all'` + `mrv = '1'` | ✅ One row per country/region, 266 total |
| Countries table — all nested fields | ✅ `region.value`, `incomeLevel.value`, `lendingType.value`, `capitalCity` all resolve |
| Topics table | ✅ All 21 topics returned with full `sourceNote` text |
| Topic indicators — topic `3` (Economy & Growth) | ✅ 306 indicators returned, `topic` echo column correct |
| Invalid country code (`ZZZ`) | ✅ Returns empty rows — null data array handled gracefully, no error |
| Null value row (2025 data unpublished) | ✅ Displayed as empty, does not error |

## Install path

```
sources/community/world_bank/manifest.yaml
```

🤖 Generated with [Claude Code](https://claude.ai/code)