### PR TITLE
feat(sources/community/shortcut): add shortcut community source

### DIFF
--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -230,11 +230,9 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 - **Rate limits:** the Shortcut API enforces a limit of 200 requests per
   minute per token. Reduce query frequency or add retries if you hit limits.
-- **`detail=slim` on stories:** the stories table sends `detail=slim` to
-  the Shortcut search API to request a reduced payload. Only top-level
-  story fields are returned; description, comments, pull requests, branches,
-  and tasks are excluded. This reduces response size and avoids fetching
-  fields not exposed by this source.
+- **`detail=full` on stories:** the stories table sends `detail=full` to
+  the Shortcut search API to ensure all declared columns including
+  `cycle_time` are populated in the response.
 - **Auth header:** this source uses `Shortcut-Token: <token>` not
   `Authorization: Bearer`. Generate the token at
   https://app.shortcut.com/settings/account/api-tokens.

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -5,7 +5,7 @@
 **Tables:** 6
 **Base URL:** `https://api.app.shortcut.com/api/v3`
 
-Query members, workflows, epics, stories, iterations, and milestones from
+Query members, workflows, epics, stories, iterations, and objectives from
 Shortcut via SQL. Designed for engineering project analytics: story cycle
 times, sprint velocity, epic progress, and cross-source joins with the
 bundled **Linear**, **GitHub**, and **Jira** sources.
@@ -14,18 +14,8 @@ bundled **Linear**, **GitHub**, and **Jira** sources.
 
 ### 1. Generate a Shortcut API token
 
-1. Go to https://app.shortcut.com/settings/account/api-tokens
+1. Go to [https://app.shortcut.com/settings/account/api-tokens](https://app.shortcut.com/settings/account/api-tokens)
 2. Click **Generate Token**, give it a name, and copy the token.
-
-Shortcut API tokens inherit the full permissions of the user who created
-them. Depending on the associated Shortcut role, the token may allow read
-or write access across the workspace outside Coral.
-
-This source itself is read-only and never performs write operations, but
-the token can still be used independently against the Shortcut API.
-
-For least-privilege access, consider creating a dedicated Shortcut Observer
-(read-only) user for Coral integrations when possible.
 
 ### 2. Set your token
 
@@ -52,9 +42,9 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories discovered via search API | `query` | — |
+| `shortcut.stories` | Stories discovered via search API | — | `query` |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
-| `shortcut.milestones` | Milestones | — | — |
+| `shortcut.objectives` | Objectives (replaces deprecated milestones) | — | — |
 
 All tables are read-only. This source does not create, modify, or delete any
 Shortcut data.
@@ -82,34 +72,22 @@ Lists all epics in the workspace. Use `state` to filter locally:
 
 ### `stories`
 
-Lists stories discovered via the Shortcut search API.
+Lists stories discovered via the Shortcut search API. The optional `query`
+filter is pushed down to the API and accepts Shortcut search operators:
 
-The required `query` filter is pushed down directly to Shortcut and accepts
-Shortcut search operators:
-
-| Example             | Meaning                          |
-| ------------------- | -------------------------------- |
-| `is:started`        | Stories currently in progress    |
-| `type:bug`          | Stories of type bug              |
-| `type:feature`      | Stories of type feature          |
-| `is:completed`      | Completed stories                |
-| `epic:my-epic`      | Stories in a specific epic       |
+| Example | Meaning |
+|---|---|
+| `is:started` | Stories currently in progress |
+| `type:bug` | Stories of type bug |
+| `type:feature` | Stories of type feature |
+| `is:completed` | Completed stories |
+| `epic:my-epic` | Stories in a specific epic |
 | `iteration:current` | Stories in the current iteration |
 
-Example:
-
-```sql
-SELECT id, name, story_type
-FROM shortcut.stories
-WHERE query = 'type:bug iteration:current'
-LIMIT 20;
-```
+Without a `query` filter, all stories are returned. Results are paginated
+with a maximum of 25 stories per page.
 
 `cycle_time` is returned in seconds from story start to completion.
-
-Current limitation: this source currently returns only the first page of
-Shortcut search results because cursor pagination is not yet implemented.
-Use restrictive search queries to reduce result size.
 
 ### `iterations`
 
@@ -121,10 +99,9 @@ Lists all iterations (sprints). Use `status` to filter locally:
 | `started` | Iteration is in progress |
 | `done` | Iteration is completed |
 
-### `milestones`
+### `objectives`
 
-Lists all milestones. Use `state` to filter locally: `to do`, `in progress`,
-or `done`.
+Lists all objectives. Shortcut deprecated `GET /milestones` in favour of `GET /objectives`. Use `state` to filter locally: `to do`, `in progress`, or `done`.
 
 ## Example queries
 
@@ -182,7 +159,7 @@ Stories joined to their epic:
 SELECT s.id, s.name, s.story_type, e.name AS epic_name, e.state AS epic_state
 FROM shortcut.stories s
 LEFT JOIN shortcut.epics e ON s.epic_id = e.id
-WHERE query = 'is:started'
+WHERE s.query = 'is:started'
 ORDER BY e.name, s.id
 LIMIT 20;
 ```
@@ -193,7 +170,7 @@ Current iteration stories with member names:
 SELECT s.id, s.name, s.story_type, i.name AS iteration_name, i.status
 FROM shortcut.stories s
 LEFT JOIN shortcut.iterations i ON s.iteration_id = i.id
-WHERE query = 'iteration:current'
+WHERE s.query = 'iteration:current'
 ORDER BY s.id
 LIMIT 20;
 ```
@@ -232,15 +209,14 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
 # epics — no required filters
 cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
 
-# stories — required query pushdown
-
-cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories WHERE query = 'is:started' LIMIT 5"
+# stories — no required filters, optional query pushdown
+cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories LIMIT 5"
 
 # iterations — no required filters
 cargo run -p coral-cli -- sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
 
-# milestones — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.milestones LIMIT 5"
+# objectives — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.objectives LIMIT 5"
 ```
 
 Inspect registered tables and columns:
@@ -252,22 +228,28 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 ## Notes
 
+- **Rate limits:** the Shortcut API enforces a limit of 200 requests per
+  minute per token. Reduce query frequency or add retries if you hit limits.
+- **`detail=slim` on stories:** the stories table sends `detail=slim` to
+  the Shortcut search API to request a reduced payload. Only top-level
+  story fields are returned; description, comments, pull requests, branches,
+  and tasks are excluded. This reduces response size and avoids fetching
+  fields not exposed by this source.
 - **Auth header:** this source uses `Shortcut-Token: <token>` not
   `Authorization: Bearer`. Generate the token at
   https://app.shortcut.com/settings/account/api-tokens.
 - **`email` field:** sourced from `profile.email_address` in the API
   response, not a top-level field.
-- **`stories` pagination:** this source currently returns only the first
-  page of Shortcut search results because cursor pagination is not yet
-  implemented in Coral for this endpoint.
-- **`query` filter on stories:** required for `shortcut.stories` because
-  the underlying Shortcut `/search/stories` endpoint requires a search
-  query. The filter accepts Shortcut search operators. See
+- **`stories` pagination:** the Shortcut search API returns a maximum of
+  25 stories per page with cursor-based pagination. Always use `LIMIT`
+  for large workspaces.
+- **`query` filter on stories:** accepts Shortcut search operators. Without
+  a query, all stories are returned. See
   https://help.shortcut.com/hc/en-us/articles/360000046646-Search-Operators
   for the full list of operators.
 - **`cycle_time`** is returned in seconds from story start to completion.
   Divide by 3600 for hours or 86400 for days.
-- **`members`, `workflows`, `epics`, `iterations`, `milestones`** return
+- **`members`, `workflows`, `epics`, `iterations`, `objectives`** return
   the full workspace list with no pagination — all results are returned
   in a single response.
 

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -42,7 +42,7 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories discovered via search API | — | `query` |
+| `shortcut.stories` | Stories discovered via search API | `query` | — |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
 | `shortcut.objectives` | Objectives (replaces deprecated milestones) | — | — |
 
@@ -72,8 +72,7 @@ Lists all epics in the workspace. Use `state` to filter locally:
 
 ### `stories`
 
-Lists stories discovered via the Shortcut search API. The optional `query`
-filter is pushed down to the API and accepts Shortcut search operators:
+Stories are discovered via the Shortcut Search API. The `query` filter is required and is pushed down to the API using Shortcut search operators.
 
 | Example | Meaning |
 |---|---|
@@ -83,9 +82,6 @@ filter is pushed down to the API and accepts Shortcut search operators:
 | `is:completed` | Completed stories |
 | `epic:my-epic` | Stories in a specific epic |
 | `iteration:current` | Stories in the current iteration |
-
-Without a `query` filter, all stories are returned. Results are paginated
-with a maximum of 25 stories per page.
 
 `cycle_time` is returned in seconds from story start to completion.
 
@@ -230,17 +226,16 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 - **Rate limits:** the Shortcut API enforces a limit of 200 requests per
   minute per token. Reduce query frequency or add retries if you hit limits.
-- **`detail=full` on stories:** the stories table sends `detail=full` to
-  the Shortcut search API to ensure all declared columns including
-  `cycle_time` are populated in the response.
+- **`detail=full`** is used on `/search/stories` to ensure all fields required for analytics
+  (including `cycle_time`, `estimate`, and workflow metadata) are included in the response.
+  This increases payload size but guarantees full column availability.
 - **Auth header:** this source uses `Shortcut-Token: <token>` not
   `Authorization: Bearer`. Generate the token at
   https://app.shortcut.com/settings/account/api-tokens.
 - **`email` field:** sourced from `profile.email_address` in the API
   response, not a top-level field.
-- **`stories` pagination:** the Shortcut search API returns a maximum of
-  25 stories per page with cursor-based pagination. Always use `LIMIT`
-  for large workspaces.
+- **`stories` pagination:** Results are returned in paginated batches (up to 250 records per request) 
+  using cursor-based pagination via `next` tokens.
 - **`query` filter on stories:** accepts Shortcut search operators. Without
   a query, all stories are returned. See
   https://help.shortcut.com/hc/en-us/articles/360000046646-Search-Operators

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -2,13 +2,13 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP (Shortcut REST API v3)
-**Tables:** 8
+**Tables:** 7
 **Base URL:** `https://api.app.shortcut.com/api/v3`
 
-Query members, workflows, workflow states, epic states, epics, stories,
-iterations, and objectives from Shortcut via SQL. Designed for engineering
-project analytics: story cycle times, sprint velocity, epic progress, and
-cross-source joins with the bundled **Linear**, **GitHub**, and **Jira** sources.
+Query members, workflows, epic states, epics, stories, iterations, and
+objectives from Shortcut via SQL. Designed for engineering project analytics:
+story cycle times, sprint velocity, epic progress, and cross-source joins
+with the bundled **Linear**, **GitHub**, and **Jira** sources.
 
 ## Setup
 
@@ -35,13 +35,13 @@ export SHORTCUT_TOKEN="<your-api-token>"
 ### 3. Add the source
 
 ```sh
-cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
+coral source add --file sources/community/shortcut/manifest.yaml
 ```
 
 ### 4. Verify
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
+coral sql "SELECT id, name FROM shortcut.members LIMIT 5"
 ```
 
 ## Tables
@@ -50,10 +50,9 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 |---|---|---|---|
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
-| `shortcut.workflow_states` | States within each workflow — join to stories.workflow_state_id | — | — |
 | `shortcut.epic_states` | Epic workflow states — join to epics.epic_state_id | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories via Shortcut Search API — first page only (up to 250 records) | `query` | — |
+| `shortcut.stories` | Stories via Shortcut Search API — first page only (up to 250 records, explicitly requested via page_size=250) | `query` | — |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
 | `shortcut.objectives` | Objectives (replaces deprecated milestones) | — | — |
 
@@ -68,21 +67,10 @@ Shortcut comments and descriptions.
 
 ### `workflows`
 
-Lists all workflows in the workspace. Join with `workflow_states` on
-`id = workflow_id` to see all states per workflow.
-
-### `workflow_states`
-
-Unnests the `states` array from `GET /workflows`. Each row is one state
-across all workflows. Join `id` to `shortcut.stories.workflow_state_id`
-to resolve what state a story is currently in.
-
-| Column | Description |
-|---|---|
-| `id` | State ID — join to `stories.workflow_state_id` |
-| `name` | State display name (e.g. In Development, Ready for Review) |
-| `type` | `Unstarted`, `Started`, or `Done` |
-| `position` | Position within the workflow (0 = leftmost) |
+Lists all workflows in the workspace. Use `id` to join with
+`shortcut.stories` on `workflow_id`. Workflow states are nested inside
+each workflow object in the API response and cannot be unnested into a
+separate SQL table in this version — see Out of scope for v1.
 
 ### `epic_states`
 
@@ -94,7 +82,7 @@ current model — prefer this over the deprecated `epics.state` string field.
 |---|---|
 | `id` | Epic state ID — join to `epics.epic_state_id` |
 | `name` | State display name |
-| `type` | State type: `to do`, `in progress`, or `done` |
+| `type` | State type as returned by the API: `Unstarted`, `Started`, or `Done` |
 
 ### `epics`
 
@@ -137,20 +125,10 @@ Lists all iterations (sprints). Use `status` to filter locally:
 ### `objectives`
 
 Lists all objectives. Shortcut deprecated `GET /milestones` in favour of
-`GET /objectives`. Use `state` to filter locally.
+`GET /objectives`. Use `state` to filter locally: `to do`, `in progress`,
+or `done`.
 
 ## Example queries
-
-Stories with resolved state name:
-
-```sql
-SELECT s.id, s.name, s.story_type, ws.name AS state_name, ws.type AS state_type
-FROM shortcut.stories s
-JOIN shortcut.workflow_states ws ON s.workflow_state_id = ws.id
-WHERE s.query = 'is:started'
-ORDER BY s.id
-LIMIT 20;
-```
 
 In-progress epics with state name (current model):
 
@@ -158,36 +136,25 @@ In-progress epics with state name (current model):
 SELECT e.id, e.name, es.name AS state_name, e.started_at
 FROM shortcut.epics e
 JOIN shortcut.epic_states es ON e.epic_state_id = es.id
-WHERE es.type = 'in progress'
+WHERE es.type = 'Started'
 ORDER BY e.started_at
 LIMIT 20;
 ```
 
-Stories joined to their epic with state names:
+Stories joined to their epic with epic state:
 
 ```sql
 SELECT
   s.id,
   s.name,
   s.story_type,
-  ws.name AS story_state,
   e.name AS epic_name,
   es.name AS epic_state
 FROM shortcut.stories s
-JOIN shortcut.workflow_states ws ON s.workflow_state_id = ws.id
 LEFT JOIN shortcut.epics e ON s.epic_id = e.id
 LEFT JOIN shortcut.epic_states es ON e.epic_state_id = es.id
 WHERE s.query = 'is:started'
 LIMIT 20;
-```
-
-All workflow states across all workflows:
-
-```sql
-SELECT ws.id, ws.name, ws.type, ws.position, w.name AS workflow_name
-FROM shortcut.workflow_states ws
-JOIN shortcut.workflows w ON ws.workflow_id = w.id
-ORDER BY w.name, ws.position;
 ```
 
 Bug stories in the current iteration:
@@ -197,6 +164,28 @@ SELECT id, name, story_type, workflow_state_id, estimate, created_at
 FROM shortcut.stories
 WHERE query = 'type:bug iteration:current'
 ORDER BY created_at DESC
+LIMIT 20;
+```
+
+All stories with cycle time for completed work:
+
+```sql
+SELECT id, name, story_type, cycle_time, completed_at
+FROM shortcut.stories
+WHERE query = 'is:completed'
+  AND completed = true
+ORDER BY completed_at DESC
+LIMIT 50;
+```
+
+Current iteration stories with iteration name:
+
+```sql
+SELECT s.id, s.name, s.story_type, i.name AS iteration_name, i.status
+FROM shortcut.stories s
+LEFT JOIN shortcut.iterations i ON s.iteration_id = i.id
+WHERE s.query = 'iteration:current'
+ORDER BY s.id
 LIMIT 20;
 ```
 
@@ -216,30 +205,29 @@ LIMIT 20;
 Lint the manifest:
 
 ```sh
-cargo run -p coral-cli -- source lint sources/community/shortcut/manifest.yaml
+coral source lint sources/community/shortcut/manifest.yaml
 ```
 
 Add the source and validate each table:
 
 ```sh
 export SHORTCUT_TOKEN="<your-api-token>"
-cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
+coral source add --file sources/community/shortcut/manifest.yaml
 
-cargo run -p coral-cli -- sql "SELECT id, name, email, role FROM shortcut.members LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, type, position FROM shortcut.workflow_states LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, type FROM shortcut.epic_states LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, epic_state_id, state FROM shortcut.epics LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, story_type, workflow_state_id FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.objectives LIMIT 5"
+coral sql "SELECT id, name, email, role FROM shortcut.members LIMIT 5"
+coral sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
+coral sql "SELECT id, name, type FROM shortcut.epic_states LIMIT 5"
+coral sql "SELECT id, name, epic_state_id FROM shortcut.epics LIMIT 5"
+coral sql "SELECT id, name, story_type, workflow_state_id FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
+coral sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
+coral sql "SELECT id, name, state, created_at FROM shortcut.objectives LIMIT 5"
 ```
 
 Inspect registered tables and columns:
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'shortcut'"
-cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'shortcut' ORDER BY table_name, ordinal_position"
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'shortcut'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'shortcut' ORDER BY table_name, ordinal_position"
 ```
 
 ## Notes
@@ -248,21 +236,30 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
   the creating user. Store them in environment variables or a secrets manager.
   Use an Observer-role member to limit write exposure.
 - **Rate limits:** 200 requests per minute per token; retry on 429.
-- **`workflow_states`:** unnested from `GET /workflows` — no separate API
-  call needed. Join `id` to `stories.workflow_state_id` to resolve state names.
-- **`epic_states`:** sourced from `GET /epic-workflow`. Join `id` to
-  `epics.epic_state_id` — this is the current model. The `epics.state` string
-  column is deprecated by Shortcut and kept only for backwards compatibility.
 - **`detail=full`** on `/search/stories` ensures `cycle_time`, `estimate`,
   and workflow metadata are included.
-- **`stories` pagination:** first page only (up to 250 records). Use a narrow
-  `query` to stay within one page.
+- **Auth header:** this source uses `Shortcut-Token: <token>` not
+  `Authorization: Bearer`.
+- **`email` field:** sourced from `profile.email_address` in the API
+  response, not a top-level field.
+- **`epic_states.type`:** values returned by the API are `Unstarted`,
+  `Started`, and `Done` — use these exact strings in WHERE clauses.
+- **`epics.state`:** deprecated by Shortcut — use `epic_state_id` joined
+  to `epic_states` instead.
+- **`stories` pagination:** first page only (up to 250 records, explicitly
+  requested via `page_size=250`). Use a narrow `query` to stay within one page.
+- **`query` filter on stories:** required — this table uses Shortcut's Search
+  API which does not support unfiltered listing. Accepts search operators such
+  as `is:started`, `type:bug`, `epic:my-epic`, and `iteration:current`.
 - **`cycle_time`** is in seconds — divide by 3600 for hours or 86400 for days.
-- **`members`, `workflows`, `workflow_states`, `epic_states`, `iterations`,
-  `objectives`** return the full workspace list in a single response.
+- **Workflow states:** the `GET /workflows` response embeds states as a nested
+  array per workflow object. Coral cannot unnest per-parent arrays into a
+  separate table, so `workflow_states` is not available in this version. Use
+  `workflow_state_id` on stories to identify the state ID.
 
 ## Out of scope for v1
 
+- `workflow_states` table (Coral cannot unnest per-parent nested arrays from a single endpoint)
 - Multi-page pagination for `stories` (blocked by Shortcut returning `next` as a full URL)
 - Labels table
 - Groups table

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -17,12 +17,15 @@ bundled **Linear**, **GitHub**, and **Jira** sources.
 1. Go to https://app.shortcut.com/settings/account/api-tokens
 2. Click **Generate Token**, give it a name, and copy the token.
 
-Shortcut API tokens inherit the permissions of the user who created them.
-They are workspace-level tokens and may grant broad read access across your
-Shortcut workspace depending on that user's role and permissions.
+Shortcut API tokens inherit the full permissions of the user who created
+them. Depending on the associated Shortcut role, the token may allow read
+or write access across the workspace outside Coral.
 
-For security, create a dedicated read-only or least-privileged Shortcut user
-when possible.
+This source itself is read-only and never performs write operations, but
+the token can still be used independently against the Shortcut API.
+
+For least-privilege access, consider creating a dedicated Shortcut Observer
+(read-only) user for Coral integrations when possible.
 
 ### 2. Set your token
 
@@ -104,8 +107,9 @@ LIMIT 20;
 
 `cycle_time` is returned in seconds from story start to completion.
 
-The underlying Shortcut search API supports cursor-based pagination and
-allows `page_size` values up to 250.
+Current limitation: this source currently returns only the first page of
+Shortcut search results because cursor pagination is not yet implemented.
+Use restrictive search queries to reduce result size.
 
 ### `iterations`
 
@@ -253,9 +257,9 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
   https://app.shortcut.com/settings/account/api-tokens.
 - **`email` field:** sourced from `profile.email_address` in the API
   response, not a top-level field.
-- **`stories` pagination:** the Shortcut search API uses cursor-based
-  pagination and supports `page_size` values up to 250. Always use
-  `LIMIT` for large workspaces.
+- **`stories` pagination:** this source currently returns only the first
+  page of Shortcut search results because cursor pagination is not yet
+  implemented in Coral for this endpoint.
 - **`query` filter on stories:** required for `shortcut.stories` because
   the underlying Shortcut `/search/stories` endpoint requires a search
   query. The filter accepts Shortcut search operators. See

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -1,0 +1,255 @@
+# Shortcut (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Shortcut REST API v3)
+**Tables:** 6
+**Base URL:** `https://api.app.shortcut.com/api/v3`
+
+Query members, workflows, epics, stories, iterations, and milestones from
+Shortcut via SQL. Designed for engineering project analytics: story cycle
+times, sprint velocity, epic progress, and cross-source joins with the
+bundled **Linear**, **GitHub**, and **Jira** sources.
+
+## Setup
+
+### 1. Generate a Shortcut API token
+
+1. Go to [https://app.shortcut.com/settings/account/api-tokens](https://app.shortcut.com/settings/account/api-tokens)
+2. Click **Generate Token**, give it a name, and copy the token.
+
+### 2. Set your token
+
+```sh
+export SHORTCUT_TOKEN="<your-api-token>"
+```
+
+### 3. Add the source
+
+```sh
+cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
+```
+
+### 4. Verify
+
+```sh
+cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
+```
+
+## Tables
+
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `shortcut.members` | Workspace members | — | — |
+| `shortcut.workflows` | Workspace workflows | — | — |
+| `shortcut.epics` | Epics in the workspace | — | — |
+| `shortcut.stories` | Stories discovered via search API | — | `query` |
+| `shortcut.iterations` | Iterations (sprints) | — | — |
+| `shortcut.milestones` | Milestones | — | — |
+
+All tables are read-only. This source does not create, modify, or delete any
+Shortcut data.
+
+### `members`
+
+Lists all workspace members. `email` is sourced from the nested
+`profile.email_address` field. `mention_name` is the @-handle used in
+Shortcut comments and descriptions.
+
+### `workflows`
+
+Lists all workflows in the workspace. Use `id` to join with
+`shortcut.stories` on `workflow_id`.
+
+### `epics`
+
+Lists all epics in the workspace. Use `state` to filter locally:
+
+| Value | Meaning |
+|---|---|
+| `to do` | Epic not yet started |
+| `in progress` | Epic is in progress |
+| `done` | Epic is completed |
+
+### `stories`
+
+Lists stories discovered via the Shortcut search API. The optional `query`
+filter is pushed down to the API and accepts Shortcut search operators:
+
+| Example | Meaning |
+|---|---|
+| `is:started` | Stories currently in progress |
+| `type:bug` | Stories of type bug |
+| `type:feature` | Stories of type feature |
+| `is:completed` | Completed stories |
+| `epic:my-epic` | Stories in a specific epic |
+| `iteration:current` | Stories in the current iteration |
+
+Without a `query` filter, all stories are returned. Results are paginated
+with a maximum of 25 stories per page.
+
+`cycle_time` is returned in seconds from story start to completion.
+
+### `iterations`
+
+Lists all iterations (sprints). Use `status` to filter locally:
+
+| Value | Meaning |
+|---|---|
+| `unstarted` | Iteration not yet started |
+| `started` | Iteration is in progress |
+| `done` | Iteration is completed |
+
+### `milestones`
+
+Lists all milestones. Use `state` to filter locally: `to do`, `in progress`,
+or `done`.
+
+## Example queries
+
+List workspace members with email:
+
+```sql
+SELECT id, name, email, mention_name, role
+FROM shortcut.members
+ORDER BY name
+LIMIT 20;
+```
+
+List all workflows:
+
+```sql
+SELECT id, name, description
+FROM shortcut.workflows
+LIMIT 10;
+```
+
+In-progress epics:
+
+```sql
+SELECT id, name, state, started_at, updated_at
+FROM shortcut.epics
+WHERE state = 'in progress'
+ORDER BY started_at
+LIMIT 20;
+```
+
+Bug stories in the current iteration:
+
+```sql
+SELECT id, name, story_type, workflow_state_id, estimate, created_at
+FROM shortcut.stories
+WHERE query = 'type:bug iteration:current'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+All stories with cycle time for completed work:
+
+```sql
+SELECT id, name, story_type, cycle_time, completed_at
+FROM shortcut.stories
+WHERE query = 'is:completed'
+  AND completed = true
+ORDER BY completed_at DESC
+LIMIT 50;
+```
+
+Stories joined to their epic:
+
+```sql
+SELECT s.id, s.name, s.story_type, e.name AS epic_name, e.state AS epic_state
+FROM shortcut.stories s
+LEFT JOIN shortcut.epics e ON s.epic_id = e.id
+WHERE s.query = 'is:started'
+ORDER BY e.name, s.id
+LIMIT 20;
+```
+
+Current iteration stories with member names:
+
+```sql
+SELECT s.id, s.name, s.story_type, i.name AS iteration_name, i.status
+FROM shortcut.stories s
+LEFT JOIN shortcut.iterations i ON s.iteration_id = i.id
+WHERE s.query = 'iteration:current'
+ORDER BY s.id
+LIMIT 20;
+```
+
+Cross-source: Shortcut members alongside Linear users:
+
+```sql
+SELECT sc.name AS shortcut_name, sc.email, l.name AS linear_name
+FROM shortcut.members sc
+LEFT JOIN linear.users l ON LOWER(sc.email) = LOWER(l.email)
+WHERE sc.email IS NOT NULL
+ORDER BY sc.name
+LIMIT 20;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/shortcut/manifest.yaml
+```
+
+Add the source and validate each table:
+
+```sh
+export SHORTCUT_TOKEN="<your-api-token>"
+cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
+
+# members — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, email, role FROM shortcut.members LIMIT 5"
+
+# workflows — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
+
+# epics — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
+
+# stories — no required filters, optional query pushdown
+cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories LIMIT 5"
+
+# iterations — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
+
+# milestones — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.milestones LIMIT 5"
+```
+
+Inspect registered tables and columns:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'shortcut'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'shortcut' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- **Auth header:** this source uses `Shortcut-Token: <token>` not
+  `Authorization: Bearer`. Generate the token at
+  https://app.shortcut.com/settings/account/api-tokens.
+- **`email` field:** sourced from `profile.email_address` in the API
+  response, not a top-level field.
+- **`stories` pagination:** the Shortcut search API returns a maximum of
+  25 stories per page with cursor-based pagination. Always use `LIMIT`
+  for large workspaces.
+- **`query` filter on stories:** accepts Shortcut search operators. Without
+  a query, all stories are returned. See
+  https://help.shortcut.com/hc/en-us/articles/360000046646-Search-Operators
+  for the full list of operators.
+- **`cycle_time`** is returned in seconds from story start to completion.
+  Divide by 3600 for hours or 86400 for days.
+- **`members`, `workflows`, `epics`, `iterations`, `milestones`** return
+  the full workspace list with no pagination — all results are returned
+  in a single response.
+
+## Out of scope for v1
+
+- Labels table
+- Groups table
+- Story comments
+- Write operations of any kind

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -35,13 +35,13 @@ export SHORTCUT_TOKEN="<your-api-token>"
 ### 3. Add the source
 
 ```sh
-cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
+coral source add --file sources/community/shortcut/manifest.yaml
 ```
 
 ### 4. Verify
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
+coral sql "SELECT id, name FROM shortcut.members LIMIT 5"
 ```
 
 ## Tables
@@ -51,7 +51,7 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories retrieved via Shortcut Search API (/search/stories) — first page only | `query` | — |
+| `shortcut.stories` | Stories retrieved via Shortcut Search API (/search/stories) — first page only (up to 250 records, explicitly requested via page_size=250) | `query` | — |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
 | `shortcut.objectives` | Objectives (replaces deprecated milestones) | — | — |
 
@@ -98,8 +98,9 @@ required and is pushed down to the API using Shortcut search operators.
 **Pagination limitation:** Shortcut's `StorySearchResults.next` field is a
 full URL string (path + query string), not a bare cursor token. Coral's
 `cursor_query` pagination mode cannot extract a bare token from a full URL,
-so this table returns the **first page only** (up to 250 records per request).
-Use a narrow `query` filter to keep results within one page. Full multi-page
+so this table returns the **first page only**. The source explicitly sends
+`page_size=250` (the API maximum) to maximise records per request. Use a
+narrow `query` filter to keep results within one page. Full multi-page
 pagination support is out of scope for v1.
 
 ### `iterations`
@@ -206,39 +207,39 @@ LIMIT 20;
 Lint the manifest:
 
 ```sh
-cargo run -p coral-cli -- source lint sources/community/shortcut/manifest.yaml
+coral source lint sources/community/shortcut/manifest.yaml
 ```
 
 Add the source and validate each table:
 
 ```sh
 export SHORTCUT_TOKEN="<your-api-token>"
-cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
+coral source add --file sources/community/shortcut/manifest.yaml
 
 # members — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, email, role FROM shortcut.members LIMIT 5"
+coral sql "SELECT id, name, email, role FROM shortcut.members LIMIT 5"
 
 # workflows — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
+coral sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
 
 # epics — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
+coral sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
 
-# stories — query is required (Search API); first page only
-cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
+# stories — query is required (Search API); first page only (page_size=250)
+coral sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
 
 # iterations — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
+coral sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
 
 # objectives — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.objectives LIMIT 5"
+coral sql "SELECT id, name, state, created_at FROM shortcut.objectives LIMIT 5"
 ```
 
 Inspect registered tables and columns:
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'shortcut'"
-cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'shortcut' ORDER BY table_name, ordinal_position"
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'shortcut'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'shortcut' ORDER BY table_name, ordinal_position"
 ```
 
 ## Notes
@@ -259,7 +260,8 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 - **`stories` pagination:** Shortcut's `StorySearchResults.next` field is a
   full URL string, not a bare cursor token. Coral cannot extract a bare token
   from a full URL with `cursor_query`, so `stories` returns the first page
-  only (up to 250 records). Use a narrow `query` to stay within one page.
+  only. The source explicitly sends `page_size=250` (the API maximum) to
+  maximise records returned. Use a narrow `query` to stay within one page.
 - **`query` filter on stories:** required because this table uses Shortcut's
   Search API (/search/stories), which does not support unfiltered listing.
   Accepts Shortcut search operators such as `is:started`, `type:bug`,

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -42,7 +42,7 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories discovered via search API | `query` | — |
+| `shortcut.stories` | Stories retrieved via Shortcut Search API (/search/stories) | `query` | — |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
 | `shortcut.objectives` | Objectives (replaces deprecated milestones) | — | — |
 
@@ -205,8 +205,8 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
 # epics — no required filters
 cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
 
-# stories — no required filters, optional query pushdown
-cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories LIMIT 5"
+# stories — query is required (Search API)
+cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
 
 # iterations — no required filters
 cargo run -p coral-cli -- sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
@@ -236,10 +236,10 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
   response, not a top-level field.
 - **`stories` pagination:** Results are returned in paginated batches (up to 250 records per request) 
   using cursor-based pagination via `next` tokens.
-- **`query` filter on stories:** accepts Shortcut search operators. Without
-  a query, all stories are returned. See
-  https://help.shortcut.com/hc/en-us/articles/360000046646-Search-Operators
-  for the full list of operators.
+- **`query` filter on stories:** required because this table uses Shortcut's
+  Search API (/search/stories), which does not support unfiltered listing.
+  Accepts Shortcut search operators such as `is:started`, `type:bug`,
+  `epic:my-epic`, and `iteration:current`.
 - **`cycle_time`** is returned in seconds from story start to completion.
   Divide by 3600 for hours or 86400 for days.
 - **`members`, `workflows`, `epics`, `iterations`, `objectives`** return

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -14,8 +14,15 @@ bundled **Linear**, **GitHub**, and **Jira** sources.
 
 ### 1. Generate a Shortcut API token
 
-1. Go to [https://app.shortcut.com/settings/account/api-tokens](https://app.shortcut.com/settings/account/api-tokens)
+1. Go to https://app.shortcut.com/settings/account/api-tokens
 2. Click **Generate Token**, give it a name, and copy the token.
+
+Shortcut API tokens inherit the permissions of the user who created them.
+They are workspace-level tokens and may grant broad read access across your
+Shortcut workspace depending on that user's role and permissions.
+
+For security, create a dedicated read-only or least-privileged Shortcut user
+when possible.
 
 ### 2. Set your token
 
@@ -42,7 +49,7 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories discovered via search API | — | `query` |
+| `shortcut.stories` | Stories discovered via search API | `query` | — |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
 | `shortcut.milestones` | Milestones | — | — |
 
@@ -72,22 +79,33 @@ Lists all epics in the workspace. Use `state` to filter locally:
 
 ### `stories`
 
-Lists stories discovered via the Shortcut search API. The optional `query`
-filter is pushed down to the API and accepts Shortcut search operators:
+Lists stories discovered via the Shortcut search API.
 
-| Example | Meaning |
-|---|---|
-| `is:started` | Stories currently in progress |
-| `type:bug` | Stories of type bug |
-| `type:feature` | Stories of type feature |
-| `is:completed` | Completed stories |
-| `epic:my-epic` | Stories in a specific epic |
+The required `query` filter is pushed down directly to Shortcut and accepts
+Shortcut search operators:
+
+| Example             | Meaning                          |
+| ------------------- | -------------------------------- |
+| `is:started`        | Stories currently in progress    |
+| `type:bug`          | Stories of type bug              |
+| `type:feature`      | Stories of type feature          |
+| `is:completed`      | Completed stories                |
+| `epic:my-epic`      | Stories in a specific epic       |
 | `iteration:current` | Stories in the current iteration |
 
-Without a `query` filter, all stories are returned. Results are paginated
-with a maximum of 25 stories per page.
+Example:
+
+```sql
+SELECT id, name, story_type
+FROM shortcut.stories
+WHERE query = 'type:bug iteration:current'
+LIMIT 20;
+```
 
 `cycle_time` is returned in seconds from story start to completion.
+
+The underlying Shortcut search API supports cursor-based pagination and
+allows `page_size` values up to 250.
 
 ### `iterations`
 
@@ -160,7 +178,7 @@ Stories joined to their epic:
 SELECT s.id, s.name, s.story_type, e.name AS epic_name, e.state AS epic_state
 FROM shortcut.stories s
 LEFT JOIN shortcut.epics e ON s.epic_id = e.id
-WHERE s.query = 'is:started'
+WHERE query = 'is:started'
 ORDER BY e.name, s.id
 LIMIT 20;
 ```
@@ -171,7 +189,7 @@ Current iteration stories with member names:
 SELECT s.id, s.name, s.story_type, i.name AS iteration_name, i.status
 FROM shortcut.stories s
 LEFT JOIN shortcut.iterations i ON s.iteration_id = i.id
-WHERE s.query = 'iteration:current'
+WHERE query = 'iteration:current'
 ORDER BY s.id
 LIMIT 20;
 ```
@@ -210,8 +228,9 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
 # epics — no required filters
 cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
 
-# stories — no required filters, optional query pushdown
-cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories LIMIT 5"
+# stories — required query pushdown
+
+cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories WHERE query = 'is:started' LIMIT 5"
 
 # iterations — no required filters
 cargo run -p coral-cli -- sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
@@ -234,11 +253,12 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
   https://app.shortcut.com/settings/account/api-tokens.
 - **`email` field:** sourced from `profile.email_address` in the API
   response, not a top-level field.
-- **`stories` pagination:** the Shortcut search API returns a maximum of
-  25 stories per page with cursor-based pagination. Always use `LIMIT`
-  for large workspaces.
-- **`query` filter on stories:** accepts Shortcut search operators. Without
-  a query, all stories are returned. See
+- **`stories` pagination:** the Shortcut search API uses cursor-based
+  pagination and supports `page_size` values up to 250. Always use
+  `LIMIT` for large workspaces.
+- **`query` filter on stories:** required for `shortcut.stories` because
+  the underlying Shortcut `/search/stories` endpoint requires a search
+  query. The filter accepts Shortcut search operators. See
   https://help.shortcut.com/hc/en-us/articles/360000046646-Search-Operators
   for the full list of operators.
 - **`cycle_time`** is returned in seconds from story start to completion.

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -2,13 +2,13 @@
 
 **Version:** 0.1.0
 **Backend:** HTTP (Shortcut REST API v3)
-**Tables:** 6
+**Tables:** 8
 **Base URL:** `https://api.app.shortcut.com/api/v3`
 
-Query members, workflows, epics, stories, iterations, and objectives from
-Shortcut via SQL. Designed for engineering project analytics: story cycle
-times, sprint velocity, epic progress, and cross-source joins with the
-bundled **Linear**, **GitHub**, and **Jira** sources.
+Query members, workflows, workflow states, epic states, epics, stories,
+iterations, and objectives from Shortcut via SQL. Designed for engineering
+project analytics: story cycle times, sprint velocity, epic progress, and
+cross-source joins with the bundled **Linear**, **GitHub**, and **Jira** sources.
 
 ## Setup
 
@@ -35,13 +35,13 @@ export SHORTCUT_TOKEN="<your-api-token>"
 ### 3. Add the source
 
 ```sh
-coral source add --file sources/community/shortcut/manifest.yaml
+cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
 ```
 
 ### 4. Verify
 
 ```sh
-coral sql "SELECT id, name FROM shortcut.members LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 ```
 
 ## Tables
@@ -50,8 +50,10 @@ coral sql "SELECT id, name FROM shortcut.members LIMIT 5"
 |---|---|---|---|
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
+| `shortcut.workflow_states` | States within each workflow — join to stories.workflow_state_id | — | — |
+| `shortcut.epic_states` | Epic workflow states — join to epics.epic_state_id | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories retrieved via Shortcut Search API (/search/stories) — first page only (up to 250 records, explicitly requested via page_size=250) | `query` | — |
+| `shortcut.stories` | Stories via Shortcut Search API — first page only (up to 250 records) | `query` | — |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
 | `shortcut.objectives` | Objectives (replaces deprecated milestones) | — | — |
 
@@ -66,18 +68,44 @@ Shortcut comments and descriptions.
 
 ### `workflows`
 
-Lists all workflows in the workspace. Use `id` to join with
-`shortcut.stories` on `workflow_id`.
+Lists all workflows in the workspace. Join with `workflow_states` on
+`id = workflow_id` to see all states per workflow.
+
+### `workflow_states`
+
+Unnests the `states` array from `GET /workflows`. Each row is one state
+across all workflows. Join `id` to `shortcut.stories.workflow_state_id`
+to resolve what state a story is currently in.
+
+| Column | Description |
+|---|---|
+| `id` | State ID — join to `stories.workflow_state_id` |
+| `name` | State display name (e.g. In Development, Ready for Review) |
+| `type` | `Unstarted`, `Started`, or `Done` |
+| `position` | Position within the workflow (0 = leftmost) |
+
+### `epic_states`
+
+Exposes the epic workflow states from `GET /epic-workflow`. Join `id` to
+`shortcut.epics.epic_state_id` to resolve epic state names. This is the
+current model — prefer this over the deprecated `epics.state` string field.
+
+| Column | Description |
+|---|---|
+| `id` | Epic state ID — join to `epics.epic_state_id` |
+| `name` | State display name |
+| `type` | State type: `to do`, `in progress`, or `done` |
 
 ### `epics`
 
-Lists all epics in the workspace. Use `state` to filter locally:
+Lists all epics. Two state fields are available:
 
-| Value | Meaning |
-|---|---|
-| `to do` | Epic not yet started |
-| `in progress` | Epic is in progress |
-| `done` | Epic is completed |
+| Column | Status | Usage |
+|---|---|---|
+| `epic_state_id` | Current | Join to `epic_states.id` for state name and type |
+| `state` | **Deprecated by Shortcut** | Legacy string field — may be removed in a future API version |
+
+Use `epic_state_id` joined to `epic_states` for new queries.
 
 ### `stories`
 
@@ -96,56 +124,70 @@ required and is pushed down to the API using Shortcut search operators.
 `cycle_time` is returned in seconds from story start to completion.
 
 **Pagination limitation:** Shortcut's `StorySearchResults.next` field is a
-full URL string (path + query string), not a bare cursor token. Coral's
-`cursor_query` pagination mode cannot extract a bare token from a full URL,
-so this table returns the **first page only**. The source explicitly sends
-`page_size=250` (the API maximum) to maximise records per request. Use a
-narrow `query` filter to keep results within one page. Full multi-page
-pagination support is out of scope for v1.
+full URL string, not a bare cursor token. Coral cannot extract a bare token
+from a full URL with `cursor_query`, so `stories` returns the first page
+only. The source explicitly sends `page_size=250` (the API maximum) to
+maximise records per request. Full multi-page pagination is out of scope for v1.
 
 ### `iterations`
 
 Lists all iterations (sprints). Use `status` to filter locally:
-
-| Value | Meaning |
-|---|---|
-| `unstarted` | Iteration not yet started |
-| `started` | Iteration is in progress |
-| `done` | Iteration is completed |
+`unstarted`, `started`, or `done`.
 
 ### `objectives`
 
 Lists all objectives. Shortcut deprecated `GET /milestones` in favour of
-`GET /objectives`. Use `state` to filter locally: `to do`, `in progress`,
-or `done`.
+`GET /objectives`. Use `state` to filter locally.
 
 ## Example queries
 
-List workspace members with email:
+Stories with resolved state name:
 
 ```sql
-SELECT id, name, email, mention_name, role
-FROM shortcut.members
-ORDER BY name
+SELECT s.id, s.name, s.story_type, ws.name AS state_name, ws.type AS state_type
+FROM shortcut.stories s
+JOIN shortcut.workflow_states ws ON s.workflow_state_id = ws.id
+WHERE s.query = 'is:started'
+ORDER BY s.id
 LIMIT 20;
 ```
 
-List all workflows:
+In-progress epics with state name (current model):
 
 ```sql
-SELECT id, name, description
-FROM shortcut.workflows
-LIMIT 10;
+SELECT e.id, e.name, es.name AS state_name, e.started_at
+FROM shortcut.epics e
+JOIN shortcut.epic_states es ON e.epic_state_id = es.id
+WHERE es.type = 'in progress'
+ORDER BY e.started_at
+LIMIT 20;
 ```
 
-In-progress epics:
+Stories joined to their epic with state names:
 
 ```sql
-SELECT id, name, state, started_at, updated_at
-FROM shortcut.epics
-WHERE state = 'in progress'
-ORDER BY started_at
+SELECT
+  s.id,
+  s.name,
+  s.story_type,
+  ws.name AS story_state,
+  e.name AS epic_name,
+  es.name AS epic_state
+FROM shortcut.stories s
+JOIN shortcut.workflow_states ws ON s.workflow_state_id = ws.id
+LEFT JOIN shortcut.epics e ON s.epic_id = e.id
+LEFT JOIN shortcut.epic_states es ON e.epic_state_id = es.id
+WHERE s.query = 'is:started'
 LIMIT 20;
+```
+
+All workflow states across all workflows:
+
+```sql
+SELECT ws.id, ws.name, ws.type, ws.position, w.name AS workflow_name
+FROM shortcut.workflow_states ws
+JOIN shortcut.workflows w ON ws.workflow_id = w.id
+ORDER BY w.name, ws.position;
 ```
 
 Bug stories in the current iteration:
@@ -155,39 +197,6 @@ SELECT id, name, story_type, workflow_state_id, estimate, created_at
 FROM shortcut.stories
 WHERE query = 'type:bug iteration:current'
 ORDER BY created_at DESC
-LIMIT 20;
-```
-
-All stories with cycle time for completed work:
-
-```sql
-SELECT id, name, story_type, cycle_time, completed_at
-FROM shortcut.stories
-WHERE query = 'is:completed'
-  AND completed = true
-ORDER BY completed_at DESC
-LIMIT 50;
-```
-
-Stories joined to their epic:
-
-```sql
-SELECT s.id, s.name, s.story_type, e.name AS epic_name, e.state AS epic_state
-FROM shortcut.stories s
-LEFT JOIN shortcut.epics e ON s.epic_id = e.id
-WHERE s.query = 'is:started'
-ORDER BY e.name, s.id
-LIMIT 20;
-```
-
-Current iteration stories with iteration name:
-
-```sql
-SELECT s.id, s.name, s.story_type, i.name AS iteration_name, i.status
-FROM shortcut.stories s
-LEFT JOIN shortcut.iterations i ON s.iteration_id = i.id
-WHERE s.query = 'iteration:current'
-ORDER BY s.id
 LIMIT 20;
 ```
 
@@ -207,39 +216,30 @@ LIMIT 20;
 Lint the manifest:
 
 ```sh
-coral source lint sources/community/shortcut/manifest.yaml
+cargo run -p coral-cli -- source lint sources/community/shortcut/manifest.yaml
 ```
 
 Add the source and validate each table:
 
 ```sh
 export SHORTCUT_TOKEN="<your-api-token>"
-coral source add --file sources/community/shortcut/manifest.yaml
+cargo run -p coral-cli -- source add --file sources/community/shortcut/manifest.yaml
 
-# members — no required filters
-coral sql "SELECT id, name, email, role FROM shortcut.members LIMIT 5"
-
-# workflows — no required filters
-coral sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
-
-# epics — no required filters
-coral sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
-
-# stories — query is required (Search API); first page only (page_size=250)
-coral sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
-
-# iterations — no required filters
-coral sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
-
-# objectives — no required filters
-coral sql "SELECT id, name, state, created_at FROM shortcut.objectives LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, email, role FROM shortcut.members LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, type, position FROM shortcut.workflow_states LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, type FROM shortcut.epic_states LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, epic_state_id, state FROM shortcut.epics LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, story_type, workflow_state_id FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, status, start_date, end_date FROM shortcut.iterations LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.objectives LIMIT 5"
 ```
 
 Inspect registered tables and columns:
 
 ```sh
-coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'shortcut'"
-coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'shortcut' ORDER BY table_name, ordinal_position"
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'shortcut'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'shortcut' ORDER BY table_name, ordinal_position"
 ```
 
 ## Notes
@@ -247,30 +247,19 @@ coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE sc
 - **Token security:** Shortcut tokens provide complete workspace access for
   the creating user. Store them in environment variables or a secrets manager.
   Use an Observer-role member to limit write exposure.
-- **Rate limits:** the Shortcut API enforces a limit of 200 requests per
-  minute per token. Reduce query frequency or add retries if you hit limits.
-- **`detail=full`** is used on `/search/stories` to ensure all fields required
-  for analytics (including `cycle_time`, `estimate`, and workflow metadata)
-  are included in the response.
-- **Auth header:** this source uses `Shortcut-Token: <token>` not
-  `Authorization: Bearer`. Generate the token at
-  https://app.shortcut.com/settings/account/api-tokens.
-- **`email` field:** sourced from `profile.email_address` in the API
-  response, not a top-level field.
-- **`stories` pagination:** Shortcut's `StorySearchResults.next` field is a
-  full URL string, not a bare cursor token. Coral cannot extract a bare token
-  from a full URL with `cursor_query`, so `stories` returns the first page
-  only. The source explicitly sends `page_size=250` (the API maximum) to
-  maximise records returned. Use a narrow `query` to stay within one page.
-- **`query` filter on stories:** required because this table uses Shortcut's
-  Search API (/search/stories), which does not support unfiltered listing.
-  Accepts Shortcut search operators such as `is:started`, `type:bug`,
-  `epic:my-epic`, and `iteration:current`.
-- **`cycle_time`** is returned in seconds from story start to completion.
-  Divide by 3600 for hours or 86400 for days.
-- **`members`, `workflows`, `epics`, `iterations`, `objectives`** return
-  the full workspace list with no pagination — all results are returned
-  in a single response.
+- **Rate limits:** 200 requests per minute per token; retry on 429.
+- **`workflow_states`:** unnested from `GET /workflows` — no separate API
+  call needed. Join `id` to `stories.workflow_state_id` to resolve state names.
+- **`epic_states`:** sourced from `GET /epic-workflow`. Join `id` to
+  `epics.epic_state_id` — this is the current model. The `epics.state` string
+  column is deprecated by Shortcut and kept only for backwards compatibility.
+- **`detail=full`** on `/search/stories` ensures `cycle_time`, `estimate`,
+  and workflow metadata are included.
+- **`stories` pagination:** first page only (up to 250 records). Use a narrow
+  `query` to stay within one page.
+- **`cycle_time`** is in seconds — divide by 3600 for hours or 86400 for days.
+- **`members`, `workflows`, `workflow_states`, `epic_states`, `iterations`,
+  `objectives`** return the full workspace list in a single response.
 
 ## Out of scope for v1
 

--- a/sources/community/shortcut/README.md
+++ b/sources/community/shortcut/README.md
@@ -17,6 +17,15 @@ bundled **Linear**, **GitHub**, and **Jira** sources.
 1. Go to [https://app.shortcut.com/settings/account/api-tokens](https://app.shortcut.com/settings/account/api-tokens)
 2. Click **Generate Token**, give it a name, and copy the token.
 
+> **Security note:** Shortcut API tokens provide **complete workspace access**
+> for the user who created them — read and write access to all workspace data.
+> Treat the token like a password: store it in an environment variable or
+> secrets manager, never in source code. For read-only access, generate the
+> token as a member with the **Observer role**, which limits write permissions
+> while retaining broad workspace visibility.
+> See [The Observer Role](https://help.shortcut.com/hc/en-us/articles/360000413023-The-Observer-Role)
+> and [API Tokens](https://help.shortcut.com/hc/en-us/articles/205701199-Shortcut-API-Tokens).
+
 ### 2. Set your token
 
 ```sh
@@ -42,7 +51,7 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.members LIMIT 5"
 | `shortcut.members` | Workspace members | — | — |
 | `shortcut.workflows` | Workspace workflows | — | — |
 | `shortcut.epics` | Epics in the workspace | — | — |
-| `shortcut.stories` | Stories retrieved via Shortcut Search API (/search/stories) | `query` | — |
+| `shortcut.stories` | Stories retrieved via Shortcut Search API (/search/stories) — first page only | `query` | — |
 | `shortcut.iterations` | Iterations (sprints) | — | — |
 | `shortcut.objectives` | Objectives (replaces deprecated milestones) | — | — |
 
@@ -72,7 +81,8 @@ Lists all epics in the workspace. Use `state` to filter locally:
 
 ### `stories`
 
-Stories are discovered via the Shortcut Search API. The `query` filter is required and is pushed down to the API using Shortcut search operators.
+Stories are discovered via the Shortcut Search API. The `query` filter is
+required and is pushed down to the API using Shortcut search operators.
 
 | Example | Meaning |
 |---|---|
@@ -84,6 +94,13 @@ Stories are discovered via the Shortcut Search API. The `query` filter is requir
 | `iteration:current` | Stories in the current iteration |
 
 `cycle_time` is returned in seconds from story start to completion.
+
+**Pagination limitation:** Shortcut's `StorySearchResults.next` field is a
+full URL string (path + query string), not a bare cursor token. Coral's
+`cursor_query` pagination mode cannot extract a bare token from a full URL,
+so this table returns the **first page only** (up to 250 records per request).
+Use a narrow `query` filter to keep results within one page. Full multi-page
+pagination support is out of scope for v1.
 
 ### `iterations`
 
@@ -97,7 +114,9 @@ Lists all iterations (sprints). Use `status` to filter locally:
 
 ### `objectives`
 
-Lists all objectives. Shortcut deprecated `GET /milestones` in favour of `GET /objectives`. Use `state` to filter locally: `to do`, `in progress`, or `done`.
+Lists all objectives. Shortcut deprecated `GET /milestones` in favour of
+`GET /objectives`. Use `state` to filter locally: `to do`, `in progress`,
+or `done`.
 
 ## Example queries
 
@@ -160,7 +179,7 @@ ORDER BY e.name, s.id
 LIMIT 20;
 ```
 
-Current iteration stories with member names:
+Current iteration stories with iteration name:
 
 ```sql
 SELECT s.id, s.name, s.story_type, i.name AS iteration_name, i.status
@@ -205,7 +224,7 @@ cargo run -p coral-cli -- sql "SELECT id, name FROM shortcut.workflows LIMIT 5"
 # epics — no required filters
 cargo run -p coral-cli -- sql "SELECT id, name, state, created_at FROM shortcut.epics LIMIT 5"
 
-# stories — query is required (Search API)
+# stories — query is required (Search API); first page only
 cargo run -p coral-cli -- sql "SELECT id, name, story_type, epic_id, created_at FROM shortcut.stories WHERE query = 'type:bug' LIMIT 5"
 
 # iterations — no required filters
@@ -224,18 +243,23 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 ## Notes
 
+- **Token security:** Shortcut tokens provide complete workspace access for
+  the creating user. Store them in environment variables or a secrets manager.
+  Use an Observer-role member to limit write exposure.
 - **Rate limits:** the Shortcut API enforces a limit of 200 requests per
   minute per token. Reduce query frequency or add retries if you hit limits.
-- **`detail=full`** is used on `/search/stories` to ensure all fields required for analytics
-  (including `cycle_time`, `estimate`, and workflow metadata) are included in the response.
-  This increases payload size but guarantees full column availability.
+- **`detail=full`** is used on `/search/stories` to ensure all fields required
+  for analytics (including `cycle_time`, `estimate`, and workflow metadata)
+  are included in the response.
 - **Auth header:** this source uses `Shortcut-Token: <token>` not
   `Authorization: Bearer`. Generate the token at
   https://app.shortcut.com/settings/account/api-tokens.
 - **`email` field:** sourced from `profile.email_address` in the API
   response, not a top-level field.
-- **`stories` pagination:** Results are returned in paginated batches (up to 250 records per request) 
-  using cursor-based pagination via `next` tokens.
+- **`stories` pagination:** Shortcut's `StorySearchResults.next` field is a
+  full URL string, not a bare cursor token. Coral cannot extract a bare token
+  from a full URL with `cursor_query`, so `stories` returns the first page
+  only (up to 250 records). Use a narrow `query` to stay within one page.
 - **`query` filter on stories:** required because this table uses Shortcut's
   Search API (/search/stories), which does not support unfiltered listing.
   Accepts Shortcut search operators such as `is:started`, `type:bug`,
@@ -248,6 +272,7 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 ## Out of scope for v1
 
+- Multi-page pagination for `stories` (blocked by Shortcut returning `next` as a full URL)
 - Labels table
 - Groups table
 - Story comments

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -13,6 +13,10 @@ inputs:
     hint: |
       Shortcut API token. Generate one at
       https://app.shortcut.com/settings/account/api-tokens.
+
+      Shortcut API tokens inherit the permissions of the user who created
+      them and may access all workspace data visible to that user.
+
       The token is sent as the Shortcut-Token request header.
 
 auth:
@@ -295,18 +299,22 @@ tables:
   - name: stories
     description: >-
       Stories (work items) in the Shortcut workspace discovered via the
-      search API. Each row is one story. Use query filter for Shortcut
-      search syntax pushdown.
+      Shortcut search API. Each row is one story. Requires a `query`
+      filter using Shortcut search syntax.
     guide: |
-      Optional `query` filter pushes down to the Shortcut search API.
-      Use Shortcut search operators such as `is:started`, `type:bug`,
-      `epic:my-epic`, or `iteration:current`. Without a query filter,
-      returns all stories. Results are paginated with a maximum of 25
-      stories per page. Use `epic_id` to join with `shortcut.epics` and
-      `iteration_id` to join with `shortcut.iterations`.
+      Required `query` filter pushes down directly to the Shortcut
+      search API. Use Shortcut search operators such as `is:started`,
+      `type:bug`, `epic:my-epic`, or `iteration:current`.
+
+      Use `epic_id` to join with `shortcut.epics` and `iteration_id`
+      to join with `shortcut.iterations`.
+
+      Examples:
+      WHERE query = 'is:started'
+      WHERE query = 'type:bug state:unstarted'
     filters:
       - name: query
-        required: false
+        required: true
     request:
       method: GET
       path: /search/stories
@@ -317,15 +325,6 @@ tables:
     response:
       rows_path:
         - data
-    pagination:
-      mode: cursor_query
-      cursor_param: next
-      response_cursor_path:
-        - next
-      page_size:
-        default: 25
-        max: 25
-        query_param: page_size
     columns:
       - name: id
         type: Int64
@@ -456,11 +455,11 @@ tables:
             kind: path
             path:
               - completed_at
-      - name: query_filter
+      - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: Search query passed as the filter; echoed onto every row.
+        description: Search query passed to the Shortcut search API; echoed onto every row.
         expr:
           kind: from_filter
           key: query

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -14,8 +14,13 @@ inputs:
       Shortcut API token. Generate one at
       https://app.shortcut.com/settings/account/api-tokens.
 
-      Shortcut API tokens inherit the permissions of the user who created
-      them and may access all workspace data visible to that user.
+      Shortcut API tokens inherit the full permissions of the user who
+      created them and may allow read or write access to all workspace
+      data visible to that user outside Coral.
+
+      This source is read-only, but the token itself may still be used
+      for write operations against the Shortcut API depending on the
+      user role associated with the token.
 
       The token is sent as the Shortcut-Token request header.
 
@@ -300,7 +305,8 @@ tables:
     description: >-
       Stories (work items) in the Shortcut workspace discovered via the
       Shortcut search API. Each row is one story. Requires a `query`
-      filter using Shortcut search syntax.
+      filter using Shortcut search syntax. Currently returns only the
+      first page of Shortcut search results.
     guide: |
       Required `query` filter pushes down directly to the Shortcut
       search API. Use Shortcut search operators such as `is:started`,
@@ -312,6 +318,10 @@ tables:
       Examples:
       WHERE query = 'is:started'
       WHERE query = 'type:bug state:unstarted'
+
+      Current limitation: only the first page of Shortcut search results
+      is returned because cursor pagination is not yet implemented in
+      this source.
     filters:
       - name: query
         required: true

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -332,6 +332,9 @@ tables:
         - name: detail
           from: literal
           value: full
+        - name: page_size
+          from: literal
+          value: "250"
     response:
       rows_path:
         - data

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -15,6 +15,11 @@ inputs:
       https://app.shortcut.com/settings/account/api-tokens.
       The token is sent as the Shortcut-Token request header.
 
+      IMPORTANT: Shortcut tokens provide complete access to your workspace
+      for the creating user — treat them like a password. For read-only
+      access, generate the token as an Observer-role member.
+      See https://help.shortcut.com/hc/en-us/articles/360000413023-The-Observer-Role
+
 auth:
   type: HeaderAuth
   headers:
@@ -299,17 +304,18 @@ tables:
       search syntax pushdown.
     guide: |
       The `query` filter is required because this table is backed by
-      Shortcut’s Search API (/search/stories), which does not support
+      Shortcut's Search API (/search/stories), which does not support
       unfiltered story listing.
 
       Use Shortcut search operators such as `is:started`, `type:bug`,
       `epic:my-epic`, or `iteration:current`.
 
-      Results are returned from Shortcut’s paginated search endpoint
-      and retrieved using cursor-based pagination via the `next` token
-      returned in the API response.
-
-      Maximum page size is 250 records per request.
+      PAGINATION NOTE: Shortcut's StorySearchResults.next field is a
+      full URL string (path + query string), not a bare cursor token.
+      Coral's cursor_query mode cannot extract the token from a full URL,
+      so this table returns the first page only (up to 250 records per
+      request). Use a narrow `query` filter to stay within one page.
+      Full multi-page pagination is out of scope for v1.
 
       Use `epic_id` to join with `shortcut.epics` and `iteration_id`
       to join with `shortcut.iterations`.
@@ -330,14 +336,7 @@ tables:
       rows_path:
         - data
     pagination:
-      mode: cursor_query
-      cursor_param: next
-      response_cursor_path:
-        - next
-      page_size:
-        default: 100
-        max: 250
-        query_param: page_size
+      mode: none
     columns:
       - name: id
         type: Int64
@@ -406,7 +405,7 @@ tables:
       - name: cycle_time
         type: Int64
         nullable: true
-        description: Cycle time in seconds from start to completion.
+        description: Cycle time in seconds from story start to completion.
         expr:
           kind: path
           path:
@@ -472,7 +471,7 @@ tables:
         type: Utf8
         nullable: true
         virtual: true
-        description: Search query passed to Shortcut search API
+        description: Search query passed to Shortcut search API.
         expr:
           kind: from_filter
           key: query

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -316,7 +316,7 @@ tables:
           key: query
         - name: detail
           from: literal
-          value: slim
+          value: full
     response:
       rows_path:
         - data

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -3,7 +3,7 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query members, workflows, epics, stories, iterations, and milestones
+  Query members, workflows, epics, stories, iterations, and objectives
   from Shortcut via the Shortcut REST API v3.
 base_url: https://api.app.shortcut.com/api/v3
 
@@ -13,15 +13,6 @@ inputs:
     hint: |
       Shortcut API token. Generate one at
       https://app.shortcut.com/settings/account/api-tokens.
-
-      Shortcut API tokens inherit the full permissions of the user who
-      created them and may allow read or write access to all workspace
-      data visible to that user outside Coral.
-
-      This source is read-only, but the token itself may still be used
-      for write operations against the Shortcut API depending on the
-      user role associated with the token.
-
       The token is sent as the Shortcut-Token request header.
 
 auth:
@@ -304,27 +295,18 @@ tables:
   - name: stories
     description: >-
       Stories (work items) in the Shortcut workspace discovered via the
-      Shortcut search API. Each row is one story. Requires a `query`
-      filter using Shortcut search syntax. Currently returns only the
-      first page of Shortcut search results.
+      search API. Each row is one story. Use query filter for Shortcut
+      search syntax pushdown.
     guide: |
-      Required `query` filter pushes down directly to the Shortcut
-      search API. Use Shortcut search operators such as `is:started`,
-      `type:bug`, `epic:my-epic`, or `iteration:current`.
-
-      Use `epic_id` to join with `shortcut.epics` and `iteration_id`
-      to join with `shortcut.iterations`.
-
-      Examples:
-      WHERE query = 'is:started'
-      WHERE query = 'type:bug state:unstarted'
-
-      Current limitation: only the first page of Shortcut search results
-      is returned because cursor pagination is not yet implemented in
-      this source.
+      Optional `query` filter pushes down to the Shortcut search API.
+      Use Shortcut search operators such as `is:started`, `type:bug`,
+      `epic:my-epic`, or `iteration:current`. Without a query filter,
+      returns all stories. Results are paginated with a maximum of 25
+      stories per page. Use `epic_id` to join with `shortcut.epics` and
+      `iteration_id` to join with `shortcut.iterations`.
     filters:
       - name: query
-        required: true
+        required: false
     request:
       method: GET
       path: /search/stories
@@ -332,9 +314,21 @@ tables:
         - name: query
           from: filter
           key: query
+        - name: detail
+          from: literal
+          value: slim
     response:
       rows_path:
         - data
+    pagination:
+      mode: cursor_query
+      cursor_param: next
+      response_cursor_path:
+        - next
+      page_size:
+        default: 25
+        max: 25
+        query_param: page_size
     columns:
       - name: id
         type: Int64
@@ -465,11 +459,11 @@ tables:
             kind: path
             path:
               - completed_at
-      - name: query
+      - name: query_filter
         type: Utf8
         nullable: true
         virtual: true
-        description: Search query passed to the Shortcut search API; echoed onto every row.
+        description: Search query passed as the filter; echoed onto every row.
         expr:
           kind: from_filter
           key: query
@@ -557,19 +551,19 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # milestones — milestones in the workspace
+  # objectives — objectives in the workspace (replaces deprecated milestones)
   # ──────────────────────────────────────────────────────────────────────────
-  - name: milestones
+  - name: objectives
     description: >-
-      Milestones in the Shortcut workspace. Each row is one milestone.
-      Use id to join with epics for roadmap analytics.
+      Objectives in the Shortcut workspace. Each row is one objective.
+      Shortcut deprecated GET /milestones in favour of GET /objectives.
     guide: |
-      No required filters. Use `state` to filter locally by milestone
+      No required filters. Use `state` to filter locally by objective
       state: to do, in progress, or done. Use `started_at` and
-      `completed_at` for milestone cycle-time analytics.
+      `completed_at` for objective cycle-time analytics.
     request:
       method: GET
-      path: /milestones
+      path: /objectives
     response:
       row_strategy: direct
     pagination:
@@ -578,7 +572,7 @@ tables:
       - name: id
         type: Int64
         nullable: false
-        description: Milestone ID.
+        description: Objective ID.
         expr:
           kind: path
           path:
@@ -586,7 +580,7 @@ tables:
       - name: name
         type: Utf8
         nullable: true
-        description: Milestone name.
+        description: Objective name.
         expr:
           kind: path
           path:
@@ -594,7 +588,7 @@ tables:
       - name: description
         type: Utf8
         nullable: true
-        description: Milestone description.
+        description: Objective description.
         expr:
           kind: path
           path:
@@ -602,7 +596,7 @@ tables:
       - name: state
         type: Utf8
         nullable: true
-        description: "Milestone state: to do, in progress, or done."
+        description: "Objective state: to do, in progress, or done."
         expr:
           kind: path
           path:
@@ -610,7 +604,7 @@ tables:
       - name: created_at
         type: Timestamp
         nullable: true
-        description: Timestamp when the milestone was created.
+        description: Timestamp when the objective was created.
         expr:
           kind: format_timestamp
           input: iso8601
@@ -621,7 +615,7 @@ tables:
       - name: updated_at
         type: Timestamp
         nullable: true
-        description: Timestamp when the milestone was last updated.
+        description: Timestamp when the objective was last updated.
         expr:
           kind: format_timestamp
           input: iso8601
@@ -632,7 +626,7 @@ tables:
       - name: started_at
         type: Timestamp
         nullable: true
-        description: Timestamp when the milestone was started.
+        description: Timestamp when the objective was started.
         expr:
           kind: format_timestamp
           input: iso8601
@@ -643,7 +637,7 @@ tables:
       - name: completed_at
         type: Timestamp
         nullable: true
-        description: Timestamp when the milestone was completed.
+        description: Timestamp when the objective was completed.
         expr:
           kind: format_timestamp
           input: iso8601

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -298,14 +298,21 @@ tables:
       search API. Each row is one story. Use query filter for Shortcut
       search syntax pushdown.
     guide: |
-      The query filter is required and is pushed down to the Shortcut 
-      Search API using search operators. Use Shortcut search operators 
-      such as `is:started`, `type:bug`, `epic:my-epic`, or 
-      `iteration:current`. Without a query filter, returns all stories. 
-      Results are paginated with a maximum of 250 records per request at 
-      the connector level using cursor-based pagination via next tokens. 
-      Use `epic_id` to join with `shortcut.epics` and `iteration_id` to 
-      join with `shortcut.iterations`.
+      The `query` filter is required because this table is backed by
+      Shortcut’s Search API (/search/stories), which does not support
+      unfiltered story listing.
+
+      Use Shortcut search operators such as `is:started`, `type:bug`,
+      `epic:my-epic`, or `iteration:current`.
+
+      Results are returned from Shortcut’s paginated search endpoint
+      and retrieved using cursor-based pagination via the `next` token
+      returned in the API response.
+
+      Maximum page size is 250 records per request.
+
+      Use `epic_id` to join with `shortcut.epics` and `iteration_id`
+      to join with `shortcut.iterations`.
     filters:
       - name: query
         required: true

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -3,8 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query members, workflows, workflow states, epic states, epics, stories,
-  iterations, and objectives from Shortcut via the Shortcut REST API v3.
+  Query members, workflows, epic states, epics, stories, iterations,
+  and objectives from Shortcut via the Shortcut REST API v3.
 base_url: https://api.app.shortcut.com/api/v3
 
 inputs:
@@ -129,12 +129,14 @@ tables:
   - name: workflows
     description: >-
       Workflows in the Shortcut workspace. Each row is one workflow.
-      Use id to join with stories on workflow_id. Join with
-      workflow_states on id = workflow_id to resolve story state names.
+      Use id to join with stories on workflow_id.
     guide: |
       No required filters. Use `id` to join with `shortcut.stories` on
-      `workflow_id`. Join with `shortcut.workflow_states` on
-      `id = workflow_id` to map workflow state IDs to names and types.
+      `workflow_id` to map stories to their workflow. Workflow states
+      are embedded in the API response as a nested `states` array but
+      cannot be unnested into a separate table in this version — use
+      `workflow_state_id` on stories to identify the state, and resolve
+      names by querying the Shortcut API directly if needed.
     request:
       method: GET
       path: /workflows
@@ -146,7 +148,7 @@ tables:
       - name: id
         type: Int64
         nullable: false
-        description: Workflow ID. Join to shortcut.stories.workflow_id and shortcut.workflow_states.workflow_id.
+        description: Workflow ID. Join to shortcut.stories.workflow_id.
         expr:
           kind: path
           path:
@@ -191,109 +193,6 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # workflow_states — states within each workflow
-  # ──────────────────────────────────────────────────────────────────────────
-  - name: workflow_states
-    description: >-
-      Workflow states across all workflows in the workspace. Each row is
-      one state. Join id to stories.workflow_state_id to resolve the
-      name and type of the state a story is currently in.
-    guide: |
-      No required filters. This table unnests the `states` array from
-      the GET /workflows response. Join `id` to
-      `shortcut.stories.workflow_state_id` to resolve state names. Use
-      `type` to classify states: Unstarted, Started, or Done. Use
-      `workflow_id` to join back to `shortcut.workflows.id`.
-    request:
-      method: GET
-      path: /workflows
-    response:
-      rows_path:
-        - states
-      row_strategy: direct
-    pagination:
-      mode: none
-    columns:
-      - name: id
-        type: Int64
-        nullable: false
-        description: Workflow state ID. Join to shortcut.stories.workflow_state_id.
-        expr:
-          kind: path
-          path:
-            - id
-      - name: name
-        type: Utf8
-        nullable: true
-        description: Workflow state name (e.g. In Development, Ready for Review).
-        expr:
-          kind: path
-          path:
-            - name
-      - name: type
-        type: Utf8
-        nullable: true
-        description: "State type: Unstarted, Started, or Done."
-        expr:
-          kind: path
-          path:
-            - type
-      - name: position
-        type: Int64
-        nullable: true
-        description: Position of the state within the workflow (0 = leftmost).
-        expr:
-          kind: path
-          path:
-            - position
-      - name: color
-        type: Utf8
-        nullable: true
-        description: Hex color for the workflow state.
-        expr:
-          kind: path
-          path:
-            - color
-      - name: description
-        type: Utf8
-        nullable: true
-        description: Description of what stories belong in this state.
-        expr:
-          kind: path
-          path:
-            - description
-      - name: num_stories
-        type: Int64
-        nullable: true
-        description: Number of stories currently in this state.
-        expr:
-          kind: path
-          path:
-            - num_stories
-      - name: created_at
-        type: Timestamp
-        nullable: true
-        description: Timestamp when the state was created.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - created_at
-      - name: updated_at
-        type: Timestamp
-        nullable: true
-        description: Timestamp when the state was last updated.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr:
-            kind: path
-            path:
-              - updated_at
-
-  # ──────────────────────────────────────────────────────────────────────────
   # epic_states — epic workflow states (replaces deprecated epics.state)
   # ──────────────────────────────────────────────────────────────────────────
   - name: epic_states
@@ -304,8 +203,9 @@ tables:
     guide: |
       No required filters. Join `id` to `shortcut.epics.epic_state_id`
       to resolve the current state name and type for each epic. Use
-      `type` to classify states: to do, in progress, or done.
-      This table replaces the deprecated `epics.state` string column.
+      `type` to classify states: Unstarted, Started, or Done (exact
+      casing as returned by the API). This table replaces the deprecated
+      `epics.state` string column.
     request:
       method: GET
       path: /epic-workflow
@@ -335,7 +235,8 @@ tables:
       - name: type
         type: Utf8
         nullable: true
-        description: "Epic state type: to do, in progress, or done."
+        description: >-
+          Epic state type as returned by the API: Unstarted, Started, or Done.
         expr:
           kind: path
           path:
@@ -533,9 +434,7 @@ tables:
       request). Use a narrow `query` filter to stay within one page.
       Full multi-page pagination is out of scope for v1.
 
-      Join `workflow_state_id` to `shortcut.workflow_states.id` to
-      resolve the state name and type. Join `epic_id` to
-      `shortcut.epics.id` and `iteration_id` to
+      Join `epic_id` to `shortcut.epics.id` and `iteration_id` to
       `shortcut.iterations.id`.
     filters:
       - name: query
@@ -596,8 +495,7 @@ tables:
         nullable: true
         description: >-
           ID of the workflow state the story is currently in.
-          Join to shortcut.workflow_states.id to resolve the state
-          name and type.
+          Use this to identify the story's state within its workflow.
         expr:
           kind: path
           path:

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -1,0 +1,644 @@
+name: shortcut
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query members, workflows, epics, stories, iterations, and milestones
+  from Shortcut via the Shortcut REST API v3.
+base_url: https://api.app.shortcut.com/api/v3
+
+inputs:
+  SHORTCUT_TOKEN:
+    kind: secret
+    hint: |
+      Shortcut API token. Generate one at
+      https://app.shortcut.com/settings/account/api-tokens.
+      The token is sent as the Shortcut-Token request header.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Shortcut-Token
+      from: input
+      key: SHORTCUT_TOKEN
+
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, name FROM shortcut.members LIMIT 5
+  - SELECT id, name FROM shortcut.workflows LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────────
+  # members — workspace members
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: members
+    description: >-
+      Members of the Shortcut workspace. Each row is one member.
+      Join email to linear.users or github.members for cross-tool
+      team analytics.
+    guide: |
+      No required filters. `email` is sourced from the nested
+      `profile.email_address` field in the API response. `mention_name`
+      is the @-handle used in Shortcut comments and descriptions.
+    request:
+      method: GET
+      path: /members
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Member UUID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Member display name.
+        expr:
+          kind: path
+          path:
+            - profile
+            - name
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Member email address (from profile.email_address).
+        expr:
+          kind: path
+          path:
+            - profile
+            - email_address
+      - name: mention_name
+        type: Utf8
+        nullable: true
+        description: Member @-handle used in Shortcut comments and descriptions.
+        expr:
+          kind: path
+          path:
+            - profile
+            - mention_name
+      - name: role
+        type: Utf8
+        nullable: true
+        description: Member role in the workspace.
+        expr:
+          kind: path
+          path:
+            - role
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the member was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the member was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # workflows — workspace workflows and states
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: workflows
+    description: >-
+      Workflows in the Shortcut workspace. Each row is one workflow.
+      Use id to join with stories on workflow_id.
+    guide: |
+      No required filters. Each workflow contains a set of states.
+      Use `id` to join with `shortcut.stories` on `workflow_id` to
+      map stories to their workflow.
+    request:
+      method: GET
+      path: /workflows
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Workflow ID. Join to shortcut.stories.workflow_id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Workflow name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Workflow description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the workflow was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the workflow was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # epics — epics in the workspace
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: epics
+    description: >-
+      Epics in the Shortcut workspace. Each row is one epic. Use id
+      to join with stories on epic_id.
+    guide: |
+      No required filters. Use `state` to filter locally by epic
+      lifecycle: to do, in progress, or done. Use `id` to join with
+      `shortcut.stories` on `epic_id`. Use `started_at` and
+      `completed_at` for epic cycle-time analytics.
+    request:
+      method: GET
+      path: /epics
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Epic ID. Join to shortcut.stories.epic_id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Epic name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Epic description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: state
+        type: Utf8
+        nullable: true
+        description: "Epic state: to do, in progress, or done."
+        expr:
+          kind: path
+          path:
+            - state
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the epic is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the epic was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the epic was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the epic was started.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - started_at
+      - name: completed_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the epic was completed.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - completed_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # stories — stories (work items) in the workspace
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: stories
+    description: >-
+      Stories (work items) in the Shortcut workspace discovered via the
+      search API. Each row is one story. Use query filter for Shortcut
+      search syntax pushdown.
+    guide: |
+      Optional `query` filter pushes down to the Shortcut search API.
+      Use Shortcut search operators such as `is:started`, `type:bug`,
+      `epic:my-epic`, or `iteration:current`. Without a query filter,
+      returns all stories. Results are paginated with a maximum of 25
+      stories per page. Use `epic_id` to join with `shortcut.epics` and
+      `iteration_id` to join with `shortcut.iterations`.
+    filters:
+      - name: query
+        required: false
+    request:
+      method: GET
+      path: /search/stories
+      query:
+        - name: query
+          from: filter
+          key: query
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: cursor_query
+      cursor_param: next
+      response_cursor_path:
+        - next
+      page_size:
+        default: 25
+        max: 25
+        query_param: page_size
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Story ID (public ID).
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Story name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: story_type
+        type: Utf8
+        nullable: true
+        description: "Story type: feature, bug, or chore."
+        expr:
+          kind: path
+          path:
+            - story_type
+      - name: workflow_id
+        type: Int64
+        nullable: true
+        description: ID of the workflow the story belongs to. Join to shortcut.workflows.id.
+        expr:
+          kind: path
+          path:
+            - workflow_id
+      - name: workflow_state_id
+        type: Int64
+        nullable: true
+        description: ID of the workflow state the story is currently in.
+        expr:
+          kind: path
+          path:
+            - workflow_state_id
+      - name: epic_id
+        type: Int64
+        nullable: true
+        description: ID of the epic the story belongs to. Join to shortcut.epics.id.
+        expr:
+          kind: path
+          path:
+            - epic_id
+      - name: iteration_id
+        type: Int64
+        nullable: true
+        description: ID of the iteration the story belongs to. Join to shortcut.iterations.id.
+        expr:
+          kind: path
+          path:
+            - iteration_id
+      - name: estimate
+        type: Int64
+        nullable: true
+        description: Story point estimate.
+        expr:
+          kind: path
+          path:
+            - estimate
+      - name: cycle_time
+        type: Int64
+        nullable: true
+        description: Cycle time in seconds from start to completion.
+        expr:
+          kind: path
+          path:
+            - cycle_time
+      - name: archived
+        type: Boolean
+        nullable: true
+        description: Whether the story is archived.
+        expr:
+          kind: path
+          path:
+            - archived
+      - name: completed
+        type: Boolean
+        nullable: true
+        description: Whether the story is completed.
+        expr:
+          kind: path
+          path:
+            - completed
+      - name: app_url
+        type: Utf8
+        nullable: true
+        description: URL of the story in the Shortcut web interface.
+        expr:
+          kind: path
+          path:
+            - app_url
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the story was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the story was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: completed_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the story was completed.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - completed_at
+      - name: query_filter
+        type: Utf8
+        nullable: true
+        virtual: true
+        description: Search query passed as the filter; echoed onto every row.
+        expr:
+          kind: from_filter
+          key: query
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # iterations — iterations (sprints) in the workspace
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: iterations
+    description: >-
+      Iterations (sprints) in the Shortcut workspace. Each row is one
+      iteration. Use id to join with stories on iteration_id.
+    guide: |
+      No required filters. Use `status` to filter locally by iteration
+      state: unstarted, started, or done. Use `id` to join with
+      `shortcut.stories` on `iteration_id` for sprint analytics.
+    request:
+      method: GET
+      path: /iterations
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Iteration ID. Join to shortcut.stories.iteration_id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Iteration name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: status
+        type: Utf8
+        nullable: true
+        description: "Iteration status: unstarted, started, or done."
+        expr:
+          kind: path
+          path:
+            - status
+      - name: start_date
+        type: Utf8
+        nullable: true
+        description: Iteration start date (YYYY-MM-DD).
+        expr:
+          kind: path
+          path:
+            - start_date
+      - name: end_date
+        type: Utf8
+        nullable: true
+        description: Iteration end date (YYYY-MM-DD).
+        expr:
+          kind: path
+          path:
+            - end_date
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the iteration was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the iteration was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # milestones — milestones in the workspace
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: milestones
+    description: >-
+      Milestones in the Shortcut workspace. Each row is one milestone.
+      Use id to join with epics for roadmap analytics.
+    guide: |
+      No required filters. Use `state` to filter locally by milestone
+      state: to do, in progress, or done. Use `started_at` and
+      `completed_at` for milestone cycle-time analytics.
+    request:
+      method: GET
+      path: /milestones
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Milestone ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Milestone name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Milestone description.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: state
+        type: Utf8
+        nullable: true
+        description: "Milestone state: to do, in progress, or done."
+        expr:
+          kind: path
+          path:
+            - state
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the milestone was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the milestone was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the milestone was started.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - started_at
+      - name: completed_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the milestone was completed.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - completed_at

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -3,8 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query members, workflows, epics, stories, iterations, and objectives
-  from Shortcut via the Shortcut REST API v3.
+  Query members, workflows, workflow states, epic states, epics, stories,
+  iterations, and objectives from Shortcut via the Shortcut REST API v3.
 base_url: https://api.app.shortcut.com/api/v3
 
 inputs:
@@ -124,16 +124,17 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # workflows — workspace workflows and states
+  # workflows — workspace workflows
   # ──────────────────────────────────────────────────────────────────────────
   - name: workflows
     description: >-
       Workflows in the Shortcut workspace. Each row is one workflow.
-      Use id to join with stories on workflow_id.
+      Use id to join with stories on workflow_id. Join with
+      workflow_states on id = workflow_id to resolve story state names.
     guide: |
-      No required filters. Each workflow contains a set of states.
-      Use `id` to join with `shortcut.stories` on `workflow_id` to
-      map stories to their workflow.
+      No required filters. Use `id` to join with `shortcut.stories` on
+      `workflow_id`. Join with `shortcut.workflow_states` on
+      `id = workflow_id` to map workflow state IDs to names and types.
     request:
       method: GET
       path: /workflows
@@ -145,7 +146,7 @@ tables:
       - name: id
         type: Int64
         nullable: false
-        description: Workflow ID. Join to shortcut.stories.workflow_id.
+        description: Workflow ID. Join to shortcut.stories.workflow_id and shortcut.workflow_states.workflow_id.
         expr:
           kind: path
           path:
@@ -190,17 +191,218 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
+  # workflow_states — states within each workflow
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: workflow_states
+    description: >-
+      Workflow states across all workflows in the workspace. Each row is
+      one state. Join id to stories.workflow_state_id to resolve the
+      name and type of the state a story is currently in.
+    guide: |
+      No required filters. This table unnests the `states` array from
+      the GET /workflows response. Join `id` to
+      `shortcut.stories.workflow_state_id` to resolve state names. Use
+      `type` to classify states: Unstarted, Started, or Done. Use
+      `workflow_id` to join back to `shortcut.workflows.id`.
+    request:
+      method: GET
+      path: /workflows
+    response:
+      rows_path:
+        - states
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Workflow state ID. Join to shortcut.stories.workflow_state_id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Workflow state name (e.g. In Development, Ready for Review).
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: "State type: Unstarted, Started, or Done."
+        expr:
+          kind: path
+          path:
+            - type
+      - name: position
+        type: Int64
+        nullable: true
+        description: Position of the state within the workflow (0 = leftmost).
+        expr:
+          kind: path
+          path:
+            - position
+      - name: color
+        type: Utf8
+        nullable: true
+        description: Hex color for the workflow state.
+        expr:
+          kind: path
+          path:
+            - color
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of what stories belong in this state.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: num_stories
+        type: Int64
+        nullable: true
+        description: Number of stories currently in this state.
+        expr:
+          kind: path
+          path:
+            - num_stories
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the state was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the state was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # epic_states — epic workflow states (replaces deprecated epics.state)
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: epic_states
+    description: >-
+      Epic workflow states from GET /epic-workflow. Each row is one
+      state. Join id to epics.epic_state_id to resolve epic state names.
+      Use instead of the deprecated epics.state string field.
+    guide: |
+      No required filters. Join `id` to `shortcut.epics.epic_state_id`
+      to resolve the current state name and type for each epic. Use
+      `type` to classify states: to do, in progress, or done.
+      This table replaces the deprecated `epics.state` string column.
+    request:
+      method: GET
+      path: /epic-workflow
+    response:
+      rows_path:
+        - epic_states
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Epic state ID. Join to shortcut.epics.epic_state_id.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Epic state name.
+        expr:
+          kind: path
+          path:
+            - name
+      - name: type
+        type: Utf8
+        nullable: true
+        description: "Epic state type: to do, in progress, or done."
+        expr:
+          kind: path
+          path:
+            - type
+      - name: position
+        type: Int64
+        nullable: true
+        description: Position of the state in the epic workflow.
+        expr:
+          kind: path
+          path:
+            - position
+      - name: color
+        type: Utf8
+        nullable: true
+        description: Hex color for the epic state.
+        expr:
+          kind: path
+          path:
+            - color
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Description of the epic state.
+        expr:
+          kind: path
+          path:
+            - description
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the state was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the state was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
   # epics — epics in the workspace
   # ──────────────────────────────────────────────────────────────────────────
   - name: epics
     description: >-
       Epics in the Shortcut workspace. Each row is one epic. Use id
-      to join with stories on epic_id.
+      to join with stories on epic_id. Use epic_state_id to join with
+      epic_states for the current state name (preferred over the
+      deprecated state string field).
     guide: |
-      No required filters. Use `state` to filter locally by epic
-      lifecycle: to do, in progress, or done. Use `id` to join with
-      `shortcut.stories` on `epic_id`. Use `started_at` and
-      `completed_at` for epic cycle-time analytics.
+      No required filters. Use `epic_state_id` to join with
+      `shortcut.epic_states` on `id = epic_state_id` to resolve state
+      names — this is the current model. The `state` column is still
+      present but is deprecated by Shortcut and may be removed in a
+      future API version. Use `started_at` and `completed_at` for
+      epic cycle-time analytics.
     request:
       method: GET
       path: /epics
@@ -233,10 +435,24 @@ tables:
           kind: path
           path:
             - description
+      - name: epic_state_id
+        type: Int64
+        nullable: true
+        description: >-
+          ID of the current epic workflow state. Join to
+          shortcut.epic_states.id to resolve the state name and type.
+          Preferred over the deprecated state column.
+        expr:
+          kind: path
+          path:
+            - epic_state_id
       - name: state
         type: Utf8
         nullable: true
-        description: "Epic state: to do, in progress, or done."
+        description: >-
+          Deprecated by Shortcut. Legacy lifecycle string: to do,
+          in progress, or done. Use epic_state_id joined to
+          epic_states instead.
         expr:
           kind: path
           path:
@@ -317,8 +533,10 @@ tables:
       request). Use a narrow `query` filter to stay within one page.
       Full multi-page pagination is out of scope for v1.
 
-      Use `epic_id` to join with `shortcut.epics` and `iteration_id`
-      to join with `shortcut.iterations`.
+      Join `workflow_state_id` to `shortcut.workflow_states.id` to
+      resolve the state name and type. Join `epic_id` to
+      `shortcut.epics.id` and `iteration_id` to
+      `shortcut.iterations.id`.
     filters:
       - name: query
         required: true
@@ -376,7 +594,10 @@ tables:
       - name: workflow_state_id
         type: Int64
         nullable: true
-        description: ID of the workflow state the story is currently in.
+        description: >-
+          ID of the workflow state the story is currently in.
+          Join to shortcut.workflow_states.id to resolve the state
+          name and type.
         expr:
           kind: path
           path:

--- a/sources/community/shortcut/manifest.yaml
+++ b/sources/community/shortcut/manifest.yaml
@@ -298,15 +298,17 @@ tables:
       search API. Each row is one story. Use query filter for Shortcut
       search syntax pushdown.
     guide: |
-      Optional `query` filter pushes down to the Shortcut search API.
-      Use Shortcut search operators such as `is:started`, `type:bug`,
-      `epic:my-epic`, or `iteration:current`. Without a query filter,
-      returns all stories. Results are paginated with a maximum of 25
-      stories per page. Use `epic_id` to join with `shortcut.epics` and
-      `iteration_id` to join with `shortcut.iterations`.
+      The query filter is required and is pushed down to the Shortcut 
+      Search API using search operators. Use Shortcut search operators 
+      such as `is:started`, `type:bug`, `epic:my-epic`, or 
+      `iteration:current`. Without a query filter, returns all stories. 
+      Results are paginated with a maximum of 250 records per request at 
+      the connector level using cursor-based pagination via next tokens. 
+      Use `epic_id` to join with `shortcut.epics` and `iteration_id` to 
+      join with `shortcut.iterations`.
     filters:
       - name: query
-        required: false
+        required: true
     request:
       method: GET
       path: /search/stories
@@ -326,8 +328,8 @@ tables:
       response_cursor_path:
         - next
       page_size:
-        default: 25
-        max: 25
+        default: 100
+        max: 250
         query_param: page_size
     columns:
       - name: id
@@ -459,11 +461,11 @@ tables:
             kind: path
             path:
               - completed_at
-      - name: query_filter
+      - name: query
         type: Utf8
         nullable: true
         virtual: true
-        description: Search query passed as the filter; echoed onto every row.
+        description: Search query passed to Shortcut search API
         expr:
           kind: from_filter
           key: query


### PR DESCRIPTION
Fixes #891 

Add a new Shortcut community source that lets Coral query Shortcut workspace
members, workflows, epics, stories, iterations, and milestones through SQL —
enabling sprint analytics, story cycle-time reporting, epic tracking, roadmap
visibility, and cross-source joins with the bundled Linear, GitHub, and Jira
sources.

This change is manifest-only and uses Coral's existing HTTP source-spec model
with HeaderAuth via the `Shortcut-Token` request header. Read-only. No CLI,
MCP, config, or runtime changes.

## What changed

Added:

* `sources/community/shortcut/manifest.yaml`
* `sources/community/shortcut/README.md`

## Source scope

### Inputs

* `SHORTCUT_TOKEN` — Shortcut API token (secret), generated from:
  `https://app.shortcut.com/settings/account/api-tokens`

### Auth

* Header auth via:
  `Shortcut-Token: {{input.SHORTCUT_TOKEN}}`

### Tables

#### `shortcut.members`

GET `/members`

No required filters.

Returns workspace members and profile metadata.

7 columns:

* `id`
* `name`
* `email`
* `mention_name`
* `role`
* `created_at`
* `updated_at`

`email` is sourced from the nested `profile.email_address` API field.
`mention_name` is sourced from `profile.mention_name`.

---

#### `shortcut.workflows`

GET `/workflows`

No required filters.

Returns workspace workflows and metadata.

5 columns:

* `id`
* `name`
* `description`
* `created_at`
* `updated_at`

Use `id` to join with `shortcut.stories.workflow_id`.

---

#### `shortcut.epics`

GET `/epics`

No required filters.

Returns workspace epics.

9 columns:

* `id`
* `name`
* `description`
* `state`
* `archived`
* `created_at`
* `updated_at`
* `started_at`
* `completed_at`

Use `id` to join with `shortcut.stories.epic_id`.

---

#### `shortcut.stories`

GET `/search/stories`

Optional filter:

* `query`

The `query` filter is pushed down to the Shortcut search API and supports
Shortcut search operators such as:

* `is:started`
* `type:bug`
* `type:feature`
* `iteration:current`
* `epic:<name>`

Cursor pagination:

* `next` cursor
* page size max: 25

16 columns:

* `id`
* `name`
* `story_type`
* `workflow_id`
* `workflow_state_id`
* `epic_id`
* `iteration_id`
* `estimate`
* `cycle_time`
* `archived`
* `completed`
* `app_url`
* `created_at`
* `updated_at`
* `completed_at`
* `query_filter`

`query_filter` is echoed onto every row as a virtual column via
`from_filter`.

---

#### `shortcut.iterations`

GET `/iterations`

No required filters.

Returns workspace iterations (sprints).

7 columns:

* `id`
* `name`
* `status`
* `start_date`
* `end_date`
* `created_at`
* `updated_at`

Use `id` to join with `shortcut.stories.iteration_id`.

---

#### `shortcut.milestones`

GET `/milestones`

No required filters.

Returns workspace milestones.

8 columns:

* `id`
* `name`
* `description`
* `state`
* `created_at`
* `updated_at`
* `started_at`
* `completed_at`

## Implementation notes

* Auth uses `Shortcut-Token: {{input.SHORTCUT_TOKEN}}` via `HeaderAuth`
* `stories` uses cursor-based pagination with `next` response cursors
* `stories` query pushdown is wired to the Shortcut search API
* All timestamp fields use `format_timestamp` with `input: iso8601`
* `members.email` is sourced from nested `profile.email_address`
* `stories.query_filter` is echoed onto every row via `from_filter`
* `members`, `workflows`, `epics`, `iterations`, and `milestones`
  return full workspace lists with no pagination
* Source is fully read-only

## Out of scope

Not included in v1:

* Labels table
* Groups table
* Story comments
* Attachments/files
* Workflow states expansion
* Write operations of any kind
