### PR TITLE
Add avatar_url column to GitHub connector

### DIFF
--- a/sources/core/github/manifest.yaml
+++ b/sources/core/github/manifest.yaml
@@ -576,6 +576,10 @@ functions:
       offset_start: 0
       link_header_require_results: false
     columns:
+      - name: avatar_url
+        type: Utf8
+        nullable: true
+        expr: {kind: path, path: [avatar_url]}
       - name: login
         type: Utf8
         nullable: true


### PR DESCRIPTION
## What this PR does

Adds `avatar_url` column to GitHub connector to expose user profile image data in query results.

## Why this is useful

This allows AI agents to access and display user profile avatars when querying GitHub user data.

## Changes made

* Added `avatar_url` field in columns mapping
* Ensured proper YAML structure consistency

## Testing

* Project builds successfully with `cargo build`
* No breaking changes introduced
