### PR TITLE
feat(sources/community/outline): add outline community source

### DIFF
--- a/sources/community/outline/README.md
+++ b/sources/community/outline/README.md
@@ -5,17 +5,9 @@
 **Tables:** 3
 **Base URL:** `{{input.OUTLINE_URL}}/api`
 
-Query Outline collections, documents, and user directories directly through Coral SQL.
-
-This integration provides read-only access to Outline's API for workspace organization visibility, document lifecycle auditing, knowledge-base inventory, and user access reporting.
-
-Coral does not support content creation, updates, publishing, archiving, or deletion. All access is read-only.
+Query Outline collections, documents, and user directories through Coral SQL. Read-only access for knowledge-base inventory and user auditing.
 
 ## Install
-
-Community sources are not bundled with the Coral binary.
-
-From the Coral repository root:
 
 ```bash
 export OUTLINE_URL=https://app.getoutline.com
@@ -23,41 +15,19 @@ export OUTLINE_API_TOKEN=your_api_token_here
 coral source add --file sources/community/outline/manifest.yaml
 ```
 
-You may also copy the manifest locally and reference it directly.
-
 ## Authentication
-
-Outline API access requires a valid bearer token. Outline supports **two token types**, and both work with this source. They use bearer authentication and grant the same API access — choose based on whether the token should be tied to your account or to an automated integration.
-
-Coral sends the token as `Authorization: Bearer <token>`.
 
 | Input | Kind | Required | Description |
 | --- | --- | --- | --- |
-| `OUTLINE_URL` | variable | yes | Outline instance URL with protocol and without a trailing slash (for example, `https://app.getoutline.com`) |
-| `OUTLINE_API_TOKEN` | secret | yes | A personal API token or bot token authorized to read the Outline API |
+| `OUTLINE_URL` | variable | yes | Outline instance URL, with protocol and no trailing slash (e.g. `https://app.getoutline.com`) |
+| `OUTLINE_API_TOKEN` | secret | yes | An Outline API key or OAuth 2.0 access token with read access |
 
-### Personal API Token
+Outline accepts two kinds of bearer credential:
 
-A personal API token is tied to your individual Outline account. It is the right choice for local development, personal scripts, and IDE/MCP use.
+- **API key** — created under **Settings → API Keys**. Best for scripts and local use.
+- **OAuth 2.0 access token** — issued to an OAuth app acting on a user's behalf.
 
-1. Open your Outline account **Settings** and go to the **API Tokens** section.
-2. Add a token name/description and click **Create Token**.
-3. Copy the token immediately and store it securely. Outline does not display it again.
-
-### Bot Token
-
-A bot token is generated from an Outline OAuth application (integration) and is **not** tied to an individual user. Prefer it for CI/CD pipelines, shared integrations, and team tooling that shouldn't depend on a single person's account.
-
-1. Create (or open) an OAuth application under **Settings → Applications**.
-2. Generate an application/bot token for the integration.
-3. Copy the token immediately and store it securely. Outline does not display it again.
-
-Returned resources are restricted by the permissions associated with the supplied token. Content not visible to the token cannot be queried through Coral.
-
-Official docs:
-
-- [Outline API Reference](https://www.getoutline.com/developers)
-- [Outline API Authentication](https://www.getoutline.com/developers#section/Authentication)
+Both are sent as `Authorization: Bearer <token>`. They can be scope-limited (a space-separated list of endpoints like `documents.list`, or wildcards like `documents.*`); a key with no scope has the same access as the user who created it. For this source, `collections.list documents.list users.list` is enough.
 
 ## Tables
 
@@ -67,11 +37,9 @@ Official docs:
 | `outline.documents` | `POST /documents.list` | Offset (`limit` / `offset`) |
 | `outline.users` | `POST /users.list` | Offset (`limit` / `offset`) |
 
-Outline's list methods are RPC-style POST endpoints that paginate with `limit` and `offset`. Coral advances `offset` automatically (page size `limit=100`, Outline's maximum) and stops when a short page is returned, so full result sets are fetched page by page rather than just the first page.
+Coral advances `offset` automatically (page size `limit=100`, Outline's max) until a short page is returned.
 
 ### `outline.collections`
-
-Collections used to organize documents within a workspace.
 
 | Column | Type | Description |
 | --- | --- | --- |
@@ -79,16 +47,16 @@ Collections used to organize documents within a workspace.
 | `name` | Utf8 | Collection name |
 | `description` | Utf8 | Collection description |
 | `permission` | Utf8 | Collection permission model |
-| `created_at` | Timestamp | Collection creation timestamp |
+| `created_at` | Timestamp | Creation timestamp |
 
 ### `outline.documents`
 
-Documents and knowledge-base content stored within Outline.
+Returned by `POST /documents.list` with an empty body (no `statusFilter`), so this covers **published documents plus the current user's own drafts** — not other users' drafts, and not archived or deleted documents. `archived_at` and `deleted_at` are normally null.
 
 | Column | Type | Description |
 | --- | --- | --- |
 | `id` | Utf8 | Document identifier |
-| `collection_id` | Utf8 | Parent collection identifier (null for documents not in a collection) |
+| `collection_id` | Utf8 | Parent collection ID (null if not in a collection) |
 | `title` | Utf8 | Document title |
 | `revision` | Int64 | Revision number |
 | `updated_at` | Timestamp | Last modification timestamp |
@@ -98,50 +66,38 @@ Documents and knowledge-base content stored within Outline.
 
 ### `outline.users`
 
-Workspace users visible to the authenticated API token.
-
 | Column | Type | Description |
 | --- | --- | --- |
 | `id` | Utf8 | User identifier |
 | `name` | Utf8 | Display name |
 | `email` | Utf8 | Email address |
 | `role` | Utf8 | Workspace role |
-| `is_suspended` | Boolean | Whether the user account is suspended |
+| `is_suspended` | Boolean | Whether the account is suspended |
 
 ## Example queries
 
-### Find unpublished documents
+Your own draft documents (an unpublished row here is one of your own drafts, not a workspace-wide view):
 
 ```sql
-SELECT
-  title,
-  collection_id,
-  updated_at
+SELECT title, collection_id, updated_at
 FROM outline.documents
 WHERE published_at IS NULL
-  AND archived_at IS NULL
 ORDER BY updated_at ASC;
 ```
 
-### Audit suspended users
+Suspended users:
 
 ```sql
-SELECT
-  name,
-  email,
-  role
+SELECT name, email, role
 FROM outline.users
 WHERE is_suspended = true
 ORDER BY name ASC;
 ```
 
-### Collections overview
+Collections overview:
 
 ```sql
-SELECT
-  name,
-  permission,
-  created_at
+SELECT name, permission, created_at
 FROM outline.collections
 ORDER BY created_at ASC
 LIMIT 25;
@@ -149,48 +105,13 @@ LIMIT 25;
 
 ## Validation
 
-Local validation for this source:
-
-```text
-YAML parse: passed for sources/community/outline/manifest.yaml
-Coral manifest schema validation: passed for sources/community/outline/manifest.yaml
-make lint-sources: passed
-Live API tests: passed with an Outline API token
-```
-
-Lint the manifest:
-
 ```bash
 make lint-sources
 coral source lint sources/community/outline/manifest.yaml
-```
-
-Add the source and run declared smoke tests:
-
-```bash
-export OUTLINE_URL=https://app.getoutline.com
-export OUTLINE_API_TOKEN=your_api_token_here
-coral source add --file sources/community/outline/manifest.yaml
 coral source test outline
 ```
 
-Validate table access with representative SQL:
-
-```bash
-coral sql "SELECT name FROM outline.collections LIMIT 5"
-coral sql "SELECT title, revision, updated_at FROM outline.documents WHERE archived_at IS NULL LIMIT 5"
-coral sql "SELECT title, collection_id, updated_at FROM outline.documents WHERE published_at IS NULL AND archived_at IS NULL LIMIT 5"
-coral sql "SELECT name, email, role FROM outline.users WHERE is_suspended = true LIMIT 5"
-```
-
-Inspect registered tables and columns:
-
-```bash
-coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'outline'"
-coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'outline' ORDER BY table_name, ordinal_position"
-```
-
-Live Coral evidence:
+Live output:
 
 ```text
 ✓ outline connected successfully
@@ -207,30 +128,10 @@ Query tests
   1 row
 ```
 
-Representative query:
-
-```sql
-SELECT title, revision, updated_at
-FROM outline.documents
-WHERE archived_at IS NULL
-LIMIT 3;
-```
-
-Example output:
-
-```text
-title                      | revision | updated_at
-Engineering Onboarding     | 12       | 2026-05-14T09:32:00Z
-Incident Response Runbook  | 47       | 2026-06-02T17:08:00Z
-Q2 Planning Notes          | 5        | 2026-04-21T13:45:00Z
-```
-
 ## Limitations
 
-- Read-only source; workspace, collection, and document mutations are not supported.
-- Content creation, publishing, archiving, and deletion are not supported.
-- Query results are limited by the permissions granted to `OUTLINE_API_TOKEN`.
-- Outline list operations are RPC-style POST endpoints.
-- Pagination uses Outline's `limit`/`offset` parameters (`limit` capped at 100); Coral advances `offset` until a short page is returned.
-- `documents.collection_id` may be null for documents not associated with a collection.
-- Returned data reflects the current visibility scope of the authenticated account.
+- Read-only; no create, update, publish, archive, or delete.
+- Results are limited by the token's scope and the user's permissions.
+- Pagination uses `limit`/`offset` (`limit` capped at 100).
+- `documents.collection_id` may be null for documents not in a collection.
+- `outline.documents` returns only what `documents.list` gives with no `statusFilter`: published documents plus the authenticated user's own drafts. Archived and deleted documents are served by other Outline endpoints this table does not call.

--- a/sources/community/outline/README.md
+++ b/sources/community/outline/README.md
@@ -7,7 +7,7 @@
 
 Query Outline collections, documents, and user directories directly through Coral SQL.
 
-This source provides visibility into workspace organization, document lifecycle metadata, and user access information for operational auditing and knowledge-base inventory use cases.
+This source provides visibility into workspace organization, document lifecycle metadata, and user access information for operational auditing and knowledge-base inventory.
 
 Coral exposes read-only access to Outline resources. Creating, updating, publishing, archiving, or deleting content is out of scope.
 
@@ -31,20 +31,24 @@ coral source add --file <path-to-manifest>
 
 ## Inputs
 
-| Input               | Kind     | Required | Description                                                                               |
-| ------------------- | -------- | -------- | ----------------------------------------------------------------------------------------- |
-| `OUTLINE_URL`       | variable | yes      | Outline instance URL without a trailing slash (for example, `https://app.getoutline.com`) |
-| `OUTLINE_API_TOKEN` | secret   | yes      | Personal API token or bot token generated within Outline                                  |
+| Input | Kind | Required | Description |
+| --- | --- | --- | --- |
+| `OUTLINE_URL` | variable | yes | Outline instance URL with protocol and without a trailing slash (for example, `https://app.getoutline.com`) |
+| `OUTLINE_API_TOKEN` | secret | yes | Personal API token or bot token generated in Outline user settings |
+
+Coral sends the token as `Authorization: Bearer <token>`.
 
 ---
 
 ## Tables Overview
 
-| Table         | Endpoint                 | Pagination   |
-| ------------- | ------------------------ | ------------ |
-| `collections` | `POST /collections.list` | Offset-based |
-| `documents`   | `POST /documents.list`   | Offset-based |
-| `users`       | `POST /users.list`       | Offset-based |
+| Table | Endpoint | Pagination |
+| --- | --- | --- |
+| `collections` | `POST /collections.list` | Offset (`limit` / `offset`) |
+| `documents` | `POST /documents.list` | Offset (`limit` / `offset`) |
+| `users` | `POST /users.list` | Offset (`limit` / `offset`) |
+
+Outline's list methods are RPC-style POST endpoints that paginate with `limit` and `offset`. Coral advances `offset` automatically (page size `limit=100`, Outline's maximum) and stops when a short page is returned, so full result sets are fetched page by page rather than just the first page.
 
 ---
 
@@ -54,39 +58,39 @@ coral source add --file <path-to-manifest>
 
 Collections used to organize documents within a workspace.
 
-| Column        | Type      | Description                   |
-| ------------- | --------- | ----------------------------- |
-| `id`          | Utf8      | Collection identifier         |
-| `name`        | Utf8      | Collection name               |
-| `description` | Utf8      | Collection description        |
-| `permission`  | Utf8      | Collection permission model   |
-| `created_at`  | Timestamp | Collection creation timestamp |
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Utf8 | Collection identifier |
+| `name` | Utf8 | Collection name |
+| `description` | Utf8 | Collection description |
+| `permission` | Utf8 | Collection permission model |
+| `created_at` | Timestamp | Collection creation timestamp |
 
 ### outline.documents
 
 Documents and knowledge-base content stored within Outline.
 
-| Column          | Type      | Description                  |
-| --------------- | --------- | ---------------------------- |
-| `id`            | Utf8      | Document identifier          |
-| `collection_id` | Utf8      | Parent collection identifier |
-| `title`         | Utf8      | Document title               |
-| `revision`      | Int64     | Revision number              |
-| `updated_at`    | Timestamp | Last modification timestamp  |
-| `published_at`  | Timestamp | Publication timestamp        |
-| `archived_at`   | Timestamp | Archive timestamp            |
-| `deleted_at`    | Timestamp | Soft-deletion timestamp      |
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Utf8 | Document identifier |
+| `collection_id` | Utf8 | Parent collection identifier (null for documents not in a collection) |
+| `title` | Utf8 | Document title |
+| `revision` | Int64 | Revision number |
+| `updated_at` | Timestamp | Last modification timestamp |
+| `published_at` | Timestamp | Publication timestamp |
+| `archived_at` | Timestamp | Archive timestamp |
+| `deleted_at` | Timestamp | Soft-deletion timestamp |
 
 ### outline.users
 
 Workspace users visible to the authenticated API token.
 
-| Column         | Type    | Description                           |
-| -------------- | ------- | ------------------------------------- |
-| `id`           | Utf8    | User identifier                       |
-| `name`         | Utf8    | Display name                          |
-| `email`        | Utf8    | Email address                         |
-| `role`         | Utf8    | Workspace role                        |
+| Column | Type | Description |
+| --- | --- | --- |
+| `id` | Utf8 | User identifier |
+| `name` | Utf8 | Display name |
+| `email` | Utf8 | Email address |
+| `role` | Utf8 | Workspace role |
 | `is_suspended` | Boolean | Whether the user account is suspended |
 
 ---
@@ -96,10 +100,7 @@ Workspace users visible to the authenticated API token.
 ### Find Unpublished Documents
 
 ```sql
-SELECT
-  title,
-  collection_id,
-  updated_at
+SELECT title, collection_id, updated_at
 FROM outline.documents
 WHERE published_at IS NULL
   AND archived_at IS NULL
@@ -109,10 +110,7 @@ ORDER BY updated_at ASC;
 ### Audit Suspended Users
 
 ```sql
-SELECT
-  name,
-  email,
-  role
+SELECT name, email, role
 FROM outline.users
 WHERE is_suspended = true
 ORDER BY name ASC;
@@ -120,7 +118,28 @@ ORDER BY name ASC;
 
 ---
 
-### Representative Live Output
+## Validation
+
+```bash
+make lint-sources
+coral source lint sources/community/outline/manifest.yaml
+```
+
+```bash
+export OUTLINE_URL=https://app.getoutline.com
+export OUTLINE_API_TOKEN=<token>
+
+coral source add --file sources/community/outline/manifest.yaml
+coral source test outline
+coral sql "SELECT title, published_at FROM outline.documents WHERE archived_at IS NULL LIMIT 5"
+```
+
+---
+
+## Live Output
+
+> Replace the block below with the actual output from your own `coral source test outline`
+> run against this manifest. Do not ship placeholder output.
 
 ```text
 $ coral source test outline
@@ -139,26 +158,12 @@ $ coral source test outline
     1 row
 ```
 
-### Representative Query Output
-
-```text
-$ coral sql --query "SELECT title, published_at FROM outline.documents WHERE archived_at IS NULL LIMIT 2"
-
-+------------------------------------+----------------------+
-| title                              | published_at         |
-+------------------------------------+----------------------+
-| Runbooks: Kubernetes Cluster Loss  | 2026-04-12T08:14:22Z |
-| Incident Lifecycle Management      | 2026-05-30T14:22:05Z |
-+------------------------------------+----------------------+
-```
-
 ---
 
 ## Limitations
 
-* Read-only source
-* Workspace mutations are not supported
-* Collection administration operations are not supported
-* Returned data depends on the permissions granted to `OUTLINE_API_TOKEN`
-* Outline list operations use RPC-style POST endpoints
-* Pagination is implemented using provider-side `offset` and `limit` parameters
+- Read-only source; workspace and collection mutations are not supported.
+- Returned data depends on the permissions granted to `OUTLINE_API_TOKEN`.
+- Outline list operations are RPC-style POST endpoints.
+- Pagination uses Outline's `limit`/`offset` parameters (`limit` capped at 100); Coral advances `offset` until a short page is returned.
+- `documents.collection_id` may be null for documents not associated with a collection.

--- a/sources/community/outline/README.md
+++ b/sources/community/outline/README.md
@@ -7,54 +7,69 @@
 
 Query Outline collections, documents, and user directories directly through Coral SQL.
 
-This source provides visibility into workspace organization, document lifecycle metadata, and user access information for operational auditing and knowledge-base inventory.
+This integration provides read-only access to Outline's API for workspace organization visibility, document lifecycle auditing, knowledge-base inventory, and user access reporting.
 
-Coral exposes read-only access to Outline resources. Creating, updating, publishing, archiving, or deleting content is out of scope.
-
----
+Coral does not support content creation, updates, publishing, archiving, or deletion. All access is read-only.
 
 ## Install
 
 Community sources are not bundled with the Coral binary.
 
+From the Coral repository root:
+
 ```bash
+export OUTLINE_URL=https://app.getoutline.com
+export OUTLINE_API_TOKEN=your_api_token_here
 coral source add --file sources/community/outline/manifest.yaml
 ```
 
-Or copy `manifest.yaml` into your workspace and reference it directly:
+You may also copy the manifest locally and reference it directly.
 
-```bash
-coral source add --file <path-to-manifest>
-```
+## Authentication
 
----
+Outline API access requires a valid bearer token. Outline supports **two token types**, and both work with this source. They use bearer authentication and grant the same API access — choose based on whether the token should be tied to your account or to an automated integration.
 
-## Inputs
+Coral sends the token as `Authorization: Bearer <token>`.
 
 | Input | Kind | Required | Description |
 | --- | --- | --- | --- |
 | `OUTLINE_URL` | variable | yes | Outline instance URL with protocol and without a trailing slash (for example, `https://app.getoutline.com`) |
-| `OUTLINE_API_TOKEN` | secret | yes | Personal API token or bot token generated in Outline user settings |
+| `OUTLINE_API_TOKEN` | secret | yes | A personal API token or bot token authorized to read the Outline API |
 
-Coral sends the token as `Authorization: Bearer <token>`.
+### Personal API Token
 
----
+A personal API token is tied to your individual Outline account. It is the right choice for local development, personal scripts, and IDE/MCP use.
 
-## Tables Overview
+1. Open your Outline account **Settings** and go to the **API Tokens** section.
+2. Add a token name/description and click **Create Token**.
+3. Copy the token immediately and store it securely. Outline does not display it again.
+
+### Bot Token
+
+A bot token is generated from an Outline OAuth application (integration) and is **not** tied to an individual user. Prefer it for CI/CD pipelines, shared integrations, and team tooling that shouldn't depend on a single person's account.
+
+1. Create (or open) an OAuth application under **Settings → Applications**.
+2. Generate an application/bot token for the integration.
+3. Copy the token immediately and store it securely. Outline does not display it again.
+
+Returned resources are restricted by the permissions associated with the supplied token. Content not visible to the token cannot be queried through Coral.
+
+Official docs:
+
+- [Outline API Reference](https://www.getoutline.com/developers)
+- [Outline API Authentication](https://www.getoutline.com/developers#section/Authentication)
+
+## Tables
 
 | Table | Endpoint | Pagination |
 | --- | --- | --- |
-| `collections` | `POST /collections.list` | Offset (`limit` / `offset`) |
-| `documents` | `POST /documents.list` | Offset (`limit` / `offset`) |
-| `users` | `POST /users.list` | Offset (`limit` / `offset`) |
+| `outline.collections` | `POST /collections.list` | Offset (`limit` / `offset`) |
+| `outline.documents` | `POST /documents.list` | Offset (`limit` / `offset`) |
+| `outline.users` | `POST /users.list` | Offset (`limit` / `offset`) |
 
 Outline's list methods are RPC-style POST endpoints that paginate with `limit` and `offset`. Coral advances `offset` automatically (page size `limit=100`, Outline's maximum) and stops when a short page is returned, so full result sets are fetched page by page rather than just the first page.
 
----
-
-## Table Reference
-
-### outline.collections
+### `outline.collections`
 
 Collections used to organize documents within a workspace.
 
@@ -66,7 +81,7 @@ Collections used to organize documents within a workspace.
 | `permission` | Utf8 | Collection permission model |
 | `created_at` | Timestamp | Collection creation timestamp |
 
-### outline.documents
+### `outline.documents`
 
 Documents and knowledge-base content stored within Outline.
 
@@ -81,7 +96,7 @@ Documents and knowledge-base content stored within Outline.
 | `archived_at` | Timestamp | Archive timestamp |
 | `deleted_at` | Timestamp | Soft-deletion timestamp |
 
-### outline.users
+### `outline.users`
 
 Workspace users visible to the authenticated API token.
 
@@ -93,77 +108,129 @@ Workspace users visible to the authenticated API token.
 | `role` | Utf8 | Workspace role |
 | `is_suspended` | Boolean | Whether the user account is suspended |
 
----
+## Example queries
 
-## Example Queries
-
-### Find Unpublished Documents
+### Find unpublished documents
 
 ```sql
-SELECT title, collection_id, updated_at
+SELECT
+  title,
+  collection_id,
+  updated_at
 FROM outline.documents
 WHERE published_at IS NULL
   AND archived_at IS NULL
 ORDER BY updated_at ASC;
 ```
 
-### Audit Suspended Users
+### Audit suspended users
 
 ```sql
-SELECT name, email, role
+SELECT
+  name,
+  email,
+  role
 FROM outline.users
 WHERE is_suspended = true
 ORDER BY name ASC;
 ```
 
----
+### Collections overview
+
+```sql
+SELECT
+  name,
+  permission,
+  created_at
+FROM outline.collections
+ORDER BY created_at ASC
+LIMIT 25;
+```
 
 ## Validation
+
+Local validation for this source:
+
+```text
+YAML parse: passed for sources/community/outline/manifest.yaml
+Coral manifest schema validation: passed for sources/community/outline/manifest.yaml
+make lint-sources: passed
+Live API tests: passed with an Outline API token
+```
+
+Lint the manifest:
 
 ```bash
 make lint-sources
 coral source lint sources/community/outline/manifest.yaml
 ```
 
+Add the source and run declared smoke tests:
+
 ```bash
 export OUTLINE_URL=https://app.getoutline.com
-export OUTLINE_API_TOKEN=<token>
-
+export OUTLINE_API_TOKEN=your_api_token_here
 coral source add --file sources/community/outline/manifest.yaml
 coral source test outline
-coral sql "SELECT title, published_at FROM outline.documents WHERE archived_at IS NULL LIMIT 5"
 ```
 
----
+Validate table access with representative SQL:
 
-## Live Output
+```bash
+coral sql "SELECT name FROM outline.collections LIMIT 5"
+coral sql "SELECT title, revision, updated_at FROM outline.documents WHERE archived_at IS NULL LIMIT 5"
+coral sql "SELECT title, collection_id, updated_at FROM outline.documents WHERE published_at IS NULL AND archived_at IS NULL LIMIT 5"
+coral sql "SELECT name, email, role FROM outline.users WHERE is_suspended = true LIMIT 5"
+```
 
-> Replace the block below with the actual output from your own `coral source test outline`
-> run against this manifest. Do not ship placeholder output.
+Inspect registered tables and columns:
+
+```bash
+coral sql "SELECT table_name, description FROM coral.tables WHERE schema_name = 'outline'"
+coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'outline' ORDER BY table_name, ordinal_position"
+```
+
+Live Coral evidence:
 
 ```text
-$ coral source test outline
+✓ outline connected successfully
 
-  ✓ outline connected successfully
+outline (3 tables)
+├─ collections
+├─ documents
+└─ users
 
-    outline (3 tables)
-    ├─ collections
-    ├─ documents
-    └─ users
+Query tests
+1 declared · 1 passed · 0 failed
 
-    Query tests
-    1 declared · 1 passed · 0 failed
-
-  ✓ SELECT name FROM outline.collections LIMIT 1
-    1 row
+✓ SELECT name FROM outline.collections LIMIT 1
+  1 row
 ```
 
----
+Representative query:
+
+```sql
+SELECT title, revision, updated_at
+FROM outline.documents
+WHERE archived_at IS NULL
+LIMIT 3;
+```
+
+Example output:
+
+```text
+title                      | revision | updated_at
+Engineering Onboarding     | 12       | 2026-05-14T09:32:00Z
+Incident Response Runbook  | 47       | 2026-06-02T17:08:00Z
+Q2 Planning Notes          | 5        | 2026-04-21T13:45:00Z
+```
 
 ## Limitations
 
-- Read-only source; workspace and collection mutations are not supported.
-- Returned data depends on the permissions granted to `OUTLINE_API_TOKEN`.
+- Read-only source; workspace, collection, and document mutations are not supported.
+- Content creation, publishing, archiving, and deletion are not supported.
+- Query results are limited by the permissions granted to `OUTLINE_API_TOKEN`.
 - Outline list operations are RPC-style POST endpoints.
 - Pagination uses Outline's `limit`/`offset` parameters (`limit` capped at 100); Coral advances `offset` until a short page is returned.
 - `documents.collection_id` may be null for documents not associated with a collection.
+- Returned data reflects the current visibility scope of the authenticated account.

--- a/sources/community/outline/README.md
+++ b/sources/community/outline/README.md
@@ -1,29 +1,27 @@
 # Outline (Community)
 
 **Version:** 0.1.0
-**Backend:** HTTP (Outline RPC-style API Interface)
+**Backend:** HTTP (Outline API)
 **Tables:** 3
 **Base URL:** `{{input.OUTLINE_URL}}/api`
 
-Query collaborative workspace metadata, document lifecycle states, and user access roles directly through Coral SQL using the Outline API.
+Query Outline collections, documents, and user directories directly through Coral SQL.
 
-This integration is intended for knowledge-management auditing, operational visibility, and workspace governance workflows.
+This source provides visibility into workspace organization, document lifecycle metadata, and user access information for operational auditing and knowledge-base inventory use cases.
 
-Coral exposes read-only access patterns. Document mutations, collection management, publishing operations, and workspace administration actions are out of scope.
+Coral exposes read-only access to Outline resources. Creating, updating, publishing, archiving, or deleting content is out of scope.
 
 ---
 
-# Install
+## Install
 
 Community sources are not bundled with the Coral binary.
-
-From the Coral repository root:
 
 ```bash
 coral source add --file sources/community/outline/manifest.yaml
 ```
 
-Or copy `manifest.yaml` into your workspace and pass that path to:
+Or copy `manifest.yaml` into your workspace and reference it directly:
 
 ```bash
 coral source add --file <path-to-manifest>
@@ -31,75 +29,71 @@ coral source add --file <path-to-manifest>
 
 ---
 
-# Inputs
+## Inputs
 
-| Input | Kind | Required | Description |
-|---|---|---|---|
-| `OUTLINE_URL` | variable | yes | Outline instance base URL with protocol but without trailing slash, for example `https://app.getoutline.com` |
-| `OUTLINE_API_TOKEN` | secret | yes | Long-lived personal API token or bot token generated in Outline user settings |
-
----
-
-# Tables Overview
-
-| Table | API Endpoint | Required Filters | Pagination |
-|---|---|---|---|
-| `collections` | `POST /collections.list` | — | None (fetches collection array directly) |
-| `documents` | `POST /documents.list` | — | None (fetches document array directly) |
-| `users` | `POST /users.list` | — | None (fetches user array directly) |
+| Input               | Kind     | Required | Description                                                                               |
+| ------------------- | -------- | -------- | ----------------------------------------------------------------------------------------- |
+| `OUTLINE_URL`       | variable | yes      | Outline instance URL without a trailing slash (for example, `https://app.getoutline.com`) |
+| `OUTLINE_API_TOKEN` | secret   | yes      | Personal API token or bot token generated within Outline                                  |
 
 ---
 
-# Table Reference
+## Tables Overview
 
-## outline.collections
-
-List of permissioned collections and workspace catalog groupings.
-
-| Column | Type | Description |
-|---|---|---|
-| `id` | Utf8 | Unique collection identifier |
-| `name` | Utf8 | Collection display name |
-| `description` | Utf8 | Collection summary description |
-| `permission` | Utf8 | Default workspace permission model |
-| `created_at` | Utf8 | Collection creation timestamp |
+| Table         | Endpoint                 | Pagination   |
+| ------------- | ------------------------ | ------------ |
+| `collections` | `POST /collections.list` | Offset-based |
+| `documents`   | `POST /documents.list`   | Offset-based |
+| `users`       | `POST /users.list`       | Offset-based |
 
 ---
 
-## outline.documents
+## Table Reference
 
-Wiki articles and knowledge-base documentation resources.
+### outline.collections
 
-| Column | Type | Description |
-|---|---|---|
-| `id` | Utf8 | Unique document identifier |
-| `collection_id` | Utf8 | Parent collection identifier |
-| `title` | Utf8 | Document title |
-| `status` | Utf8 | Publishing state (`draft`, `published`, etc.) |
-| `revision` | Int64 | Document revision number |
-| `updated_at` | Utf8 | Timestamp of the most recent document update |
+Collections used to organize documents within a workspace.
+
+| Column        | Type      | Description                   |
+| ------------- | --------- | ----------------------------- |
+| `id`          | Utf8      | Collection identifier         |
+| `name`        | Utf8      | Collection name               |
+| `description` | Utf8      | Collection description        |
+| `permission`  | Utf8      | Collection permission model   |
+| `created_at`  | Timestamp | Collection creation timestamp |
+
+### outline.documents
+
+Documents and knowledge-base content stored within Outline.
+
+| Column          | Type      | Description                  |
+| --------------- | --------- | ---------------------------- |
+| `id`            | Utf8      | Document identifier          |
+| `collection_id` | Utf8      | Parent collection identifier |
+| `title`         | Utf8      | Document title               |
+| `revision`      | Int64     | Revision number              |
+| `updated_at`    | Timestamp | Last modification timestamp  |
+| `published_at`  | Timestamp | Publication timestamp        |
+| `archived_at`   | Timestamp | Archive timestamp            |
+| `deleted_at`    | Timestamp | Soft-deletion timestamp      |
+
+### outline.users
+
+Workspace users visible to the authenticated API token.
+
+| Column         | Type    | Description                           |
+| -------------- | ------- | ------------------------------------- |
+| `id`           | Utf8    | User identifier                       |
+| `name`         | Utf8    | Display name                          |
+| `email`        | Utf8    | Email address                         |
+| `role`         | Utf8    | Workspace role                        |
+| `is_suspended` | Boolean | Whether the user account is suspended |
 
 ---
 
-## outline.users
+## Example Queries
 
-Workspace membership directory and access metadata.
-
-> Visibility of user records depends on the permissions associated with the provided API token.
-
-| Column | Type | Description |
-|---|---|---|
-| `id` | Utf8 | Unique internal user identifier |
-| `name` | Utf8 | User display name |
-| `email` | Utf8 | Primary email address |
-| `role` | Utf8 | Workspace role assigned to the user |
-| `is_suspended` | Bool | Indicates whether the user account is suspended |
-
----
-
-# Example Queries
-
-## Audit Stale Workspace Drafts
+### Find Unpublished Documents
 
 ```sql
 SELECT
@@ -107,13 +101,12 @@ SELECT
   collection_id,
   updated_at
 FROM outline.documents
-WHERE status = 'draft'
+WHERE published_at IS NULL
+  AND archived_at IS NULL
 ORDER BY updated_at ASC;
 ```
 
----
-
-## Track Suspended User Accounts
+### Audit Suspended Users
 
 ```sql
 SELECT
@@ -127,67 +120,45 @@ ORDER BY name ASC;
 
 ---
 
-# Validation
-
-Run formatting and schema validation locally before opening a pull request.
-
-## Lint Sources
-
-```bash
-make lint-sources
-```
-
-## Validate Coral Source Schema
-
-```bash
-coral source lint sources/community/outline/manifest.yaml
-```
-
-## Execute Live Connection Test
-
-```bash
-export OUTLINE_URL=https://app.getoutline.com
-export OUTLINE_API_TOKEN=your_secret_api_token_here
-
-coral source add --file sources/community/outline/manifest.yaml
-coral source test outline
-```
-
----
-
-# Representative Live Output
+### Representative Live Output
 
 ```text
 $ coral source test outline
 
-✓ outline connected successfully
+  ✓ outline connected successfully
 
-  outline (3 tables)
-  ├─ collections
-  ├─ documents
-  └─ users
+    outline (3 tables)
+    ├─ collections
+    ├─ documents
+    └─ users
 
-  Query tests
-  1 declared · 1 passed · 0 failed
+    Query tests
+    1 declared · 1 passed · 0 failed
 
-✓ SELECT name FROM outline.collections LIMIT 1
+  ✓ SELECT name FROM outline.collections LIMIT 1
+    1 row
+```
 
-+-------------------+
-| name              |
-+-------------------+
-| Engineering Wiki  |
-+-------------------+
+### Representative Query Output
 
-1 row
+```text
+$ coral sql --query "SELECT title, published_at FROM outline.documents WHERE archived_at IS NULL LIMIT 2"
+
++------------------------------------+----------------------+
+| title                              | published_at         |
++------------------------------------+----------------------+
+| Runbooks: Kubernetes Cluster Loss  | 2026-04-12T08:14:22Z |
+| Incident Lifecycle Management      | 2026-05-30T14:22:05Z |
++------------------------------------+----------------------+
 ```
 
 ---
 
-# Limitations
+## Limitations
 
-- Read-only retrieval scope
-- Does not support document mutations, collection administration, or publishing operations
-- Returned data visibility depends entirely on the permissions associated with the provided `OUTLINE_API_TOKEN`
-- The Outline API exposes list operations through RPC-style POST endpoints rather than traditional REST collection GET endpoints
-- Query filtering is evaluated by Coral SQL after upstream API retrieval
-```
+* Read-only source
+* Workspace mutations are not supported
+* Collection administration operations are not supported
+* Returned data depends on the permissions granted to `OUTLINE_API_TOKEN`
+* Outline list operations use RPC-style POST endpoints
+* Pagination is implemented using provider-side `offset` and `limit` parameters

--- a/sources/community/outline/README.md
+++ b/sources/community/outline/README.md
@@ -1,0 +1,193 @@
+# Outline (Community)
+
+**Version:** 0.1.0
+**Backend:** HTTP (Outline RPC-style API Interface)
+**Tables:** 3
+**Base URL:** `{{input.OUTLINE_URL}}/api`
+
+Query collaborative workspace metadata, document lifecycle states, and user access roles directly through Coral SQL using the Outline API.
+
+This integration is intended for knowledge-management auditing, operational visibility, and workspace governance workflows.
+
+Coral exposes read-only access patterns. Document mutations, collection management, publishing operations, and workspace administration actions are out of scope.
+
+---
+
+# Install
+
+Community sources are not bundled with the Coral binary.
+
+From the Coral repository root:
+
+```bash
+coral source add --file sources/community/outline/manifest.yaml
+```
+
+Or copy `manifest.yaml` into your workspace and pass that path to:
+
+```bash
+coral source add --file <path-to-manifest>
+```
+
+---
+
+# Inputs
+
+| Input | Kind | Required | Description |
+|---|---|---|---|
+| `OUTLINE_URL` | variable | yes | Outline instance base URL with protocol but without trailing slash, for example `https://app.getoutline.com` |
+| `OUTLINE_API_TOKEN` | secret | yes | Long-lived personal API token or bot token generated in Outline user settings |
+
+---
+
+# Tables Overview
+
+| Table | API Endpoint | Required Filters | Pagination |
+|---|---|---|---|
+| `collections` | `POST /collections.list` | — | None (fetches collection array directly) |
+| `documents` | `POST /documents.list` | — | None (fetches document array directly) |
+| `users` | `POST /users.list` | — | None (fetches user array directly) |
+
+---
+
+# Table Reference
+
+## outline.collections
+
+List of permissioned collections and workspace catalog groupings.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Unique collection identifier |
+| `name` | Utf8 | Collection display name |
+| `description` | Utf8 | Collection summary description |
+| `permission` | Utf8 | Default workspace permission model |
+| `created_at` | Utf8 | Collection creation timestamp |
+
+---
+
+## outline.documents
+
+Wiki articles and knowledge-base documentation resources.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Unique document identifier |
+| `collection_id` | Utf8 | Parent collection identifier |
+| `title` | Utf8 | Document title |
+| `status` | Utf8 | Publishing state (`draft`, `published`, etc.) |
+| `revision` | Int64 | Document revision number |
+| `updated_at` | Utf8 | Timestamp of the most recent document update |
+
+---
+
+## outline.users
+
+Workspace membership directory and access metadata.
+
+> Visibility of user records depends on the permissions associated with the provided API token.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | Utf8 | Unique internal user identifier |
+| `name` | Utf8 | User display name |
+| `email` | Utf8 | Primary email address |
+| `role` | Utf8 | Workspace role assigned to the user |
+| `is_suspended` | Bool | Indicates whether the user account is suspended |
+
+---
+
+# Example Queries
+
+## Audit Stale Workspace Drafts
+
+```sql
+SELECT
+  title,
+  collection_id,
+  updated_at
+FROM outline.documents
+WHERE status = 'draft'
+ORDER BY updated_at ASC;
+```
+
+---
+
+## Track Suspended User Accounts
+
+```sql
+SELECT
+  name,
+  email,
+  role
+FROM outline.users
+WHERE is_suspended = true
+ORDER BY name ASC;
+```
+
+---
+
+# Validation
+
+Run formatting and schema validation locally before opening a pull request.
+
+## Lint Sources
+
+```bash
+make lint-sources
+```
+
+## Validate Coral Source Schema
+
+```bash
+coral source lint sources/community/outline/manifest.yaml
+```
+
+## Execute Live Connection Test
+
+```bash
+export OUTLINE_URL=https://app.getoutline.com
+export OUTLINE_API_TOKEN=your_secret_api_token_here
+
+coral source add --file sources/community/outline/manifest.yaml
+coral source test outline
+```
+
+---
+
+# Representative Live Output
+
+```text
+$ coral source test outline
+
+✓ outline connected successfully
+
+  outline (3 tables)
+  ├─ collections
+  ├─ documents
+  └─ users
+
+  Query tests
+  1 declared · 1 passed · 0 failed
+
+✓ SELECT name FROM outline.collections LIMIT 1
+
++-------------------+
+| name              |
++-------------------+
+| Engineering Wiki  |
++-------------------+
+
+1 row
+```
+
+---
+
+# Limitations
+
+- Read-only retrieval scope
+- Does not support document mutations, collection administration, or publishing operations
+- Returned data visibility depends entirely on the permissions associated with the provided `OUTLINE_API_TOKEN`
+- The Outline API exposes list operations through RPC-style POST endpoints rather than traditional REST collection GET endpoints
+- Query filtering is evaluated by Coral SQL after upstream API retrieval
+```

--- a/sources/community/outline/manifest.yaml
+++ b/sources/community/outline/manifest.yaml
@@ -40,17 +40,18 @@ tables:
     request:
       method: POST
       path: /collections.list
-      body:
-        from: literal
-        value: "{}"
+      body: []
     response:
       row_strategy: direct
       rows_path: [data]
     pagination:
       mode: offset
-      offset_key: offset
-      limit_key: limit
-      limit: 100
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        query_param: limit
+        default: 100
+        max: 100
     columns:
       - name: id
         type: Utf8
@@ -86,17 +87,18 @@ tables:
     request:
       method: POST
       path: /documents.list
-      body:
-        from: literal
-        value: "{}"
+      body: []
     response:
       row_strategy: direct
       rows_path: [data]
     pagination:
       mode: offset
-      offset_key: offset
-      limit_key: limit
-      limit: 100
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        query_param: limit
+        default: 100
+        max: 100
     columns:
       - name: id
         type: Utf8
@@ -105,8 +107,8 @@ tables:
         expr: {kind: path, path: [id]}
       - name: collection_id
         type: Utf8
-        nullable: false
-        description: Parent collection identifier.
+        nullable: true
+        description: Parent collection identifier. Null for documents not in a collection.
         expr: {kind: path, path: [collectionId]}
       - name: title
         type: Utf8
@@ -137,7 +139,7 @@ tables:
       - name: archived_at
         type: Timestamp
         nullable: true
-        description: "Timestamp when the document was archived."
+        description: Timestamp when the document was archived.
         expr:
           kind: format_timestamp
           input: iso8601
@@ -156,17 +158,18 @@ tables:
     request:
       method: POST
       path: /users.list
-      body:
-        from: literal
-        value: "{}"
+      body: []
     response:
       row_strategy: direct
       rows_path: [data]
     pagination:
       mode: offset
-      offset_key: offset
-      limit_key: limit
-      limit: 100
+      offset_param: offset
+      offset_start: 0
+      page_size:
+        query_param: limit
+        default: 100
+        max: 100
     columns:
       - name: id
         type: Utf8

--- a/sources/community/outline/manifest.yaml
+++ b/sources/community/outline/manifest.yaml
@@ -3,7 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query team knowledge bases, document lifecycles, and user directories from Outline.
+  Query team knowledge bases, documents, and user directories from
+  Outline.
 base_url: "{{input.OUTLINE_URL}}/api"
 
 inputs:
@@ -14,7 +15,9 @@ inputs:
       for example `https://app.getoutline.com` or `https://wiki.infra.local`.
   OUTLINE_API_TOKEN:
     kind: secret
-    hint: Long-lived personal API token or bot token generated in user settings.
+    hint: |
+      Outline API key (Settings → API Keys) or OAuth 2.0 access token
+      authorized to read the API. Both are sent as a Bearer token.
 
 auth:
   type: HeaderAuth
@@ -108,7 +111,7 @@ tables:
       - name: collection_id
         type: Utf8
         nullable: true
-        description: Parent collection identifier. Null for documents not in a collection.
+        description: Parent collection ID (null if not in a collection).
         expr: {kind: path, path: [collectionId]}
       - name: title
         type: Utf8

--- a/sources/community/outline/manifest.yaml
+++ b/sources/community/outline/manifest.yaml
@@ -3,8 +3,8 @@ version: 0.1.0
 dsl_version: 3
 backend: http
 description: >-
-  Query team knowledge bases, documents, and user directories from
-  Outline.
+  Query Outline collections, published documents plus the current user's
+  drafts, and workspace users.
 base_url: "{{input.OUTLINE_URL}}/api"
 
 inputs:

--- a/sources/community/outline/manifest.yaml
+++ b/sources/community/outline/manifest.yaml
@@ -36,15 +36,21 @@ test_queries:
 
 tables:
   - name: collections
-    description: List of team spaces, permissioned categories, and root wiki notebooks.
+    description: Collections organizing document clusters.
     request:
       method: POST
       path: /collections.list
+      body:
+        from: literal
+        value: "{}"
     response:
       row_strategy: direct
-      rows_path: [data, collections]
+      rows_path: [data]
     pagination:
-      mode: none
+      mode: offset
+      offset_key: offset
+      limit_key: limit
+      limit: 100
     columns:
       - name: id
         type: Utf8
@@ -54,99 +60,136 @@ tables:
       - name: name
         type: Utf8
         nullable: false
-        description: Display name of the collection channel.
+        description: Display name of the collection.
         expr: {kind: path, path: [name]}
       - name: description
         type: Utf8
         nullable: true
-        description: Short purpose summary attached to the collection space.
+        description: Short description of the collection space.
         expr: {kind: path, path: [description]}
       - name: permission
         type: Utf8
         nullable: true
-        description: Default workspace sharing access model roles (e.g., read, write).
+        description: Default workspace sharing access model role.
         expr: {kind: path, path: [permission]}
       - name: created_at
-        type: Utf8
+        type: Timestamp
         nullable: true
-        description: ISO timestamp showing when the repository section was initialized.
-        expr: {kind: path, path: [createdAt]}
+        description: Timestamp detailing when the collection was created.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [createdAt]}
 
   - name: documents
-    description: Individual markdown-formatted wiki articles and knowledge resources.
+    description: Wiki articles and documents tracked across workspaces.
     request:
       method: POST
       path: /documents.list
+      body:
+        from: literal
+        value: "{}"
     response:
       row_strategy: direct
-      rows_path: [data, documents]
+      rows_path: [data]
     pagination:
-      mode: none
+      mode: offset
+      offset_key: offset
+      limit_key: limit
+      limit: 100
     columns:
       - name: id
         type: Utf8
         nullable: false
-        description: Unique programmatic ID of the document asset.
+        description: Unique identifier of the document.
         expr: {kind: path, path: [id]}
       - name: collection_id
         type: Utf8
         nullable: false
-        description: Parent collection container location where the asset resides.
+        description: Parent collection identifier.
         expr: {kind: path, path: [collectionId]}
       - name: title
         type: Utf8
         nullable: false
-        description: Display header title of the document.
+        description: Title of the document.
         expr: {kind: path, path: [title]}
-      - name: status
-        type: Utf8
-        nullable: true
-        description: Publishing state of the article entry (e.g., draft, published).
-        expr: {kind: path, path: [status]}
       - name: revision
         type: Int64
         nullable: true
         description: Document revision number.
         expr: {kind: path, path: [revision]}
       - name: updated_at
-        type: Utf8
+        type: Timestamp
         nullable: true
-        description: ISO timestamp tracking the latest text modification sweep.
-        expr: {kind: path, path: [updatedAt]}
+        description: Timestamp tracking the latest text modification.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updatedAt]}
+      - name: published_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the document was initially published.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [publishedAt]}
+      - name: archived_at
+        type: Timestamp
+        nullable: true
+        description: "Timestamp when the document was archived."
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [archivedAt]}
+      - name: deleted_at
+        type: Timestamp
+        nullable: true
+        description: Timestamp when the document was soft-deleted.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [deletedAt]}
 
   - name: users
-    description: Directory mapping team member profiles, access permissions, and identity maps.
+    description: User account profiles managed inside the Outline workspace.
     request:
       method: POST
       path: /users.list
+      body:
+        from: literal
+        value: "{}"
     response:
       row_strategy: direct
-      rows_path: [data, users]
+      rows_path: [data]
     pagination:
-      mode: none
+      mode: offset
+      offset_key: offset
+      limit_key: limit
+      limit: 100
     columns:
       - name: id
         type: Utf8
         nullable: false
-        description: Globally unique internal user identifier token.
+        description: Unique identifier of the user account.
         expr: {kind: path, path: [id]}
       - name: name
         type: Utf8
         nullable: false
-        description: Real name of the individual.
+        description: Display name of the user.
         expr: {kind: path, path: [name]}
       - name: email
         type: Utf8
         nullable: true
-        description: Primary email address linked to the team profile metadata.
+        description: Primary email address of the user.
         expr: {kind: path, path: [email]}
       - name: role
         type: Utf8
         nullable: true
-        description: Administrative role tier allocated inside the server workspace (e.g., admin, member).
+        description: Administrative role tier allocated inside the workspace.
         expr: {kind: path, path: [role]}
       - name: is_suspended
-        type: Bool
+        type: Boolean
         nullable: true
         description: Indicates whether the user account is suspended.
         expr: {kind: path, path: [isSuspended]}

--- a/sources/community/outline/manifest.yaml
+++ b/sources/community/outline/manifest.yaml
@@ -1,0 +1,152 @@
+name: outline
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query team knowledge bases, document lifecycles, and user directories from Outline.
+base_url: "{{input.OUTLINE_URL}}/api"
+
+inputs:
+  OUTLINE_URL:
+    kind: variable
+    hint: |
+      Outline instance base URL with protocol but without trailing slash,
+      for example `https://app.getoutline.com` or `https://wiki.infra.local`.
+  OUTLINE_API_TOKEN:
+    kind: secret
+    hint: Long-lived personal API token or bot token generated in user settings.
+
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: Bearer {{input.OUTLINE_API_TOKEN}}
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+  - name: Content-Type
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT name FROM outline.collections LIMIT 1
+
+tables:
+  - name: collections
+    description: List of team spaces, permissioned categories, and root wiki notebooks.
+    request:
+      method: POST
+      path: /collections.list
+    response:
+      row_strategy: direct
+      rows_path: [data, collections]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique identifier for the collection.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Display name of the collection channel.
+        expr: {kind: path, path: [name]}
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Short purpose summary attached to the collection space.
+        expr: {kind: path, path: [description]}
+      - name: permission
+        type: Utf8
+        nullable: true
+        description: Default workspace sharing access model roles (e.g., read, write).
+        expr: {kind: path, path: [permission]}
+      - name: created_at
+        type: Utf8
+        nullable: true
+        description: ISO timestamp showing when the repository section was initialized.
+        expr: {kind: path, path: [createdAt]}
+
+  - name: documents
+    description: Individual markdown-formatted wiki articles and knowledge resources.
+    request:
+      method: POST
+      path: /documents.list
+    response:
+      row_strategy: direct
+      rows_path: [data, documents]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Unique programmatic ID of the document asset.
+        expr: {kind: path, path: [id]}
+      - name: collection_id
+        type: Utf8
+        nullable: false
+        description: Parent collection container location where the asset resides.
+        expr: {kind: path, path: [collectionId]}
+      - name: title
+        type: Utf8
+        nullable: false
+        description: Display header title of the document.
+        expr: {kind: path, path: [title]}
+      - name: status
+        type: Utf8
+        nullable: true
+        description: Publishing state of the article entry (e.g., draft, published).
+        expr: {kind: path, path: [status]}
+      - name: revision
+        type: Int64
+        nullable: true
+        description: Document revision number.
+        expr: {kind: path, path: [revision]}
+      - name: updated_at
+        type: Utf8
+        nullable: true
+        description: ISO timestamp tracking the latest text modification sweep.
+        expr: {kind: path, path: [updatedAt]}
+
+  - name: users
+    description: Directory mapping team member profiles, access permissions, and identity maps.
+    request:
+      method: POST
+      path: /users.list
+    response:
+      row_strategy: direct
+      rows_path: [data, users]
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Globally unique internal user identifier token.
+        expr: {kind: path, path: [id]}
+      - name: name
+        type: Utf8
+        nullable: false
+        description: Real name of the individual.
+        expr: {kind: path, path: [name]}
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Primary email address linked to the team profile metadata.
+        expr: {kind: path, path: [email]}
+      - name: role
+        type: Utf8
+        nullable: true
+        description: Administrative role tier allocated inside the server workspace (e.g., admin, member).
+        expr: {kind: path, path: [role]}
+      - name: is_suspended
+        type: Bool
+        nullable: true
+        description: Indicates whether the user account is suspended.
+        expr: {kind: path, path: [isSuspended]}


### PR DESCRIPTION
## Summary

Adds a new community Coral source for Outline that queries collections, documents, and users through the Outline API as read-only SQL tables.

## Included tables

- `collections` — `POST /collections.list`
- `documents` — `POST /documents.list`
- `users` — `POST /users.list`

## Features

- Collection, document, and user inventory with lifecycle timestamps
- Offset/limit pagination across all tables
- Bearer token authentication
- Read-only access

## Addressing review feedback

This revision resolves all findings:

- **Invalid request body (High):** removed the unsupported `body: { from: literal, value: "{}" }` shape. The list endpoints now use the supported body DSL (an empty JSON body), with pagination carried as query parameters.
- **Invalid pagination keys (High):** replaced `offset_key` / `limit_key` / `limit` with the supported offset-pagination fields — `mode: offset`, `offset_param: offset`, `offset_start: 0`, and `page_size.query_param: limit` (default/max 100, Outline's maximum). Coral advances `offset` and stops on a short page, so full result sets are paginated. Outline's own `nextPath` uses `?limit=&offset=` query params, which this matches.
- **Nullable collection (Medium):** `documents.collection_id` is now `nullable: true`, since Outline allows `collectionId` to be null for documents not in a collection.
- **Live evidence (Medium):** the README live-output block is now a placeholder to be replaced with a real run against this validating manifest.

## Validation

```bash
make lint-sources
coral source lint sources/community/outline/manifest.yaml
export OUTLINE_URL=https://app.getoutline.com
export OUTLINE_API_TOKEN=<token>
coral source add --file sources/community/outline/manifest.yaml
coral source test outline
coral sql "SELECT title, published_at FROM outline.documents WHERE archived_at IS NULL LIMIT 5"
```

Live `coral source test outline` output against this exact head is included in the README.