### PR TITLE
perf(engine): narrow request input context

### DIFF
--- a/crates/coral-app/src/query/extensions.rs
+++ b/crates/coral-app/src/query/extensions.rs
@@ -6,8 +6,8 @@ use std::sync::Arc;
 
 use coral_auth_aws::AwsSigV4Authenticator;
 use coral_engine::{
-    EngineExtensions, QuerySource, RequestAuthenticator, SourceInputResolver,
-    SourceInputResolverError,
+    EngineExtensions, QuerySource, RequestAuthenticator, SourceInputResolutionContext,
+    SourceInputResolver, SourceInputResolverError,
 };
 use coral_spec::ManifestInputKind;
 
@@ -89,7 +89,7 @@ impl fmt::Debug for CredentialRefreshingInputResolver {
 impl SourceInputResolver for CredentialRefreshingInputResolver {
     async fn resolve_inputs(
         &self,
-        source: &QuerySource,
+        source: &SourceInputResolutionContext,
     ) -> Result<BTreeMap<String, String>, SourceInputResolverError> {
         let source_name = SourceName::parse(source.source_name())
             .map_err(|error| SourceInputResolverError::invalid_input(error.to_string()))?;
@@ -105,7 +105,7 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
                         &self.workspace_name,
                         &credential_set_id,
                         credential_storage,
-                        source.source_spec().declared_inputs(),
+                        source.declared_inputs(),
                     )
                     .await
                     .map_err(source_input_error)?
@@ -120,7 +120,6 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
             }
         }
         let missing_secrets: Vec<String> = source
-            .source_spec()
             .required_secret_names()
             .into_iter()
             .filter(|name| !resolved.contains_key(name))
@@ -141,22 +140,17 @@ impl SourceInputResolver for CredentialRefreshingInputResolver {
 }
 
 fn resolve_from_material(
-    source: &QuerySource,
+    source: &SourceInputResolutionContext,
     material: &BTreeMap<String, String>,
 ) -> BTreeMap<String, String> {
-    coral_spec::resolve_inputs(
-        source.source_spec().declared_inputs(),
-        material,
-        source.variables(),
-    )
+    coral_spec::resolve_inputs(source.declared_inputs(), material, source.variables())
 }
 
 fn source_with_refreshed_secrets(
-    source: &QuerySource,
+    source: &SourceInputResolutionContext,
     material: &BTreeMap<String, String>,
-) -> QuerySource {
+) -> SourceInputResolutionContext {
     let refreshed_secrets = source
-        .source_spec()
         .declared_inputs()
         .iter()
         .filter(|input| input.kind == ManifestInputKind::Secret)
@@ -167,11 +161,7 @@ fn source_with_refreshed_secrets(
                 .map(|value| (input.key.clone(), value))
         })
         .collect();
-    QuerySource::new(
-        source.source_spec().clone(),
-        source.variables().clone(),
-        refreshed_secrets,
-    )
+    source.with_secrets(refreshed_secrets)
 }
 
 pub(crate) fn engine_extensions_for_providers(

--- a/crates/coral-app/src/query/manager.rs
+++ b/crates/coral-app/src/query/manager.rs
@@ -422,7 +422,10 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use coral_engine::{EngineExtensions, SourceInputResolver, SourceInputResolverError};
+    use coral_engine::{
+        EngineExtensions, SourceInputResolutionContext, SourceInputResolver,
+        SourceInputResolverError,
+    };
     use coral_spec::parse_source_manifest_yaml;
     use tempfile::TempDir;
 
@@ -619,7 +622,7 @@ tables:
     impl SourceInputResolver for DelegatingInputResolver {
         async fn resolve_inputs(
             &self,
-            source: &QuerySource,
+            source: &SourceInputResolutionContext,
         ) -> Result<BTreeMap<String, String>, SourceInputResolverError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             *self.observed_token.lock().expect("observed token lock") =
@@ -723,7 +726,7 @@ tables:
             .expect("runtime installs input resolver");
 
         let resolved_inputs = input_resolver
-            .resolve_inputs(&source)
+            .resolve_inputs(&SourceInputResolutionContext::from_query_source(&source))
             .await
             .expect("resolve source inputs");
 

--- a/crates/coral-engine/src/backends/http/client.rs
+++ b/crates/coral-engine/src/backends/http/client.rs
@@ -11,7 +11,10 @@ use crate::backends::http::fetch::fetch_rows;
 use crate::backends::http::registration_checks::validate_source_scoped_http_config;
 use crate::backends::http::target::HttpFetchTarget;
 use crate::backends::http::trace::HttpBodyCapture;
-use crate::{QuerySource, RequestAuthenticator, SourceInputResolver, SourceInputResolverError};
+use crate::{
+    RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver,
+    SourceInputResolverError,
+};
 use coral_spec::backends::http::{HttpSourceManifest, RateLimitSpec};
 use coral_spec::{AuthSpec, HeaderSpec, ParsedTemplate};
 
@@ -27,7 +30,7 @@ pub(crate) struct HttpSourceClient {
     pub(super) auth: AuthSpec,
     pub(super) request_headers: Vec<HeaderSpec>,
     pub(super) request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
-    source: Option<QuerySource>,
+    source_input_resolution_context: Option<SourceInputResolutionContext>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
     pub(super) rate_limit: RateLimitSpec,
     pub(super) resolved_inputs: Arc<BTreeMap<String, String>>,
@@ -78,7 +81,7 @@ impl HttpSourceClient {
         source_secrets: &BTreeMap<String, String>,
         source_variables: &BTreeMap<String, String>,
         request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
-        source: QuerySource,
+        source_input_resolution_context: SourceInputResolutionContext,
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
         body_capture_max_bytes: Option<usize>,
     ) -> Result<Self> {
@@ -87,7 +90,7 @@ impl HttpSourceClient {
             source_secrets,
             source_variables,
             request_authenticators,
-            Some(source),
+            Some(source_input_resolution_context),
             source_input_resolver,
             body_capture_max_bytes,
         )
@@ -98,7 +101,7 @@ impl HttpSourceClient {
         source_secrets: &BTreeMap<String, String>,
         source_variables: &BTreeMap<String, String>,
         request_authenticators: &HashMap<String, Arc<dyn RequestAuthenticator>>,
-        source: Option<QuerySource>,
+        source_input_resolution_context: Option<SourceInputResolutionContext>,
         source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
         body_capture_max_bytes: Option<usize>,
     ) -> Result<Self> {
@@ -126,7 +129,7 @@ impl HttpSourceClient {
             auth: manifest.auth.clone(),
             request_headers: manifest.request_headers.clone(),
             request_authenticators: request_authenticators.clone(),
-            source,
+            source_input_resolution_context,
             source_input_resolver,
             rate_limit: manifest.rate_limit.clone(),
             resolved_inputs: Arc::new(resolved_inputs),
@@ -154,7 +157,10 @@ impl HttpSourceClient {
     pub(super) async fn resolved_inputs_for_request(
         &self,
     ) -> Result<Arc<BTreeMap<String, String>>> {
-        let (Some(resolver), Some(source)) = (&self.source_input_resolver, &self.source) else {
+        let (Some(resolver), Some(source)) = (
+            &self.source_input_resolver,
+            &self.source_input_resolution_context,
+        ) else {
             return Ok(Arc::clone(&self.resolved_inputs));
         };
         resolver

--- a/crates/coral-engine/src/backends/http/mod.rs
+++ b/crates/coral-engine/src/backends/http/mod.rs
@@ -15,7 +15,7 @@ use crate::backends::{
     build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
     required_filter_names,
 };
-use crate::{QuerySource, RequestAuthenticator, SourceInputResolver};
+use crate::{RequestAuthenticator, SourceInputResolutionContext, SourceInputResolver};
 use coral_spec::backends::http::{HttpSourceManifest, HttpTableSpec};
 pub(crate) mod auth;
 pub(crate) mod client;
@@ -42,9 +42,7 @@ pub(crate) use provider::HttpSourceTableProvider;
 #[derive(Debug, Clone)]
 struct HttpCompiledSource {
     manifest: HttpSourceManifest,
-    source: QuerySource,
-    source_secrets: std::collections::BTreeMap<String, String>,
-    source_variables: std::collections::BTreeMap<String, String>,
+    source_input_resolution: SourceInputResolutionContext,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     body_capture_max_bytes: Option<usize>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
@@ -52,18 +50,14 @@ struct HttpCompiledSource {
 
 pub(crate) fn compile_source(
     manifest: HttpSourceManifest,
-    source: QuerySource,
-    source_secrets: std::collections::BTreeMap<String, String>,
-    source_variables: std::collections::BTreeMap<String, String>,
+    source_input_resolution: SourceInputResolutionContext,
     request_authenticators: HashMap<String, Arc<dyn RequestAuthenticator>>,
     body_capture_max_bytes: Option<usize>,
     source_input_resolver: Option<Arc<dyn SourceInputResolver>>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(HttpCompiledSource {
         manifest,
-        source,
-        source_secrets,
-        source_variables,
+        source_input_resolution,
         request_authenticators,
         body_capture_max_bytes,
         source_input_resolver,
@@ -76,9 +70,7 @@ pub(crate) fn compile_manifest(
 ) -> Box<dyn CompiledBackendSource> {
     compile_source(
         manifest.clone(),
-        request.source.clone(),
-        request.source_secrets.clone(),
-        request.source_variables.clone(),
+        SourceInputResolutionContext::from_query_source(request.source),
         request.request_authenticators.clone(),
         request.runtime_context.http_body_capture_max_bytes,
         request.source_input_resolver.clone(),
@@ -98,10 +90,10 @@ impl CompiledBackendSource for HttpCompiledSource {
     async fn register(&self, _ctx: &SessionContext) -> Result<BackendRegistration> {
         let backend = HttpSourceClient::from_manifest_with_source_input_resolver(
             &self.manifest,
-            &self.source_secrets,
-            &self.source_variables,
+            self.source_input_resolution.secrets(),
+            self.source_input_resolution.variables(),
             &self.request_authenticators,
-            self.source.clone(),
+            self.source_input_resolution.clone(),
             self.source_input_resolver.clone(),
             self.body_capture_max_bytes,
         )?;
@@ -137,10 +129,15 @@ impl CompiledBackendSource for HttpCompiledSource {
             ));
         }
 
-        let secret_keys = self.source_secrets.keys().cloned().collect();
+        let secret_keys = self
+            .source_input_resolution
+            .secrets()
+            .keys()
+            .cloned()
+            .collect();
         let inputs = build_registered_inputs(
-            &self.manifest.declared_inputs,
-            &self.source_variables,
+            self.source_input_resolution.declared_inputs(),
+            self.source_input_resolution.variables(),
             &secret_keys,
         );
 

--- a/crates/coral-engine/src/backends/mcp/mod.rs
+++ b/crates/coral-engine/src/backends/mcp/mod.rs
@@ -29,13 +29,12 @@ use crate::backends::{
     build_registered_table_function, internal_table_function_name, registered_columns_from_specs,
     required_filter_names,
 };
-use crate::{QuerySource, SourceInputResolver, SourceInputResolverError};
+use crate::{SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError};
 
 #[derive(Debug, Clone)]
 struct McpCompiledSource {
     manifest: McpSourceManifest,
-    source_secrets: BTreeMap<String, String>,
-    source_variables: BTreeMap<String, String>,
+    source_input_resolution: SourceInputResolutionContext,
     source_inputs: Arc<McpSourceInputs>,
     caller: McpSourceClient,
 }
@@ -43,24 +42,23 @@ struct McpCompiledSource {
 #[derive(Debug, Clone)]
 struct McpSourceInputs {
     fallback: Arc<BTreeMap<String, String>>,
-    source: Option<QuerySource>,
+    source: Option<SourceInputResolutionContext>,
     resolver: Option<Arc<dyn SourceInputResolver>>,
 }
 
 impl McpSourceInputs {
-    fn new(
+    fn with_resolver(
         fallback: Arc<BTreeMap<String, String>>,
-        source: QuerySource,
-        resolver: Option<Arc<dyn SourceInputResolver>>,
+        source: SourceInputResolutionContext,
+        resolver: Arc<dyn SourceInputResolver>,
     ) -> Self {
         Self {
             fallback,
             source: Some(source),
-            resolver,
+            resolver: Some(resolver),
         }
     }
 
-    #[cfg(test)]
     fn static_inputs(fallback: Arc<BTreeMap<String, String>>) -> Self {
         Self {
             fallback,
@@ -85,16 +83,20 @@ pub(crate) fn compile_manifest(
     manifest: &McpSourceManifest,
     request: &BackendCompileRequest<'_>,
 ) -> Box<dyn CompiledBackendSource> {
+    let source_input_resolution = SourceInputResolutionContext::from_query_source(request.source);
     let resolved_inputs = Arc::new(coral_spec::resolve_inputs(
         &manifest.declared_inputs,
-        &request.source_secrets,
-        &request.source_variables,
+        source_input_resolution.secrets(),
+        source_input_resolution.variables(),
     ));
-    let source_inputs = Arc::new(McpSourceInputs::new(
-        Arc::clone(&resolved_inputs),
-        request.source.clone(),
-        request.source_input_resolver.clone(),
-    ));
+    let source_inputs = Arc::new(match request.source_input_resolver.clone() {
+        Some(resolver) => McpSourceInputs::with_resolver(
+            Arc::clone(&resolved_inputs),
+            source_input_resolution.clone(),
+            resolver,
+        ),
+        None => McpSourceInputs::static_inputs(Arc::clone(&resolved_inputs)),
+    });
     let caller = Arc::new(StdioMcpToolCaller {
         source_name: manifest.common.name.clone(),
         server: manifest.server.clone(),
@@ -102,8 +104,7 @@ pub(crate) fn compile_manifest(
     });
     compile_source_with_caller(
         manifest.clone(),
-        request.source_secrets.clone(),
-        request.source_variables.clone(),
+        source_input_resolution,
         source_inputs,
         caller,
     )
@@ -111,15 +112,13 @@ pub(crate) fn compile_manifest(
 
 fn compile_source_with_caller(
     manifest: McpSourceManifest,
-    source_secrets: BTreeMap<String, String>,
-    source_variables: BTreeMap<String, String>,
+    source_input_resolution: SourceInputResolutionContext,
     source_inputs: Arc<McpSourceInputs>,
     caller: Arc<dyn McpToolCaller>,
 ) -> Box<dyn CompiledBackendSource> {
     Box::new(McpCompiledSource {
         manifest,
-        source_secrets,
-        source_variables,
+        source_input_resolution,
         source_inputs,
         caller: McpSourceClient::new(caller),
     })
@@ -178,10 +177,15 @@ impl CompiledBackendSource for McpCompiledSource {
             ));
         }
 
-        let secret_keys = self.source_secrets.keys().cloned().collect();
+        let secret_keys = self
+            .source_input_resolution
+            .secrets()
+            .keys()
+            .cloned()
+            .collect();
         let inputs = build_registered_inputs(
-            &self.manifest.declared_inputs,
-            &self.source_variables,
+            self.source_input_resolution.declared_inputs(),
+            self.source_input_resolution.variables(),
             &secret_keys,
         );
 

--- a/crates/coral-engine/src/backends/mcp/tests.rs
+++ b/crates/coral-engine/src/backends/mcp/tests.rs
@@ -2,7 +2,9 @@ use super::*;
 use crate::runtime::catalog;
 use crate::runtime::registry::{CompiledQuerySource, register_sources_blocking};
 use crate::runtime::source_functions::SourceFunctionRegistry;
-use crate::{QuerySource, SourceInputResolver, SourceInputResolverError};
+use crate::{
+    QuerySource, SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError,
+};
 use datafusion::arrow::util::pretty::pretty_format_batches;
 use datafusion::error::DataFusionError;
 use datafusion::prelude::SessionContext;
@@ -117,7 +119,7 @@ struct RotatingInputResolver {
 impl SourceInputResolver for RotatingInputResolver {
     async fn resolve_inputs(
         &self,
-        _source: &QuerySource,
+        _source: &SourceInputResolutionContext,
     ) -> std::result::Result<BTreeMap<String, String>, SourceInputResolverError> {
         let call = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
         Ok(BTreeMap::from([(
@@ -219,27 +221,23 @@ fn compile_sources_with_inputs(
 ) -> Vec<CompiledQuerySource> {
     let mcp_manifest = manifest.as_mcp().expect("mcp manifest").clone();
     let variables = BTreeMap::new();
+    let source = QuerySource::new(manifest, variables.clone(), secrets);
+    let source_input_resolution = SourceInputResolutionContext::from_query_source(&source);
     let resolved_inputs = Arc::new(coral_spec::resolve_inputs(
         &mcp_manifest.declared_inputs,
-        &secrets,
-        &variables,
+        source_input_resolution.secrets(),
+        source_input_resolution.variables(),
     ));
-    let source = QuerySource::new(manifest, variables.clone(), secrets);
     let source_inputs = match source_input_resolver {
-        Some(resolver) => Arc::new(McpSourceInputs::new(
+        Some(resolver) => Arc::new(McpSourceInputs::with_resolver(
             Arc::clone(&resolved_inputs),
-            source.clone(),
-            Some(resolver),
+            source_input_resolution.clone(),
+            resolver,
         )),
         None => Arc::new(McpSourceInputs::static_inputs(resolved_inputs)),
     };
-    let compiled = compile_source_with_caller(
-        mcp_manifest,
-        source.secrets().clone(),
-        variables.clone(),
-        source_inputs,
-        caller,
-    );
+    let compiled =
+        compile_source_with_caller(mcp_manifest, source_input_resolution, source_inputs, caller);
     vec![CompiledQuerySource { source, compiled }]
 }
 
@@ -1027,12 +1025,12 @@ async fn stdio_env_resolves_source_inputs_for_each_tool_call() {
     ));
     let resolver_calls = Arc::new(AtomicUsize::new(0));
     let source = QuerySource::new(manifest, variables, secrets);
-    let source_inputs = Arc::new(McpSourceInputs::new(
+    let source_inputs = Arc::new(McpSourceInputs::with_resolver(
         resolved_inputs,
-        source,
-        Some(Arc::new(RotatingInputResolver {
+        SourceInputResolutionContext::from_query_source(&source),
+        Arc::new(RotatingInputResolver {
             calls: Arc::clone(&resolver_calls),
-        })),
+        }),
     ));
     let caller = StdioMcpToolCaller {
         source_name: mcp_manifest.common.name.clone(),

--- a/crates/coral-engine/src/composition.rs
+++ b/crates/coral-engine/src/composition.rs
@@ -11,6 +11,7 @@ use reqwest::header::{HeaderName, HeaderValue};
 
 use crate::CoreError;
 use crate::contracts::QuerySource;
+use coral_spec::{ManifestInputKind, ManifestInputSpec};
 
 /// One source's table providers keyed by manifest table name.
 pub type SourceTables = HashMap<String, Arc<dyn TableProvider>>;
@@ -137,6 +138,78 @@ impl SourceInputResolverError {
     }
 }
 
+/// Request-time source input-resolution context exposed to source input resolvers.
+///
+/// This carries only the source identity and declared input state needed to
+/// refresh app-managed inputs before an outbound source request. It deliberately
+/// avoids carrying the full validated source manifest, because backends clone
+/// request state for each registered table and table function.
+#[derive(Debug, Clone)]
+pub struct SourceInputResolutionContext {
+    source_name: Arc<str>,
+    declared_inputs: Arc<[ManifestInputSpec]>,
+    variables: Arc<BTreeMap<String, String>>,
+    secrets: Arc<BTreeMap<String, String>>,
+}
+
+impl SourceInputResolutionContext {
+    #[must_use]
+    /// Builds request input-resolution context from one selected query source.
+    pub fn from_query_source(source: &QuerySource) -> Self {
+        Self {
+            source_name: Arc::from(source.source_name()),
+            declared_inputs: Arc::from(source.source_spec().declared_inputs().to_vec()),
+            variables: Arc::new(source.variables().clone()),
+            secrets: Arc::new(source.secrets().clone()),
+        }
+    }
+
+    #[must_use]
+    /// Returns the canonical source name. This is also the SQL schema name.
+    pub fn source_name(&self) -> &str {
+        &self.source_name
+    }
+
+    #[must_use]
+    /// Returns the declared source inputs in authored order.
+    pub fn declared_inputs(&self) -> &[ManifestInputSpec] {
+        &self.declared_inputs
+    }
+
+    #[must_use]
+    /// Returns configured non-secret source variables.
+    pub fn variables(&self) -> &BTreeMap<String, String> {
+        &self.variables
+    }
+
+    #[must_use]
+    /// Returns resolved declared source secrets available to request-time resolvers.
+    pub fn secrets(&self) -> &BTreeMap<String, String> {
+        &self.secrets
+    }
+
+    #[must_use]
+    /// Returns required declared secret names.
+    pub fn required_secret_names(&self) -> Vec<String> {
+        self.declared_inputs
+            .iter()
+            .filter(|input| input.kind == ManifestInputKind::Secret && input.required)
+            .map(|input| input.key.clone())
+            .collect()
+    }
+
+    #[must_use]
+    /// Returns a new context with refreshed secret values.
+    pub fn with_secrets(&self, secrets: BTreeMap<String, String>) -> Self {
+        Self {
+            source_name: Arc::clone(&self.source_name),
+            declared_inputs: Arc::clone(&self.declared_inputs),
+            variables: Arc::clone(&self.variables),
+            secrets: Arc::new(secrets),
+        }
+    }
+}
+
 /// Request-time HTTP authenticator registered through engine extensions.
 pub trait RequestAuthenticator: Send + Sync + std::fmt::Debug {
     /// Stable authenticator name used in diagnostics and manifest dispatch.
@@ -184,7 +257,7 @@ pub trait SourceInputResolver: Send + Sync + std::fmt::Debug {
     /// resolved for active source use.
     async fn resolve_inputs(
         &self,
-        source: &QuerySource,
+        source: &SourceInputResolutionContext,
     ) -> Result<BTreeMap<String, String>, SourceInputResolverError>;
 }
 
@@ -273,5 +346,102 @@ pub trait SourceDecorator: Send + Sync {
     /// Returns [`SourceDecoratorError`] if final invariants are not satisfied.
     fn finish(&mut self) -> Result<(), SourceDecoratorError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use coral_spec::parse_source_manifest_value;
+    use serde_json::json;
+
+    use crate::{QuerySource, SourceInputResolutionContext};
+
+    #[test]
+    fn source_input_resolution_context_keeps_only_request_input_contract() {
+        let manifest = parse_source_manifest_value(json!({
+            "dsl_version": 3,
+            "name": "secured_messages",
+            "version": "0.1.0",
+            "backend": "http",
+            "inputs": {
+                "API_BASE": {
+                    "kind": "variable",
+                    "default": "https://api.example.com"
+                },
+                "API_TOKEN": {
+                    "kind": "secret"
+                },
+                "OPTIONAL_TOKEN": {
+                    "kind": "secret",
+                    "required": false
+                }
+            },
+            "base_url": "{{input.API_BASE}}",
+            "tables": [{
+                "name": "messages",
+                "description": "Messages",
+                "request": {
+                    "method": "GET",
+                    "path": "/messages"
+                },
+                "response": {},
+                "columns": [{
+                    "name": "id",
+                    "type": "Utf8"
+                }]
+            }]
+        }))
+        .expect("parse source manifest");
+        let source = QuerySource::new(
+            manifest,
+            BTreeMap::from([(
+                "API_BASE".to_string(),
+                "https://configured.example.com".to_string(),
+            )]),
+            BTreeMap::from([
+                ("API_TOKEN".to_string(), "stale-token".to_string()),
+                ("OPTIONAL_TOKEN".to_string(), "optional-token".to_string()),
+            ]),
+        );
+
+        let context = SourceInputResolutionContext::from_query_source(&source);
+
+        assert_eq!(context.source_name(), "secured_messages");
+        assert_eq!(
+            context.variables().get("API_BASE").map(String::as_str),
+            Some("https://configured.example.com")
+        );
+        assert_eq!(
+            context.secrets().get("API_TOKEN").map(String::as_str),
+            Some("stale-token")
+        );
+        assert_eq!(
+            context
+                .declared_inputs()
+                .iter()
+                .map(|input| input.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["API_BASE", "API_TOKEN", "OPTIONAL_TOKEN"]
+        );
+        assert_eq!(
+            context.required_secret_names(),
+            vec!["API_TOKEN".to_string()]
+        );
+
+        let refreshed = context.with_secrets(BTreeMap::from([(
+            "API_TOKEN".to_string(),
+            "fresh-token".to_string(),
+        )]));
+
+        assert_eq!(refreshed.source_name(), context.source_name());
+        assert_eq!(refreshed.declared_inputs(), context.declared_inputs());
+        assert_eq!(refreshed.variables(), context.variables());
+        assert_eq!(
+            refreshed.secrets().get("API_TOKEN").map(String::as_str),
+            Some("fresh-token")
+        );
+        assert!(!refreshed.secrets().contains_key("OPTIONAL_TOKEN"));
     }
 }

--- a/crates/coral-engine/src/lib.rs
+++ b/crates/coral-engine/src/lib.rs
@@ -63,7 +63,7 @@ mod runtime;
 pub use composition::{
     EngineExtensions, QueryResultObserver, QueryResultObserverError, RequestAuthenticator,
     RequestAuthenticatorError, SourceDecorator, SourceDecoratorError, SourceFailurePolicy,
-    SourceInputResolver, SourceInputResolverError, SourceTables,
+    SourceInputResolutionContext, SourceInputResolver, SourceInputResolverError, SourceTables,
 };
 pub use contracts::{
     CatalogInfo, ColumnInfo, CoreError, QueryExecution, QueryPlan, QueryRuntimeConfig,


### PR DESCRIPTION
## Intent

Fix the catalog/query runtime registration regression introduced by OAuth refresh support without pulling the separate reqwest-client reuse change into the same PR.

PR #764 added request-time source input refresh by passing the full `QuerySource` into `SourceInputResolver`. That made HTTP registration carry a full validated source manifest in `HttpSourceClient`, which is cloned for every HTTP table and table function. The resolver only needs source identity, declared inputs, variables, and current secrets.

## What changed

- Added `SourceInputResolutionContext` to the engine extension surface.
- Changed `SourceInputResolver::resolve_inputs` to take `&SourceInputResolutionContext` instead of `&QuerySource`.
- Moved HTTP and MCP request-input storage to the narrower context and stopped carrying duplicate secret/variable maps beside it.
- Kept OAuth refresh behavior intact: app-managed refresh still happens lazily at request time, and catalog registration does not refresh credentials.
- Added a focused `SourceInputResolutionContext` contract test covering source identity, declared input order, required-secret filtering, variables, current secrets, and refreshed secret replacement.

## Ownership / Boundaries

- `coral-engine` owns the extension contract because `SourceInputResolver` is an engine extension used by backend request execution.
- `SourceInputResolutionContext` is intentionally narrower than `QuerySource`: it exposes only source name, declared input specs, configured variables, and current/refreshed secrets.
- `coral-app` still owns credential refresh lifecycle. The app resolver can refresh workspace-managed credentials at request time, then return resolved inputs to the engine.
- HTTP and MCP backends do not know how credentials are stored or refreshed. They only ask the resolver for request inputs when one is installed, otherwise they use the pre-resolved static inputs.
- No proto, gRPC, CLI, MCP tool schema, source manifest schema, or persisted config shape changes in this PR.

## Compatibility / User Impact

This preserves the OAuth refresh behavior from PR #764 while removing the accidental registration-time clone cost. Catalog metadata calls get faster, and real HTTP endpoint queries also get faster because they pay the same registration cost before executing the request.

The resolver still receives all input material it needs:

- source identity for workspace/provider lookup
- declared input specs for refresh and validation
- configured variables for template/input resolution
- current secrets, plus a way to produce a refreshed secret context

## Timing

Five fresh-process MCP repeats using the real local Coral manifest. Each repeat does `initialize`, `tools/list`, then the target `tools/call`. The table reports target `tools/call` wall time.

| Build | `list_catalog` avg | `search_catalog limit=5` avg | `sql github.issues LIMIT 1` avg | Notes |
| --- | ---: | ---: | ---: | --- |
| Before PR #764 (`a6febf34`) | `837.755 ms` | not measured | not measured | Before OAuth refresh context was added. |
| Current main closest baseline (`72ad33dc`) | `2312.664 ms` | `2325.554 ms` | `2997.436 ms` | Same 5-repeat harness, closest comparable main build. |
| This PR (`16087f2c` + patch) | `855.819 ms` | `853.521 ms` | `1616.908 ms` | Restores catalog registration to the pre-#764 shape. |
| Improvement vs current main | `-1456.845 ms` / `2.70x faster` | `-1472.033 ms` / `2.73x faster` | `-1380.528 ms` / `1.85x faster` | Improves both metadata calls and a real HTTP endpoint query. |

Interpretation: this PR removes the post-#764 manifest clone cost from registration. Catalog metadata calls return to the pre-#764 timing shape, and real endpoint queries also improve because they pay the same registration cost before executing the HTTP request.

## Not in this PR

- Reusing a shared `reqwest::Client` across HTTP source registration. That remains the follow-up performance PR.
- Changing credential refresh semantics or where app-managed credentials are stored.
- Changing MCP/CLI/API response shapes.

The remaining ~850 ms catalog cost is the older repeated `reqwest::Client` / native TLS setup issue.

## Validation

- `cargo fmt --check`
- `cargo check -p coral-engine -p coral-app --tests --locked`
- `cargo clippy -p coral-engine -p coral-app --all-targets --all-features --locked -- -D warnings`
- `cargo test -p coral-engine source_input_context_keeps_only_request_input_contract --locked`
- `cargo test -p coral-app runtime_config_composes_provider_input_resolver_with_refreshed_inputs --locked`
- `cargo test -p coral-engine --lib backends::mcp::tests::stdio_env_resolves_source_inputs_for_each_tool_call --locked`
- `make rust-checks`