### PR TITLE
perf(engine): reuse default HTTP source client

### DIFF
--- a/crates/coral-engine/src/backends/common.rs
+++ b/crates/coral-engine/src/backends/common.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt::Write;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use crate::{QueryRuntimeContext, QuerySource, RequestAuthenticator, SourceInputResolver};
 use async_trait::async_trait;
@@ -135,15 +135,44 @@ pub(crate) struct BackendCompileRequest<'a> {
     pub(crate) source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
 }
 
+/// Shared resources available while registering one batch of compiled sources.
+///
+/// Every backend receives this context. Most backends ignore it today; HTTP uses
+/// it to share default transport setup across sources registered in the same
+/// runtime build.
+#[derive(Default)]
+pub(crate) struct BackendRegistrationContext {
+    default_http_client: OnceLock<Result<reqwest::Client, String>>,
+}
+
+impl BackendRegistrationContext {
+    pub(crate) fn default_http_client(
+        &self,
+        build_client: impl FnOnce() -> Result<reqwest::Client, String>,
+    ) -> Result<reqwest::Client, String> {
+        self.default_http_client
+            .get_or_init(build_client)
+            .as_ref()
+            .cloned()
+            .map_err(Clone::clone)
+    }
+}
+
 #[async_trait]
 pub(crate) trait CompiledBackendSource: Send + Sync {
     fn schema_name(&self) -> &str;
 
     fn source_name(&self) -> &str;
 
+    /// Register this compiled source into a `DataFusion` session.
+    ///
+    /// The registration context is batch-scoped and backend-agnostic. Backends
+    /// should use it only for resources that are safe to share across sources in
+    /// the same registration pass.
     async fn register(
         &self,
         ctx: &SessionContext,
+        registration: &BackendRegistrationContext,
     ) -> datafusion::error::Result<BackendRegistration>;
 }
 
@@ -359,4 +388,47 @@ pub(crate) fn schema_from_columns(
         ));
     }
     Ok(Arc::new(Schema::new(fields)))
+}
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[test]
+    fn default_http_client_is_shared_only_within_registration_context() {
+        let build_count = AtomicUsize::new(0);
+        let first_context = BackendRegistrationContext::default();
+
+        first_context
+            .default_http_client(|| build_counted_client(&build_count))
+            .expect("first context should build a client");
+        first_context
+            .default_http_client(|| build_counted_client(&build_count))
+            .expect("first context should reuse its client");
+
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            1,
+            "one registration context should build one default HTTP client"
+        );
+
+        let second_context = BackendRegistrationContext::default();
+        second_context
+            .default_http_client(|| build_counted_client(&build_count))
+            .expect("new context should build its own client");
+
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            2,
+            "default HTTP clients should not be process-global"
+        );
+    }
+
+    fn build_counted_client(build_count: &AtomicUsize) -> Result<reqwest::Client, String> {
+        build_count.fetch_add(1, Ordering::SeqCst);
+        reqwest::Client::builder()
+            .build()
+            .map_err(|error| error.to_string())
+    }
 }

--- a/crates/coral-engine/src/backends/file/mod.rs
+++ b/crates/coral-engine/src/backends/file/mod.rs
@@ -21,8 +21,8 @@ use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, build_registered_inputs, build_registered_table,
+    BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
+    RegisteredSource, RegisteredTable, build_registered_inputs, build_registered_table,
     registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
 };
 use coral_spec::backends::file::{FileFormat, FileSourceManifest, FileTableSpec};
@@ -74,7 +74,11 @@ impl CompiledBackendSource for FileCompiledSource {
         &self.manifest.common.name
     }
 
-    async fn register(&self, ctx: &SessionContext) -> Result<BackendRegistration> {
+    async fn register(
+        &self,
+        ctx: &SessionContext,
+        _registration: &BackendRegistrationContext,
+    ) -> Result<BackendRegistration> {
         let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
         let mut table_infos = Vec::with_capacity(self.manifest.tables.len());
         let resolved_inputs = coral_spec::resolve_inputs(

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use datafusion::error::{DataFusionError, Result};
 use serde_json::Value;
 
+use crate::backends::BackendRegistrationContext;
 use crate::backends::http::fetch::fetch_rows;
 use crate::backends::http::registration_checks::validate_source_scoped_http_config;
 use crate::backends::http::target::HttpFetchTarget;
@@ -37,6 +38,39 @@ pub(crate) struct HttpSourceClient {
     pub(super) body_capture: HttpBodyCapture,
 }
 
+pub(crate) struct HttpSourceClientRuntime {
+    source_input_resolution_context: Option<SourceInputResolutionContext>,
+    source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+    body_capture_max_bytes: Option<usize>,
+    http: reqwest::Client,
+}
+
+impl HttpSourceClientRuntime {
+    pub(crate) fn new(
+        source_input_resolution_context: SourceInputResolutionContext,
+        source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
+        body_capture_max_bytes: Option<usize>,
+        http: reqwest::Client,
+    ) -> Self {
+        Self {
+            source_input_resolution_context: Some(source_input_resolution_context),
+            source_input_resolver,
+            body_capture_max_bytes,
+            http,
+        }
+    }
+
+    #[cfg(test)]
+    fn static_inputs(body_capture_max_bytes: Option<usize>, http: reqwest::Client) -> Self {
+        Self {
+            source_input_resolution_context: None,
+            source_input_resolver: None,
+            body_capture_max_bytes,
+            http,
+        }
+    }
+}
+
 impl std::fmt::Debug for HttpSourceClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HttpSourceClient")
@@ -48,6 +82,25 @@ impl std::fmt::Debug for HttpSourceClient {
             .field("body_capture", &self.body_capture)
             .finish_non_exhaustive()
     }
+}
+
+pub(super) fn default_http_client(
+    registration: &BackendRegistrationContext,
+    source_name: &str,
+) -> Result<reqwest::Client> {
+    registration
+        .default_http_client(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS))
+                .user_agent(DEFAULT_HTTP_USER_AGENT)
+                .build()
+                .map_err(|error| error.to_string())
+        })
+        .map_err(|error| {
+            DataFusionError::Execution(format!(
+                "failed to build HTTP client for source '{source_name}': {error}"
+            ))
+        })
 }
 
 impl HttpSourceClient {
@@ -64,15 +117,14 @@ impl HttpSourceClient {
         source_variables: &BTreeMap<String, String>,
         request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
         body_capture_max_bytes: Option<usize>,
+        http: reqwest::Client,
     ) -> Result<Self> {
         Self::build(
             manifest,
             source_secrets,
             source_variables,
             request_authenticators,
-            None,
-            None,
-            body_capture_max_bytes,
+            HttpSourceClientRuntime::static_inputs(body_capture_max_bytes, http),
         )
     }
 
@@ -81,18 +133,14 @@ impl HttpSourceClient {
         source_secrets: &BTreeMap<String, String>,
         source_variables: &BTreeMap<String, String>,
         request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
-        source_input_resolution_context: SourceInputResolutionContext,
-        source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-        body_capture_max_bytes: Option<usize>,
+        runtime: HttpSourceClientRuntime,
     ) -> Result<Self> {
         Self::build(
             manifest,
             source_secrets,
             source_variables,
             request_authenticators,
-            Some(source_input_resolution_context),
-            source_input_resolver,
-            body_capture_max_bytes,
+            runtime,
         )
     }
 
@@ -101,39 +149,27 @@ impl HttpSourceClient {
         source_secrets: &BTreeMap<String, String>,
         source_variables: &BTreeMap<String, String>,
         request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
-        source_input_resolution_context: Option<SourceInputResolutionContext>,
-        source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
-        body_capture_max_bytes: Option<usize>,
+        runtime: HttpSourceClientRuntime,
     ) -> Result<Self> {
         let resolved_inputs =
             coral_spec::resolve_inputs(&manifest.declared_inputs, source_secrets, source_variables);
         validate_source_scoped_http_config(manifest, request_authenticators, &resolved_inputs)?;
 
         let request_timeout = Duration::from_secs(DEFAULT_HTTP_REQUEST_TIMEOUT_SECS);
-        let http = reqwest::Client::builder()
-            .timeout(request_timeout)
-            .user_agent(DEFAULT_HTTP_USER_AGENT)
-            .build()
-            .map_err(|error| {
-                DataFusionError::Execution(format!(
-                    "failed to build HTTP client for source '{}': {error}",
-                    manifest.common.name
-                ))
-            })?;
 
         Ok(Self {
-            http,
+            http: runtime.http,
             request_timeout,
             source_schema: manifest.common.name.clone(),
             base_url: manifest.base_url.clone(),
             auth: manifest.auth.clone(),
             request_headers: manifest.request_headers.clone(),
             request_authenticators: request_authenticators.clone(),
-            source_input_resolution_context,
-            source_input_resolver,
+            source_input_resolution_context: runtime.source_input_resolution_context,
+            source_input_resolver: runtime.source_input_resolver,
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
-            body_capture: HttpBodyCapture::new(body_capture_max_bytes),
+            body_capture: HttpBodyCapture::new(runtime.body_capture_max_bytes),
         })
     }
 

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -10,10 +10,10 @@ use datafusion::error::Result;
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, SourceTableFunctions, build_registered_inputs, build_registered_table,
-    build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
-    required_filter_names,
+    BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
+    RegisteredSource, RegisteredTable, SourceTableFunctions, build_registered_inputs,
+    build_registered_table, build_registered_table_function, internal_table_function_name,
+    registered_columns_from_specs, required_filter_names,
 };
 use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
@@ -35,7 +35,7 @@ mod trace;
 mod transport;
 mod url;
 
-pub(crate) use client::HttpSourceClient;
+pub(crate) use client::{HttpSourceClient, HttpSourceClientRuntime};
 pub(crate) use error::ProviderQueryError;
 pub(crate) use provider::HttpSourceTableProvider;
 
@@ -87,15 +87,24 @@ impl CompiledBackendSource for HttpCompiledSource {
         &self.manifest.common.name
     }
 
-    async fn register(&self, _ctx: &SessionContext) -> Result<BackendRegistration> {
+    async fn register(
+        &self,
+        _ctx: &SessionContext,
+        registration: &BackendRegistrationContext,
+    ) -> Result<BackendRegistration> {
+        let http = client::default_http_client(registration, &self.manifest.common.name)?;
+        let runtime = HttpSourceClientRuntime::new(
+            self.source_input_resolution.clone(),
+            self.source_input_resolver.clone(),
+            self.body_capture_max_bytes,
+            http,
+        );
         let backend = HttpSourceClient::from_manifest_with_source_input_resolver(
             &self.manifest,
             self.source_input_resolution.secrets(),
             self.source_input_resolution.variables(),
             &self.request_authenticators,
-            self.source_input_resolution.clone(),
-            self.source_input_resolver.clone(),
-            self.body_capture_max_bytes,
+            runtime,
         )?;
         let mut tables: HashMap<String, Arc<dyn TableProvider>> = HashMap::new();
         let mut table_infos = Vec::with_capacity(self.manifest.tables.len());

--- a/crates/coral-engine/src/backends/http/registration_checks.rs
+++ b/crates/coral-engine/src/backends/http/registration_checks.rs
@@ -190,11 +190,18 @@ fn validate_header_inputs(
 #[cfg(test)]
 mod tests {
     use std::collections::{BTreeMap, HashMap};
+    use std::sync::OnceLock;
 
     use serde_json::json;
 
     use crate::backends::http::client::HttpSourceClient;
     use crate::backends::http::test_support::parse_http_manifest;
+
+    static TEST_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+    fn test_http_client() -> reqwest::Client {
+        TEST_HTTP_CLIENT.get_or_init(reqwest::Client::new).clone()
+    }
 
     #[test]
     fn backend_client_requires_source_scoped_credentials() {
@@ -233,6 +240,7 @@ mod tests {
             &BTreeMap::new(),
             &HashMap::new(),
             None,
+            test_http_client(),
         )
         .expect_err("missing source-scoped credentials must fail");
 
@@ -274,6 +282,7 @@ mod tests {
             &BTreeMap::new(),
             &HashMap::new(),
             None,
+            test_http_client(),
         )
         .expect_err("missing table request path inputs must fail");
 
@@ -319,6 +328,7 @@ mod tests {
             &BTreeMap::new(),
             &HashMap::new(),
             None,
+            test_http_client(),
         )
         .expect_err("missing table request header inputs must fail");
 
@@ -364,6 +374,7 @@ mod tests {
             &BTreeMap::new(),
             &HashMap::new(),
             None,
+            test_http_client(),
         )
         .expect_err("missing table request query inputs must fail");
 
@@ -410,6 +421,7 @@ mod tests {
             &BTreeMap::new(),
             &HashMap::new(),
             None,
+            test_http_client(),
         )
         .expect_err("missing table request body inputs must fail");
 
@@ -456,6 +468,7 @@ mod tests {
             &BTreeMap::new(),
             &HashMap::new(),
             None,
+            test_http_client(),
         )
         .expect_err("missing request route inputs must fail");
 
@@ -549,6 +562,7 @@ mod tests {
                 &BTreeMap::new(),
                 &HashMap::new(),
                 None,
+                test_http_client(),
             )
             .expect_err(&format!(
                 "missing function request {name} input should fail"

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -24,8 +24,8 @@ use self::function::McpSourceTableFunction;
 use self::provider::McpTableProvider;
 use self::transport::StdioMcpToolCaller;
 use crate::backends::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    SourceTableFunctions, build_registered_inputs, build_registered_table,
+    BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
+    RegisteredSource, SourceTableFunctions, build_registered_inputs, build_registered_table,
     build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
     required_filter_names,
 };
@@ -137,6 +137,7 @@ impl CompiledBackendSource for McpCompiledSource {
     async fn register(
         &self,
         _ctx: &datafusion::prelude::SessionContext,
+        _registration: &BackendRegistrationContext,
     ) -> Result<BackendRegistration> {
         let mut table_functions =
             SourceTableFunctions::with_capacity(self.manifest.functions.len());

--- a/crates/coral-engine/src/backends/mod.rs
+++ b/crates/coral-engine/src/backends/mod.rs
@@ -75,11 +75,11 @@ use coral_spec::ValidatedSourceManifest;
 
 pub(crate) mod common;
 pub(crate) use common::{
-    BackendCompileRequest, BackendRegistration, CompiledBackendSource, RegisteredSource,
-    RegisteredTable, RegisteredTableFunction, SourceTableFunctions, build_registered_inputs,
-    build_registered_table, build_registered_table_function, internal_table_function_name,
-    registered_columns_from_schema, registered_columns_from_specs, required_filter_names,
-    schema_from_columns,
+    BackendCompileRequest, BackendRegistration, BackendRegistrationContext, CompiledBackendSource,
+    RegisteredSource, RegisteredTable, RegisteredTableFunction, SourceTableFunctions,
+    build_registered_inputs, build_registered_table, build_registered_table_function,
+    internal_table_function_name, registered_columns_from_schema, registered_columns_from_specs,
+    required_filter_names, schema_from_columns,
 };
 
 pub(crate) mod file;

--- a/crates/coral-engine/src/runtime/registry.rs
+++ b/crates/coral-engine/src/runtime/registry.rs
@@ -6,7 +6,8 @@ use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::prelude::SessionContext;
 
 use crate::backends::{
-    BackendRegistration, CompiledBackendSource, RegisteredSource, SourceTableFunctions,
+    BackendRegistration, BackendRegistrationContext, CompiledBackendSource, RegisteredSource,
+    SourceTableFunctions,
 };
 use crate::runtime::error::{datafusion_to_core, source_decorator_error_to_core};
 use crate::runtime::schema_provider::StaticSchemaProvider;
@@ -91,6 +92,7 @@ pub(crate) async fn register_sources(
 
     let mut result = SourceRegistrationResult::default();
     let mut seen_schemas = std::collections::HashSet::new();
+    let registration_context = BackendRegistrationContext::default();
 
     for source in sources {
         match source {
@@ -100,7 +102,14 @@ pub(crate) async fn register_sources(
                 let schema_name = compiled_source.schema_name().to_string();
                 let source_name = compiled_source.source_name().to_string();
 
-                match register_source(ctx, &mut seen_schemas, compiled_source.as_ref()).await {
+                match register_source(
+                    ctx,
+                    &registration_context,
+                    &mut seen_schemas,
+                    compiled_source.as_ref(),
+                )
+                .await
+                {
                     Ok(registration) => {
                         let BackendRegistration {
                             tables,
@@ -190,6 +199,7 @@ pub(crate) fn register_sources_blocking(
 
 async fn register_source(
     ctx: &SessionContext,
+    registration_context: &BackendRegistrationContext,
     seen_schemas: &mut std::collections::HashSet<String>,
     source: &dyn CompiledBackendSource,
 ) -> DataFusionResult<BackendRegistration> {
@@ -202,7 +212,7 @@ async fn register_source(
         )));
     }
 
-    source.register(ctx).await
+    source.register(ctx, registration_context).await
 }
 
 fn push_source_failure(


### PR DESCRIPTION
## Intent

Second PR in the catalog cold-start stack. This builds on #962 by removing the remaining repeated default HTTP transport setup during source registration.

#962 narrows request-input state so HTTP/MCP registration no longer clones full source manifests. This PR leaves that contract alone and changes only the default HTTP client lifecycle.

## What changed

- Added a batch-scoped `BackendRegistrationContext` shared across one runtime registration pass.
- Reused one default `reqwest::Client` for HTTP sources registered in that pass.
- Kept source-specific HTTP config, auth, headers, rate limits, resolved inputs, request-input refresh, and body-capture settings per source.
- Added a focused registration-context test proving the default HTTP client is shared within one registration pass but not process-global.

## Ownership / Boundaries

- `coral-engine` owns this because source registration and backend runtime construction live in the engine.
- The registration context is backend-agnostic. Every backend receives it; HTTP uses it today, while file and MCP ignore it.
- The shared client is batch-scoped, not global. A new runtime registration pass gets a new context and therefore a new default client.
- This only shares the default transport client. It does not merge source auth, resolved inputs, headers, rate limits, request-input resolver state, or source metadata.
- No proto, gRPC, CLI, MCP tool schema, source manifest schema, or persisted config shape changes.

## Compatibility / User Impact

This reduces cold metadata latency and also improves real HTTP endpoint queries, because both paths pay runtime/source registration before returning metadata or executing a provider request.

This assumes the current HTTP source manifest contract: sources do not declare per-source proxy, custom TLS roots, client certificates, timeout, or user-agent settings. If that contract grows later, the registration context is the seam where the client cache key should become configuration-aware.

## Timing

Five fresh-process MCP repeats using the real local Coral manifest. Each repeat does `initialize`, `tools/list`, then the target `tools/call`. The table reports target `tools/call` wall time.

| Build | `list_catalog` avg | `search_catalog limit=5` avg | `sql github.issues LIMIT 1` avg | Notes |
| --- | ---: | ---: | ---: | --- |
| Current main closest baseline (`72ad33dc`) | `2312.664 ms` | `2325.554 ms` | `2997.436 ms` | Closest comparable pre-stack main run. |
| #962 only (`16087f2c` + #962) | `855.819 ms` | `853.521 ms` | `1616.908 ms` | Removes the post-#764 manifest clone cost. |
| This PR stacked on #962 (`b632fd5f`) | `257.712 ms` | `270.592 ms` | `902.318 ms` | Reuses one default HTTP client per registration pass. |
| Incremental improvement vs #962 | `-598.107 ms` / `3.32x faster` | `-582.929 ms` / `3.15x faster` | `-714.590 ms` / `1.79x faster` | This PR's isolated contribution. |
| Combined improvement vs current main | `-2054.952 ms` / `8.97x faster` | `-2054.962 ms` / `8.59x faster` | `-2095.118 ms` / `3.32x faster` | Stack effect from #962 + this PR. |

Interpretation: #962 removes the source-manifest clone regression. This PR removes the older repeated `reqwest::Client` / native TLS setup cost by doing the default client build once per registration batch instead of once per HTTP source.

## Not in this PR

- Per-source/custom HTTP transport configuration. There is no source manifest surface for that today.
- Global process-wide HTTP client caching.
- Credential refresh or request-input resolver behavior changes. Those stay in #962's `SourceInputContext` contract.

## Validation

- `cargo fmt --check`
- `cargo clippy -p coral-engine --all-targets --all-features --locked -- -D warnings`
- `cargo test -p coral-engine --lib backends::common::tests::default_http_client_is_shared_only_within_registration_context --locked`
- Fresh 5-repeat MCP timing run recorded in `/tmp/coral_shared_stacked_repeats.log`