### PR TITLE
feat(sources/community/webhooks): add webhook source spec

### DIFF
--- a/sources/community/webhooks/README.md
+++ b/sources/community/webhooks/README.md
@@ -1,0 +1,131 @@
+# sources/webhooks — Webhook Deliveries as SQL
+
+Coral source spec that exposes incoming webhook deliveries as a queryable SQL
+table. A lightweight FastAPI receiver (`kraken/webhook_receiver.py`) runs
+locally on port 9000, validates per-source HMAC signatures, and appends each
+valid delivery to a local JSONL file. Coral's file backend makes that file
+queryable immediately.
+
+This design enables KRAKEN voyages to JOIN real-time event data (GitHub pushes,
+Sentry alerts, Stripe payment failures, PagerDuty incidents) directly into
+federated SQL queries without polling any external API — and without any data
+leaving the laptop.
+
+**Authentication:** None for reads (Coral reads a local file). Per-source HMAC
+secrets are required by the receiver for ingestion.
+
+**Backend:** File (Coral file backend reads JSONL written by the receiver).
+
+**Bounty eligible:** Yes — $100 + $50 charity (see PROPOSAL.md)
+
+---
+
+## Tables
+
+| Table | Key Columns |
+|---|---|
+| `deliveries` | `id`, `source`, `event_type`, `payload`, `received_at` |
+| `subscriptions` | `source`, `receiver_url`, `secret_alias`, `active` |
+
+---
+
+## Quick start
+
+### 1. Start the receiver
+
+```bash
+# Via kraken CLI
+kraken webhook:serve
+
+# Or directly with uvicorn
+uvicorn kraken.webhook_receiver:app --port 9000
+```
+
+### 2. Configure secrets (per source)
+
+```bash
+# Set the HMAC secret for GitHub webhooks
+export KRAKEN_WEBHOOK_SECRET_GITHUB="your-github-webhook-secret"
+
+# Or use a single shared secret for local testing
+export KRAKEN_WEBHOOK_SECRET="dev-secret"
+```
+
+### 3. Expose publicly (for external providers)
+
+Use ngrok or a similar tunnel so GitHub / Sentry / Stripe can reach port 9000:
+
+```bash
+ngrok http 9000
+# Then configure https://<ngrok-id>.ngrok.io/webhook/github in GitHub
+```
+
+### 4. Query deliveries via Coral SQL
+
+```sql
+SELECT
+    id,
+    source,
+    event_type,
+    received_at,
+    json_extract_string(payload, '$.repository.full_name') AS repo
+FROM webhooks.deliveries
+WHERE source = 'github'
+  AND event_type = 'push'
+  AND received_at >= NOW() - INTERVAL '1 hour'
+ORDER BY received_at DESC
+```
+
+---
+
+## Supported sources
+
+| Source | Signature header | Algorithm |
+|---|---|---|
+| `github` | `X-Hub-Signature-256` | HMAC-SHA256 |
+| `sentry` | `Sentry-Hook-Signature` | HMAC-SHA256 |
+| `stripe` | `Stripe-Signature` | HMAC-SHA256 |
+| `pagerduty` | `X-Webhook-Signature` | HMAC-SHA256 |
+| `linear` | `Linear-Signature` | HMAC-SHA256 |
+
+Add new sources by extending `_SOURCE_SIG_HEADERS` in
+`kraken/webhook_receiver.py` and setting the corresponding
+`KRAKEN_WEBHOOK_SECRET_<SOURCE>` environment variable.
+
+---
+
+## Example: Hot Deploy voyage with webhook trigger
+
+```sql
+SELECT
+    w.received_at                                           AS push_time,
+    json_extract_string(w.payload, '$.pusher.name')        AS pusher,
+    json_extract_string(w.payload, '$.repository.name')    AS repo,
+    json_extract_string(w.payload, '$.after')              AS new_sha,
+    d.id                                                    AS deploy_id,
+    d.status                                                AS deploy_status,
+    d.created_at                                            AS deploy_time,
+    s.title                                                 AS sentry_error
+FROM webhooks.deliveries AS w
+JOIN github.deployments AS d
+    ON d.sha = json_extract_string(w.payload, '$.after')
+LEFT JOIN sentry.issues AS s
+    ON s.first_seen >= w.received_at
+    AND s.first_seen <= w.received_at + INTERVAL '15 minutes'
+WHERE w.source = 'github'
+  AND w.event_type = 'push'
+  AND w.received_at >= NOW() - INTERVAL '2 hours'
+ORDER BY
+    w.received_at DESC
+LIMIT 20
+```
+
+---
+
+## Security
+
+- The receiver rejects all deliveries that fail HMAC validation with HTTP 403.
+- Secrets are never logged or included in responses.
+- HMAC comparisons use `hmac.compare_digest` to prevent timing attacks.
+- The JSONL file is local only — it never leaves the laptop unless you
+  explicitly expose it (which would violate CLAUDE.md Rule 6).

--- a/sources/community/webhooks/manifest.yaml
+++ b/sources/community/webhooks/manifest.yaml
@@ -1,0 +1,114 @@
+name: webhooks
+version: 0.1.0
+dsl_version: 3
+description: >
+  Real-time webhook deliveries as a queryable Coral SQL table. A lightweight
+  FastAPI receiver (kraken/webhook_receiver.py) listens on port 9000,
+  validates per-source HMAC signatures, and appends validated deliveries to a
+  local JSONL file. Coral reads that file as this source. Enables KRAKEN
+  voyages to JOIN live GitHub push events, Sentry alert webhooks, Stripe
+  payment failures, PagerDuty incidents, and Linear issue updates directly
+  into a federated SQL query without polling any external API.
+backend: file
+
+inputs:
+  WEBHOOKS_PATH:
+    kind: variable
+    default: "~/.kraken/webhooks.jsonl"
+    hint: >
+      Path to the JSONL file where the local webhook receiver appends validated
+      deliveries. Defaults to ~/.kraken/webhooks.jsonl. The receiver must be
+      running (kraken webhook:serve) before deliveries will appear.
+
+tables:
+  # ── deliveries ─────────────────────────────────────────────────────────────
+  - name: deliveries
+    description: >
+      One row per validated webhook delivery received by the local receiver.
+      The payload column contains the raw JSON body as a string — use
+      json_extract_string(payload, '$.field') in Coral SQL to reach into it.
+      hmac_valid is always true here because the receiver rejects deliveries
+      that fail signature validation before writing them. Rows are appended
+      in arrival order; use received_at for time-series filtering.
+    source:
+      location: "file://{{input.WEBHOOKS_PATH}}"
+      glob: "*.jsonl"
+    format: jsonl
+    columns:
+      - name: id
+        type: Utf8
+        description: "Delivery UUID assigned by the local receiver"
+      - name: source
+        type: Utf8
+        description: "Originating service name, e.g. github, sentry, stripe, pagerduty, linear"
+      - name: event_type
+        type: Utf8
+        description: "Provider-specific event type, e.g. push, issues.opened, payment_intent.failed"
+      - name: payload
+        type: Utf8
+        description: "Raw JSON body of the webhook delivery as a string"
+      - name: received_at
+        type: Timestamp
+        description: "UTC timestamp when the receiver accepted this delivery"
+      - name: hmac_valid
+        type: Boolean
+        description: "True if HMAC signature was verified before writing (always true in this table)"
+      - name: delivery_id
+        type: Utf8
+        description: "Provider-assigned delivery ID from the X-Delivery-ID or X-GitHub-Delivery header, if present"
+      - name: content_length_bytes
+        type: Int64
+        description: "Byte length of the raw payload"
+    filters:
+      - name: received_at
+        mode: exact
+        operators: [">=", "<=", ">", "<"]
+        description: "Filter by delivery receipt time — always include a date filter for production queries"
+      - name: source
+        mode: exact
+        operators: ["=", "IN"]
+        description: "Filter by originating service name, e.g. source = 'github'"
+      - name: event_type
+        mode: exact
+        operators: ["=", "LIKE", "IN"]
+        description: "Filter by event type, e.g. event_type = 'push'"
+
+  # ── subscriptions ──────────────────────────────────────────────────────────
+  - name: subscriptions
+    description: >
+      Configuration rows declaring which webhook sources are active, their
+      receiver URLs, and which secret key alias to use for HMAC validation.
+      Written by kraken webhook:register and read by the receiver on startup.
+      One row per registered source.
+    source:
+      location: "file://~/.kraken/webhook_subscriptions.jsonl"
+      glob: "*.jsonl"
+    format: jsonl
+    columns:
+      - name: source
+        type: Utf8
+        description: "Service name this subscription is for, e.g. github"
+      - name: receiver_url
+        type: Utf8
+        description: "Public URL (e.g. via ngrok) where the provider will deliver webhooks"
+      - name: secret_alias
+        type: Utf8
+        description: "Name of the Supabase credential that holds the HMAC secret for this source"
+      - name: events
+        type: Utf8
+        description: "Comma-separated list of event types this subscription covers"
+      - name: active
+        type: Boolean
+        description: "Whether this subscription is currently active"
+      - name: registered_at
+        type: Timestamp
+        description: "UTC timestamp when this subscription was registered"
+    filters:
+      - name: source
+        mode: exact
+        operators: ["="]
+        description: "Look up subscription config for a specific source"
+      - name: active
+        mode: exact
+        operators: ["="]
+        description: "Filter to active subscriptions only"


### PR DESCRIPTION
Adds a community `webhooks` source spec for querying local webhook delivery JSONL data.

Includes:
- `sources/community/webhooks/manifest.yaml`
- README with setup, table docs, SQL examples, auth notes
- No external credentials required

Source came from the KRAKEN source-spec bounty work.

Related bounty tracker: https://github.com/guglxni/kraken/issues/17
