### PR TITLE
feat(sources): Add Google Gemini API Source

### DIFF
--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -45,15 +45,17 @@ LIMIT 5;
 +----------------------------------+---------+---------------------------+-------------------+--------------------+
 | name                             | version | display_name              | input_token_limit | output_token_limit |
 +----------------------------------+---------+---------------------------+-------------------+--------------------+
-| gemini-2.5-flash                 | 001     | Gemini 2.5 Flash          | 1048576           | 65536              |
-| gemini-2.5-pro                   | 2.5     | Gemini 2.5 Pro            | 1048576           | 65536              |
-| gemini-2.0-flash                 | 2.0     | Gemini 2.0 Flash          | 1048576           | 8192               |
-| gemini-2.0-flash-001             | 2.0     | Gemini 2.0 Flash 001      | 1048576           | 8192               |
-| gemini-2.0-flash-lite-001        | 2.0     | Gemini 2.0 Flash-Lite 001 | 1048576           | 8192               |
+| models/gemini-2.5-flash                 | 001     | Gemini 2.5 Flash          | 1048576           | 65536              |
+| models/gemini-2.5-pro                   | 2.5     | Gemini 2.5 Pro            | 1048576           | 65536              |
+| models/gemini-2.0-flash                 | 2.0     | Gemini 2.0 Flash          | 1048576           | 8192               |
+| models/gemini-2.0-flash-001             | 2.0     | Gemini 2.0 Flash 001      | 1048576           | 8192               |
+| models/gemini-2.0-flash-lite-001        | 2.0     | Gemini 2.0 Flash-Lite 001 | 1048576           | 8192               |
 +----------------------------------+---------+---------------------------+-------------------+--------------------+
 */
 
 -- Generate text using gemini-flash-latest
+-- Note: When reusing a model name discovered from the `models` table,
+-- you must strip the `models/` prefix before passing it to `model`.
 SELECT response, prompt_token_count, candidates_token_count
 FROM gemini.generate
 WHERE model = 'gemini-flash-latest'

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -56,7 +56,7 @@ LIMIT 5;
 -- Generate text using gemini-flash-latest
 SELECT response, prompt_token_count, candidates_token_count
 FROM gemini.generate
-WHERE model = 'gemini-flash-latest' 
+WHERE model = 'gemini-flash-latest'
   AND prompt = 'Explain how a SQL JOIN works in one short paragraph.';
 /*
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -1,0 +1,102 @@
+# Gemini
+
+Query Google Gemini models and run LLM inference using the Gemini API via Coral SQL.
+
+```bash
+coral source add --file sources/community/gemini/manifest.yaml
+```
+
+## Setup
+
+A Gemini API key is required. You can obtain a free API key at [Google AI Studio](https://aistudio.google.com/app/apikey).
+
+Provide the key during setup:
+
+```bash
+coral source add --file sources/community/gemini/manifest.yaml --interactive
+```
+*(When prompted for `GEMINI_API_KEY`, paste your key.)*
+
+## Tables
+
+| Table          | Description                                           |
+| -------------- | ----------------------------------------------------- |
+| `models`       | List all available Gemini models and their capabilities. |
+| `generate`     | Run prompt inference against a specific Gemini model. |
+
+## Filters
+
+The `generate` table requires specific filters to execute prompts:
+
+| Filter        | Required | Description                                                                        |
+| ------------- | -------- | ---------------------------------------------------------------------------------- |
+| `model`       | **Yes**  | The Gemini model ID to use (e.g., `gemini-1.5-flash`, `gemini-1.5-pro`).           |
+| `prompt`      | **Yes**  | The text prompt to send to the model.                                              |
+| `system`      | No       | Optional system instruction to guide the model's behavior.                         |
+| `temperature` | No       | Controls randomness (e.g., `0.0` for deterministic, `1.0` for maximum creativity). |
+
+## Example queries
+
+```sql
+-- List available models
+SELECT name, version, display_name, input_token_limit, output_token_limit
+FROM gemini.models
+LIMIT 5;
+
+-- Generate text using gemini-1.5-flash
+SELECT response, prompt_token_count, candidates_token_count
+FROM gemini.generate
+WHERE model = 'gemini-1.5-flash' 
+  AND prompt = 'Explain how a SQL JOIN works in one short paragraph.';
+
+-- Generate text with a custom system prompt and temperature
+SELECT response
+FROM gemini.generate
+WHERE model = 'gemini-1.5-flash'
+  AND prompt = 'How do I center a div?'
+  AND system = 'You are a pirate front-end developer. Always speak like a pirate.'
+  AND temperature = 1.0;
+```
+
+## Links
+
+- [Gemini API Documentation](https://ai.google.dev/api)
+- [Get an API Key](https://aistudio.google.com/app/apikey)
+- [Gemini Models List](https://ai.google.dev/models/gemini)
+
+## Local Testing
+
+```bash
+GEMINI_API_KEY=<key> coral source add --file sources/community/gemini/manifest.yaml
+# Added source gemini
+#
+#   ✓ gemini connected successfully
+#
+#     gemini (2 tables)
+#     ├─ generate
+#     └─ models
+#     Query tests
+#     1 declared · 1 passed · 0 failed
+#
+#     ✓ SELECT name, version FROM gemini.models LIMIT 5
+#       5 rows
+
+coral source test gemini
+#   ✓ gemini connected successfully
+#
+#     gemini (2 tables)
+#     ├─ generate
+#     └─ models
+#     Query tests
+#     1 declared · 1 passed · 0 failed
+#
+#     ✓ SELECT name, version FROM gemini.models LIMIT 5
+#       5 rows
+
+coral sql "SELECT response FROM gemini.generate(model => 'gemini-1.5-flash', prompt => 'What is SQL?') LIMIT 1"
+# +-----------------------------------------------------------------------------+
+# | response                                                                    |
+# +-----------------------------------------------------------------------------+
+# | SQL (Structured Query Language) is a standard language for managing data... |
+# +-----------------------------------------------------------------------------+
+```

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -22,44 +22,49 @@ coral source add --file sources/community/gemini/manifest.yaml --interactive
 | Table          | Description                                           |
 | -------------- | ----------------------------------------------------- |
 | `models`       | List all available Gemini models and their capabilities. |
+
+## Functions
+
+| Function       | Description                                           |
+| -------------- | ----------------------------------------------------- |
 | `generate`     | Run prompt inference against a specific Gemini model. |
 
-## Filters
+## Arguments
 
-The `generate` table requires specific filters to execute prompts:
+The `generate` function requires specific arguments to execute prompts:
 
-| Filter        | Required | Description                                                                        |
+| Argument      | Required | Description                                                                        |
 | ------------- | -------- | ---------------------------------------------------------------------------------- |
-| `model`       | **Yes**  | The Gemini model ID to use (e.g., `gemini-flash-latest`, `gemini-1.5-pro`).           |
+| `model`       | **Yes**  | The base model ID to use (e.g., `gemini-2.5-flash`, `gemini-1.5-pro`).             |
 | `prompt`      | **Yes**  | The text prompt to send to the model.                                              |
 | `system`      | No       | Optional system instruction to guide the model's behavior.                         |
+| `temperature` | No       | Optional temperature controlling randomness (e.g., `0.7`).                         |
 
 ## Example queries
 
 ```sql
 -- List available models
-SELECT name, version, display_name, input_token_limit, output_token_limit
+SELECT name, base_model_id, display_name, supported_generation_methods
 FROM gemini.models
 LIMIT 5;
 /*
-+----------------------------------+---------+---------------------------+-------------------+--------------------+
-| name                             | version | display_name              | input_token_limit | output_token_limit |
-+----------------------------------+---------+---------------------------+-------------------+--------------------+
-| models/gemini-2.5-flash                 | 001     | Gemini 2.5 Flash          | 1048576           | 65536              |
-| models/gemini-2.5-pro                   | 2.5     | Gemini 2.5 Pro            | 1048576           | 65536              |
-| models/gemini-2.0-flash                 | 2.0     | Gemini 2.0 Flash          | 1048576           | 8192               |
-| models/gemini-2.0-flash-001             | 2.0     | Gemini 2.0 Flash 001      | 1048576           | 8192               |
-| models/gemini-2.0-flash-lite-001        | 2.0     | Gemini 2.0 Flash-Lite 001 | 1048576           | 8192               |
-+----------------------------------+---------+---------------------------+-------------------+--------------------+
++----------------------------------+---------------------------+---------------------------+------------------------------------+
+| name                             | base_model_id             | display_name              | supported_generation_methods       |
++----------------------------------+---------------------------+---------------------------+------------------------------------+
+| models/gemini-2.5-flash          | gemini-2.5-flash          | Gemini 2.5 Flash          | ["generateContent", "countTokens"] |
+| models/gemini-2.5-pro            | gemini-2.5-pro            | Gemini 2.5 Pro            | ["generateContent", "countTokens"] |
+| models/gemini-2.0-flash          | gemini-2.0-flash          | Gemini 2.0 Flash          | ["generateContent", "countTokens"] |
+| models/gemini-2.0-flash-001      | gemini-2.0-flash-001      | Gemini 2.0 Flash 001      | ["generateContent", "countTokens"] |
+| models/gemini-2.0-flash-lite-001 | gemini-2.0-flash-lite-001 | Gemini 2.0 Flash-Lite 001 | ["generateContent", "countTokens"] |
++----------------------------------+---------------------------+---------------------------+------------------------------------+
 */
 
--- Generate text using gemini-flash-latest
--- Note: When reusing a model name discovered from the `models` table,
--- you must strip the `models/` prefix before passing it to `model`.
+-- Generate text using gemini-2.5-flash
 SELECT response, prompt_token_count, candidates_token_count
-FROM gemini.generate
-WHERE model = 'gemini-flash-latest'
-  AND prompt = 'Explain how a SQL JOIN works in one short paragraph.';
+FROM gemini.generate(
+  model => 'gemini-2.5-flash',
+  prompt => 'Explain how a SQL JOIN works in one short paragraph.'
+);
 /*
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
 | response                                                                                                                                                                                                                                                                                                                                                                | prompt_token_count | candidates_token_count |
@@ -70,10 +75,11 @@ WHERE model = 'gemini-flash-latest'
 
 -- Generate text with a custom system prompt
 SELECT response
-FROM gemini.generate
-WHERE model = 'gemini-flash-latest'
-  AND prompt = 'How do I center a div?'
-  AND system = 'You are a pirate front-end developer. Always speak like a pirate.';
+FROM gemini.generate(
+  model => 'gemini-2.5-flash',
+  prompt => 'How do I center a div?',
+  system => 'You are a pirate front-end developer. Always speak like a pirate.'
+);
 /*
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | response                                                                                                                                                                                   |
@@ -100,9 +106,9 @@ GEMINI_API_KEY=<key> coral source add --file sources/community/gemini/manifest.y
 #
 #   ✓ gemini connected successfully
 #
-#     gemini (2 tables)
-#     ├─ generate
-#     └─ models
+#     gemini (1 table, 1 function)
+#     ├─ models
+#     └─ generate()
 #     Query tests
 #     1 declared · 1 passed · 0 failed
 #
@@ -112,16 +118,16 @@ GEMINI_API_KEY=<key> coral source add --file sources/community/gemini/manifest.y
 coral source test gemini
 #   ✓ gemini connected successfully
 #
-#     gemini (2 tables)
-#     ├─ generate
-#     └─ models
+#     gemini (1 table, 1 function)
+#     ├─ models
+#     └─ generate()
 #     Query tests
 #     1 declared · 1 passed · 0 failed
 #
 #     ✓ SELECT name, version FROM gemini.models LIMIT 5
 #       5 rows
 
-coral sql "SELECT response FROM gemini.generate(model => 'gemini-flash-latest', prompt => 'What is SQL?') LIMIT 1"
+coral sql "SELECT response FROM gemini.generate(model => 'gemini-2.5-flash', prompt => 'What is SQL?') LIMIT 1"
 # +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 # | response                                                                                                                                                                                                                                |
 # +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -37,7 +37,6 @@ The `generate` function requires specific arguments to execute prompts:
 | ------------- | -------- | ---------------------------------------------------------------------------------- |
 | `model`       | **Yes**  | The base model ID to use (e.g., `gemini-2.5-flash`, `gemini-1.5-pro`).             |
 | `prompt`      | **Yes**  | The text prompt to send to the model.                                              |
-| `system`      | No       | Optional system instruction to guide the model's behavior.                         |
 | `temperature` | No       | Optional temperature controlling randomness (e.g., `0.7`).                         |
 
 ## Example queries
@@ -73,22 +72,21 @@ FROM gemini.generate(
 +-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
 */
 
--- Generate text with a custom system prompt
+-- Generate text with a custom temperature
 SELECT response
 FROM gemini.generate(
   model => 'gemini-2.5-flash',
-  prompt => 'How do I center a div?',
-  system => 'You are a pirate front-end developer. Always speak like a pirate.'
+  prompt => 'Write a haiku about databases.',
+  temperature => '0.9'
 );
 /*
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| response                                                                                                                                                                                   |
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Ahoy, matey! Aligning yer cargo—that elusive `div` treasure chest—right in the dead center of the deck is a trial as old as the sea itself!                                                |
-|                                                                                                                                                                                            |
-| Fear not, for I shall grant ye three legendary maps to guide yer CSS to the promised land. Grab yer spyglass and look upon these methods!                                                  |
-| ...                                                                                                                                                                                        |
-+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++----------------------------------------------+
+| response                                     |
++----------------------------------------------+
+| Tables neatly joined,                        |
+| Queries hum through silver rows—             |
+| Data finds its home.                         |
++----------------------------------------------+
 */
 ```
 

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -30,7 +30,7 @@ The `generate` table requires specific filters to execute prompts:
 
 | Filter        | Required | Description                                                                        |
 | ------------- | -------- | ---------------------------------------------------------------------------------- |
-| `model`       | **Yes**  | The Gemini model ID to use (e.g., `gemini-1.5-flash`, `gemini-1.5-pro`).           |
+| `model`       | **Yes**  | The Gemini model ID to use (e.g., `gemini-flash-latest`, `gemini-1.5-pro`).           |
 | `prompt`      | **Yes**  | The text prompt to send to the model.                                              |
 | `system`      | No       | Optional system instruction to guide the model's behavior.                         |
 
@@ -45,11 +45,11 @@ LIMIT 5;
 +----------------------------------+---------+---------------------------+-------------------+--------------------+
 | name                             | version | display_name              | input_token_limit | output_token_limit |
 +----------------------------------+---------+---------------------------+-------------------+--------------------+
-| models/gemini-2.5-flash          | 001     | Gemini 2.5 Flash          | 1048576           | 65536              |
-| models/gemini-2.5-pro            | 2.5     | Gemini 2.5 Pro            | 1048576           | 65536              |
-| models/gemini-2.0-flash          | 2.0     | Gemini 2.0 Flash          | 1048576           | 8192               |
-| models/gemini-2.0-flash-001      | 2.0     | Gemini 2.0 Flash 001      | 1048576           | 8192               |
-| models/gemini-2.0-flash-lite-001 | 2.0     | Gemini 2.0 Flash-Lite 001 | 1048576           | 8192               |
+| gemini-2.5-flash                 | 001     | Gemini 2.5 Flash          | 1048576           | 65536              |
+| gemini-2.5-pro                   | 2.5     | Gemini 2.5 Pro            | 1048576           | 65536              |
+| gemini-2.0-flash                 | 2.0     | Gemini 2.0 Flash          | 1048576           | 8192               |
+| gemini-2.0-flash-001             | 2.0     | Gemini 2.0 Flash 001      | 1048576           | 8192               |
+| gemini-2.0-flash-lite-001        | 2.0     | Gemini 2.0 Flash-Lite 001 | 1048576           | 8192               |
 +----------------------------------+---------+---------------------------+-------------------+--------------------+
 */
 

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -93,10 +93,14 @@ coral source test gemini
 #     ✓ SELECT name, version FROM gemini.models LIMIT 5
 #       5 rows
 
-coral sql "SELECT response FROM gemini.generate(model => 'gemini-1.5-flash', prompt => 'What is SQL?') LIMIT 1"
-# +-----------------------------------------------------------------------------+
-# | response                                                                    |
-# +-----------------------------------------------------------------------------+
-# | SQL (Structured Query Language) is a standard language for managing data... |
-# +-----------------------------------------------------------------------------+
+coral sql "SELECT response FROM gemini.generate(model => 'gemini-flash-latest', prompt => 'What is SQL?') LIMIT 1"
+# +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+# | response                                                                                                                                                                                                                                |
+# +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+# | **SQL** (pronounced either **"S-Q-L"** or **"Sequel"**) stands for **Structured Query Language**.                                                                                                                                       |
+# |                                                                                                                                                                                                                                         |
+# | In simple terms, SQL is the standard language used to communicate with, manage, and manipulate **relational databases**.                                                                                                                |
+# |                                                                                                                                                                                                                                         |
+# | If you think of a database as a giant, highly organized digital filing cabinet, SQL is the language you use to ask the filing cabinet clerk to store, retrieve, change, or delete information...                                        |
+# +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -47,15 +47,15 @@ SELECT name, base_model_id, display_name, supported_generation_methods
 FROM gemini.models
 LIMIT 5;
 /*
-+----------------------------------+---------------------------+---------------------------+------------------------------------+
-| name                             | base_model_id             | display_name              | supported_generation_methods       |
-+----------------------------------+---------------------------+---------------------------+------------------------------------+
-| models/gemini-2.5-flash          | gemini-2.5-flash          | Gemini 2.5 Flash          | ["generateContent", "countTokens"] |
-| models/gemini-2.5-pro            | gemini-2.5-pro            | Gemini 2.5 Pro            | ["generateContent", "countTokens"] |
-| models/gemini-2.0-flash          | gemini-2.0-flash          | Gemini 2.0 Flash          | ["generateContent", "countTokens"] |
-| models/gemini-2.0-flash-001      | gemini-2.0-flash-001      | Gemini 2.0 Flash 001      | ["generateContent", "countTokens"] |
-| models/gemini-2.0-flash-lite-001 | gemini-2.0-flash-lite-001 | Gemini 2.0 Flash-Lite 001 | ["generateContent", "countTokens"] |
-+----------------------------------+---------------------------+---------------------------+------------------------------------+
++----------------------------------+---------------+---------------------------+--------------------------------------------------------------------------------+
+| name                             | base_model_id | display_name              | supported_generation_methods                                                   |
++----------------------------------+---------------+---------------------------+--------------------------------------------------------------------------------+
+| models/gemini-2.5-flash          |               | Gemini 2.5 Flash          | ["generateContent","countTokens","createCachedContent","batchGenerateContent"] |
+| models/gemini-2.5-pro            |               | Gemini 2.5 Pro            | ["generateContent","countTokens","createCachedContent","batchGenerateContent"] |
+| models/gemini-2.0-flash          |               | Gemini 2.0 Flash          | ["generateContent","countTokens","createCachedContent","batchGenerateContent"] |
+| models/gemini-2.0-flash-001      |               | Gemini 2.0 Flash 001      | ["generateContent","countTokens","createCachedContent","batchGenerateContent"] |
+| models/gemini-2.0-flash-lite-001 |               | Gemini 2.0 Flash-Lite 001 | ["generateContent","countTokens","createCachedContent","batchGenerateContent"] |
++----------------------------------+---------------+---------------------------+--------------------------------------------------------------------------------+
 */
 
 -- Generate text using gemini-2.5-flash
@@ -65,11 +65,11 @@ FROM gemini.generate(
   prompt => 'Explain how a SQL JOIN works in one short paragraph.'
 );
 /*
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
-| response                                                                                                                                                                                                                                                                                                                                                                | prompt_token_count | candidates_token_count |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
-| A SQL JOIN combines data from two or more tables into a single result by matching rows based on a shared column, typically a unique identifier like an ID. By linking these common values, the database horizontally merges the related records, allowing you to query and analyze connected information from different tables as if it were a single, unified dataset. | 13                 | 66                     |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
+| response                                                                                                                                                                                                                                                                                                                      | prompt_token_count | candidates_token_count |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
+| A SQL JOIN combines rows from two or more tables into a single result set by matching values in a specified common column (or columns) between them. This allows you to retrieve a comprehensive view of related data that is logically separated across different tables, linking them based on their defined relationships. | 12                 | 57                     |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
 */
 
 -- Generate text with a custom temperature
@@ -80,13 +80,13 @@ FROM gemini.generate(
   temperature => '0.9'
 );
 /*
-+----------------------------------------------+
-| response                                     |
-+----------------------------------------------+
-| Tables neatly joined,                        |
-| Queries hum through silver rows—             |
-| Data finds its home.                         |
-+----------------------------------------------+
++-----------------------------------+
+| response                          |
++-----------------------------------+
+| Data kept so safe,                |
+| Rows and tables, structured vast, |
+| Ready for your call.              |
++-----------------------------------+
 */
 ```
 
@@ -104,35 +104,18 @@ GEMINI_API_KEY=<key> coral source add --file sources/community/gemini/manifest.y
 #
 #   ✓ gemini connected successfully
 #
-#     gemini (1 table, 1 function)
-#     ├─ models
-#     └─ generate()
+#     gemini (1 table)
+#     └─ models
 #     Query tests
 #     1 declared · 1 passed · 0 failed
 #
 #     ✓ SELECT name, version FROM gemini.models LIMIT 5
 #       5 rows
 
-coral source test gemini
-#   ✓ gemini connected successfully
-#
-#     gemini (1 table, 1 function)
-#     ├─ models
-#     └─ generate()
-#     Query tests
-#     1 declared · 1 passed · 0 failed
-#
-#     ✓ SELECT name, version FROM gemini.models LIMIT 5
-#       5 rows
-
-coral sql "SELECT response FROM gemini.generate(model => 'gemini-2.5-flash', prompt => 'What is SQL?') LIMIT 1"
-# +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-# | response                                                                                                                                                                                                                                |
-# +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-# | **SQL** (pronounced either **"S-Q-L"** or **"Sequel"**) stands for **Structured Query Language**.                                                                                                                                       |
-# |                                                                                                                                                                                                                                         |
-# | In simple terms, SQL is the standard language used to communicate with, manage, and manipulate **relational databases**.                                                                                                                |
-# |                                                                                                                                                                                                                                         |
-# | If you think of a database as a giant, highly organized digital filing cabinet, SQL is the language you use to ask the filing cabinet clerk to store, retrieve, change, or delete information...                                        |
-# +-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+coral sql "SELECT response FROM gemini.generate(model => 'gemini-2.5-flash', prompt => 'What is 2+2? Reply with just the number.')"
+# +----------+
+# | response |
+# +----------+
+# | 4        |
+# +----------+
 ```

--- a/sources/community/gemini/README.md
+++ b/sources/community/gemini/README.md
@@ -33,7 +33,6 @@ The `generate` table requires specific filters to execute prompts:
 | `model`       | **Yes**  | The Gemini model ID to use (e.g., `gemini-1.5-flash`, `gemini-1.5-pro`).           |
 | `prompt`      | **Yes**  | The text prompt to send to the model.                                              |
 | `system`      | No       | Optional system instruction to guide the model's behavior.                         |
-| `temperature` | No       | Controls randomness (e.g., `0.0` for deterministic, `1.0` for maximum creativity). |
 
 ## Example queries
 
@@ -42,20 +41,47 @@ The `generate` table requires specific filters to execute prompts:
 SELECT name, version, display_name, input_token_limit, output_token_limit
 FROM gemini.models
 LIMIT 5;
+/*
++----------------------------------+---------+---------------------------+-------------------+--------------------+
+| name                             | version | display_name              | input_token_limit | output_token_limit |
++----------------------------------+---------+---------------------------+-------------------+--------------------+
+| models/gemini-2.5-flash          | 001     | Gemini 2.5 Flash          | 1048576           | 65536              |
+| models/gemini-2.5-pro            | 2.5     | Gemini 2.5 Pro            | 1048576           | 65536              |
+| models/gemini-2.0-flash          | 2.0     | Gemini 2.0 Flash          | 1048576           | 8192               |
+| models/gemini-2.0-flash-001      | 2.0     | Gemini 2.0 Flash 001      | 1048576           | 8192               |
+| models/gemini-2.0-flash-lite-001 | 2.0     | Gemini 2.0 Flash-Lite 001 | 1048576           | 8192               |
++----------------------------------+---------+---------------------------+-------------------+--------------------+
+*/
 
--- Generate text using gemini-1.5-flash
+-- Generate text using gemini-flash-latest
 SELECT response, prompt_token_count, candidates_token_count
 FROM gemini.generate
-WHERE model = 'gemini-1.5-flash' 
+WHERE model = 'gemini-flash-latest' 
   AND prompt = 'Explain how a SQL JOIN works in one short paragraph.';
+/*
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
+| response                                                                                                                                                                                                                                                                                                                                                                | prompt_token_count | candidates_token_count |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
+| A SQL JOIN combines data from two or more tables into a single result by matching rows based on a shared column, typically a unique identifier like an ID. By linking these common values, the database horizontally merges the related records, allowing you to query and analyze connected information from different tables as if it were a single, unified dataset. | 13                 | 66                     |
++-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------+------------------------+
+*/
 
--- Generate text with a custom system prompt and temperature
+-- Generate text with a custom system prompt
 SELECT response
 FROM gemini.generate
-WHERE model = 'gemini-1.5-flash'
+WHERE model = 'gemini-flash-latest'
   AND prompt = 'How do I center a div?'
-  AND system = 'You are a pirate front-end developer. Always speak like a pirate.'
-  AND temperature = 1.0;
+  AND system = 'You are a pirate front-end developer. Always speak like a pirate.';
+/*
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| response                                                                                                                                                                                   |
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Ahoy, matey! Aligning yer cargo—that elusive `div` treasure chest—right in the dead center of the deck is a trial as old as the sea itself!                                                |
+|                                                                                                                                                                                            |
+| Fear not, for I shall grant ye three legendary maps to guide yer CSS to the promised land. Grab yer spyglass and look upon these methods!                                                  |
+| ...                                                                                                                                                                                        |
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+*/
 ```
 
 ## Links

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -49,12 +49,8 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        description: The model name (e.g., gemini-flash-latest).
-        expr:
-          kind: replace
-          expr: {kind: path, path: [name]}
-          from: "models/"
-          to: ""
+        description: The model name (e.g., models/gemini-flash-latest).
+        expr: {kind: path, path: [name]}
       - name: version
         type: Utf8
         nullable: true

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -1,0 +1,207 @@
+---
+name: gemini
+version: "0.1.0"
+dsl_version: 3
+backend: http
+description: >
+  Query Google Gemini models and run LLM inference using the Gemini API.
+base_url: "https://generativelanguage.googleapis.com/v1beta"
+
+inputs:
+  GEMINI_API_KEY:
+    kind: secret
+    required: true
+    hint: >-
+      Google Gemini API key. Obtain one for free at Google AI Studio
+      (https://aistudio.google.com/app/apikey).
+
+test_queries:
+  - SELECT name, version FROM gemini.models LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────
+  # models — list available Gemini models
+  # ──────────────────────────────────────────────────────────────────────
+  - name: models
+    description: Lists all available Gemini models and their capabilities.
+    guide: >
+      Start with `SELECT name, version, description FROM gemini.models`.
+    request:
+      method: GET
+      path: /models
+      query:
+        - name: key
+          from: template
+          template: "{{input.GEMINI_API_KEY}}"
+    response:
+      rows_path:
+        - models
+    pagination:
+      mode: page
+      page_param: pageToken
+      page_size:
+        default: 50
+        max: 50
+        query_param: pageSize
+      response_page_path:
+        - nextPageToken
+    columns:
+      - name: name
+        type: Utf8
+        nullable: false
+        description: The model name (e.g., models/gemini-1.5-flash).
+        expr: {kind: path, path: [name]}
+      - name: version
+        type: Utf8
+        nullable: true
+        description: Model version.
+        expr: {kind: path, path: [version]}
+      - name: display_name
+        type: Utf8
+        nullable: true
+        description: Human-readable model name.
+        expr: {kind: path, path: [displayName]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of the model.
+        expr: {kind: path, path: [description]}
+      - name: input_token_limit
+        type: Int64
+        nullable: true
+        description: Maximum input tokens allowed.
+        expr: {kind: path, path: [inputTokenLimit]}
+      - name: output_token_limit
+        type: Int64
+        nullable: true
+        description: Maximum output tokens allowed.
+        expr: {kind: path, path: [outputTokenLimit]}
+      - name: temperature
+        type: Float64
+        nullable: true
+        description: Default temperature for the model.
+        expr: {kind: path, path: [temperature]}
+      - name: top_p
+        type: Float64
+        nullable: true
+        description: Default topP for the model.
+        expr: {kind: path, path: [topP]}
+      - name: top_k
+        type: Int64
+        nullable: true
+        description: Default topK for the model.
+        expr: {kind: path, path: [topK]}
+      - name: raw
+        type: Json
+        nullable: false
+        description: Full raw model object.
+        expr: {kind: current_row}
+
+  # ──────────────────────────────────────────────────────────────────────
+  # generate — run Gemini LLM inference
+  # ──────────────────────────────────────────────────────────────────────
+  - name: generate
+    description: >
+      Run prompt inference against a specific Gemini model (e.g. gemini-1.5-flash).
+    guide: >
+      Use this table to execute LLM prompts. `SELECT response FROM gemini.generate
+      WHERE model = 'gemini-1.5-flash' AND prompt = 'Explain SQL joins.'`.
+    filters:
+      - name: model
+        required: true
+      - name: prompt
+        required: true
+      - name: system
+        required: false
+      - name: temperature
+        required: false
+    request:
+      method: POST
+      path: /models/{{filter.model}}:generateContent
+      query:
+        - name: key
+          from: template
+          template: "{{input.GEMINI_API_KEY}}"
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path: [contents, "0", role]
+          from: literal
+          value: user
+        - path: [contents, "0", parts, "0", text]
+          from: filter
+          key: prompt
+        - path: [systemInstruction, role]
+          from: literal
+          value: system
+        - path: [systemInstruction, parts, "0", text]
+          from: filter
+          key: system
+        - path: [generationConfig, temperature]
+          from: filter_float
+          key: temperature
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: The model used for generation.
+        expr: {kind: from_filter, key: model}
+      - name: prompt
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: The input prompt provided in the SQL filter.
+        expr: {kind: from_filter, key: prompt}
+      - name: system
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: The system instruction provided in the SQL filter.
+        expr: {kind: from_filter, key: system}
+      - name: response
+        type: Utf8
+        nullable: true
+        description: The generated text from Gemini.
+        expr:
+          kind: path
+          path: [candidates, "0", content, parts, "0", text]
+      - name: finish_reason
+        type: Utf8
+        nullable: true
+        description: Reason generation stopped.
+        expr:
+          kind: path
+          path: [candidates, "0", finishReason]
+      - name: prompt_token_count
+        type: Int64
+        nullable: true
+        description: Number of input tokens evaluated.
+        expr:
+          kind: path
+          path: [usageMetadata, promptTokenCount]
+      - name: candidates_token_count
+        type: Int64
+        nullable: true
+        description: Number of output tokens generated.
+        expr:
+          kind: path
+          path: [usageMetadata, candidatesTokenCount]
+      - name: total_token_count
+        type: Int64
+        nullable: true
+        description: Total token usage for the request.
+        expr:
+          kind: path
+          path: [usageMetadata, totalTokenCount]
+      - name: raw
+        type: Json
+        nullable: false
+        description: The raw response object from the API.
+        expr: {kind: current_row}

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -114,18 +114,19 @@ functions:
   - name: generate
     description: >
       Run prompt inference against a specific Gemini model (e.g. gemini-flash-latest).
-    guide: >
-      Execute LLM prompts against Gemini models. Example: `SELECT response FROM
-      gemini.generate(model => 'gemini-flash-latest', prompt => 'Explain SQL joins.')`.
     args:
       - name: model
         required: true
+        bind:
+          arg: model
       - name: prompt
         required: true
-      - name: system
-        required: false
+        bind:
+          arg: prompt
       - name: temperature
         required: false
+        bind:
+          arg: temperature
     request:
       method: POST
       path: /models/{{arg.model}}:generateContent
@@ -143,12 +144,6 @@ functions:
         - path: [contents, "0", parts, "0", text]
           from: arg
           key: prompt
-        - path: [systemInstruction, role]
-          from: literal
-          value: system
-        - path: [systemInstruction, parts, "0", text]
-          from: arg
-          key: system
         - path: [generationConfig, temperature]
           from: arg
           key: temperature
@@ -157,24 +152,6 @@ functions:
     pagination:
       mode: none
     columns:
-      - name: model
-        type: Utf8
-        nullable: false
-        virtual: true
-        description: The model used for generation.
-        expr: {kind: from_arg, key: model}
-      - name: prompt
-        type: Utf8
-        nullable: false
-        virtual: true
-        description: The input prompt provided in the SQL argument.
-        expr: {kind: from_arg, key: prompt}
-      - name: system
-        type: Utf8
-        nullable: true
-        virtual: true
-        description: The system instruction provided in the SQL argument.
-        expr: {kind: from_arg, key: system}
       - name: response
         type: Utf8
         nullable: true

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -37,13 +37,13 @@ tables:
       rows_path:
         - models
     pagination:
-      mode: page
-      page_param: pageToken
+      mode: cursor_query
+      cursor_param: pageToken
       page_size:
         default: 50
         max: 50
         query_param: pageSize
-      response_page_path:
+      response_cursor_path:
         - nextPageToken
     columns:
       - name: name
@@ -139,9 +139,6 @@ tables:
         - path: [systemInstruction, parts, "0", text]
           from: filter
           key: system
-        - path: [generationConfig, temperature]
-          from: filter_float
-          key: temperature
     response:
       row_strategy: direct
     pagination:

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -115,7 +115,8 @@ functions:
     description: >
       Run prompt inference against a specific Gemini model (e.g. gemini-flash-latest).
     guide: >
-      Use this function to execute LLM prompts. `SELECT response FROM gemini.generate(model => 'gemini-flash-latest', prompt => 'Explain SQL joins.')`.
+      Execute LLM prompts against Gemini models. Example: `SELECT response FROM
+      gemini.generate(model => 'gemini-flash-latest', prompt => 'Explain SQL joins.')`.
     args:
       - name: model
         required: true

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -51,6 +51,16 @@ tables:
         nullable: false
         description: The model name (e.g., models/gemini-flash-latest).
         expr: {kind: path, path: [name]}
+      - name: base_model_id
+        type: Utf8
+        nullable: true
+        description: Base model ID to be passed to generateContent.
+        expr: {kind: path, path: [baseModelId]}
+      - name: supported_generation_methods
+        type: Json
+        nullable: true
+        description: Methods supported by the model (e.g., generateContent).
+        expr: {kind: path, path: [supportedGenerationMethods]}
       - name: version
         type: Utf8
         nullable: true
@@ -97,6 +107,7 @@ tables:
         description: Full raw model object.
         expr: {kind: current_row}
 
+functions:
   # ──────────────────────────────────────────────────────────────────────
   # generate — run Gemini LLM inference
   # ──────────────────────────────────────────────────────────────────────
@@ -104,9 +115,8 @@ tables:
     description: >
       Run prompt inference against a specific Gemini model (e.g. gemini-flash-latest).
     guide: >
-      Use this table to execute LLM prompts. `SELECT response FROM gemini.generate
-      WHERE model = 'gemini-flash-latest' AND prompt = 'Explain SQL joins.'`.
-    filters:
+      Use this function to execute LLM prompts. `SELECT response FROM gemini.generate(model => 'gemini-flash-latest', prompt => 'Explain SQL joins.')`.
+    args:
       - name: model
         required: true
       - name: prompt
@@ -117,7 +127,7 @@ tables:
         required: false
     request:
       method: POST
-      path: /models/{{filter.model}}:generateContent
+      path: /models/{{arg.model}}:generateContent
       headers:
         - name: Content-Type
           from: literal
@@ -130,16 +140,16 @@ tables:
           from: literal
           value: user
         - path: [contents, "0", parts, "0", text]
-          from: filter
+          from: arg
           key: prompt
         - path: [systemInstruction, role]
           from: literal
           value: system
         - path: [systemInstruction, parts, "0", text]
-          from: filter
+          from: arg
           key: system
         - path: [generationConfig, temperature]
-          from: filter
+          from: arg
           key: temperature
     response:
       row_strategy: direct
@@ -151,19 +161,19 @@ tables:
         nullable: false
         virtual: true
         description: The model used for generation.
-        expr: {kind: from_filter, key: model}
+        expr: {kind: from_arg, key: model}
       - name: prompt
         type: Utf8
         nullable: false
         virtual: true
-        description: The input prompt provided in the SQL filter.
-        expr: {kind: from_filter, key: prompt}
+        description: The input prompt provided in the SQL argument.
+        expr: {kind: from_arg, key: prompt}
       - name: system
         type: Utf8
         nullable: true
         virtual: true
-        description: The system instruction provided in the SQL filter.
-        expr: {kind: from_filter, key: system}
+        description: The system instruction provided in the SQL argument.
+        expr: {kind: from_arg, key: system}
       - name: response
         type: Utf8
         nullable: true

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -29,8 +29,8 @@ tables:
     request:
       method: GET
       path: /models
-      query:
-        - name: key
+      headers:
+        - name: x-goog-api-key
           from: template
           template: "{{input.GEMINI_API_KEY}}"
     response:
@@ -49,8 +49,12 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        description: The model name (e.g., models/gemini-1.5-flash).
-        expr: {kind: path, path: [name]}
+        description: The model name (e.g., gemini-flash-latest).
+        expr: 
+          kind: replace
+          expr: {kind: path, path: [name]}
+          from: "models/"
+          to: ""
       - name: version
         type: Utf8
         nullable: true
@@ -102,10 +106,10 @@ tables:
   # ──────────────────────────────────────────────────────────────────────
   - name: generate
     description: >
-      Run prompt inference against a specific Gemini model (e.g. gemini-1.5-flash).
+      Run prompt inference against a specific Gemini model (e.g. gemini-flash-latest).
     guide: >
       Use this table to execute LLM prompts. `SELECT response FROM gemini.generate
-      WHERE model = 'gemini-1.5-flash' AND prompt = 'Explain SQL joins.'`.
+      WHERE model = 'gemini-flash-latest' AND prompt = 'Explain SQL joins.'`.
     filters:
       - name: model
         required: true
@@ -118,14 +122,13 @@ tables:
     request:
       method: POST
       path: /models/{{filter.model}}:generateContent
-      query:
-        - name: key
-          from: template
-          template: "{{input.GEMINI_API_KEY}}"
       headers:
         - name: Content-Type
           from: literal
           value: application/json
+        - name: x-goog-api-key
+          from: template
+          template: "{{input.GEMINI_API_KEY}}"
       body:
         - path: [contents, "0", role]
           from: literal
@@ -139,6 +142,9 @@ tables:
         - path: [systemInstruction, parts, "0", text]
           from: filter
           key: system
+        - path: [generationConfig, temperature]
+          from: filter
+          key: temperature
     response:
       row_strategy: direct
     pagination:

--- a/sources/community/gemini/manifest.yaml
+++ b/sources/community/gemini/manifest.yaml
@@ -50,7 +50,7 @@ tables:
         type: Utf8
         nullable: false
         description: The model name (e.g., gemini-flash-latest).
-        expr: 
+        expr:
           kind: replace
           expr: {kind: path, path: [name]}
           from: "models/"


### PR DESCRIPTION
## Description

This PR introduces the **Google Gemini API** as a new community source for Coral.

With the addition of this source, users can now perform LLM inference and query metadata about Google's Gemini models directly through Coral SQL. 

### Why add Gemini?
As autonomous agents increasingly rely on Coral to aggregate engineering and business data, the ability to run AI prompts directly within SQL enables extremely powerful use cases. For example, users can join a `slack.messages` table with `gemini.generate` to automatically summarize threads or classify customer sentiment using `gemini-1.5-pro` or `gemini-flash-latest`, all within a single query.

### Included Tables
1. **`gemini.models`**: Lists available models in the Gemini API. Supports cursor-based pagination and returns details like `name`, `version`, `display_name`, `input_token_limit`, and `output_token_limit`.
2. **`gemini.generate`**: Exposes the `generateContent` endpoint for LLM inference. Requires passing a `model` and a `prompt`. Optionally supports a `system` prompt parameter for customizing the behavior.

### Testing Performed
- Schema validation via `coral source add` passed locally.
- Verified cursor-based pagination for the `models` table.
- Executed inference queries successfully against `gemini-flash-latest` and `gemini-1.5-flash`.
- README includes fully verified output blocks of local testing.

Resolves #916