### PR TITLE
feat(sources/community/nvidia_nim): add NVIDIA NIM community source

### DIFF
--- a/sources/community/nvidia_nim/README.md
+++ b/sources/community/nvidia_nim/README.md
@@ -3,7 +3,7 @@
 ## Summary
 
 This source lets Coral query NVIDIA's hosted NIM API for available models and
-run bounded OpenAI-compatible chat-completion and embedding checks through SQL.
+run bounded synchronous OpenAI-compatible chat-completion checks through SQL.
 
 ## Authentication
 
@@ -23,10 +23,9 @@ API at `https://integrate.api.nvidia.com/v1`.
 
 ## Live request costs
 
-`nvidia_nim.models` is a metadata read. `nvidia_nim.chat_completions` and
-`nvidia_nim.embeddings` perform live NVIDIA NIM API calls whenever selected, so
-they can consume NVIDIA API quota, credits, or rate limits. Keep validation
-queries bounded and small.
+`nvidia_nim.models` is a metadata read. `nvidia_nim.chat_completions` performs
+live NVIDIA NIM API calls whenever selected, so it can consume NVIDIA API
+quota, credits, or rate limits. Keep validation queries bounded and small.
 
 ## Provider docs
 
@@ -41,8 +40,7 @@ queries bounded and small.
 | Table | Description | Required filters |
 | --- | --- | --- |
 | `nvidia_nim.models` | Model catalog from `GET /models`. | None |
-| `nvidia_nim.chat_completions` | Run one bounded non-streaming chat completion. | `model`, `prompt`, `max_tokens` |
-| `nvidia_nim.embeddings` | Generate one embedding vector. | `model`, `input`, `input_type` |
+| `nvidia_nim.chat_completions` | Run one bounded synchronous non-streaming chat completion. | `model`, `prompt`, `max_tokens` |
 
 ### `nvidia_nim.models`
 
@@ -57,9 +55,10 @@ LIMIT 10;
 
 ### `nvidia_nim.chat_completions`
 
-Runs a single user-message chat completion through `POST /chat/completions`.
-Always pass a positive `max_tokens` value so the request is bounded.
-NVIDIA rejects non-positive `max_tokens` values.
+Runs a single user-message chat completion through `POST /chat/completions`
+for synchronous OpenAI-compatible NVIDIA NIM models. Always pass a positive
+`max_tokens` value so the request is bounded. NVIDIA rejects non-positive
+`max_tokens` values.
 
 ```sql
 SELECT content, finish_reason, max_tokens, returned_model, total_tokens
@@ -75,30 +74,6 @@ as response ID, returned model, raw `choices`, `usage`, token counts, and
 NVIDIA `nvext` timing metadata when returned. It does not expose chat history,
 tool calls, structured-output payloads, multimodal message payloads, or
 streaming in this first version.
-
-### `nvidia_nim.embeddings`
-
-Generates an embedding vector through `POST /embeddings`. NVIDIA asymmetric
-embedding models require `input_type`, so this source makes it a required
-filter. Common values are `query` and `passage`.
-
-Select `embedding` when you need the full vector; validation examples show a
-short vector preview so terminal output stays readable. This table preserves
-top-level response metadata such as returned model, raw `data`, `usage`, and
-token counts when NVIDIA returns it.
-
-```sql
-SELECT returned_model,
-       input_type,
-       index,
-       total_tokens,
-       substr(CAST(embedding AS VARCHAR), 1, 80) AS embedding_preview
-FROM nvidia_nim.embeddings
-WHERE model = 'nvidia/llama-nemotron-embed-1b-v2'
-  AND input = 'Coral NVIDIA source validation'
-  AND input_type = 'query'
-LIMIT 1;
-```
 
 ## Validation
 
@@ -121,7 +96,7 @@ SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 5;
 ```
 
 Before opening a PR, also capture live output for one bounded chat-completion
-query and one embedding query against real models.
+query against a synchronous OpenAI-compatible chat model.
 
 ### Live validation output
 
@@ -156,9 +131,8 @@ Added source nvidia_nim
 
   PASS nvidia_nim connected successfully
 
-    nvidia_nim (3 tables)
+    nvidia_nim (2 tables)
     - chat_completions
-    - embeddings
     - models
     Query tests
     1 declared - 1 passed - 0 failed
@@ -180,9 +154,8 @@ Output:
 ```text
   PASS nvidia_nim connected successfully
 
-    nvidia_nim (3 tables)
+    nvidia_nim (2 tables)
     - chat_completions
-    - embeddings
     - models
     Query tests
     1 declared - 1 passed - 0 failed
@@ -254,37 +227,25 @@ Output:
 +-----------------------------------------------+-----------------+------------+---------------+-------------------+--------------+
 ```
 
-#### Embedding query
-
-Command:
-
-```bash
-coral sql "SELECT returned_model, input_type, index, total_tokens, substr(CAST(embedding AS VARCHAR), 1, 80) AS embedding_preview FROM nvidia_nim.embeddings WHERE model = 'nvidia/llama-nemotron-embed-1b-v2' AND input = 'Coral NVIDIA source validation' AND input_type = 'query' LIMIT 1"
-```
-
-Output:
-
-```text
-+-----------------------------------+------------+-------+--------------+----------------------------------------------------------------------------------+
-| returned_model                    | input_type | index | total_tokens | embedding_preview                                                                |
-+-----------------------------------+------------+-------+--------------+----------------------------------------------------------------------------------+
-| nvidia/llama-nemotron-embed-1b-v2 | query      | 0     | 7            | [0.003360748291015625,0.0087890625,0.01403045654296875,0.0225067138671875,0.0297 |
-+-----------------------------------+------------+-------+--------------+----------------------------------------------------------------------------------+
-```
-
 ## Scope and limitations
 
 - Targets NVIDIA's hosted NIM API at `https://integrate.api.nvidia.com/v1`.
 - Requires `NVIDIA_API_KEY` bearer authentication.
 - `chat_completions` uses required positive `max_tokens`; NVIDIA rejects
   non-positive values.
-- `chat_completions` is single-turn and non-streaming.
-- `chat_completions` and `embeddings` are live execution tables and may consume
-  NVIDIA API quota, credits, or rate limits.
-- `embeddings` requires an embedding-capable model and explicit `input_type`.
+- `chat_completions` is single-turn, synchronous, and non-streaming.
+- `chat_completions` is a live execution table and may consume NVIDIA API
+  quota, credits, or rate limits.
+- Asynchronous model-specific endpoints that return HTTP 202 with `requestId`
+  and require `/v1/status/{requestId}` polling are out of scope because Coral
+  source specs do not currently model provider polling flows.
+- Embeddings are out of scope for this first version because NVIDIA embedding
+  request bodies are model-specific. For example, some asymmetric embedding
+  models require `input_type`, while other documented embedding endpoints use
+  different request fields.
 - Does not expose streaming, tool calls, structured outputs, reranking,
-  multimodal/image/video/audio model payloads, local/self-hosted NIM management
-  endpoints, metrics, license, manifest, health, tokenize, detokenize, or
-  Responses API in this first version.
+  embeddings, multimodal/image/video/audio model payloads, local/self-hosted
+  NIM management endpoints, metrics, license, manifest, health, tokenize,
+  detokenize, or Responses API in this first version.
 - Does not include model-detail path lookups, avoiding model-ID path issues for
   IDs that contain `/`.

--- a/sources/community/nvidia_nim/README.md
+++ b/sources/community/nvidia_nim/README.md
@@ -59,6 +59,7 @@ LIMIT 10;
 
 Runs a single user-message chat completion through `POST /chat/completions`.
 Always pass a positive `max_tokens` value so the request is bounded.
+NVIDIA rejects non-positive `max_tokens` values.
 
 ```sql
 SELECT content, finish_reason, max_tokens, returned_model, total_tokens
@@ -275,7 +276,8 @@ Output:
 
 - Targets NVIDIA's hosted NIM API at `https://integrate.api.nvidia.com/v1`.
 - Requires `NVIDIA_API_KEY` bearer authentication.
-- `chat_completions` uses required positive `max_tokens`.
+- `chat_completions` uses required positive `max_tokens`; NVIDIA rejects
+  non-positive values.
 - `chat_completions` is single-turn and non-streaming.
 - `chat_completions` and `embeddings` are live execution tables and may consume
   NVIDIA API quota, credits, or rate limits.

--- a/sources/community/nvidia_nim/README.md
+++ b/sources/community/nvidia_nim/README.md
@@ -1,0 +1,288 @@
+# NVIDIA NIM Coral Source
+
+## Summary
+
+This source lets Coral query NVIDIA's hosted NIM API for available models and
+run bounded OpenAI-compatible chat-completion and embedding checks through SQL.
+
+## Authentication
+
+Create or copy an API key from NVIDIA build:
+
+https://build.nvidia.com/settings/api-keys
+
+Set the key as `NVIDIA_API_KEY` before adding or testing the source:
+
+```bash
+export NVIDIA_API_KEY="your_nvidia_api_key"
+coral source add --file sources/community/nvidia_nim/manifest.yaml
+```
+
+The key is sent as an `Authorization: Bearer ...` header to NVIDIA's hosted NIM
+API at `https://integrate.api.nvidia.com/v1`.
+
+## Live request costs
+
+`nvidia_nim.models` is a metadata read. `nvidia_nim.chat_completions` and
+`nvidia_nim.embeddings` perform live NVIDIA NIM API calls whenever selected, so
+they can consume NVIDIA API quota, credits, or rate limits. Keep validation
+queries bounded and small.
+
+## Provider docs
+
+- NVIDIA API Catalog quickstart: https://docs.api.nvidia.com/nim/docs/api-quickstart
+- NVIDIA hosted NIM LLM APIs: https://docs.api.nvidia.com/nim/reference/llm-apis
+- NVIDIA NIM LLM API reference: https://docs.nvidia.com/nim/large-language-models/latest/reference/api-reference.html
+- NVIDIA retrieval and embedding APIs: https://docs.api.nvidia.com/nim/reference/retrieval-apis
+- NVIDIA API keys: https://build.nvidia.com/settings/api-keys
+
+## Tables
+
+| Table | Description | Required filters |
+| --- | --- | --- |
+| `nvidia_nim.models` | Model catalog from `GET /models`. | None |
+| `nvidia_nim.chat_completions` | Run one bounded non-streaming chat completion. | `model`, `prompt`, `max_tokens` |
+| `nvidia_nim.embeddings` | Generate one embedding vector. | `model`, `input`, `input_type` |
+
+### `nvidia_nim.models`
+
+Lists models returned by NVIDIA's hosted NIM OpenAI-compatible `GET /models`
+endpoint.
+
+```sql
+SELECT id, object, owned_by
+FROM nvidia_nim.models
+LIMIT 10;
+```
+
+### `nvidia_nim.chat_completions`
+
+Runs a single user-message chat completion through `POST /chat/completions`.
+Always pass a positive `max_tokens` value so the request is bounded.
+
+```sql
+SELECT content, finish_reason, max_tokens, returned_model, total_tokens
+FROM nvidia_nim.chat_completions
+WHERE model = 'meta/llama-3.1-8b-instruct'
+  AND prompt = 'Reply with exactly: Coral NVIDIA works.'
+  AND max_tokens = 20
+LIMIT 1;
+```
+
+This table is single-turn only. It preserves top-level response metadata such
+as response ID, returned model, raw `choices`, `usage`, token counts, and
+NVIDIA `nvext` timing metadata when returned. It does not expose chat history,
+tool calls, structured-output payloads, multimodal message payloads, or
+streaming in this first version.
+
+### `nvidia_nim.embeddings`
+
+Generates an embedding vector through `POST /embeddings`. NVIDIA asymmetric
+embedding models require `input_type`, so this source makes it a required
+filter. Common values are `query` and `passage`.
+
+Select `embedding` when you need the full vector; validation examples show a
+short vector preview so terminal output stays readable. This table preserves
+top-level response metadata such as returned model, raw `data`, `usage`, and
+token counts when NVIDIA returns it.
+
+```sql
+SELECT returned_model,
+       input_type,
+       index,
+       total_tokens,
+       substr(CAST(embedding AS VARCHAR), 1, 80) AS embedding_preview
+FROM nvidia_nim.embeddings
+WHERE model = 'nvidia/llama-nemotron-embed-1b-v2'
+  AND input = 'Coral NVIDIA source validation'
+  AND input_type = 'query'
+LIMIT 1;
+```
+
+## Validation
+
+Run the source-level checks with a valid `NVIDIA_API_KEY` before opening or
+updating a PR. The API key is required for `source add`, `source test`, and live
+SQL queries, but it should never be printed or committed.
+
+```bash
+coral source lint sources/community/nvidia_nim/manifest.yaml
+
+export NVIDIA_API_KEY="your_nvidia_api_key"
+coral source add --file sources/community/nvidia_nim/manifest.yaml
+coral source test nvidia_nim
+```
+
+The declared test query covers model discovery:
+
+```sql
+SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 5;
+```
+
+Before opening a PR, also capture live output for one bounded chat-completion
+query and one embedding query against real models.
+
+### Live validation output
+
+The following output was captured against NVIDIA NIM with a valid API key.
+
+#### Manifest lint
+
+Command:
+
+```bash
+coral source lint sources/community/nvidia_nim/manifest.yaml
+```
+
+Output:
+
+```text
+Manifest is valid
+```
+
+#### Add source and run declared tests
+
+Command:
+
+```bash
+coral source add --file sources/community/nvidia_nim/manifest.yaml
+```
+
+Output:
+
+```text
+Added source nvidia_nim
+
+  PASS nvidia_nim connected successfully
+
+    nvidia_nim (3 tables)
+    - chat_completions
+    - embeddings
+    - models
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 5
+      5 rows
+```
+
+#### Re-run source tests
+
+Command:
+
+```bash
+coral source test nvidia_nim
+```
+
+Output:
+
+```text
+  PASS nvidia_nim connected successfully
+
+    nvidia_nim (3 tables)
+    - chat_completions
+    - embeddings
+    - models
+    Query tests
+    1 declared - 1 passed - 0 failed
+
+    PASS SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 5
+      5 rows
+```
+
+#### Model inventory query
+
+Command:
+
+```bash
+coral sql "SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 10"
+```
+
+Output:
+
+```text
++------------------------------------------+--------+-------------+
+| id                                       | object | owned_by    |
++------------------------------------------+--------+-------------+
+| 01-ai/yi-large                           | model  | 01-ai       |
+| abacusai/dracarys-llama-3.1-70b-instruct | model  | abacusai    |
+| adept/fuyu-8b                            | model  | adept       |
+| ai21labs/jamba-1.5-large-instruct        | model  | ai21labs    |
+| aisingapore/sea-lion-7b-instruct         | model  | aisingapore |
+| baai/bge-m3                              | model  | baai        |
+| bigcode/starcoder2-15b                   | model  | bigcode     |
+| bytedance/seed-oss-36b-instruct          | model  | bytedance   |
+| databricks/dbrx-instruct                 | model  | databricks  |
+| deepseek-ai/deepseek-coder-6.7b-instruct | model  | deepseek-ai |
++------------------------------------------+--------+-------------+
+```
+
+#### Bounded chat-completion query
+
+Command:
+
+```bash
+coral sql "SELECT content, finish_reason, max_tokens, returned_model, total_tokens FROM nvidia_nim.chat_completions WHERE model = 'meta/llama-3.1-8b-instruct' AND prompt = 'Reply with exactly: Coral NVIDIA works.' AND max_tokens = 20 LIMIT 1"
+```
+
+Output:
+
+```text
++---------------------+---------------+------------+----------------------------+--------------+
+| content             | finish_reason | max_tokens | returned_model             | total_tokens |
++---------------------+---------------+------------+----------------------------+--------------+
+| Coral NVIDIA works. | stop          | 20         | meta/llama-3.1-8b-instruct | 49           |
++---------------------+---------------+------------+----------------------------+--------------+
+```
+
+#### Chat metadata query
+
+Command:
+
+```bash
+coral sql "SELECT id, object, created, prompt_tokens, completion_tokens, total_tokens FROM nvidia_nim.chat_completions WHERE model = 'meta/llama-3.1-8b-instruct' AND prompt = 'Reply with exactly: Coral NVIDIA works.' AND max_tokens = 20 LIMIT 1"
+```
+
+Output:
+
+```text
++-----------------------------------------------+-----------------+------------+---------------+-------------------+--------------+
+| id                                            | object          | created    | prompt_tokens | completion_tokens | total_tokens |
++-----------------------------------------------+-----------------+------------+---------------+-------------------+--------------+
+| chatcmpl-00cc3dd3-da23-46a3-b6bc-9e1f31d5a2d3 | chat.completion | 1779980907 | 43            | 6                 | 49           |
++-----------------------------------------------+-----------------+------------+---------------+-------------------+--------------+
+```
+
+#### Embedding query
+
+Command:
+
+```bash
+coral sql "SELECT returned_model, input_type, index, total_tokens, substr(CAST(embedding AS VARCHAR), 1, 80) AS embedding_preview FROM nvidia_nim.embeddings WHERE model = 'nvidia/llama-nemotron-embed-1b-v2' AND input = 'Coral NVIDIA source validation' AND input_type = 'query' LIMIT 1"
+```
+
+Output:
+
+```text
++-----------------------------------+------------+-------+--------------+----------------------------------------------------------------------------------+
+| returned_model                    | input_type | index | total_tokens | embedding_preview                                                                |
++-----------------------------------+------------+-------+--------------+----------------------------------------------------------------------------------+
+| nvidia/llama-nemotron-embed-1b-v2 | query      | 0     | 7            | [0.003360748291015625,0.0087890625,0.01403045654296875,0.0225067138671875,0.0297 |
++-----------------------------------+------------+-------+--------------+----------------------------------------------------------------------------------+
+```
+
+## Scope and limitations
+
+- Targets NVIDIA's hosted NIM API at `https://integrate.api.nvidia.com/v1`.
+- Requires `NVIDIA_API_KEY` bearer authentication.
+- `chat_completions` uses required positive `max_tokens`.
+- `chat_completions` is single-turn and non-streaming.
+- `chat_completions` and `embeddings` are live execution tables and may consume
+  NVIDIA API quota, credits, or rate limits.
+- `embeddings` requires an embedding-capable model and explicit `input_type`.
+- Does not expose streaming, tool calls, structured outputs, reranking,
+  multimodal/image/video/audio model payloads, local/self-hosted NIM management
+  endpoints, metrics, license, manifest, health, tokenize, detokenize, or
+  Responses API in this first version.
+- Does not include model-detail path lookups, avoiding model-ID path issues for
+  IDs that contain `/`.

--- a/sources/community/nvidia_nim/manifest.yaml
+++ b/sources/community/nvidia_nim/manifest.yaml
@@ -2,7 +2,7 @@ name: nvidia_nim
 version: 0.1.0
 dsl_version: 3
 backend: http
-description: Query NVIDIA NIM model catalogs and run bounded OpenAI-compatible chat and embedding checks through SQL.
+description: Query NVIDIA NIM model catalogs and run bounded synchronous OpenAI-compatible chat checks through SQL.
 base_url: https://integrate.api.nvidia.com/v1
 inputs:
   NVIDIA_API_KEY:
@@ -52,7 +52,7 @@ tables:
         description: Model owner or provider.
 
   - name: chat_completions
-    description: Run one non-streaming NVIDIA NIM chat completion with required bounded SQL filters.
+    description: Run one synchronous non-streaming NVIDIA NIM chat completion with required bounded SQL filters.
     filters:
       - name: model
         required: true
@@ -252,129 +252,3 @@ tables:
             - message
             - role
 
-  - name: embeddings
-    description: Generate one embedding vector through NVIDIA NIM POST /embeddings.
-    filters:
-      - name: model
-        required: true
-      - name: input
-        required: true
-      - name: input_type
-        required: true
-    request:
-      method: POST
-      path: /embeddings
-      headers:
-        - name: Content-Type
-          from: literal
-          value: application/json
-      body:
-        - path:
-            - model
-          from: filter
-          key: model
-        - path:
-            - input
-          from: filter
-          key: input
-        - path:
-            - input_type
-          from: filter
-          key: input_type
-    response:
-      row_strategy: direct
-    pagination:
-      mode: none
-    columns:
-      - name: model
-        type: Utf8
-        nullable: false
-        virtual: true
-        description: Embedding model supplied in SQL filter.
-        expr:
-          kind: from_filter
-          key: model
-      - name: input
-        type: Utf8
-        nullable: false
-        virtual: true
-        description: Input text supplied in SQL filter.
-        expr:
-          kind: from_filter
-          key: input
-      - name: input_type
-        type: Utf8
-        nullable: false
-        virtual: true
-        description: NVIDIA embedding input type supplied in SQL filter, such as query or passage.
-        expr:
-          kind: from_filter
-          key: input_type
-      - name: object
-        type: Utf8
-        nullable: true
-        description: API object type.
-      - name: returned_model
-        type: Utf8
-        nullable: true
-        description: Actual embedding model returned by NVIDIA NIM.
-        expr:
-          kind: path
-          path:
-            - model
-      - name: usage
-        type: Json
-        nullable: true
-        description: Token usage metadata returned by NVIDIA NIM.
-      - name: prompt_tokens
-        type: Int64
-        nullable: true
-        description: Prompt token count when returned by NVIDIA NIM.
-        expr:
-          kind: path
-          path:
-            - usage
-            - prompt_tokens
-      - name: total_tokens
-        type: Int64
-        nullable: true
-        description: Total token count when returned by NVIDIA NIM.
-        expr:
-          kind: path
-          path:
-            - usage
-            - total_tokens
-      - name: data
-        type: Json
-        nullable: true
-        description: Raw embedding data array returned by NVIDIA NIM.
-      - name: index
-        type: Int64
-        nullable: true
-        description: First embedding row index.
-        expr:
-          kind: path
-          path:
-            - data
-            - "0"
-            - index
-      - name: embedding_object
-        type: Utf8
-        nullable: true
-        description: First embedding object type.
-        expr:
-          kind: path
-          path:
-            - data
-            - "0"
-            - object
-      - name: embedding
-        type: Json
-        nullable: true
-        description: Embedding vector returned by NVIDIA NIM.
-        expr:
-          kind: path
-          path:
-            - data
-            - "0"
-            - embedding

--- a/sources/community/nvidia_nim/manifest.yaml
+++ b/sources/community/nvidia_nim/manifest.yaml
@@ -117,7 +117,7 @@ tables:
         type: Int64
         nullable: false
         virtual: true
-        description: Positive max_tokens value supplied in SQL filter.
+        description: Positive max_tokens value supplied in SQL filter; NVIDIA rejects non-positive values.
         expr:
           kind: from_filter
           key: max_tokens

--- a/sources/community/nvidia_nim/manifest.yaml
+++ b/sources/community/nvidia_nim/manifest.yaml
@@ -1,0 +1,380 @@
+name: nvidia_nim
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: Query NVIDIA NIM model catalogs and run bounded OpenAI-compatible chat and embedding checks through SQL.
+base_url: https://integrate.api.nvidia.com/v1
+inputs:
+  NVIDIA_API_KEY:
+    kind: secret
+    hint: |
+      NVIDIA API key for build.nvidia.com / NVIDIA NIM.
+
+      Create or copy an API key from:
+      https://build.nvidia.com/settings/api-keys
+
+      The key is sent as a Bearer token to NVIDIA's hosted NIM API.
+auth:
+  type: HeaderAuth
+  headers:
+    - name: Authorization
+      from: template
+      template: "Bearer {{input.NVIDIA_API_KEY}}"
+test_queries:
+  - SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 5
+tables:
+  - name: models
+    description: NVIDIA NIM models from GET /models.
+    request:
+      method: GET
+      path: /models
+    response:
+      rows_path:
+        - data
+    pagination:
+      mode: none
+    columns:
+      - name: id
+        type: Utf8
+        nullable: false
+        description: Model ID used in NVIDIA NIM OpenAI-compatible requests.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: created
+        type: Int64
+        nullable: true
+        description: Model creation timestamp when returned by the API.
+      - name: owned_by
+        type: Utf8
+        nullable: true
+        description: Model owner or provider.
+
+  - name: chat_completions
+    description: Run one non-streaming NVIDIA NIM chat completion with required bounded SQL filters.
+    filters:
+      - name: model
+        required: true
+      - name: prompt
+        required: true
+      - name: max_tokens
+        required: true
+    request:
+      method: POST
+      path: /chat/completions
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - messages
+            - "0"
+            - role
+          from: literal
+          value: user
+        - path:
+            - messages
+            - "0"
+            - content
+          from: filter
+          key: prompt
+        - path:
+            - max_tokens
+          from: filter_int
+          key: max_tokens
+        - path:
+            - stream
+          from: literal
+          value: false
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Model supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: prompt
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Prompt supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: prompt
+      - name: max_tokens
+        type: Int64
+        nullable: false
+        virtual: true
+        description: Positive max_tokens value supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: max_tokens
+      - name: id
+        type: Utf8
+        nullable: true
+        description: Chat completion response ID.
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: created
+        type: Int64
+        nullable: true
+        description: Response creation timestamp.
+      - name: returned_model
+        type: Utf8
+        nullable: true
+        description: Actual model returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - model
+      - name: usage
+        type: Json
+        nullable: true
+        description: Token usage metadata returned by NVIDIA NIM.
+      - name: prompt_tokens
+        type: Int64
+        nullable: true
+        description: Prompt token count when returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - usage
+            - prompt_tokens
+      - name: completion_tokens
+        type: Int64
+        nullable: true
+        description: Completion token count when returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - usage
+            - completion_tokens
+      - name: total_tokens
+        type: Int64
+        nullable: true
+        description: Total token count when returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - usage
+            - total_tokens
+      - name: prompt_tokens_details
+        type: Json
+        nullable: true
+        description: Prompt token detail metadata when returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - usage
+            - prompt_tokens_details
+      - name: nvext
+        type: Json
+        nullable: true
+        description: NVIDIA extension metadata such as worker and timing details.
+      - name: nvext_timing
+        type: Json
+        nullable: true
+        description: NVIDIA timing metadata when returned.
+        expr:
+          kind: path
+          path:
+            - nvext
+            - timing
+      - name: choices
+        type: Json
+        nullable: true
+        description: Raw choices array returned by NVIDIA NIM.
+      - name: index
+        type: Int64
+        nullable: true
+        description: First choice index.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - index
+      - name: finish_reason
+        type: Utf8
+        nullable: true
+        description: Why the model stopped.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - finish_reason
+      - name: content
+        type: Utf8
+        nullable: true
+        description: Assistant response text.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - message
+            - content
+      - name: reasoning_content
+        type: Utf8
+        nullable: true
+        description: Reasoning text when returned by the model.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - message
+            - reasoning_content
+      - name: message_role
+        type: Utf8
+        nullable: true
+        description: Assistant message role.
+        expr:
+          kind: path
+          path:
+            - choices
+            - "0"
+            - message
+            - role
+
+  - name: embeddings
+    description: Generate one embedding vector through NVIDIA NIM POST /embeddings.
+    filters:
+      - name: model
+        required: true
+      - name: input
+        required: true
+      - name: input_type
+        required: true
+    request:
+      method: POST
+      path: /embeddings
+      headers:
+        - name: Content-Type
+          from: literal
+          value: application/json
+      body:
+        - path:
+            - model
+          from: filter
+          key: model
+        - path:
+            - input
+          from: filter
+          key: input
+        - path:
+            - input_type
+          from: filter
+          key: input_type
+    response:
+      row_strategy: direct
+    pagination:
+      mode: none
+    columns:
+      - name: model
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Embedding model supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: model
+      - name: input
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: Input text supplied in SQL filter.
+        expr:
+          kind: from_filter
+          key: input
+      - name: input_type
+        type: Utf8
+        nullable: false
+        virtual: true
+        description: NVIDIA embedding input type supplied in SQL filter, such as query or passage.
+        expr:
+          kind: from_filter
+          key: input_type
+      - name: object
+        type: Utf8
+        nullable: true
+        description: API object type.
+      - name: returned_model
+        type: Utf8
+        nullable: true
+        description: Actual embedding model returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - model
+      - name: usage
+        type: Json
+        nullable: true
+        description: Token usage metadata returned by NVIDIA NIM.
+      - name: prompt_tokens
+        type: Int64
+        nullable: true
+        description: Prompt token count when returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - usage
+            - prompt_tokens
+      - name: total_tokens
+        type: Int64
+        nullable: true
+        description: Total token count when returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - usage
+            - total_tokens
+      - name: data
+        type: Json
+        nullable: true
+        description: Raw embedding data array returned by NVIDIA NIM.
+      - name: index
+        type: Int64
+        nullable: true
+        description: First embedding row index.
+        expr:
+          kind: path
+          path:
+            - data
+            - "0"
+            - index
+      - name: embedding_object
+        type: Utf8
+        nullable: true
+        description: First embedding object type.
+        expr:
+          kind: path
+          path:
+            - data
+            - "0"
+            - object
+      - name: embedding
+        type: Json
+        nullable: true
+        description: Embedding vector returned by NVIDIA NIM.
+        expr:
+          kind: path
+          path:
+            - data
+            - "0"
+            - embedding

--- a/sources/community/nvidia_nim/manifest.yaml
+++ b/sources/community/nvidia_nim/manifest.yaml
@@ -251,4 +251,3 @@ tables:
             - "0"
             - message
             - role
-


### PR DESCRIPTION
﻿## Summary

Closes #957.

This source lets Coral query NVIDIA's hosted NIM API for available models and run bounded synchronous OpenAI-compatible chat-completion checks through SQL.

## Why this source

NVIDIA NIM is a useful hosted API surface for running NVIDIA and partner models through OpenAI-compatible endpoints. Coral does not currently include an NVIDIA NIM source under `sources/core` or `sources/community`, so this community source adds a focused SQL surface for model discovery and small synchronous chat validation workflows.

This source helps users:

- Discover available NVIDIA NIM models.
- Run bounded synchronous chat-completion smoke tests through SQL.
- Inspect returned model, usage, token counts, raw response arrays, and NVIDIA timing metadata where returned.

The first version is intentionally narrow. It uses documented NVIDIA hosted NIM API endpoints, requires positive token bounds for live chat calls, documents async polling endpoints as out of scope, and avoids model-detail path lookups so model IDs containing `/` remain safe.

## Provider docs

- NVIDIA API Catalog quickstart: https://docs.api.nvidia.com/nim/docs/api-quickstart
- NVIDIA hosted NIM LLM APIs: https://docs.api.nvidia.com/nim/reference/llm-apis
- NVIDIA NIM LLM API reference: https://docs.nvidia.com/nim/large-language-models/latest/reference/api-reference.html
- NVIDIA API keys: https://build.nvidia.com/settings/api-keys

## Source shape

- `nvidia_nim.models` lists model catalog rows from `GET /models`.
- `nvidia_nim.chat_completions` runs one bounded synchronous non-streaming chat completion with required `model`, `prompt`, and `max_tokens` filters. It preserves top-level response metadata, raw `choices`, `usage`, token counts, returned model, and NVIDIA `nvext` timing metadata when returned.

## Source scope

- Targets NVIDIA's hosted NIM API at `https://integrate.api.nvidia.com/v1`.
- Requires `NVIDIA_API_KEY` bearer authentication.
- `nvidia_nim.models` is a metadata read.
- `nvidia_nim.chat_completions` performs live NVIDIA NIM API calls when selected, so it can consume NVIDIA API quota, credits, or rate limits.
- Chat calls require a positive `max_tokens` bound; NVIDIA rejects non-positive values.
- Chat is documented as single-turn, synchronous, and non-streaming.
- Asynchronous model-specific endpoints that return HTTP 202 with `requestId` and require `/v1/status/{requestId}` polling are intentionally out of scope because Coral source specs do not currently model provider polling flows.
- Embeddings are intentionally out of scope for this first version because NVIDIA embedding request bodies are model-specific. Some asymmetric embedding models require `input_type`, while other documented embedding endpoints use different request fields.
- Streaming, tool calls, structured outputs, reranking, embeddings, multimodal/image/video/audio model payloads, local/self-hosted NIM management endpoints, metrics, license, manifest, health, tokenize, detokenize, and Responses API are intentionally out of scope for the first version.
- No model-detail path lookup is included, avoiding model-ID path issues for IDs that contain `/`.

## Validation

Validated against NVIDIA NIM with a valid API key.

### 1. Lint

```bash
$ coral source lint sources/community/nvidia_nim/manifest.yaml
Manifest is valid
```

### 2. Add source

```bash
$ coral source add --file sources/community/nvidia_nim/manifest.yaml
Added source nvidia_nim

  ✓ nvidia_nim connected successfully

    nvidia_nim (2 tables)
    ├─ chat_completions
    └─ models
    Query tests
    1 declared · 1 passed · 0 failed

    ✓ SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 5
      5 rows
```

### 3. Inspect tables

```bash
$ coral sql "SELECT table_name FROM coral.tables WHERE schema_name = 'nvidia_nim' ORDER BY table_name"
+------------------+
| table_name       |
+------------------+
| chat_completions |
| models           |
+------------------+
```

### 4. Inspect columns

```bash
$ coral sql "SELECT table_name, column_name, data_type FROM coral.columns WHERE schema_name = 'nvidia_nim' ORDER BY table_name, ordinal_position"
+------------------+-----------------------+-----------+
| table_name       | column_name           | data_type |
+------------------+-----------------------+-----------+
| chat_completions | model                 | Utf8      |
| chat_completions | prompt                | Utf8      |
| chat_completions | max_tokens            | Int64     |
| chat_completions | id                    | Utf8      |
| chat_completions | object                | Utf8      |
| chat_completions | created               | Int64     |
| chat_completions | returned_model        | Utf8      |
| chat_completions | usage                 | Json      |
| chat_completions | prompt_tokens         | Int64     |
| chat_completions | completion_tokens     | Int64     |
| chat_completions | total_tokens          | Int64     |
| chat_completions | prompt_tokens_details | Json      |
| chat_completions | nvext                 | Json      |
| chat_completions | nvext_timing          | Json      |
| chat_completions | choices               | Json      |
| chat_completions | index                 | Int64     |
| chat_completions | finish_reason         | Utf8      |
| chat_completions | content               | Utf8      |
| chat_completions | reasoning_content     | Utf8      |
| chat_completions | message_role          | Utf8      |
| models           | id                    | Utf8      |
| models           | object                | Utf8      |
| models           | created               | Int64     |
| models           | owned_by              | Utf8      |
+------------------+-----------------------+-----------+
```

### 5. Inspect inputs

```bash
$ coral sql "SELECT key, kind, required FROM coral.inputs WHERE schema_name = 'nvidia_nim' ORDER BY key"
+----------------+--------+----------+
| key            | kind   | required |
+----------------+--------+----------+
| NVIDIA_API_KEY | secret | true     |
+----------------+--------+----------+
```

### 6. Source test

```bash
$ coral source test nvidia_nim
  ✓ nvidia_nim connected successfully

    nvidia_nim (2 tables)
    ├─ chat_completions
    └─ models
    Query tests
    1 declared · 1 passed · 0 failed

    ✓ SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 5
      5 rows
```

### 7. Model inventory query

```bash
$ coral sql "SELECT id, object, owned_by FROM nvidia_nim.models LIMIT 10"
+------------------------------------------+--------+-------------+
| id                                       | object | owned_by    |
+------------------------------------------+--------+-------------+
| 01-ai/yi-large                           | model  | 01-ai       |
| abacusai/dracarys-llama-3.1-70b-instruct | model  | abacusai    |
| adept/fuyu-8b                            | model  | adept       |
| ai21labs/jamba-1.5-large-instruct        | model  | ai21labs    |
| aisingapore/sea-lion-7b-instruct         | model  | aisingapore |
| baai/bge-m3                              | model  | baai        |
| bigcode/starcoder2-15b                   | model  | bigcode     |
| bytedance/seed-oss-36b-instruct          | model  | bytedance   |
| databricks/dbrx-instruct                 | model  | databricks  |
| deepseek-ai/deepseek-coder-6.7b-instruct | model  | deepseek-ai |
+------------------------------------------+--------+-------------+
```

### 8. Bounded synchronous chat-completion query

```bash
$ coral sql "SELECT content, finish_reason, max_tokens, returned_model, total_tokens FROM nvidia_nim.chat_completions WHERE model = 'meta/llama-3.1-8b-instruct' AND prompt = 'Reply with exactly: Coral NVIDIA works.' AND max_tokens = 20 LIMIT 1"
+---------------------+---------------+------------+----------------------------+--------------+
| content             | finish_reason | max_tokens | returned_model             | total_tokens |
+---------------------+---------------+------------+----------------------------+--------------+
| Coral NVIDIA works. | stop          | 20         | meta/llama-3.1-8b-instruct | 49           |
+---------------------+---------------+------------+----------------------------+--------------+
```

### 9. Chat metadata query

```bash
$ coral sql "SELECT id, object, created, prompt_tokens, completion_tokens, total_tokens FROM nvidia_nim.chat_completions WHERE model = 'meta/llama-3.1-8b-instruct' AND prompt = 'Reply with exactly: Coral NVIDIA works.' AND max_tokens = 20 LIMIT 1"
+-----------------------------------------------+-----------------+------------+---------------+-------------------+--------------+
| id                                            | object          | created    | prompt_tokens | completion_tokens | total_tokens |
+-----------------------------------------------+-----------------+------------+---------------+-------------------+--------------+
| chatcmpl-00cc3dd3-da23-46a3-b6bc-9e1f31d5a2d3 | chat.completion | 1779980907 | 43            | 6                 | 49           |
+-----------------------------------------------+-----------------+------------+---------------+-------------------+--------------+
```


## Proof screenshots

![NVIDIA NIM proof 1](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/01.png)

![NVIDIA NIM proof 2](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/02.png)

![NVIDIA NIM proof 3](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/03.png)

![NVIDIA NIM proof 4](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/04.png)

![NVIDIA NIM proof 5](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/05.png)

![NVIDIA NIM proof 6](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/06.png)

![NVIDIA NIM proof 7](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/07.png)

![NVIDIA NIM proof 8](https://raw.githubusercontent.com/FiscalMindset/coral/nvidia-nim-proof-assets/output_proof/nvidia_nim/new/08.png)
