### PR TITLE
feat: HTTP request observability

### DIFF
--- a/crates/coral-engine/Cargo.toml
+++ b/crates/coral-engine/Cargo.toml
@@ -29,6 +29,7 @@ reqwest.workspace = true
 rmcp.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 strsim.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -102,7 +102,7 @@ impl HttpSourceClient {
         filter_values: &HashMap<String, String>,
         arg_values: &HashMap<String, String>,
         sql_limit: Option<usize>,
-        request_explain: &crate::backends::http::request::ResolvedHttpRequest,
+        projection: Option<&Vec<usize>>,
     ) -> Result<Vec<Value>> {
         fetch_rows(
             self,
@@ -110,7 +110,7 @@ impl HttpSourceClient {
             filter_values,
             arg_values,
             sql_limit,
-            request_explain,
+            projection,
         )
         .await
     }

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -102,7 +102,16 @@ impl HttpSourceClient {
         filter_values: &HashMap<String, String>,
         arg_values: &HashMap<String, String>,
         sql_limit: Option<usize>,
+        request_explain: &crate::backends::http::request::ResolvedHttpRequest,
     ) -> Result<Vec<Value>> {
-        fetch_rows(self, target, filter_values, arg_values, sql_limit).await
+        fetch_rows(
+            self,
+            target,
+            filter_values,
+            arg_values,
+            sql_limit,
+            request_explain,
+        )
+        .await
     }
 }

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -12,8 +12,9 @@ use crate::backends::http::pagination::{
     PageState, apply_pagination_body_fields, apply_pagination_query_pairs, page_is_exhausted,
     pagination_state_values, resolve_page_size,
 };
-use crate::backends::http::request::ResolvedHttpRequest;
-use crate::backends::http::request::{build_query_pairs, build_request_body};
+use crate::backends::http::request::{
+    build_outgoing_request_explain, build_query_pairs, build_request_body,
+};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::transport::{OutgoingHttpRequest, execute_request};
 use crate::backends::http::url::{join_url, normalize_base_url};
@@ -41,7 +42,7 @@ pub(super) async fn fetch_rows(
     filter_values: &HashMap<String, String>,
     arg_values: &HashMap<String, String>,
     sql_limit: Option<usize>,
-    request_explain: &ResolvedHttpRequest,
+    projection: Option<&Vec<usize>>,
 ) -> Result<Vec<Value>> {
     let mut all_rows = Vec::new();
     let limits = resolve_fetch_limits(target, sql_limit);
@@ -145,6 +146,15 @@ pub(super) async fn fetch_rows(
             })?;
             (query_pairs, body)
         };
+
+        let request_explain = build_outgoing_request_explain(
+            active_request.method,
+            &url,
+            &query_pairs,
+            body.as_ref(),
+            page_size.or(limits.effective_limit),
+            projection.map(|projection| projection.as_slice()),
+        )?;
 
         let request = execute_request(
             &client.http,

--- a/crates/coral-engine/src/backends/http/fetch.rs
+++ b/crates/coral-engine/src/backends/http/fetch.rs
@@ -12,6 +12,7 @@ use crate::backends::http::pagination::{
     PageState, apply_pagination_body_fields, apply_pagination_query_pairs, page_is_exhausted,
     pagination_state_values, resolve_page_size,
 };
+use crate::backends::http::request::ResolvedHttpRequest;
 use crate::backends::http::request::{build_query_pairs, build_request_body};
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::transport::{OutgoingHttpRequest, execute_request};
@@ -40,6 +41,7 @@ pub(super) async fn fetch_rows(
     filter_values: &HashMap<String, String>,
     arg_values: &HashMap<String, String>,
     sql_limit: Option<usize>,
+    request_explain: &ResolvedHttpRequest,
 ) -> Result<Vec<Value>> {
     let mut all_rows = Vec::new();
     let limits = resolve_fetch_limits(target, sql_limit);
@@ -165,6 +167,7 @@ pub(super) async fn fetch_rows(
                 render_context,
                 allow_404_empty: target.response().allow_404_empty,
                 link_header_require_results: pagination.link_header_require_results,
+                request_explain,
             },
         )
         .await?;

--- a/crates/coral-engine/src/backends/http/function.rs
+++ b/crates/coral-engine/src/backends/http/function.rs
@@ -20,8 +20,10 @@ use datafusion::physical_plan::ExecutionPlan;
 
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::provider::{HttpJsonExecRequest, http_json_exec};
+use crate::backends::http::request::build_request_explain;
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
+use crate::backends::shared::template::{EMPTY_MAP, RenderContext};
 use crate::backends::shared::filter_expr::literal_to_string;
 
 struct FunctionCallContext<'a> {
@@ -137,6 +139,19 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
         _filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let render_context = RenderContext::new(
+            &EMPTY_MAP,
+            &self.arg_values,
+            &EMPTY_MAP,
+            self.state.resolved_inputs.as_ref(),
+        );
+        let request_explain = build_request_explain(
+            &self.state.backend.base_url,
+            self.state.target.resolved_request(),
+            &render_context,
+            limit,
+            projection.map(|projection| projection.as_slice()),
+        )?;
         http_json_exec(HttpJsonExecRequest {
             backend: self.state.backend.clone(),
             source_schema: &self.state.source_schema,
@@ -146,6 +161,7 @@ impl TableProvider for HttpSourceFunctionCallTableProvider {
             arg_values: self.arg_values.clone(),
             projection,
             limit,
+            request_explain,
         })
     }
 }

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -73,7 +73,7 @@ struct HttpFetchPlan {
     filter_values: Arc<HashMap<String, String>>,
     arg_values: Arc<HashMap<String, String>>,
     limit: Option<usize>,
-    request_explain: crate::backends::http::request::ResolvedHttpRequest,
+    projection: Option<Vec<usize>>,
 }
 
 pub(crate) struct HttpJsonExecRequest<'a> {
@@ -97,7 +97,7 @@ impl RowFetcher for HttpFetchPlan {
                 &self.filter_values,
                 &self.arg_values,
                 self.limit,
-                &self.request_explain,
+                self.projection.as_ref(),
             )
             .await
     }
@@ -124,7 +124,7 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         filter_values: filter_values.clone(),
         arg_values: arg_values.clone(),
         limit,
-        request_explain: request_explain.clone(),
+        projection: projection.cloned(),
     });
 
     let converter = {

--- a/crates/coral-engine/src/backends/http/provider.rs
+++ b/crates/coral-engine/src/backends/http/provider.rs
@@ -14,11 +14,13 @@ use serde_json::Value;
 
 use crate::backends::http::HttpSourceClient;
 use crate::backends::http::ProviderQueryError;
+use crate::backends::http::request::build_request_explain;
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::schema_from_columns;
 use crate::backends::shared::filter_expr::{extract_filter_values, literal_to_string};
 use crate::backends::shared::json_exec::{JsonExec, RowFetcher};
 use crate::backends::shared::mapping::convert_items;
+use crate::backends::shared::template::EMPTY_MAP;
 use coral_spec::FilterMode;
 use coral_spec::backends::http::HttpTableSpec;
 
@@ -71,6 +73,7 @@ struct HttpFetchPlan {
     filter_values: Arc<HashMap<String, String>>,
     arg_values: Arc<HashMap<String, String>>,
     limit: Option<usize>,
+    request_explain: crate::backends::http::request::ResolvedHttpRequest,
 }
 
 pub(crate) struct HttpJsonExecRequest<'a> {
@@ -82,6 +85,7 @@ pub(crate) struct HttpJsonExecRequest<'a> {
     pub(crate) arg_values: HashMap<String, String>,
     pub(crate) projection: Option<&'a Vec<usize>>,
     pub(crate) limit: Option<usize>,
+    pub(crate) request_explain: crate::backends::http::request::ResolvedHttpRequest,
 }
 
 #[async_trait]
@@ -93,6 +97,7 @@ impl RowFetcher for HttpFetchPlan {
                 &self.filter_values,
                 &self.arg_values,
                 self.limit,
+                &self.request_explain,
             )
             .await
     }
@@ -108,6 +113,7 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         arg_values,
         projection,
         limit,
+        request_explain,
     } = request;
     let target = Arc::new(target);
     let filter_values = Arc::new(filter_values);
@@ -118,6 +124,7 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         filter_values: filter_values.clone(),
         arg_values: arg_values.clone(),
         limit,
+        request_explain: request_explain.clone(),
     });
 
     let converter = {
@@ -143,6 +150,7 @@ pub(crate) fn http_json_exec(request: HttpJsonExecRequest<'_>) -> Result<Arc<dyn
         fetcher,
         converter,
         projection.cloned(),
+        Some(request_explain.into_json_exec_explain()),
     )?;
 
     Ok(Arc::new(exec))
@@ -209,6 +217,19 @@ impl TableProvider for HttpSourceTableProvider {
         let filter_value_keys: HashSet<String> = filter_values.keys().cloned().collect();
         let active_request = self.table.resolve_request(&filter_value_keys).clone();
         let target = self.target.with_resolved_request(active_request);
+        let render_context = crate::backends::shared::template::RenderContext::new(
+            &filter_values,
+            &EMPTY_MAP,
+            &EMPTY_MAP,
+            self.backend.resolved_inputs.as_ref(),
+        );
+        let request_explain = build_request_explain(
+            &self.backend.base_url,
+            target.resolved_request(),
+            &render_context,
+            limit,
+            projection.map(|projection| projection.as_slice()),
+        )?;
 
         http_json_exec(HttpJsonExecRequest {
             backend: self.backend.clone(),
@@ -219,6 +240,7 @@ impl TableProvider for HttpSourceTableProvider {
             arg_values: HashMap::new(),
             projection,
             limit,
+            request_explain,
         })
     }
 }

--- a/crates/coral-engine/src/backends/http/request.rs
+++ b/crates/coral-engine/src/backends/http/request.rs
@@ -119,7 +119,7 @@ pub(super) fn build_outgoing_request_explain(
             .iter()
             .map(|(name, value)| json!({"name": name, "value": value}))
             .collect::<Vec<_>>(),
-        "body": body.map(request_body_to_json),
+        "body": body.map(request_body_summary),
         "limit": limit,
         "projection": projection,
     }))
@@ -154,10 +154,17 @@ fn http_method_label(method: HttpMethod) -> &'static str {
     }
 }
 
-fn request_body_to_json(body: &RequestBody) -> Value {
+fn request_body_summary(body: &RequestBody) -> Value {
     match body {
-        RequestBody::Json(value) => value.clone(),
-        RequestBody::Text(text) => Value::String(text.clone()),
+        RequestBody::Json(value) => json!({
+            "kind": "json",
+            "empty": value.as_object().is_some_and(|object| object.is_empty())
+                || value.as_array().is_some_and(|array| array.is_empty()),
+        }),
+        RequestBody::Text(text) => json!({
+            "kind": "text",
+            "empty": text.is_empty(),
+        }),
     }
 }
 pub(super) fn build_query_pairs(
@@ -456,7 +463,9 @@ mod tests {
 
         assert_ne!(first.resolved_request(), second.resolved_request());
         assert_ne!(first.fingerprint(), second.fingerprint());
-        assert!(first.resolved_request().contains("first page"));
-        assert!(second.resolved_request().contains("second page"));
+        assert!(first.resolved_request().contains("\"kind\":\"text\""));
+        assert!(second.resolved_request().contains("\"kind\":\"text\""));
+        assert!(!first.resolved_request().contains("first page"));
+        assert!(!second.resolved_request().contains("second page"));
     }
 }

--- a/crates/coral-engine/src/backends/http/request.rs
+++ b/crates/coral-engine/src/backends/http/request.rs
@@ -1,10 +1,17 @@
 //! Request query and body construction for HTTP-backed sources.
 
-use datafusion::error::{DataFusionError, Result};
-use serde_json::{Map, Value};
+use std::fmt;
 
+use datafusion::error::{DataFusionError, Result};
+use serde_json::{Map, Value, json};
+
+use sha2::{Digest, Sha256};
+use crate::backends::http::transport::build_logged_url;
+use crate::backends::http::url::{join_url, normalize_base_url};
+use crate::backends::shared::json_exec::JsonExecExplain;
 use crate::backends::shared::template::{RenderContext, resolve_value_source, value_to_string};
 use coral_spec::BodySpec;
+use coral_spec::{ParsedTemplate, RequestSpec};
 
 #[derive(Debug, Clone)]
 pub(super) enum RequestBody {
@@ -12,6 +19,97 @@ pub(super) enum RequestBody {
     Text(String),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ResolvedHttpRequest {
+    resolved_request: String,
+    fingerprint: String,
+}
+
+impl ResolvedHttpRequest {
+    #[must_use]
+    pub(super) fn new(resolved_request: String, fingerprint: String) -> Self {
+        Self {
+            resolved_request,
+            fingerprint,
+        }
+    }
+
+    #[must_use]
+    pub(super) fn resolved_request(&self) -> &str {
+        &self.resolved_request
+    }
+
+    #[must_use]
+    pub(super) fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    #[must_use]
+    pub(super) fn into_json_exec_explain(self) -> JsonExecExplain {
+        JsonExecExplain::new(self.resolved_request, self.fingerprint)
+    }
+}
+
+impl fmt::Display for ResolvedHttpRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "resolved_request={} fingerprint={}", self.resolved_request, self.fingerprint)
+    }
+}
+
+pub(super) fn build_request_explain(
+    base_url: &ParsedTemplate,
+    request: &RequestSpec,
+    render_context: &RenderContext<'_>,
+    limit: Option<usize>,
+    projection: Option<&[usize]>,
+) -> Result<ResolvedHttpRequest> {
+    let base_url = normalize_base_url(&crate::backends::shared::template::render_template(
+        base_url,
+        render_context,
+    )?);
+    let rendered_path = crate::backends::shared::template::render_template(
+        &request.path,
+        render_context,
+    )?;
+    let url = join_url(&base_url, &rendered_path)?;
+    let query_pairs = build_query_pairs(request, render_context)?;
+    let logged_url = build_logged_url(&url, &query_pairs);
+    let projection = projection.map(|indices| indices.to_vec());
+    let resolved_request = serde_json::to_string(&json!({
+        "request": request,
+        "call": {
+            "url": logged_url,
+            "query": query_pairs
+                .iter()
+                .map(|(name, value)| json!({"name": name, "value": value}))
+                .collect::<Vec<_>>(),
+            "limit": limit,
+            "projection": projection,
+        },
+    }))
+    .map_err(|error| {
+        DataFusionError::Execution(format!("failed to serialize HTTP request explain payload: {error}"))
+    })?;
+    let fingerprint_payload = json!({
+        "url": logged_url,
+        "query": query_pairs
+            .iter()
+            .map(|(name, value)| json!({"name": name, "value": value}))
+            .collect::<Vec<_>>(),
+        "limit": limit,
+        "projection": projection,
+    });
+    let fingerprint = request_fingerprint(&fingerprint_payload)?;
+    Ok(ResolvedHttpRequest::new(resolved_request, fingerprint))
+}
+
+fn request_fingerprint(payload: &Value) -> Result<String> {
+    let bytes = serde_json::to_vec(payload).map_err(|error| {
+        DataFusionError::Execution(format!("failed to serialize HTTP request fingerprint payload: {error}"))
+    })?;
+    let digest = Sha256::digest(bytes);
+    Ok(format!("{digest:x}"))
+}
 pub(super) fn build_query_pairs(
     request: &coral_spec::RequestSpec,
     render_context: &RenderContext<'_>,
@@ -120,10 +218,13 @@ mod tests {
 
     use serde_json::json;
 
-    use super::{RequestBody, build_request_body, set_path_value};
+    use super::{
+        build_request_body, build_request_explain, set_path_value, RequestBody,
+    };
     use crate::backends::shared::template::RenderContext;
     use coral_spec::{
-        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, RequestSpec, ValueSourceSpec,
+        BodyFieldSpec, BodySpec, HttpMethod, ParsedTemplate, QueryParamSpec, RequestSpec,
+        ValueSourceSpec,
     };
 
     #[test]
@@ -227,5 +328,57 @@ mod tests {
                 "Statistics": ["Average"]
             })
         );
+    }
+
+    #[test]
+    fn build_request_explain_is_stable_for_the_same_input() {
+        let request = RequestSpec {
+            method: HttpMethod::GET,
+            path: ParsedTemplate::parse("/items").expect("template"),
+            query: vec![QueryParamSpec {
+                name: "limit".to_string(),
+                value: ValueSourceSpec::Literal {
+                    value: json!(10),
+                },
+            }],
+            body: BodySpec::default(),
+            headers: vec![],
+        };
+        let base_url = ParsedTemplate::parse("https://api.example.com").expect("template");
+        let resolved_inputs = BTreeMap::new();
+        let context = RenderContext::source_scoped(&resolved_inputs);
+
+        let explain_one = build_request_explain(
+            &base_url,
+            &request,
+            &context,
+            Some(5),
+            Some(&[0, 2]),
+        )
+        .expect("request explain should build");
+        let explain_two = build_request_explain(
+            &base_url,
+            &request,
+            &context,
+            Some(5),
+            Some(&[0, 2]),
+        )
+        .expect("request explain should build");
+        let explain_different_limit = build_request_explain(
+            &base_url,
+            &request,
+            &context,
+            Some(6),
+            Some(&[0, 2]),
+        )
+        .expect("request explain should build");
+
+        assert_eq!(explain_one.resolved_request(), explain_two.resolved_request());
+        assert_eq!(explain_one.fingerprint(), explain_two.fingerprint());
+        assert_ne!(
+            explain_one.fingerprint(),
+            explain_different_limit.fingerprint()
+        );
+        assert!(explain_one.resolved_request().contains("https://api.example.com/items"));
     }
 }

--- a/crates/coral-engine/src/backends/http/request.rs
+++ b/crates/coral-engine/src/backends/http/request.rs
@@ -10,8 +10,7 @@ use crate::backends::http::transport::build_logged_url;
 use crate::backends::http::url::{join_url, normalize_base_url};
 use crate::backends::shared::json_exec::JsonExecExplain;
 use crate::backends::shared::template::{RenderContext, resolve_value_source, value_to_string};
-use coral_spec::BodySpec;
-use coral_spec::{ParsedTemplate, RequestSpec};
+use coral_spec::{BodySpec, HttpMethod, ParsedTemplate, RequestSpec};
 
 #[derive(Debug, Clone)]
 pub(super) enum RequestBody {
@@ -103,12 +102,63 @@ pub(super) fn build_request_explain(
     Ok(ResolvedHttpRequest::new(resolved_request, fingerprint))
 }
 
+pub(super) fn build_outgoing_request_explain(
+    method: HttpMethod,
+    url: &str,
+    query_pairs: &[(String, String)],
+    body: Option<&RequestBody>,
+    limit: Option<usize>,
+    projection: Option<&[usize]>,
+) -> Result<ResolvedHttpRequest> {
+    let logged_url = build_logged_url(url, query_pairs);
+    let projection = projection.map(|indices| indices.to_vec());
+    let resolved_request = serde_json::to_string(&json!({
+        "method": http_method_label(method),
+        "url": logged_url,
+        "query": query_pairs
+            .iter()
+            .map(|(name, value)| json!({"name": name, "value": value}))
+            .collect::<Vec<_>>(),
+        "body": body.map(request_body_to_json),
+        "limit": limit,
+        "projection": projection,
+    }))
+    .map_err(|error| {
+        DataFusionError::Execution(format!("failed to serialize HTTP outgoing request explain payload: {error}"))
+    })?;
+    let fingerprint_payload = json!({
+        "url": logged_url,
+        "query": query_pairs
+            .iter()
+            .map(|(name, value)| json!({"name": name, "value": value}))
+            .collect::<Vec<_>>(),
+        "limit": limit,
+        "projection": projection,
+    });
+    let fingerprint = request_fingerprint(&fingerprint_payload)?;
+    Ok(ResolvedHttpRequest::new(resolved_request, fingerprint))
+}
+
 fn request_fingerprint(payload: &Value) -> Result<String> {
     let bytes = serde_json::to_vec(payload).map_err(|error| {
         DataFusionError::Execution(format!("failed to serialize HTTP request fingerprint payload: {error}"))
     })?;
     let digest = Sha256::digest(bytes);
     Ok(format!("{digest:x}"))
+}
+
+fn http_method_label(method: HttpMethod) -> &'static str {
+    match method {
+        HttpMethod::GET => "GET",
+        HttpMethod::POST => "POST",
+    }
+}
+
+fn request_body_to_json(body: &RequestBody) -> Value {
+    match body {
+        RequestBody::Json(value) => value.clone(),
+        RequestBody::Text(text) => Value::String(text.clone()),
+    }
 }
 pub(super) fn build_query_pairs(
     request: &coral_spec::RequestSpec,
@@ -219,7 +269,8 @@ mod tests {
     use serde_json::json;
 
     use super::{
-        build_request_body, build_request_explain, set_path_value, RequestBody,
+        build_outgoing_request_explain, build_request_body, build_request_explain,
+        set_path_value, RequestBody,
     };
     use crate::backends::shared::template::RenderContext;
     use coral_spec::{
@@ -380,5 +431,32 @@ mod tests {
             explain_different_limit.fingerprint()
         );
         assert!(explain_one.resolved_request().contains("https://api.example.com/items"));
+    }
+
+    #[test]
+    fn build_outgoing_request_explain_reflects_page_specific_values() {
+        let first = build_outgoing_request_explain(
+            HttpMethod::GET,
+            "https://api.example.com/items?page=1",
+            &[("page".to_string(), "1".to_string())],
+            Some(&RequestBody::Text("first page".to_string())),
+            Some(25),
+            Some(&[0, 1]),
+        )
+        .expect("outgoing request explain should build");
+        let second = build_outgoing_request_explain(
+            HttpMethod::GET,
+            "https://api.example.com/items?page=2",
+            &[("page".to_string(), "2".to_string())],
+            Some(&RequestBody::Text("second page".to_string())),
+            Some(25),
+            Some(&[0, 1]),
+        )
+        .expect("outgoing request explain should build");
+
+        assert_ne!(first.resolved_request(), second.resolved_request());
+        assert_ne!(first.fingerprint(), second.fingerprint());
+        assert!(first.resolved_request().contains("first page"));
+        assert!(second.resolved_request().contains("second page"));
     }
 }

--- a/crates/coral-engine/src/backends/http/transport.rs
+++ b/crates/coral-engine/src/backends/http/transport.rs
@@ -18,6 +18,7 @@ use crate::backends::http::error::{pagination_error, provider_error};
 use crate::backends::http::pagination::extract_next_link_url;
 use crate::backends::http::rate_limit::{RateLimitDecision, check_rate_limit};
 use crate::backends::http::request::RequestBody;
+use crate::backends::http::request::ResolvedHttpRequest;
 use crate::backends::http::response::{ResponseDecodeContext, decode_response_body};
 use crate::backends::http::trace::{
     HttpBodyCapture, inject_trace_context, record_http_processing_error, record_http_status_error,
@@ -48,6 +49,7 @@ pub(super) struct OutgoingHttpRequest<'a> {
     pub(super) render_context: RenderContext<'a>,
     pub(super) allow_404_empty: bool,
     pub(super) link_header_require_results: bool,
+    pub(super) request_explain: &'a ResolvedHttpRequest,
 }
 
 #[expect(
@@ -82,6 +84,7 @@ pub(super) async fn execute_request(
         render_context,
         allow_404_empty,
         link_header_require_results,
+        request_explain,
     } = request;
     let mut server_error_retries = 0usize;
     let mut throttle_retries = 0usize;
@@ -141,6 +144,8 @@ pub(super) async fn execute_request(
             http.request.method = method_label,
             http.request.query_count = query_pairs.len(),
             http.request.resend_count = field::Empty,
+            coral.http.request.fingerprint = field::Empty,
+            coral.http.request.resolved = field::Empty,
             http.response.body.size = field::Empty,
             http.response.status_code = field::Empty,
             net.peer.name = field::Empty,
@@ -152,6 +157,14 @@ pub(super) async fn execute_request(
             server.address = field::Empty,
             server.port = field::Empty,
             url.full = %traced_url,
+        );
+        request_span.record(
+            "coral.http.request.resolved",
+            field::display(request_explain.resolved_request()),
+        );
+        request_span.record(
+            "coral.http.request.fingerprint",
+            field::display(request_explain.fingerprint()),
         );
         record_trace_http_endpoint(&request_span, &trace_endpoint);
         if attempt > 1 {
@@ -394,7 +407,7 @@ fn build_http_request(
     }
 }
 
-fn build_logged_url(url: &str, query_pairs: &[(String, String)]) -> String {
+pub(super) fn build_logged_url(url: &str, query_pairs: &[(String, String)]) -> String {
     if query_pairs.is_empty() {
         return url.to_string();
     }

--- a/crates/coral-engine/src/backends/mcp/function.rs
+++ b/crates/coral-engine/src/backends/mcp/function.rs
@@ -177,6 +177,7 @@ impl TableProvider for McpFunctionCallTableProvider {
             fetcher,
             converter,
             projection.cloned(),
+            None,
         )?;
         Ok(Arc::new(exec))
     }

--- a/crates/coral-engine/src/backends/mcp/provider.rs
+++ b/crates/coral-engine/src/backends/mcp/provider.rs
@@ -192,6 +192,7 @@ impl TableProvider for McpTableProvider {
             fetcher,
             converter,
             projection.cloned(),
+            None,
         )?;
         Ok(Arc::new(exec))
     }

--- a/crates/coral-engine/src/backends/shared/json_exec.rs
+++ b/crates/coral-engine/src/backends/shared/json_exec.rs
@@ -32,6 +32,39 @@ pub(crate) type Fetcher = Arc<dyn RowFetcher>;
 /// Converts fetched JSON rows into a projected `RecordBatch`.
 pub(crate) type Converter = Arc<dyn Fn(&[Value]) -> Result<RecordBatch> + Send + Sync>;
 
+/// Extra request metadata shown in `DataFusion` explain output.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct JsonExecExplain {
+    resolved_request: String,
+    fingerprint: String,
+}
+
+impl JsonExecExplain {
+    #[must_use]
+    pub(crate) fn new(resolved_request: impl Into<String>, fingerprint: impl Into<String>) -> Self {
+        Self {
+            resolved_request: resolved_request.into(),
+            fingerprint: fingerprint.into(),
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn resolved_request(&self) -> &str {
+        &self.resolved_request
+    }
+
+    #[must_use]
+    pub(crate) fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+}
+
+impl fmt::Display for JsonExecExplain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "resolved_request={} fingerprint={}", self.resolved_request, self.fingerprint)
+    }
+}
+
 /// Execution-plan node for backends that fetch JSON rows and convert them into
 /// `Arrow` record batches.
 pub(crate) struct JsonExec {
@@ -42,6 +75,7 @@ pub(crate) struct JsonExec {
     fetcher: Fetcher,
     converter: Converter,
     projection: Option<Vec<usize>>,
+    explain: Option<JsonExecExplain>,
 }
 
 impl fmt::Debug for JsonExec {
@@ -49,6 +83,7 @@ impl fmt::Debug for JsonExec {
         f.debug_struct("JsonExec")
             .field("source", &self.source_name)
             .field("table", &self.table_name)
+            .field("explain", &self.explain)
             .finish_non_exhaustive()
     }
 }
@@ -67,6 +102,7 @@ impl JsonExec {
         fetcher: Fetcher,
         converter: Converter,
         projection: Option<Vec<usize>>,
+        explain: Option<JsonExecExplain>,
     ) -> Result<Self> {
         let projected_schema = match &projection {
             Some(indices) => Arc::new(schema.project(indices).map_err(|error| {
@@ -89,13 +125,18 @@ impl JsonExec {
             fetcher,
             converter,
             projection,
+            explain,
         })
     }
 }
 
 impl DisplayAs for JsonExec {
     fn fmt_as(&self, _format: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}Exec: table={}", self.source_name, self.table_name)
+        write!(f, "{}Exec: table={}", self.source_name, self.table_name)?;
+        if let Some(explain) = &self.explain {
+            write!(f, " {explain}")?;
+        }
+        Ok(())
     }
 }
 
@@ -215,6 +256,7 @@ mod tests {
             noop_fetcher(),
             converter_with_schema(schema),
             Some(vec![1]),
+            None,
         )
         .expect("projection should succeed");
 
@@ -233,6 +275,7 @@ mod tests {
             noop_fetcher(),
             converter_with_schema(schema),
             Some(vec![1]),
+            None,
         )
         .expect_err("invalid projection should return an error");
 


### PR DESCRIPTION
## Description
HTTP request observability is now threaded through the HTTP execution path. The shared plan node in json_exec.rs now carries `JsonExecExplain`, and the HTTP provider/function paths build a resolved request snapshot plus a stable SHA-256 fingerprint from URL, query params, limit, and projection in request.rs, provider.rs, and function.rs. That same observation is emitted in the HTTP request span in transport.rs as `coral.http.request.resolved` and `coral.http.request.fingerprint`.

Validation was limited to editor-level static error checks because this environment does not have `cargo` or `rustup` installed on PATH. The touched Rust files passed `get_errors`, and I also added a focused unit test for the request fingerprint helper in request.rs.


fixes #918