### PR TITLE
feat(sources/community/freshservice): add Freshservice source

### DIFF
--- a/sources/community/freshservice/README.md
+++ b/sources/community/freshservice/README.md
@@ -21,7 +21,7 @@ Official docs:
 
 - <https://api.freshservice.com/>
 - <https://api.freshservice.com/#tickets>
-- <https://api.freshservice.com/#assets>
+- <https://api.freshservice.com/v2/#view_all_assets_for_freshservice_itam>
 
 ## Tables
 
@@ -30,9 +30,9 @@ Official docs:
 | `freshservice.tickets` | Ticket metadata. Supports `updated_since`, `requester_id`, `email`, and `workspace_id`. |
 | `freshservice.agents` | Agents. |
 | `freshservice.requesters` | Requesters. |
-| `freshservice.departments` | Departments. |
-| `freshservice.assets` | Assets. Supports `updated_since`. |
-| `freshservice.locations` | Locations. |
+| `freshservice.departments` | Departments. Supports `workspace_id`. |
+| `freshservice.assets` | Current Freshservice ITAM assets. Supports `last_updated_gt` and `last_updated_lt`. |
+| `freshservice.locations` | Locations. Supports `workspace_id`. |
 
 ## Examples
 
@@ -61,6 +61,7 @@ Review asset ownership:
 ```sql
 SELECT id, display_id, name, user_id, department_id, location_id
 FROM freshservice.assets
+WHERE last_updated_gt = '2026-05-01T00:00:00Z'
 LIMIT 25;
 ```
 
@@ -71,8 +72,14 @@ LIMIT 25;
 - Ticket conversations, notes, and asset custom-field payloads are intentionally
   omitted from v1 to keep the source read-only and avoid exposing sensitive
   text or credentials.
+- `freshservice.assets` uses the current Freshservice ITAM endpoint
+  `/api/v2/itam/assets`. The legacy `/api/v2/assets` endpoint for older
+  signups is not modeled by this source.
 - Ticket and asset tables have conservative default fetch limits. Use provider
   filters and SQL `LIMIT` for production service desks.
+- Freshservice workspace and MSP accounts may default departments and locations
+  to a primary workspace when `workspace_id` is omitted. Provide `workspace_id`
+  to query a specific workspace.
 - Results depend on the API key owner's Freshservice role and workspace access.
 
 ## Validation

--- a/sources/community/freshservice/README.md
+++ b/sources/community/freshservice/README.md
@@ -1,0 +1,98 @@
+# Freshservice
+
+Query Freshservice ITSM and asset metadata from Coral. The source covers
+tickets, agents, requesters, departments, assets, and locations.
+
+## Authentication
+
+Create or copy a Freshservice API key from your Freshservice profile and
+provide:
+
+| Input | Description |
+| --- | --- |
+| `FRESHSERVICE_DOMAIN` | Account URL, for example `https://example.freshservice.com`. |
+| `FRESHSERVICE_API_KEY` | Freshservice API key. |
+
+Freshservice API keys are modeled as secrets and sent using HTTP Basic auth as
+the username with `X` as the placeholder password. Use a least-privilege agent
+or admin account whose API key can read only the records Coral agents need.
+
+Official docs:
+
+- <https://api.freshservice.com/>
+- <https://api.freshservice.com/#tickets>
+- <https://api.freshservice.com/#assets>
+
+## Tables
+
+| Table | Description |
+| --- | --- |
+| `freshservice.tickets` | Ticket metadata. Supports `updated_since`, `requester_id`, `email`, and `workspace_id`. |
+| `freshservice.agents` | Agents. |
+| `freshservice.requesters` | Requesters. |
+| `freshservice.departments` | Departments. |
+| `freshservice.assets` | Assets. Supports `updated_since`. |
+| `freshservice.locations` | Locations. |
+
+## Examples
+
+List recently updated tickets:
+
+```sql
+SELECT id, subject, status, priority, requester_id, updated_at
+FROM freshservice.tickets
+WHERE updated_since = '2026-05-01T00:00:00Z'
+ORDER BY updated_at DESC
+LIMIT 25;
+```
+
+Map tickets to agents:
+
+```sql
+SELECT t.id, t.subject, t.status, a.email AS responder_email
+FROM freshservice.tickets AS t
+LEFT JOIN freshservice.agents AS a
+  ON t.responder_id = a.id
+LIMIT 25;
+```
+
+Review asset ownership:
+
+```sql
+SELECT id, display_id, name, user_id, department_id, location_id
+FROM freshservice.assets
+LIMIT 25;
+```
+
+## Notes
+
+- Freshservice list endpoints are modeled with `page` and `per_page`
+  pagination. Page size is capped at 100.
+- Ticket conversations, notes, and asset custom-field payloads are intentionally
+  omitted from v1 to keep the source read-only and avoid exposing sensitive
+  text or credentials.
+- Ticket and asset tables have conservative default fetch limits. Use provider
+  filters and SQL `LIMIT` for production service desks.
+- Results depend on the API key owner's Freshservice role and workspace access.
+
+## Validation
+
+- YAML parsing: passed
+- Coral manifest schema validation: passed
+- `git diff --check`: passed
+- `make lint-sources`: passed
+
+Manual Freshservice tenant validation:
+
+```text
+API verified: Freshservice tenant and tickets endpoint responded as expected.
+Tenant: https://opensourcecontributor.freshservice.com
+Endpoint checked: GET /api/v2/tickets
+
+Verified:
+- Tenant is reachable.
+- Freshservice API v2 tickets endpoint exists.
+- Unauthenticated API access is blocked with 403 access_denied.
+- A live test incident was created in the tenant (#INC-1).
+- Authenticated browser-session API access returned ticket data.
+```

--- a/sources/community/freshservice/README.md
+++ b/sources/community/freshservice/README.md
@@ -56,25 +56,27 @@ LEFT JOIN freshservice.agents AS a
 LIMIT 25;
 ```
 
-Review asset ownership:
+Review ITAM assets:
 
 ```sql
-SELECT id, display_id, name, user_id, department_id, location_id
+SELECT asset_id, asset_no, type_id, service_level, serial_no, rack
 FROM freshservice.assets
-WHERE last_updated_gt = '2026-05-01T00:00:00Z'
+WHERE last_updated_gt = '2026-05-01'
 LIMIT 25;
 ```
 
 ## Notes
 
-- Freshservice list endpoints are modeled with `page` and `per_page`
-  pagination. Page size is capped at 100.
+- Freshservice list endpoints are modeled with provider-specific pagination.
+  Most tables use `page` and `per_page`; `freshservice.assets` uses ITAM
+  `offset` and `limit`. Page size is capped at 100.
 - Ticket conversations, notes, and asset custom-field payloads are intentionally
   omitted from v1 to keep the source read-only and avoid exposing sensitive
   text or credentials.
 - `freshservice.assets` uses the current Freshservice ITAM endpoint
-  `/api/v2/itam/assets`. The legacy `/api/v2/assets` endpoint for older
-  signups is not modeled by this source.
+  `/api/v2/itam/assets`. Use `last_updated_gt` and `last_updated_lt` in
+  `YYYY-MM-DD` format. The legacy `/api/v2/assets` endpoint for older signups
+  is not modeled by this source.
 - Ticket and asset tables have conservative default fetch limits. Use provider
   filters and SQL `LIMIT` for production service desks.
 - Freshservice workspace and MSP accounts may default departments and locations

--- a/sources/community/freshservice/manifest.yaml
+++ b/sources/community/freshservice/manifest.yaml
@@ -262,10 +262,10 @@ tables:
         type: Utf8
         nullable: true
         description: Requester job title.
-      - name: department_id
-        type: Int64
+      - name: department_ids
+        type: Json
         nullable: true
-        description: Department ID.
+        description: Department IDs associated with the requester.
       - name: active
         type: Boolean
         nullable: true
@@ -362,9 +362,9 @@ tables:
     description: Freshservice assets visible to the API key.
     guide: |
       Uses the current Freshservice ITAM assets endpoint. Asset inventories can
-      be large, so use `last_updated_gt`, `last_updated_lt`, and SQL LIMIT to
-      narrow production queries. Legacy `/assets` accounts created before
-      March 31, 2026 are intentionally not modeled by this v1 source.
+      be large, so use date-only `last_updated_gt`, `last_updated_lt`, and SQL
+      LIMIT to narrow production queries. Legacy `/assets` accounts created
+      before March 31, 2026 are intentionally not modeled by this v1 source.
     filters:
       - name: last_updated_gt
       - name: last_updated_lt
@@ -383,66 +383,37 @@ tables:
       rows_path: [assets]
       row_strategy: direct
     pagination:
-      mode: page
-      page_param: page
-      page_start: 1
+      mode: offset
+      offset_param: offset
       page_size:
         default: 100
         max: 100
-        query_param: per_page
+        query_param: limit
     columns:
-      - name: id
+      - name: asset_id
         type: Int64
         nullable: false
-        description: Asset ID.
-      - name: display_id
-        type: Int64
-        nullable: true
-        description: Human-readable asset display ID.
-      - name: name
+        description: Freshservice ITAM asset ID.
+      - name: asset_no
         type: Utf8
         nullable: true
-        description: Asset name.
-      - name: asset_type_id
+        description: Freshservice ITAM asset number.
+      - name: type_id
         type: Int64
         nullable: true
-        description: Asset type ID.
-      - name: user_id
-        type: Int64
-        nullable: true
-        description: Assigned user ID.
-      - name: department_id
-        type: Int64
-        nullable: true
-        description: Department ID.
-      - name: location_id
-        type: Int64
-        nullable: true
-        description: Location ID.
-      - name: impact
+        description: Freshservice ITAM asset type ID.
+      - name: service_level
         type: Utf8
         nullable: true
-        description: Asset impact.
-      - name: usage_type
+        description: Freshservice ITAM service level.
+      - name: serial_no
         type: Utf8
         nullable: true
-        description: Asset usage type.
-      - name: created_at
-        type: Timestamp
+        description: Asset serial number.
+      - name: rack
+        type: Utf8
         nullable: true
-        description: Asset creation time.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr: {kind: path, path: [created_at]}
-      - name: updated_at
-        type: Timestamp
-        nullable: true
-        description: Asset update time.
-        expr:
-          kind: format_timestamp
-          input: iso8601
-          expr: {kind: path, path: [updated_at]}
+        description: Rack metadata when returned by Freshservice ITAM.
 
   - name: locations
     description: Freshservice locations.

--- a/sources/community/freshservice/manifest.yaml
+++ b/sources/community/freshservice/manifest.yaml
@@ -1,0 +1,474 @@
+name: freshservice
+version: 0.1.0
+dsl_version: 3
+backend: http
+description: >-
+  Query Freshservice tickets, agents, requesters, departments, assets, and
+  locations.
+base_url: "{{input.FRESHSERVICE_DOMAIN}}/api/v2"
+
+inputs:
+  FRESHSERVICE_DOMAIN:
+    kind: variable
+    hint: |
+      Freshservice account URL without a trailing slash, for example
+      `https://example.freshservice.com`.
+  FRESHSERVICE_API_KEY:
+    kind: secret
+    hint: |
+      Freshservice API key. The key is sent with HTTP Basic auth as the
+      username and a placeholder password.
+
+auth:
+  type: BasicAuth
+  username: "{{input.FRESHSERVICE_API_KEY}}"
+  password: X
+
+request_headers:
+  - name: Accept
+    from: literal
+    value: application/json
+
+test_queries:
+  - SELECT id, subject, status FROM freshservice.tickets LIMIT 1
+  - SELECT id, email FROM freshservice.requesters LIMIT 1
+
+tables:
+  - name: tickets
+    description: Freshservice tickets visible to the API key.
+    guide: |
+      Ticket inventory can be large. Use SQL LIMIT and provider filters such as
+      `updated_since`, `requester_id`, or `email` to narrow production queries.
+      This table intentionally does not expose ticket conversations.
+    filters:
+      - name: updated_since
+      - name: requester_id
+      - name: email
+      - name: workspace_id
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /tickets
+      query:
+        - name: updated_since
+          from: filter
+          key: updated_since
+        - name: requester_id
+          from: filter
+          key: requester_id
+        - name: email
+          from: filter
+          key: email
+        - name: workspace_id
+          from: filter
+          key: workspace_id
+    response:
+      rows_path: [tickets]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Freshservice ticket ID.
+      - name: subject
+        type: Utf8
+        nullable: true
+        description: Ticket subject.
+      - name: description_text
+        type: Utf8
+        nullable: true
+        description: Plain-text ticket description.
+      - name: status
+        type: Int64
+        nullable: true
+        description: Ticket status code.
+      - name: priority
+        type: Int64
+        nullable: true
+        description: Ticket priority code.
+      - name: source
+        type: Int64
+        nullable: true
+        description: Ticket source code.
+      - name: requester_id
+        type: Int64
+        nullable: true
+        description: Requester user ID.
+      - name: responder_id
+        type: Int64
+        nullable: true
+        description: Assigned agent ID.
+      - name: group_id
+        type: Int64
+        nullable: true
+        description: Assigned group ID.
+      - name: department_id
+        type: Int64
+        nullable: true
+        description: Department ID.
+      - name: workspace_id
+        type: Int64
+        nullable: true
+        description: Freshservice workspace ID when returned.
+      - name: category
+        type: Utf8
+        nullable: true
+        description: Ticket category.
+      - name: sub_category
+        type: Utf8
+        nullable: true
+        description: Ticket subcategory.
+      - name: item_category
+        type: Utf8
+        nullable: true
+        description: Ticket item category.
+      - name: tags
+        type: Json
+        nullable: true
+        description: Ticket tags.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Ticket creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Ticket update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+      - name: due_by
+        type: Timestamp
+        nullable: true
+        description: Ticket due time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [due_by]}
+
+  - name: agents
+    description: Freshservice agents.
+    guide: |
+      Lists agents visible to the API key. Use this table to map responder IDs
+      on tickets to people.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /agents
+    response:
+      rows_path: [agents]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Agent ID.
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Agent email.
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: Agent first name.
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Agent last name.
+      - name: job_title
+        type: Utf8
+        nullable: true
+        description: Agent job title.
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the agent is active.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Agent creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Agent update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: requesters
+    description: Freshservice requesters.
+    guide: |
+      Lists requesters visible to the API key. Use SQL LIMIT when scanning
+      larger service desks.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /requesters
+    response:
+      rows_path: [requesters]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Requester ID.
+      - name: primary_email
+        type: Utf8
+        nullable: true
+        description: Requester primary email.
+      - name: email
+        type: Utf8
+        nullable: true
+        description: Requester email when returned.
+      - name: first_name
+        type: Utf8
+        nullable: true
+        description: Requester first name.
+      - name: last_name
+        type: Utf8
+        nullable: true
+        description: Requester last name.
+      - name: job_title
+        type: Utf8
+        nullable: true
+        description: Requester job title.
+      - name: department_id
+        type: Int64
+        nullable: true
+        description: Department ID.
+      - name: active
+        type: Boolean
+        nullable: true
+        description: Whether the requester is active.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Requester creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Requester update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: departments
+    description: Freshservice departments.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /departments
+    response:
+      rows_path: [departments]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Department ID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Department name.
+      - name: description
+        type: Utf8
+        nullable: true
+        description: Department description.
+      - name: head_user_id
+        type: Int64
+        nullable: true
+        description: Department head user ID.
+      - name: prime_user_id
+        type: Int64
+        nullable: true
+        description: Prime user ID.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Department creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Department update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: assets
+    description: Freshservice assets visible to the API key.
+    guide: |
+      Asset inventories can be large. This table uses a conservative default
+      fetch limit and exposes metadata only, not sensitive custom fields.
+    filters:
+      - name: updated_since
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /assets
+      query:
+        - name: updated_since
+          from: filter
+          key: updated_since
+    response:
+      rows_path: [assets]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Asset ID.
+      - name: display_id
+        type: Int64
+        nullable: true
+        description: Human-readable asset display ID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Asset name.
+      - name: asset_type_id
+        type: Int64
+        nullable: true
+        description: Asset type ID.
+      - name: user_id
+        type: Int64
+        nullable: true
+        description: Assigned user ID.
+      - name: department_id
+        type: Int64
+        nullable: true
+        description: Department ID.
+      - name: location_id
+        type: Int64
+        nullable: true
+        description: Location ID.
+      - name: impact
+        type: Utf8
+        nullable: true
+        description: Asset impact.
+      - name: usage_type
+        type: Utf8
+        nullable: true
+        description: Asset usage type.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Asset creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Asset update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}
+
+  - name: locations
+    description: Freshservice locations.
+    fetch_limit_default: 100
+    request:
+      method: GET
+      path: /locations
+    response:
+      rows_path: [locations]
+      row_strategy: direct
+    pagination:
+      mode: page
+      page_param: page
+      page_start: 1
+      page_size:
+        default: 100
+        max: 100
+        query_param: per_page
+    columns:
+      - name: id
+        type: Int64
+        nullable: false
+        description: Location ID.
+      - name: name
+        type: Utf8
+        nullable: true
+        description: Location name.
+      - name: parent_location_id
+        type: Int64
+        nullable: true
+        description: Parent location ID.
+      - name: created_at
+        type: Timestamp
+        nullable: true
+        description: Location creation time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [created_at]}
+      - name: updated_at
+        type: Timestamp
+        nullable: true
+        description: Location update time.
+        expr:
+          kind: format_timestamp
+          input: iso8601
+          expr: {kind: path, path: [updated_at]}

--- a/sources/community/freshservice/manifest.yaml
+++ b/sources/community/freshservice/manifest.yaml
@@ -31,7 +31,7 @@ request_headers:
 
 test_queries:
   - SELECT id, subject, status FROM freshservice.tickets LIMIT 1
-  - SELECT id, email FROM freshservice.requesters LIMIT 1
+  - SELECT id, primary_email FROM freshservice.requesters LIMIT 1
 
 tables:
   - name: tickets
@@ -250,10 +250,6 @@ tables:
         type: Utf8
         nullable: true
         description: Requester primary email.
-      - name: email
-        type: Utf8
-        nullable: true
-        description: Requester email when returned.
       - name: first_name
         type: Utf8
         nullable: true
@@ -293,10 +289,20 @@ tables:
 
   - name: departments
     description: Freshservice departments.
+    guide: |
+      Freshservice workspace and MSP accounts default to the primary workspace
+      when `workspace_id` is omitted. Use `workspace_id` to query a specific
+      workspace.
+    filters:
+      - name: workspace_id
     fetch_limit_default: 100
     request:
       method: GET
       path: /departments
+      query:
+        - name: workspace_id
+          from: filter
+          key: workspace_id
     response:
       rows_path: [departments]
       row_strategy: direct
@@ -329,6 +335,12 @@ tables:
         type: Int64
         nullable: true
         description: Prime user ID.
+      - name: workspace_id
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional workspace filter.
+        expr: {kind: from_filter, key: workspace_id}
       - name: created_at
         type: Timestamp
         nullable: true
@@ -349,18 +361,24 @@ tables:
   - name: assets
     description: Freshservice assets visible to the API key.
     guide: |
-      Asset inventories can be large. This table uses a conservative default
-      fetch limit and exposes metadata only, not sensitive custom fields.
+      Uses the current Freshservice ITAM assets endpoint. Asset inventories can
+      be large, so use `last_updated_gt`, `last_updated_lt`, and SQL LIMIT to
+      narrow production queries. Legacy `/assets` accounts created before
+      March 31, 2026 are intentionally not modeled by this v1 source.
     filters:
-      - name: updated_since
+      - name: last_updated_gt
+      - name: last_updated_lt
     fetch_limit_default: 100
     request:
       method: GET
-      path: /assets
+      path: /itam/assets
       query:
-        - name: updated_since
+        - name: last_updated_gt
           from: filter
-          key: updated_since
+          key: last_updated_gt
+        - name: last_updated_lt
+          from: filter
+          key: last_updated_lt
     response:
       rows_path: [assets]
       row_strategy: direct
@@ -428,10 +446,20 @@ tables:
 
   - name: locations
     description: Freshservice locations.
+    guide: |
+      Freshservice workspace and MSP accounts default to the primary workspace
+      when `workspace_id` is omitted. Use `workspace_id` to query a specific
+      workspace.
+    filters:
+      - name: workspace_id
     fetch_limit_default: 100
     request:
       method: GET
       path: /locations
+      query:
+        - name: workspace_id
+          from: filter
+          key: workspace_id
     response:
       rows_path: [locations]
       row_strategy: direct
@@ -456,6 +484,12 @@ tables:
         type: Int64
         nullable: true
         description: Parent location ID.
+      - name: workspace_id
+        type: Int64
+        nullable: true
+        virtual: true
+        description: Optional workspace filter.
+        expr: {kind: from_filter, key: workspace_id}
       - name: created_at
         type: Timestamp
         nullable: true


### PR DESCRIPTION
Summary:
- Adds a community Coral source for Freshservice tickets, agents, requesters, departments, assets, and locations.
- Keeps API credentials as secret input and uses bounded page/per_page pagination.
- Includes README setup, examples, limitations, and Freshservice tenant/API validation evidence.

Validation:
- YAML parsing: passed
- Coral manifest schema validation: passed
- git diff --check: passed
- make lint-sources: passed
- Freshservice API verified against live tenant endpoint