### PR TITLE
feat(sources/community/rootly): add rootly community source

### DIFF
--- a/sources/community/rootly/README.md
+++ b/sources/community/rootly/README.md
@@ -39,7 +39,7 @@ export ROOTLY_TOKEN="<your-api-key-or-oauth-token>"
 ### 3. Add the source
 
 ```sh
-cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+coral source add --file sources/community/rootly/manifest.yaml
 ```
 
 ### 4. First successful query (recommended)
@@ -207,33 +207,37 @@ LIMIT 20;
 ### Lint manifest
 
 ```sh
-cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
+coral source lint sources/community/rootly/manifest.yaml
 ```
 
 ### Add source
 
 ```sh
 export ROOTLY_TOKEN="<your-api-key>"
-cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+coral source add --file sources/community/rootly/manifest.yaml
 ```
 
 ### Validate tables
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, title, status, severity__slug FROM rootly.incidents LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, short_id, summary, source, status FROM rootly.alerts LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
+coral sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+coral sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
+coral sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
+coral sql "SELECT id, title, status, severity__slug FROM rootly.incidents LIMIT 5"
+coral sql "SELECT id, short_id, summary, source, status FROM rootly.alerts LIMIT 5"
+coral sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
 ```
 
 ### Inspect registered tables and columns
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
-cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
 ```
+
+---
+
+> **Building from source?** Replace `coral` with `cargo run -p coral-cli --` in all commands above.
 
 ---
 

--- a/sources/community/rootly/README.md
+++ b/sources/community/rootly/README.md
@@ -30,27 +30,19 @@ Designed for **incident lifecycle analytics and operational reliability workflow
 
 Rootly also supports OAuth 2.0 tokens — both API keys and OAuth tokens can be used interchangeably via the same `Authorization: Bearer` header.
 
----
-
 ### 2. Set your token
 
 ```sh
 export ROOTLY_TOKEN="<your-api-key-or-oauth-token>"
 ```
 
----
-
 ### 3. Add the source
 
 ```sh
-coral source add --file sources/community/rootly/manifest.yaml
+cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
 ```
 
----
-
 ### 4. First successful query (recommended)
-
-Use this to verify your setup and immediately see operational data:
 
 ```sql
 SELECT id, title, status, severity_name, started_at
@@ -71,67 +63,46 @@ LIMIT 5;
 
 ## Tables
 
-| Table              | Description                                 | Required filters |
-| ------------------ | ------------------------------------------- | ---------------- |
-| `rootly.users`     | Users in the organization                   | —                |
-| `rootly.services`  | Services defined in the organization        | —                |
-| `rootly.teams`     | Teams in the organization                   | —                |
-| `rootly.incidents` | Incident lifecycle records (MTTR/MTTD/MTTA) | —                |
-| `rootly.alerts`    | Alerts from external monitoring systems     | —                |
-| `rootly.schedules` | On-call schedules                           | —                |
+| Table | Description | Required filters | Optional filters |
+|---|---|---|---|
+| `rootly.users` | Users in the organization | — | — |
+| `rootly.services` | Services defined in the organization | — | — |
+| `rootly.teams` | Teams in the organization | — | — |
+| `rootly.incidents` | Incident lifecycle records (MTTR/MTTD/MTTA) | — | `status`, `severity`, `started_at_gte`, `started_at_lte`, `created_at_gte`, `created_at_lte` |
+| `rootly.alerts` | Alerts from external monitoring systems | — | `status`, `source`, `created_at_gte`, `created_at_lte` |
+| `rootly.schedules` | On-call schedules | — | — |
 
 All tables are **read-only**. This source does not create, modify, or delete Rootly data.
 
 ---
 
-## API Behavior
+## API behavior
 
 ### JSON:API format
 
-Rootly uses JSON:API. All fields are nested under `attributes`, while `id` is at the top level.
-
----
+Rootly uses JSON:API. All resource fields are nested under `attributes`, while `id` is at the top level. The `role_id` column on `users` is sourced from `relationships.role.data.id`.
 
 ### Pagination
 
-Rootly uses **page-based pagination across all endpoints**:
+All endpoints use page-based pagination:
 
-* `page[number]`
-* `page[size]`
-* Default page size: 25
-* Maximum page size: 100
+* `page[number]` / `page[size]`
+* Default page size: 25, maximum: 100
 
-Pagination is consistent across all resources (users, incidents, services, alerts, etc.). Large datasets (especially incidents and alerts) should always expect multiple pages.
+### Pushed filters
 
----
+`incidents` and `alerts` support server-side filter pushdown — these reduce API traffic and pagination depth for large workspaces:
 
-### Date filtering behavior
+**incidents:** `status`, `severity`, `started_at_gte`, `started_at_lte`, `created_at_gte`, `created_at_lte`
 
-For performance and operational use cases, always filter large datasets by time.
-These filters push down to the Rootly API — they are not applied locally.
+**alerts:** `status`, `source`, `created_at_gte`, `created_at_lte`
 
-Supported pushed filters for `incidents`:
-
-* `status`, `severity`
-* `started_at_gte` / `started_at_lte`
-* `created_at_gte` / `created_at_lte`
-
-Supported pushed filters for `alerts`:
-
-* `status`, `source`
-* `created_at_gte` / `created_at_lte`
-
-For incident-heavy workloads, use date ranges (e.g. last 7/30/90 days) to avoid large pagination scans.
-
----
+For large organizations always supply a time filter to avoid unbounded pagination scans.
 
 ### Rate limits
 
-Rootly enforces **workspace-level API rate limits**.
-
-* Requests may be throttled during high incident activity
+* Default: ~3000 GET calls per API key per 60 seconds
 * `429 Too Many Requests` responses should be retried with exponential backoff
-* Long-running incident queries may hit limits in large organizations
 
 ---
 
@@ -147,8 +118,6 @@ ORDER BY started_at DESC
 LIMIT 20;
 ```
 
----
-
 ### Resolved incidents (MTTR analysis)
 
 ```sql
@@ -159,9 +128,7 @@ ORDER BY resolved_at DESC
 LIMIT 50;
 ```
 
----
-
-### Incidents in a time window
+### Incidents in a time window (pushed filter)
 
 ```sql
 SELECT id, title, severity_name, status, started_at
@@ -170,8 +137,6 @@ WHERE started_at_gte = '2025-01-01T00:00:00Z'
   AND started_at_lte = '2025-03-31T23:59:59Z'
 ORDER BY started_at DESC;
 ```
-
----
 
 ### Services with GitHub mapping
 
@@ -182,8 +147,6 @@ WHERE github_repository_name IS NOT NULL
 ORDER BY name
 LIMIT 20;
 ```
-
----
 
 ### On-call ownership view
 
@@ -200,8 +163,6 @@ ORDER BY s.name
 LIMIT 20;
 ```
 
----
-
 ### Alerts by source system
 
 ```sql
@@ -212,12 +173,10 @@ ORDER BY alert_count DESC
 LIMIT 10;
 ```
 
----
-
 ### Alerts with external correlation
 
 ```sql
-SELECT id, external_id, external_url, source, status, created_at
+SELECT id, alert_id, details, source, status, created_at
 FROM rootly.alerts
 WHERE status = 'triggered'
 ORDER BY created_at DESC
@@ -228,46 +187,49 @@ LIMIT 20;
 
 ## Validation
 
-### Lint manifest
+Lint the manifest:
 
 ```sh
-coral source lint sources/community/rootly/manifest.yaml
+cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
 ```
 
----
-
-### Add source
+Add the source:
 
 ```sh
 export ROOTLY_TOKEN="<your-api-key>"
-coral source add --file sources/community/rootly/manifest.yaml
+cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
 ```
 
----
-
-### Validate tables
+Validate tables:
 
 ```sh
-coral sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
-coral sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
-coral sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
-coral sql "SELECT id, title, status, severity_name FROM rootly.incidents LIMIT 5"
-coral sql "SELECT id, external_id, source, status FROM rootly.alerts LIMIT 5"
-coral sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, title, status, severity_name FROM rootly.incidents LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, alert_id, details, source, status FROM rootly.alerts LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
+```
+
+Inspect registered tables and columns:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
 ```
 
 ---
 
 ## Notes
 
-* **JSON:API format:** all fields are under `attributes`, `id` is top-level
+* **JSON:API format:** all fields are under `attributes`, `id` is top-level; `role_id` on users comes from `relationships.role.data.id`
 * **Auth:** API keys and OAuth tokens both use `Authorization: Bearer`
-* **Pagination:** consistent page-based pagination across all endpoints
-* **Rate limits:** workspace-level limits; retry on 429 with backoff
-* **Date fields:** timestamps are ISO 8601 format
-* **Pushed filters:** `incidents` and `alerts` support server-side filtering by status, source, and date range — use these for large workspaces
-* **Cross-source joins:** incidents expose Jira, Linear, GitHub, Shortcut IDs for correlation
-* **Operational use case:** optimized for incident lifecycle and reliability analytics
+* **Pagination:** consistent page-based pagination (`page[number]` / `page[size]`) across all endpoints
+* **Pushed filters:** `incidents` and `alerts` support API-side filtering by status, severity/source, and date range — always use these for large workspaces
+* **Rate limits:** ~3000 GET calls per 60 seconds per API key; retry on 429 with backoff
+* **Timestamps:** ISO 8601 format throughout
+* **Alert fields:** `alert_id`, `details`, and `user_id` are the live-verified attributes returned by the Rootly API. The OpenAPI spec lists `summary/description` but these are not present in actual API responses.
+* **Cross-source joins:** incidents expose `jira_issue_key`, `linear_issue_id`, `github_issue_id`, and `shortcut_story_id` for correlation
 
 ---
 

--- a/sources/community/rootly/README.md
+++ b/sources/community/rootly/README.md
@@ -1,0 +1,249 @@
+# Rootly (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Rootly REST API v1)
+**Tables:** 6
+**Base URL:** `https://api.rootly.com/v1`
+
+Query incidents, services, users, teams, alerts, and on-call schedules from
+Rootly via SQL. Designed for incident analytics: MTTR reporting, response
+time tracking, on-call coverage visibility, and cross-source joins with the
+bundled **Jira**, **Linear**, **GitHub**, and **Shortcut** sources.
+
+## Setup
+
+### 1. Generate a Rootly API key
+
+1. In your Rootly workspace, go to
+   **Organization Settings → API Keys**
+2. Click **Generate API Key**, give it a name, and copy the key.
+
+> This source also works with Rootly OAuth 2.0 access tokens — paste
+> the OAuth token the same way as an API key.
+
+### 2. Set your token
+
+```sh
+export ROOTLY_TOKEN="<your-api-key>"
+```
+
+### 3. Add the source
+
+```sh
+cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+```
+
+### 4. Verify
+
+```sh
+cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `rootly.users` | Users in the organization | — |
+| `rootly.services` | Services defined in the organization | — |
+| `rootly.teams` | Teams in the organization | — |
+| `rootly.incidents` | Incidents in the organization | — |
+| `rootly.alerts` | Alerts in the organization | — |
+| `rootly.schedules` | On-call schedules | — |
+
+All tables are read-only. This source does not create, modify, or delete any
+Rootly data.
+
+> **Note:** Rootly uses JSON:API format. All resource fields are sourced
+> from the nested `attributes` object in each response item. `id` is at
+> the top level of each item.
+
+### `users`
+
+Lists all users in the organization. Join `email` to `linear.users` or
+`github.members` for cross-source team analytics.
+
+### `services`
+
+Lists all services. Use `pagerduty_id` or `opsgenie_id` to join with
+PagerDuty or OpsGenie sources. Use `github_repository_name` to join with
+`github.repos`.
+
+### `teams`
+
+Lists all teams. Use `pagerduty_id` to join with PagerDuty teams.
+
+### `incidents`
+
+Lists all incidents. Use `status` to filter locally:
+
+| Value | Meaning |
+|---|---|
+| `started` | Incident is active |
+| `mitigated` | Incident has been mitigated |
+| `resolved` | Incident is resolved |
+| `cancelled` | Incident was cancelled |
+
+Use `jira_issue_key`, `linear_issue_id`, `github_issue_id`, or
+`shortcut_story_id` for cross-source joins. Use `started_at`,
+`mitigated_at`, and `resolved_at` for MTTR and response-time analytics.
+
+### `alerts`
+
+Lists all alerts. Use `source` to filter by the originating alert system.
+
+### `schedules`
+
+Lists all on-call schedules. Use `owner_user_id` to join with
+`rootly.users.id`. Use `all_time_coverage` to identify 24/7 schedules.
+
+## Example queries
+
+List all users:
+
+```sql
+SELECT id, full_name, email, role_id, time_zone
+FROM rootly.users
+ORDER BY full_name
+LIMIT 20;
+```
+
+List services with GitHub repository connections:
+
+```sql
+SELECT id, name, slug, github_repository_name, github_repository_branch
+FROM rootly.services
+WHERE github_repository_name IS NOT NULL
+ORDER BY name
+LIMIT 20;
+```
+
+Active incidents by severity:
+
+```sql
+SELECT id, title, severity_name, status, started_at, slack_channel_name
+FROM rootly.incidents
+WHERE status = 'started'
+ORDER BY started_at DESC
+LIMIT 20;
+```
+
+Resolved incidents for MTTR analysis:
+
+```sql
+SELECT
+  id,
+  title,
+  severity_name,
+  started_at,
+  mitigated_at,
+  resolved_at
+FROM rootly.incidents
+WHERE status = 'resolved'
+ORDER BY resolved_at DESC
+LIMIT 50;
+```
+
+Incidents linked to Jira issues (cross-source):
+
+```sql
+SELECT
+  i.id,
+  i.title,
+  i.severity_name,
+  i.status,
+  i.jira_issue_key,
+  i.started_at
+FROM rootly.incidents i
+WHERE i.jira_issue_key IS NOT NULL
+ORDER BY i.started_at DESC
+LIMIT 20;
+```
+
+On-call schedules with owner details:
+
+```sql
+SELECT
+  s.id,
+  s.name,
+  s.all_time_coverage,
+  s.shift_report_time_zone,
+  u.full_name AS owner_name,
+  u.email AS owner_email
+FROM rootly.schedules s
+LEFT JOIN rootly.users u ON s.owner_user_id = u.id
+ORDER BY s.name
+LIMIT 20;
+```
+
+Alerts by source system:
+
+```sql
+SELECT source, COUNT(*) AS alert_count
+FROM rootly.alerts
+GROUP BY source
+ORDER BY alert_count DESC
+LIMIT 10;
+```
+
+## Validation
+
+Lint the manifest:
+
+```sh
+cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
+```
+
+Add the source and validate each table:
+
+```sh
+export ROOTLY_TOKEN="<your-api-key>"
+cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+
+# users — no required filters
+cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+
+# services — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, slug, pagerduty_id FROM rootly.services LIMIT 5"
+
+# teams — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
+
+# incidents — no required filters
+cargo run -p coral-cli -- sql "SELECT id, title, status, severity_name, started_at, resolved_at FROM rootly.incidents LIMIT 5"
+
+# alerts — no required filters
+cargo run -p coral-cli -- sql "SELECT id, alert_id, source, created_at FROM rootly.alerts LIMIT 5"
+
+# schedules — no required filters
+cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id, all_time_coverage FROM rootly.schedules LIMIT 5"
+```
+
+Inspect registered tables and columns:
+
+```sh
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
+```
+
+## Notes
+
+- **JSON:API format:** Rootly uses JSON:API. All resource fields are nested
+  under `attributes` in the API response. `id` is at the top level of each
+  item. This is handled transparently by the column path expressions.
+- **Auth:** both Rootly API keys and OAuth 2.0 access tokens work with
+  `Authorization: Bearer`. Rootly detects the token type automatically.
+- **`Content-Type`:** Rootly requires `application/vnd.api+json` not
+  `application/json`.
+- **Pagination:** all tables use `page[number]` and `page[size]` query
+  parameters. Default page size is 25; maximum is 100.
+- **Cross-source joins:** `incidents` exposes `jira_issue_key`,
+  `linear_issue_id`, `github_issue_id`, and `shortcut_story_id` for
+  joining with other Coral sources.
+
+## Out of scope for v1
+
+- Incident action items and timeline events
+- Retrospectives
+- Workflows and playbooks
+- OAuth authorization-code flow (deferred — use API key for now)
+- Write operations of any kind

--- a/sources/community/rootly/README.md
+++ b/sources/community/rootly/README.md
@@ -43,7 +43,7 @@ export ROOTLY_TOKEN="<your-api-key-or-oauth-token>"
 ### 3. Add the source
 
 ```sh
-cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+coral source add --file sources/community/rootly/manifest.yaml
 ```
 
 ---
@@ -107,14 +107,19 @@ Pagination is consistent across all resources (users, incidents, services, alert
 
 ### Date filtering behavior
 
-For performance and operational use cases, always filter large datasets by time:
+For performance and operational use cases, always filter large datasets by time.
+These filters push down to the Rootly API — they are not applied locally.
 
-Supported timestamp fields:
+Supported pushed filters for `incidents`:
 
-* `started_at`
-* `created_at`
-* `resolved_at`
-* `mitigated_at`
+* `status`, `severity`
+* `started_at_gte` / `started_at_lte`
+* `created_at_gte` / `created_at_lte`
+
+Supported pushed filters for `alerts`:
+
+* `status`, `source`
+* `created_at_gte` / `created_at_lte`
 
 For incident-heavy workloads, use date ranges (e.g. last 7/30/90 days) to avoid large pagination scans.
 
@@ -127,18 +132,6 @@ Rootly enforces **workspace-level API rate limits**.
 * Requests may be throttled during high incident activity
 * `429 Too Many Requests` responses should be retried with exponential backoff
 * Long-running incident queries may hit limits in large organizations
-
----
-
-## Search functions
-
-All search functions require a non-empty `term`.
-
-| Function                     | Description                                   |
-| ---------------------------- | --------------------------------------------- |
-| `search_deals(term)`         | Search deals by title and fields (if enabled) |
-| `search_persons(term)`       | Search people by name and metadata            |
-| `search_organizations(term)` | Search organizations by name and attributes   |
 
 ---
 
@@ -164,6 +157,18 @@ FROM rootly.incidents
 WHERE status = 'resolved'
 ORDER BY resolved_at DESC
 LIMIT 50;
+```
+
+---
+
+### Incidents in a time window
+
+```sql
+SELECT id, title, severity_name, status, started_at
+FROM rootly.incidents
+WHERE started_at_gte = '2025-01-01T00:00:00Z'
+  AND started_at_lte = '2025-03-31T23:59:59Z'
+ORDER BY started_at DESC;
 ```
 
 ---
@@ -209,12 +214,24 @@ LIMIT 10;
 
 ---
 
+### Alerts with external correlation
+
+```sql
+SELECT id, external_id, external_url, source, status, created_at
+FROM rootly.alerts
+WHERE status = 'triggered'
+ORDER BY created_at DESC
+LIMIT 20;
+```
+
+---
+
 ## Validation
 
 ### Lint manifest
 
 ```sh
-cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
+coral source lint sources/community/rootly/manifest.yaml
 ```
 
 ---
@@ -223,7 +240,7 @@ cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
 
 ```sh
 export ROOTLY_TOKEN="<your-api-key>"
-cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+coral source add --file sources/community/rootly/manifest.yaml
 ```
 
 ---
@@ -231,12 +248,12 @@ cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.ya
 ### Validate tables
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, title, status, severity_name FROM rootly.incidents LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, alert_id, source FROM rootly.alerts LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
+coral sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+coral sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
+coral sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
+coral sql "SELECT id, title, status, severity_name FROM rootly.incidents LIMIT 5"
+coral sql "SELECT id, external_id, source, status FROM rootly.alerts LIMIT 5"
+coral sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
 ```
 
 ---
@@ -247,7 +264,8 @@ cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id FROM rootly.schedu
 * **Auth:** API keys and OAuth tokens both use `Authorization: Bearer`
 * **Pagination:** consistent page-based pagination across all endpoints
 * **Rate limits:** workspace-level limits; retry on 429 with backoff
-* **Date fields:** timestamps are ISO8601 format
+* **Date fields:** timestamps are ISO 8601 format
+* **Pushed filters:** `incidents` and `alerts` support server-side filtering by status, source, and date range — use these for large workspaces
 * **Cross-source joins:** incidents expose Jira, Linear, GitHub, Shortcut IDs for correlation
 * **Operational use case:** optimized for incident lifecycle and reliability analytics
 

--- a/sources/community/rootly/README.md
+++ b/sources/community/rootly/README.md
@@ -5,27 +5,40 @@
 **Tables:** 6
 **Base URL:** `https://api.rootly.com/v1`
 
-Query incidents, services, users, teams, alerts, and on-call schedules from
-Rootly via SQL. Designed for incident analytics: MTTR reporting, response
-time tracking, on-call coverage visibility, and cross-source joins with the
-bundled **Jira**, **Linear**, **GitHub**, and **Shortcut** sources.
+Query incidents, services, users, teams, alerts, and on-call schedules from Rootly via SQL.
+
+Designed for **incident lifecycle analytics and operational reliability workflows**, including:
+
+* Incident detection → acknowledgment → mitigation → resolution tracking
+* MTTR / MTTD / MTTA analysis
+* On-call coverage and ownership visibility
+* Alert correlation and incident causality analysis
+* Cross-source joins with Jira, Linear, GitHub, and Shortcut
+
+---
 
 ## Setup
 
 ### 1. Generate a Rootly API key
 
-1. In your Rootly workspace, go to
+1. In your Rootly workspace, go to:
    **Organization Settings → API Keys**
-2. Click **Generate API Key**, give it a name, and copy the key.
+2. Generate a new API key and copy it.
 
-> This source also works with Rootly OAuth 2.0 access tokens — paste
-> the OAuth token the same way as an API key.
+> The API key must have **read access to incidents, services, teams, users, alerts, and schedules**.
+> Keys are **workspace-scoped** and inherit permissions based on the role that created them.
+
+Rootly also supports OAuth 2.0 tokens — both API keys and OAuth tokens can be used interchangeably via the same `Authorization: Bearer` header.
+
+---
 
 ### 2. Set your token
 
 ```sh
-export ROOTLY_TOKEN="<your-api-key>"
+export ROOTLY_TOKEN="<your-api-key-or-oauth-token>"
 ```
+
+---
 
 ### 3. Add the source
 
@@ -33,81 +46,129 @@ export ROOTLY_TOKEN="<your-api-key>"
 cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
 ```
 
-### 4. Verify
+---
 
-```sh
-cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+### 4. First successful query (recommended)
+
+Use this to verify your setup and immediately see operational data:
+
+```sql
+SELECT id, title, status, severity_name, started_at
+FROM rootly.incidents
+ORDER BY started_at DESC
+LIMIT 5;
 ```
+
+Or validate service ingestion:
+
+```sql
+SELECT id, name, slug, github_repository_name
+FROM rootly.services
+LIMIT 5;
+```
+
+---
 
 ## Tables
 
-| Table | Description | Required filters |
-|---|---|---|
-| `rootly.users` | Users in the organization | — |
-| `rootly.services` | Services defined in the organization | — |
-| `rootly.teams` | Teams in the organization | — |
-| `rootly.incidents` | Incidents in the organization | — |
-| `rootly.alerts` | Alerts in the organization | — |
-| `rootly.schedules` | On-call schedules | — |
+| Table              | Description                                 | Required filters |
+| ------------------ | ------------------------------------------- | ---------------- |
+| `rootly.users`     | Users in the organization                   | —                |
+| `rootly.services`  | Services defined in the organization        | —                |
+| `rootly.teams`     | Teams in the organization                   | —                |
+| `rootly.incidents` | Incident lifecycle records (MTTR/MTTD/MTTA) | —                |
+| `rootly.alerts`    | Alerts from external monitoring systems     | —                |
+| `rootly.schedules` | On-call schedules                           | —                |
 
-All tables are read-only. This source does not create, modify, or delete any
-Rootly data.
+All tables are **read-only**. This source does not create, modify, or delete Rootly data.
 
-> **Note:** Rootly uses JSON:API format. All resource fields are sourced
-> from the nested `attributes` object in each response item. `id` is at
-> the top level of each item.
+---
 
-### `users`
+## API Behavior
 
-Lists all users in the organization. Join `email` to `linear.users` or
-`github.members` for cross-source team analytics.
+### JSON:API format
 
-### `services`
+Rootly uses JSON:API. All fields are nested under `attributes`, while `id` is at the top level.
 
-Lists all services. Use `pagerduty_id` or `opsgenie_id` to join with
-PagerDuty or OpsGenie sources. Use `github_repository_name` to join with
-`github.repos`.
+---
 
-### `teams`
+### Pagination
 
-Lists all teams. Use `pagerduty_id` to join with PagerDuty teams.
+Rootly uses **page-based pagination across all endpoints**:
 
-### `incidents`
+* `page[number]`
+* `page[size]`
+* Default page size: 25
+* Maximum page size: 100
 
-Lists all incidents. Use `status` to filter locally:
+Pagination is consistent across all resources (users, incidents, services, alerts, etc.). Large datasets (especially incidents and alerts) should always expect multiple pages.
 
-| Value | Meaning |
-|---|---|
-| `started` | Incident is active |
-| `mitigated` | Incident has been mitigated |
-| `resolved` | Incident is resolved |
-| `cancelled` | Incident was cancelled |
+---
 
-Use `jira_issue_key`, `linear_issue_id`, `github_issue_id`, or
-`shortcut_story_id` for cross-source joins. Use `started_at`,
-`mitigated_at`, and `resolved_at` for MTTR and response-time analytics.
+### Date filtering behavior
 
-### `alerts`
+For performance and operational use cases, always filter large datasets by time:
 
-Lists all alerts. Use `source` to filter by the originating alert system.
+Supported timestamp fields:
 
-### `schedules`
+* `started_at`
+* `created_at`
+* `resolved_at`
+* `mitigated_at`
 
-Lists all on-call schedules. Use `owner_user_id` to join with
-`rootly.users.id`. Use `all_time_coverage` to identify 24/7 schedules.
+For incident-heavy workloads, use date ranges (e.g. last 7/30/90 days) to avoid large pagination scans.
+
+---
+
+### Rate limits
+
+Rootly enforces **workspace-level API rate limits**.
+
+* Requests may be throttled during high incident activity
+* `429 Too Many Requests` responses should be retried with exponential backoff
+* Long-running incident queries may hit limits in large organizations
+
+---
+
+## Search functions
+
+All search functions require a non-empty `term`.
+
+| Function                     | Description                                   |
+| ---------------------------- | --------------------------------------------- |
+| `search_deals(term)`         | Search deals by title and fields (if enabled) |
+| `search_persons(term)`       | Search people by name and metadata            |
+| `search_organizations(term)` | Search organizations by name and attributes   |
+
+---
 
 ## Example queries
 
-List all users:
+### Active incidents
 
 ```sql
-SELECT id, full_name, email, role_id, time_zone
-FROM rootly.users
-ORDER BY full_name
+SELECT id, title, severity_name, status, started_at
+FROM rootly.incidents
+WHERE status = 'started'
+ORDER BY started_at DESC
 LIMIT 20;
 ```
 
-List services with GitHub repository connections:
+---
+
+### Resolved incidents (MTTR analysis)
+
+```sql
+SELECT id, title, severity_name, started_at, mitigated_at, resolved_at
+FROM rootly.incidents
+WHERE status = 'resolved'
+ORDER BY resolved_at DESC
+LIMIT 50;
+```
+
+---
+
+### Services with GitHub mapping
 
 ```sql
 SELECT id, name, slug, github_repository_name, github_repository_branch
@@ -117,56 +178,15 @@ ORDER BY name
 LIMIT 20;
 ```
 
-Active incidents by severity:
+---
 
-```sql
-SELECT id, title, severity_name, status, started_at, slack_channel_name
-FROM rootly.incidents
-WHERE status = 'started'
-ORDER BY started_at DESC
-LIMIT 20;
-```
-
-Resolved incidents for MTTR analysis:
-
-```sql
-SELECT
-  id,
-  title,
-  severity_name,
-  started_at,
-  mitigated_at,
-  resolved_at
-FROM rootly.incidents
-WHERE status = 'resolved'
-ORDER BY resolved_at DESC
-LIMIT 50;
-```
-
-Incidents linked to Jira issues (cross-source):
-
-```sql
-SELECT
-  i.id,
-  i.title,
-  i.severity_name,
-  i.status,
-  i.jira_issue_key,
-  i.started_at
-FROM rootly.incidents i
-WHERE i.jira_issue_key IS NOT NULL
-ORDER BY i.started_at DESC
-LIMIT 20;
-```
-
-On-call schedules with owner details:
+### On-call ownership view
 
 ```sql
 SELECT
   s.id,
   s.name,
   s.all_time_coverage,
-  s.shift_report_time_zone,
   u.full_name AS owner_name,
   u.email AS owner_email
 FROM rootly.schedules s
@@ -175,7 +195,9 @@ ORDER BY s.name
 LIMIT 20;
 ```
 
-Alerts by source system:
+---
+
+### Alerts by source system
 
 ```sql
 SELECT source, COUNT(*) AS alert_count
@@ -185,65 +207,56 @@ ORDER BY alert_count DESC
 LIMIT 10;
 ```
 
+---
+
 ## Validation
 
-Lint the manifest:
+### Lint manifest
 
 ```sh
 cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
 ```
 
-Add the source and validate each table:
+---
+
+### Add source
 
 ```sh
 export ROOTLY_TOKEN="<your-api-key>"
 cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
-
-# users — no required filters
-cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
-
-# services — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, slug, pagerduty_id FROM rootly.services LIMIT 5"
-
-# teams — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
-
-# incidents — no required filters
-cargo run -p coral-cli -- sql "SELECT id, title, status, severity_name, started_at, resolved_at FROM rootly.incidents LIMIT 5"
-
-# alerts — no required filters
-cargo run -p coral-cli -- sql "SELECT id, alert_id, source, created_at FROM rootly.alerts LIMIT 5"
-
-# schedules — no required filters
-cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id, all_time_coverage FROM rootly.schedules LIMIT 5"
 ```
 
-Inspect registered tables and columns:
+---
+
+### Validate tables
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
-cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
+cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, title, status, severity_name FROM rootly.incidents LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, alert_id, source FROM rootly.alerts LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
 ```
+
+---
 
 ## Notes
 
-- **JSON:API format:** Rootly uses JSON:API. All resource fields are nested
-  under `attributes` in the API response. `id` is at the top level of each
-  item. This is handled transparently by the column path expressions.
-- **Auth:** both Rootly API keys and OAuth 2.0 access tokens work with
-  `Authorization: Bearer`. Rootly detects the token type automatically.
-- **`Content-Type`:** Rootly requires `application/vnd.api+json` not
-  `application/json`.
-- **Pagination:** all tables use `page[number]` and `page[size]` query
-  parameters. Default page size is 25; maximum is 100.
-- **Cross-source joins:** `incidents` exposes `jira_issue_key`,
-  `linear_issue_id`, `github_issue_id`, and `shortcut_story_id` for
-  joining with other Coral sources.
+* **JSON:API format:** all fields are under `attributes`, `id` is top-level
+* **Auth:** API keys and OAuth tokens both use `Authorization: Bearer`
+* **Pagination:** consistent page-based pagination across all endpoints
+* **Rate limits:** workspace-level limits; retry on 429 with backoff
+* **Date fields:** timestamps are ISO8601 format
+* **Cross-source joins:** incidents expose Jira, Linear, GitHub, Shortcut IDs for correlation
+* **Operational use case:** optimized for incident lifecycle and reliability analytics
+
+---
 
 ## Out of scope for v1
 
-- Incident action items and timeline events
-- Retrospectives
-- Workflows and playbooks
-- OAuth authorization-code flow (deferred — use API key for now)
-- Write operations of any kind
+* Incident timeline events / retrospectives
+* Workflow automation / playbooks
+* Write operations (create/update/delete)
+* OAuth authorization code flow
+* Advanced incident mutation APIs

--- a/sources/community/rootly/README.md
+++ b/sources/community/rootly/README.md
@@ -39,7 +39,7 @@ export ROOTLY_TOKEN="<your-api-key-or-oauth-token>"
 ### 3. Add the source
 
 ```sh
-coral source add --file sources/community/rootly/manifest.yaml
+cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
 ```
 
 ### 4. First successful query (recommended)
@@ -106,10 +106,10 @@ For large organizations always supply a time filter to avoid unbounded paginatio
 
 ### Rate limits
 
-Rootly's default rate limit is **5 GET requests per API key per 60 seconds**. Contact your Rootly Customer Success Manager to increase this.
+Rootly's default rate limit is **3000 GET, HEAD, and OPTIONS calls per API key per minute**, calculated over a 1-minute sliding window. Contact your Rootly Customer Success Manager to increase this threshold.
 
 * `429 Too Many Requests` responses should be retried with exponential backoff
-* For bulk analytics queries, space out requests accordingly
+* `X-RateLimit-Remaining` and `X-RateLimit-Reset` headers are included in every response
 
 ---
 
@@ -207,32 +207,32 @@ LIMIT 20;
 ### Lint manifest
 
 ```sh
-coral source lint sources/community/rootly/manifest.yaml
+cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
 ```
 
 ### Add source
 
 ```sh
 export ROOTLY_TOKEN="<your-api-key>"
-coral source add --file sources/community/rootly/manifest.yaml
+cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
 ```
 
 ### Validate tables
 
 ```sh
-coral sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
-coral sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
-coral sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
-coral sql "SELECT id, title, status, severity__slug FROM rootly.incidents LIMIT 5"
-coral sql "SELECT id, short_id, summary, source, status FROM rootly.alerts LIMIT 5"
-coral sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, title, status, severity__slug FROM rootly.incidents LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, short_id, summary, source, status FROM rootly.alerts LIMIT 5"
+cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
 ```
 
 ### Inspect registered tables and columns
 
 ```sh
-coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
-coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
+cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
+cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
 ```
 
 ---
@@ -243,10 +243,10 @@ coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE sc
 * **Auth:** API keys and OAuth tokens both use `Authorization: Bearer`
 * **Pagination:** consistent page-based pagination (`page[number]` / `page[size]`) across all endpoints; default 25, max 100
 * **Pushed filters:** `incidents` and `alerts` support API-side filtering by status, severity/source, and date range — always use these for large workspaces
-* **Rate limits:** default 5 GET requests per API key per 60 seconds; retry on 429 with backoff
+* **Rate limits:** default 3000 GET requests per API key per minute; retry on 429 with backoff
 * **Timestamps:** ISO 8601 format throughout
 * **Severity:** nested JSON:API relationship on incidents — access via `severity__name` and `severity__slug`; use the `severity` filter with the slug value
-* **Alert fields:** mapped from the documented Rootly alert schema (`short_id`, `summary`, `description`, `external_id`, `external_url`, `deduplication_key`, `notification_target_type`, `notification_target_id`)
+* **Alert fields:** mapped from the documented Rootly alert schema (`short_id`, `summary`, `description`, `external_id`, `external_url`, `deduplication_key`, `notification_target_id`)
 * **Cross-source joins:** incidents expose `jira_issue_key`, `linear_issue_id`, `github_issue_id`, and `shortcut_story_id` for correlation
 
 ---

--- a/sources/community/rootly/README.md
+++ b/sources/community/rootly/README.md
@@ -39,13 +39,13 @@ export ROOTLY_TOKEN="<your-api-key-or-oauth-token>"
 ### 3. Add the source
 
 ```sh
-cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+coral source add --file sources/community/rootly/manifest.yaml
 ```
 
 ### 4. First successful query (recommended)
 
 ```sql
-SELECT id, title, status, severity_name, started_at
+SELECT id, title, status, started_at
 FROM rootly.incidents
 ORDER BY started_at DESC
 LIMIT 5;
@@ -82,6 +82,11 @@ All tables are **read-only**. This source does not create, modify, or delete Roo
 
 Rootly uses JSON:API. All resource fields are nested under `attributes`, while `id` is at the top level. The `role_id` column on `users` is sourced from `relationships.role.data.id`.
 
+Severity on incidents is a nested JSON:API relationship. The manifest maps it via double-underscore notation:
+
+* `severity__name` → `attributes.severity.data.attributes.name`
+* `severity__slug` → `attributes.severity.data.attributes.slug`
+
 ### Pagination
 
 All endpoints use page-based pagination:
@@ -101,8 +106,10 @@ For large organizations always supply a time filter to avoid unbounded paginatio
 
 ### Rate limits
 
-* Default: ~3000 GET calls per API key per 60 seconds
+Rootly's default rate limit is **5 GET requests per API key per 60 seconds**. Contact your Rootly Customer Success Manager to increase this.
+
 * `429 Too Many Requests` responses should be retried with exponential backoff
+* For bulk analytics queries, space out requests accordingly
 
 ---
 
@@ -111,7 +118,7 @@ For large organizations always supply a time filter to avoid unbounded paginatio
 ### Active incidents
 
 ```sql
-SELECT id, title, severity_name, status, started_at
+SELECT id, title, severity__name, status, started_at
 FROM rootly.incidents
 WHERE status = 'started'
 ORDER BY started_at DESC
@@ -121,7 +128,7 @@ LIMIT 20;
 ### Resolved incidents (MTTR analysis)
 
 ```sql
-SELECT id, title, severity_name, started_at, mitigated_at, resolved_at
+SELECT id, title, severity__slug, started_at, mitigated_at, resolved_at
 FROM rootly.incidents
 WHERE status = 'resolved'
 ORDER BY resolved_at DESC
@@ -131,11 +138,21 @@ LIMIT 50;
 ### Incidents in a time window (pushed filter)
 
 ```sql
-SELECT id, title, severity_name, status, started_at
+SELECT id, title, severity__slug, status, started_at
 FROM rootly.incidents
 WHERE started_at_gte = '2025-01-01T00:00:00Z'
   AND started_at_lte = '2025-03-31T23:59:59Z'
 ORDER BY started_at DESC;
+```
+
+### Filter incidents by severity (pushed filter)
+
+```sql
+SELECT id, title, severity__name, status, started_at
+FROM rootly.incidents
+WHERE severity = 'sev0'
+ORDER BY started_at DESC
+LIMIT 20;
 ```
 
 ### Services with GitHub mapping
@@ -176,7 +193,7 @@ LIMIT 10;
 ### Alerts with external correlation
 
 ```sql
-SELECT id, alert_id, details, source, status, created_at
+SELECT id, short_id, external_id, external_url, source, status, created_at
 FROM rootly.alerts
 WHERE status = 'triggered'
 ORDER BY created_at DESC
@@ -187,35 +204,35 @@ LIMIT 20;
 
 ## Validation
 
-Lint the manifest:
+### Lint manifest
 
 ```sh
-cargo run -p coral-cli -- source lint sources/community/rootly/manifest.yaml
+coral source lint sources/community/rootly/manifest.yaml
 ```
 
-Add the source:
+### Add source
 
 ```sh
 export ROOTLY_TOKEN="<your-api-key>"
-cargo run -p coral-cli -- source add --file sources/community/rootly/manifest.yaml
+coral source add --file sources/community/rootly/manifest.yaml
 ```
 
-Validate tables:
+### Validate tables
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, title, status, severity_name FROM rootly.incidents LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, alert_id, details, source, status FROM rootly.alerts LIMIT 5"
-cargo run -p coral-cli -- sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
+coral sql "SELECT id, full_name, email FROM rootly.users LIMIT 5"
+coral sql "SELECT id, name, slug FROM rootly.services LIMIT 5"
+coral sql "SELECT id, name, slug FROM rootly.teams LIMIT 5"
+coral sql "SELECT id, title, status, severity__slug FROM rootly.incidents LIMIT 5"
+coral sql "SELECT id, short_id, summary, source, status FROM rootly.alerts LIMIT 5"
+coral sql "SELECT id, name, owner_user_id FROM rootly.schedules LIMIT 5"
 ```
 
-Inspect registered tables and columns:
+### Inspect registered tables and columns
 
 ```sh
-cargo run -p coral-cli -- sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
-cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'rootly'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'rootly' ORDER BY table_name, ordinal_position"
 ```
 
 ---
@@ -224,11 +241,12 @@ cargo run -p coral-cli -- sql "SELECT table_name, column_name, data_type FROM co
 
 * **JSON:API format:** all fields are under `attributes`, `id` is top-level; `role_id` on users comes from `relationships.role.data.id`
 * **Auth:** API keys and OAuth tokens both use `Authorization: Bearer`
-* **Pagination:** consistent page-based pagination (`page[number]` / `page[size]`) across all endpoints
+* **Pagination:** consistent page-based pagination (`page[number]` / `page[size]`) across all endpoints; default 25, max 100
 * **Pushed filters:** `incidents` and `alerts` support API-side filtering by status, severity/source, and date range — always use these for large workspaces
-* **Rate limits:** ~3000 GET calls per 60 seconds per API key; retry on 429 with backoff
+* **Rate limits:** default 5 GET requests per API key per 60 seconds; retry on 429 with backoff
 * **Timestamps:** ISO 8601 format throughout
-* **Alert fields:** `alert_id`, `details`, and `user_id` are the live-verified attributes returned by the Rootly API. The OpenAPI spec lists `summary/description` but these are not present in actual API responses.
+* **Severity:** nested JSON:API relationship on incidents — access via `severity__name` and `severity__slug`; use the `severity` filter with the slug value
+* **Alert fields:** mapped from the documented Rootly alert schema (`short_id`, `summary`, `description`, `external_id`, `external_url`, `deduplication_key`, `notification_target_type`, `notification_target_id`)
 * **Cross-source joins:** incidents expose `jira_issue_key`, `linear_issue_id`, `github_issue_id`, and `shortcut_story_id` for correlation
 
 ---

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -1,0 +1,854 @@
+name: rootly
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query incidents, services, users, teams, alerts, and schedules from
+  Rootly via the Rootly REST API v1.
+base_url: https://api.rootly.com/v1
+
+inputs:
+  ROOTLY_TOKEN:
+    kind: secret
+    hint: |
+      Rootly API key or OAuth 2.0 access token. Generate an API key at
+      Organization Settings → API Keys in your Rootly workspace. The
+      token is sent as Authorization: Bearer and works with both API
+      keys and OAuth 2.0 access tokens — Rootly detects the type
+      automatically.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.ROOTLY_TOKEN}}
+
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/vnd.api+json
+
+test_queries:
+  - SELECT id, full_name, email FROM rootly.users LIMIT 5
+  - SELECT id, name, slug FROM rootly.services LIMIT 5
+
+tables:
+  # ──────────────────────────────────────────────────────────────────────────
+  # users — users in the organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: users
+    description: >-
+      Users in the Rootly organization. Each row is one user. Join
+      email to linear.users or github.members for cross-tool analytics.
+    guide: |
+      No required filters. All fields are sourced from the nested
+      attributes object in the JSON:API response. Join `email` to
+      `linear.users` or `github.members` for cross-source team analytics.
+    request:
+      method: GET
+      path: /users
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: page
+      page_size:
+        default: 25
+        max: 100
+        query_param: page[size]
+      page_param: page[number]
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: User ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: email
+        type: Utf8
+        nullable: true
+        description: User email address.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - email
+      - name: full_name
+        type: Utf8
+        nullable: true
+        description: User full name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - full_name
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: User first name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - first_name
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: User last name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - last_name
+      - name: role_id
+        type: Utf8
+        nullable: true
+        description: Role ID assigned to the user.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - role_id
+      - name: time_zone
+        type: Utf8
+        nullable: true
+        description: User time zone.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - time_zone
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the user was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the user was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # services — services defined in the organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: services
+    description: >-
+      Services defined in the Rootly organization. Each row is one
+      service. Use pagerduty_id or opsgenie_id for cross-source joins.
+    guide: |
+      No required filters. Use `pagerduty_id` or `opsgenie_id` to
+      join with PagerDuty or OpsGenie sources. Use
+      `github_repository_name` to join with `github.repos`.
+    request:
+      method: GET
+      path: /services
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: page
+      page_size:
+        default: 25
+        max: 100
+        query_param: page[size]
+      page_param: page[number]
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Service ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Service name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - name
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Service slug.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - slug
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Service description.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - description
+      - name: color
+        type: Utf8
+        nullable: true
+        description: Service color hex code.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - color
+      - name: pagerduty_id
+        type: Utf8
+        nullable: true
+        description: PagerDuty service ID for cross-source joins.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - pagerduty_id
+      - name: opsgenie_id
+        type: Utf8
+        nullable: true
+        description: OpsGenie service ID for cross-source joins.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - opsgenie_id
+      - name: github_repository_name
+        type: Utf8
+        nullable: true
+        description: Connected GitHub repository name. Join to github.repos.name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - github_repository_name
+      - name: github_repository_branch
+        type: Utf8
+        nullable: true
+        description: Connected GitHub repository default branch.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - github_repository_branch
+      - name: gitlab_repository_name
+        type: Utf8
+        nullable: true
+        description: Connected GitLab repository name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - gitlab_repository_name
+      - name: alerts_email_address
+        type: Utf8
+        nullable: true
+        description: Email address used to route alerts to this service.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - alerts_email_address
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the service was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the service was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # teams — teams in the organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: teams
+    description: >-
+      Teams in the Rootly organization. Each row is one team. Use
+      pagerduty_id or opsgenie_id for cross-source joins.
+    guide: |
+      No required filters. Use `pagerduty_id` to join with PagerDuty
+      teams. Join `shortcut.stories` or `linear.issues` via team name
+      for cross-source engineering analytics.
+    request:
+      method: GET
+      path: /teams
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: page
+      page_size:
+        default: 25
+        max: 100
+        query_param: page[size]
+      page_param: page[number]
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Team ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Team name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - name
+      - name: slug
+        type: Utf8
+        nullable: true
+        description: Team slug.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - slug
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Team description.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - description
+      - name: color
+        type: Utf8
+        nullable: true
+        description: Team color hex code.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - color
+      - name: pagerduty_id
+        type: Utf8
+        nullable: true
+        description: PagerDuty team ID for cross-source joins.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - pagerduty_id
+      - name: opsgenie_id
+        type: Utf8
+        nullable: true
+        description: OpsGenie team ID for cross-source joins.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - opsgenie_id
+      - name: alerts_email_address
+        type: Utf8
+        nullable: true
+        description: Email address used to route alerts to this team.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - alerts_email_address
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the team was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the team was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # incidents — incidents in the organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: incidents
+    description: >-
+      Incidents in the Rootly organization. Each row is one incident.
+      Use started_at, mitigated_at, and resolved_at for MTTR analytics.
+    guide: |
+      No required filters. Use `status` to filter locally: started,
+      mitigated, resolved, or cancelled. Use `severity_name` to filter
+      by severity. Use `jira_issue_key`, `linear_issue_id`, or
+      `github_issue_id` for cross-source joins. Use `started_at`,
+      `mitigated_at`, and `resolved_at` for MTTR and response-time
+      analytics.
+    request:
+      method: GET
+      path: /incidents
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: page
+      page_size:
+        default: 25
+        max: 100
+        query_param: page[size]
+      page_param: page[number]
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Incident ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: title
+        type: Utf8
+        nullable: true
+        description: Incident title.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - title
+      - name: sequential_id
+        type: Int64
+        nullable: true
+        description: Sequential incident number within the organization.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - sequential_id
+      - name: status
+        type: Utf8
+        nullable: true
+        description: "Incident status: started, mitigated, resolved, or cancelled."
+        expr:
+          kind: path
+          path:
+            - attributes
+            - status
+      - name: severity_name
+        type: Utf8
+        nullable: true
+        description: Severity name such as sev0, sev1, sev2, or sev3.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - severity_name
+      - name: kind
+        type: Utf8
+        nullable: true
+        description: Incident kind.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - kind
+      - name: summary
+        type: Utf8
+        nullable: true
+        description: Incident summary.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - summary
+      - name: url
+        type: Utf8
+        nullable: true
+        description: URL of the incident in Rootly.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - url
+      - name: slack_channel_name
+        type: Utf8
+        nullable: true
+        description: Slack channel name created for this incident.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - slack_channel_name
+      - name: jira_issue_key
+        type: Utf8
+        nullable: true
+        description: Linked Jira issue key. Join to jira.issues.key.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - jira_issue_key
+      - name: linear_issue_id
+        type: Utf8
+        nullable: true
+        description: Linked Linear issue ID for cross-source joins.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - linear_issue_id
+      - name: github_issue_id
+        type: Utf8
+        nullable: true
+        description: Linked GitHub issue ID for cross-source joins.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - github_issue_id
+      - name: shortcut_story_id
+        type: Utf8
+        nullable: true
+        description: Linked Shortcut story ID. Join to shortcut.stories.id.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - shortcut_story_id
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was started.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - started_at
+      - name: detected_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was detected.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - detected_at
+      - name: acknowledged_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was acknowledged.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - acknowledged_at
+      - name: mitigated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was mitigated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - mitigated_at
+      - name: resolved_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident was resolved.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - resolved_at
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident record was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the incident record was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # alerts — alerts in the organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: alerts
+    description: >-
+      Alerts in the Rootly organization. Each row is one alert. Use
+      source to identify the originating system.
+    guide: |
+      No required filters. Use `source` to filter locally by the
+      originating alert system. Use `alert_id` to correlate with the
+      external system's alert identifier.
+    request:
+      method: GET
+      path: /alerts
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: page
+      page_size:
+        default: 25
+        max: 100
+        query_param: page[size]
+      page_param: page[number]
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Alert ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: alert_id
+        type: Utf8
+        nullable: true
+        description: External alert identifier from the source system.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - alert_id
+      - name: source
+        type: Utf8
+        nullable: true
+        description: Source system that generated the alert.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - source
+      - name: details
+        type: Utf8
+        nullable: true
+        description: Alert details.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - details
+      - name: user_id
+        type: Int64
+        nullable: true
+        description: ID of the user associated with the alert.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - user_id
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the alert was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the alert was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - updated_at
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # schedules — on-call schedules in the organization
+  # ──────────────────────────────────────────────────────────────────────────
+  - name: schedules
+    description: >-
+      On-call schedules in the Rootly organization. Each row is one
+      schedule. Use owner_user_id to join with rootly.users.
+    guide: |
+      No required filters. Use `owner_user_id` to join with
+      `rootly.users.id` to identify schedule owners. Use
+      `all_time_coverage` to identify 24/7 schedules.
+    request:
+      method: GET
+      path: /schedules
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: page
+      page_size:
+        default: 25
+        max: 100
+        query_param: page[size]
+      page_param: page[number]
+      page_start: 1
+      page_step: 1
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Schedule ID.
+        expr:
+          kind: path
+          path:
+            - id
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Schedule name.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - name
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Schedule description.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - description
+      - name: owner_user_id
+        type: Utf8
+        nullable: true
+        description: ID of the user who owns the schedule. Join to rootly.users.id.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - owner_user_id
+      - name: all_time_coverage
+        type: Boolean
+        nullable: true
+        description: Whether the schedule provides 24/7 coverage.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - all_time_coverage
+      - name: shift_report_time_zone
+        type: Utf8
+        nullable: true
+        description: Time zone for shift reports.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - shift_report_time_zone
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the schedule was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - created_at
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the schedule was last updated.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - updated_at

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -30,12 +30,12 @@ request_headers:
     value: application/vnd.api+json
 
 test_queries:
-  - SELECT id, full_name, email FROM rootly.users LIMIT 5
-  - SELECT id, name, slug FROM rootly.services LIMIT 5
+  - SELECT id, title, status FROM rootly.incidents LIMIT 1
+  - SELECT id, name, slug FROM rootly.services LIMIT 1
 
 tables:
   # ──────────────────────────────────────────────────────────────────────────
-  # users — users in the organization
+  # users
   # ──────────────────────────────────────────────────────────────────────────
   - name: users
     description: >-
@@ -155,7 +155,7 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # services — services defined in the organization
+  # services
   # ──────────────────────────────────────────────────────────────────────────
   - name: services
     description: >-
@@ -305,7 +305,7 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # teams — teams in the organization
+  # teams
   # ──────────────────────────────────────────────────────────────────────────
   - name: teams
     description: >-
@@ -428,7 +428,7 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # incidents — incidents in the organization
+  # incidents
   # ──────────────────────────────────────────────────────────────────────────
   - name: incidents
     description: >-
@@ -440,13 +440,19 @@ tables:
 
       Common filter patterns:
       - `status` = started | mitigated | resolved | cancelled
-      - `severity` = sev0 | sev1 | sev2 | sev3
+      - `severity` = slug of the severity (e.g. sev0, sev1, critical, high)
       - `started_at_gte` / `started_at_lte` for time-bounded incident windows
       - `created_at_gte` / `created_at_lte` for creation date ranges
 
       For large organizations always supply a time filter to avoid
-      unbounded pagination scans. Use `jira_issue_key`, `linear_issue_id`,
-      or `github_issue_id` for cross-source joins.
+      unbounded pagination scans.
+
+      Severity is a nested JSON:API object in the response. Use
+      `severity__name` and `severity__slug` to access the severity name
+      and slug. The `filter[severity]` pushdown accepts the severity slug.
+
+      Use `jira_issue_key`, `linear_issue_id`, or `github_issue_id` for
+      cross-source joins.
     filters:
       - name: status
         type: Utf8
@@ -456,7 +462,8 @@ tables:
       - name: severity
         type: Utf8
         description: >-
-          Filter by severity slug, e.g. sev0, sev1, sev2, sev3.
+          Filter by severity slug (e.g. sev0, sev1, critical, high).
+          Matches against the severity slug field.
       - name: started_at_gte
         type: Utf8
         description: Return incidents with started_at >= this ISO8601 timestamp.
@@ -539,15 +546,35 @@ tables:
           path:
             - attributes
             - status
-      - name: severity_name
+      - name: severity__name
         type: Utf8
         nullable: true
-        description: Severity name such as sev0, sev1, sev2, or sev3.
+        description: >-
+          Name of the severity (e.g. SEV0, SEV1). Sourced from
+          attributes.severity.data.attributes.name in the JSON:API response.
         expr:
           kind: path
           path:
             - attributes
-            - severity_name
+            - severity
+            - data
+            - attributes
+            - name
+      - name: severity__slug
+        type: Utf8
+        nullable: true
+        description: >-
+          Slug of the severity (e.g. sev0, sev1). Sourced from
+          attributes.severity.data.attributes.slug in the JSON:API response.
+          Use this value with the severity filter.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - severity
+            - data
+            - attributes
+            - slug
       - name: kind
         type: Utf8
         nullable: true
@@ -706,7 +733,7 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # alerts — alerts in the organization
+  # alerts
   # ──────────────────────────────────────────────────────────────────────────
   - name: alerts
     description: >-
@@ -717,12 +744,12 @@ tables:
       No required filters. All filters push down to the Rootly API.
 
       Common filter patterns:
-      - `status` for alert lifecycle state
+      - `status` for alert lifecycle state (open, triggered, acknowledged, resolved, deferred)
       - `source` to narrow by originating system
       - `created_at_gte` / `created_at_lte` for time-bounded windows
 
       For large organizations always supply a time filter to avoid
-      unbounded pagination scans. Use `alert_id` to correlate with
+      unbounded pagination scans. Use `external_id` to correlate with
       the external system's alert identifier.
     filters:
       - name: status
@@ -774,6 +801,15 @@ tables:
           kind: path
           path:
             - id
+      - name: short_id
+        type: Utf8
+        nullable: true
+        description: Human-readable short identifier for the alert.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - short_id
       - name: source
         type: Utf8
         nullable: true
@@ -786,39 +822,89 @@ tables:
       - name: status
         type: Utf8
         nullable: true
-        description: Alert lifecycle status.
+        description: "Alert lifecycle status: open, triggered, acknowledged, resolved, deferred."
         expr:
           kind: path
           path:
             - attributes
             - status
-      - name: alert_id
+      - name: summary
         type: Utf8
         nullable: true
-        description: External alert identifier from the source system (attributes.alert_id).
+        description: Summary of the alert.
         expr:
           kind: path
           path:
             - attributes
-            - alert_id
-      - name: details
+            - summary
+      - name: description
         type: Utf8
         nullable: true
-        description: Alert details as returned by the Rootly API.
+        description: Description of the alert.
         expr:
           kind: path
           path:
             - attributes
-            - details
-      - name: user_id
+            - description
+      - name: noise
         type: Utf8
         nullable: true
-        description: ID of the user associated with the alert. Join to rootly.users.id.
+        description: Whether the alert is marked as noise. One of noise, not_noise.
         expr:
           kind: path
           path:
             - attributes
-            - user_id
+            - noise
+      - name: external_id
+        type: Utf8
+        nullable: true
+        description: External alert identifier from the source system.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - external_id
+      - name: external_url
+        type: Utf8
+        nullable: true
+        description: URL linking back to the alert in the source system.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - external_url
+      - name: deduplication_key
+        type: Utf8
+        nullable: true
+        description: Deduplication key used to group related alerts.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - deduplication_key
+      - name: notification_target_type
+        type: Utf8
+        nullable: true
+        description: >-
+          Type of the notification target (User, Group, EscalationPolicy,
+          Service, Functionality). Only present for organizations with
+          Rootly On-Call enabled.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - notification_target_type
+      - name: notification_target_id
+        type: Utf8
+        nullable: true
+        description: >-
+          ID of the notification target object. Only present for organizations
+          with Rootly On-Call enabled.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - notification_target_id
       - name: started_at
         type: Timestamp
         nullable: true
@@ -869,7 +955,7 @@ tables:
               - updated_at
 
   # ──────────────────────────────────────────────────────────────────────────
-  # schedules — on-call schedules in the organization
+  # schedules
   # ──────────────────────────────────────────────────────────────────────────
   - name: schedules
     description: >-

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -439,7 +439,7 @@ tables:
       No required filters. All filters push down to the Rootly API.
 
       Common filter patterns:
-      - `status` = started | mitigated | resolved | cancelled
+      - `status` = started | mitigated | resolved | cancelled | in_triage | acknowledged | closed (see Rootly incident lifecycle docs for the full status list)
       - `severity` = slug of the severity (e.g. sev0, sev1, critical, high)
       - `started_at_gte` / `started_at_lte` for time-bounded incident windows
       - `created_at_gte` / `created_at_lte` for creation date ranges
@@ -457,8 +457,9 @@ tables:
       - name: status
         type: Utf8
         description: >-
-          Filter by incident status. One of: started, mitigated,
-          resolved, cancelled.
+          Filter by incident status. Common values include: started,
+          mitigated, resolved, cancelled, in_triage, acknowledged,
+          closed. See Rootly incident lifecycle docs for the full list.
       - name: severity
         type: Utf8
         description: >-
@@ -744,7 +745,7 @@ tables:
       No required filters. All filters push down to the Rootly API.
 
       Common filter patterns:
-      - `status` for alert lifecycle state (open, triggered, acknowledged, resolved, deferred)
+      - `status` for alert lifecycle state (open, triggered, acknowledged, resolved)
       - `source` to narrow by originating system
       - `created_at_gte` / `created_at_lte` for time-bounded windows
 
@@ -822,7 +823,7 @@ tables:
       - name: status
         type: Utf8
         nullable: true
-        description: "Alert lifecycle status: open, triggered, acknowledged, resolved, deferred."
+        description: "Alert lifecycle status: open, triggered, acknowledged, or resolved."
         expr:
           kind: path
           path:

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -882,18 +882,6 @@ tables:
           path:
             - attributes
             - deduplication_key
-      - name: notification_target_type
-        type: Utf8
-        nullable: true
-        description: >-
-          Type of the notification target (User, Group, EscalationPolicy,
-          Service, Functionality). Only present for organizations with
-          Rootly On-Call enabled.
-        expr:
-          kind: path
-          path:
-            - attributes
-            - notification_target_type
       - name: notification_target_id
         type: Utf8
         nullable: true

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -722,7 +722,7 @@ tables:
       - `created_at_gte` / `created_at_lte` for time-bounded windows
 
       For large organizations always supply a time filter to avoid
-      unbounded pagination scans. Use `external_id` to correlate with
+      unbounded pagination scans. Use `alert_id` to correlate with
       the external system's alert identifier.
     filters:
       - name: status
@@ -774,33 +774,6 @@ tables:
           kind: path
           path:
             - id
-      - name: external_id
-        type: Utf8
-        nullable: true
-        description: External alert identifier from the source system (attributes.external_id).
-        expr:
-          kind: path
-          path:
-            - attributes
-            - external_id
-      - name: external_url
-        type: Utf8
-        nullable: true
-        description: URL linking back to the alert in the source system.
-        expr:
-          kind: path
-          path:
-            - attributes
-            - external_url
-      - name: deduplication_key
-        type: Utf8
-        nullable: true
-        description: Deduplication key used to group related alerts.
-        expr:
-          kind: path
-          path:
-            - attributes
-            - deduplication_key
       - name: source
         type: Utf8
         nullable: true
@@ -819,10 +792,19 @@ tables:
           path:
             - attributes
             - status
+      - name: alert_id
+        type: Utf8
+        nullable: true
+        description: External alert identifier from the source system (attributes.alert_id).
+        expr:
+          kind: path
+          path:
+            - attributes
+            - alert_id
       - name: details
         type: Utf8
         nullable: true
-        description: Alert details.
+        description: Alert details as returned by the Rootly API.
         expr:
           kind: path
           path:

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -45,6 +45,8 @@ tables:
       No required filters. All fields are sourced from the nested
       attributes object in the JSON:API response. Join `email` to
       `linear.users` or `github.members` for cross-source team analytics.
+      Note: `role_id` is sourced from the relationships object
+      (`relationships.role.data.id`) rather than attributes.
     request:
       method: GET
       path: /users
@@ -108,12 +110,16 @@ tables:
       - name: role_id
         type: Utf8
         nullable: true
-        description: Role ID assigned to the user.
+        description: >-
+          Role ID assigned to the user. Sourced from
+          relationships.role.data.id in the JSON:API response.
         expr:
           kind: path
           path:
-            - attributes
-            - role_id
+            - relationships
+            - role
+            - data
+            - id
       - name: time_zone
         type: Utf8
         nullable: true
@@ -428,16 +434,63 @@ tables:
     description: >-
       Incidents in the Rootly organization. Each row is one incident.
       Use started_at, mitigated_at, and resolved_at for MTTR analytics.
+      All filters push down to the Rootly API for efficient narrowing.
     guide: |
-      No required filters. Use `status` to filter locally: started,
-      mitigated, resolved, or cancelled. Use `severity_name` to filter
-      by severity. Use `jira_issue_key`, `linear_issue_id`, or
-      `github_issue_id` for cross-source joins. Use `started_at`,
-      `mitigated_at`, and `resolved_at` for MTTR and response-time
-      analytics.
+      No required filters. All filters push down to the Rootly API.
+
+      Common filter patterns:
+      - `status` = started | mitigated | resolved | cancelled
+      - `severity` = sev0 | sev1 | sev2 | sev3
+      - `started_at_gte` / `started_at_lte` for time-bounded incident windows
+      - `created_at_gte` / `created_at_lte` for creation date ranges
+
+      For large organizations always supply a time filter to avoid
+      unbounded pagination scans. Use `jira_issue_key`, `linear_issue_id`,
+      or `github_issue_id` for cross-source joins.
+    filters:
+      - name: status
+        type: Utf8
+        description: >-
+          Filter by incident status. One of: started, mitigated,
+          resolved, cancelled.
+      - name: severity
+        type: Utf8
+        description: >-
+          Filter by severity slug, e.g. sev0, sev1, sev2, sev3.
+      - name: started_at_gte
+        type: Utf8
+        description: Return incidents with started_at >= this ISO8601 timestamp.
+      - name: started_at_lte
+        type: Utf8
+        description: Return incidents with started_at <= this ISO8601 timestamp.
+      - name: created_at_gte
+        type: Utf8
+        description: Return incidents with created_at >= this ISO8601 timestamp.
+      - name: created_at_lte
+        type: Utf8
+        description: Return incidents with created_at <= this ISO8601 timestamp.
     request:
       method: GET
       path: /incidents
+      query:
+        - name: filter[status]
+          from: filter
+          key: status
+        - name: filter[severity]
+          from: filter
+          key: severity
+        - name: filter[started_at][gte]
+          from: filter
+          key: started_at_gte
+        - name: filter[started_at][lte]
+          from: filter
+          key: started_at_lte
+        - name: filter[created_at][gte]
+          from: filter
+          key: created_at_gte
+        - name: filter[created_at][lte]
+          from: filter
+          key: created_at_lte
     response:
       rows_path:
         - data
@@ -658,14 +711,48 @@ tables:
   - name: alerts
     description: >-
       Alerts in the Rootly organization. Each row is one alert. Use
-      source to identify the originating system.
+      source to identify the originating system. All filters push down
+      to the Rootly API for efficient narrowing.
     guide: |
-      No required filters. Use `source` to filter locally by the
-      originating alert system. Use `alert_id` to correlate with the
-      external system's alert identifier.
+      No required filters. All filters push down to the Rootly API.
+
+      Common filter patterns:
+      - `status` for alert lifecycle state
+      - `source` to narrow by originating system
+      - `created_at_gte` / `created_at_lte` for time-bounded windows
+
+      For large organizations always supply a time filter to avoid
+      unbounded pagination scans. Use `external_id` to correlate with
+      the external system's alert identifier.
+    filters:
+      - name: status
+        type: Utf8
+        description: Filter by alert status.
+      - name: source
+        type: Utf8
+        description: Filter by originating alert source system.
+      - name: created_at_gte
+        type: Utf8
+        description: Return alerts with created_at >= this ISO8601 timestamp.
+      - name: created_at_lte
+        type: Utf8
+        description: Return alerts with created_at <= this ISO8601 timestamp.
     request:
       method: GET
       path: /alerts
+      query:
+        - name: filter[status]
+          from: filter
+          key: status
+        - name: filter[source]
+          from: filter
+          key: source
+        - name: filter[created_at][gte]
+          from: filter
+          key: created_at_gte
+        - name: filter[created_at][lte]
+          from: filter
+          key: created_at_lte
     response:
       rows_path:
         - data
@@ -687,15 +774,33 @@ tables:
           kind: path
           path:
             - id
-      - name: alert_id
+      - name: external_id
         type: Utf8
         nullable: true
-        description: External alert identifier from the source system.
+        description: External alert identifier from the source system (attributes.external_id).
         expr:
           kind: path
           path:
             - attributes
-            - alert_id
+            - external_id
+      - name: external_url
+        type: Utf8
+        nullable: true
+        description: URL linking back to the alert in the source system.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - external_url
+      - name: deduplication_key
+        type: Utf8
+        nullable: true
+        description: Deduplication key used to group related alerts.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - deduplication_key
       - name: source
         type: Utf8
         nullable: true
@@ -705,6 +810,15 @@ tables:
           path:
             - attributes
             - source
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Alert lifecycle status.
+        expr:
+          kind: path
+          path:
+            - attributes
+            - status
       - name: details
         type: Utf8
         nullable: true
@@ -723,6 +837,30 @@ tables:
           path:
             - attributes
             - user_id
+      - name: started_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the alert started.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - started_at
+      - name: ended_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the alert ended.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr:
+            kind: path
+            path:
+              - attributes
+              - ended_at
       - name: created_at
         type: Timestamp
         nullable: true

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -439,7 +439,8 @@ tables:
       No required filters. All filters push down to the Rootly API.
 
       Common filter patterns:
-      - `status` = started | mitigated | resolved | cancelled | in_triage | acknowledged | closed (see Rootly incident lifecycle docs for the full status list)
+      - `status` = started | mitigated | resolved | cancelled | in_triage | acknowledged | closed 
+      (see Rootly incident lifecycle docs for the full status list)
       - `severity` = slug of the severity (e.g. sev0, sev1, critical, high)
       - `started_at_gte` / `started_at_lte` for time-bounded incident windows
       - `created_at_gte` / `created_at_lte` for creation date ranges

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -715,9 +715,9 @@ tables:
             - attributes
             - details
       - name: user_id
-        type: Int64
+        type: Utf8
         nullable: true
-        description: ID of the user associated with the alert.
+        description: ID of the user associated with the alert. Join to rootly.users.id.
         expr:
           kind: path
           path:

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -439,7 +439,7 @@ tables:
       No required filters. All filters push down to the Rootly API.
 
       Common filter patterns:
-      - `status` = started | mitigated | resolved | cancelled | in_triage | acknowledged | closed 
+      - `status` = started | mitigated | resolved | cancelled | in_triage | acknowledged | closed
       (see Rootly incident lifecycle docs for the full status list)
       - `severity` = slug of the severity (e.g. sev0, sev1, critical, high)
       - `started_at_gte` / `started_at_lte` for time-bounded incident windows

--- a/sources/community/rootly/manifest.yaml
+++ b/sources/community/rootly/manifest.yaml
@@ -541,7 +541,11 @@ tables:
       - name: status
         type: Utf8
         nullable: true
-        description: "Incident status: started, mitigated, resolved, or cancelled."
+        description: >-
+          Incident status. Common values: started, mitigated, resolved,
+          cancelled, in_triage, acknowledged, closed. See
+          https://docs.rootly.com/incidents/incident-lifecycle for the
+          full list including planned-maintenance states.
         expr:
           kind: path
           path:


### PR DESCRIPTION
Fixes #927 

Add a new Rootly community source that lets Coral query incidents,
services, users, teams, alerts, and on-call schedules through SQL —
enabling MTTR analytics, response-time reporting, on-call coverage
visibility, and cross-source joins with bundled Jira, Linear, GitHub,
and Shortcut sources.

This change is manifest-only and uses Coral's existing HTTP source-spec
model with bearer-token authentication. Read-only. No CLI, MCP, config,
or runtime changes.

## What changed

Added:

* `sources/community/rootly/manifest.yaml`
* `sources/community/rootly/README.md`

## Source scope

### Inputs

* `ROOTLY_TOKEN` — Rootly API key or OAuth 2.0 access token (secret)

### Auth

* `Authorization: Bearer {{input.ROOTLY_TOKEN}}`
* Works with both Rootly API keys and OAuth 2.0 access tokens
* Content-Type: `application/vnd.api+json`

### Tables

#### `rootly.users`

GET `/users`

* page pagination using `page[number]` and `page[size]`
* JSON:API response with rows sourced from `data`
* 9 columns:
  `id`, `email`, `full_name`, `first_name`, `last_name`,
  `role_id`, `time_zone`, `created_at`, `updated_at`
* supports cross-source joins with `linear.users` and `github.members`
  via email

#### `rootly.services`

GET `/services`

* page pagination using `page[number]` and `page[size]`
* JSON:API response with rows sourced from `data`
* 12 columns:
  `id`, `name`, `slug`, `description`, `color`,
  `pagerduty_id`, `opsgenie_id`,
  `github_repository_name`, `github_repository_branch`,
  `gitlab_repository_name`, `alerts_email_address`,
  `created_at`, `updated_at`
* supports joins with GitHub repositories and incident-management tools

#### `rootly.teams`

GET `/teams`

* page pagination using `page[number]` and `page[size]`
* JSON:API response with rows sourced from `data`
* 10 columns:
  `id`, `name`, `slug`, `description`, `color`,
  `pagerduty_id`, `opsgenie_id`,
  `alerts_email_address`, `created_at`, `updated_at`

#### `rootly.incidents`

GET `/incidents`

* page pagination using `page[number]` and `page[size]`
* JSON:API response with rows sourced from `data`
* 18 columns:
  `id`, `title`, `sequential_id`, `status`,
  `severity_name`, `kind`, `summary`, `url`,
  `slack_channel_name`, `jira_issue_key`,
  `linear_issue_id`, `github_issue_id`,
  `shortcut_story_id`, `started_at`,
  `detected_at`, `acknowledged_at`,
  `mitigated_at`, `resolved_at`,
  `created_at`, `updated_at`
* designed for MTTR and incident-response analytics
* supports joins with Jira, Linear, GitHub, and Shortcut

#### `rootly.alerts`

GET `/alerts`

* page pagination using `page[number]` and `page[size]`
* JSON:API response with rows sourced from `data`
* 7 columns:
  `id`, `alert_id`, `source`,
  `details`, `user_id`,
  `created_at`, `updated_at`

#### `rootly.schedules`

GET `/schedules`

* page pagination using `page[number]` and `page[size]`
* JSON:API response with rows sourced from `data`
* 8 columns:
  `id`, `name`, `description`,
  `owner_user_id`, `all_time_coverage`,
  `shift_report_time_zone`,
  `created_at`, `updated_at`
* supports joins with `rootly.users`

## Implementation notes

* all endpoints use JSON:API response format
* rows are extracted via `rows_path: [data]`
* all timestamps use `format_timestamp` with `input: iso8601`
* pagination uses:

  * `page[number]`
  * `page[size]`
* default page size: 25
* maximum page size: 100
* all tables are read-only
* Rootly resource attributes are sourced from nested
  `attributes.*` paths
* authentication uses bearer-token header auth via:
  `Authorization: Bearer {{input.ROOTLY_TOKEN}}`
* source supports both API keys and OAuth access tokens
  transparently

## Out of scope

Not included in v1:

* incident timeline events
* action items
* retrospectives
* workflows and playbooks
* OAuth authorization-code flow
* write operations of any kind
