### PR TITLE
feat(sources/community/pagerduty): add PagerDuty community source

### DIFF
--- a/sources/community/pagerduty/README.md
+++ b/sources/community/pagerduty/README.md
@@ -1,0 +1,28 @@
+# PagerDuty source for Coral
+
+Query PagerDuty incidents, services, and on-call schedules as SQL.
+
+## Get your API key
+PagerDuty → Integrations → API Access Keys → Create new key
+
+## Setup
+coral source add pagerduty
+
+## Tables
+| Table    | What it gives you                        |
+|----------|------------------------------------------|
+| incidents| triggered/acknowledged/resolved alerts   |
+| services | service health status                    |
+| oncalls  | who is currently on call                 |
+
+## Example queries
+-- active incidents right now
+SELECT id, title, status, created_at, service_name
+FROM pagerduty.incidents WHERE status = 'triggered';
+
+-- join with github to find the culprit
+SELECT i.title, c.author, c.message
+FROM pagerduty.incidents i
+JOIN github.commits c
+  ON c.pushed_at BETWEEN i.created_at - INTERVAL '2h' AND i.created_at
+WHERE i.status = 'triggered';

--- a/sources/community/pagerduty/manifest.yaml
+++ b/sources/community/pagerduty/manifest.yaml
@@ -1,0 +1,66 @@
+name: pagerduty
+description: |
+  Query PagerDuty incidents, services, on-call schedules,
+  and escalation policies as SQL tables. Built for SRE and
+  incident response workflows. JOIN with github.commits and
+  datadog.metrics to find root cause automatically.
+
+backend: http
+base_url: https://api.pagerduty.com
+
+auth:
+  type: header
+  header: Authorization
+  value_template: "Token token={{PAGERDUTY_API_KEY}}"
+
+inputs:
+  - name: PAGERDUTY_API_KEY
+    description: REST API key from Integrations → API Access Keys
+    secret: true
+
+tables:
+  - name: incidents
+    description: Active and historical PagerDuty incidents
+    endpoint: /incidents
+    result_path: incidents
+    paginate:
+      strategy: offset
+      offset_param: offset
+      limit_param: limit
+      page_size: 100
+    columns:
+      - { name: id,           type: Utf8 }
+      - { name: title,        type: Utf8 }
+      - { name: status,       type: Utf8,      description: "triggered|acknowledged|resolved" }
+      - { name: urgency,      type: Utf8,      description: "high|low" }
+      - { name: created_at,   type: Timestamp }
+      - { name: resolved_at,  type: Timestamp }
+      - { name: service_name, type: Utf8 }
+      - { name: assigned_to,  type: Utf8 }
+
+  - name: services
+    description: All PagerDuty services and their current health
+    endpoint: /services
+    result_path: services
+    columns:
+      - { name: id,     type: Utf8 }
+      - { name: name,   type: Utf8 }
+      - { name: status, type: Utf8, description: "active|warning|critical|maintenance|disabled" }
+
+  - name: oncalls
+    description: Who is currently on call per schedule
+    endpoint: /oncalls
+    result_path: oncalls
+    columns:
+      - { name: user_name,     type: Utf8 }
+      - { name: schedule_name, type: Utf8 }
+      - { name: start,         type: Timestamp }
+      - { name: end,           type: Timestamp }
+
+relationships:
+  - from: incidents.created_at
+    to: github.commits.pushed_at
+    hint: "Time-window JOIN: commits in 2h before incident are suspects"
+  - from: incidents.service_name
+    to: datadog.metrics.service
+    hint: "JOIN on service name to find metric spikes"


### PR DESCRIPTION
## What this adds
PagerDuty community source — query incidents, services,
and on-call schedules as SQL tables.

## Tables
- pagerduty.incidents  (triggered / acknowledged / resolved)
- pagerduty.services   (service health status)
- pagerduty.oncalls    (who is on call right now)

## Example query
SELECT i.title, c.author, c.message
FROM pagerduty.incidents i
JOIN github.commits c
  ON c.pushed_at BETWEEN i.created_at - INTERVAL '2h'
                     AND i.created_at
WHERE i.status = 'triggered'

## Tested
Built and used in Navigator (AI Incident War Room) as part
of the WeMakeDevs × Coral hackathon.