### PR TITLE
docs(mcp): tighten Coral discovery guidance

### DIFF
--- a/crates/coral-mcp/src/guide_template.md
+++ b/crates/coral-mcp/src/guide_template.md
@@ -4,24 +4,40 @@
 
 ## Discovery Workflow
 
-Treat Coral like a read-only SQL database. The MCP discovery tools are catalog helpers, not replacement APIs. Inspect tables, parameterized table functions, and columns first, then answer with set-based SQL.
+Treat Coral like a read-only SQL database. The MCP discovery tools are catalog helpers, not replacement APIs. Discover only enough metadata to write the next useful SQL query.
+
+For clear-intent tasks where the user names or strongly implies a source, do not scan the whole catalog first.
+
+1. Pick the schema from the request, for example `slack`, `linear`, `github`, or `datadog`.
+2. Use `search_catalog` with that schema, or `list_catalog` with that schema when you need a source-local inventory.
+3. Inspect columns only for the table you plan to query.
+4. Run SQL once the table or function reference, required filters or arguments, and useful columns are clear.
+
+Use broad catalog scans only when the source is unclear or the user asks for inventory.
 
 Prefer one SQL statement with `JOIN`, `CROSS JOIN`, CTEs, subqueries, aggregates, or window functions over fetching rows and combining them in the agent. Use `CROSS JOIN` explicitly when the query needs every combination of rows from two relations. Call table functions from `FROM` with named arguments, for example `github.search_issues(q => 'repo:withcoral/coral deploy failure')`.
 
 ```sql
--- List visible tables, descriptions, and required filters
-SELECT schema_name, table_name, description, required_filters FROM coral.tables ORDER BY schema_name, table_name;
+-- List visible tables, descriptions, and required filters for one source
+SELECT table_name, description, required_filters
+FROM coral.tables
+WHERE schema_name = '<schema>'
+ORDER BY table_name;
 
--- List parameterized table functions
-SELECT schema_name, function_name, description, arguments_json, result_columns_json FROM coral.table_functions ORDER BY schema_name, function_name;
+-- List parameterized table functions for one source
+SELECT function_name, description, arguments_json, result_columns_json
+FROM coral.table_functions
+WHERE schema_name = '<schema>'
+ORDER BY function_name;
 
 -- Inspect columns for one visible table, including nullability and filter-only virtual columns
 {{COLUMNS_EXAMPLE}}
 
 -- Discover provider-native table functions, including search/retrieval surfaces
-SELECT schema_name, function_name, kind, arguments_json, result_columns_json, search_limits_json
+SELECT function_name, kind, arguments_json, result_columns_json, search_limits_json
 FROM coral.table_functions
-ORDER BY schema_name, function_name;
+WHERE schema_name = '<schema>'
+ORDER BY function_name;
 ```
 
 ## Catalog Metadata
@@ -72,8 +88,8 @@ WHERE json_get_str(rules, 0, 'clauses', 0, 'values', 0) = 'phoebe-org';
 - Joins across schemas work with standard SQL after table scans complete.
 - Use `LIKE` or `ILIKE` for SQL wildcard matching with `%` and `_`. `SIMILAR TO` uses regex-shaped patterns, so write `.*` instead of `%`, `.` instead of `_`, or escape literal percent/underscore characters as `\%` and `\_`.
 - Regex operators such as `~` and `~*` treat `%` and `_` as ordinary literal characters.
-- `list_catalog` shows queryable tables and parameterized table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. Omit `kind` or pass `null` to list all item kinds.
-- `search_catalog` searches table and table-function names, descriptions, arguments, result columns, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the catalog item you need.
+- `list_catalog` shows queryable tables and parameterized table functions in pages; pass `schema`, `kind`, `limit`, and `offset` to narrow large catalogs. For clear source intent, pass `schema` instead of starting with an unfiltered catalog page.
+- `search_catalog` searches table and table-function names, descriptions, arguments, result columns, guides, and required filters with a Rust regex; use it before broad SQL metadata scans when you know part of the catalog item you need. Pass `schema` when the source is known.
 - `describe_table` returns one compact table detail with guide text, required filters, and column count; use `coral.columns` when you need full column details.
-- `list_columns` lists columns for one table; pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively. Existing tables return paginated `columns` plus `total`, `has_more`, and optional `next_offset`; regex matches add `matched_fields` per column. Missing tables return `found: false` with suggested recovery calls instead of an empty page.
+- `list_columns` lists columns for one table; use it only for the table you plan to query. Pass `pattern`, `required_only`, `limit`, and `offset` to inspect large schemas progressively. Existing tables return paginated `columns` plus `total`, `has_more`, and optional `next_offset`; regex matches add `matched_fields` per column. Missing tables return `found: false` with suggested recovery calls instead of an empty page.
 - `coral://tables` shows table summaries for all installed sources; `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` provide richer SQL metadata.

--- a/crates/coral-mcp/src/surface/resources.rs
+++ b/crates/coral-mcp/src/surface/resources.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use super::values::queryable_table_summary_values;
 
-static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral, a read-only SQL database. Treat exposed data as database schemas, tables, and table functions. Use `list_catalog` and `search_catalog` as catalog helpers, use `describe_table` and `list_columns` for table-specific metadata, use `sql` against `coral.tables`, `coral.columns`, `coral.filters`, `coral.table_functions`, and `coral.inputs` for deeper discovery, then answer with set-based SQL through `sql`. Prefer one SQL statement with joins, CROSS JOIN, CTEs, subqueries, and aggregates over row-by-row tool calls.";
+static INITIAL_INSTRUCTIONS: &str = "You are connected to Coral, a read-only SQL database. Treat exposed data as database schemas, tables, and table functions. For clear-intent tasks where the user names or implies a source, start with targeted discovery: use `search_catalog` with `schema` when possible, or `list_catalog` with `schema` or `kind`. Avoid unfiltered catalog listing unless the source is unclear or the user asks for inventory. Use `describe_table` and `list_columns` only for the specific table you plan to query. Query with `sql` as soon as you have the table or function reference, required filters or arguments, and needed columns. Prefer one set-based SQL statement with joins, CROSS JOIN, CTEs, subqueries, and aggregates over row-by-row tool calls.";
 static GUIDE_TEMPLATE: &str = include_str!("../guide_template.md");
 
 pub(crate) fn initial_instructions() -> &'static str {
@@ -159,7 +159,8 @@ mod tests {
     fn initial_instructions_frame_coral_as_sql_database() {
         let instructions = initial_instructions();
         assert!(instructions.contains("read-only SQL database"));
-        assert!(instructions.contains("catalog helpers"));
+        assert!(instructions.contains("targeted discovery"));
+        assert!(instructions.contains("Avoid unfiltered catalog listing"));
         assert!(instructions.contains("CROSS JOIN"));
         assert!(instructions.contains("row-by-row tool calls"));
     }
@@ -186,7 +187,7 @@ mod tests {
         assert!(content.contains("- slack"));
         assert!(
             content.contains(
-                "Use each table's `sql_reference` from `list_catalog` or `coral://tables`"
+                "For clear-intent tasks where the user names or strongly implies a source"
             )
         );
     }

--- a/plugins/coral/skills/coral/SKILL.md
+++ b/plugins/coral/skills/coral/SKILL.md
@@ -23,19 +23,33 @@ Use this as the Coral entrypoint for external context. Query Coral before answer
 ## Workflow
 
 1. Identify the needed source, entity, and scope from the user request.
-2. Discover tables and table functions with `list_catalog` or `search_catalog`; page large catalogs and narrow by schema or kind when useful.
-3. Read `list_catalog` or `search_catalog` for `sql_reference`, `sql_call_example`, and `required_filters`; use `coral://guide` for query patterns and `coral://tables` for table summaries.
-4. Inspect `coral.columns` for table columns, required filters, virtual columns, and descriptions.
-5. Inspect `coral.table_functions` for source-scoped function arguments and result columns.
-6. Inspect `coral.inputs` when source configuration affects the answer.
-7. Query with `sql`: select useful columns, include required filters or function arguments, and add `LIMIT` unless complete output is requested.
-8. Summarize evidence, gaps, and next action. If editing code, use the Coral result to guide changes.
+
+For clear source intent:
+
+2. Use targeted catalog discovery first: `search_catalog` with `schema` when possible, or `list_catalog` with `schema` or `kind`.
+3. Read only the catalog item or items needed for the likely query: `sql_reference`, `sql_call_example`, and `required_filters`.
+4. Use `list_columns` or `coral.columns` only for the specific table you plan to query, and only when the catalog result does not provide enough detail.
+5. Query with `sql` as soon as the table or function reference, required filters or arguments, and useful columns are known.
+
+When the source or entity is unclear:
+
+2. Read `coral://guide` or use catalog discovery to identify available schemas and likely query surfaces.
+3. Then switch back to source-scoped discovery.
+
+For deeper discovery:
+
+- Inspect `coral.table_functions` when table-function arguments or result columns are not clear from `search_catalog` or `list_catalog`.
+- Inspect `coral.inputs` when source configuration affects the answer.
+- Inspect broader `coral.tables`, `coral.columns`, `coral.filters`, or `coral.table_functions` metadata only when the source is unclear, a query fails, or the user asks for inventory.
+
+Summarize evidence, gaps, and next action. If editing code, use the Coral result to guide changes.
 
 ## Query Rules
 
 - Use each table's `sql_reference`; write `github.pulls` or `"github"."pulls"`, not `"github.pulls"`.
 - Use each table function's `sql_call_example`, filling in required arguments before querying it.
 - Keep metadata discovery bounded: page catalog discovery, query `coral.columns` for one table or `coral.table_functions` for one source when possible, and add `LIMIT` when reading broad metadata directly.
+- Do not inspect columns, functions, inputs, or broad metadata just to be complete. Stop discovery when you can write a safe first SQL query.
 - Virtual columns are filter-only and return `NULL`; check `is_virtual`.
 - Required filters must appear in `WHERE`; inspect `required_filters` and `is_required_filter`.
 - Secret inputs always return `value = NULL`; use `is_set`.


### PR DESCRIPTION
## Intent

Reduce wasted Coral catalog discovery for clear-intent tasks such as Slack, Linear, GitHub, and Datadog reads.

The benchmark traces in BENCH-468 / BENCH-437 show Codex often treated catalog discovery like an exhaustive orientation checklist. This PR tightens the guidance so agents discover only enough metadata to write the next useful SQL query.

## What Changed

- Update MCP startup instructions to prefer targeted discovery when the source is named or implied.
- Rework `coral://guide` so schema-scoped catalog examples come before broad metadata scans.
- Update the maintained `$coral` skill workflow from a sequential discovery checklist into clear-intent, unclear-source, and deeper-discovery paths.

## Ownership / Boundaries

This is a guidance-only change in the MCP and maintained agent-skill surfaces. It does not change gRPC/proto contracts, catalog result shapes, search ranking, or query execution behavior.

## Compatibility / User Impact

Filtered and unfiltered `list_catalog`, `search_catalog`, `describe_table`, `list_columns`, and `sql` behavior is unchanged. The user-visible impact is the guidance exposed through MCP instructions, `coral://guide`, and the in-repo Coral skill.

## Not in This PR

- Source-aware `search_catalog` ranking.
- A schema-summary response for unfiltered `list_catalog`.
- Catalog item column previews or table-function result previews.
- GitHub PR/code-search ergonomic surface changes.

## Validation

- `cargo fmt --check`
- `cargo test -p coral-mcp surface::resources`
- `cargo run --locked -p xtask -- export-skills --dest /tmp/coral-skills-export-check`
- `make rust-checks`
