### PR TITLE
perf(catalog): cache workspace metadata snapshots

### DIFF
--- a/crates/coral-app/src/bootstrap/server.rs
+++ b/crates/coral-app/src/bootstrap/server.rs
@@ -37,6 +37,7 @@ use tower::{Layer, Service};
 use super::env::AppEnvironment;
 use super::error::AppError;
 use crate::EngineExtensionsProvider;
+use crate::catalog::cache::CatalogMetadataCache;
 use crate::catalog::service::CatalogService;
 use crate::credentials::config::CredentialStorageConfig;
 use crate::credentials::{CredentialManager, CredentialStore};
@@ -262,10 +263,12 @@ impl ServerBuilder {
         let credential_store =
             CredentialStore::with_preference(layout.clone(), credential_config.storage);
         let credential_manager = CredentialManager::new(credential_store);
-        let source_manager = SourceManager::new(
+        let catalog_cache = CatalogMetadataCache::default();
+        let source_manager = SourceManager::with_catalog_cache(
             config_store.clone(),
             credential_manager.clone(),
             layout.clone(),
+            catalog_cache.clone(),
         );
         let feedback_manager =
             FeedbackManager::with_publisher(layout.clone(), self.config.feedback_publisher);
@@ -276,11 +279,12 @@ impl ServerBuilder {
             .query_runtime_context()
             .with_http_body_capture_max_bytes(http_body_capture_max_bytes);
 
-        let query_manager = QueryManager::new(
+        let query_manager = QueryManager::with_catalog_cache(
             config_store,
             credential_manager,
             query_runtime_context,
             layout,
+            catalog_cache,
             self.config.engine_extensions_providers,
         );
         let trace_service = if telemetry_config.trace_history.enabled {

--- a/crates/coral-app/src/catalog/cache.rs
+++ b/crates/coral-app/src/catalog/cache.rs
@@ -1,0 +1,218 @@
+//! Workspace-scoped cache for query-visible catalog metadata.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+
+use coral_engine::CatalogInfo;
+
+use crate::workspaces::WorkspaceName;
+
+#[derive(Clone, Default)]
+pub(crate) struct CatalogMetadataCache {
+    state: Arc<Mutex<CatalogMetadataCacheState>>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct CatalogMetadataSignature(u64);
+
+impl CatalogMetadataSignature {
+    pub(crate) fn from_hash(hash: u64) -> Self {
+        Self(hash)
+    }
+}
+
+#[derive(Default)]
+struct CatalogMetadataCacheState {
+    entries: BTreeMap<WorkspaceName, CatalogMetadataCacheEntry>,
+    versions: BTreeMap<WorkspaceName, u64>,
+}
+
+struct CatalogMetadataCacheEntry {
+    version: u64,
+    signature: CatalogMetadataSignature,
+    snapshot: Arc<CatalogInfo>,
+}
+
+impl CatalogMetadataCache {
+    pub(crate) async fn get_or_insert_with<E, F, Fut>(
+        &self,
+        workspace_name: &WorkspaceName,
+        signature: CatalogMetadataSignature,
+        mut build: F,
+    ) -> Result<Arc<CatalogInfo>, E>
+    where
+        F: FnMut() -> Fut,
+        Fut: Future<Output = Result<CatalogInfo, E>>,
+    {
+        loop {
+            let observed_version = {
+                let mut state = self
+                    .state
+                    .lock()
+                    .expect("catalog metadata cache mutex poisoned");
+                let version = state.workspace_version(workspace_name);
+                if let Some(entry) = state.entries.get(workspace_name)
+                    && entry.version == version
+                    && entry.signature == signature
+                {
+                    return Ok(entry.snapshot.clone());
+                }
+                state.entries.remove(workspace_name);
+                version
+            };
+
+            let snapshot = Arc::new(build().await?);
+            let mut state = self
+                .state
+                .lock()
+                .expect("catalog metadata cache mutex poisoned");
+            let current_version = state.workspace_version(workspace_name);
+            if current_version == observed_version {
+                state.entries.insert(
+                    workspace_name.clone(),
+                    CatalogMetadataCacheEntry {
+                        version: current_version,
+                        signature,
+                        snapshot: snapshot.clone(),
+                    },
+                );
+                return Ok(snapshot);
+            }
+        }
+    }
+
+    pub(crate) fn invalidate_workspace(&self, workspace_name: &WorkspaceName) {
+        let mut state = self
+            .state
+            .lock()
+            .expect("catalog metadata cache mutex poisoned");
+        let next_version = state
+            .versions
+            .get(workspace_name)
+            .copied()
+            .unwrap_or_default()
+            .saturating_add(1);
+        state.versions.insert(workspace_name.clone(), next_version);
+        state.entries.remove(workspace_name);
+    }
+}
+
+impl CatalogMetadataCacheState {
+    fn workspace_version(&self, workspace_name: &WorkspaceName) -> u64 {
+        self.versions
+            .get(workspace_name)
+            .copied()
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn repeated_workspace_lookup_builds_once() {
+        let cache = CatalogMetadataCache::default();
+        let workspace = WorkspaceName::default();
+        let builds = AtomicUsize::new(0);
+
+        let first = cache
+            .get_or_insert_with(&workspace, signature(1), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("first catalog");
+        let second = cache
+            .get_or_insert_with(&workspace, signature(1), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("cached catalog");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(builds.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn changed_signature_rebuilds_snapshot() {
+        let cache = CatalogMetadataCache::default();
+        let workspace = WorkspaceName::default();
+        let builds = AtomicUsize::new(0);
+
+        cache
+            .get_or_insert_with(&workspace, signature(1), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("first catalog");
+        cache
+            .get_or_insert_with(&workspace, signature(2), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("changed catalog");
+
+        assert_eq!(builds.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn invalidation_rebuilds_only_that_workspace() {
+        let cache = CatalogMetadataCache::default();
+        let default_workspace = WorkspaceName::default();
+        let other_workspace = WorkspaceName::parse("other").expect("workspace");
+        let builds = AtomicUsize::new(0);
+
+        cache
+            .get_or_insert_with(&default_workspace, signature(1), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("default catalog");
+        cache
+            .get_or_insert_with(&other_workspace, signature(1), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("other catalog");
+
+        cache.invalidate_workspace(&default_workspace);
+
+        cache
+            .get_or_insert_with(&other_workspace, signature(1), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("other cached catalog");
+        cache
+            .get_or_insert_with(&default_workspace, signature(1), || async {
+                builds.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, ()>(empty_catalog())
+            })
+            .await
+            .expect("rebuilt default catalog");
+
+        assert_eq!(builds.load(Ordering::SeqCst), 3);
+    }
+
+    fn empty_catalog() -> CatalogInfo {
+        CatalogInfo {
+            sources: Vec::new(),
+            tables: Vec::new(),
+            table_functions: Vec::new(),
+        }
+    }
+
+    fn signature(value: u64) -> CatalogMetadataSignature {
+        CatalogMetadataSignature::from_hash(value)
+    }
+}

--- a/crates/coral-app/src/catalog/mod.rs
+++ b/crates/coral-app/src/catalog/mod.rs
@@ -1,4 +1,5 @@
 //! App-owned catalog discovery behavior.
 
+pub(crate) mod cache;
 pub(crate) mod discovery;
 pub(crate) mod service;

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -1,7 +1,9 @@
 //! Query-time loading, validation, and execution over installed sources.
 
 use std::collections::BTreeMap;
+use std::collections::hash_map::DefaultHasher;
 use std::future::Future;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -15,7 +17,10 @@ use tracing::Instrument as _;
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use crate::bootstrap::AppError;
-use crate::credentials::{CredentialManager, CredentialSetId, CredentialsError};
+use crate::catalog::cache::{CatalogMetadataCache, CatalogMetadataSignature};
+use crate::credentials::{
+    CredentialManager, CredentialSetId, CredentialStorageKind, CredentialsError,
+};
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
@@ -40,10 +45,12 @@ pub(crate) struct QueryManager {
     credential_manager: CredentialManager,
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
+    catalog_cache: CatalogMetadataCache,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
 }
 
 impl QueryManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
@@ -51,11 +58,30 @@ impl QueryManager {
         layout: AppStateLayout,
         engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
     ) -> Self {
+        Self::with_catalog_cache(
+            config_store,
+            credential_manager,
+            runtime_context,
+            layout,
+            CatalogMetadataCache::default(),
+            engine_extensions_providers,
+        )
+    }
+
+    pub(crate) fn with_catalog_cache(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        runtime_context: QueryRuntimeContext,
+        layout: AppStateLayout,
+        catalog_cache: CatalogMetadataCache,
+        engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    ) -> Self {
         Self {
             config_store,
             credential_manager,
             runtime_context,
             layout,
+            catalog_cache,
             engine_extensions_providers,
         }
     }
@@ -66,13 +92,8 @@ impl QueryManager {
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_config(&sources);
-        CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
-            .await
-            .map_err(QueryManagerError::Core)
+        let catalog = self.catalog_snapshot(workspace_name).await?;
+        Ok(filter_tables(&catalog.tables, schema_filter, table_filter))
     }
 
     pub(crate) async fn list_catalog(
@@ -80,13 +101,8 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, QueryManagerError> {
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_config(&sources);
-        CoralQuery::list_catalog(&sources, runtime, schema_filter)
-            .await
-            .map_err(QueryManagerError::Core)
+        let catalog = self.catalog_snapshot(workspace_name).await?;
+        Ok(filter_catalog(&catalog, schema_filter))
     }
 
     pub(crate) async fn execute_sql(
@@ -241,6 +257,126 @@ impl QueryManager {
             engine_extensions_for_providers(&self.engine_extensions_providers, selected_sources);
         QueryRuntimeConfig::new(self.runtime_context.clone(), extensions)
     }
+
+    async fn catalog_snapshot(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Arc<CatalogInfo>, QueryManagerError> {
+        let signature = self.catalog_metadata_signature(workspace_name)?;
+        self.catalog_cache
+            .get_or_insert_with(workspace_name, signature, || async {
+                let sources = self
+                    .load_query_sources(workspace_name)
+                    .map_err(QueryManagerError::App)?;
+                let runtime = self.runtime_config(&sources);
+                CoralQuery::list_catalog(&sources, runtime, None)
+                    .await
+                    .map_err(QueryManagerError::Core)
+            })
+            .await
+    }
+
+    fn catalog_metadata_signature(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<CatalogMetadataSignature, QueryManagerError> {
+        let sources = self
+            .config_store
+            .list_workspace_sources(workspace_name)
+            .map_err(QueryManagerError::App)?;
+        let mut hasher = DefaultHasher::new();
+        for source in &sources {
+            hash_catalog_metadata_source_inputs(
+                &mut hasher,
+                workspace_name,
+                source,
+                &self.layout,
+                &self.credential_manager,
+            )
+            .map_err(QueryManagerError::App)?;
+        }
+        Ok(CatalogMetadataSignature::from_hash(hasher.finish()))
+    }
+}
+
+fn hash_catalog_metadata_source_inputs(
+    hasher: &mut DefaultHasher,
+    workspace_name: &WorkspaceName,
+    source: &InstalledSource,
+    layout: &AppStateLayout,
+    credential_manager: &CredentialManager,
+) -> Result<(), AppError> {
+    source.name.as_str().hash(hasher);
+    source.version.hash(hasher);
+    source.variables.hash(hasher);
+    source.secrets.hash(hasher);
+    source
+        .credential_storage
+        .map(CredentialStorageKind::as_config_value)
+        .hash(hasher);
+    source.origin.as_config_value().hash(hasher);
+
+    if source.origin == crate::sources::model::SourceOrigin::Imported {
+        match std::fs::read(layout.manifest_file(workspace_name, &source.name)) {
+            Ok(manifest) => manifest.hash(hasher),
+            Err(error) => {
+                "manifest-error".hash(hasher);
+                error.kind().hash(hasher);
+                error.to_string().hash(hasher);
+            }
+        }
+    }
+
+    if let Some(credential_storage) = source.credential_storage_for_material() {
+        let credential_set_id = CredentialSetId::for_source(&source.name);
+        match credential_manager.read_material(
+            workspace_name,
+            &credential_set_id,
+            credential_storage,
+        ) {
+            Ok(material) => material.hash(hasher),
+            Err(error @ AppError::Credentials(CredentialsError::Unavailable(_))) => {
+                return Err(error);
+            }
+            Err(error) => {
+                "credential-error".hash(hasher);
+                error.to_string().hash(hasher);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn filter_catalog(catalog: &CatalogInfo, schema_filter: Option<&str>) -> CatalogInfo {
+    CatalogInfo {
+        sources: catalog
+            .sources
+            .iter()
+            .filter(|source| schema_filter.is_none_or(|value| source.schema_name == value))
+            .cloned()
+            .collect(),
+        tables: filter_tables(&catalog.tables, schema_filter, None),
+        table_functions: catalog
+            .table_functions
+            .iter()
+            .filter(|function| schema_filter.is_none_or(|value| function.schema_name == value))
+            .cloned()
+            .collect(),
+    }
+}
+
+fn filter_tables(
+    tables: &[TableInfo],
+    schema_filter: Option<&str>,
+    table_filter: Option<&str>,
+) -> Vec<TableInfo> {
+    tables
+        .iter()
+        .filter(|table| schema_filter.is_none_or(|value| table.schema_name == value))
+        .filter(|table| table_filter.is_none_or(|value| table.table_name == value))
+        .cloned()
+        .collect()
 }
 
 #[derive(Clone, Copy)]

--- a/crates/coral-app/src/sources/manager.rs
+++ b/crates/coral-app/src/sources/manager.rs
@@ -3,6 +3,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::bootstrap::AppError;
+use crate::catalog::cache::CatalogMetadataCache;
 use crate::credentials::oauth::{
     OAuthCredentialManager, OAuthCredentialMaterial, StartOAuthCredentialRequest,
     material_key_belongs_to_input,
@@ -29,6 +30,7 @@ pub(crate) struct SourceManager {
     credential_manager: CredentialManager,
     oauth_manager: OAuthCredentialManager,
     layout: AppStateLayout,
+    catalog_cache: CatalogMetadataCache,
 }
 
 pub(crate) struct CreateBundledSourceCommand {
@@ -145,16 +147,32 @@ struct SourceRollbackState {
 }
 
 impl SourceManager {
+    #[cfg(test)]
     pub(crate) fn new(
         config_store: ConfigStore,
         credential_manager: CredentialManager,
         layout: AppStateLayout,
+    ) -> Self {
+        Self::with_catalog_cache(
+            config_store,
+            credential_manager,
+            layout,
+            CatalogMetadataCache::default(),
+        )
+    }
+
+    pub(crate) fn with_catalog_cache(
+        config_store: ConfigStore,
+        credential_manager: CredentialManager,
+        layout: AppStateLayout,
+        catalog_cache: CatalogMetadataCache,
     ) -> Self {
         Self {
             config_store,
             credential_manager,
             oauth_manager: OAuthCredentialManager::new(),
             layout,
+            catalog_cache,
         }
     }
 
@@ -468,6 +486,7 @@ impl SourceManager {
             self.restore_source_rollback_state(workspace_name, source_name, Some(previous), None);
             return Err(error);
         }
+        self.catalog_cache.invalidate_workspace(workspace_name);
         cleanup_empty_parent(&self.layout.workspaces_root(), source_dir.parent());
         cleanup_empty_parent(
             &self.layout.workspaces_root(),
@@ -591,6 +610,7 @@ impl SourceManager {
             );
             return Err(error);
         }
+        self.catalog_cache.invalidate_workspace(workspace_name);
         Ok(apply_candidate_metadata(stored, request.candidate))
     }
 

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -4,16 +4,34 @@
 )]
 
 use coral_api::v1::{
-    DescribeTableRequest, ListCatalogRequest, ListColumnsRequest, PaginationRequest,
-    SearchCatalogRequest, SearchColumnsRequest, catalog_item,
+    DeleteSourceRequest, DescribeTableRequest, ListCatalogRequest, ListCatalogResponse,
+    ListColumnsRequest, PaginationRequest, SearchCatalogRequest, SearchColumnsRequest,
+    catalog_item,
 };
+use coral_app::{EngineExtensions, EngineExtensionsProvider, QuerySource};
 use coral_client::default_workspace;
+use std::fs;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use tonic::Request;
 
 use super::harness::{
     GrpcHarness, fixture_manifest_with_functions_yaml, fixture_manifest_with_multiple_tables_yaml,
     fixture_manifest_with_required_filter_yaml,
 };
+
+struct CountingEngineExtensionsProvider {
+    runtime_builds: Arc<AtomicUsize>,
+}
+
+impl EngineExtensionsProvider for CountingEngineExtensionsProvider {
+    fn extensions_for(&self, _selected_sources: &[QuerySource]) -> EngineExtensions {
+        self.runtime_builds.fetch_add(1, Ordering::SeqCst);
+        EngineExtensions::default()
+    }
+}
 
 #[tokio::test]
 async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
@@ -75,6 +93,171 @@ async fn search_catalog_matches_metadata_and_paginates_after_filtering() {
             .iter()
             .any(|field| field == "result_columns")
     );
+}
+
+#[tokio::test]
+async fn catalog_metadata_reuses_snapshot_until_source_changes() {
+    let runtime_builds = Arc::new(AtomicUsize::new(0));
+    let harness = GrpcHarness::new_with_engine_extensions_provider(Arc::new(
+        CountingEngineExtensionsProvider {
+            runtime_builds: runtime_builds.clone(),
+        },
+    ))
+    .await;
+    harness
+        .import_source(
+            fixture_manifest_with_functions_yaml(),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    call_cached_metadata_endpoints(&harness).await;
+    assert_eq!(runtime_builds.load(Ordering::SeqCst), 1);
+
+    harness
+        .import_source(
+            fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+    let refreshed = list_catalog_page(&harness, "", 0, "list refreshed catalog").await;
+
+    assert_eq!(runtime_builds.load(Ordering::SeqCst), 2);
+    assert_catalog_has_source(&refreshed, "local_messages");
+
+    edit_local_messages_manifest(&harness);
+    let edited = list_catalog_page(&harness, "local_messages", 1, "list edited catalog").await;
+
+    assert_eq!(runtime_builds.load(Ordering::SeqCst), 3);
+    assert_edited_events_description(&edited);
+
+    delete_source(&harness, "local_messages").await;
+    let after_delete = list_catalog_page(&harness, "", 0, "list catalog after delete").await;
+
+    assert_eq!(runtime_builds.load(Ordering::SeqCst), 4);
+    assert_catalog_missing_source(&after_delete, "local_messages");
+}
+
+async fn call_cached_metadata_endpoints(harness: &GrpcHarness) {
+    harness
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(default_workspace()),
+            schema_name: String::new(),
+            kind: 0,
+            pagination: None,
+        }))
+        .await
+        .expect("list catalog");
+    harness
+        .catalog_client()
+        .search_catalog(Request::new(SearchCatalogRequest {
+            workspace: Some(default_workspace()),
+            pattern: "Issue".to_string(),
+            ignore_case: true,
+            schema_name: String::new(),
+            kind: 0,
+            pagination: None,
+        }))
+        .await
+        .expect("search catalog");
+    harness
+        .catalog_client()
+        .describe_table(Request::new(DescribeTableRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "searchy".to_string(),
+            table_name: "placeholder".to_string(),
+        }))
+        .await
+        .expect("describe table");
+    harness
+        .catalog_client()
+        .list_columns(Request::new(ListColumnsRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "searchy".to_string(),
+            table_name: "placeholder".to_string(),
+            pattern: None,
+            ignore_case: true,
+            required_only: false,
+            pagination: None,
+        }))
+        .await
+        .expect("list columns");
+}
+
+async fn list_catalog_page(
+    harness: &GrpcHarness,
+    schema_name: &str,
+    kind: i32,
+    context: &str,
+) -> ListCatalogResponse {
+    harness
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(default_workspace()),
+            schema_name: schema_name.to_string(),
+            kind,
+            pagination: Some(PaginationRequest {
+                limit: 50,
+                offset: 0,
+            }),
+        }))
+        .await
+        .expect(context)
+        .into_inner()
+}
+
+fn edit_local_messages_manifest(harness: &GrpcHarness) {
+    let manifest_path = harness
+        .config_dir()
+        .join("workspaces/default/sources/local_messages/manifest.yaml");
+    let edited_manifest = fs::read_to_string(&manifest_path)
+        .expect("read imported manifest")
+        .replace("Fixture events", "Edited fixture events");
+    fs::write(&manifest_path, edited_manifest).expect("edit imported manifest");
+}
+
+fn assert_catalog_has_source(response: &ListCatalogResponse, schema_name: &str) {
+    assert!(
+        response
+            .sources
+            .iter()
+            .any(|source| source.schema_name == schema_name)
+    );
+}
+
+fn assert_catalog_missing_source(response: &ListCatalogResponse, schema_name: &str) {
+    assert!(
+        response
+            .sources
+            .iter()
+            .all(|source| source.schema_name != schema_name)
+    );
+}
+
+fn assert_edited_events_description(response: &ListCatalogResponse) {
+    let events = response
+        .items
+        .iter()
+        .find_map(|item| match item.item.as_ref().expect("catalog item") {
+            catalog_item::Item::Table(table) if table.name == "events" => Some(table),
+            catalog_item::Item::Table(_) | catalog_item::Item::TableFunction(_) => None,
+        })
+        .expect("events table");
+    assert_eq!(events.description, "Edited fixture events");
+}
+
+async fn delete_source(harness: &GrpcHarness, name: &str) {
+    harness
+        .source_client()
+        .delete_source(Request::new(DeleteSourceRequest {
+            workspace: Some(default_workspace()),
+            name: name.to_string(),
+        }))
+        .await
+        .expect("delete source");
 }
 
 #[tokio::test]

--- a/crates/coral-app/tests/grpc/harness.rs
+++ b/crates/coral-app/tests/grpc/harness.rs
@@ -1,11 +1,13 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use coral_api::v1::{
     ExecuteSqlRequest, ImportSourceRequest, ListCatalogRequest, ListSourcesRequest,
     PaginationRequest, Source, SourceSecret, SourceVariable, TableSummary, ValidateSourceRequest,
     ValidateSourceResponse, catalog_item, import_source_response,
 };
+use coral_app::EngineExtensionsProvider;
 use coral_client::{
     AppClient, CatalogClient, QueryClient, SourceClient, batches_to_json_rows,
     decode_execute_sql_response, default_workspace,
@@ -31,21 +33,33 @@ impl GrpcHarness {
     pub(crate) async fn new() -> Self {
         let temp_dir = TempDir::new().expect("temp dir");
         let config_dir = temp_dir.path().join("coral-config");
-        Self::start_with_parts(temp_dir, config_dir).await
+        Self::start_with_parts(temp_dir, config_dir, None).await
     }
 
     pub(crate) async fn start_with_config_dir(config_dir: PathBuf) -> Self {
         let temp_dir = TempDir::new().expect("temp dir");
-        Self::start_with_parts(temp_dir, config_dir).await
+        Self::start_with_parts(temp_dir, config_dir, None).await
     }
 
-    async fn start_with_parts(temp_dir: TempDir, config_dir: PathBuf) -> Self {
+    pub(crate) async fn new_with_engine_extensions_provider(
+        provider: Arc<dyn EngineExtensionsProvider>,
+    ) -> Self {
+        let temp_dir = TempDir::new().expect("temp dir");
+        let config_dir = temp_dir.path().join("coral-config");
+        Self::start_with_parts(temp_dir, config_dir, Some(provider)).await
+    }
+
+    async fn start_with_parts(
+        temp_dir: TempDir,
+        config_dir: PathBuf,
+        provider: Option<Arc<dyn EngineExtensionsProvider>>,
+    ) -> Self {
         ensure_file_credentials_config(&config_dir);
-        let server = ServerBuilder::new()
-            .with_config_dir(&config_dir)
-            .start()
-            .await
-            .expect("start server");
+        let mut builder = ServerBuilder::new().with_config_dir(&config_dir);
+        if let Some(provider) = provider {
+            builder = builder.add_engine_extensions_provider(provider);
+        }
+        let server = builder.start().await.expect("start server");
         let app = AppClient::connect(server.endpoint_uri())
             .await
             .expect("connect client");


### PR DESCRIPTION
## Summary
- Add an app-owned workspace catalog metadata cache for query-visible catalog snapshots.
- Serve `list_catalog` and `list_tables` from the cached full `CatalogInfo` snapshot instead of rebuilding the query runtime for each metadata call.
- Invalidate the cache after successful source create/import/delete mutations, and reject cache hits when the workspace catalog input signature changes.

## Rationale
The latest available OTEL traces showed repeated metadata calls spending hundreds of milliseconds rebuilding catalog/runtime state even when the caller was only doing discovery:

- `coral://catalog` trace `988bc41629521a9302e609c1f17cf8e5`: about 875ms.
- `coral://tables` trace `999449697538f6bd19b99e542d16dbf6`: about 863ms.
- Repeated `search_catalog`, `describe_table`, `list_columns`, and `search_columns` probes: about 198-244ms each in the sampled burst.
- Earlier same-day aggregates had `CatalogService/SearchCatalog` avg 455ms p95 940ms, `ListCatalog` avg 353ms p95 928ms, and `DescribeTable` avg 393ms p95 923ms.

Root cause: `QueryManager::list_catalog` and `QueryManager::list_tables` rebuilt the workspace query runtime on every metadata request, then discarded the result. `CatalogDiscovery` fans multiple public metadata endpoints through those methods, so one agent discovery burst paid the same setup cost over and over.

## Design
The cache lives in `coral-app`, behind `QueryManager`, because this is app state and source lifecycle behavior rather than MCP presentation logic. It does not cache SQL execution, SQL explain, or source validation.

Freshness is not TTL-based. Cache entries store a workspace catalog-input signature. `QueryManager` recomputes the signature before serving a cached snapshot. The signature covers installed source identity/config, variables, visible secret keys, credential storage, imported manifest bytes, and credential material values hashed in memory. Raw secret values are not logged or persisted.

`SourceManager` owns explicit invalidation after successful source mutations. `ServerBuilder` wires the same cache into `SourceManager` and `QueryManager`, so source create/import/delete changes invalidate metadata without adding duplicate gRPC-adapter invalidation.

## Expected impact
For an unchanged workspace, a discovery burst such as `list_catalog` -> `search_catalog` -> `describe_table` -> `list_columns` should pay one runtime/catalog build instead of four. More generally, `N` metadata calls over unchanged catalog inputs should pay one build plus cheap filtering/search over the snapshot.

Conservative expected reduction for the observed class: 3-6 fewer runtime/catalog rebuilds per metadata-heavy discovery burst, reducing repeated 200-900ms setup costs to one setup cost until source/catalog inputs change.

## Verification
- `cargo test -p coral-app catalog::cache -- --nocapture`
- `cargo test -p coral-app --test grpc catalog_metadata_reuses_snapshot_until_source_changes -- --nocapture`
- `cargo test -p coral-app --test grpc catalog_discovery_tests -- --nocapture`
- `cargo test -p coral-mcp mcp_surface_refreshes_and_renders_dynamic_guide -- --nocapture`
- `cargo test -p coral-cli --all-features --test mcp mcp_stdio_lists_tools_and_resources -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `make docs-check`
- `make rust-checks`

The gRPC regression proves the concrete reduction: after one import, `list_catalog`, `search_catalog`, `describe_table`, and `list_columns` cause exactly one runtime build. A second import, an out-of-band imported-manifest edit, and a source delete each force exactly one fresh build and return the updated catalog state.
