### PR TITLE
docs(sources/community/openrouter): update provider docs links

### DIFF
--- a/sources/community/openrouter/README.md
+++ b/sources/community/openrouter/README.md
@@ -64,14 +64,14 @@ queries bounded and small.
 
 ## Provider docs
 
-- OpenRouter API reference: https://openrouter.ai/docs/api-reference/overview
-- Authentication: https://openrouter.ai/docs/api-reference/authentication
-- List models: https://openrouter.ai/docs/api-reference/list-available-models
-- Get current key: https://openrouter.ai/docs/api-reference/get-current-api-key
-- Chat completions: https://openrouter.ai/docs/api-reference/chat-completion
-- Embeddings: https://openrouter.ai/docs/api-reference/create-embedding
-- List embedding models: https://openrouter.ai/docs/api-reference/list-embedding-models
-- Rate limits and credits: https://openrouter.ai/docs/api-reference/limits
+- OpenRouter API reference: https://openrouter.ai/docs/api/reference/overview
+- Authentication: https://openrouter.ai/docs/api/reference/authentication
+- List models: https://openrouter.ai/docs/api/api-reference/models/get-models
+- Get current key: https://openrouter.ai/docs/api/api-reference/api-keys/get-current-key
+- Chat completions: https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request
+- Embeddings: https://openrouter.ai/docs/api/api-reference/embeddings/create-embeddings
+- List embedding models: https://openrouter.ai/docs/api/api-reference/embeddings/list-embeddings-models
+- Rate limits and credits: https://openrouter.ai/docs/api/reference/limits
 
 ## Tables
 


### PR DESCRIPTION
﻿## Summary

Updates the OpenRouter provider documentation links in the community source README after OpenRouter moved several API reference pages.

## What changed

Updated the `Provider docs` block in `sources/community/openrouter/README.md`:

- OpenRouter API reference:
  - from `https://openrouter.ai/docs/api-reference/overview`
  - to `https://openrouter.ai/docs/api/reference/overview`
- Authentication:
  - from `https://openrouter.ai/docs/api-reference/authentication`
  - to `https://openrouter.ai/docs/api/reference/authentication`
- List models:
  - from `https://openrouter.ai/docs/api-reference/list-available-models`
  - to `https://openrouter.ai/docs/api/api-reference/models/get-models`
- Get current key:
  - from `https://openrouter.ai/docs/api-reference/get-current-api-key`
  - to `https://openrouter.ai/docs/api/api-reference/api-keys/get-current-key`
- Chat completions:
  - from `https://openrouter.ai/docs/api-reference/chat-completion`
  - to `https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request`
- Embeddings:
  - from `https://openrouter.ai/docs/api-reference/create-embedding`
  - to `https://openrouter.ai/docs/api/api-reference/embeddings/create-embeddings`
- List embedding models:
  - from `https://openrouter.ai/docs/api-reference/list-embedding-models`
  - to `https://openrouter.ai/docs/api/api-reference/embeddings/list-embeddings-models`
- Rate limits and credits:
  - from `https://openrouter.ai/docs/api-reference/limits`
  - to `https://openrouter.ai/docs/api/reference/limits`

This is README-only cleanup; the OpenRouter source manifest and behavior are unchanged.

## Validation

Docs-only change. Verified the updated OpenRouter links open successfully.
