### PR TITLE
feat(search): use tantivy backing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,7 +98,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -109,7 +109,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -125,6 +125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
  "object",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -643,6 +652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a7139abd3d9cebf8cd6f920a389cf3dc9576172e32f4563f188cae3c3eb019"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +711,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]
@@ -781,6 +824,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cfg-if"
@@ -1000,12 +1049,12 @@ dependencies = [
  "prost",
  "regex",
  "reqwest",
- "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.10.9",
  "sqlparser",
+ "tantivy",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1208,6 +1257,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2037,6 +2114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "datasketches"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c286de4e81ea2590afc24d754e0f83810c566f50a1388fa75ebd57928c0d9745"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,6 +2155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -2136,6 +2220,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2169,13 +2259,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2189,18 +2290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
-name = "fallible-streaming-iterator"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
-
-[[package]]
 name = "fancy-regex"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2299,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
 
 [[package]]
 name = "fastrand"
@@ -2295,6 +2390,16 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2512,15 +2617,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2546,6 +2642,12 @@ checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest 0.11.2",
 ]
+
+[[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
 
 [[package]]
 name = "http"
@@ -2875,6 +2977,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2902,7 +3013,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -2996,6 +3107,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
 name = "lexical-core"
@@ -3093,17 +3210,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libsqlite3-sys"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3241,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3177,10 +3292,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -3197,6 +3330,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3226,6 +3365,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
+
+[[package]]
 name = "nix"
 version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3380,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3252,7 +3407,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3411,6 +3566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oneshot"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3512,10 +3673,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "parking_lot"
@@ -4098,6 +4277,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "recursive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4272,20 +4471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
-dependencies = [
- "bitflags",
- "fallible-iterator",
- "fallible-streaming-iterator",
- "hashlink",
- "libsqlite3-sys",
- "smallvec",
-]
-
-[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,6 +4506,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,7 +4540,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4659,6 +4854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e40b6cf54d988dc1a2223531b969c9a9e30906ad90ef64890c27b4bfbb46ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4683,7 +4887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4724,7 +4928,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4792,6 +4996,154 @@ dependencies = [
 ]
 
 [[package]]
+name = "tantivy"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edde6a10743fff00a4e1a8c9ef020bf5f3cbad301b7d2d39f2b07f123c4eac07"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "datasketches",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "itertools",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror",
+ "time",
+ "typetag",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fed3d674429bcd2de5d0a6d1aa5495fed8afd9c5ecce993019caf7615f53fa4"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57166f5bcfd478f370ab8445afb4678dce44801fa5ce5c451aaf8595583c5dc"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf10915aa75da3c3b0d58b58853d2e889efbaf32d4982a4c3715dde6bba23e5"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfadb8526b6da90704feb293b0701a6aae62ea14983143344be2dc5ce30f1d82"
+dependencies = [
+ "fnv",
+ "nom 7.1.3",
+ "ordered-float 5.3.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2cfc3ac5164cbadc28965ffb145a8f47582a60ae5897859ad8d4316596c606"
+dependencies = [
+ "futures-util",
+ "itertools",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbb051742da9d53ca9e8fff43a9b10e319338b24e2c0e15d0372df19ffeb951"
+dependencies = [
+ "murmurhash32",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac258c2c6390673f2685813afeeafcb8c4e0ee7de8dd3fc46838dcc37263f98"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,7 +5165,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4859,7 +5211,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -4869,6 +5221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5298,10 +5651,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typetag"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicase"
@@ -5364,6 +5747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,12 +5781,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -5607,7 +5990,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5733,6 +6116,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ prost = "0.14.1"
 reqwest = { version = "0.12", default-features = false, features = ["charset", "http2", "json", "rustls-tls-native-roots", "system-proxy"] }
 regex = "1"
 rmcp = { version = "1.6.0", features = ["client", "transport-child-process"] }
-rusqlite = { version = "0.37", features = ["bundled"] }
 rust-embed = { version = "8", features = ["mime-guess"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
@@ -85,6 +84,7 @@ serde_yaml = "0.9"
 sha2 = "0.10"
 sqlparser = "0.61.0"
 strsim = "0.11"
+tantivy = "0.26.1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/crates/coral-app/Cargo.toml
+++ b/crates/coral-app/Cargo.toml
@@ -22,12 +22,12 @@ opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true
 regex.workspace = true
 reqwest.workspace = true
-rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
 sqlparser.workspace = true
+tantivy.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-stream = { workspace = true, features = ["net"] }

--- a/crates/coral-app/src/search/index.rs
+++ b/crates/coral-app/src/search/index.rs
@@ -1,40 +1,74 @@
-//! Workspace-scoped `SQLite` storage for Universal Search retrieval.
+//! Workspace-scoped Tantivy storage for Universal Search retrieval.
 
-use std::path::PathBuf;
-use std::time::Duration;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
 
+use chrono::{SecondsFormat, Utc};
 use coral_engine::{
     CatalogInfo, ColumnInfo, TableFunctionArgumentInfo, TableFunctionInfo,
     TableFunctionResultColumnInfo, TableInfo,
 };
-use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+use tantivy::collector::TopDocs;
+use tantivy::query::{BooleanQuery, Occur, Query, QueryParser, TermQuery};
+use tantivy::schema::{
+    Field, IndexRecordOption, STORED, STRING, Schema, TextFieldIndexing, TextOptions, Value as _,
+};
+use tantivy::tokenizer::{LowerCaser, NgramTokenizer, TextAnalyzer};
+use tantivy::{Index, IndexWriter, ReloadPolicy, TantivyDocument, Term};
+use uuid::Uuid;
 
 use crate::sources::SourceName;
 use crate::state::AppStateLayout;
 use crate::storage::fs::ensure_dir;
 use crate::workspaces::WorkspaceName;
 
-pub(crate) const SEARCH_INDEX_SCHEMA_VERSION: u32 = 1;
+pub(crate) const SEARCH_INDEX_SCHEMA_VERSION: u32 = 2;
+
+const OBSERVED_STATE_FILE_NAME: &str = "observed_values.json";
+const TRIGRAM_TOKENIZER: &str = "coral_trigram";
+const TANTIVY_VERSION: &str = "0.26.1";
+const WRITER_MEMORY_BUDGET_BYTES: usize = 50_000_000;
 
 #[derive(Debug, Clone)]
 pub(crate) struct SearchIndexStore {
     path: PathBuf,
-    capabilities: SqliteSearchCapabilities,
+    index: Index,
+    fields: SearchIndexFields,
+    capabilities: TantivySearchCapabilities,
 }
 
 impl SearchIndexStore {
+    pub(crate) fn replace_workspace_catalog(
+        layout: &AppStateLayout,
+        workspace_name: &WorkspaceName,
+        catalog: &CatalogInfo,
+    ) -> Result<Self, SearchIndexError> {
+        Self::replace_catalog_index(layout.search_index_dir(workspace_name), catalog)
+    }
+
+    pub(crate) fn replace_catalog_index(
+        path: impl Into<PathBuf>,
+        catalog: &CatalogInfo,
+    ) -> Result<Self, SearchIndexError> {
+        let path = path.into();
+        replace_catalog_index_at(&path, catalog)?;
+        Self::open(path)
+    }
+
     pub(crate) fn open_workspace(
         layout: &AppStateLayout,
         workspace_name: &WorkspaceName,
     ) -> Result<Self, SearchIndexError> {
-        Self::open(layout.search_index_file(workspace_name))
+        Self::open(layout.search_index_dir(workspace_name))
     }
 
     pub(crate) fn open_existing_workspace(
         layout: &AppStateLayout,
         workspace_name: &WorkspaceName,
     ) -> Result<Option<Self>, SearchIndexError> {
-        let path = layout.search_index_file(workspace_name);
+        let path = layout.search_index_dir(workspace_name);
         if !path.exists() {
             return Ok(None);
         }
@@ -43,519 +77,403 @@ impl SearchIndexStore {
 
     pub(crate) fn open(path: impl Into<PathBuf>) -> Result<Self, SearchIndexError> {
         let path = path.into();
-        if let Some(parent) = path.parent() {
-            ensure_dir(parent)?;
-        }
+        ensure_dir(&path)?;
 
-        let mut connection = Connection::open(&path)?;
-        configure_connection(&connection)?;
-        let capabilities = detect_capabilities(&connection)?;
-        ensure_supported(&capabilities)?;
-        migrate(&mut connection)?;
-
-        Ok(Self { path, capabilities })
+        let index = open_or_create_index(&path)?;
+        Self::from_index(path, index)
     }
 
-    pub(crate) fn connect(&self) -> Result<Connection, SearchIndexError> {
-        let connection = Connection::open(&self.path)?;
-        configure_connection(&connection)?;
-        Ok(connection)
+    fn from_index(path: PathBuf, index: Index) -> Result<Self, SearchIndexError> {
+        register_tokenizers(&index)?;
+        let fields = SearchIndexFields::from_schema(&index.schema())?;
+        Ok(Self {
+            path,
+            index,
+            fields,
+            capabilities: TantivySearchCapabilities {
+                tantivy_version: TANTIVY_VERSION.to_string(),
+                tokenizer: TRIGRAM_TOKENIZER.to_string(),
+            },
+        })
     }
 
     #[cfg(test)]
-    pub(crate) fn path(&self) -> &std::path::Path {
+    pub(crate) fn path(&self) -> &Path {
         &self.path
     }
 
-    pub(crate) fn capabilities(&self) -> &SqliteSearchCapabilities {
+    pub(crate) fn capabilities(&self) -> &TantivySearchCapabilities {
         &self.capabilities
-    }
-
-    pub(crate) fn replace_catalog(
-        &self,
-        workspace_name: &WorkspaceName,
-        catalog: &CatalogInfo,
-    ) -> Result<(), SearchIndexError> {
-        let records = catalog_entity_records(catalog);
-        let mut connection = self.connect()?;
-        let transaction = connection.transaction()?;
-
-        transaction.execute(
-            "DELETE FROM catalog_entities_fts WHERE workspace = ?1",
-            params![workspace_name.as_str()],
-        )?;
-        transaction.execute(
-            "DELETE FROM catalog_entities WHERE workspace = ?1",
-            params![workspace_name.as_str()],
-        )?;
-
-        {
-            let mut entity_insert = transaction.prepare(
-                "
-                INSERT INTO catalog_entities (
-                    workspace,
-                    entity_key,
-                    result_type,
-                    surface_kind,
-                    schema_name,
-                    surface_name,
-                    name,
-                    data_type,
-                    is_required,
-                    description,
-                    updated_at
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10,
-                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-                ",
-            )?;
-            let mut fts_insert = transaction.prepare(
-                "
-                INSERT INTO catalog_entities_fts (
-                    workspace,
-                    entity_key,
-                    name,
-                    qualified_name,
-                    description,
-                    searchable_text
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-                ",
-            )?;
-
-            for record in records {
-                entity_insert.execute(params![
-                    workspace_name.as_str(),
-                    &record.entity_key,
-                    record.result_type.as_str(),
-                    record.surface_kind.as_str(),
-                    &record.schema_name,
-                    &record.surface_name,
-                    &record.name,
-                    &record.data_type,
-                    i64::from(record.required),
-                    &record.description,
-                ])?;
-                fts_insert.execute(params![
-                    workspace_name.as_str(),
-                    &record.entity_key,
-                    &record.name,
-                    &record.qualified_name,
-                    &record.description,
-                    &record.searchable_text,
-                ])?;
-            }
-        }
-
-        transaction.execute(
-            "
-            INSERT INTO search_index_meta (key, value, updated_at)
-            VALUES (?1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-                strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-            ON CONFLICT(key) DO UPDATE SET
-                value = excluded.value,
-                updated_at = excluded.updated_at
-            ",
-            params![format!("catalog_refreshed_at:{}", workspace_name.as_str())],
-        )?;
-        transaction.commit()?;
-        Ok(())
     }
 
     pub(crate) fn search_catalog(
         &self,
-        workspace_name: &WorkspaceName,
+        _workspace_name: &WorkspaceName,
         terms: &[String],
         limit: usize,
     ) -> Result<Vec<CatalogSearchHit>, SearchIndexError> {
-        let Some(match_query) = fts_match_query(terms) else {
+        let Some(query) = self.scoped_query("catalog", terms) else {
             return Ok(Vec::new());
         };
-        let connection = self.connect()?;
-        let mut statement = connection.prepare(
-            "
-            SELECT
-                e.entity_key,
-                e.result_type,
-                e.surface_kind,
-                e.schema_name,
-                e.surface_name,
-                e.name,
-                e.data_type,
-                e.is_required,
-                e.description,
-                f.name,
-                f.qualified_name,
-                f.description,
-                f.searchable_text,
-                bm25(catalog_entities_fts, 4.0, 5.0, 2.0, 1.0) AS rank
-            FROM catalog_entities_fts f
-            JOIN catalog_entities e
-                ON e.workspace = f.workspace AND e.entity_key = f.entity_key
-            WHERE f.workspace = ?1 AND catalog_entities_fts MATCH ?2
-            ORDER BY rank ASC, e.result_type ASC, e.entity_key ASC
-            LIMIT ?3
-            ",
-        )?;
-        let rows = statement.query_map(
-            params![
-                workspace_name.as_str(),
-                match_query,
-                i64::try_from(limit).unwrap_or(i64::MAX),
-            ],
-            |row| {
-                let result_type_raw: String = row.get(1)?;
-                let surface_kind_raw: String = row.get(2)?;
-                let name_field: String = row.get(9)?;
-                let qualified_name: String = row.get(10)?;
-                let description_field: String = row.get(11)?;
-                let searchable_text: String = row.get(12)?;
-                Ok(CatalogSearchHit {
-                    entity_key: row.get(0)?,
-                    result_type: CatalogSearchResultType::from_str(&result_type_raw),
-                    surface_kind: CatalogSearchSurfaceKind::from_str(&surface_kind_raw),
-                    schema_name: row.get(3)?,
-                    surface_name: row.get(4)?,
-                    name: row.get(5)?,
-                    data_type: row.get(6)?,
-                    required: row.get::<_, i64>(7)? != 0,
-                    description: row.get(8)?,
-                    matched_fields: matched_fields(
-                        terms,
-                        [
-                            ("name", name_field.as_str()),
-                            ("qualified_name", qualified_name.as_str()),
-                            ("description", description_field.as_str()),
-                            ("searchable_text", searchable_text.as_str()),
-                        ],
-                    ),
-                    score: 0,
-                })
-            },
-        )?;
-
-        let mut hits = Vec::new();
-        for row in rows {
-            hits.push(row?);
-        }
-        let hit_count = u32::try_from(hits.len()).unwrap_or(u32::MAX);
-        for (position, hit) in hits.iter_mut().enumerate() {
-            let position = u32::try_from(position).unwrap_or(u32::MAX);
-            hit.score = hit_count.saturating_sub(position);
-        }
+        let docs = self.search_documents(&query, limit)?;
+        let mut hits = docs
+            .into_iter()
+            .filter(|doc| doc_text(doc, self.fields.entity_kind) == "catalog")
+            .map(|doc| CatalogSearchHit {
+                entity_key: doc_text(&doc, self.fields.doc_key),
+                result_type: CatalogSearchResultType::from_str(&doc_text(
+                    &doc,
+                    self.fields.result_type,
+                )),
+                surface_kind: CatalogSearchSurfaceKind::from_str(&doc_text(
+                    &doc,
+                    self.fields.surface_kind,
+                )),
+                schema_name: doc_text(&doc, self.fields.schema_name),
+                surface_name: doc_text(&doc, self.fields.surface_name),
+                name: doc_text(&doc, self.fields.name),
+                data_type: doc_text(&doc, self.fields.data_type),
+                required: doc_text(&doc, self.fields.required) == "true",
+                description: doc_text(&doc, self.fields.description),
+                matched_fields: matched_fields(
+                    terms,
+                    [
+                        ("name", doc_text(&doc, self.fields.name).as_str()),
+                        (
+                            "qualified_name",
+                            doc_text(&doc, self.fields.qualified_name).as_str(),
+                        ),
+                        (
+                            "description",
+                            doc_text(&doc, self.fields.description).as_str(),
+                        ),
+                        (
+                            "searchable_text",
+                            doc_text(&doc, self.fields.searchable_text).as_str(),
+                        ),
+                    ],
+                ),
+                score: 0,
+            })
+            .collect::<Vec<_>>();
+        assign_rank_scores(&mut hits, |hit, score| hit.score = score);
         Ok(hits)
     }
 
-    #[expect(
-        clippy::too_many_lines,
-        reason = "Observed-value SQLite upsert keeps paired table/FTS writes in one transaction."
-    )]
     pub(crate) fn upsert_observed_values(
         &self,
-        workspace_name: &WorkspaceName,
+        _workspace_name: &WorkspaceName,
         records: Vec<ObservedValueRecord>,
     ) -> Result<(), SearchIndexError> {
         if records.is_empty() {
             return Ok(());
         }
 
-        let mut connection = self.connect()?;
-        let transaction = connection.transaction()?;
+        let mut state = self.load_observed_state()?;
+        let mut stored = state
+            .records
+            .into_iter()
+            .map(|record| (record.doc_key(), record))
+            .collect::<BTreeMap<_, _>>();
+        let now = now_timestamp();
+        let mut affected_keys = BTreeSet::new();
 
-        {
-            let mut value_upsert = transaction.prepare(
-                "
-                INSERT INTO observed_values (
-                    workspace,
-                    source_name,
-                    surface_kind,
-                    surface_name,
-                    column_name,
-                    normalized_value_key,
-                    display_value,
-                    sensitivity_tier,
-                    suggested_operator,
-                    first_observed_at,
-                    last_observed_at,
-                    observed_count,
-                    updated_at
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9,
-                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-                    ?10,
-                    strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-                ON CONFLICT (
-                    workspace,
-                    source_name,
-                    surface_kind,
-                    surface_name,
-                    column_name,
-                    normalized_value_key
-                )
-                DO UPDATE SET
-                    display_value = excluded.display_value,
-                    sensitivity_tier = excluded.sensitivity_tier,
-                    suggested_operator = excluded.suggested_operator,
-                    last_observed_at = excluded.last_observed_at,
-                    observed_count = observed_values.observed_count + excluded.observed_count,
-                    updated_at = excluded.updated_at
-                ",
-            )?;
-            let mut fts_delete = transaction.prepare(
-                "
-                DELETE FROM observed_values_fts
-                WHERE workspace = ?1
-                    AND source_name = ?2
-                    AND surface_kind = ?3
-                    AND surface_name = ?4
-                    AND column_name = ?5
-                    AND normalized_value_key = ?6
-                ",
-            )?;
-            let mut fts_insert = transaction.prepare(
-                "
-                INSERT INTO observed_values_fts (
-                    workspace,
-                    source_name,
-                    surface_kind,
-                    surface_name,
-                    column_name,
-                    normalized_value_key,
-                    display_value,
-                    searchable_text
-                )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-                ",
-            )?;
-
-            for record in records {
-                value_upsert.execute(params![
-                    workspace_name.as_str(),
-                    &record.source_name,
-                    record.surface_kind.as_str(),
-                    &record.surface_name,
-                    &record.column_name,
-                    &record.normalized_value_key,
-                    &record.display_value,
-                    record.sensitivity_tier.as_str(),
-                    record.suggested_operator.as_str(),
-                    i64::try_from(record.observed_count).unwrap_or(i64::MAX),
-                ])?;
-                fts_delete.execute(params![
-                    workspace_name.as_str(),
-                    &record.source_name,
-                    record.surface_kind.as_str(),
-                    &record.surface_name,
-                    &record.column_name,
-                    &record.normalized_value_key,
-                ])?;
-                fts_insert.execute(params![
-                    workspace_name.as_str(),
-                    &record.source_name,
-                    record.surface_kind.as_str(),
-                    &record.surface_name,
-                    &record.column_name,
-                    &record.normalized_value_key,
-                    &record.display_value,
-                    &record.searchable_text,
-                ])?;
-            }
+        for record in records {
+            let key = observed_doc_key(
+                &record.source_name,
+                record.surface_kind,
+                &record.surface_name,
+                &record.column_name,
+                &record.normalized_value_key,
+            );
+            affected_keys.insert(key.clone());
+            stored
+                .entry(key)
+                .and_modify(|existing| {
+                    existing.display_value.clone_from(&record.display_value);
+                    existing.searchable_text.clone_from(&record.searchable_text);
+                    existing.sensitivity_tier = record.sensitivity_tier.as_str().to_string();
+                    existing.suggested_operator = record.suggested_operator.as_str().to_string();
+                    existing.last_observed_at.clone_from(&now);
+                    existing.observed_count = existing
+                        .observed_count
+                        .saturating_add(record.observed_count);
+                })
+                .or_insert_with(|| ObservedValueStoredRecord {
+                    source_name: record.source_name,
+                    surface_kind: record.surface_kind.as_str().to_string(),
+                    surface_name: record.surface_name,
+                    column_name: record.column_name,
+                    normalized_value_key: record.normalized_value_key,
+                    display_value: record.display_value,
+                    searchable_text: record.searchable_text,
+                    sensitivity_tier: record.sensitivity_tier.as_str().to_string(),
+                    suggested_operator: record.suggested_operator.as_str().to_string(),
+                    first_observed_at: now.clone(),
+                    last_observed_at: now.clone(),
+                    observed_count: record.observed_count,
+                });
         }
 
-        transaction.commit()?;
+        let mut writer = self.writer()?;
+        for key in &affected_keys {
+            let _opstamp = writer.delete_term(Term::from_field_text(self.fields.doc_key, key));
+            if let Some(record) = stored.get(key) {
+                writer.add_document(self.observed_document(record))?;
+            }
+        }
+        writer.commit()?;
+
+        state = ObservedValueState {
+            schema_version: SEARCH_INDEX_SCHEMA_VERSION,
+            records: stored.into_values().collect(),
+        };
+        self.write_observed_state(&state)?;
         Ok(())
     }
 
     pub(crate) fn search_observed_values(
         &self,
-        workspace_name: &WorkspaceName,
+        _workspace_name: &WorkspaceName,
         terms: &[String],
         limit: usize,
     ) -> Result<Vec<ObservedValueSearchHit>, SearchIndexError> {
-        let Some(match_query) = fts_match_query(terms) else {
+        let Some(query) = self.scoped_query("observed_value", terms) else {
             return Ok(Vec::new());
         };
-        let connection = self.connect()?;
-        let mut statement = connection.prepare(
-            "
-            SELECT
-                o.source_name,
-                o.surface_name,
-                o.column_name,
-                o.normalized_value_key,
-                o.display_value,
-                o.last_observed_at,
-                f.display_value,
-                f.searchable_text,
-                bm25(observed_values_fts, 4.0, 2.0) AS rank
-            FROM observed_values_fts f
-            JOIN observed_values o
-                ON o.workspace = f.workspace
-                AND o.source_name = f.source_name
-                AND o.surface_kind = f.surface_kind
-                AND o.surface_name = f.surface_name
-                AND o.column_name = f.column_name
-                AND o.normalized_value_key = f.normalized_value_key
-            WHERE f.workspace = ?1 AND observed_values_fts MATCH ?2
-            ORDER BY rank ASC, o.last_observed_at DESC, o.source_name ASC,
-                o.surface_name ASC, o.column_name ASC
-            LIMIT ?3
-            ",
-        )?;
-        let rows = statement.query_map(
-            params![
-                workspace_name.as_str(),
-                match_query,
-                i64::try_from(limit).unwrap_or(i64::MAX),
-            ],
-            |row| {
-                let display_field: String = row.get(6)?;
-                let searchable_text: String = row.get(7)?;
-                Ok(ObservedValueSearchHit {
-                    source_name: row.get(0)?,
-                    surface_name: row.get(1)?,
-                    column_name: row.get(2)?,
-                    normalized_value_key: row.get(3)?,
-                    display_value: row.get(4)?,
-                    last_observed_at: row.get(5)?,
-                    matched_fields: matched_fields(
-                        terms,
-                        [
-                            ("value", display_field.as_str()),
-                            ("source_name", ""),
-                            ("surface_name", ""),
-                            ("column_name", ""),
-                            ("searchable_text", searchable_text.as_str()),
-                        ],
-                    ),
-                    score: 0,
-                })
-            },
-        )?;
-
-        let mut hits = Vec::new();
-        for row in rows {
-            let mut hit = row?;
-            hit.matched_fields.extend(matched_fields(
-                terms,
-                [
-                    ("source_name", hit.source_name.as_str()),
-                    ("surface_name", hit.surface_name.as_str()),
-                    ("column_name", hit.column_name.as_str()),
-                ],
-            ));
-            hit.matched_fields.sort();
-            hit.matched_fields.dedup();
-            hits.push(hit);
-        }
-        let hit_count = u32::try_from(hits.len()).unwrap_or(u32::MAX);
-        for (position, hit) in hits.iter_mut().enumerate() {
-            let position = u32::try_from(position).unwrap_or(u32::MAX);
-            hit.score = hit_count.saturating_sub(position);
-        }
+        let docs = self.search_documents(&query, limit)?;
+        let mut hits = docs
+            .into_iter()
+            .filter(|doc| doc_text(doc, self.fields.entity_kind) == "observed_value")
+            .map(|doc| ObservedValueSearchHit {
+                source_name: doc_text(&doc, self.fields.source_name),
+                surface_name: doc_text(&doc, self.fields.surface_name),
+                column_name: doc_text(&doc, self.fields.column_name),
+                normalized_value_key: doc_text(&doc, self.fields.normalized_value_key),
+                display_value: doc_text(&doc, self.fields.display_value),
+                last_observed_at: doc_text(&doc, self.fields.last_observed_at),
+                score: 0,
+            })
+            .collect::<Vec<_>>();
+        assign_rank_scores(&mut hits, |hit, score| hit.score = score);
         Ok(hits)
     }
 
     pub(crate) fn delete_observed_values_for_source(
         &self,
-        workspace_name: &WorkspaceName,
+        _workspace_name: &WorkspaceName,
         source_name: &SourceName,
     ) -> Result<(), SearchIndexError> {
-        let mut connection = self.connect()?;
-        let transaction = connection.transaction()?;
-        transaction.execute(
-            "
-            DELETE FROM observed_values_fts
-            WHERE workspace = ?1 AND source_name = ?2
-            ",
-            params![workspace_name.as_str(), source_name.as_str()],
-        )?;
-        transaction.execute(
-            "
-            DELETE FROM observed_values
-            WHERE workspace = ?1 AND source_name = ?2
-            ",
-            params![workspace_name.as_str(), source_name.as_str()],
-        )?;
-        transaction.commit()?;
+        let mut state = self.load_observed_state()?;
+        let (removed, retained): (Vec<_>, Vec<_>) = state
+            .records
+            .into_iter()
+            .partition(|record| record.source_name == source_name.as_str());
+        if removed.is_empty() {
+            return Ok(());
+        }
+
+        let mut writer = self.writer()?;
+        for record in &removed {
+            let _opstamp = writer.delete_term(Term::from_field_text(
+                self.fields.doc_key,
+                &record.doc_key(),
+            ));
+        }
+        writer.commit()?;
+
+        state.records = retained;
+        self.write_observed_state(&state)?;
         Ok(())
     }
 
     pub(crate) fn purge_observed_values_before(
         &self,
-        workspace_name: &WorkspaceName,
+        _workspace_name: &WorkspaceName,
         cutoff: &str,
     ) -> Result<(), SearchIndexError> {
-        let mut connection = self.connect()?;
-        let rows_to_purge = {
-            let mut statement = connection.prepare(
-                "
-                SELECT source_name, surface_kind, surface_name, column_name, normalized_value_key
-                FROM observed_values
-                WHERE workspace = ?1 AND last_observed_at < ?2
-                ",
-            )?;
-            let rows = statement.query_map(params![workspace_name.as_str(), cutoff], |row| {
-                Ok(ObservedValueKey {
-                    source_name: row.get(0)?,
-                    surface_kind: row.get(1)?,
-                    surface_name: row.get(2)?,
-                    column_name: row.get(3)?,
-                    normalized_value_key: row.get(4)?,
-                })
-            })?;
-            let mut rows_to_purge = Vec::new();
-            for row in rows {
-                rows_to_purge.push(row?);
-            }
-            rows_to_purge
-        };
-        if rows_to_purge.is_empty() {
+        let mut state = self.load_observed_state()?;
+        let (removed, retained): (Vec<_>, Vec<_>) = state
+            .records
+            .into_iter()
+            .partition(|record| record.last_observed_at.as_str() < cutoff);
+        if removed.is_empty() {
             return Ok(());
         }
 
-        let transaction = connection.transaction()?;
-        {
-            let mut fts_delete = transaction.prepare(
-                "
-                DELETE FROM observed_values_fts
-                WHERE workspace = ?1
-                    AND source_name = ?2
-                    AND surface_kind = ?3
-                    AND surface_name = ?4
-                    AND column_name = ?5
-                    AND normalized_value_key = ?6
-                ",
-            )?;
-            for row in &rows_to_purge {
-                fts_delete.execute(params![
-                    workspace_name.as_str(),
-                    &row.source_name,
-                    &row.surface_kind,
-                    &row.surface_name,
-                    &row.column_name,
-                    &row.normalized_value_key,
-                ])?;
-            }
+        let mut writer = self.writer()?;
+        for record in &removed {
+            let _opstamp = writer.delete_term(Term::from_field_text(
+                self.fields.doc_key,
+                &record.doc_key(),
+            ));
         }
-        transaction.execute(
-            "
-            DELETE FROM observed_values
-            WHERE workspace = ?1 AND last_observed_at < ?2
-            ",
-            params![workspace_name.as_str(), cutoff],
-        )?;
-        transaction.commit()?;
+        writer.commit()?;
+
+        state.records = retained;
+        self.write_observed_state(&state)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn observed_count_for_test(
+        &self,
+        display_value: &str,
+    ) -> Result<Option<u64>, SearchIndexError> {
+        Ok(self
+            .load_observed_state()?
+            .records
+            .into_iter()
+            .find(|record| record.display_value == display_value)
+            .map(|record| record.observed_count))
+    }
+
+    fn writer(&self) -> Result<IndexWriter, SearchIndexError> {
+        Ok(self.index.writer(WRITER_MEMORY_BUDGET_BYTES)?)
+    }
+
+    fn scoped_query(&self, entity_kind: &'static str, terms: &[String]) -> Option<Box<dyn Query>> {
+        let query_text = tantivy_query_text(terms)?;
+        let mut parser = QueryParser::for_index(
+            &self.index,
+            vec![
+                self.fields.name_text,
+                self.fields.qualified_name_text,
+                self.fields.description_text,
+                self.fields.searchable_text_text,
+                self.fields.value_text,
+            ],
+        );
+        parser.set_field_boost(self.fields.name_text, 4.0);
+        parser.set_field_boost(self.fields.qualified_name_text, 5.0);
+        parser.set_field_boost(self.fields.description_text, 2.0);
+        parser.set_field_boost(self.fields.value_text, 4.0);
+        let (parsed_query, errors) = parser.parse_query_lenient(&query_text);
+        if !errors.is_empty() {
+            tracing::debug!(
+                entity_kind,
+                query = query_text,
+                errors = ?errors,
+                "Tantivy query parser ignored invalid search clauses"
+            );
+        }
+        let kind_query = Box::new(TermQuery::new(
+            Term::from_field_text(self.fields.entity_kind, entity_kind),
+            IndexRecordOption::Basic,
+        ));
+        Some(Box::new(BooleanQuery::new(vec![
+            (Occur::Must, kind_query),
+            (Occur::Must, parsed_query),
+        ])))
+    }
+
+    fn search_documents(
+        &self,
+        query: &dyn Query,
+        limit: usize,
+    ) -> Result<Vec<TantivyDocument>, SearchIndexError> {
+        let reader = self
+            .index
+            .reader_builder()
+            .reload_policy(ReloadPolicy::Manual)
+            .try_into()?;
+        reader.reload()?;
+        let searcher = reader.searcher();
+        let top_docs = searcher.search(query, &TopDocs::with_limit(limit).order_by_score())?;
+        let mut documents = Vec::with_capacity(top_docs.len());
+        for (_score, address) in top_docs {
+            documents.push(searcher.doc(address)?);
+        }
+        Ok(documents)
+    }
+
+    fn catalog_document(&self, record: &CatalogEntityRecord) -> TantivyDocument {
+        let mut doc = TantivyDocument::default();
+        doc.add_text(self.fields.doc_key, &record.entity_key);
+        doc.add_text(self.fields.entity_kind, "catalog");
+        doc.add_text(self.fields.result_type, record.result_type.as_str());
+        doc.add_text(self.fields.surface_kind, record.surface_kind.as_str());
+        doc.add_text(self.fields.schema_name, &record.schema_name);
+        doc.add_text(self.fields.source_name, &record.schema_name);
+        doc.add_text(self.fields.surface_name, &record.surface_name);
+        doc.add_text(self.fields.name, &record.name);
+        doc.add_text(self.fields.qualified_name, &record.qualified_name);
+        doc.add_text(self.fields.data_type, &record.data_type);
+        doc.add_text(
+            self.fields.required,
+            if record.required { "true" } else { "false" },
+        );
+        doc.add_text(self.fields.description, &record.description);
+        doc.add_text(self.fields.searchable_text, &record.searchable_text);
+        doc.add_text(self.fields.name_text, &record.name);
+        doc.add_text(self.fields.qualified_name_text, &record.qualified_name);
+        doc.add_text(self.fields.description_text, &record.description);
+        doc.add_text(self.fields.searchable_text_text, &record.searchable_text);
+        doc
+    }
+
+    fn observed_document(&self, record: &ObservedValueStoredRecord) -> TantivyDocument {
+        let mut doc = TantivyDocument::default();
+        doc.add_text(self.fields.doc_key, record.doc_key());
+        doc.add_text(self.fields.entity_kind, "observed_value");
+        doc.add_text(self.fields.source_name, &record.source_name);
+        doc.add_text(self.fields.schema_name, &record.source_name);
+        doc.add_text(self.fields.surface_kind, &record.surface_kind);
+        doc.add_text(self.fields.surface_name, &record.surface_name);
+        doc.add_text(self.fields.column_name, &record.column_name);
+        doc.add_text(self.fields.name, &record.column_name);
+        doc.add_text(
+            self.fields.qualified_name,
+            format!(
+                "{}.{}.{}",
+                record.source_name, record.surface_name, record.column_name
+            ),
+        );
+        doc.add_text(
+            self.fields.normalized_value_key,
+            &record.normalized_value_key,
+        );
+        doc.add_text(self.fields.display_value, &record.display_value);
+        doc.add_text(self.fields.searchable_text, &record.searchable_text);
+        doc.add_text(self.fields.last_observed_at, &record.last_observed_at);
+        doc.add_text(
+            self.fields.observed_count,
+            record.observed_count.to_string(),
+        );
+        doc.add_text(self.fields.name_text, &record.column_name);
+        doc.add_text(
+            self.fields.qualified_name_text,
+            format!(
+                "{}.{}.{}",
+                record.source_name, record.surface_name, record.column_name
+            ),
+        );
+        doc.add_text(self.fields.searchable_text_text, &record.searchable_text);
+        doc.add_text(self.fields.value_text, &record.display_value);
+        doc
+    }
+
+    fn observed_state_file(&self) -> PathBuf {
+        observed_state_file_for_index(&self.path)
+    }
+
+    fn load_observed_state(&self) -> Result<ObservedValueState, SearchIndexError> {
+        load_observed_state_for_index(&self.path)
+    }
+
+    fn write_observed_state(&self, state: &ObservedValueState) -> Result<(), SearchIndexError> {
+        let path = self.observed_state_file();
+        let temp_path = path.with_extension("json.tmp");
+        fs::write(&temp_path, serde_json::to_vec_pretty(state)?)?;
+        fs::rename(temp_path, path)?;
         Ok(())
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct SqliteSearchCapabilities {
-    pub(crate) sqlite_version: String,
-    pub(crate) fts5: bool,
-    pub(crate) trigram: bool,
+pub(crate) struct TantivySearchCapabilities {
+    pub(crate) tantivy_version: String,
+    pub(crate) tokenizer: String,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -563,12 +481,11 @@ pub(crate) enum SearchIndexError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
     #[error(transparent)]
-    Sqlite(#[from] rusqlite::Error),
-    #[error("SQLite {sqlite_version} does not support required search feature: {feature}")]
-    UnsupportedCapability {
-        feature: &'static str,
-        sqlite_version: String,
-    },
+    Tantivy(#[from] tantivy::TantivyError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error("Tantivy search index schema is missing required field '{field}'")]
+    MissingField { field: &'static str },
 }
 
 #[derive(Debug, Clone)]
@@ -621,6 +538,23 @@ pub(crate) enum CatalogSearchSurfaceKind {
     TableFunction,
 }
 
+impl CatalogSearchSurfaceKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::TableFunction => "table_function",
+        }
+    }
+
+    fn from_str(value: &str) -> Option<Self> {
+        match value {
+            "table" => Some(Self::Table),
+            "table_function" => Some(Self::TableFunction),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ObservedValueRecord {
     pub(crate) source_name: String,
@@ -643,7 +577,6 @@ pub(crate) struct ObservedValueSearchHit {
     pub(crate) normalized_value_key: String,
     pub(crate) display_value: String,
     pub(crate) last_observed_at: String,
-    pub(crate) matched_fields: Vec<String>,
     pub(crate) score: u32,
 }
 
@@ -668,7 +601,7 @@ pub(crate) enum ObservedValueSensitivityTier {
 }
 
 impl ObservedValueSensitivityTier {
-    const fn as_str(self) -> &'static str {
+    pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::LowRisk => "low_risk",
         }
@@ -681,36 +614,56 @@ pub(crate) enum ObservedValueSuggestedOperator {
 }
 
 impl ObservedValueSuggestedOperator {
-    const fn as_str(self) -> &'static str {
+    pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Exact => "exact",
         }
     }
 }
 
-#[derive(Debug)]
-struct ObservedValueKey {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ObservedValueState {
+    schema_version: u32,
+    records: Vec<ObservedValueStoredRecord>,
+}
+
+impl Default for ObservedValueState {
+    fn default() -> Self {
+        Self {
+            schema_version: SEARCH_INDEX_SCHEMA_VERSION,
+            records: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ObservedValueStoredRecord {
     source_name: String,
     surface_kind: String,
     surface_name: String,
     column_name: String,
     normalized_value_key: String,
+    display_value: String,
+    searchable_text: String,
+    sensitivity_tier: String,
+    suggested_operator: String,
+    first_observed_at: String,
+    last_observed_at: String,
+    observed_count: u64,
 }
 
-impl CatalogSearchSurfaceKind {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Table => "table",
-            Self::TableFunction => "table_function",
-        }
-    }
-
-    fn from_str(value: &str) -> Option<Self> {
-        match value {
-            "table" => Some(Self::Table),
-            "table_function" => Some(Self::TableFunction),
-            _ => None,
-        }
+impl ObservedValueStoredRecord {
+    fn doc_key(&self) -> String {
+        observed_doc_key(
+            &self.source_name,
+            match self.surface_kind.as_str() {
+                "table_function" => ObservedValueSurfaceKind::TableFunction,
+                _ => ObservedValueSurfaceKind::Table,
+            },
+            &self.surface_name,
+            &self.column_name,
+            &self.normalized_value_key,
+        )
     }
 }
 
@@ -729,154 +682,266 @@ struct CatalogEntityRecord {
     searchable_text: String,
 }
 
-fn configure_connection(connection: &Connection) -> Result<(), SearchIndexError> {
-    connection.busy_timeout(Duration::from_secs(5))?;
-    connection.pragma_update(None, "foreign_keys", "ON")?;
+#[derive(Debug, Clone, Copy)]
+struct SearchIndexFields {
+    doc_key: Field,
+    entity_kind: Field,
+    result_type: Field,
+    surface_kind: Field,
+    source_name: Field,
+    schema_name: Field,
+    surface_name: Field,
+    column_name: Field,
+    name: Field,
+    qualified_name: Field,
+    data_type: Field,
+    required: Field,
+    description: Field,
+    normalized_value_key: Field,
+    display_value: Field,
+    searchable_text: Field,
+    last_observed_at: Field,
+    observed_count: Field,
+    name_text: Field,
+    qualified_name_text: Field,
+    description_text: Field,
+    searchable_text_text: Field,
+    value_text: Field,
+}
+
+impl SearchIndexFields {
+    fn from_schema(schema: &Schema) -> Result<Self, SearchIndexError> {
+        Ok(Self {
+            doc_key: required_field(schema, "doc_key")?,
+            entity_kind: required_field(schema, "entity_kind")?,
+            result_type: required_field(schema, "result_type")?,
+            surface_kind: required_field(schema, "surface_kind")?,
+            source_name: required_field(schema, "source_name")?,
+            schema_name: required_field(schema, "schema_name")?,
+            surface_name: required_field(schema, "surface_name")?,
+            column_name: required_field(schema, "column_name")?,
+            name: required_field(schema, "name")?,
+            qualified_name: required_field(schema, "qualified_name")?,
+            data_type: required_field(schema, "data_type")?,
+            required: required_field(schema, "required")?,
+            description: required_field(schema, "description")?,
+            normalized_value_key: required_field(schema, "normalized_value_key")?,
+            display_value: required_field(schema, "display_value")?,
+            searchable_text: required_field(schema, "searchable_text")?,
+            last_observed_at: required_field(schema, "last_observed_at")?,
+            observed_count: required_field(schema, "observed_count")?,
+            name_text: required_field(schema, "name_text")?,
+            qualified_name_text: required_field(schema, "qualified_name_text")?,
+            description_text: required_field(schema, "description_text")?,
+            searchable_text_text: required_field(schema, "searchable_text_text")?,
+            value_text: required_field(schema, "value_text")?,
+        })
+    }
+}
+
+fn replace_catalog_index_at(path: &Path, catalog: &CatalogInfo) -> Result<(), SearchIndexError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    ensure_dir(parent)?;
+
+    let replacement_path = sibling_index_path(path, "rebuild");
+    if replacement_path.exists() {
+        fs::remove_dir_all(&replacement_path)?;
+    }
+
+    let observed_state = load_observed_state_for_index(path)?;
+    if let Err(error) = build_replacement_index(&replacement_path, catalog, &observed_state) {
+        if let Err(cleanup_error) = fs::remove_dir_all(&replacement_path) {
+            tracing::warn!(
+                path = %replacement_path.display(),
+                error = %cleanup_error,
+                "failed to remove incomplete Tantivy replacement index"
+            );
+        }
+        return Err(error);
+    }
+
+    swap_index_directory(path, &replacement_path)
+}
+
+fn build_replacement_index(
+    path: &Path,
+    catalog: &CatalogInfo,
+    observed_state: &ObservedValueState,
+) -> Result<(), SearchIndexError> {
+    ensure_dir(path)?;
+    let index = Index::create_in_dir(path, search_schema())?;
+    let store = SearchIndexStore::from_index(path.to_path_buf(), index)?;
+    let mut writer = store.writer()?;
+
+    for record in catalog_entity_records(catalog) {
+        writer.add_document(store.catalog_document(&record))?;
+    }
+    for record in &observed_state.records {
+        writer.add_document(store.observed_document(record))?;
+    }
+    writer.commit()?;
     Ok(())
 }
 
-fn detect_capabilities(
-    connection: &Connection,
-) -> Result<SqliteSearchCapabilities, SearchIndexError> {
-    let sqlite_version =
-        connection.query_row("SELECT sqlite_version()", [], |row| row.get::<_, String>(0))?;
-    let fts5 = connection
-        .execute_batch(
-            "
-            CREATE VIRTUAL TABLE temp.coral_search_fts5_check USING fts5(value);
-            DROP TABLE temp.coral_search_fts5_check;
-            ",
-        )
-        .is_ok();
-    let trigram = connection
-        .execute_batch(
-            "
-            CREATE VIRTUAL TABLE temp.coral_search_trigram_check
-            USING fts5(value, tokenize = 'trigram');
-            DROP TABLE temp.coral_search_trigram_check;
-            ",
-        )
-        .is_ok();
+fn swap_index_directory(path: &Path, replacement_path: &Path) -> Result<(), SearchIndexError> {
+    let old_path = if path.exists() {
+        let old_path = sibling_index_path(path, "old");
+        if old_path.exists() {
+            fs::remove_dir_all(&old_path)?;
+        }
+        fs::rename(path, &old_path)?;
+        Some(old_path)
+    } else {
+        None
+    };
 
-    Ok(SqliteSearchCapabilities {
-        sqlite_version,
-        fts5,
-        trigram,
-    })
-}
-
-fn ensure_supported(capabilities: &SqliteSearchCapabilities) -> Result<(), SearchIndexError> {
-    if !capabilities.fts5 {
-        return Err(SearchIndexError::UnsupportedCapability {
-            feature: "FTS5",
-            sqlite_version: capabilities.sqlite_version.clone(),
-        });
+    if let Err(error) = fs::rename(replacement_path, path) {
+        if let Some(old_path) = &old_path
+            && let Err(restore_error) = fs::rename(old_path, path)
+        {
+            tracing::warn!(
+                old_path = %old_path.display(),
+                path = %path.display(),
+                error = %restore_error,
+                "failed to restore previous Tantivy search index after replacement failure"
+            );
+        }
+        return Err(error.into());
     }
-    if !capabilities.trigram {
-        return Err(SearchIndexError::UnsupportedCapability {
-            feature: "FTS5 trigram tokenizer",
-            sqlite_version: capabilities.sqlite_version.clone(),
-        });
+
+    if let Some(old_path) = old_path
+        && let Err(error) = fs::remove_dir_all(&old_path)
+    {
+        tracing::warn!(
+            path = %old_path.display(),
+            error = %error,
+            "failed to remove replaced Tantivy search index"
+        );
     }
     Ok(())
 }
 
-fn migrate(connection: &mut Connection) -> Result<(), SearchIndexError> {
-    let transaction = connection.transaction()?;
-    transaction.execute_batch(
-        "
-        CREATE TABLE IF NOT EXISTS search_index_meta (
-            key TEXT PRIMARY KEY,
-            value TEXT NOT NULL,
-            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-        );
+fn sibling_index_path(path: &Path, label: &str) -> PathBuf {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("tantivy");
+    parent.join(format!(".{name}-{label}-{}", Uuid::new_v4()))
+}
 
-        CREATE TABLE IF NOT EXISTS catalog_entities (
-            workspace TEXT NOT NULL,
-            entity_key TEXT NOT NULL,
-            result_type TEXT NOT NULL,
-            surface_kind TEXT NOT NULL,
-            schema_name TEXT NOT NULL,
-            surface_name TEXT NOT NULL,
-            name TEXT NOT NULL,
-            data_type TEXT NOT NULL DEFAULT '',
-            is_required INTEGER NOT NULL DEFAULT 0,
-            description TEXT NOT NULL DEFAULT '',
-            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-            PRIMARY KEY (workspace, entity_key)
-        );
+fn observed_state_file_for_index(path: &Path) -> PathBuf {
+    path.parent().unwrap_or(path).join(OBSERVED_STATE_FILE_NAME)
+}
 
-        CREATE VIRTUAL TABLE IF NOT EXISTS catalog_entities_fts USING fts5(
-            workspace UNINDEXED,
-            entity_key UNINDEXED,
-            name,
-            qualified_name,
-            description,
-            searchable_text,
-            tokenize = 'trigram'
-        );
-
-        CREATE TABLE IF NOT EXISTS observed_values (
-            workspace TEXT NOT NULL,
-            source_name TEXT NOT NULL,
-            surface_kind TEXT NOT NULL,
-            surface_name TEXT NOT NULL,
-            column_name TEXT NOT NULL,
-            normalized_value_key TEXT NOT NULL,
-            display_value TEXT NOT NULL DEFAULT '',
-            sensitivity_tier TEXT NOT NULL DEFAULT 'low_risk',
-            suggested_operator TEXT NOT NULL DEFAULT 'exact',
-            first_observed_at TEXT NOT NULL,
-            last_observed_at TEXT NOT NULL,
-            observed_count INTEGER NOT NULL DEFAULT 1,
-            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-            PRIMARY KEY (
-                workspace,
-                source_name,
-                surface_kind,
-                surface_name,
-                column_name,
-                normalized_value_key
-            )
-        );
-
-        CREATE INDEX IF NOT EXISTS observed_values_last_observed_idx
-            ON observed_values (workspace, last_observed_at);
-
-        CREATE VIRTUAL TABLE IF NOT EXISTS observed_values_fts USING fts5(
-            workspace UNINDEXED,
-            source_name UNINDEXED,
-            surface_kind UNINDEXED,
-            surface_name UNINDEXED,
-            column_name UNINDEXED,
-            normalized_value_key UNINDEXED,
-            display_value,
-            searchable_text,
-            tokenize = 'trigram'
-        );
-
-        ",
-    )?;
-    transaction.execute(
-        "
-        INSERT INTO search_index_meta (key, value, updated_at)
-        SELECT 'schema_version', ?1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-        WHERE NOT EXISTS (
-            SELECT 1 FROM search_index_meta
-            WHERE key = 'schema_version' AND value = ?1
-        )
-        ON CONFLICT(key) DO UPDATE SET
-            value = excluded.value,
-            updated_at = excluded.updated_at
-        ",
-        params![SEARCH_INDEX_SCHEMA_VERSION.to_string()],
-    )?;
-    let user_version: u32 = transaction.query_row("PRAGMA user_version", [], |row| row.get(0))?;
-    if user_version != SEARCH_INDEX_SCHEMA_VERSION {
-        transaction.pragma_update(None, "user_version", SEARCH_INDEX_SCHEMA_VERSION)?;
+fn load_observed_state_for_index(path: &Path) -> Result<ObservedValueState, SearchIndexError> {
+    let path = observed_state_file_for_index(path);
+    if !path.exists() {
+        return Ok(ObservedValueState::default());
     }
-    transaction.commit()?;
+    let contents = fs::read_to_string(path)?;
+    let mut state: ObservedValueState = serde_json::from_str(&contents)?;
+    if state.schema_version != SEARCH_INDEX_SCHEMA_VERSION {
+        state = ObservedValueState::default();
+    }
+    Ok(state)
+}
+
+fn open_or_create_index(path: &Path) -> Result<Index, SearchIndexError> {
+    let meta_file = path.join("meta.json");
+    if meta_file.exists() {
+        let index = Index::open_in_dir(path)?;
+        if schema_has_required_fields(&index.schema()) {
+            return Ok(index);
+        }
+        fs::remove_dir_all(path)?;
+        ensure_dir(path)?;
+    }
+    Ok(Index::create_in_dir(path, search_schema())?)
+}
+
+fn search_schema() -> Schema {
+    let mut builder = Schema::builder();
+    builder.add_text_field("doc_key", STRING | STORED);
+    builder.add_text_field("entity_kind", STRING | STORED);
+    builder.add_text_field("result_type", STRING | STORED);
+    builder.add_text_field("surface_kind", STRING | STORED);
+    builder.add_text_field("source_name", STRING | STORED);
+    builder.add_text_field("schema_name", STRING | STORED);
+    builder.add_text_field("surface_name", STRING | STORED);
+    builder.add_text_field("column_name", STRING | STORED);
+    builder.add_text_field("name", STRING | STORED);
+    builder.add_text_field("qualified_name", STRING | STORED);
+    builder.add_text_field("data_type", STRING | STORED);
+    builder.add_text_field("required", STRING | STORED);
+    builder.add_text_field("description", stored_text_options());
+    builder.add_text_field("normalized_value_key", STRING | STORED);
+    builder.add_text_field("display_value", stored_text_options());
+    builder.add_text_field("searchable_text", stored_text_options());
+    builder.add_text_field("last_observed_at", STRING | STORED);
+    builder.add_text_field("observed_count", STRING | STORED);
+    builder.add_text_field("name_text", trigram_text_options());
+    builder.add_text_field("qualified_name_text", trigram_text_options());
+    builder.add_text_field("description_text", trigram_text_options());
+    builder.add_text_field("searchable_text_text", trigram_text_options());
+    builder.add_text_field("value_text", trigram_text_options());
+    builder.build()
+}
+
+fn stored_text_options() -> TextOptions {
+    TextOptions::default().set_stored()
+}
+
+fn trigram_text_options() -> TextOptions {
+    TextOptions::default().set_indexing_options(
+        TextFieldIndexing::default()
+            .set_tokenizer(TRIGRAM_TOKENIZER)
+            .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+    )
+}
+
+fn register_tokenizers(index: &Index) -> Result<(), SearchIndexError> {
+    let tokenizer = TextAnalyzer::builder(NgramTokenizer::all_ngrams(3, 3)?)
+        .filter(LowerCaser)
+        .build();
+    index.tokenizers().register(TRIGRAM_TOKENIZER, tokenizer);
     Ok(())
+}
+
+fn schema_has_required_fields(schema: &Schema) -> bool {
+    [
+        "doc_key",
+        "entity_kind",
+        "result_type",
+        "surface_kind",
+        "source_name",
+        "schema_name",
+        "surface_name",
+        "column_name",
+        "name",
+        "qualified_name",
+        "data_type",
+        "required",
+        "description",
+        "normalized_value_key",
+        "display_value",
+        "searchable_text",
+        "last_observed_at",
+        "observed_count",
+        "name_text",
+        "qualified_name_text",
+        "description_text",
+        "searchable_text_text",
+        "value_text",
+    ]
+    .into_iter()
+    .all(|field| schema.get_field(field).is_ok())
+}
+
+fn required_field(schema: &Schema, field: &'static str) -> Result<Field, SearchIndexError> {
+    schema
+        .get_field(field)
+        .map_err(|_error| SearchIndexError::MissingField { field })
 }
 
 fn catalog_entity_records(catalog: &CatalogInfo) -> Vec<CatalogEntityRecord> {
@@ -1101,6 +1166,23 @@ fn table_function_result_column_record(
     });
 }
 
+fn observed_doc_key(
+    source_name: &str,
+    surface_kind: ObservedValueSurfaceKind,
+    surface_name: &str,
+    column_name: &str,
+    normalized_value_key: &str,
+) -> String {
+    format!(
+        "observed:{}:{}:{}:{}:{}",
+        source_name,
+        surface_kind.as_str(),
+        surface_name,
+        column_name,
+        normalized_value_key
+    )
+}
+
 fn qualified_name(schema_name: &str, surface_name: &str) -> String {
     format!("{schema_name}.{surface_name}")
 }
@@ -1113,17 +1195,21 @@ fn join_search_text<const N: usize>(parts: [&str; N]) -> String {
         .join(" ")
 }
 
-fn fts_match_query(terms: &[String]) -> Option<String> {
+fn tantivy_query_text(terms: &[String]) -> Option<String> {
     let phrases = terms
         .iter()
         .filter(|term| term.chars().count() >= 3)
-        .map(|term| format!("\"{}\"", term.replace('"', "\"\"")))
+        .map(|term| format!("\"{}\"", escape_tantivy_phrase(term)))
         .collect::<Vec<_>>();
     if phrases.is_empty() {
         None
     } else {
         Some(phrases.join(" OR "))
     }
+}
+
+fn escape_tantivy_phrase(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 fn matched_fields<const N: usize>(
@@ -1145,18 +1231,36 @@ fn matched_fields<const N: usize>(
     matched
 }
 
+fn doc_text(doc: &TantivyDocument, field: Field) -> String {
+    doc.get_first(field)
+        .and_then(|value| value.as_str())
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn now_timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn assign_rank_scores<T>(hits: &mut [T], mut set_score: impl FnMut(&mut T, u32)) {
+    let hit_count = u32::try_from(hits.len()).unwrap_or(u32::MAX);
+    for (position, hit) in hits.iter_mut().enumerate() {
+        let position = u32::try_from(position).unwrap_or(u32::MAX);
+        set_score(hit, hit_count.saturating_sub(position));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use coral_engine::{
         CatalogInfo, TableFunctionArgumentInfo, TableFunctionInfo, TableFunctionResultColumnInfo,
     };
-    use rusqlite::OptionalExtension as _;
     use tempfile::tempdir;
 
     use super::{
         CatalogSearchResultType, ObservedValueRecord, ObservedValueSensitivityTier,
-        ObservedValueSuggestedOperator, ObservedValueSurfaceKind, SEARCH_INDEX_SCHEMA_VERSION,
-        SearchIndexStore, fts_match_query,
+        ObservedValueState, ObservedValueSuggestedOperator, ObservedValueSurfaceKind,
+        SEARCH_INDEX_SCHEMA_VERSION, SearchIndexStore, tantivy_query_text,
     };
     use crate::state::AppStateLayout;
     use crate::workspaces::WorkspaceName;
@@ -1169,73 +1273,37 @@ mod tests {
         let workspace = WorkspaceName::parse("default").expect("workspace");
         let store = SearchIndexStore::open_workspace(&layout, &workspace).expect("store");
 
-        assert_eq!(store.path(), layout.search_index_file(&workspace));
-        assert!(store.capabilities().fts5);
-        assert!(store.capabilities().trigram);
-
-        let connection = store.connect().expect("connect");
-        let user_version: u32 = connection
-            .query_row("PRAGMA user_version", [], |row| row.get(0))
-            .expect("user_version");
-        assert_eq!(user_version, SEARCH_INDEX_SCHEMA_VERSION);
-
-        let schema_version = connection
-            .query_row(
-                "SELECT value FROM search_index_meta WHERE key = 'schema_version'",
-                [],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()
-            .expect("schema_version query")
-            .expect("schema_version");
-        assert_eq!(schema_version, SEARCH_INDEX_SCHEMA_VERSION.to_string());
+        assert_eq!(store.path(), layout.search_index_dir(&workspace));
+        assert_eq!(store.capabilities().tantivy_version, "0.26.1");
+        assert_eq!(store.capabilities().tokenizer, "coral_trigram");
+        assert!(store.path().join("meta.json").exists());
     }
 
     #[test]
-    fn catalog_fts_supports_bm25_trigram_matches() {
+    fn catalog_tantivy_supports_bm25_trigram_matches() {
         let temp = tempdir().expect("tempdir");
-        let store = SearchIndexStore::open(temp.path().join("search.sqlite")).expect("store");
-        let connection = store.connect().expect("connect");
-        connection
-            .execute(
-                "
-                INSERT INTO catalog_entities_fts (
-                    workspace,
-                    entity_key,
-                    name,
-                    qualified_name,
-                    description,
-                    searchable_text
-                )
-                VALUES ('default', 'function:github.search_commits', 'search_commits',
-                    'github.search_commits', 'Search commits', 'github commit sha')
-                ",
-                [],
-            )
-            .expect("insert fts row");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let store = SearchIndexStore::replace_catalog_index(
+            temp.path().join("tantivy"),
+            &catalog_with_search_function(),
+        )
+        .expect("replace catalog");
 
-        let row_count: u32 = connection
-            .query_row(
-                "
-                SELECT count(*)
-                FROM catalog_entities_fts
-                WHERE catalog_entities_fts MATCH '\"commit\"'
-                ORDER BY bm25(catalog_entities_fts)
-                ",
-                [],
-                |row| row.get(0),
-            )
-            .expect("fts query");
-        assert_eq!(row_count, 1);
+        let hits = store
+            .search_catalog(&workspace, &["commit".to_string()], 10)
+            .expect("search catalog");
+        assert!(
+            hits.iter()
+                .any(|hit| hit.surface_name == "search_deployments")
+        );
     }
 
     #[test]
     fn replace_catalog_indexes_function_metadata() {
         let temp = tempdir().expect("tempdir");
         let workspace = WorkspaceName::parse("default").expect("workspace");
-        let store = SearchIndexStore::open(temp.path().join("search.sqlite")).expect("store");
-        store
-            .replace_catalog(&workspace, &catalog_with_search_function())
+        let path = temp.path().join("tantivy");
+        let store = SearchIndexStore::replace_catalog_index(&path, &catalog_with_search_function())
             .expect("replace catalog");
 
         let hits = store
@@ -1257,15 +1325,14 @@ mod tests {
             == Some(CatalogSearchResultType::ColumnHint)
             && hit.name == "sha"));
 
-        store
-            .replace_catalog(
-                &workspace,
-                &CatalogInfo {
-                    tables: Vec::new(),
-                    table_functions: Vec::new(),
-                },
-            )
-            .expect("replace empty catalog");
+        let store = SearchIndexStore::replace_catalog_index(
+            &path,
+            &CatalogInfo {
+                tables: Vec::new(),
+                table_functions: Vec::new(),
+            },
+        )
+        .expect("replace empty catalog");
         let hits = store
             .search_catalog(&workspace, &["github".to_string()], 10)
             .expect("search empty catalog");
@@ -1273,9 +1340,40 @@ mod tests {
     }
 
     #[test]
-    fn fts_match_query_quotes_technical_terms() {
+    fn replace_catalog_rebuild_preserves_observed_values() {
+        let temp = tempdir().expect("tempdir");
+        let workspace = WorkspaceName::parse("default").expect("workspace");
+        let path = temp.path().join("tantivy");
+        {
+            let store = SearchIndexStore::open(&path).expect("store");
+            store
+                .upsert_observed_values(&workspace, vec![observed_record("payments-api", 1)])
+                .expect("upsert observed");
+        }
+
+        let store = SearchIndexStore::replace_catalog_index(&path, &catalog_with_search_function())
+            .expect("replace catalog");
+
+        assert!(
+            !store
+                .search_catalog(&workspace, &["deployments".to_string()], 10)
+                .expect("search catalog")
+                .is_empty()
+        );
+        let observed_hits = store
+            .search_observed_values(&workspace, &["payments-api".to_string()], 10)
+            .expect("search observed");
+        assert_eq!(observed_hits.len(), 1);
         assert_eq!(
-            fts_match_query(&["github.search_commits".to_string(), "id".to_string()])
+            observed_hits.first().expect("observed hit").display_value,
+            "payments-api"
+        );
+    }
+
+    #[test]
+    fn tantivy_query_text_quotes_technical_terms() {
+        assert_eq!(
+            tantivy_query_text(&["github.search_commits".to_string(), "id".to_string()])
                 .expect("query"),
             "\"github.search_commits\""
         );
@@ -1285,7 +1383,7 @@ mod tests {
     fn observed_values_upsert_count_and_search() {
         let temp = tempdir().expect("tempdir");
         let workspace = WorkspaceName::parse("default").expect("workspace");
-        let store = SearchIndexStore::open(temp.path().join("search.sqlite")).expect("store");
+        let store = SearchIndexStore::open(temp.path().join("tantivy")).expect("store");
 
         store
             .upsert_observed_values(
@@ -1303,20 +1401,14 @@ mod tests {
         assert_eq!(hits.len(), 1);
         let hit = hits.first().expect("observed hit");
         assert_eq!(hit.column_name, "service");
-        let observed_count: i64 = store
-            .connect()
-            .expect("connect")
-            .query_row(
-                "
-                SELECT observed_count
-                FROM observed_values
-                WHERE workspace = 'default' AND display_value = 'payments-api'
-                ",
-                [],
-                |row| row.get(0),
-            )
-            .expect("observed count");
-        assert_eq!(observed_count, 3);
+
+        assert_eq!(
+            store
+                .observed_count_for_test("payments-api")
+                .expect("observed state")
+                .expect("stored observed value"),
+            3
+        );
     }
 
     #[test]
@@ -1324,7 +1416,7 @@ mod tests {
         let temp = tempdir().expect("tempdir");
         let workspace = WorkspaceName::parse("default").expect("workspace");
         let source = crate::sources::SourceName::parse("notion").expect("source");
-        let store = SearchIndexStore::open(temp.path().join("search.sqlite")).expect("store");
+        let store = SearchIndexStore::open(temp.path().join("tantivy")).expect("store");
 
         store
             .upsert_observed_values(
@@ -1340,18 +1432,16 @@ mod tests {
                 ],
             )
             .expect("upsert observed");
+
+        let mut state = store.load_observed_state().expect("observed state");
+        for record in &mut state.records {
+            if record.source_name == "github" {
+                record.last_observed_at = "2000-01-01T00:00:00.000Z".to_string();
+            }
+        }
         store
-            .connect()
-            .expect("connect")
-            .execute(
-                "
-                UPDATE observed_values
-                SET last_observed_at = '2000-01-01T00:00:00.000Z'
-                WHERE source_name = 'github'
-                ",
-                [],
-            )
-            .expect("age observed value");
+            .write_observed_state(&state)
+            .expect("write aged observed state");
 
         store
             .purge_observed_values_before(&workspace, "2001-01-01T00:00:00.000Z")
@@ -1410,12 +1500,20 @@ mod tests {
             surface_kind: ObservedValueSurfaceKind::Table,
             surface_name: "deployments".to_string(),
             column_name: "service".to_string(),
-            normalized_value_key: value.to_ascii_lowercase(),
+            normalized_value_key: format!("key:{value}"),
             display_value: value.to_string(),
             searchable_text: format!("github deployments service {value}"),
             sensitivity_tier: ObservedValueSensitivityTier::LowRisk,
             suggested_operator: ObservedValueSuggestedOperator::Exact,
             observed_count,
         }
+    }
+
+    #[test]
+    fn observed_state_version_matches_index_schema_version() {
+        assert_eq!(
+            ObservedValueState::default().schema_version,
+            SEARCH_INDEX_SCHEMA_VERSION
+        );
     }
 }

--- a/crates/coral-app/src/search/observed.rs
+++ b/crates/coral-app/src/search/observed.rs
@@ -21,7 +21,7 @@ use crate::search::index::{
 use crate::state::AppStateLayout;
 use crate::workspaces::WorkspaceName;
 
-/// Query-result observer that writes direct-provenance cell values into search `SQLite`.
+/// Query-result observer that writes direct-provenance cell values into search index storage.
 pub(crate) struct ObservedValueIndexer {
     layout: AppStateLayout,
     workspace_name: WorkspaceName,
@@ -668,20 +668,13 @@ mod tests {
             .search_observed_values(&workspace, &["payments-api".to_string()], 10)
             .expect("search observed");
         assert_eq!(hits.len(), 1);
-        let observed_count: i64 = store
-            .connect()
-            .expect("connect")
-            .query_row(
-                "
-                SELECT observed_count
-                FROM observed_values
-                WHERE workspace = 'default' AND display_value = 'payments-api'
-                ",
-                [],
-                |row| row.get(0),
-            )
-            .expect("observed count");
-        assert_eq!(observed_count, 3);
+        assert_eq!(
+            store
+                .observed_count_for_test("payments-api")
+                .expect("observed state")
+                .expect("observed count"),
+            3
+        );
     }
 
     fn query_source(name: &str) -> QuerySource {

--- a/crates/coral-app/src/search/service.rs
+++ b/crates/coral-app/src/search/service.rs
@@ -69,11 +69,14 @@ impl SearchIndexRefresher {
         catalog: &CatalogInfo,
     ) -> Result<SearchIndexStore, SearchIndexError> {
         let mut refreshed_workspaces = self.refreshed_workspaces.lock().await;
-        let index = SearchIndexStore::open_workspace(&self.layout, workspace_name)?;
-        if !refreshed_workspaces.contains(workspace_name) {
-            index.replace_catalog(workspace_name, catalog)?;
+        let index = if refreshed_workspaces.contains(workspace_name) {
+            SearchIndexStore::open_workspace(&self.layout, workspace_name)?
+        } else {
+            let index =
+                SearchIndexStore::replace_workspace_catalog(&self.layout, workspace_name, catalog)?;
             refreshed_workspaces.insert(workspace_name.clone());
-        }
+            index
+        };
         Ok(index)
     }
 
@@ -217,10 +220,9 @@ impl UniversalSearch {
         let capabilities = index.capabilities();
         tracing::debug!(
             workspace = %workspace_name,
-            sqlite_version = %capabilities.sqlite_version,
-            fts5 = capabilities.fts5,
-            trigram = capabilities.trigram,
-            "using SQLite catalog search index"
+            tantivy_version = %capabilities.tantivy_version,
+            tokenizer = %capabilities.tokenizer,
+            "using Tantivy catalog search index"
         );
         let search_limit = usize::try_from(limit)
             .unwrap_or(usize::MAX)
@@ -664,23 +666,15 @@ fn observed_provider_note(state: SearchProviderState, total_count: usize) -> Str
 }
 
 fn catalog_index_error_status(error: &SearchIndexError) -> CatalogProviderStatus {
-    let state = match error {
-        SearchIndexError::UnsupportedCapability { .. } => SearchProviderState::Partial,
-        SearchIndexError::Io(_) | SearchIndexError::Sqlite(_) => SearchProviderState::Error,
-    };
     CatalogProviderStatus {
-        state,
+        state: SearchProviderState::Error,
         note: format!("Catalog metadata search index is unavailable: {error}"),
     }
 }
 
 fn observed_index_error_status(error: &SearchIndexError) -> ObservedProviderStatus {
-    let state = match error {
-        SearchIndexError::UnsupportedCapability { .. } => SearchProviderState::Partial,
-        SearchIndexError::Io(_) | SearchIndexError::Sqlite(_) => SearchProviderState::Error,
-    };
     ObservedProviderStatus {
-        state,
+        state: SearchProviderState::Error,
         note: format!("Observed-value search index is unavailable: {error}"),
     }
 }

--- a/crates/coral-app/src/state/layout.rs
+++ b/crates/coral-app/src/state/layout.rs
@@ -86,8 +86,8 @@ impl AppStateLayout {
         self.workspace_dir(workspace_name).join("search")
     }
 
-    pub(crate) fn search_index_file(&self, workspace_name: &WorkspaceName) -> PathBuf {
-        self.search_dir(workspace_name).join("search.sqlite")
+    pub(crate) fn search_index_dir(&self, workspace_name: &WorkspaceName) -> PathBuf {
+        self.search_dir(workspace_name).join("tantivy")
     }
 
     pub(crate) fn source_dir(
@@ -160,12 +160,12 @@ mod tests {
                 .join("reports.jsonl")
         );
         assert_eq!(
-            layout.search_index_file(&workspace_name),
+            layout.search_index_dir(&workspace_name),
             config_dir
                 .join("workspaces")
                 .join("default")
                 .join("search")
-                .join("search.sqlite")
+                .join("tantivy")
         );
         assert_eq!(
             layout.local_trace_store_dir(),

--- a/crates/coral-app/tests/grpc/search_tests.rs
+++ b/crates/coral-app/tests/grpc/search_tests.rs
@@ -9,7 +9,10 @@ use coral_api::v1::{
     SearchSurfaceKind,
 };
 use coral_client::default_workspace;
-use rusqlite::Connection;
+use tantivy::collector::Count;
+use tantivy::query::{BooleanQuery, Occur, TermQuery};
+use tantivy::schema::IndexRecordOption;
+use tantivy::{Index, Term};
 use tonic::Request;
 
 use super::harness::{
@@ -55,9 +58,9 @@ async fn search_returns_typed_metadata_and_native_search_results() {
             .join("workspaces")
             .join("default")
             .join("search")
-            .join("search.sqlite")
+            .join("tantivy")
             .exists(),
-        "search should create the workspace SQLite search index"
+        "search should create the workspace Tantivy search index"
     );
     assert!(response.results.iter().any(|result| result.r#type
         == SearchResultType::NativeSearchPath as i32
@@ -258,25 +261,39 @@ fn assert_provider_state(
 }
 
 fn catalog_entity_count(harness: &GrpcHarness, surface_name: &str) -> u32 {
-    let connection = Connection::open(search_index_path(harness)).expect("open search index");
-    connection
-        .query_row(
-            "SELECT count(*) FROM catalog_entities WHERE workspace = 'default' AND surface_name = ?1",
-            [surface_name],
-            |row| row.get(0),
-        )
-        .expect("catalog entity count")
+    catalog_count_for_terms(harness, vec![("surface_name", surface_name)])
 }
 
 fn total_catalog_entity_count(harness: &GrpcHarness) -> u32 {
-    let connection = Connection::open(search_index_path(harness)).expect("open search index");
-    connection
-        .query_row(
-            "SELECT count(*) FROM catalog_entities WHERE workspace = 'default'",
-            [],
-            |row| row.get(0),
-        )
-        .expect("total catalog entity count")
+    catalog_count_for_terms(harness, Vec::new())
+}
+
+fn catalog_count_for_terms(harness: &GrpcHarness, terms: Vec<(&str, &str)>) -> u32 {
+    let index = Index::open_in_dir(search_index_path(harness)).expect("open search index");
+    let schema = index.schema();
+    let entity_kind = schema.get_field("entity_kind").expect("entity_kind field");
+    let mut clauses = vec![(
+        Occur::Must,
+        Box::new(TermQuery::new(
+            Term::from_field_text(entity_kind, "catalog"),
+            IndexRecordOption::Basic,
+        )) as Box<dyn tantivy::query::Query>,
+    )];
+    for (field_name, value) in terms {
+        let field = schema.get_field(field_name).expect("field");
+        clauses.push((
+            Occur::Must,
+            Box::new(TermQuery::new(
+                Term::from_field_text(field, value),
+                IndexRecordOption::Basic,
+            )),
+        ));
+    }
+    let query = BooleanQuery::new(clauses);
+    let reader = index.reader().expect("reader");
+    let searcher = reader.searcher();
+    let count = searcher.search(&query, &Count).expect("catalog count");
+    u32::try_from(count).expect("count fits u32")
 }
 
 fn search_index_path(harness: &GrpcHarness) -> std::path::PathBuf {
@@ -285,5 +302,5 @@ fn search_index_path(harness: &GrpcHarness) -> std::path::PathBuf {
         .join("workspaces")
         .join("default")
         .join("search")
-        .join("search.sqlite")
+        .join("tantivy")
 }


### PR DESCRIPTION
## Summary
- replace the SQLite universal-search backing with a workspace-scoped Tantivy index
- index catalog metadata and observed values into one strict Tantivy schema with stored fields for typed result reconstruction
- use a Coral trigram tokenizer plus Tantivy BM25 for identifier-friendly retrieval
- rebuild catalog refreshes into a replacement Tantivy directory and swap it into place instead of tombstoning/reinserting catalog docs in the existing index
- keep observed-value counts/retention metadata in a workspace-local sidecar next to the Tantivy directory and rehydrate observed-value docs during catalog replacement

## Validation
- make rust-checks
- focused search index/service tests and gRPC source-mutation dirty-refresh test
- local CLI smoke with a disposable JSONL source confirmed observed-value search returns the indexed value
- local release benchmark on configured sources: 21,085 catalog docs; existing-index replacement refresh delta mean 579.659 ms / median 578.393 ms over 10 runs
