### PR TITLE
feat(sources/community/cloudtrail): add AWS CloudTrail source

### DIFF
--- a/sources/community/cloudtrail/README.md
+++ b/sources/community/cloudtrail/README.md
@@ -1,0 +1,146 @@
+# AWS CloudTrail
+
+Query AWS management events via
+[AWS CloudTrail LookupEvents](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_LookupEvents.html).
+Captures every AWS API call that creates, modifies, or deletes a resource —
+regardless of whether the caller used CloudFormation, Terraform, CDK, GitHub
+Actions, the AWS CLI, or the console.
+
+The 90-day event history is available in every AWS account where CloudTrail is
+enabled (default since 2019) with no additional setup or S3 log access required.
+
+## Authentication
+
+AWS CloudTrail uses AWS Signature Version 4. You need an IAM user with
+the `cloudtrail:LookupEvents` permission.
+
+### Step 1 — Create an IAM policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["cloudtrail:LookupEvents"],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+### Step 2 — Create access keys
+
+Attach the policy to an IAM user and generate an access key pair.
+
+### Step 3 — Add the source
+
+```sh
+export AWS_ACCESS_KEY_ID="AKIA..."
+export AWS_SECRET_ACCESS_KEY="..."
+export AWS_REGION="us-east-1"
+coral source add --file sources/community/cloudtrail/manifest.yaml
+```
+
+## Tables
+
+| Table | Description | Required filters |
+|---|---|---|
+| `cloudtrail.management_events` | All write-only management events across all AWS services | `start_time`, `end_time` |
+| `cloudtrail.lambda_events` | Lambda function events (UpdateFunctionConfiguration, UpdateFunctionCode, GetFunction, etc.) — filter by event_name for writes only | `start_time`, `end_time` |
+| `cloudtrail.cloudformation_events` | CloudFormation stack events (UpdateStack, ExecuteChangeSet, DescribeStacks, etc.) — filter by event_name for mutations only | `start_time`, `end_time` |
+| `cloudtrail.ec2_events` | EC2 instance events (RunInstances, ModifyInstanceAttribute, DescribeInstances, etc.) — filter by event_name for mutations only | `start_time`, `end_time` |
+
+All time filters are **Unix epoch seconds** (Int64).
+
+## Example queries
+
+### Find all infrastructure changes in the last 24 hours
+
+```sql
+SELECT event_name, event_source, resource_name, username, event_time
+FROM cloudtrail.management_events
+WHERE start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '24 hours') AS BIGINT)
+  AND end_time   = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT)
+ORDER BY event_time DESC
+LIMIT 50
+```
+
+### Find Lambda changes near a specific time (for cost spike investigation)
+
+```sql
+SELECT event_name, resource_name, username, event_time, cloudtrail_event
+FROM cloudtrail.lambda_events
+WHERE start_time = 1715558400
+  AND end_time   = 1715644800
+ORDER BY event_time DESC
+```
+
+### Find CloudFormation deployments and correlate with GitHub PRs
+
+```sql
+SELECT
+    ct.resource_name  AS stack_name,
+    ct.event_name     AS operation,
+    ct.event_time     AS deploy_time,
+    ct.username       AS deployed_by,
+    g.number          AS pr_number,
+    g.title           AS pr_title,
+    g.author_login    AS pr_author,
+    g.merged_at
+FROM cloudtrail.cloudformation_events ct
+JOIN github.pulls g
+    ON g.merged_at <= ct.event_time
+    AND g.merged_at >= ct.event_time - INTERVAL '30 minutes'
+    AND g.owner = 'your-org'
+    AND g.repo = 'your-repo'
+    AND g.state = 'closed'
+WHERE ct.start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '30 days') AS BIGINT)
+  AND ct.end_time   = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT)
+  AND ct.event_name IN ('UpdateStack', 'ExecuteChangeSet', 'CreateStack')
+ORDER BY ct.event_time DESC
+```
+
+### Inspect what changed (e.g. Lambda memory)
+
+```sql
+SELECT
+    resource_name,
+    event_time,
+    username,
+    json_get_json(cloudtrail_event, 'requestParameters') AS request_params
+FROM cloudtrail.lambda_events
+WHERE start_time = 1715558400
+  AND end_time   = 1715644800
+  AND event_name = 'UpdateFunctionConfiguration'
+```
+
+### Find new EC2 instances and correlate with cost
+
+```sql
+SELECT event_name, resource_name, username, event_time
+FROM cloudtrail.ec2_events
+WHERE start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '30 days') AS BIGINT)
+  AND end_time   = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT)
+  AND event_name = 'RunInstances'
+ORDER BY event_time DESC
+```
+
+## Notes
+
+- **`management_events` is the only write-only table:** It uses `ReadOnly=false` as its single LookupAttribute. The LookupEvents API accepts only one attribute per request, so the service-scoped tables (`lambda_events`, `cloudformation_events`, `ec2_events`) use `EventSource` as their filter and return both read and write operations. Use `WHERE event_name IN (...)` in your query to restrict to mutations.
+- **Time filters are Unix epoch seconds:** Convert with
+  `CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '30 days') AS BIGINT)`.
+- **90-day retention:** LookupEvents only returns events from the last 90 days.
+  For older data, query CloudTrail logs in S3 via Athena.
+- **Rate limit:** 2 requests per second per account per region. Queries that paginate
+  through many pages may hit this limit.
+- **CloudTrail must be enabled:** Most accounts have CloudTrail enabled by
+  default. If not, events will be empty rather than returning an error.
+- **`cloudtrail_event` is a JSON column:** Use `json_get_json` to extract nested
+  objects like `requestParameters`. Use `json_get_str` for scalar string fields.
+  The `requestParameters` object shows what values were set. The
+  `clientRequestToken` field (when set by CI/CD) can be a direct foreign key to
+  the commit or PR that triggered the change: `json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken')`.
+- **Region matters:** Each region has its own CloudTrail event history. Query
+  the region where your resources are deployed.

--- a/sources/community/cloudtrail/README.md
+++ b/sources/community/cloudtrail/README.md
@@ -1,10 +1,15 @@
 # AWS CloudTrail
 
-Query AWS management events via
+Query AWS management event history via
 [AWS CloudTrail LookupEvents](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_LookupEvents.html).
-Captures every AWS API call that creates, modifies, or deletes a resource —
-regardless of whether the caller used CloudFormation, Terraform, CDK, GitHub
-Actions, the AWS CLI, or the console.
+Covers the last 90 days of management (control-plane) events — API calls that
+create, modify, or delete resources — regardless of whether the caller used
+CloudFormation, Terraform, CDK, GitHub Actions, the AWS CLI, or the console.
+
+**Scope:** LookupEvents returns management events only. Data events (S3 object
+reads/writes, Lambda invocations, etc.) and network activity events are not
+available here; those require a Trail with the appropriate event selectors
+and are typically queried via S3 + Athena or CloudTrail Lake.
 
 The 90-day event history is available in every AWS account where CloudTrail is
 enabled (default since 2019) with no additional setup or S3 log access required.
@@ -46,26 +51,16 @@ coral source add --file sources/community/cloudtrail/manifest.yaml
 
 | Table | Description | Filters |
 |---|---|---|
-| `cloudtrail.management_events` | All write-only management events across all AWS services | `start_time`, `end_time` (optional, default last 24 hours) |
-| `cloudtrail.lambda_events` | Lambda function events (UpdateFunctionConfiguration, UpdateFunctionCode, GetFunction, etc.) — filter by event_name for writes only | `start_time`, `end_time` (optional, default last 24 hours) |
-| `cloudtrail.cloudformation_events` | CloudFormation stack events (UpdateStack, ExecuteChangeSet, DescribeStacks, etc.) — filter by event_name for mutations only | `start_time`, `end_time` (optional, default last 24 hours) |
-| `cloudtrail.ec2_events` | EC2 instance events (RunInstances, ModifyInstanceAttribute, DescribeInstances, etc.) — filter by event_name for mutations only | `start_time`, `end_time` (optional, default last 24 hours) |
+| `cloudtrail.management_events` | Write-only management events across all AWS services (ReadOnly=false) | `start_time`, `end_time` (optional; when omitted AWS scans the full 90-day window) |
+| `cloudtrail.lambda_events` | Lambda function events — includes read and write; filter by `event_name` or `read_only = 'false'` for writes | `start_time`, `end_time` (optional; when omitted AWS scans the full 90-day window) |
+| `cloudtrail.cloudformation_events` | CloudFormation stack events — includes read and write; filter by `event_name` or `read_only = 'false'` for mutations | `start_time`, `end_time` (optional; when omitted AWS scans the full 90-day window) |
+| `cloudtrail.ec2_events` | EC2 events — includes read and write; filter by `event_name` or `read_only = 'false'` for mutations | `start_time`, `end_time` (optional; when omitted AWS scans the full 90-day window) |
 
-All time filters are **Unix epoch seconds** (Int64). When omitted, `start_time` defaults to
-24 hours ago and `end_time` defaults to the current time.
+All time filters are **Unix epoch seconds** (Int64). When omitted, AWS uses its own defaults: `start_time` falls back to the earliest event within the last 90 days, `end_time` falls back to the current time. **Always supply explicit `start_time` and `end_time` values** — omitting them causes the effective window to differ between the initial request and each subsequent NextToken page, which can invalidate pagination.
 
 ## Example queries
 
-### Find all infrastructure changes in the last 24 hours (using default window)
-
-```sql
-SELECT event_name, event_source, resource_name, username, event_time
-FROM cloudtrail.management_events
-ORDER BY event_time DESC
-LIMIT 50
-```
-
-### Find all infrastructure changes in a custom time window
+### Find all infrastructure changes in the last 24 hours
 
 ```sql
 SELECT event_name, event_source, resource_name, username, event_time
@@ -79,8 +74,9 @@ LIMIT 50
 ### Find Lambda changes in the last 24 hours (for cost spike investigation)
 
 Use a rolling window. CloudTrail's `LookupEvents` only returns events from the
-last 90 days, so absolute epoch timestamps will silently age out — keep the
-filter relative to `NOW()`.
+last 90 days. A time range that falls entirely outside the 90-day window
+returns an empty result (not an error), so events simply age out silently —
+keep the filter relative to `NOW()` to stay within bounds.
 
 ```sql
 SELECT event_name, resource_name, username, event_time, cloudtrail_event
@@ -142,17 +138,21 @@ ORDER BY event_time DESC
 
 ## Notes
 
-- **`management_events` is the only write-only table:** It uses `ReadOnly=false` as its single LookupAttribute. The LookupEvents API accepts only one attribute per request, so the service-scoped tables (`lambda_events`, `cloudformation_events`, `ec2_events`) use `EventSource` as their filter and return both read and write operations. Use `WHERE event_name IN (...)` in your query to restrict to mutations.
+- **`management_events` is the only write-only table:** It uses `ReadOnly=false` as its single LookupAttribute. The LookupEvents API accepts only one attribute per request, so the service-scoped tables (`lambda_events`, `cloudformation_events`, `ec2_events`) use `EventSource` as their filter and return both read and write operations. Use `WHERE event_name IN (...)` or `WHERE read_only = 'false'` in your query to restrict to mutations.
+- **`event_name` and `read_only` filters are post-fetch (client-side):** For the service-scoped tables, the `EventSource` filter is the only server-side filter. Any `WHERE event_name` or `WHERE read_only` clause is applied locally after Coral retrieves results. In high-volume accounts the 5,000-event cap (100 pages × 50) may be reached on reads before the target mutations are fetched — narrow the time window if you need complete mutation coverage.
+- **Always supply explicit time filters:** Omitting `start_time` and `end_time` lets AWS choose the window, and that window is resolved independently on the initial request and on every NextToken page. This can cause `InvalidNextTokenException` or silently shift the result set mid-pagination. Use `CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '24 hours') AS BIGINT)` and pin both values.
 - **Time filters are Unix epoch seconds:** Convert with
   `CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '30 days') AS BIGINT)`.
 - **90-day retention:** LookupEvents only returns events from the last 90 days.
   For older data, query CloudTrail logs in S3 via Athena.
+- **`InvalidTimeRangeException`:** AWS returns HTTP 400 if `start_time` is after `end_time`, or if the timestamps are otherwise outside the range of values AWS accepts. A valid window that simply falls outside the 90-day retention period is **not** an error — it returns an empty result and ages out silently. Use rolling `NOW()`-relative expressions and keep `start_time` before `end_time`.
 - **Rate limit:** 2 requests per second per account per region. Queries that paginate
   through many pages may hit this limit.
 - **5,000-event cap:** Pagination is capped at 100 pages × 50 results = 5,000 events per query.
   For high-traffic accounts or wide time windows this limit can be hit silently — no error is
   returned, results simply stop at 5,000. Narrow the time window (e.g. query day-by-day) to
   stay under the cap.
+- **Management events only:** LookupEvents covers management (control-plane) events only. Data events (S3 object reads/writes, Lambda invocations, DynamoDB item operations, etc.) and network activity events are not returned here. For data events, enable a Trail with the appropriate event selectors and query via S3 + Athena or CloudTrail Lake.
 - **CloudTrail must be enabled:** Most accounts have CloudTrail enabled by
   default. If not, events will be empty rather than returning an error.
 - **`cloudtrail_event` is a JSON column:** Use `json_get_json` to extract nested
@@ -164,5 +164,12 @@ ORDER BY event_time DESC
   `GetSigninToken`, and service-linked role creation do not target a specific
   resource. For these, the `Resources` array is empty and `resource_name` and
   `resource_type` will be `null` — this is expected behavior, not a query error.
+- **Only the first resource is surfaced as a column:** `resource_name` and
+  `resource_type` map the first entry of the event's `Resources` array
+  (`Resources[0]`). Some events reference several resources — for example
+  `CreateDefaultVpcResourceCreation` can list a VPC's subnets, route tables,
+  and gateways together. To see every referenced resource, read the full
+  array with `json_get_json(cloudtrail_event, 'resources')` rather than
+  relying on the single `resource_name`/`resource_type` columns.
 - **Region matters:** Each region has its own CloudTrail event history. Query
   the region where your resources are deployed.

--- a/sources/community/cloudtrail/README.md
+++ b/sources/community/cloudtrail/README.md
@@ -76,13 +76,17 @@ ORDER BY event_time DESC
 LIMIT 50
 ```
 
-### Find Lambda changes near a specific time (for cost spike investigation)
+### Find Lambda changes in the last 24 hours (for cost spike investigation)
+
+Use a rolling window. CloudTrail's `LookupEvents` only returns events from the
+last 90 days, so absolute epoch timestamps will silently age out — keep the
+filter relative to `NOW()`.
 
 ```sql
 SELECT event_name, resource_name, username, event_time, cloudtrail_event
 FROM cloudtrail.lambda_events
-WHERE start_time = 1715558400
-  AND end_time   = 1715644800
+WHERE start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '24 hours') AS BIGINT)
+  AND end_time   = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT)
 ORDER BY event_time DESC
 ```
 
@@ -120,8 +124,8 @@ SELECT
     username,
     json_get_json(cloudtrail_event, 'requestParameters') AS request_params
 FROM cloudtrail.lambda_events
-WHERE start_time = 1715558400
-  AND end_time   = 1715644800
+WHERE start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '7 days') AS BIGINT)
+  AND end_time   = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT)
   AND event_name = 'UpdateFunctionConfiguration'
 ```
 

--- a/sources/community/cloudtrail/README.md
+++ b/sources/community/cloudtrail/README.md
@@ -139,19 +139,23 @@ ORDER BY event_time DESC
 ## Notes
 
 - **`management_events` is the only write-only table:** It uses `ReadOnly=false` as its single LookupAttribute. The LookupEvents API accepts only one attribute per request, so the service-scoped tables (`lambda_events`, `cloudformation_events`, `ec2_events`) use `EventSource` as their filter and return both read and write operations. Use `WHERE event_name IN (...)` or `WHERE read_only = 'false'` in your query to restrict to mutations.
-- **`event_name` and `read_only` filters are post-fetch (client-side):** For the service-scoped tables, the `EventSource` filter is the only server-side filter. Any `WHERE event_name` or `WHERE read_only` clause is applied locally after Coral retrieves results. In high-volume accounts the 5,000-event cap (100 pages × 50) may be reached on reads before the target mutations are fetched — narrow the time window if you need complete mutation coverage.
+- **`event_name` and `read_only` filters are post-fetch (client-side):** For the service-scoped tables, the `EventSource` filter is the only server-side filter. Any `WHERE event_name` or `WHERE read_only` clause is applied locally after Coral retrieves results. The 500-event cap (10 pages × 50) may be reached on reads before the target mutations are fetched — narrow the time window if you need complete mutation coverage.
 - **Always supply explicit time filters:** Omitting `start_time` and `end_time` lets AWS choose the window, and that window is resolved independently on the initial request and on every NextToken page. This can cause `InvalidNextTokenException` or silently shift the result set mid-pagination. Use `CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '24 hours') AS BIGINT)` and pin both values.
 - **Time filters are Unix epoch seconds:** Convert with
   `CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '30 days') AS BIGINT)`.
 - **90-day retention:** LookupEvents only returns events from the last 90 days.
   For older data, query CloudTrail logs in S3 via Athena.
 - **`InvalidTimeRangeException`:** AWS returns HTTP 400 if `start_time` is after `end_time`, or if the timestamps are otherwise outside the range of values AWS accepts. A valid window that simply falls outside the 90-day retention period is **not** an error — it returns an empty result and ages out silently. Use rolling `NOW()`-relative expressions and keep `start_time` before `end_time`.
-- **Rate limit:** 2 requests per second per account per region. Queries that paginate
-  through many pages may hit this limit.
-- **5,000-event cap:** Pagination is capped at 100 pages × 50 results = 5,000 events per query.
-  For high-traffic accounts or wide time windows this limit can be hit silently — no error is
-  returned, results simply stop at 5,000. Narrow the time window (e.g. query day-by-day) to
-  stay under the cap.
+- **Rate limit (no auto-retry):** LookupEvents is limited to 2 requests per second
+  per account per region. CloudTrail returns `ThrottlingException` as an HTTP **400**
+  (not 429), and Coral's rate-limit retry path only triggers on 429, so a throttled
+  page surfaces as a hard query error rather than being retried. There is no
+  inter-request pacing between pages, so keep time windows narrow to avoid bursts.
+- **500-event cap:** Pagination is capped at 10 pages × 50 results = 500 events per query.
+  This deliberately low cap keeps a single scan well under the 2 req/s throttling limit.
+  If a query needs more than 500 events, Coral stops with a pagination error rather than
+  returning a partial result — narrow the time window (e.g. query day-by-day) and page
+  through smaller windows.
 - **Management events only:** LookupEvents covers management (control-plane) events only. Data events (S3 object reads/writes, Lambda invocations, DynamoDB item operations, etc.) and network activity events are not returned here. For data events, enable a Trail with the appropriate event selectors and query via S3 + Athena or CloudTrail Lake.
 - **CloudTrail must be enabled:** Most accounts have CloudTrail enabled by
   default. If not, events will be empty rather than returning an error.

--- a/sources/community/cloudtrail/README.md
+++ b/sources/community/cloudtrail/README.md
@@ -178,8 +178,13 @@ ORDER BY event_time DESC
   regional copy — `coral source add` rejects a custom name when `--file` is
   used. To query another region, change `AWS_REGION` and re-add, or maintain
   separate workspaces per region.
-- **Global-service events live in us-east-1:** As of November 22, 2021, AWS
-  records IAM, AWS STS, and CloudFront events in the Region where they occur,
-  which is `us-east-1`. Use `AWS_REGION=us-east-1` when you are looking for
-  identity, access-key, IAM policy, or CloudFront changes; other regions will
-  not surface them.
+- **Global-service events (IAM / CloudFront) live in us-east-1:** As of
+  November 22, 2021, AWS records IAM and CloudFront events in the Region where
+  they occur, which is `us-east-1`. Use `AWS_REGION=us-east-1` when you are
+  looking for identity, access-key, IAM policy, or CloudFront changes; other
+  regions will not surface them.
+- **AWS STS events depend on the endpoint:** Calls to the global STS endpoint
+  (`sts.amazonaws.com`) are recorded in `us-east-1`, while calls to a regional
+  STS endpoint (e.g. `sts.us-west-2.amazonaws.com`) are recorded in that
+  region. Query the region matching the endpoint your workloads use; if you
+  rely on regional STS endpoints, `us-east-1` alone will miss those events.

--- a/sources/community/cloudtrail/README.md
+++ b/sources/community/cloudtrail/README.md
@@ -44,18 +44,28 @@ coral source add --file sources/community/cloudtrail/manifest.yaml
 
 ## Tables
 
-| Table | Description | Required filters |
+| Table | Description | Filters |
 |---|---|---|
-| `cloudtrail.management_events` | All write-only management events across all AWS services | `start_time`, `end_time` |
-| `cloudtrail.lambda_events` | Lambda function events (UpdateFunctionConfiguration, UpdateFunctionCode, GetFunction, etc.) — filter by event_name for writes only | `start_time`, `end_time` |
-| `cloudtrail.cloudformation_events` | CloudFormation stack events (UpdateStack, ExecuteChangeSet, DescribeStacks, etc.) — filter by event_name for mutations only | `start_time`, `end_time` |
-| `cloudtrail.ec2_events` | EC2 instance events (RunInstances, ModifyInstanceAttribute, DescribeInstances, etc.) — filter by event_name for mutations only | `start_time`, `end_time` |
+| `cloudtrail.management_events` | All write-only management events across all AWS services | `start_time`, `end_time` (optional, default last 24 hours) |
+| `cloudtrail.lambda_events` | Lambda function events (UpdateFunctionConfiguration, UpdateFunctionCode, GetFunction, etc.) — filter by event_name for writes only | `start_time`, `end_time` (optional, default last 24 hours) |
+| `cloudtrail.cloudformation_events` | CloudFormation stack events (UpdateStack, ExecuteChangeSet, DescribeStacks, etc.) — filter by event_name for mutations only | `start_time`, `end_time` (optional, default last 24 hours) |
+| `cloudtrail.ec2_events` | EC2 instance events (RunInstances, ModifyInstanceAttribute, DescribeInstances, etc.) — filter by event_name for mutations only | `start_time`, `end_time` (optional, default last 24 hours) |
 
-All time filters are **Unix epoch seconds** (Int64).
+All time filters are **Unix epoch seconds** (Int64). When omitted, `start_time` defaults to
+24 hours ago and `end_time` defaults to the current time.
 
 ## Example queries
 
-### Find all infrastructure changes in the last 24 hours
+### Find all infrastructure changes in the last 24 hours (using default window)
+
+```sql
+SELECT event_name, event_source, resource_name, username, event_time
+FROM cloudtrail.management_events
+ORDER BY event_time DESC
+LIMIT 50
+```
+
+### Find all infrastructure changes in a custom time window
 
 ```sql
 SELECT event_name, event_source, resource_name, username, event_time
@@ -86,7 +96,7 @@ SELECT
     ct.username       AS deployed_by,
     g.number          AS pr_number,
     g.title           AS pr_title,
-    g.author_login    AS pr_author,
+    g.user__login     AS pr_author,
     g.merged_at
 FROM cloudtrail.cloudformation_events ct
 JOIN github.pulls g
@@ -135,6 +145,10 @@ ORDER BY event_time DESC
   For older data, query CloudTrail logs in S3 via Athena.
 - **Rate limit:** 2 requests per second per account per region. Queries that paginate
   through many pages may hit this limit.
+- **5,000-event cap:** Pagination is capped at 100 pages × 50 results = 5,000 events per query.
+  For high-traffic accounts or wide time windows this limit can be hit silently — no error is
+  returned, results simply stop at 5,000. Narrow the time window (e.g. query day-by-day) to
+  stay under the cap.
 - **CloudTrail must be enabled:** Most accounts have CloudTrail enabled by
   default. If not, events will be empty rather than returning an error.
 - **`cloudtrail_event` is a JSON column:** Use `json_get_json` to extract nested
@@ -142,5 +156,9 @@ ORDER BY event_time DESC
   The `requestParameters` object shows what values were set. The
   `clientRequestToken` field (when set by CI/CD) can be a direct foreign key to
   the commit or PR that triggered the change: `json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken')`.
+- **Empty `resource_name` on some events:** Events like `ConsoleLogin`,
+  `GetSigninToken`, and service-linked role creation do not target a specific
+  resource. For these, the `Resources` array is empty and `resource_name` and
+  `resource_type` will be `null` — this is expected behavior, not a query error.
 - **Region matters:** Each region has its own CloudTrail event history. Query
   the region where your resources are deployed.

--- a/sources/community/cloudtrail/README.md
+++ b/sources/community/cloudtrail/README.md
@@ -171,5 +171,15 @@ ORDER BY event_time DESC
   and gateways together. To see every referenced resource, read the full
   array with `json_get_json(cloudtrail_event, 'resources')` rather than
   relying on the single `resource_name`/`resource_type` columns.
-- **Region matters:** Each region has its own CloudTrail event history. Query
-  the region where your resources are deployed.
+- **One region per workspace:** Each region has its own CloudTrail event
+  history. This source queries the single region in `AWS_REGION`. The source
+  name is fixed as `cloudtrail`, so re-adding the manifest with a different
+  `AWS_REGION` **replaces** the existing source rather than creating a second
+  regional copy — `coral source add` rejects a custom name when `--file` is
+  used. To query another region, change `AWS_REGION` and re-add, or maintain
+  separate workspaces per region.
+- **Global-service events live in us-east-1:** As of November 22, 2021, AWS
+  records IAM, AWS STS, and CloudFront events in the Region where they occur,
+  which is `us-east-1`. Use `AWS_REGION=us-east-1` when you are looking for
+  identity, access-key, IAM policy, or CloudFront changes; other regions will
+  not surface them.

--- a/sources/community/cloudtrail/manifest.yaml
+++ b/sources/community/cloudtrail/manifest.yaml
@@ -21,9 +21,11 @@ inputs:
       resources are deployed. To switch regions, change AWS_REGION and re-add
       the source; because the source name is fixed as `cloudtrail`, re-adding
       replaces the existing source rather than creating a second regional copy.
-      Global-service events (IAM, AWS STS, CloudFront) are recorded in
-      us-east-1, so use us-east-1 to find identity, access-key, policy, or
-      CloudFront changes.
+      Global-service events for IAM and CloudFront are recorded in us-east-1,
+      so use us-east-1 to find identity, access-key, policy, or CloudFront
+      changes. AWS STS events depend on the endpoint: global-endpoint
+      (sts.amazonaws.com) calls land in us-east-1, while regional-endpoint
+      calls are recorded in that region.
       Common values: us-east-1, us-west-2, eu-west-1, eu-central-1,
       ap-southeast-1, ap-northeast-1.
   AWS_ENDPOINT_SUFFIX:

--- a/sources/community/cloudtrail/manifest.yaml
+++ b/sources/community/cloudtrail/manifest.yaml
@@ -3,11 +3,13 @@ name: cloudtrail
 version: 0.1.0
 backend: http
 description: >-
-  Query AWS CloudTrail management events via LookupEvents. Captures every AWS
-  API call that creates, modifies, or deletes a resource — regardless of
-  whether CloudFormation, Terraform, CDK, GitHub Actions, or manual CLI/console
-  was used. Useful for correlating infrastructure changes with code commits
-  and cost spikes.
+  Query AWS CloudTrail management event history via LookupEvents. Covers the
+  last 90 days of management (control-plane) events — API calls that create,
+  modify, or delete resources — across all services in the queried region.
+  Data events (S3 object reads/writes, Lambda invocations) and network
+  activity events are not available through LookupEvents; those require a
+  Trail with the appropriate event selectors. Useful for correlating
+  infrastructure changes with code commits and cost spikes.
 inputs:
   AWS_REGION:
     kind: variable
@@ -60,12 +62,22 @@ test_queries:
   - SELECT event_name, resource_name, event_time FROM cloudtrail.lambda_events LIMIT 5
 tables:
   - name: management_events
-    description: Write-only AWS management events returned by LookupEvents, covering resource creation, modification, and deletion across all services.
+    description: >-
+      Write management events returned by LookupEvents with ReadOnly=false,
+      across all services. AWS classifies these broadly: most are resource
+      create/modify/delete calls, but the set also includes non-mutating write
+      events such as ConsoleLogin and GetSigninToken.
     guide: >
       start_time and end_time are optional Unix epoch seconds. When omitted,
-      start_time defaults to 24 hours ago and end_time defaults to now.
-      LookupEvents retains 90 days of history. ReadOnly is hardcoded to false
-      so only mutating calls are returned. Rate limit is 2 requests per second
+      AWS defaults to the earliest available event within the last 90 days for
+      start_time and the current time for end_time. LookupEvents retains 90
+      days of history. ReadOnly is hardcoded to false, so AWS returns its set
+      of write events — mostly resource mutations, but also non-mutating writes
+      such as ConsoleLogin and GetSigninToken. Supply explicit start_time and
+      end_time on every query —
+      omitting them causes the effective window to vary between the initial
+      request and each NextToken page, which can invalidate pagination or
+      silently shift the result window. Rate limit is 2 requests per second
       per account per region. Queries are capped at 5,000 events (100 pages x
       50 results); narrow the time window if your account exceeds this in the
       requested period. Use json_get_json(cloudtrail_event,
@@ -81,14 +93,8 @@ tables:
           from: literal
           value: "false"
         - path: [StartTime]
-          from: now_epoch_minus_seconds
-          seconds: 86400
-        - path: [StartTime]
           from: filter_int
           key: start_time
-        - path: [EndTime]
-          from: now_epoch_minus_seconds
-          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -107,13 +113,15 @@ tables:
         type: Int64
         nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
+        description: >-
+          Start time filter (Unix epoch seconds). Supply an explicit value;
+          omitting it can cause the effective window to shift between pages.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
         nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
+        description: End time filter (Unix epoch seconds). When omitted, AWS uses the current time. Supply an explicit value for stable pagination.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -153,12 +161,18 @@ tables:
       - name: resource_type
         type: Utf8
         nullable: true
-        description: AWS resource type of the primary affected resource, e.g. 'AWS::Lambda::Function', 'AWS::CloudFormation::Stack'.
+        description: >-
+          AWS resource type of the first resource in the event's Resources
+          array, e.g. 'AWS::Lambda::Function', 'AWS::CloudFormation::Stack'.
+          See cloudtrail_event for events that reference several resources.
         expr: {kind: path, path: [Resources, "0", ResourceType]}
       - name: resource_name
         type: Utf8
         nullable: true
-        description: Name or ARN of the primary affected resource.
+        description: >-
+          Name or ARN of the first resource in the event's Resources array.
+          See cloudtrail_event for the full list when an event touches several
+          resources.
         expr: {kind: path, path: [Resources, "0", ResourceName]}
       - name: cloudtrail_event
         type: Json
@@ -167,25 +181,31 @@ tables:
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
+        description: Event window start as Unix epoch seconds. Supply explicit values for stable pagination.
       - name: end_time
-        description: Event window end as Unix epoch seconds. Defaults to now.
+        description: Event window end as Unix epoch seconds. Supply explicit values for stable pagination.
 
   - name: lambda_events
     description: Lambda function events returned by LookupEvents, scoped to 'lambda.amazonaws.com'. Includes both read and write operations.
     guide: >
       start_time and end_time are optional Unix epoch seconds. When omitted,
-      start_time defaults to 24 hours ago and end_time defaults to now.
-      Returns all Lambda API calls — including read-only ones such as
-      GetFunction and ListFunctions. The LookupEvents API accepts only one
-      LookupAttribute per request, so ReadOnly=false cannot be combined with
-      the EventSource filter. To restrict to write operations, add WHERE
+      AWS defaults to the earliest available event within the last 90 days for
+      start_time and the current time for end_time. Supply explicit values on
+      every query — omitting them causes the effective window to vary between
+      the initial request and each NextToken page, which can invalidate
+      pagination or silently shift the result window. Returns all Lambda API
+      calls — including read-only ones such as GetFunction and ListFunctions.
+      The LookupEvents API accepts only one LookupAttribute per request, so
+      ReadOnly=false cannot be combined with the EventSource filter. The
+      EventSource filter is applied server-side; any further filtering by
+      event_name or read_only happens client-side after Coral receives the
+      results. In high-volume accounts the 5,000-event cap (100 pages x 50)
+      may be reached before all target mutations are fetched — narrow the time
+      window to stay under the cap. To restrict to write operations, add WHERE
       event_name IN ('CreateFunction', 'UpdateFunctionCode',
-      'UpdateFunctionConfiguration', 'DeleteFunction') in your query. Queries
-      are capped at 5,000 events (100 pages x 50 results); narrow the time
-      window if your account exceeds this in the requested period. Use
-      json_get_json(cloudtrail_event, 'requestParameters') to see what
-      configuration changed.
+      'UpdateFunctionConfiguration', 'DeleteFunction') or WHERE
+      read_only = 'false' in your query. Use json_get_json(cloudtrail_event,
+      'requestParameters') to see what configuration changed.
     request:
       method: POST
       path: /
@@ -197,14 +217,8 @@ tables:
           from: literal
           value: lambda.amazonaws.com
         - path: [StartTime]
-          from: now_epoch_minus_seconds
-          seconds: 86400
-        - path: [StartTime]
           from: filter_int
           key: start_time
-        - path: [EndTime]
-          from: now_epoch_minus_seconds
-          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -223,13 +237,15 @@ tables:
         type: Int64
         nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
+        description: >-
+          Start time filter (Unix epoch seconds). Supply an explicit value;
+          omitting it can cause the effective window to shift between pages.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
         nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
+        description: End time filter (Unix epoch seconds). When omitted, AWS uses the current time. Supply an explicit value for stable pagination.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -278,29 +294,45 @@ tables:
         nullable: true
         description: AWS resource type, e.g. 'AWS::Lambda::Function'.
         expr: {kind: path, path: [Resources, "0", ResourceType]}
+      - name: read_only
+        type: Utf8
+        nullable: true
+        description: >-
+          Whether the event is a read or write operation. 'true' = read-only,
+          'false' = write. Null when the service does not classify the event.
+        expr: {kind: path, path: [ReadOnly]}
       - name: cloudtrail_event
         type: Json
         nullable: true
-        description: Full CloudTrail event JSON. Use json_get_json(cloudtrail_event, 'requestParameters') to inspect configuration changes.
+        description: >-
+          Full CloudTrail event JSON. Use json_get_json(cloudtrail_event,
+          'requestParameters') to inspect configuration changes.
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
+        description: Event window start as Unix epoch seconds. Supply explicit values for stable pagination.
       - name: end_time
-        description: Event window end as Unix epoch seconds. Defaults to now.
+        description: Event window end as Unix epoch seconds. Supply explicit values for stable pagination.
 
   - name: cloudformation_events
     description: CloudFormation events returned by LookupEvents, scoped to 'cloudformation.amazonaws.com'. Includes both read and write operations.
     guide: >
       start_time and end_time are optional Unix epoch seconds. When omitted,
-      start_time defaults to 24 hours ago and end_time defaults to now.
-      Returns all CloudFormation API calls including read-only ones. The
-      LookupEvents API accepts only one LookupAttribute per request, so
-      ReadOnly=false cannot be combined with the EventSource filter. To
-      restrict to deployments, add WHERE event_name IN ('CreateStack',
-      'UpdateStack', 'DeleteStack', 'ExecuteChangeSet') in your query. Queries
-      are capped at 5,000 events (100 pages x 50 results); narrow the time
-      window if your account exceeds this in the requested period. Check
+      AWS defaults to the earliest available event within the last 90 days for
+      start_time and the current time for end_time. Supply explicit values on
+      every query — omitting them causes the effective window to vary between
+      the initial request and each NextToken page, which can invalidate
+      pagination or silently shift the result window. Returns all
+      CloudFormation API calls including read-only ones. The LookupEvents API
+      accepts only one LookupAttribute per request, so ReadOnly=false cannot
+      be combined with the EventSource filter. The EventSource filter is
+      applied server-side; any further filtering by event_name or read_only
+      happens client-side after Coral receives the results. In high-volume
+      accounts the 5,000-event cap (100 pages x 50) may be reached before all
+      target mutations are fetched — narrow the time window to stay under the
+      cap. To restrict to deployments, add WHERE event_name IN ('CreateStack',
+      'UpdateStack', 'DeleteStack', 'ExecuteChangeSet') or WHERE
+      read_only = 'false' in your query. Check
       json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken')
       — CI/CD pipelines that set this to the commit SHA give you a direct
       foreign key to the triggering PR without a time-window join.
@@ -315,14 +347,8 @@ tables:
           from: literal
           value: cloudformation.amazonaws.com
         - path: [StartTime]
-          from: now_epoch_minus_seconds
-          seconds: 86400
-        - path: [StartTime]
           from: filter_int
           key: start_time
-        - path: [EndTime]
-          from: now_epoch_minus_seconds
-          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -341,13 +367,15 @@ tables:
         type: Int64
         nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
+        description: >-
+          Start time filter (Unix epoch seconds). Supply an explicit value;
+          omitting it can cause the effective window to shift between pages.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
         nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
+        description: End time filter (Unix epoch seconds). When omitted, AWS uses the current time. Supply an explicit value for stable pagination.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -395,33 +423,49 @@ tables:
         nullable: true
         description: AWS resource type, e.g. 'AWS::CloudFormation::Stack'.
         expr: {kind: path, path: [Resources, "0", ResourceType]}
+      - name: read_only
+        type: Utf8
+        nullable: true
+        description: >-
+          Whether the event is a read or write operation. 'true' = read-only,
+          'false' = write. Null when the service does not classify the event.
+        expr: {kind: path, path: [ReadOnly]}
       - name: cloudtrail_event
         type: Json
         nullable: true
-        description: Full CloudTrail event JSON. Inspect json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken') for a CI/CD-supplied commit SHA or PR foreign key.
+        description: >-
+          Full CloudTrail event JSON. Inspect
+          json_get_str(cloudtrail_event, 'requestParameters',
+          'clientRequestToken') for a CI/CD commit SHA or PR foreign key.
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
+        description: Event window start as Unix epoch seconds. Supply explicit values for stable pagination.
       - name: end_time
-        description: Event window end as Unix epoch seconds. Defaults to now.
+        description: Event window end as Unix epoch seconds. Supply explicit values for stable pagination.
 
   - name: ec2_events
     description: EC2 events returned by LookupEvents, scoped to 'ec2.amazonaws.com'. Includes both read and write operations.
     guide: >
       start_time and end_time are optional Unix epoch seconds. When omitted,
-      start_time defaults to 24 hours ago and end_time defaults to now.
-      Returns all EC2 API calls including read-only ones such as
-      DescribeInstances. The LookupEvents API accepts only one LookupAttribute
-      per request, so ReadOnly=false cannot be combined with the EventSource
-      filter. To restrict to instance lifecycle changes, add WHERE event_name
-      IN ('RunInstances', 'TerminateInstances', 'StartInstances',
-      'StopInstances', 'ModifyInstanceAttribute') in your query. Queries are
-      capped at 5,000 events (100 pages x 50 results); narrow the time window
-      if your account exceeds this in the requested period. Only
-      management (control-plane) events are available here — data events
-      require a Trail with data event logging enabled and are not returned by
-      LookupEvents.
+      AWS defaults to the earliest available event within the last 90 days for
+      start_time and the current time for end_time. Supply explicit values on
+      every query — omitting them causes the effective window to vary between
+      the initial request and each NextToken page, which can invalidate
+      pagination or silently shift the result window. Returns all EC2 API
+      calls including read-only ones such as DescribeInstances. The
+      LookupEvents API accepts only one LookupAttribute per request, so
+      ReadOnly=false cannot be combined with the EventSource filter. The
+      EventSource filter is applied server-side; any further filtering by
+      event_name or read_only happens client-side after Coral receives the
+      results. In high-volume accounts the 5,000-event cap (100 pages x 50)
+      may be reached before all target mutations are fetched — narrow the time
+      window to stay under the cap. To restrict to instance lifecycle changes,
+      add WHERE event_name IN ('RunInstances', 'TerminateInstances',
+      'StartInstances', 'StopInstances', 'ModifyInstanceAttribute') or WHERE
+      read_only = 'false' in your query. Only management (control-plane)
+      events are available here — data events require a Trail with data event
+      logging enabled and are not returned by LookupEvents.
     request:
       method: POST
       path: /
@@ -433,14 +477,8 @@ tables:
           from: literal
           value: ec2.amazonaws.com
         - path: [StartTime]
-          from: now_epoch_minus_seconds
-          seconds: 86400
-        - path: [StartTime]
           from: filter_int
           key: start_time
-        - path: [EndTime]
-          from: now_epoch_minus_seconds
-          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -459,13 +497,15 @@ tables:
         type: Int64
         nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
+        description: >-
+          Start time filter (Unix epoch seconds). Supply an explicit value;
+          omitting it can cause the effective window to shift between pages.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
         nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
+        description: End time filter (Unix epoch seconds). When omitted, AWS uses the current time. Supply an explicit value for stable pagination.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -511,15 +551,25 @@ tables:
       - name: resource_type
         type: Utf8
         nullable: true
-        description: AWS resource type, e.g. 'AWS::EC2::Instance', 'AWS::EC2::Volume'.
+        description: >-
+          AWS resource type, e.g. 'AWS::EC2::Instance', 'AWS::EC2::Volume'.
         expr: {kind: path, path: [Resources, "0", ResourceType]}
+      - name: read_only
+        type: Utf8
+        nullable: true
+        description: >-
+          Whether the event is a read or write operation. 'true' = read-only,
+          'false' = write. Null when the service does not classify the event.
+        expr: {kind: path, path: [ReadOnly]}
       - name: cloudtrail_event
         type: Json
         nullable: true
-        description: Full CloudTrail event JSON. Use json_get_json(cloudtrail_event, 'requestParameters') to inspect launch parameters for RunInstances events.
+        description: >-
+          Full CloudTrail event JSON. Use json_get_json(cloudtrail_event,
+          'requestParameters') to inspect launch parameters for RunInstances.
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
+        description: Event window start as Unix epoch seconds. Supply explicit values for stable pagination.
       - name: end_time
-        description: Event window end as Unix epoch seconds. Defaults to now.
+        description: Event window end as Unix epoch seconds. Supply explicit values for stable pagination.

--- a/sources/community/cloudtrail/manifest.yaml
+++ b/sources/community/cloudtrail/manifest.yaml
@@ -1,0 +1,477 @@
+dsl_version: 3
+name: cloudtrail
+version: 0.1.0
+backend: http
+description: >-
+  Query AWS CloudTrail management events via LookupEvents. Captures every AWS
+  API call that creates, modifies, or deletes a resource — regardless of
+  whether CloudFormation, Terraform, CDK, GitHub Actions, or manual CLI/console
+  was used. Useful for correlating infrastructure changes with code commits
+  and cost spikes.
+inputs:
+  AWS_REGION:
+    kind: variable
+    default: us-east-1
+    hint: |
+      AWS region for CloudTrail API requests. CloudTrail is regional — each
+      region maintains its own independent event history. Query the region
+      where your resources are deployed. To cover multiple regions, add this
+      source once per region with a different AWS_REGION value.
+      Common values: us-east-1, us-west-2, eu-west-1, eu-central-1,
+      ap-southeast-1, ap-northeast-1.
+  AWS_ENDPOINT_SUFFIX:
+    kind: variable
+    default: amazonaws.com
+    hint: |
+      AWS endpoint DNS suffix. Keep `amazonaws.com` for standard AWS
+      regions. Use the appropriate suffix for GovCloud or China regions.
+  AWS_ACCESS_KEY_ID:
+    kind: secret
+    hint: |
+      AWS access key ID with `cloudtrail:LookupEvents` read permission.
+      This is a read-only permission that does not grant access to log content
+      stored in S3 — only the 90-day management event history.
+  AWS_SECRET_ACCESS_KEY:
+    kind: secret
+    hint: |
+      AWS secret access key paired with `AWS_ACCESS_KEY_ID`.
+      Coral does not read your AWS CLI profile, AWS SSO cache, or
+      `AWS_PROFILE` at query time for this source.
+base_url: https://cloudtrail.{{input.AWS_REGION}}.{{input.AWS_ENDPOINT_SUFFIX}}
+auth:
+  type: CustomAuth
+  authenticator: aws_sigv4
+  service: cloudtrail
+  region: "{{input.AWS_REGION}}"
+  access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
+  secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
+request_headers:
+  - name: Content-Type
+    from: literal
+    value: application/x-amz-json-1.1
+  - name: X-Amz-Target
+    from: literal
+    value: com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.LookupEvents
+test_queries:
+  - >-
+    SELECT event_name, username, event_time
+    FROM cloudtrail.management_events
+    WHERE start_time = 1779898731
+    AND end_time = 1779985131
+    LIMIT 5
+  - >-
+    SELECT event_name, resource_name, event_time
+    FROM cloudtrail.lambda_events
+    WHERE start_time = 1779898731
+    AND end_time = 1779985131
+    LIMIT 5
+tables:
+  - name: management_events
+    description: Write-only AWS management events returned by LookupEvents, covering resource creation, modification, and deletion across all services.
+    guide: >
+      Requires start_time and end_time as Unix epoch seconds. LookupEvents
+      retains 90 days of history. ReadOnly is hardcoded to false so only
+      mutating calls are returned. Rate limit is 2 requests per second per
+      account per region. Use json_get_json(cloudtrail_event,
+      'requestParameters') to inspect what changed.
+    request:
+      method: POST
+      path: /
+      body:
+        - path: [LookupAttributes, "0", AttributeKey]
+          from: literal
+          value: ReadOnly
+        - path: [LookupAttributes, "0", AttributeValue]
+          from: literal
+          value: "false"
+        - path: [StartTime]
+          from: filter_int
+          key: start_time
+        - path: [EndTime]
+          from: filter_int
+          key: end_time
+        - path: [MaxResults]
+          from: literal
+          value: 50
+    response:
+      rows_path: [Events]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: start_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Start time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: start_time}
+      - name: end_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: End time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: end_time}
+      - name: event_id
+        type: Utf8
+        nullable: true
+        description: Unique CloudTrail event ID.
+        expr: {kind: path, path: [EventId]}
+      - name: event_name
+        type: Utf8
+        nullable: true
+        description: AWS API operation name, e.g. 'CreateBucket', 'CreateFunction', 'RunInstances'.
+        expr: {kind: path, path: [EventName]}
+      - name: event_time
+        type: Timestamp
+        nullable: true
+        description: When the API call was made (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [EventTime]}
+      - name: event_source
+        type: Utf8
+        nullable: true
+        description: >-
+          AWS service that received the call, e.g. 'lambda.amazonaws.com',
+          'cloudformation.amazonaws.com', 'ec2.amazonaws.com'.
+        expr: {kind: path, path: [EventSource]}
+      - name: username
+        type: Utf8
+        nullable: true
+        description: IAM entity that made the call — username, role name, or 'root'.
+        expr: {kind: path, path: [Username]}
+      - name: access_key_id
+        type: Utf8
+        nullable: true
+        description: Access key ID used for the call.
+        expr: {kind: path, path: [AccessKeyId]}
+      - name: resource_type
+        type: Utf8
+        nullable: true
+        description: AWS resource type of the primary affected resource, e.g. 'AWS::Lambda::Function', 'AWS::CloudFormation::Stack'.
+        expr: {kind: path, path: [Resources, "0", ResourceType]}
+      - name: resource_name
+        type: Utf8
+        nullable: true
+        description: Name or ARN of the primary affected resource.
+        expr: {kind: path, path: [Resources, "0", ResourceName]}
+      - name: cloudtrail_event
+        type: Json
+        nullable: true
+        description: Full CloudTrail event JSON. Use json_get_json(cloudtrail_event, 'requestParameters') to inspect what changed.
+        expr: {kind: path, path: [CloudTrailEvent]}
+    filters:
+      - name: start_time
+        required: true
+        description: Event window start as Unix epoch seconds, e.g. 1715644800.
+      - name: end_time
+        required: true
+        description: Event window end as Unix epoch seconds, e.g. 1715731200.
+
+  - name: lambda_events
+    description: Lambda function events returned by LookupEvents, scoped to 'lambda.amazonaws.com'. Includes both read and write operations.
+    guide: >
+      Requires start_time and end_time as Unix epoch seconds. Returns all
+      Lambda API calls — including read-only ones such as GetFunction and
+      ListFunctions. The LookupEvents API accepts only one LookupAttribute per
+      request, so ReadOnly=false cannot be combined with the EventSource filter.
+      To restrict to write operations, add WHERE event_name IN
+      ('CreateFunction', 'UpdateFunctionCode', 'UpdateFunctionConfiguration',
+      'DeleteFunction') in your query. Use json_get_json(cloudtrail_event,
+      'requestParameters') to see what configuration changed.
+    request:
+      method: POST
+      path: /
+      body:
+        - path: [LookupAttributes, "0", AttributeKey]
+          from: literal
+          value: EventSource
+        - path: [LookupAttributes, "0", AttributeValue]
+          from: literal
+          value: lambda.amazonaws.com
+        - path: [StartTime]
+          from: filter_int
+          key: start_time
+        - path: [EndTime]
+          from: filter_int
+          key: end_time
+        - path: [MaxResults]
+          from: literal
+          value: 50
+    response:
+      rows_path: [Events]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: start_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Start time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: start_time}
+      - name: end_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: End time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: end_time}
+      - name: event_id
+        type: Utf8
+        nullable: true
+        description: Unique CloudTrail event ID.
+        expr: {kind: path, path: [EventId]}
+      - name: event_name
+        type: Utf8
+        nullable: true
+        description: >-
+          Lambda API operation name, e.g. 'UpdateFunctionConfiguration',
+          'UpdateFunctionCode', 'CreateFunction', 'DeleteFunction',
+          'GetFunction'. Includes read and write operations — filter by
+          event_name to restrict to mutations.
+        expr: {kind: path, path: [EventName]}
+      - name: event_time
+        type: Timestamp
+        nullable: true
+        description: When the Lambda API call was made (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [EventTime]}
+      - name: username
+        type: Utf8
+        nullable: true
+        description: IAM entity that made the call. Role names reveal CI/CD pipeline names.
+        expr: {kind: path, path: [Username]}
+      - name: access_key_id
+        type: Utf8
+        nullable: true
+        description: Access key ID used for the call.
+        expr: {kind: path, path: [AccessKeyId]}
+      - name: resource_name
+        type: Utf8
+        nullable: true
+        description: Lambda function name or ARN.
+        expr: {kind: path, path: [Resources, "0", ResourceName]}
+      - name: cloudtrail_event
+        type: Json
+        nullable: true
+        description: Full CloudTrail event JSON. Use json_get_json(cloudtrail_event, 'requestParameters') to inspect configuration changes.
+        expr: {kind: path, path: [CloudTrailEvent]}
+    filters:
+      - name: start_time
+        required: true
+        description: Event window start as Unix epoch seconds.
+      - name: end_time
+        required: true
+        description: Event window end as Unix epoch seconds.
+
+  - name: cloudformation_events
+    description: CloudFormation events returned by LookupEvents, scoped to 'cloudformation.amazonaws.com'. Includes both read and write operations.
+    guide: >
+      Requires start_time and end_time as Unix epoch seconds. Returns all
+      CloudFormation API calls including read-only ones. The LookupEvents API
+      accepts only one LookupAttribute per request, so ReadOnly=false cannot be
+      combined with the EventSource filter. To restrict to deployments, add
+      WHERE event_name IN ('CreateStack', 'UpdateStack', 'DeleteStack',
+      'ExecuteChangeSet') in your query. Check
+      json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken')
+      — CI/CD pipelines that set this to the commit SHA give you a direct
+      foreign key to the triggering PR without a time-window join.
+    request:
+      method: POST
+      path: /
+      body:
+        - path: [LookupAttributes, "0", AttributeKey]
+          from: literal
+          value: EventSource
+        - path: [LookupAttributes, "0", AttributeValue]
+          from: literal
+          value: cloudformation.amazonaws.com
+        - path: [StartTime]
+          from: filter_int
+          key: start_time
+        - path: [EndTime]
+          from: filter_int
+          key: end_time
+        - path: [MaxResults]
+          from: literal
+          value: 50
+    response:
+      rows_path: [Events]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: start_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Start time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: start_time}
+      - name: end_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: End time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: end_time}
+      - name: event_id
+        type: Utf8
+        nullable: true
+        description: Unique CloudTrail event ID.
+        expr: {kind: path, path: [EventId]}
+      - name: event_name
+        type: Utf8
+        nullable: true
+        description: >-
+          CloudFormation API operation, e.g. 'UpdateStack', 'CreateStack',
+          'ExecuteChangeSet', 'DeleteStack', 'DescribeStacks'. Includes read
+          and write operations — filter by event_name to restrict to mutations.
+        expr: {kind: path, path: [EventName]}
+      - name: event_time
+        type: Timestamp
+        nullable: true
+        description: When the CloudFormation operation was initiated (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [EventTime]}
+      - name: username
+        type: Utf8
+        nullable: true
+        description: IAM entity that triggered the operation. For GitHub Actions this is the assumed role name.
+        expr: {kind: path, path: [Username]}
+      - name: access_key_id
+        type: Utf8
+        nullable: true
+        description: Access key ID used for the operation.
+        expr: {kind: path, path: [AccessKeyId]}
+      - name: resource_name
+        type: Utf8
+        nullable: true
+        description: CloudFormation stack name.
+        expr: {kind: path, path: [Resources, "0", ResourceName]}
+      - name: cloudtrail_event
+        type: Json
+        nullable: true
+        description: Full CloudTrail event JSON. Inspect json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken') for a CI/CD-supplied commit SHA or PR foreign key.
+        expr: {kind: path, path: [CloudTrailEvent]}
+    filters:
+      - name: start_time
+        required: true
+        description: Event window start as Unix epoch seconds.
+      - name: end_time
+        required: true
+        description: Event window end as Unix epoch seconds.
+
+  - name: ec2_events
+    description: EC2 events returned by LookupEvents, scoped to 'ec2.amazonaws.com'. Includes both read and write operations.
+    guide: >
+      Requires start_time and end_time as Unix epoch seconds. Returns all EC2
+      API calls including read-only ones such as DescribeInstances. The
+      LookupEvents API accepts only one LookupAttribute per request, so
+      ReadOnly=false cannot be combined with the EventSource filter. To restrict
+      to instance lifecycle changes, add WHERE event_name IN ('RunInstances',
+      'TerminateInstances', 'StartInstances', 'StopInstances',
+      'ModifyInstanceAttribute') in your query. Only management (control-plane)
+      events are available here — data events require a Trail with data event
+      logging enabled and are not returned by LookupEvents.
+    request:
+      method: POST
+      path: /
+      body:
+        - path: [LookupAttributes, "0", AttributeKey]
+          from: literal
+          value: EventSource
+        - path: [LookupAttributes, "0", AttributeValue]
+          from: literal
+          value: ec2.amazonaws.com
+        - path: [StartTime]
+          from: filter_int
+          key: start_time
+        - path: [EndTime]
+          from: filter_int
+          key: end_time
+        - path: [MaxResults]
+          from: literal
+          value: 50
+    response:
+      rows_path: [Events]
+    pagination:
+      mode: cursor_body
+      cursor_body_path: [NextToken]
+      response_cursor_path: [NextToken]
+      max_pages: 100
+    columns:
+      - name: start_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Start time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: start_time}
+      - name: end_time
+        type: Int64
+        nullable: false
+        virtual: true
+        description: End time filter (Unix epoch seconds).
+        expr: {kind: from_filter, key: end_time}
+      - name: event_id
+        type: Utf8
+        nullable: true
+        description: Unique CloudTrail event ID.
+        expr: {kind: path, path: [EventId]}
+      - name: event_name
+        type: Utf8
+        nullable: true
+        description: >-
+          EC2 API operation name, e.g. 'RunInstances', 'TerminateInstances',
+          'ModifyInstanceAttribute', 'DescribeInstances'. Includes read and
+          write operations — filter by event_name to restrict to mutations.
+        expr: {kind: path, path: [EventName]}
+      - name: event_time
+        type: Timestamp
+        nullable: true
+        description: When the EC2 API call was made (UTC).
+        expr:
+          kind: format_timestamp
+          input: seconds
+          expr: {kind: path, path: [EventTime]}
+      - name: username
+        type: Utf8
+        nullable: true
+        description: IAM entity that made the call. Distinguishes automated deployments from manual console changes.
+        expr: {kind: path, path: [Username]}
+      - name: access_key_id
+        type: Utf8
+        nullable: true
+        description: Access key ID used for the call.
+        expr: {kind: path, path: [AccessKeyId]}
+      - name: resource_name
+        type: Utf8
+        nullable: true
+        description: EC2 instance ID (e.g. 'i-0abc123') or resource identifier.
+        expr: {kind: path, path: [Resources, "0", ResourceName]}
+      - name: resource_type
+        type: Utf8
+        nullable: true
+        description: AWS resource type, e.g. 'AWS::EC2::Instance', 'AWS::EC2::Volume'.
+        expr: {kind: path, path: [Resources, "0", ResourceType]}
+      - name: cloudtrail_event
+        type: Json
+        nullable: true
+        description: Full CloudTrail event JSON. Use json_get_json(cloudtrail_event, 'requestParameters') to inspect launch parameters for RunInstances events.
+        expr: {kind: path, path: [CloudTrailEvent]}
+    filters:
+      - name: start_time
+        required: true
+        description: Event window start as Unix epoch seconds.
+      - name: end_time
+        required: true
+        description: Event window end as Unix epoch seconds.

--- a/sources/community/cloudtrail/manifest.yaml
+++ b/sources/community/cloudtrail/manifest.yaml
@@ -65,8 +65,14 @@ request_headers:
     from: literal
     value: com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.LookupEvents
 test_queries:
-  - SELECT event_name, username, event_time FROM cloudtrail.management_events LIMIT 5
-  - SELECT event_name, resource_name, event_time FROM cloudtrail.lambda_events LIMIT 5
+  - >-
+    SELECT event_name, username, event_time FROM cloudtrail.management_events
+    WHERE start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '7 days') AS BIGINT)
+    AND end_time = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT) LIMIT 5
+  - >-
+    SELECT event_name, resource_name, event_time FROM cloudtrail.ec2_events
+    WHERE start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '7 days') AS BIGINT)
+    AND end_time = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT) LIMIT 5
 tables:
   - name: management_events
     description: >-
@@ -85,9 +91,11 @@ tables:
       omitting them causes the effective window to vary between the initial
       request and each NextToken page, which can invalidate pagination or
       silently shift the result window. Rate limit is 2 requests per second
-      per account per region. Queries are capped at 5,000 events (100 pages x
-      50 results); narrow the time window if your account exceeds this in the
-      requested period. Use json_get_json(cloudtrail_event,
+      per account per region, and CloudTrail returns ThrottlingException as
+      HTTP 400 (not 429), which Coral does not auto-retry. To stay well under
+      the limit, pagination is capped at 500 events (10 pages x 50 results);
+      narrow the time window (for example query day-by-day) if your account
+      exceeds this in the requested period. Use json_get_json(cloudtrail_event,
       'requestParameters') to inspect what changed.
     request:
       method: POST
@@ -114,7 +122,7 @@ tables:
       mode: cursor_body
       cursor_body_path: [NextToken]
       response_cursor_path: [NextToken]
-      max_pages: 100
+      max_pages: 10
     columns:
       - name: start_time
         type: Int64
@@ -206,9 +214,11 @@ tables:
       ReadOnly=false cannot be combined with the EventSource filter. The
       EventSource filter is applied server-side; any further filtering by
       event_name or read_only happens client-side after Coral receives the
-      results. In high-volume accounts the 5,000-event cap (100 pages x 50)
-      may be reached before all target mutations are fetched — narrow the time
-      window to stay under the cap. To restrict to write operations, add WHERE
+      results. The 500-event cap (10 pages x 50) may be reached before all
+      target mutations are fetched — narrow the time window to stay under the
+      cap. CloudTrail returns ThrottlingException as HTTP 400 (not 429), which
+      Coral does not auto-retry, so keep windows small. To restrict to write
+      operations, add WHERE
       event_name IN ('CreateFunction', 'UpdateFunctionCode',
       'UpdateFunctionConfiguration', 'DeleteFunction') or WHERE
       read_only = 'false' in your query. Use json_get_json(cloudtrail_event,
@@ -238,7 +248,7 @@ tables:
       mode: cursor_body
       cursor_body_path: [NextToken]
       response_cursor_path: [NextToken]
-      max_pages: 100
+      max_pages: 10
     columns:
       - name: start_time
         type: Int64
@@ -334,10 +344,12 @@ tables:
       accepts only one LookupAttribute per request, so ReadOnly=false cannot
       be combined with the EventSource filter. The EventSource filter is
       applied server-side; any further filtering by event_name or read_only
-      happens client-side after Coral receives the results. In high-volume
-      accounts the 5,000-event cap (100 pages x 50) may be reached before all
+      happens client-side after Coral receives the results. The 500-event cap
+      (10 pages x 50) may be reached before all
       target mutations are fetched — narrow the time window to stay under the
-      cap. To restrict to deployments, add WHERE event_name IN ('CreateStack',
+      cap. CloudTrail returns ThrottlingException as HTTP 400 (not 429), which
+      Coral does not auto-retry, so keep windows small. To restrict to
+      deployments, add WHERE event_name IN ('CreateStack',
       'UpdateStack', 'DeleteStack', 'ExecuteChangeSet') or WHERE
       read_only = 'false' in your query. Check
       json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken')
@@ -368,7 +380,7 @@ tables:
       mode: cursor_body
       cursor_body_path: [NextToken]
       response_cursor_path: [NextToken]
-      max_pages: 100
+      max_pages: 10
     columns:
       - name: start_time
         type: Int64
@@ -465,9 +477,11 @@ tables:
       ReadOnly=false cannot be combined with the EventSource filter. The
       EventSource filter is applied server-side; any further filtering by
       event_name or read_only happens client-side after Coral receives the
-      results. In high-volume accounts the 5,000-event cap (100 pages x 50)
-      may be reached before all target mutations are fetched — narrow the time
-      window to stay under the cap. To restrict to instance lifecycle changes,
+      results. The 500-event cap (10 pages x 50) may be reached before all
+      target mutations are fetched — narrow the time window to stay under the
+      cap. CloudTrail returns ThrottlingException as HTTP 400 (not 429), which
+      Coral does not auto-retry, so keep windows small. To restrict to instance
+      lifecycle changes,
       add WHERE event_name IN ('RunInstances', 'TerminateInstances',
       'StartInstances', 'StopInstances', 'ModifyInstanceAttribute') or WHERE
       read_only = 'false' in your query. Only management (control-plane)
@@ -498,7 +512,7 @@ tables:
       mode: cursor_body
       cursor_body_path: [NextToken]
       response_cursor_path: [NextToken]
-      max_pages: 100
+      max_pages: 10
     columns:
       - name: start_time
         type: Int64

--- a/sources/community/cloudtrail/manifest.yaml
+++ b/sources/community/cloudtrail/manifest.yaml
@@ -16,9 +16,14 @@ inputs:
     default: us-east-1
     hint: |
       AWS region for CloudTrail API requests. CloudTrail is regional — each
-      region maintains its own independent event history. Query the region
-      where your resources are deployed. To cover multiple regions, add this
-      source once per region with a different AWS_REGION value.
+      region maintains its own independent event history, so this source
+      queries one region per workspace. Set it to the region where your
+      resources are deployed. To switch regions, change AWS_REGION and re-add
+      the source; because the source name is fixed as `cloudtrail`, re-adding
+      replaces the existing source rather than creating a second regional copy.
+      Global-service events (IAM, AWS STS, CloudFront) are recorded in
+      us-east-1, so use us-east-1 to find identity, access-key, policy, or
+      CloudFront changes.
       Common values: us-east-1, us-west-2, eu-west-1, eu-central-1,
       ap-southeast-1, ap-northeast-1.
   AWS_ENDPOINT_SUFFIX:

--- a/sources/community/cloudtrail/manifest.yaml
+++ b/sources/community/cloudtrail/manifest.yaml
@@ -46,6 +46,9 @@ auth:
   access_key_id: "{{input.AWS_ACCESS_KEY_ID}}"
   secret_access_key: "{{input.AWS_SECRET_ACCESS_KEY}}"
 request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
   - name: Content-Type
     from: literal
     value: application/x-amz-json-1.1
@@ -53,26 +56,19 @@ request_headers:
     from: literal
     value: com.amazonaws.cloudtrail.v20131101.CloudTrail_20131101.LookupEvents
 test_queries:
-  - >-
-    SELECT event_name, username, event_time
-    FROM cloudtrail.management_events
-    WHERE start_time = 1779898731
-    AND end_time = 1779985131
-    LIMIT 5
-  - >-
-    SELECT event_name, resource_name, event_time
-    FROM cloudtrail.lambda_events
-    WHERE start_time = 1779898731
-    AND end_time = 1779985131
-    LIMIT 5
+  - SELECT event_name, username, event_time FROM cloudtrail.management_events LIMIT 5
+  - SELECT event_name, resource_name, event_time FROM cloudtrail.lambda_events LIMIT 5
 tables:
   - name: management_events
     description: Write-only AWS management events returned by LookupEvents, covering resource creation, modification, and deletion across all services.
     guide: >
-      Requires start_time and end_time as Unix epoch seconds. LookupEvents
-      retains 90 days of history. ReadOnly is hardcoded to false so only
-      mutating calls are returned. Rate limit is 2 requests per second per
-      account per region. Use json_get_json(cloudtrail_event,
+      start_time and end_time are optional Unix epoch seconds. When omitted,
+      start_time defaults to 24 hours ago and end_time defaults to now.
+      LookupEvents retains 90 days of history. ReadOnly is hardcoded to false
+      so only mutating calls are returned. Rate limit is 2 requests per second
+      per account per region. Queries are capped at 5,000 events (100 pages x
+      50 results); narrow the time window if your account exceeds this in the
+      requested period. Use json_get_json(cloudtrail_event,
       'requestParameters') to inspect what changed.
     request:
       method: POST
@@ -85,8 +81,14 @@ tables:
           from: literal
           value: "false"
         - path: [StartTime]
+          from: now_epoch_minus_seconds
+          seconds: 86400
+        - path: [StartTime]
           from: filter_int
           key: start_time
+        - path: [EndTime]
+          from: now_epoch_minus_seconds
+          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -103,15 +105,15 @@ tables:
     columns:
       - name: start_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds).
+        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds).
+        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -165,23 +167,25 @@ tables:
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        required: true
-        description: Event window start as Unix epoch seconds, e.g. 1715644800.
+        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
       - name: end_time
-        required: true
-        description: Event window end as Unix epoch seconds, e.g. 1715731200.
+        description: Event window end as Unix epoch seconds. Defaults to now.
 
   - name: lambda_events
     description: Lambda function events returned by LookupEvents, scoped to 'lambda.amazonaws.com'. Includes both read and write operations.
     guide: >
-      Requires start_time and end_time as Unix epoch seconds. Returns all
-      Lambda API calls — including read-only ones such as GetFunction and
-      ListFunctions. The LookupEvents API accepts only one LookupAttribute per
-      request, so ReadOnly=false cannot be combined with the EventSource filter.
-      To restrict to write operations, add WHERE event_name IN
-      ('CreateFunction', 'UpdateFunctionCode', 'UpdateFunctionConfiguration',
-      'DeleteFunction') in your query. Use json_get_json(cloudtrail_event,
-      'requestParameters') to see what configuration changed.
+      start_time and end_time are optional Unix epoch seconds. When omitted,
+      start_time defaults to 24 hours ago and end_time defaults to now.
+      Returns all Lambda API calls — including read-only ones such as
+      GetFunction and ListFunctions. The LookupEvents API accepts only one
+      LookupAttribute per request, so ReadOnly=false cannot be combined with
+      the EventSource filter. To restrict to write operations, add WHERE
+      event_name IN ('CreateFunction', 'UpdateFunctionCode',
+      'UpdateFunctionConfiguration', 'DeleteFunction') in your query. Queries
+      are capped at 5,000 events (100 pages x 50 results); narrow the time
+      window if your account exceeds this in the requested period. Use
+      json_get_json(cloudtrail_event, 'requestParameters') to see what
+      configuration changed.
     request:
       method: POST
       path: /
@@ -193,8 +197,14 @@ tables:
           from: literal
           value: lambda.amazonaws.com
         - path: [StartTime]
+          from: now_epoch_minus_seconds
+          seconds: 86400
+        - path: [StartTime]
           from: filter_int
           key: start_time
+        - path: [EndTime]
+          from: now_epoch_minus_seconds
+          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -211,15 +221,15 @@ tables:
     columns:
       - name: start_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds).
+        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds).
+        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -258,6 +268,16 @@ tables:
         nullable: true
         description: Lambda function name or ARN.
         expr: {kind: path, path: [Resources, "0", ResourceName]}
+      - name: event_source
+        type: Utf8
+        nullable: true
+        description: AWS service that received the call. Always 'lambda.amazonaws.com' for this table.
+        expr: {kind: path, path: [EventSource]}
+      - name: resource_type
+        type: Utf8
+        nullable: true
+        description: AWS resource type, e.g. 'AWS::Lambda::Function'.
+        expr: {kind: path, path: [Resources, "0", ResourceType]}
       - name: cloudtrail_event
         type: Json
         nullable: true
@@ -265,21 +285,22 @@ tables:
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        required: true
-        description: Event window start as Unix epoch seconds.
+        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
       - name: end_time
-        required: true
-        description: Event window end as Unix epoch seconds.
+        description: Event window end as Unix epoch seconds. Defaults to now.
 
   - name: cloudformation_events
     description: CloudFormation events returned by LookupEvents, scoped to 'cloudformation.amazonaws.com'. Includes both read and write operations.
     guide: >
-      Requires start_time and end_time as Unix epoch seconds. Returns all
-      CloudFormation API calls including read-only ones. The LookupEvents API
-      accepts only one LookupAttribute per request, so ReadOnly=false cannot be
-      combined with the EventSource filter. To restrict to deployments, add
-      WHERE event_name IN ('CreateStack', 'UpdateStack', 'DeleteStack',
-      'ExecuteChangeSet') in your query. Check
+      start_time and end_time are optional Unix epoch seconds. When omitted,
+      start_time defaults to 24 hours ago and end_time defaults to now.
+      Returns all CloudFormation API calls including read-only ones. The
+      LookupEvents API accepts only one LookupAttribute per request, so
+      ReadOnly=false cannot be combined with the EventSource filter. To
+      restrict to deployments, add WHERE event_name IN ('CreateStack',
+      'UpdateStack', 'DeleteStack', 'ExecuteChangeSet') in your query. Queries
+      are capped at 5,000 events (100 pages x 50 results); narrow the time
+      window if your account exceeds this in the requested period. Check
       json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken')
       — CI/CD pipelines that set this to the commit SHA give you a direct
       foreign key to the triggering PR without a time-window join.
@@ -294,8 +315,14 @@ tables:
           from: literal
           value: cloudformation.amazonaws.com
         - path: [StartTime]
+          from: now_epoch_minus_seconds
+          seconds: 86400
+        - path: [StartTime]
           from: filter_int
           key: start_time
+        - path: [EndTime]
+          from: now_epoch_minus_seconds
+          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -312,15 +339,15 @@ tables:
     columns:
       - name: start_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds).
+        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds).
+        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -358,6 +385,16 @@ tables:
         nullable: true
         description: CloudFormation stack name.
         expr: {kind: path, path: [Resources, "0", ResourceName]}
+      - name: event_source
+        type: Utf8
+        nullable: true
+        description: AWS service that received the call. Always 'cloudformation.amazonaws.com' for this table.
+        expr: {kind: path, path: [EventSource]}
+      - name: resource_type
+        type: Utf8
+        nullable: true
+        description: AWS resource type, e.g. 'AWS::CloudFormation::Stack'.
+        expr: {kind: path, path: [Resources, "0", ResourceType]}
       - name: cloudtrail_event
         type: Json
         nullable: true
@@ -365,24 +402,26 @@ tables:
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        required: true
-        description: Event window start as Unix epoch seconds.
+        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
       - name: end_time
-        required: true
-        description: Event window end as Unix epoch seconds.
+        description: Event window end as Unix epoch seconds. Defaults to now.
 
   - name: ec2_events
     description: EC2 events returned by LookupEvents, scoped to 'ec2.amazonaws.com'. Includes both read and write operations.
     guide: >
-      Requires start_time and end_time as Unix epoch seconds. Returns all EC2
-      API calls including read-only ones such as DescribeInstances. The
-      LookupEvents API accepts only one LookupAttribute per request, so
-      ReadOnly=false cannot be combined with the EventSource filter. To restrict
-      to instance lifecycle changes, add WHERE event_name IN ('RunInstances',
-      'TerminateInstances', 'StartInstances', 'StopInstances',
-      'ModifyInstanceAttribute') in your query. Only management (control-plane)
-      events are available here — data events require a Trail with data event
-      logging enabled and are not returned by LookupEvents.
+      start_time and end_time are optional Unix epoch seconds. When omitted,
+      start_time defaults to 24 hours ago and end_time defaults to now.
+      Returns all EC2 API calls including read-only ones such as
+      DescribeInstances. The LookupEvents API accepts only one LookupAttribute
+      per request, so ReadOnly=false cannot be combined with the EventSource
+      filter. To restrict to instance lifecycle changes, add WHERE event_name
+      IN ('RunInstances', 'TerminateInstances', 'StartInstances',
+      'StopInstances', 'ModifyInstanceAttribute') in your query. Queries are
+      capped at 5,000 events (100 pages x 50 results); narrow the time window
+      if your account exceeds this in the requested period. Only
+      management (control-plane) events are available here — data events
+      require a Trail with data event logging enabled and are not returned by
+      LookupEvents.
     request:
       method: POST
       path: /
@@ -394,8 +433,14 @@ tables:
           from: literal
           value: ec2.amazonaws.com
         - path: [StartTime]
+          from: now_epoch_minus_seconds
+          seconds: 86400
+        - path: [StartTime]
           from: filter_int
           key: start_time
+        - path: [EndTime]
+          from: now_epoch_minus_seconds
+          seconds: 0
         - path: [EndTime]
           from: filter_int
           key: end_time
@@ -412,15 +457,15 @@ tables:
     columns:
       - name: start_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: Start time filter (Unix epoch seconds).
+        description: Start time filter (Unix epoch seconds). Defaults to 24 hours ago when omitted.
         expr: {kind: from_filter, key: start_time}
       - name: end_time
         type: Int64
-        nullable: false
+        nullable: true
         virtual: true
-        description: End time filter (Unix epoch seconds).
+        description: End time filter (Unix epoch seconds). Defaults to now when omitted.
         expr: {kind: from_filter, key: end_time}
       - name: event_id
         type: Utf8
@@ -458,6 +503,11 @@ tables:
         nullable: true
         description: EC2 instance ID (e.g. 'i-0abc123') or resource identifier.
         expr: {kind: path, path: [Resources, "0", ResourceName]}
+      - name: event_source
+        type: Utf8
+        nullable: true
+        description: AWS service that received the call. Always 'ec2.amazonaws.com' for this table.
+        expr: {kind: path, path: [EventSource]}
       - name: resource_type
         type: Utf8
         nullable: true
@@ -470,8 +520,6 @@ tables:
         expr: {kind: path, path: [CloudTrailEvent]}
     filters:
       - name: start_time
-        required: true
-        description: Event window start as Unix epoch seconds.
+        description: Event window start as Unix epoch seconds. Defaults to 24 hours ago.
       - name: end_time
-        required: true
-        description: Event window end as Unix epoch seconds.
+        description: Event window end as Unix epoch seconds. Defaults to now.


### PR DESCRIPTION
Adds a new read-only community source for AWS CloudTrail under `sources/community/cloudtrail/`, exposing management events via the LookupEvents API.

## Changes

- `manifest.yaml`: Four tables using SigV4 auth (`service: cloudtrail`), same authenticator pattern as `cloudwatch_metrics` and `cloudwatch_logs`:
  - `management_events` : all write-only management events across all AWS services (filtered via `ReadOnly=false`)
  - `lambda_events` : Lambda function changes scoped to `lambda.amazonaws.com`
  - `cloudformation_events` : CloudFormation stack operations scoped to `cloudformation.amazonaws.com`
  - `ec2_events` : EC2 instance lifecycle and configuration changes scoped to `ec2.amazonaws.com`
- `README.md`: Setup instructions, IAM policy, table descriptions, and SQL examples

## Implementation notes

- Uses `aws_sigv4` authenticator (`service: cloudtrail`) - same pattern as `cloudwatch_metrics` and `cloudwatch_logs`
- `EventTime` is Unix epoch seconds mapped via `format_timestamp: seconds`
- `cloudtrail_event` is a JSON column; use `json_get_json(cloudtrail_event, 'requestParameters')` to extract the request parameters object, or `json_get_str(cloudtrail_event, 'requestParameters', 'clientRequestToken')` for scalar leaf fields
- CloudTrail is regional ,so `AWS_REGION` hint documents common values and notes each region has independent event history
- Works for all deployment methods: CloudFormation, Terraform, CDK, GitHub Actions, manual CLI/console
- 90-day management event history is available in every account by default - no S3 trail or additional setup required
- Rate limit: 2 requests per second per account per region

## Verification

**coral source add**
```
Added source cloudtrail (secrets: keychain)
✓ cloudtrail connected successfully
```

**coral source test**
```
✓ cloudtrail connected successfully
Secrets: keychain

cloudtrail (4 tables)
├─ cloudformation_events
├─ ec2_events
├─ lambda_events
└─ management_events

Query tests
2 declared · 2 passed · 0 failed

✓ SELECT event_name, username, event_time FROM cloudtrail.management_events
  WHERE start_time = 1746057600 AND end_time = 1748736000 LIMIT 5
  0 rows

✓ SELECT event_name, resource_name, event_time FROM cloudtrail.lambda_events
  WHERE start_time = 1746057600 AND end_time = 1748736000 LIMIT 5
  0 rows
```

**Live query on management events from real AWS account**
```sql
SELECT event_name, username, event_time
FROM cloudtrail.management_events
WHERE start_time = CAST(EXTRACT(EPOCH FROM NOW() - INTERVAL '7 days') AS BIGINT)
  AND end_time   = CAST(EXTRACT(EPOCH FROM NOW()) AS BIGINT)
LIMIT 5
```

| event_name | username | event_time |
|---|---|---|
| CreateAccessKey | [redacted] | 2026-05-28T11:58:36Z |
| CreateUser | [redacted] | 2026-05-28T11:58:12Z |
| AttachUserPolicy | [redacted] | 2026-05-28T11:58:12Z |
| CreatePolicy | [redacted] | 2026-05-28T11:57:50Z |
| CreateServiceLinkedRole | [redacted] | 2026-05-28T09:48:51Z |

_username values redacted_
