### PR TITLE
perf(app): cache catalog discovery snapshots

### DIFF
--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -3,7 +3,9 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Instant;
+use std::time::SystemTime;
 
 use coral_engine::{
     CatalogInfo, CoralQuery, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,
@@ -19,7 +21,7 @@ use crate::credentials::{CredentialManager, CredentialSetId};
 use crate::query::extensions::{EngineExtensionsProvider, engine_extensions_for_providers};
 use crate::sources::SourceName;
 use crate::sources::catalog::resolve_installed_manifest;
-use crate::sources::model::InstalledSource;
+use crate::sources::model::{InstalledSource, SourceOrigin};
 use crate::state::{AppStateLayout, ConfigStore};
 use crate::workspaces::WorkspaceName;
 
@@ -34,6 +36,29 @@ pub(crate) struct ValidatedSource {
     pub(crate) report: SourceValidationReport,
 }
 
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct CatalogCacheKey {
+    sources: Vec<CatalogSourceCacheKey>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct CatalogSourceCacheKey {
+    name: String,
+    version: Option<String>,
+    variables: BTreeMap<String, String>,
+    secrets: Vec<String>,
+    origin: SourceOrigin,
+    manifest_file_len: Option<u64>,
+    manifest_modified: Option<SystemTime>,
+}
+
+#[derive(Debug, Clone)]
+struct CachedCatalog {
+    workspace_name: WorkspaceName,
+    key: CatalogCacheKey,
+    catalog: CatalogInfo,
+}
+
 #[derive(Clone)]
 pub(crate) struct QueryManager {
     config_store: ConfigStore,
@@ -41,6 +66,7 @@ pub(crate) struct QueryManager {
     runtime_context: QueryRuntimeContext,
     layout: AppStateLayout,
     engine_extensions_providers: Vec<Arc<dyn EngineExtensionsProvider>>,
+    catalog_cache: Arc<Mutex<Option<CachedCatalog>>>,
 }
 
 impl QueryManager {
@@ -57,7 +83,12 @@ impl QueryManager {
             runtime_context,
             layout,
             engine_extensions_providers,
+            catalog_cache: Arc::new(Mutex::new(None)),
         }
+    }
+
+    pub(crate) fn invalidate_catalog_cache(&self) {
+        *self.catalog_cache.lock().expect("catalog cache poisoned") = None;
     }
 
     pub(crate) async fn list_tables(
@@ -66,13 +97,13 @@ impl QueryManager {
         schema_filter: Option<&str>,
         table_filter: Option<&str>,
     ) -> Result<Vec<TableInfo>, QueryManagerError> {
-        let sources = self
-            .load_query_sources(workspace_name)
-            .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_config(&sources);
-        CoralQuery::list_tables(&sources, runtime, schema_filter, table_filter)
-            .await
-            .map_err(QueryManagerError::Core)
+        let catalog = self.catalog_info(workspace_name).await?;
+        Ok(catalog
+            .tables
+            .into_iter()
+            .filter(|table| schema_filter.is_none_or(|schema| table.schema_name == schema))
+            .filter(|table| table_filter.is_none_or(|name| table.table_name == name))
+            .collect())
     }
 
     pub(crate) async fn list_catalog(
@@ -80,13 +111,79 @@ impl QueryManager {
         workspace_name: &WorkspaceName,
         schema_filter: Option<&str>,
     ) -> Result<CatalogInfo, QueryManagerError> {
+        let catalog = self.catalog_info(workspace_name).await?;
+        Ok(filter_catalog(catalog, schema_filter))
+    }
+
+    async fn catalog_info(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<CatalogInfo, QueryManagerError> {
         let sources = self
-            .load_query_sources(workspace_name)
+            .workspace_sources(workspace_name)
             .map_err(QueryManagerError::App)?;
-        let runtime = self.runtime_config(&sources);
-        CoralQuery::list_catalog(&sources, runtime, schema_filter)
+        let key = self.catalog_cache_key(workspace_name, &sources);
+        if let Some(cached) = self
+            .catalog_cache
+            .lock()
+            .expect("catalog cache poisoned")
+            .as_ref()
+            && cached.workspace_name == *workspace_name
+            && cached.key == key
+        {
+            return Ok(cached.catalog.clone());
+        }
+
+        let query_sources = self.load_query_sources_from_sources(workspace_name, &sources);
+        let runtime = self.runtime_config(&query_sources);
+        let catalog = CoralQuery::list_catalog(&query_sources, runtime, None)
             .await
-            .map_err(QueryManagerError::Core)
+            .map_err(QueryManagerError::Core)?;
+        *self.catalog_cache.lock().expect("catalog cache poisoned") = Some(CachedCatalog {
+            workspace_name: workspace_name.clone(),
+            key,
+            catalog: catalog.clone(),
+        });
+        Ok(catalog)
+    }
+
+    fn workspace_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+    ) -> Result<Vec<InstalledSource>, AppError> {
+        let catalog = self.config_store.load_catalog()?;
+        Ok(catalog.workspace_sources(workspace_name))
+    }
+
+    fn catalog_cache_key(
+        &self,
+        workspace_name: &WorkspaceName,
+        sources: &[InstalledSource],
+    ) -> CatalogCacheKey {
+        CatalogCacheKey {
+            sources: sources
+                .iter()
+                .map(|source| {
+                    let manifest_metadata = match source.origin {
+                        SourceOrigin::Bundled => None,
+                        SourceOrigin::Imported => std::fs::metadata(
+                            self.layout.manifest_file(workspace_name, &source.name),
+                        )
+                        .ok(),
+                    };
+                    CatalogSourceCacheKey {
+                        name: source.name.to_string(),
+                        version: source.version.clone(),
+                        variables: source.variables.clone(),
+                        secrets: source.secrets.clone(),
+                        origin: source.origin,
+                        manifest_file_len: manifest_metadata.as_ref().map(std::fs::Metadata::len),
+                        manifest_modified: manifest_metadata
+                            .and_then(|metadata| metadata.modified().ok()),
+                    }
+                })
+                .collect(),
+        }
     }
 
     pub(crate) async fn execute_sql(
@@ -165,10 +262,18 @@ impl QueryManager {
         &self,
         workspace_name: &WorkspaceName,
     ) -> Result<Vec<QuerySource>, AppError> {
-        let catalog = self.config_store.load_catalog()?;
+        let sources = self.workspace_sources(workspace_name)?;
+        Ok(self.load_query_sources_from_sources(workspace_name, &sources))
+    }
+
+    fn load_query_sources_from_sources(
+        &self,
+        workspace_name: &WorkspaceName,
+        sources: &[InstalledSource],
+    ) -> Vec<QuerySource> {
         let mut query_sources = Vec::new();
-        for source in catalog.workspace_sources(workspace_name) {
-            match self.load_query_source(workspace_name, &source) {
+        for source in sources {
+            match self.load_query_source(workspace_name, source) {
                 Ok((query_source, _version)) => query_sources.push(query_source),
                 Err(error) => {
                     tracing::warn!(
@@ -179,7 +284,7 @@ impl QueryManager {
                 }
             }
         }
-        Ok(query_sources)
+        query_sources
     }
 
     fn load_query_source(
@@ -232,6 +337,18 @@ impl QueryManager {
             engine_extensions_for_providers(&self.engine_extensions_providers, selected_sources),
         )
     }
+}
+
+fn filter_catalog(mut catalog: CatalogInfo, schema_filter: Option<&str>) -> CatalogInfo {
+    if let Some(schema_name) = schema_filter {
+        catalog
+            .tables
+            .retain(|table| table.schema_name == schema_name);
+        catalog
+            .table_functions
+            .retain(|function| function.schema_name == schema_name);
+    }
+    catalog
 }
 
 #[derive(Clone, Copy)]

--- a/crates/coral-app/src/sources/service.rs
+++ b/crates/coral-app/src/sources/service.rs
@@ -155,6 +155,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<CreateBundledSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -166,6 +167,7 @@ impl SourceServiceApi for SourceService {
             let installed = sources
                 .create_bundled_source(&workspace_name, &command)
                 .map_err(app_status)?;
+            queries.invalidate_catalog_cache();
             Ok(Response::new(CreateBundledSourceResponse {
                 source: Some(installed_source_to_proto(&workspace_name, installed)),
             }))
@@ -179,6 +181,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::CreateBundledSourceWithOAuthStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let queries = self.queries.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -196,14 +199,16 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .create_bundled_source_with_oauth(
                                 &workspace_name,
                                 command,
                                 event_sender,
                             )
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        queries.invalidate_catalog_cache();
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(Box::pin(stream.map(|response| {
@@ -220,6 +225,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<Self::ImportSourceStream>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let queries = self.queries.clone();
         instrument_grpc(span.clone(), async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -232,6 +238,7 @@ impl SourceServiceApi for SourceService {
                 let installed = sources
                     .import_source(&workspace_name, &command)
                     .map_err(app_status)?;
+                queries.invalidate_catalog_cache();
                 let response = ImportSourceResponse {
                     event: Some(import_source_response::Event::Source(
                         installed_source_to_proto(&response_workspace_name, installed),
@@ -254,10 +261,12 @@ impl SourceServiceApi for SourceService {
             let stream =
                 import_source_response_stream(response_workspace_name, move |event_sender| {
                     instrument_grpc(span, async move {
-                        sources
+                        let installed = sources
                             .import_source_with_credentials(&workspace_name, command, event_sender)
                             .await
-                            .map_err(app_status)
+                            .map_err(app_status)?;
+                        queries.invalidate_catalog_cache();
+                        Ok(installed)
                     })
                 });
             Ok(Response::new(stream))
@@ -271,6 +280,7 @@ impl SourceServiceApi for SourceService {
     ) -> Result<Response<DeleteSourceResponse>, Status> {
         let span = grpc_span(&request);
         let sources = self.sources.clone();
+        let queries = self.queries.clone();
         instrument_grpc(span, async move {
             let request = request.into_inner();
             let workspace_name = workspace_name_from_proto(request.workspace.as_ref())?;
@@ -278,6 +288,7 @@ impl SourceServiceApi for SourceService {
             sources
                 .delete_source(&workspace_name, &source_name)
                 .map_err(app_status)?;
+            queries.invalidate_catalog_cache();
             Ok(Response::new(DeleteSourceResponse {}))
         })
         .await

--- a/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
+++ b/crates/coral-app/tests/grpc/catalog_discovery_tests.rs
@@ -153,6 +153,65 @@ async fn list_catalog_returns_tables_and_table_functions_with_filters_and_pagina
 }
 
 #[tokio::test]
+async fn list_catalog_reflects_imported_source_updates_after_cached_read() {
+    let harness = GrpcHarness::new().await;
+    harness
+        .import_source(
+            fixture_manifest_with_multiple_tables_yaml(harness.temp_path()),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let initial = harness
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "local_messages".to_string(),
+            kind: 1,
+            pagination: Some(PaginationRequest {
+                limit: 10,
+                offset: 0,
+            }),
+        }))
+        .await
+        .expect("initial list catalog")
+        .into_inner();
+    assert_eq!(
+        initial.pagination.expect("initial pagination").total_count,
+        3
+    );
+
+    harness
+        .import_source(
+            fixture_manifest_with_required_filter_yaml()
+                .replace("name: filtered_messages", "name: local_messages"),
+            Vec::new(),
+            Vec::new(),
+        )
+        .await;
+
+    let updated = harness
+        .catalog_client()
+        .list_catalog(Request::new(ListCatalogRequest {
+            workspace: Some(default_workspace()),
+            schema_name: "local_messages".to_string(),
+            kind: 1,
+            pagination: Some(PaginationRequest {
+                limit: 10,
+                offset: 0,
+            }),
+        }))
+        .await
+        .expect("updated list catalog")
+        .into_inner();
+    assert_eq!(
+        updated.pagination.expect("updated pagination").total_count,
+        1
+    );
+}
+
+#[tokio::test]
 async fn list_columns_filters_required_columns_and_patterns() {
     let harness = GrpcHarness::new().await;
     harness


### PR DESCRIPTION
## Summary

- Cache the engine-produced `CatalogInfo` inside `coral-app::QueryManager` so unchanged workspace catalog discovery does not rebuild the query runtime on every request.
- Reuse that snapshot for `list_catalog`, `search_catalog`, `describe_table`, and `list_columns` through the existing app catalog discovery path.
- Invalidate the cache after source create/import/delete operations, and key it by installed source bindings plus imported-manifest file metadata so external manifest edits are noticed.
- Add a regression test that warms the cache, reimports a source with a different manifest, and verifies `list_catalog` sees the new catalog.

## Why

Profiling the MCP catalog helper path showed the wasted time was app-side runtime construction, not MCP JSON shaping. A release-mode harness with a 600-item synthetic catalog showed `list_catalog` repeatedly under `coral_engine::runtime::query::build_runtime`, then HTTP backend registration, `reqwest::ClientBuilder::build`, and macOS native TLS root loading.

## Before / after

Measured with the same temporary release-mode gRPC harness on the PR parent (`83a8ae6d`) and this PR (`05e0a143`). Catalog shape: `20` HTTP sources, each with `20` tables and `10` table functions, for `600` total catalog items. The page size was `200` for `list_catalog` and `100` for `search_catalog`.

| Case | Before | After |
| --- | ---: | ---: |
| first `list_catalog` | `1822.723 ms` | `1756.265 ms` |
| repeated `list_catalog` avg, 5 calls | `1858.559 ms` | `0.677 ms` |
| repeated `search_catalog` avg, 5 calls | `1922.596 ms` | `0.950 ms` |
| first `search_catalog` on a fresh server | not separately captured before; expected same runtime-build path as repeated before calls | `1726.674 ms` |

Raw samples:

- before `list_catalog`: `1826.602, 1890.798, 1806.125, 1856.459, 1912.810 ms`
- after `list_catalog`: `0.831, 0.718, 0.621, 0.628, 0.589 ms`
- before `search_catalog`: `1904.597, 1944.133, 1917.825, 1927.086, 1919.339 ms`
- after `search_catalog`: `1.070, 0.941, 0.885, 0.853, 1.000 ms`

This PR optimizes the hot discovery path. Cold catalog discovery still pays one runtime build per workspace/catalog version. SQL execution, explain, and source validation keep their existing fresh-runtime behavior.

Refs BENCH-468.

## Validation

- `cargo check -p coral-app --tests`
- `cargo test -p coral-app --test grpc catalog_discovery -- --nocapture`
- `cargo test -p coral-mcp`
- `make rust-checks`